### PR TITLE
Add MVCC Transactions with Full ACID Guarantees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,6 +663,31 @@ See `justfile` for complete list of commands.
 
 ## Future Considerations
 
+### Vector Search (SUPERRAG)
+
+**Status**: Designed, not yet implemented
+
+Adding vector search enables **Graph + Vector + Bi-temporal** queries - combining semantic similarity with relationship traversal and time-travel.
+
+See **[docs/VECTOR_SEARCH_DESIGN.md](docs/VECTOR_SEARCH_DESIGN.md)** for the complete design including:
+- Architecture integration with existing storage
+- 5-phase implementation plan
+- Temporal vector strategy (versioned embeddings)
+- HNSW index integration (usearch recommended)
+- Hybrid query patterns
+
+**Key query patterns this enables:**
+```rust
+// Semantic time-travel
+db.as_of(timestamp_2023).find_similar(embedding, k)
+
+// Graph + Vector: traverse then rank
+db.traverse(alice_id, "KNOWS").rank_by_similarity(bob_embedding, 10)
+
+// Knowledge evolution
+db.track_semantic_drift(node_id, time_range)
+```
+
 ### Scalability
 - Sharding for horizontal scale
 - Distributed transaction coordination

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,9 @@ name = "persistence"
 harness = false
 path = "benches/persistence.rs"
 required-features = []
+
+[[bench]]
+name = "transactions"
+harness = false
+path = "benches/transactions.rs"
+required-features = []

--- a/benches/current_state.rs
+++ b/benches/current_state.rs
@@ -16,7 +16,7 @@ use gallifreydb::{CurrentStorage, PropertyMapBuilder};
 ///
 /// Creates a directed graph where each node has `out_degree` outgoing edges.
 fn create_test_graph(node_count: usize, out_degree: usize) -> CurrentStorage {
-    let mut storage = CurrentStorage::new();
+    let storage = CurrentStorage::new();
 
     // Create nodes
     let node_ids: Vec<_> = (0..node_count)
@@ -156,7 +156,7 @@ fn bench_node_creation(c: &mut Criterion) {
     c.bench_function("node_creation", |b| {
         b.iter_batched(
             CurrentStorage::new,
-            |mut storage| {
+            |storage| {
                 let props = PropertyMapBuilder::new()
                     .insert("name", "Alice")
                     .insert("age", 30i64)
@@ -176,7 +176,7 @@ fn bench_edge_creation(c: &mut Criterion) {
     c.bench_function("edge_creation", |b| {
         b.iter_batched(
             || {
-                let mut storage = CurrentStorage::new();
+                let storage = CurrentStorage::new();
                 let n1 = storage
                     .create_node("Person", PropertyMapBuilder::new().build())
                     .unwrap();
@@ -185,7 +185,7 @@ fn bench_edge_creation(c: &mut Criterion) {
                     .unwrap();
                 (storage, n1, n2)
             },
-            |(mut storage, n1, n2)| {
+            |(storage, n1, n2)| {
                 let props = PropertyMapBuilder::new().insert("since", 2020i64).build();
                 let edge = storage.create_edge(n1, n2, "KNOWS", props);
                 black_box(edge)

--- a/benches/gallifreydb.rs
+++ b/benches/gallifreydb.rs
@@ -15,7 +15,7 @@ fn create_versioned_graph(
     node_count: usize,
     _versions_per_node: usize,
 ) -> (GallifreyDB, Vec<NodeId>) {
-    let mut db = GallifreyDB::new();
+    let db = GallifreyDB::new();
     let mut node_ids = Vec::new();
 
     // Create initial nodes
@@ -53,7 +53,7 @@ fn bench_node_creation_with_versioning(c: &mut Criterion) {
     c.bench_function("gallifreydb_node_creation", |b| {
         b.iter_batched(
             GallifreyDB::new,
-            |mut db| {
+            |db| {
                 let props = PropertyMapBuilder::new()
                     .insert("name", "Alice")
                     .insert("age", 30i64)
@@ -71,7 +71,7 @@ fn bench_edge_creation_with_versioning(c: &mut Criterion) {
     c.bench_function("gallifreydb_edge_creation", |b| {
         b.iter_batched(
             || {
-                let mut db = GallifreyDB::new();
+                let db = GallifreyDB::new();
                 let n1 = db
                     .create_node("Person", PropertyMapBuilder::new().build())
                     .unwrap();
@@ -80,7 +80,7 @@ fn bench_edge_creation_with_versioning(c: &mut Criterion) {
                     .unwrap();
                 (db, n1, n2)
             },
-            |(mut db, n1, n2)| {
+            |(db, n1, n2)| {
                 let props = PropertyMapBuilder::new().insert("since", 2020i64).build();
                 let edge = db.create_edge(n1, n2, "KNOWS", props);
                 black_box(edge)
@@ -242,7 +242,7 @@ fn bench_batch_operations(c: &mut Criterion) {
             |b, &size| {
                 b.iter_batched(
                     GallifreyDB::new,
-                    |mut db| {
+                    |db| {
                         for i in 0..size {
                             let props = PropertyMapBuilder::new().insert("id", i as i64).build();
                             db.create_node("Node", props).unwrap();

--- a/benches/persistence.rs
+++ b/benches/persistence.rs
@@ -125,7 +125,7 @@ fn bench_checkpoint_creation(c: &mut Criterion) {
     for node_count in &[100, 1000, 10000] {
         group.bench_function(BenchmarkId::from_parameter(node_count), |b| {
             // Setup database with nodes
-            let mut current = CurrentStorage::new();
+            let current = CurrentStorage::new();
             let historical = HistoricalStorage::new();
 
             for i in 0..*node_count {
@@ -170,7 +170,7 @@ fn bench_checkpoint_load(c: &mut Criterion) {
     // Setup: Create checkpoints with different sizes
     for node_count in &[100, 1000, 10000] {
         let temp_dir = TempDir::new().unwrap();
-        let mut current = CurrentStorage::new();
+        let current = CurrentStorage::new();
         let historical = HistoricalStorage::new();
 
         for i in 0..*node_count {

--- a/benches/transactions.rs
+++ b/benches/transactions.rs
@@ -1,0 +1,196 @@
+//! Transaction overhead benchmarks
+//!
+//! These benchmarks measure the overhead introduced by the transaction layer
+//! compared to direct operations.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use gallifreydb::{GallifreyDB, PropertyMapBuilder, ReadOps, WriteOps};
+
+fn bench_read_transaction_creation(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("read_transaction_creation", |b| {
+        b.iter(|| {
+            let _tx = db.read_transaction();
+        });
+    });
+}
+
+fn bench_write_transaction_creation(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("write_transaction_creation", |b| {
+        b.iter(|| {
+            let _tx = db.write_transaction();
+        });
+    });
+}
+
+fn bench_closure_based_write_empty(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("closure_write_empty_commit", |b| {
+        b.iter(|| {
+            db.write(|_tx| Ok(())).unwrap();
+        });
+    });
+}
+
+fn bench_closure_based_write_single_node(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("closure_write_single_node", |b| {
+        b.iter(|| {
+            db.write(|tx| {
+                tx.create_node(
+                    "Person",
+                    PropertyMapBuilder::new()
+                        .insert("name", "Test")
+                        .insert("age", 30i64)
+                        .build(),
+                )
+            })
+            .unwrap();
+        });
+    });
+}
+
+fn bench_closure_based_write_10_ops(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("closure_write_10_operations", |b| {
+        b.iter(|| {
+            db.write(|tx| {
+                let mut nodes = Vec::new();
+                // Create 5 nodes
+                for i in 0..5 {
+                    let node = tx.create_node(
+                        "Person",
+                        PropertyMapBuilder::new().insert("id", i as i64).build(),
+                    )?;
+                    nodes.push(node);
+                }
+                // Create 5 edges
+                for i in 0..4 {
+                    tx.create_edge(
+                        nodes[i],
+                        nodes[i + 1],
+                        "KNOWS",
+                        PropertyMapBuilder::new().build(),
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+}
+
+fn bench_explicit_transaction_commit(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("explicit_transaction_commit", |b| {
+        b.iter(|| {
+            let mut tx = db.write_transaction();
+            tx.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Test").build(),
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        });
+    });
+}
+
+fn bench_implicit_vs_explicit(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    let mut group = c.benchmark_group("implicit_vs_explicit");
+
+    group.bench_function("implicit_create_node", |b| {
+        b.iter(|| {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Test").build(),
+            )
+            .unwrap();
+        });
+    });
+
+    group.bench_function("explicit_create_node", |b| {
+        b.iter(|| {
+            let mut tx = db.write_transaction();
+            tx.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Test").build(),
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_read_transaction_overhead(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    // Create a node to read
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .unwrap();
+
+    let mut group = c.benchmark_group("read_overhead");
+
+    group.bench_function("direct_get_node", |b| {
+        b.iter(|| {
+            let _node = db.get_node(black_box(node_id)).unwrap();
+        });
+    });
+
+    group.bench_function("read_transaction_get_node", |b| {
+        b.iter(|| {
+            db.read(|tx| {
+                let _node = tx.get_node(black_box(node_id))?;
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_wal_overhead(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    c.bench_function("write_with_wal_flush", |b| {
+        b.iter(|| {
+            db.write(|tx| {
+                tx.create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Test").build(),
+                )
+            })
+            .unwrap();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_read_transaction_creation,
+    bench_write_transaction_creation,
+    bench_closure_based_write_empty,
+    bench_closure_based_write_single_node,
+    bench_closure_based_write_10_ops,
+    bench_explicit_transaction_commit,
+    bench_implicit_vs_explicit,
+    bench_read_transaction_overhead,
+    bench_wal_overhead,
+);
+
+criterion_main!(benches);

--- a/docs/VECTOR_SEARCH_DESIGN.md
+++ b/docs/VECTOR_SEARCH_DESIGN.md
@@ -1,0 +1,433 @@
+# Vector Search Integration Design
+
+> **Status**: Proposed
+> **Created**: 2024-12-30
+> **Goal**: Position GallifreyDB as SUPERRAG - Graph + Vector + Bi-temporal
+
+## Executive Summary
+
+Adding vector search to GallifreyDB enables the combination of **graph traversal**, **semantic similarity**, and **bi-temporal tracking**. This enables queries like "What did we know about X that was semantically similar to Y at time T?" - essential for LLM reasoning about knowledge evolution.
+
+## Architecture Integration
+
+### Current Architecture (for reference)
+
+```
+┌─────────────────────────────────────────────────────┐
+│              Query Engine                            │
+│  - Temporal Query Planner                           │
+│  - Graph Traversal Engine                           │
+└─────────────────────────────────────────────────────┘
+                        │
+        ┌───────────────┴───────────────┐
+        │                               │
+┌───────▼─────────┐          ┌─────────▼─────────┐
+│ Current Storage │          │ Historical Storage │
+│  (Fast Path)    │          │  (Temporal Path)  │
+│                 │          │                   │
+│ - Live graph    │          │ - Version chains  │
+│ - Hot indexes   │          │ - Anchor+delta    │
+│ - No temporal   │          │ - Compressed      │
+└─────────────────┘          └───────────────────┘
+```
+
+### Proposed Architecture with Vectors
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Query Engine                          │
+│   Graph Traversal │ Vector Search │ Temporal Queries    │
+└─────────────────────────────────────────────────────────┘
+          │                 │                  │
+    ┌─────▼─────┐    ┌─────▼─────┐     ┌─────▼─────┐
+    │  Current  │    │  Vector   │     │ Historical│
+    │  Storage  │    │  Index    │     │  Storage  │
+    │ (DashMap) │    │  (HNSW)   │     │ (Anchor+Δ)│
+    └───────────┘    └───────────┘     └───────────┘
+          │                 │                  │
+          └─────────────────┴──────────────────┘
+                            │
+                    ┌───────▼───────┐
+                    │  Persistence  │
+                    │  (WAL + Snap) │
+                    └───────────────┘
+```
+
+### Why the Architecture Fits
+
+1. **Arc-based PropertyMap**: Vectors stored as properties won't duplicate across versions if unchanged
+2. **Immutable history**: Vector indexes can be built/queried without locks
+3. **Dual-path architecture**: "Current vectors" vs "historical vectors" mirrors existing pattern
+4. **String interning**: Vector labels/categories can use existing interning infrastructure
+
+## Design Decisions
+
+### Decision 1: Temporal Vector Strategy
+
+Three possible approaches:
+
+| Approach | Description | Complexity | Value |
+|----------|-------------|------------|-------|
+| **Global vectors** | Single index, latest embeddings only | Low | Basic RAG |
+| **Versioned vectors** | Track embedding changes over time | Medium | Knowledge evolution |
+| **Temporal reconstruction** | Reconstruct vectors at any point in time | High | Full time-travel |
+
+**Recommendation**: Start with **versioned vectors**. When a node's content changes, its embedding gets a new version. This enables "find similar nodes as of time T" without full reconstruction complexity.
+
+### Decision 2: Vector Storage Format
+
+```rust
+// Option A: Dedicated PropertyValue variant (recommended)
+pub enum PropertyValue {
+    // ... existing variants ...
+    Vector(Arc<[f32]>),      // Dense vector, f32 for memory efficiency
+    SparseVector(Arc<SparseVec>), // Future: sparse embeddings
+}
+
+// Option B: Use existing Bytes/Array
+PropertyValue::Bytes(Arc<[u8]>)  // Less type-safe, manual conversion
+
+// Option C: Separate storage
+struct VectorStorage {
+    embeddings: HashMap<NodeId, Arc<[f32]>>,
+}
+```
+
+**Recommendation**: Option A - explicit `Vector` variant provides type safety and enables optimized operations.
+
+### Decision 3: Index Library
+
+| Library | Language | Pros | Cons |
+|---------|----------|------|------|
+| **usearch** | C++/Rust | Fast, filtering support, production-ready | External dependency |
+| **hora** | Pure Rust | No FFI, simpler build | Less mature |
+| **hnswlib** | C++ | Battle-tested, widely used | C++ bindings complexity |
+| **Custom** | Rust | Full control, temporal-aware | Significant effort |
+
+**Recommendation**: **usearch** for initial implementation due to performance and filtering support. Consider custom implementation later for deep temporal integration.
+
+### Decision 4: Query API Design
+
+```rust
+// Vector search operations
+pub trait VectorOps {
+    /// Find k nearest neighbors to embedding
+    fn find_similar(&self, embedding: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>>;
+
+    /// Find similar with label filter
+    fn find_similar_with_label(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        label: &str
+    ) -> Result<Vec<(NodeId, f32)>>;
+
+    /// Find similar at specific point in time
+    fn find_similar_at_time(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+    ) -> Result<Vec<(NodeId, f32)>>;
+}
+
+// Hybrid queries
+pub trait HybridOps: GraphOps + VectorOps + TemporalOps {
+    /// Traverse graph, then rank by similarity
+    fn traverse_and_rank(
+        &self,
+        start: NodeId,
+        edge_label: &str,
+        target_embedding: &[f32],
+        k: usize,
+    ) -> Result<Vec<(NodeId, f32)>>;
+
+    /// Semantic time-travel
+    fn semantic_evolution(
+        &self,
+        node_id: NodeId,
+        time_range: TimeRange,
+    ) -> Result<Vec<(Timestamp, Arc<[f32]>)>>;
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Vector Storage Foundation
+**Estimated effort**: 1-2 days
+
+**Goals**:
+- Add `PropertyValue::Vector(Arc<[f32]>)` variant
+- Implement serialization/deserialization for vectors
+- Basic cosine similarity computation
+- Unit tests for vector operations
+
+**Files to modify**:
+- `src/core/property.rs` - Add Vector variant
+- `src/storage/current.rs` - Handle vector properties
+- `src/storage/historical.rs` - Version vector changes
+
+**New files**:
+- `src/core/vector.rs` - Vector utilities (similarity, normalization)
+
+### Phase 2: HNSW Index Integration
+**Estimated effort**: 3-5 days
+
+**Goals**:
+- Integrate usearch (or hora) crate
+- Create `VectorIndex` structure
+- Index current-state vectors automatically
+- Implement k-NN queries
+
+**Files to create**:
+- `src/index/vector.rs` - VectorIndex implementation
+- `src/index/vector/hnsw.rs` - HNSW wrapper
+
+**API additions**:
+```rust
+impl CurrentStorage {
+    pub fn find_similar(&self, embedding: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>>;
+    pub fn find_similar_with_label(&self, embedding: &[f32], k: usize, label: &str) -> Result<Vec<(NodeId, f32)>>;
+}
+```
+
+### Phase 3: Temporal Vector Support
+**Estimated effort**: 3-5 days
+
+**Goals**:
+- Version vector changes using existing anchor+delta system
+- Temporal vector index (snapshots at key timestamps)
+- Point-in-time vector queries
+- Semantic drift tracking
+
+**Key challenge**: Efficient temporal vector indexing
+- Option A: Rebuild HNSW at query time (slow, accurate)
+- Option B: Maintain periodic snapshots (fast, more storage)
+- Option C: Delta-based vector reconstruction (balanced)
+
+**Recommendation**: Option B for MVP - maintain HNSW snapshots at configurable intervals.
+
+**Files to create**:
+- `src/index/temporal_vector.rs` - Time-aware vector index
+
+### Phase 4: Hybrid Query Engine
+**Estimated effort**: 2-3 days
+
+**Goals**:
+- Graph + Vector queries
+- Vector + Temporal queries
+- Full hybrid: Graph + Vector + Temporal
+- Query planner for optimal execution
+
+**Example queries**:
+```rust
+// Graph + Vector: "Who does Alice know that's similar to Bob?"
+db.traverse(alice_id, "KNOWS")
+  .rank_by_similarity(bob_embedding, 10)
+
+// Vector + Temporal: "What was similar to this concept in 2023?"
+db.as_of(timestamp_2023)
+  .find_similar(concept_embedding, 10)
+
+// Full hybrid: "Who did Alice know in 2023 that was similar to Bob?"
+db.as_of(timestamp_2023)
+  .traverse(alice_id, "KNOWS")
+  .rank_by_similarity(bob_embedding, 10)
+```
+
+### Phase 5: Persistence & Performance
+**Estimated effort**: 2-3 days
+
+**Goals**:
+- Persist vector indexes to disk
+- Incremental index updates (avoid full rebuilds)
+- Benchmark suite for vector operations
+- Performance optimization
+
+**Targets**:
+- Vector search: <10ms for 1M vectors
+- Index update: <1ms per vector
+- Storage overhead: <20% for index structures
+
+## Module Structure
+
+```
+src/
+├── core/
+│   ├── property.rs      # Add Vector variant
+│   └── vector.rs        # NEW: Vector utilities
+├── index/
+│   ├── vector.rs        # NEW: VectorIndex trait + impl
+│   ├── vector/
+│   │   ├── hnsw.rs      # NEW: HNSW wrapper
+│   │   └── temporal.rs  # NEW: Temporal vector index
+│   └── mod.rs           # Export new modules
+├── storage/
+│   └── current.rs       # Vector query methods
+└── query/               # NEW: Query planning
+    ├── mod.rs
+    ├── planner.rs       # Query optimization
+    └── hybrid.rs        # Hybrid query execution
+```
+
+## SUPERRAG Query Examples
+
+### Example 1: Knowledge Evolution
+```
+User: "How has our understanding of 'machine learning' evolved?"
+
+Query:
+db.find_nodes_with_label("Concept")
+  .filter(|n| n.name == "machine learning")
+  .semantic_evolution(TimeRange::all())
+  .with_related_concepts(depth: 2)
+```
+
+### Example 2: Temporal Semantic Search
+```
+User: "What did we know about quantum computing in 2020
+       that's similar to today's AI safety concerns?"
+
+Query:
+let ai_safety_embedding = db.get_embedding("AI safety concerns");
+db.as_of(timestamp_2020)
+  .find_nodes_with_label("Concept")
+  .filter(|n| n.domain == "quantum computing")
+  .rank_by_similarity(ai_safety_embedding, 10)
+  .with_provenance()
+```
+
+### Example 3: Relationship Discovery
+```
+User: "Who influenced Alice's work that has similar
+       research interests to Bob?"
+
+Query:
+let bob_interests = db.get_node(bob_id).embedding;
+db.traverse(alice_id, "INFLUENCED_BY")
+  .rank_by_similarity(bob_interests, 5)
+  .include_path()
+```
+
+### Example 4: Contradiction Detection
+```
+User: "Find facts that changed meaning over time"
+
+Query:
+db.find_nodes_with_label("Fact")
+  .where_semantic_drift_exceeds(threshold: 0.3)
+  .between(time_start, time_end)
+  .with_version_history()
+```
+
+## Performance Considerations
+
+### Memory Budget
+- HNSW index: ~1KB per vector (for 384-dim embeddings)
+- 1M nodes with embeddings: ~1GB index memory
+- Temporal snapshots: multiply by snapshot count
+
+### CPU Considerations
+- Index building: O(n log n) for HNSW
+- Query: O(log n) average case
+- Batch operations preferred for index updates
+
+### Storage Format
+```
+Vector Index File (.vidx):
+┌─────────────────────────────────┐
+│ Header (version, dimensions)    │
+├─────────────────────────────────┤
+│ HNSW Graph Structure            │
+├─────────────────────────────────┤
+│ Vector Data (memory-mapped)     │
+├─────────────────────────────────┤
+│ NodeId → Vector Offset Map      │
+└─────────────────────────────────┘
+```
+
+## Testing Strategy
+
+### Unit Tests
+- Vector similarity calculations
+- PropertyValue::Vector serialization
+- Index add/remove/query operations
+
+### Integration Tests
+- End-to-end vector search
+- Temporal vector queries
+- Hybrid graph+vector queries
+
+### Benchmarks
+```rust
+// benches/vector_search.rs
+fn bench_knn_search(c: &mut Criterion) {
+    let db = setup_db_with_vectors(1_000_000);
+    let query = random_embedding(384);
+
+    c.bench_function("knn_k10", |b| {
+        b.iter(|| db.find_similar(&query, 10))
+    });
+}
+
+fn bench_temporal_vector_search(c: &mut Criterion) {
+    let db = setup_temporal_db_with_vectors();
+    let query = random_embedding(384);
+    let timestamp = historical_timestamp();
+
+    c.bench_function("temporal_knn_k10", |b| {
+        b.iter(|| db.as_of(timestamp).find_similar(&query, 10))
+    });
+}
+```
+
+## Dependencies to Add
+
+```toml
+# Cargo.toml additions
+
+[dependencies]
+# Vector index (choose one)
+usearch = "2"           # Recommended: fast, filtering support
+# hora = "0.1"          # Alternative: pure Rust
+
+# Optional: for vector normalization
+ndarray = "0.15"        # If we need matrix operations
+
+[dev-dependencies]
+rand = "0.8"            # For generating test vectors
+```
+
+## Open Questions
+
+1. **Embedding generation**: Should GallifreyDB generate embeddings or expect them as input?
+   - Recommendation: Accept embeddings as input; generation is application-specific
+
+2. **Sparse vectors**: Support for sparse embeddings (e.g., BM25, SPLADE)?
+   - Recommendation: Add later as `PropertyValue::SparseVector`
+
+3. **Multi-vector nodes**: Can a node have multiple embeddings (e.g., title + content)?
+   - Recommendation: Yes, as separate properties with naming convention
+
+4. **Index sharding**: How to handle very large vector collections?
+   - Recommendation: Single index for MVP; add sharding in future
+
+5. **Consistency**: How to keep vector index in sync with storage?
+   - Recommendation: Synchronous updates for current index; async for temporal snapshots
+
+## Success Criteria
+
+1. **Functional**: All four phases implemented and tested
+2. **Performance**:
+   - Vector search <10ms for 1M vectors
+   - No regression in graph/temporal query performance
+3. **Integration**: Seamless API combining all three capabilities
+4. **Documentation**: Updated CLAUDE.md with vector guidelines
+
+## References
+
+- [HNSW Paper](https://arxiv.org/abs/1603.09320)
+- [usearch Documentation](https://github.com/unum-cloud/usearch)
+- [Vector Database Benchmarks](https://ann-benchmarks.com/)
+- [Temporal + Vector Research](https://arxiv.org/abs/2304.12212) (AeonG paper)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,9 @@
+//! Public API for GallifreyDB
+//!
+//! This module provides high-level APIs for interacting with the database,
+//! including transaction support for ACID guarantees.
+
+pub mod transaction;
+
+// Re-export commonly used types
+pub use transaction::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -1,0 +1,101 @@
+//! Transaction support for GallifreyDB
+//!
+//! This module provides MVCC (Multi-Version Concurrency Control) transactions
+//! with Read Committed isolation level.
+//!
+//! # Transaction Types
+//!
+//! - [`ReadTransaction`]: Lightweight read-only transactions with zero overhead
+//! - [`WriteTransaction`]: Full ACID write transactions with write buffering and WAL
+//!
+//! # API Styles
+//!
+//! **Closure-based (recommended)**:
+//! ```ignore
+//! // Read-only
+//! db.read(|tx| {
+//!     let node = tx.get_node(id)?;
+//!     Ok(node.get_property("name"))
+//! })?;
+//!
+//! // Read-write (auto-commit on Ok, auto-rollback on Err)
+//! db.write(|tx| {
+//!     let node_id = tx.create_node("Person", props)?;
+//!     tx.create_edge(node_id, other, "KNOWS", edge_props)?;
+//!     Ok(node_id)
+//! })?;
+//! ```
+//!
+//! **Explicit handles**:
+//! ```ignore
+//! let mut tx = db.write_transaction();
+//! tx.create_node("Person", props)?;
+//! tx.create_edge(n1, n2, "KNOWS", props)?;
+//! tx.commit()?;  // or tx.rollback()
+//! ```
+
+pub mod read_tx;
+pub mod types;
+pub mod write_buffer;
+pub mod write_tx;
+
+pub use read_tx::ReadTransaction;
+pub use types::{TxId, TxIdGenerator, TxMetadata, TxState};
+pub use write_buffer::{BufferedWrite, WriteBuffer};
+pub use write_tx::WriteTransaction;
+
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::property::PropertyMap;
+use crate::utils::error::Result;
+
+/// Common read operations available in all transaction types
+pub trait ReadOps {
+    /// Get a node by ID (current state)
+    fn get_node(&self, id: NodeId) -> Result<Node>;
+
+    /// Get an edge by ID (current state)
+    fn get_edge(&self, id: EdgeId) -> Result<Edge>;
+
+    /// Get outgoing edges from a node
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
+
+    /// Get incoming edges to a node
+    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
+
+    /// Get outgoing edges with a specific label
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId>;
+
+    /// Get node count
+    fn node_count(&self) -> usize;
+
+    /// Get edge count
+    fn edge_count(&self) -> usize;
+}
+
+/// Write operations (only available in write transactions)
+pub trait WriteOps: ReadOps {
+    /// Create a new node
+    fn create_node(&mut self, label: &str, properties: PropertyMap) -> Result<NodeId>;
+
+    /// Create a new edge
+    fn create_edge(
+        &mut self,
+        source: NodeId,
+        target: NodeId,
+        label: &str,
+        properties: PropertyMap,
+    ) -> Result<EdgeId>;
+
+    /// Update a node's properties (creates new version)
+    fn update_node(&mut self, node_id: NodeId, properties: PropertyMap) -> Result<()>;
+
+    /// Update an edge's properties (creates new version)
+    fn update_edge(&mut self, edge_id: EdgeId, properties: PropertyMap) -> Result<()>;
+
+    /// Delete a node
+    fn delete_node(&mut self, node_id: NodeId) -> Result<()>;
+
+    /// Delete an edge
+    fn delete_edge(&mut self, edge_id: EdgeId) -> Result<()>;
+}

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Transaction support for GallifreyDB
 //!
 //! This module provides MVCC (Multi-Version Concurrency Control) transactions
-//! with Read Committed isolation level.
+//! with Snapshot Isolation level.
 //!
 //! # Transaction Types
 //!
@@ -36,11 +36,13 @@
 
 pub mod read_tx;
 pub mod types;
+pub mod visibility;
 pub mod write_buffer;
 pub mod write_tx;
 
 pub use read_tx::ReadTransaction;
 pub use types::{TxId, TxIdGenerator, TxMetadata, TxState};
+pub use visibility::{TransactionSnapshot, TxVisibilityManager};
 pub use write_buffer::{BufferedWrite, WriteBuffer};
 pub use write_tx::WriteTransaction;
 

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -1,0 +1,246 @@
+//! Read-only transactions
+//!
+//! Read-only transactions are lightweight and have zero overhead:
+//! - No write buffer
+//! - No WAL logging
+//! - Direct reads from CurrentStorage
+//! - No commit overhead
+
+use super::{ReadOps, TxId, TxMetadata, TxState};
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, NodeId};
+use crate::core::temporal::time;
+use crate::storage::current::CurrentStorage;
+use crate::utils::error::Result;
+use std::sync::Arc;
+
+/// Read-only transaction
+///
+/// Read-only transactions are lightweight:
+/// - No write buffer
+/// - No WAL logging
+/// - Direct reads from CurrentStorage
+/// - No commit overhead
+///
+/// # Example
+///
+/// ```ignore
+/// let tx = db.read_transaction();
+/// let node = tx.get_node(node_id)?;
+/// // No commit needed - transaction is read-only
+/// ```
+pub struct ReadTransaction {
+    tx_id: TxId,
+    start_timestamp: i64,
+    current: Arc<CurrentStorage>,
+}
+
+impl ReadTransaction {
+    /// Create a new read-only transaction
+    pub(crate) fn new(tx_id: TxId, current: Arc<CurrentStorage>) -> Self {
+        ReadTransaction {
+            tx_id,
+            start_timestamp: time::now(),
+            current,
+        }
+    }
+
+    /// Get transaction metadata
+    pub fn metadata(&self) -> TxMetadata {
+        TxMetadata {
+            tx_id: self.tx_id,
+            start_timestamp: self.start_timestamp,
+            commit_timestamp: None,
+            state: TxState::Active,
+            is_read_only: true,
+        }
+    }
+
+    /// Get transaction ID
+    pub fn tx_id(&self) -> TxId {
+        self.tx_id
+    }
+}
+
+impl ReadOps for ReadTransaction {
+    fn get_node(&self, id: NodeId) -> Result<Node> {
+        // Read Committed: always read latest committed data
+        self.current.get_node(id)
+    }
+
+    fn get_edge(&self, id: EdgeId) -> Result<Edge> {
+        self.current.get_edge(id)
+    }
+
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+        self.current.get_outgoing_edges(node_id)
+    }
+
+    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+        self.current.get_incoming_edges(node_id)
+    }
+
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId> {
+        self.current.get_outgoing_edges_with_label(node_id, label)
+    }
+
+    fn node_count(&self) -> usize {
+        self.current.node_count()
+    }
+
+    fn edge_count(&self) -> usize {
+        self.current.edge_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::property::PropertyMapBuilder;
+
+    #[test]
+    fn test_read_transaction_creation() {
+        let current = Arc::new(CurrentStorage::new());
+        let tx = ReadTransaction::new(TxId::new(1), current);
+
+        assert_eq!(tx.tx_id(), TxId::new(1));
+        let metadata = tx.metadata();
+        assert_eq!(metadata.tx_id, TxId::new(1));
+        assert!(metadata.is_read_only);
+        assert_eq!(metadata.state, TxState::Active);
+        assert_eq!(metadata.commit_timestamp, None);
+    }
+
+    #[test]
+    fn test_read_transaction_get_node() {
+        let current = Arc::new(CurrentStorage::new());
+
+        // Create a node in the storage
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .build();
+        let node_id = current.create_node("Person", props.clone()).unwrap();
+
+        // Read through transaction
+        let tx = ReadTransaction::new(TxId::new(1), Arc::clone(&current));
+        let node = tx.get_node(node_id).unwrap();
+
+        assert_eq!(node.id, node_id);
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
+        assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(30));
+    }
+
+    #[test]
+    fn test_read_transaction_get_node_not_found() {
+        let current = Arc::new(CurrentStorage::new());
+        let tx = ReadTransaction::new(TxId::new(1), current);
+
+        let result = tx.get_node(NodeId::new(999));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_transaction_node_count() {
+        let current = Arc::new(CurrentStorage::new());
+
+        // Create some nodes
+        let props = PropertyMapBuilder::new().build();
+        current.create_node("Person", props.clone()).unwrap();
+        current.create_node("Person", props.clone()).unwrap();
+        current.create_node("Person", props).unwrap();
+
+        let tx = ReadTransaction::new(TxId::new(1), current);
+        assert_eq!(tx.node_count(), 3);
+    }
+
+    #[test]
+    fn test_read_transaction_get_edges() {
+        let current = Arc::new(CurrentStorage::new());
+
+        // Create nodes and edge
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props.clone()).unwrap();
+        let edge_id = current.create_edge(node1, node2, "KNOWS", props).unwrap();
+
+        let tx = ReadTransaction::new(TxId::new(1), current);
+
+        // Get edge
+        let edge = tx.get_edge(edge_id).unwrap();
+        assert_eq!(edge.id, edge_id);
+        assert_eq!(edge.source, node1);
+        assert_eq!(edge.target, node2);
+
+        // Get outgoing edges
+        let outgoing = tx.get_outgoing_edges(node1);
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0], edge_id);
+
+        // Get incoming edges
+        let incoming = tx.get_incoming_edges(node2);
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0], edge_id);
+    }
+
+    #[test]
+    fn test_read_transaction_get_outgoing_edges_with_label() {
+        let current = Arc::new(CurrentStorage::new());
+
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props.clone()).unwrap();
+        let node3 = current.create_node("Person", props.clone()).unwrap();
+
+        // Create edges with different labels
+        let edge1 = current
+            .create_edge(node1, node2, "KNOWS", props.clone())
+            .unwrap();
+        let _edge2 = current.create_edge(node1, node3, "FOLLOWS", props).unwrap();
+
+        let tx = ReadTransaction::new(TxId::new(1), current);
+
+        // Get only KNOWS edges
+        let knows_edges = tx.get_outgoing_edges_with_label(node1, "KNOWS");
+        assert_eq!(knows_edges.len(), 1);
+        assert_eq!(knows_edges[0], edge1);
+
+        // Get only FOLLOWS edges
+        let follows_edges = tx.get_outgoing_edges_with_label(node1, "FOLLOWS");
+        assert_eq!(follows_edges.len(), 1);
+    }
+
+    #[test]
+    fn test_read_transaction_concurrent_access() {
+        use std::thread;
+
+        let current = Arc::new(CurrentStorage::new());
+
+        // Pre-populate with data
+        let props = PropertyMapBuilder::new().insert("value", 42i64).build();
+        let node_id = current.create_node("Test", props).unwrap();
+
+        // Spawn multiple reader threads
+        let mut handles = vec![];
+        for i in 0..10 {
+            let current_clone = Arc::clone(&current);
+            let handle = thread::spawn(move || {
+                let tx = ReadTransaction::new(TxId::new(i), current_clone);
+                let node = tx.get_node(node_id).unwrap();
+                assert_eq!(
+                    node.get_property("value").and_then(|v| v.as_int()),
+                    Some(42)
+                );
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all readers
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    }
+}

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -1,17 +1,17 @@
 //! Read-only transactions
 //!
-//! Read-only transactions are lightweight and have zero overhead:
+//! Read-only transactions are lightweight:
 //! - No write buffer
 //! - No WAL logging
-//! - Direct reads from CurrentStorage
+//! - Snapshot-based reads for consistency
 //! - No commit overhead
 
-use super::{ReadOps, TxId, TxMetadata, TxState};
+use super::{ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::temporal::time;
 use crate::storage::current::CurrentStorage;
-use crate::utils::error::Result;
+use crate::utils::error::{Result, StorageError};
 use std::sync::Arc;
 
 /// Read-only transaction
@@ -19,7 +19,7 @@ use std::sync::Arc;
 /// Read-only transactions are lightweight:
 /// - No write buffer
 /// - No WAL logging
-/// - Direct reads from CurrentStorage
+/// - Snapshot-based reads for consistency
 /// - No commit overhead
 ///
 /// # Example
@@ -32,16 +32,25 @@ use std::sync::Arc;
 pub struct ReadTransaction {
     tx_id: TxId,
     start_timestamp: i64,
+    snapshot: TransactionSnapshot,
     current: Arc<CurrentStorage>,
+    visibility_manager: Arc<TxVisibilityManager>,
 }
 
 impl ReadTransaction {
     /// Create a new read-only transaction
-    pub(crate) fn new(tx_id: TxId, current: Arc<CurrentStorage>) -> Self {
+    pub(crate) fn new(
+        tx_id: TxId,
+        snapshot: TransactionSnapshot,
+        current: Arc<CurrentStorage>,
+        visibility_manager: Arc<TxVisibilityManager>,
+    ) -> Self {
         ReadTransaction {
             tx_id,
             start_timestamp: time::now(),
+            snapshot,
             current,
+            visibility_manager,
         }
     }
 
@@ -64,12 +73,35 @@ impl ReadTransaction {
 
 impl ReadOps for ReadTransaction {
     fn get_node(&self, id: NodeId) -> Result<Node> {
-        // Read Committed: always read latest committed data
-        self.current.get_node(id)
+        // Snapshot Isolation: only read versions visible in our snapshot
+        let node = self.current.get_node(id)?;
+
+        // Check if this version is visible in our snapshot
+        if !self
+            .visibility_manager
+            .is_visible(&self.snapshot, node.metadata.created_by_tx)
+        {
+            // Version not visible - return NodeNotFound
+            return Err(StorageError::NodeNotFound(id).into());
+        }
+
+        Ok(node)
     }
 
     fn get_edge(&self, id: EdgeId) -> Result<Edge> {
-        self.current.get_edge(id)
+        // Snapshot Isolation: only read versions visible in our snapshot
+        let edge = self.current.get_edge(id)?;
+
+        // Check if this version is visible in our snapshot
+        if !self
+            .visibility_manager
+            .is_visible(&self.snapshot, edge.metadata.created_by_tx)
+        {
+            // Version not visible - return EdgeNotFound
+            return Err(StorageError::EdgeNotFound(id).into());
+        }
+
+        Ok(edge)
     }
 
     fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
@@ -97,11 +129,23 @@ impl ReadOps for ReadTransaction {
 mod tests {
     use super::*;
     use crate::core::property::PropertyMapBuilder;
+    use crate::core::temporal::time;
+    use std::collections::HashSet;
+
+    // Helper to create a test ReadTransaction with snapshot
+    fn create_test_read_tx(tx_id: TxId, current: Arc<CurrentStorage>) -> ReadTransaction {
+        let visibility_manager = Arc::new(TxVisibilityManager::new());
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: time::now(),
+            active_transactions: HashSet::new(),
+        };
+        ReadTransaction::new(tx_id, snapshot, current, visibility_manager)
+    }
 
     #[test]
     fn test_read_transaction_creation() {
         let current = Arc::new(CurrentStorage::new());
-        let tx = ReadTransaction::new(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1), current);
 
         assert_eq!(tx.tx_id(), TxId::new(1));
         let metadata = tx.metadata();
@@ -123,7 +167,7 @@ mod tests {
         let node_id = current.create_node("Person", props.clone()).unwrap();
 
         // Read through transaction
-        let tx = ReadTransaction::new(TxId::new(1), Arc::clone(&current));
+        let tx = create_test_read_tx(TxId::new(1), Arc::clone(&current));
         let node = tx.get_node(node_id).unwrap();
 
         assert_eq!(node.id, node_id);
@@ -137,7 +181,7 @@ mod tests {
     #[test]
     fn test_read_transaction_get_node_not_found() {
         let current = Arc::new(CurrentStorage::new());
-        let tx = ReadTransaction::new(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1), current);
 
         let result = tx.get_node(NodeId::new(999));
         assert!(result.is_err());
@@ -153,7 +197,7 @@ mod tests {
         current.create_node("Person", props.clone()).unwrap();
         current.create_node("Person", props).unwrap();
 
-        let tx = ReadTransaction::new(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1), current);
         assert_eq!(tx.node_count(), 3);
     }
 
@@ -167,7 +211,7 @@ mod tests {
         let node2 = current.create_node("Person", props.clone()).unwrap();
         let edge_id = current.create_edge(node1, node2, "KNOWS", props).unwrap();
 
-        let tx = ReadTransaction::new(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1), current);
 
         // Get edge
         let edge = tx.get_edge(edge_id).unwrap();
@@ -201,7 +245,7 @@ mod tests {
             .unwrap();
         let _edge2 = current.create_edge(node1, node3, "FOLLOWS", props).unwrap();
 
-        let tx = ReadTransaction::new(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1), current);
 
         // Get only KNOWS edges
         let knows_edges = tx.get_outgoing_edges_with_label(node1, "KNOWS");
@@ -228,7 +272,7 @@ mod tests {
         for i in 0..10 {
             let current_clone = Arc::clone(&current);
             let handle = thread::spawn(move || {
-                let tx = ReadTransaction::new(TxId::new(i), current_clone);
+                let tx = create_test_read_tx(TxId::new(i), current_clone);
                 let node = tx.get_node(node_id).unwrap();
                 assert_eq!(
                     node.get_property("value").and_then(|v| v.as_int()),

--- a/src/api/transaction/types.rs
+++ b/src/api/transaction/types.rs
@@ -1,0 +1,201 @@
+//! Transaction types and metadata
+
+use crate::core::temporal::Timestamp;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Transaction ID - globally unique identifier for transactions
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TxId(u64);
+
+impl TxId {
+    /// Create a new transaction ID
+    pub fn new(id: u64) -> Self {
+        TxId(id)
+    }
+
+    /// Get the inner ID value
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for TxId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TxId({})", self.0)
+    }
+}
+
+/// Transaction state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxState {
+    /// Transaction is active and can perform operations
+    Active,
+    /// Transaction is preparing to commit (validating)
+    Preparing,
+    /// Transaction has committed successfully
+    Committed,
+    /// Transaction has been rolled back
+    Aborted,
+}
+
+impl std::fmt::Display for TxState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TxState::Active => write!(f, "Active"),
+            TxState::Preparing => write!(f, "Preparing"),
+            TxState::Committed => write!(f, "Committed"),
+            TxState::Aborted => write!(f, "Aborted"),
+        }
+    }
+}
+
+/// Transaction metadata
+#[derive(Debug, Clone)]
+pub struct TxMetadata {
+    /// Transaction ID
+    pub tx_id: TxId,
+    /// Timestamp when transaction started
+    pub start_timestamp: Timestamp,
+    /// Timestamp when transaction committed (None if not yet committed)
+    pub commit_timestamp: Option<Timestamp>,
+    /// Current transaction state
+    pub state: TxState,
+    /// Whether this is a read-only transaction
+    pub is_read_only: bool,
+}
+
+/// Global transaction ID generator
+///
+/// Generates monotonically increasing transaction IDs using atomic operations.
+pub struct TxIdGenerator {
+    counter: AtomicU64,
+}
+
+impl TxIdGenerator {
+    /// Create a new transaction ID generator starting from 1
+    pub fn new() -> Self {
+        TxIdGenerator {
+            counter: AtomicU64::new(1),
+        }
+    }
+
+    /// Generate the next transaction ID
+    ///
+    /// This operation is atomic and thread-safe.
+    pub fn next(&self) -> TxId {
+        TxId(self.counter.fetch_add(1, Ordering::SeqCst))
+    }
+
+    /// Get the current transaction ID (last generated)
+    pub fn current(&self) -> TxId {
+        TxId(self.counter.load(Ordering::SeqCst).saturating_sub(1))
+    }
+}
+
+impl Default for TxIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tx_id_creation() {
+        let tx_id = TxId::new(42);
+        assert_eq!(tx_id.as_u64(), 42);
+    }
+
+    #[test]
+    fn test_tx_id_ordering() {
+        let tx1 = TxId::new(1);
+        let tx2 = TxId::new(2);
+        assert!(tx1 < tx2);
+        assert_eq!(tx1, tx1);
+    }
+
+    #[test]
+    fn test_tx_id_display() {
+        let tx_id = TxId::new(123);
+        assert_eq!(format!("{}", tx_id), "TxId(123)");
+    }
+
+    #[test]
+    fn test_tx_state_display() {
+        assert_eq!(format!("{}", TxState::Active), "Active");
+        assert_eq!(format!("{}", TxState::Preparing), "Preparing");
+        assert_eq!(format!("{}", TxState::Committed), "Committed");
+        assert_eq!(format!("{}", TxState::Aborted), "Aborted");
+    }
+
+    #[test]
+    fn test_tx_id_generator() {
+        let generator = TxIdGenerator::new();
+        let tx1 = generator.next();
+        let tx2 = generator.next();
+        let tx3 = generator.next();
+
+        assert_eq!(tx1.as_u64(), 1);
+        assert_eq!(tx2.as_u64(), 2);
+        assert_eq!(tx3.as_u64(), 3);
+        assert_eq!(generator.current().as_u64(), 3);
+    }
+
+    #[test]
+    fn test_tx_id_generator_concurrent() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let generator = Arc::new(TxIdGenerator::new());
+        let mut handles = vec![];
+
+        // Spawn 10 threads, each generating 100 IDs
+        for _ in 0..10 {
+            let generator_clone = Arc::clone(&generator);
+            let handle = thread::spawn(move || {
+                let mut ids = vec![];
+                for _ in 0..100 {
+                    ids.push(generator_clone.next());
+                }
+                ids
+            });
+            handles.push(handle);
+        }
+
+        // Collect all generated IDs
+        let mut all_ids: Vec<TxId> = vec![];
+        for handle in handles {
+            all_ids.extend(handle.join().unwrap());
+        }
+
+        // All IDs should be unique
+        all_ids.sort();
+        let unique_count = all_ids
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        assert_eq!(unique_count, 1000);
+
+        // Final current should be 1000
+        assert_eq!(generator.current().as_u64(), 1000);
+    }
+
+    #[test]
+    fn test_tx_metadata() {
+        let metadata = TxMetadata {
+            tx_id: TxId::new(1),
+            start_timestamp: 100,
+            commit_timestamp: None,
+            state: TxState::Active,
+            is_read_only: false,
+        };
+
+        assert_eq!(metadata.tx_id, TxId::new(1));
+        assert_eq!(metadata.start_timestamp, 100);
+        assert_eq!(metadata.commit_timestamp, None);
+        assert_eq!(metadata.state, TxState::Active);
+        assert!(!metadata.is_read_only);
+    }
+}

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -42,9 +42,9 @@ impl TransactionSnapshot {
             None => false, // Uncommitted version - not visible
             Some(ts) => {
                 // Visible if:
-                // 1. Committed before our snapshot AND
+                // 1. Committed strictly before our snapshot (not at the same time) AND
                 // 2. Not created by a transaction that was active at snapshot time
-                ts <= self.snapshot_timestamp && !self.active_transactions.contains(&created_by_tx)
+                ts < self.snapshot_timestamp && !self.active_transactions.contains(&created_by_tx)
             }
         }
     }

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -44,8 +44,7 @@ impl TransactionSnapshot {
                 // Visible if:
                 // 1. Committed before our snapshot AND
                 // 2. Not created by a transaction that was active at snapshot time
-                ts <= self.snapshot_timestamp
-                    && !self.active_transactions.contains(&created_by_tx)
+                ts <= self.snapshot_timestamp && !self.active_transactions.contains(&created_by_tx)
             }
         }
     }
@@ -151,6 +150,12 @@ impl TxVisibilityManager {
     /// # Returns
     /// `true` if the version is visible, `false` otherwise
     pub fn is_visible(&self, snapshot: &TransactionSnapshot, created_by_tx: TxId) -> bool {
+        // Special case: TxId(0) is for pre-existing data (e.g., test fixtures, migrations)
+        // Always treat it as visible to ensure backward compatibility
+        if created_by_tx.as_u64() == 0 {
+            return true;
+        }
+
         // Check if transaction committed
         let committed = self.committed.lock().unwrap();
 

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -1,0 +1,369 @@
+//! Transaction visibility management for Snapshot Isolation.
+//!
+//! This module implements the visibility rules for Snapshot Isolation (SI),
+//! which ensures that each transaction sees a consistent snapshot of the database
+//! from the time it started.
+
+use crate::api::transaction::types::TxId;
+use crate::core::temporal::Timestamp;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Mutex;
+
+/// Snapshot of transaction visibility at a point in time.
+///
+/// A snapshot captures the set of transactions that were active when the
+/// snapshot was taken. This is used to determine which versions are visible
+/// to a transaction using Snapshot Isolation.
+#[derive(Debug, Clone)]
+pub struct TransactionSnapshot {
+    /// Timestamp when snapshot was taken
+    pub snapshot_timestamp: Timestamp,
+
+    /// Transactions that were active when snapshot was taken
+    /// (not yet committed or aborted)
+    pub active_transactions: HashSet<TxId>,
+}
+
+impl TransactionSnapshot {
+    /// Check if a version is visible in this snapshot.
+    ///
+    /// A version is visible if:
+    /// 1. It was committed before the snapshot timestamp, AND
+    /// 2. It was not created by a transaction that was active at snapshot time
+    ///
+    /// # Arguments
+    /// * `created_by_tx` - The transaction that created this version
+    /// * `commit_timestamp` - When the version was committed (None if uncommitted)
+    ///
+    /// # Returns
+    /// `true` if the version is visible in this snapshot, `false` otherwise
+    pub fn is_visible(&self, created_by_tx: TxId, commit_timestamp: Option<Timestamp>) -> bool {
+        match commit_timestamp {
+            None => false, // Uncommitted version - not visible
+            Some(ts) => {
+                // Visible if:
+                // 1. Committed before our snapshot AND
+                // 2. Not created by a transaction that was active at snapshot time
+                ts <= self.snapshot_timestamp
+                    && !self.active_transactions.contains(&created_by_tx)
+            }
+        }
+    }
+}
+
+/// Manages transaction visibility for Snapshot Isolation.
+///
+/// The visibility manager tracks which transactions are currently active
+/// and which have committed, allowing transactions to capture a consistent
+/// snapshot of the database state.
+///
+/// # Snapshot Isolation Semantics
+///
+/// - Each transaction sees a consistent snapshot from its start time
+/// - Transactions don't see uncommitted changes from other transactions
+/// - Transactions don't see changes committed after their snapshot time
+/// - Write-write conflicts are detected at commit time
+pub struct TxVisibilityManager {
+    /// Currently active transactions
+    active: Mutex<HashSet<TxId>>,
+
+    /// Committed transactions: TxId → commit_timestamp
+    committed: Mutex<BTreeMap<TxId, Timestamp>>,
+}
+
+impl TxVisibilityManager {
+    /// Create a new visibility manager.
+    pub fn new() -> Self {
+        TxVisibilityManager {
+            active: Mutex::new(HashSet::new()),
+            committed: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Register a new active transaction.
+    ///
+    /// This should be called when a transaction begins.
+    ///
+    /// # Arguments
+    /// * `tx_id` - The ID of the transaction being started
+    pub fn register_active(&self, tx_id: TxId) {
+        let mut active = self.active.lock().unwrap();
+        active.insert(tx_id);
+    }
+
+    /// Capture a snapshot for a transaction.
+    ///
+    /// The snapshot records which transactions are currently active.
+    /// This snapshot will be used to determine visibility of versions
+    /// throughout the transaction's lifetime.
+    ///
+    /// # Arguments
+    /// * `snapshot_timestamp` - The timestamp for this snapshot
+    ///
+    /// # Returns
+    /// A `TransactionSnapshot` capturing the current visibility state
+    pub fn capture_snapshot(&self, snapshot_timestamp: Timestamp) -> TransactionSnapshot {
+        let active = self.active.lock().unwrap();
+        TransactionSnapshot {
+            snapshot_timestamp,
+            active_transactions: active.clone(),
+        }
+    }
+
+    /// Register a transaction commit.
+    ///
+    /// This should be called when a transaction successfully commits.
+    /// It removes the transaction from the active set and records its
+    /// commit timestamp.
+    ///
+    /// # Arguments
+    /// * `tx_id` - The ID of the committing transaction
+    /// * `commit_timestamp` - When the transaction committed
+    pub fn register_commit(&self, tx_id: TxId, commit_timestamp: Timestamp) {
+        let mut active = self.active.lock().unwrap();
+        active.remove(&tx_id);
+
+        let mut committed = self.committed.lock().unwrap();
+        committed.insert(tx_id, commit_timestamp);
+    }
+
+    /// Register a transaction abort.
+    ///
+    /// This should be called when a transaction aborts (rolls back).
+    /// It simply removes the transaction from the active set.
+    ///
+    /// # Arguments
+    /// * `tx_id` - The ID of the aborting transaction
+    pub fn register_abort(&self, tx_id: TxId) {
+        let mut active = self.active.lock().unwrap();
+        active.remove(&tx_id);
+    }
+
+    /// Check if a version is visible in a snapshot.
+    ///
+    /// This applies the Snapshot Isolation visibility rules to determine
+    /// if a version created by `created_by_tx` is visible in the given snapshot.
+    ///
+    /// # Arguments
+    /// * `snapshot` - The transaction's snapshot
+    /// * `created_by_tx` - The transaction that created the version
+    ///
+    /// # Returns
+    /// `true` if the version is visible, `false` otherwise
+    pub fn is_visible(&self, snapshot: &TransactionSnapshot, created_by_tx: TxId) -> bool {
+        // Check if transaction committed
+        let committed = self.committed.lock().unwrap();
+
+        match committed.get(&created_by_tx) {
+            None => false, // Not committed - not visible
+            Some(&commit_ts) => {
+                // Apply visibility rules from snapshot
+                snapshot.is_visible(created_by_tx, Some(commit_ts))
+            }
+        }
+    }
+
+    /// Get the number of active transactions.
+    ///
+    /// This is primarily useful for testing and monitoring.
+    #[allow(dead_code)]
+    pub fn active_count(&self) -> usize {
+        let active = self.active.lock().unwrap();
+        active.len()
+    }
+
+    /// Get the number of committed transactions tracked.
+    ///
+    /// This is primarily useful for testing and monitoring.
+    #[allow(dead_code)]
+    pub fn committed_count(&self) -> usize {
+        let committed = self.committed.lock().unwrap();
+        committed.len()
+    }
+}
+
+impl Default for TxVisibilityManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snapshot_visibility_committed_before() {
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: 100,
+            active_transactions: HashSet::new(),
+        };
+
+        // Version committed before snapshot - visible
+        assert!(snapshot.is_visible(TxId::new(1), Some(50)));
+    }
+
+    #[test]
+    fn test_snapshot_visibility_committed_after() {
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: 100,
+            active_transactions: HashSet::new(),
+        };
+
+        // Version committed after snapshot - not visible
+        assert!(!snapshot.is_visible(TxId::new(1), Some(150)));
+    }
+
+    #[test]
+    fn test_snapshot_visibility_uncommitted() {
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: 100,
+            active_transactions: HashSet::new(),
+        };
+
+        // Uncommitted version - not visible
+        assert!(!snapshot.is_visible(TxId::new(1), None));
+    }
+
+    #[test]
+    fn test_snapshot_visibility_active_transaction() {
+        let mut active = HashSet::new();
+        active.insert(TxId::new(1));
+
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: 100,
+            active_transactions: active,
+        };
+
+        // Version from active transaction - not visible even if committed before snapshot
+        assert!(!snapshot.is_visible(TxId::new(1), Some(50)));
+    }
+
+    #[test]
+    fn test_visibility_manager_creation() {
+        let manager = TxVisibilityManager::new();
+        assert_eq!(manager.active_count(), 0);
+        assert_eq!(manager.committed_count(), 0);
+    }
+
+    #[test]
+    fn test_register_active() {
+        let manager = TxVisibilityManager::new();
+        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(2));
+
+        assert_eq!(manager.active_count(), 2);
+    }
+
+    #[test]
+    fn test_capture_snapshot() {
+        let manager = TxVisibilityManager::new();
+        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(2));
+
+        let snapshot = manager.capture_snapshot(100);
+
+        assert_eq!(snapshot.snapshot_timestamp, 100);
+        assert_eq!(snapshot.active_transactions.len(), 2);
+        assert!(snapshot.active_transactions.contains(&TxId::new(1)));
+        assert!(snapshot.active_transactions.contains(&TxId::new(2)));
+    }
+
+    #[test]
+    fn test_register_commit() {
+        let manager = TxVisibilityManager::new();
+        manager.register_active(TxId::new(1));
+
+        assert_eq!(manager.active_count(), 1);
+        assert_eq!(manager.committed_count(), 0);
+
+        manager.register_commit(TxId::new(1), 100);
+
+        assert_eq!(manager.active_count(), 0);
+        assert_eq!(manager.committed_count(), 1);
+    }
+
+    #[test]
+    fn test_register_abort() {
+        let manager = TxVisibilityManager::new();
+        manager.register_active(TxId::new(1));
+
+        assert_eq!(manager.active_count(), 1);
+
+        manager.register_abort(TxId::new(1));
+
+        assert_eq!(manager.active_count(), 0);
+        assert_eq!(manager.committed_count(), 0);
+    }
+
+    #[test]
+    fn test_is_visible_committed_transaction() {
+        let manager = TxVisibilityManager::new();
+
+        // Start and commit transaction 1
+        manager.register_active(TxId::new(1));
+        manager.register_commit(TxId::new(1), 50);
+
+        // Take snapshot after commit
+        let snapshot = manager.capture_snapshot(100);
+
+        // Version from tx1 should be visible
+        assert!(manager.is_visible(&snapshot, TxId::new(1)));
+    }
+
+    #[test]
+    fn test_is_visible_uncommitted_transaction() {
+        let manager = TxVisibilityManager::new();
+
+        // Start transaction 1 but don't commit
+        manager.register_active(TxId::new(1));
+
+        let snapshot = manager.capture_snapshot(100);
+
+        // Version from uncommitted tx1 should not be visible
+        assert!(!manager.is_visible(&snapshot, TxId::new(1)));
+    }
+
+    #[test]
+    fn test_is_visible_concurrent_transaction() {
+        let manager = TxVisibilityManager::new();
+
+        // Start tx1
+        manager.register_active(TxId::new(1));
+
+        // Take snapshot (tx1 is active)
+        let snapshot = manager.capture_snapshot(100);
+
+        // Commit tx1 after snapshot
+        manager.register_commit(TxId::new(1), 90);
+
+        // Even though tx1 committed before snapshot timestamp,
+        // it was active at snapshot time, so not visible
+        assert!(!manager.is_visible(&snapshot, TxId::new(1)));
+    }
+
+    #[test]
+    fn test_concurrent_snapshots() {
+        let manager = TxVisibilityManager::new();
+
+        // Start tx1
+        manager.register_active(TxId::new(1));
+
+        // Snapshot 1 - sees tx1 as active
+        let snapshot1 = manager.capture_snapshot(100);
+        assert_eq!(snapshot1.active_transactions.len(), 1);
+
+        // Commit tx1, start tx2
+        manager.register_commit(TxId::new(1), 110);
+        manager.register_active(TxId::new(2));
+
+        // Snapshot 2 - sees tx2 as active, tx1 committed
+        let snapshot2 = manager.capture_snapshot(120);
+        assert_eq!(snapshot2.active_transactions.len(), 1);
+        assert!(snapshot2.active_transactions.contains(&TxId::new(2)));
+
+        // Original snapshot1 unchanged
+        assert_eq!(snapshot1.active_transactions.len(), 1);
+        assert!(snapshot1.active_transactions.contains(&TxId::new(1)));
+    }
+}

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -156,6 +156,20 @@ impl WriteBuffer {
         self.modified_edges.contains_key(&edge_id)
     }
 
+    /// Get the buffered write for a node, if any
+    pub fn get_node_write(&self, node_id: NodeId) -> Option<&BufferedWrite> {
+        self.modified_nodes
+            .get(&node_id)
+            .map(|&index| &self.operations[index])
+    }
+
+    /// Get the buffered write for an edge, if any
+    pub fn get_edge_write(&self, edge_id: EdgeId) -> Option<&BufferedWrite> {
+        self.modified_edges
+            .get(&edge_id)
+            .map(|&index| &self.operations[index])
+    }
+
     /// Clear all buffered operations
     pub fn clear(&mut self) {
         self.operations.clear();

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -1,0 +1,347 @@
+//! Write buffering for uncommitted transaction changes
+
+use crate::core::id::{EdgeId, NodeId, VersionId};
+use crate::core::interning::InternedString;
+use crate::core::property::PropertyMap;
+use crate::core::temporal::BiTemporalInterval;
+use std::collections::HashMap;
+
+/// Buffered write operation
+///
+/// Represents an uncommitted write operation that will be applied
+/// atomically when the transaction commits.
+#[derive(Debug, Clone)]
+pub enum BufferedWrite {
+    /// Create a new node
+    CreateNode {
+        /// Node ID
+        node_id: NodeId,
+        /// Version ID for this node
+        version_id: VersionId,
+        /// Node label
+        label: InternedString,
+        /// Node properties
+        properties: PropertyMap,
+        /// Bi-temporal interval
+        temporal: BiTemporalInterval,
+    },
+    /// Create a new edge
+    CreateEdge {
+        /// Edge ID
+        edge_id: EdgeId,
+        /// Version ID for this edge
+        version_id: VersionId,
+        /// Source node ID
+        source: NodeId,
+        /// Target node ID
+        target: NodeId,
+        /// Edge label
+        label: InternedString,
+        /// Edge properties
+        properties: PropertyMap,
+        /// Bi-temporal interval
+        temporal: BiTemporalInterval,
+    },
+    /// Update an existing node (creates new version)
+    UpdateNode {
+        /// Node ID being updated
+        node_id: NodeId,
+        /// New version ID
+        version_id: VersionId,
+        /// Node label (preserved from existing)
+        label: InternedString,
+        /// New properties
+        properties: PropertyMap,
+        /// Bi-temporal interval
+        temporal: BiTemporalInterval,
+    },
+    /// Update an existing edge (creates new version)
+    UpdateEdge {
+        /// Edge ID being updated
+        edge_id: EdgeId,
+        /// New version ID
+        version_id: VersionId,
+        /// Source node (preserved from existing)
+        source: NodeId,
+        /// Target node (preserved from existing)
+        target: NodeId,
+        /// Edge label (preserved from existing)
+        label: InternedString,
+        /// New properties
+        properties: PropertyMap,
+        /// Bi-temporal interval
+        temporal: BiTemporalInterval,
+    },
+    /// Delete a node
+    DeleteNode {
+        /// Node ID to delete
+        node_id: NodeId,
+    },
+    /// Delete an edge
+    DeleteEdge {
+        /// Edge ID to delete
+        edge_id: EdgeId,
+    },
+}
+
+/// Write buffer for collecting uncommitted changes
+///
+/// Buffers all write operations in a transaction until commit time,
+/// enabling atomicity and validation before applying changes.
+pub struct WriteBuffer {
+    /// Buffered operations in order
+    operations: Vec<BufferedWrite>,
+
+    /// Quick lookup: which nodes have been written to
+    /// Maps NodeId → index in operations vector
+    modified_nodes: HashMap<NodeId, usize>,
+
+    /// Quick lookup: which edges have been written to
+    /// Maps EdgeId → index in operations vector
+    modified_edges: HashMap<EdgeId, usize>,
+}
+
+impl WriteBuffer {
+    /// Create a new empty write buffer
+    pub fn new() -> Self {
+        WriteBuffer {
+            operations: Vec::new(),
+            modified_nodes: HashMap::new(),
+            modified_edges: HashMap::new(),
+        }
+    }
+
+    /// Create a write buffer with pre-allocated capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        WriteBuffer {
+            operations: Vec::with_capacity(capacity),
+            modified_nodes: HashMap::with_capacity(capacity / 2),
+            modified_edges: HashMap::with_capacity(capacity / 2),
+        }
+    }
+
+    /// Add a write operation to the buffer
+    pub fn add(&mut self, write: BufferedWrite) {
+        let index = self.operations.len();
+
+        // Track which entities are modified for conflict detection
+        match &write {
+            BufferedWrite::CreateNode { node_id, .. }
+            | BufferedWrite::UpdateNode { node_id, .. }
+            | BufferedWrite::DeleteNode { node_id } => {
+                self.modified_nodes.insert(*node_id, index);
+            }
+            BufferedWrite::CreateEdge { edge_id, .. }
+            | BufferedWrite::UpdateEdge { edge_id, .. }
+            | BufferedWrite::DeleteEdge { edge_id } => {
+                self.modified_edges.insert(*edge_id, index);
+            }
+        }
+
+        self.operations.push(write);
+    }
+
+    /// Get all operations in order
+    pub fn operations(&self) -> &[BufferedWrite] {
+        &self.operations
+    }
+
+    /// Check if a node has been modified in this buffer
+    pub fn has_modified_node(&self, node_id: NodeId) -> bool {
+        self.modified_nodes.contains_key(&node_id)
+    }
+
+    /// Check if an edge has been modified in this buffer
+    pub fn has_modified_edge(&self, edge_id: EdgeId) -> bool {
+        self.modified_edges.contains_key(&edge_id)
+    }
+
+    /// Clear all buffered operations
+    pub fn clear(&mut self) {
+        self.operations.clear();
+        self.modified_nodes.clear();
+        self.modified_edges.clear();
+    }
+
+    /// Get the number of buffered operations
+    pub fn len(&self) -> usize {
+        self.operations.len()
+    }
+
+    /// Check if buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+}
+
+impl Default for WriteBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::temporal::time;
+
+    #[test]
+    fn test_write_buffer_creation() {
+        let buffer = WriteBuffer::new();
+        assert_eq!(buffer.len(), 0);
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn test_write_buffer_add_node() {
+        let mut buffer = WriteBuffer::new();
+        let node_id = NodeId::new(1);
+        let version_id = VersionId::new(1);
+        let label = crate::core::interning::GLOBAL_INTERNER.intern("Person");
+        let properties = PropertyMap::new();
+        let temporal = BiTemporalInterval::current(time::now());
+
+        buffer.add(BufferedWrite::CreateNode {
+            node_id,
+            version_id,
+            label,
+            properties,
+            temporal,
+        });
+
+        assert_eq!(buffer.len(), 1);
+        assert!(!buffer.is_empty());
+        assert!(buffer.has_modified_node(node_id));
+        assert!(!buffer.has_modified_node(NodeId::new(2)));
+    }
+
+    #[test]
+    fn test_write_buffer_add_edge() {
+        let mut buffer = WriteBuffer::new();
+        let edge_id = EdgeId::new(1);
+        let version_id = VersionId::new(1);
+        let source = NodeId::new(1);
+        let target = NodeId::new(2);
+        let label = crate::core::interning::GLOBAL_INTERNER.intern("KNOWS");
+        let properties = PropertyMap::new();
+        let temporal = BiTemporalInterval::current(time::now());
+
+        buffer.add(BufferedWrite::CreateEdge {
+            edge_id,
+            version_id,
+            source,
+            target,
+            label,
+            properties,
+            temporal,
+        });
+
+        assert_eq!(buffer.len(), 1);
+        assert!(buffer.has_modified_edge(edge_id));
+        assert!(!buffer.has_modified_edge(EdgeId::new(2)));
+    }
+
+    #[test]
+    fn test_write_buffer_multiple_operations() {
+        let mut buffer = WriteBuffer::new();
+        let node_id = NodeId::new(1);
+        let edge_id = EdgeId::new(1);
+        let version_id = VersionId::new(1);
+        let label = crate::core::interning::GLOBAL_INTERNER.intern("Test");
+        let properties = PropertyMap::new();
+        let temporal = BiTemporalInterval::current(time::now());
+
+        // Add node
+        buffer.add(BufferedWrite::CreateNode {
+            node_id,
+            version_id,
+            label,
+            properties: properties.clone(),
+            temporal,
+        });
+
+        // Add edge
+        buffer.add(BufferedWrite::CreateEdge {
+            edge_id,
+            version_id,
+            source: node_id,
+            target: NodeId::new(2),
+            label,
+            properties,
+            temporal,
+        });
+
+        assert_eq!(buffer.len(), 2);
+        assert!(buffer.has_modified_node(node_id));
+        assert!(buffer.has_modified_edge(edge_id));
+    }
+
+    #[test]
+    fn test_write_buffer_clear() {
+        let mut buffer = WriteBuffer::new();
+        let node_id = NodeId::new(1);
+        let version_id = VersionId::new(1);
+        let label = crate::core::interning::GLOBAL_INTERNER.intern("Test");
+        let properties = PropertyMap::new();
+        let temporal = BiTemporalInterval::current(time::now());
+
+        buffer.add(BufferedWrite::CreateNode {
+            node_id,
+            version_id,
+            label,
+            properties,
+            temporal,
+        });
+
+        assert_eq!(buffer.len(), 1);
+
+        buffer.clear();
+
+        assert_eq!(buffer.len(), 0);
+        assert!(buffer.is_empty());
+        assert!(!buffer.has_modified_node(node_id));
+    }
+
+    #[test]
+    fn test_write_buffer_update_tracking() {
+        let mut buffer = WriteBuffer::new();
+        let node_id = NodeId::new(1);
+        let version_id_1 = VersionId::new(1);
+        let version_id_2 = VersionId::new(2);
+        let label = crate::core::interning::GLOBAL_INTERNER.intern("Test");
+        let properties = PropertyMap::new();
+        let temporal = BiTemporalInterval::current(time::now());
+
+        // Create node
+        buffer.add(BufferedWrite::CreateNode {
+            node_id,
+            version_id: version_id_1,
+            label,
+            properties: properties.clone(),
+            temporal,
+        });
+
+        // Update same node
+        buffer.add(BufferedWrite::UpdateNode {
+            node_id,
+            version_id: version_id_2,
+            label,
+            properties,
+            temporal,
+        });
+
+        // Should have 2 operations, but node appears once in modified_nodes
+        assert_eq!(buffer.len(), 2);
+        assert!(buffer.has_modified_node(node_id));
+
+        // The most recent operation index should be stored
+        assert_eq!(buffer.modified_nodes.get(&node_id), Some(&1));
+    }
+
+    #[test]
+    fn test_write_buffer_with_capacity() {
+        let buffer = WriteBuffer::with_capacity(10);
+        assert_eq!(buffer.operations.capacity(), 10);
+        assert!(buffer.is_empty());
+    }
+}

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -292,14 +292,17 @@ impl WriteTransaction {
                         temporal,
                     }
                 }
-                super::BufferedWrite::DeleteNode { node_id: _ } => {
-                    // For now, we'll skip delete operations in WAL
-                    // In a full implementation, we'd add DeleteNode and DeleteEdge variants to WalOperation
-                    continue;
+                super::BufferedWrite::DeleteNode { node_id } => {
+                    WalOperation::DeleteNode {
+                        node_id: *node_id,
+                        temporal,
+                    }
                 }
-                super::BufferedWrite::DeleteEdge { edge_id: _ } => {
-                    // Skip delete operations for now
-                    continue;
+                super::BufferedWrite::DeleteEdge { edge_id } => {
+                    WalOperation::DeleteEdge {
+                        edge_id: *edge_id,
+                        temporal,
+                    }
                 }
             };
 
@@ -832,5 +835,196 @@ mod tests {
 
         // Node should not be visible (auto-rollback)
         assert!(current.get_node(node_id).is_err());
+    }
+
+    #[test]
+    fn test_update_node() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create a node first in current storage
+        let props = PropertyMapBuilder::new().insert("age", 30i64).build();
+        let node_id = current.create_node("Person", props).unwrap();
+
+        // Update the node properties
+        let new_props = PropertyMapBuilder::new().insert("age", 31i64).build();
+        tx.update_node(node_id, new_props.clone()).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Verify the update was applied
+        let node = current.get_node(node_id).unwrap();
+        assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(31));
+    }
+
+    #[test]
+    fn test_update_node_not_found() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let props = PropertyMapBuilder::new().insert("age", 30i64).build();
+        let result = tx.update_node(NodeId::new(999), props);
+
+        // Should fail because node doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_edge() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create nodes and edge in current storage
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props).unwrap();
+
+        let edge_props = PropertyMapBuilder::new().insert("strength", 5i64).build();
+        let edge_id = current.create_edge(node1, node2, "KNOWS", edge_props).unwrap();
+
+        // Update the edge properties
+        let new_props = PropertyMapBuilder::new().insert("strength", 10i64).build();
+        tx.update_edge(edge_id, new_props.clone()).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Verify the update was applied
+        let edge = current.get_edge(edge_id).unwrap();
+        assert_eq!(
+            edge.get_property("strength").and_then(|v| v.as_int()),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn test_update_edge_not_found() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let props = PropertyMapBuilder::new().insert("strength", 5i64).build();
+        let result = tx.update_edge(EdgeId::new(999), props);
+
+        // Should fail because edge doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_node() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create a node first in current storage
+        let props = PropertyMapBuilder::new().build();
+        let node_id = current.create_node("Person", props).unwrap();
+
+        // Verify node exists
+        assert!(current.get_node(node_id).is_ok());
+
+        // Delete the node
+        tx.delete_node(node_id).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Verify the node was deleted
+        assert!(current.get_node(node_id).is_err());
+    }
+
+    #[test]
+    fn test_delete_node_not_found() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let result = tx.delete_node(NodeId::new(999));
+
+        // Should fail because node doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_edge() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create nodes and edge in current storage
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props).unwrap();
+
+        let edge_props = PropertyMapBuilder::new().build();
+        let edge_id = current
+            .create_edge(node1, node2, "KNOWS", edge_props)
+            .unwrap();
+
+        // Verify edge exists
+        assert!(current.get_edge(edge_id).is_ok());
+
+        // Delete the edge
+        tx.delete_edge(edge_id).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Verify the edge was deleted
+        assert!(current.get_edge(edge_id).is_err());
+    }
+
+    #[test]
+    fn test_delete_edge_not_found() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let result = tx.delete_edge(EdgeId::new(999));
+
+        // Should fail because edge doesn't exist
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_commit_after_commit_fails() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let props = PropertyMapBuilder::new().build();
+        tx.create_node("Person", props).unwrap();
+
+        // First commit should succeed
+        tx.commit().unwrap();
+
+        // Try to commit again - should fail (can't create new tx from consumed one)
+        // This is prevented by the compiler since commit consumes self
+    }
+
+    #[test]
+    fn test_operations_after_commit_prevented_by_move() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let props = PropertyMapBuilder::new().build();
+        tx.create_node("Person", props).unwrap();
+
+        // Commit consumes tx
+        tx.commit().unwrap();
+
+        // Can't use tx after commit - prevented by compiler
+        // This test documents the behavior
+    }
+
+    #[test]
+    fn test_read_ops_delegation() {
+        let (tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create some data in current storage
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props.clone()).unwrap();
+        current
+            .create_edge(node1, node2, "KNOWS", props)
+            .unwrap();
+
+        // Test ReadOps methods on transaction
+        assert_eq!(tx.node_count(), 2);
+        assert_eq!(tx.edge_count(), 1);
+        assert!(tx.get_node(node1).is_ok());
+        assert_eq!(tx.get_outgoing_edges(node1).len(), 1);
+        assert_eq!(tx.get_incoming_edges(node2).len(), 1);
+        assert_eq!(tx.get_outgoing_edges_with_label(node1, "KNOWS").len(), 1);
     }
 }

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -438,8 +438,10 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    // Create in current storage
-                    let node = Node::new(*node_id, *label, properties.clone(), *version_id);
+                    // Create in current storage with proper transaction metadata
+                    let metadata = VersionMetadata::new(self.tx_id, commit_timestamp);
+                    let node =
+                        Node::with_metadata(*node_id, *label, properties.clone(), *version_id, metadata);
                     self.current.insert_node_direct(node)?;
 
                     // Store in historical storage
@@ -467,14 +469,16 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    // Create in current storage
-                    let edge = Edge::new(
+                    // Create in current storage with proper transaction metadata
+                    let metadata = VersionMetadata::new(self.tx_id, commit_timestamp);
+                    let edge = Edge::with_metadata(
                         *edge_id,
                         *label,
                         *source,
                         *target,
                         properties.clone(),
                         *version_id,
+                        metadata,
                     );
                     self.current.insert_edge_direct(edge)?;
 
@@ -503,8 +507,10 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    // Update in current storage
-                    let node = Node::new(*node_id, *label, properties.clone(), *version_id);
+                    // Update in current storage with proper transaction metadata
+                    let metadata = VersionMetadata::new(self.tx_id, commit_timestamp);
+                    let node =
+                        Node::with_metadata(*node_id, *label, properties.clone(), *version_id, metadata);
                     self.current.update_node_direct(node)?;
 
                     // Add new version to historical storage
@@ -532,14 +538,16 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    // Update in current storage
-                    let edge = Edge::new(
+                    // Update in current storage with proper transaction metadata
+                    let metadata = VersionMetadata::new(self.tx_id, commit_timestamp);
+                    let edge = Edge::with_metadata(
                         *edge_id,
                         *label,
                         *source,
                         *target,
                         properties.clone(),
                         *version_id,
+                        metadata,
                     );
                     self.current.update_edge_direct(edge)?;
 

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -22,6 +22,7 @@ use crate::index::temporal::TemporalIndexes;
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 use crate::storage::wal::{WalOperation, WriteAheadLog};
+use crate::storage::VersionMetadata;
 use crate::utils::error::{Result, StorageError, TransactionError};
 use std::sync::{Arc, Mutex};
 
@@ -561,18 +562,68 @@ impl WriteTransaction {
                     );
                 }
                 super::BufferedWrite::DeleteNode { node_id } => {
+                    // Get the node before deleting to create tombstone
+                    let node = self.current.get_node(*node_id)?;
+
+                    // Generate version ID for tombstone
+                    let tombstone_version_id =
+                        VersionId::new(self.version_id_gen.lock().unwrap().next());
+
+                    // Create closed temporal interval marking deletion time
+                    let tombstone_temporal = BiTemporalInterval::current(commit_timestamp)
+                        .close_transaction_time(commit_timestamp);
+
+                    // Add tombstone version to historical storage
+                    self.historical.lock().unwrap().add_node_version(
+                        *node_id,
+                        tombstone_version_id,
+                        tombstone_temporal,
+                        node.label,
+                        node.properties.clone(),
+                    )?;
+
+                    // Index the tombstone version
+                    self.temporal_indexes.lock().unwrap().insert_node_version(
+                        *node_id,
+                        tombstone_version_id,
+                        tombstone_temporal,
+                    );
+
                     // Delete from current storage
                     self.current.delete_node_direct(*node_id)?;
-
-                    // TODO: Mark as deleted in historical storage (add tombstone version)
-                    // For now, we just remove from current state
                 }
                 super::BufferedWrite::DeleteEdge { edge_id } => {
+                    // Get the edge before deleting to create tombstone
+                    let edge = self.current.get_edge(*edge_id)?;
+
+                    // Generate version ID for tombstone
+                    let tombstone_version_id =
+                        VersionId::new(self.version_id_gen.lock().unwrap().next());
+
+                    // Create closed temporal interval marking deletion time
+                    let tombstone_temporal = BiTemporalInterval::current(commit_timestamp)
+                        .close_transaction_time(commit_timestamp);
+
+                    // Add tombstone version to historical storage
+                    self.historical.lock().unwrap().add_edge_version(
+                        *edge_id,
+                        tombstone_version_id,
+                        tombstone_temporal,
+                        edge.label,
+                        edge.source,
+                        edge.target,
+                        edge.properties.clone(),
+                    )?;
+
+                    // Index the tombstone version
+                    self.temporal_indexes.lock().unwrap().insert_edge_version(
+                        *edge_id,
+                        tombstone_version_id,
+                        tombstone_temporal,
+                    );
+
                     // Delete from current storage
                     self.current.delete_edge_direct(*edge_id)?;
-
-                    // TODO: Mark as deleted in historical storage (add tombstone version)
-                    // For now, we just remove from current state
                 }
             }
         }
@@ -583,9 +634,56 @@ impl WriteTransaction {
 
 impl ReadOps for WriteTransaction {
     fn get_node(&self, id: NodeId) -> Result<Node> {
-        // Snapshot Isolation: only read versions visible in our snapshot
-        // Uncommitted writes in this transaction are not visible
-        // until commit (for simplicity)
+        // Read-your-writes: check write buffer first
+        if let Some(buffered) = self.buffer.get_node_write(id) {
+            match buffered {
+                super::BufferedWrite::CreateNode {
+                    node_id,
+                    label,
+                    properties,
+                    version_id,
+                    ..
+                } => {
+                    // Return the buffered node
+                    return Ok(Node::with_metadata(
+                        *node_id,
+                        *label,
+                        properties.clone(),
+                        *version_id,
+                        VersionMetadata {
+                            created_by_tx: self.tx_id,
+                            commit_timestamp: None, // Not yet committed
+                        },
+                    ));
+                }
+                super::BufferedWrite::UpdateNode {
+                    node_id,
+                    label,
+                    properties,
+                    version_id,
+                    ..
+                } => {
+                    // Return the updated node
+                    return Ok(Node::with_metadata(
+                        *node_id,
+                        *label,
+                        properties.clone(),
+                        *version_id,
+                        VersionMetadata {
+                            created_by_tx: self.tx_id,
+                            commit_timestamp: None,
+                        },
+                    ));
+                }
+                super::BufferedWrite::DeleteNode { .. } => {
+                    // Node has been deleted in this transaction
+                    return Err(StorageError::NodeNotFound(id).into());
+                }
+                _ => {} // Not a node operation
+            }
+        }
+
+        // Fall back to snapshot-isolated read from storage
         let node = self.current.get_node(id)?;
 
         // Check if this version is visible in our snapshot
@@ -601,7 +699,64 @@ impl ReadOps for WriteTransaction {
     }
 
     fn get_edge(&self, id: EdgeId) -> Result<Edge> {
-        // Snapshot Isolation: only read versions visible in our snapshot
+        // Read-your-writes: check write buffer first
+        if let Some(buffered) = self.buffer.get_edge_write(id) {
+            match buffered {
+                super::BufferedWrite::CreateEdge {
+                    edge_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    version_id,
+                    ..
+                } => {
+                    // Return the buffered edge
+                    return Ok(Edge::with_metadata(
+                        *edge_id,
+                        *label,
+                        *source,
+                        *target,
+                        properties.clone(),
+                        *version_id,
+                        VersionMetadata {
+                            created_by_tx: self.tx_id,
+                            commit_timestamp: None,
+                        },
+                    ));
+                }
+                super::BufferedWrite::UpdateEdge {
+                    edge_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    version_id,
+                    ..
+                } => {
+                    // Return the updated edge
+                    return Ok(Edge::with_metadata(
+                        *edge_id,
+                        *label,
+                        *source,
+                        *target,
+                        properties.clone(),
+                        *version_id,
+                        VersionMetadata {
+                            created_by_tx: self.tx_id,
+                            commit_timestamp: None,
+                        },
+                    ));
+                }
+                super::BufferedWrite::DeleteEdge { .. } => {
+                    // Edge has been deleted in this transaction
+                    return Err(StorageError::EdgeNotFound(id).into());
+                }
+                _ => {} // Not an edge operation
+            }
+        }
+
+        // Fall back to snapshot-isolated read from storage
         let edge = self.current.get_edge(id)?;
 
         // Check if this version is visible in our snapshot
@@ -888,12 +1043,14 @@ mod tests {
         let (mut tx, _temp_dir) = create_test_write_tx();
         let props = PropertyMapBuilder::new().insert("name", "Alice").build();
 
-        let node_id = tx.create_node("Person", props).unwrap();
+        let node_id = tx.create_node("Person", props.clone()).unwrap();
         // ID generators start at 0, so first ID is 0
         assert_eq!(node_id.as_u64(), 0);
 
-        // Node should not be visible until commit
-        assert!(tx.get_node(node_id).is_err());
+        // Read-your-writes: should be able to read buffered node
+        let node = tx.get_node(node_id).unwrap();
+        assert_eq!(node.id, node_id);
+        assert_eq!(node.properties.get("name").unwrap(), &crate::core::property::PropertyValue::from("Alice"));
     }
 
     #[test]
@@ -907,12 +1064,16 @@ mod tests {
 
         let edge_props = PropertyMapBuilder::new().insert("since", 2020i64).build();
 
-        let edge_id = tx.create_edge(node1, node2, "KNOWS", edge_props).unwrap();
+        let edge_id = tx.create_edge(node1, node2, "KNOWS", edge_props.clone()).unwrap();
         // ID generators start at 0, so first edge ID is 0
         assert_eq!(edge_id.as_u64(), 0);
 
-        // Edge should not be visible until commit
-        assert!(tx.get_edge(edge_id).is_err());
+        // Read-your-writes: should be able to read buffered edge
+        let edge = tx.get_edge(edge_id).unwrap();
+        assert_eq!(edge.id, edge_id);
+        assert_eq!(edge.source, node1);
+        assert_eq!(edge.target, node2);
+        assert_eq!(edge.properties.get("since").unwrap(), &crate::core::property::PropertyValue::from(2020i64));
     }
 
     #[test]
@@ -1171,5 +1332,116 @@ mod tests {
         assert_eq!(tx.get_outgoing_edges(node1).len(), 1);
         assert_eq!(tx.get_incoming_edges(node2).len(), 1);
         assert_eq!(tx.get_outgoing_edges_with_label(node1, "KNOWS").len(), 1);
+    }
+
+    #[test]
+    fn test_delete_node_creates_tombstone() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+        let historical = Arc::clone(&tx.historical);
+
+        // Create a node with properties
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .build();
+        let node_id = current.create_node("Person", props).unwrap();
+
+        // Verify node exists in current storage
+        assert!(current.get_node(node_id).is_ok());
+
+        // Delete the node
+        tx.delete_node(node_id).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Verify node was deleted from current storage
+        assert!(current.get_node(node_id).is_err());
+
+        // Verify tombstone version was created in historical storage
+        let historical = historical.lock().unwrap();
+        let stats = historical.stats();
+        assert!(
+            stats.total_node_versions > 0,
+            "Expected at least one node version (tombstone) in historical storage"
+        );
+
+        // The tombstone should have a closed transaction time
+        // This is implicitly tested by the fact that a version was created
+    }
+
+    #[test]
+    fn test_delete_edge_creates_tombstone() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+        let historical = Arc::clone(&tx.historical);
+
+        // Create nodes and edge
+        let props = PropertyMapBuilder::new().build();
+        let node1 = current.create_node("Person", props.clone()).unwrap();
+        let node2 = current.create_node("Person", props.clone()).unwrap();
+
+        let edge_props = PropertyMapBuilder::new().insert("since", 2020i64).build();
+        let edge_id = current
+            .create_edge(node1, node2, "KNOWS", edge_props)
+            .unwrap();
+
+        // Verify edge exists
+        assert!(current.get_edge(edge_id).is_ok());
+
+        // Delete the edge
+        tx.delete_edge(edge_id).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Verify edge was deleted from current storage
+        assert!(current.get_edge(edge_id).is_err());
+
+        // Verify tombstone version was created in historical storage
+        let historical = historical.lock().unwrap();
+        let stats = historical.stats();
+        assert!(
+            stats.total_edge_versions > 0,
+            "Expected at least one edge version (tombstone) in historical storage"
+        );
+    }
+
+    #[test]
+    fn test_read_your_writes_update() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create a node in current storage
+        let props = PropertyMapBuilder::new().insert("age", 30i64).build();
+        let node_id = current.create_node("Person", props).unwrap();
+
+        // Update the node in the transaction
+        let new_props = PropertyMapBuilder::new().insert("age", 31i64).build();
+        tx.update_node(node_id, new_props).unwrap();
+
+        // Read-your-writes: should see the updated value
+        let node = tx.get_node(node_id).unwrap();
+        assert_eq!(
+            node.properties.get("age").unwrap(),
+            &crate::core::property::PropertyValue::from(31i64)
+        );
+    }
+
+    #[test]
+    fn test_read_your_writes_delete() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        // Create a node in current storage
+        let props = PropertyMapBuilder::new().build();
+        let node_id = current.create_node("Person", props).unwrap();
+
+        // Delete the node in the transaction
+        tx.delete_node(node_id).unwrap();
+
+        // Read-your-writes: should NOT see the deleted node
+        assert!(tx.get_node(node_id).is_err());
     }
 }

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -1,0 +1,836 @@
+//! Write transactions with ACID guarantees.
+//!
+//! Write transactions provide full ACID properties:
+//! - **Atomicity**: All-or-nothing commit via write buffering
+//! - **Consistency**: Referential integrity validation before commit
+//! - **Isolation**: Read Committed isolation level
+//! - **Durability**: WAL integration (Phase 4)
+//!
+//! Write transactions buffer all changes in memory until commit.
+//! On commit, changes are validated and applied atomically.
+
+use super::{ReadOps, TxId, TxMetadata, TxState, WriteBuffer, WriteOps};
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
+use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::property::PropertyMap;
+use crate::core::temporal::{BiTemporalInterval, Timestamp, time};
+use crate::index::temporal::TemporalIndexes;
+use crate::storage::current::CurrentStorage;
+use crate::storage::historical::HistoricalStorage;
+use crate::storage::wal::{WalOperation, WriteAheadLog};
+use crate::utils::error::{Result, TransactionError};
+use std::sync::{Arc, Mutex};
+
+/// Write transaction with full ACID guarantees.
+///
+/// Write transactions buffer all operations in memory and apply them
+/// atomically on commit. This ensures consistency and enables rollback.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut tx = db.write_transaction();
+/// let node_id = tx.create_node("Person", props)?;
+/// tx.create_edge(node_id, other, "KNOWS", edge_props)?;
+/// tx.commit()?;  // or tx.rollback()
+/// ```
+pub struct WriteTransaction {
+    tx_id: TxId,
+    start_timestamp: Timestamp,
+    state: TxState,
+
+    // Write buffer for uncommitted changes
+    buffer: WriteBuffer,
+
+    // Shared references to storage (Arc for zero-copy sharing)
+    current: Arc<CurrentStorage>,
+    historical: Arc<Mutex<HistoricalStorage>>,
+    temporal_indexes: Arc<Mutex<TemporalIndexes>>,
+    wal: Arc<Mutex<WriteAheadLog>>,
+    current_timestamp: Arc<Mutex<Timestamp>>,
+
+    // ID generators (needed for creating new entities)
+    node_id_gen: Arc<Mutex<IdGenerator>>,
+    edge_id_gen: Arc<Mutex<IdGenerator>>,
+    version_id_gen: Arc<Mutex<IdGenerator>>,
+}
+
+impl WriteTransaction {
+    /// Create a new write transaction.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        tx_id: TxId,
+        current: Arc<CurrentStorage>,
+        historical: Arc<Mutex<HistoricalStorage>>,
+        temporal_indexes: Arc<Mutex<TemporalIndexes>>,
+        wal: Arc<Mutex<WriteAheadLog>>,
+        current_timestamp: Arc<Mutex<Timestamp>>,
+        node_id_gen: Arc<Mutex<IdGenerator>>,
+        edge_id_gen: Arc<Mutex<IdGenerator>>,
+        version_id_gen: Arc<Mutex<IdGenerator>>,
+    ) -> Self {
+        WriteTransaction {
+            tx_id,
+            start_timestamp: time::now(),
+            state: TxState::Active,
+            buffer: WriteBuffer::new(),
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+        }
+    }
+
+    /// Get transaction metadata.
+    pub fn metadata(&self) -> TxMetadata {
+        TxMetadata {
+            tx_id: self.tx_id,
+            start_timestamp: self.start_timestamp,
+            commit_timestamp: None,
+            state: self.state,
+            is_read_only: false,
+        }
+    }
+
+    /// Get transaction ID.
+    pub fn tx_id(&self) -> TxId {
+        self.tx_id
+    }
+
+    /// Commit the transaction.
+    ///
+    /// This validates all buffered writes and applies them atomically
+    /// to the storage. If validation fails or any operation fails,
+    /// the transaction is rolled back.
+    pub fn commit(mut self) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Transition to preparing state
+        self.state = TxState::Preparing;
+
+        // Validate all buffered writes
+        self.validate()?;
+
+        // Acquire commit timestamp
+        let commit_timestamp = {
+            let mut ts = self.current_timestamp.lock().unwrap();
+            let current = *ts;
+            *ts += 1;
+            current
+        };
+
+        // Log operations to WAL (Durability)
+        // This must happen BEFORE applying changes
+        self.log_to_wal(commit_timestamp)?;
+
+        // Flush WAL to ensure durability
+        {
+            let mut wal = self.wal.lock().unwrap();
+            wal.flush()?;
+        }
+
+        // Apply all changes atomically
+        self.apply_changes(commit_timestamp)?;
+
+        // Mark as committed
+        self.state = TxState::Committed;
+
+        Ok(())
+    }
+
+    /// Rollback the transaction.
+    ///
+    /// Discards all buffered writes. This is automatically called
+    /// if the transaction is dropped without committing.
+    pub fn rollback(mut self) -> Result<()> {
+        if self.state == TxState::Committed {
+            return Err(TransactionError::AlreadyCommitted {
+                tx_id: self.tx_id.as_u64(),
+            }
+            .into());
+        }
+
+        // Clear the write buffer
+        self.buffer.clear();
+        self.state = TxState::Aborted;
+
+        Ok(())
+    }
+
+    /// Validate all buffered writes.
+    ///
+    /// Checks:
+    /// - Referential integrity (edges reference valid nodes)
+    /// - No constraint violations
+    fn validate(&self) -> Result<()> {
+        for write in self.buffer.operations() {
+            match write {
+                super::BufferedWrite::CreateEdge { source, target, .. }
+                | super::BufferedWrite::UpdateEdge { source, target, .. } => {
+                    // Check that source and target nodes exist
+                    // They might exist in current storage or be created in this transaction
+                    if !self.buffer.has_modified_node(*source)
+                        && self.current.get_node(*source).is_err()
+                    {
+                        return Err(TransactionError::ValidationFailed {
+                            reason: format!("Edge source node {:?} does not exist", source),
+                        }
+                        .into());
+                    }
+                    if !self.buffer.has_modified_node(*target)
+                        && self.current.get_node(*target).is_err()
+                    {
+                        return Err(TransactionError::ValidationFailed {
+                            reason: format!("Edge target node {:?} does not exist", target),
+                        }
+                        .into());
+                    }
+                }
+                _ => {
+                    // Other operations don't need validation
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Log all buffered operations to WAL.
+    ///
+    /// This ensures durability - operations are logged before being applied.
+    fn log_to_wal(&self, commit_timestamp: Timestamp) -> Result<()> {
+        let temporal = BiTemporalInterval::current(commit_timestamp);
+        let mut wal = self.wal.lock().unwrap();
+
+        for write in self.buffer.operations() {
+            let operation = match write {
+                super::BufferedWrite::CreateNode {
+                    node_id,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    let label_str = GLOBAL_INTERNER
+                        .resolve(*label)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| String::from(""));
+                    WalOperation::CreateNode {
+                        node_id: *node_id,
+                        label: label_str,
+                        properties: properties.clone(),
+                        temporal,
+                    }
+                }
+                super::BufferedWrite::CreateEdge {
+                    edge_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    let label_str = GLOBAL_INTERNER
+                        .resolve(*label)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| String::from(""));
+                    WalOperation::CreateEdge {
+                        edge_id: *edge_id,
+                        source: *source,
+                        target: *target,
+                        label: label_str,
+                        properties: properties.clone(),
+                        temporal,
+                    }
+                }
+                super::BufferedWrite::UpdateNode {
+                    node_id,
+                    version_id,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    let label_str = GLOBAL_INTERNER
+                        .resolve(*label)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| String::from(""));
+                    WalOperation::UpdateNode {
+                        node_id: *node_id,
+                        version_id: *version_id,
+                        label: label_str,
+                        properties: properties.clone(),
+                        temporal,
+                    }
+                }
+                super::BufferedWrite::UpdateEdge {
+                    edge_id,
+                    version_id,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    let label_str = GLOBAL_INTERNER
+                        .resolve(*label)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| String::from(""));
+                    WalOperation::UpdateEdge {
+                        edge_id: *edge_id,
+                        version_id: *version_id,
+                        label: label_str,
+                        properties: properties.clone(),
+                        temporal,
+                    }
+                }
+                super::BufferedWrite::DeleteNode { node_id: _ } => {
+                    // For now, we'll skip delete operations in WAL
+                    // In a full implementation, we'd add DeleteNode and DeleteEdge variants to WalOperation
+                    continue;
+                }
+                super::BufferedWrite::DeleteEdge { edge_id: _ } => {
+                    // Skip delete operations for now
+                    continue;
+                }
+            };
+
+            // Append to WAL
+            wal.append(operation)?;
+        }
+
+        Ok(())
+    }
+
+    /// Apply all buffered changes to storage.
+    fn apply_changes(&self, commit_timestamp: Timestamp) -> Result<()> {
+        let temporal = BiTemporalInterval::current(commit_timestamp);
+
+        for write in self.buffer.operations() {
+            match write {
+                super::BufferedWrite::CreateNode {
+                    node_id,
+                    version_id,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    // Create in current storage
+                    let node = Node::new(*node_id, *label, properties.clone(), *version_id);
+                    self.current.insert_node_direct(node)?;
+
+                    // Store in historical storage
+                    self.historical.lock().unwrap().add_node_version(
+                        *node_id,
+                        *version_id,
+                        temporal,
+                        *label,
+                        properties.clone(),
+                    )?;
+
+                    // Index in temporal indexes
+                    self.temporal_indexes.lock().unwrap().insert_node_version(
+                        *node_id,
+                        *version_id,
+                        temporal,
+                    );
+                }
+                super::BufferedWrite::CreateEdge {
+                    edge_id,
+                    version_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    // Create in current storage
+                    let edge = Edge::new(
+                        *edge_id,
+                        *label,
+                        *source,
+                        *target,
+                        properties.clone(),
+                        *version_id,
+                    );
+                    self.current.insert_edge_direct(edge)?;
+
+                    // Store in historical storage
+                    self.historical.lock().unwrap().add_edge_version(
+                        *edge_id,
+                        *version_id,
+                        temporal,
+                        *label,
+                        *source,
+                        *target,
+                        properties.clone(),
+                    )?;
+
+                    // Index in temporal indexes
+                    self.temporal_indexes.lock().unwrap().insert_edge_version(
+                        *edge_id,
+                        *version_id,
+                        temporal,
+                    );
+                }
+                super::BufferedWrite::UpdateNode {
+                    node_id,
+                    version_id,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    // Update in current storage
+                    let node = Node::new(*node_id, *label, properties.clone(), *version_id);
+                    self.current.update_node_direct(node)?;
+
+                    // Add new version to historical storage
+                    self.historical.lock().unwrap().add_node_version(
+                        *node_id,
+                        *version_id,
+                        temporal,
+                        *label,
+                        properties.clone(),
+                    )?;
+
+                    // Index in temporal indexes
+                    self.temporal_indexes.lock().unwrap().insert_node_version(
+                        *node_id,
+                        *version_id,
+                        temporal,
+                    );
+                }
+                super::BufferedWrite::UpdateEdge {
+                    edge_id,
+                    version_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    ..
+                } => {
+                    // Update in current storage
+                    let edge = Edge::new(
+                        *edge_id,
+                        *label,
+                        *source,
+                        *target,
+                        properties.clone(),
+                        *version_id,
+                    );
+                    self.current.update_edge_direct(edge)?;
+
+                    // Add new version to historical storage
+                    self.historical.lock().unwrap().add_edge_version(
+                        *edge_id,
+                        *version_id,
+                        temporal,
+                        *label,
+                        *source,
+                        *target,
+                        properties.clone(),
+                    )?;
+
+                    // Index in temporal indexes
+                    self.temporal_indexes.lock().unwrap().insert_edge_version(
+                        *edge_id,
+                        *version_id,
+                        temporal,
+                    );
+                }
+                super::BufferedWrite::DeleteNode { node_id } => {
+                    // Delete from current storage
+                    self.current.delete_node_direct(*node_id)?;
+
+                    // TODO: Mark as deleted in historical storage (add tombstone version)
+                    // For now, we just remove from current state
+                }
+                super::BufferedWrite::DeleteEdge { edge_id } => {
+                    // Delete from current storage
+                    self.current.delete_edge_direct(*edge_id)?;
+
+                    // TODO: Mark as deleted in historical storage (add tombstone version)
+                    // For now, we just remove from current state
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ReadOps for WriteTransaction {
+    fn get_node(&self, id: NodeId) -> Result<Node> {
+        // Read Committed: always read latest committed data
+        // Uncommitted writes in this transaction are not visible
+        // until commit (for simplicity in Phase 3)
+        self.current.get_node(id)
+    }
+
+    fn get_edge(&self, id: EdgeId) -> Result<Edge> {
+        self.current.get_edge(id)
+    }
+
+    fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+        self.current.get_outgoing_edges(node_id)
+    }
+
+    fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
+        self.current.get_incoming_edges(node_id)
+    }
+
+    fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId> {
+        self.current.get_outgoing_edges_with_label(node_id, label)
+    }
+
+    fn node_count(&self) -> usize {
+        self.current.node_count()
+    }
+
+    fn edge_count(&self) -> usize {
+        self.current.edge_count()
+    }
+}
+
+impl WriteOps for WriteTransaction {
+    fn create_node(&mut self, label: &str, properties: PropertyMap) -> Result<NodeId> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Generate IDs
+        let node_id = NodeId::new(self.node_id_gen.lock().unwrap().next());
+        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+        let label_interned = GLOBAL_INTERNER.intern(label);
+
+        // Get timestamp for temporal interval
+        let timestamp = self.start_timestamp;
+        let temporal = BiTemporalInterval::current(timestamp);
+
+        // Buffer the write
+        self.buffer.add(super::BufferedWrite::CreateNode {
+            node_id,
+            version_id,
+            label: label_interned,
+            properties,
+            temporal,
+        });
+
+        Ok(node_id)
+    }
+
+    fn create_edge(
+        &mut self,
+        source: NodeId,
+        target: NodeId,
+        label: &str,
+        properties: PropertyMap,
+    ) -> Result<EdgeId> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Generate IDs
+        let edge_id = EdgeId::new(self.edge_id_gen.lock().unwrap().next());
+        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+        let label_interned = GLOBAL_INTERNER.intern(label);
+
+        // Get timestamp for temporal interval
+        let timestamp = self.start_timestamp;
+        let temporal = BiTemporalInterval::current(timestamp);
+
+        // Buffer the write
+        self.buffer.add(super::BufferedWrite::CreateEdge {
+            edge_id,
+            version_id,
+            source,
+            target,
+            label: label_interned,
+            properties,
+            temporal,
+        });
+
+        Ok(edge_id)
+    }
+
+    fn update_node(&mut self, node_id: NodeId, properties: PropertyMap) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Get current node to preserve label
+        let node = self.current.get_node(node_id)?;
+        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+
+        // Get timestamp for temporal interval
+        let timestamp = self.start_timestamp;
+        let temporal = BiTemporalInterval::current(timestamp);
+
+        // Buffer the write
+        self.buffer.add(super::BufferedWrite::UpdateNode {
+            node_id,
+            version_id,
+            label: node.label,
+            properties,
+            temporal,
+        });
+
+        Ok(())
+    }
+
+    fn update_edge(&mut self, edge_id: EdgeId, properties: PropertyMap) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Get current edge to preserve source, target, label
+        let edge = self.current.get_edge(edge_id)?;
+        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+
+        // Get timestamp for temporal interval
+        let timestamp = self.start_timestamp;
+        let temporal = BiTemporalInterval::current(timestamp);
+
+        // Buffer the write
+        self.buffer.add(super::BufferedWrite::UpdateEdge {
+            edge_id,
+            version_id,
+            source: edge.source,
+            target: edge.target,
+            label: edge.label,
+            properties,
+            temporal,
+        });
+
+        Ok(())
+    }
+
+    fn delete_node(&mut self, node_id: NodeId) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Verify node exists
+        self.current.get_node(node_id)?;
+
+        // Buffer the write
+        self.buffer
+            .add(super::BufferedWrite::DeleteNode { node_id });
+
+        Ok(())
+    }
+
+    fn delete_edge(&mut self, edge_id: EdgeId) -> Result<()> {
+        // Check transaction state
+        if self.state != TxState::Active {
+            return Err(TransactionError::InvalidState {
+                current: format!("{:?}", self.state),
+                expected: "Active".to_string(),
+            }
+            .into());
+        }
+
+        // Verify edge exists
+        self.current.get_edge(edge_id)?;
+
+        // Buffer the write
+        self.buffer
+            .add(super::BufferedWrite::DeleteEdge { edge_id });
+
+        Ok(())
+    }
+}
+
+impl Drop for WriteTransaction {
+    fn drop(&mut self) {
+        // Auto-rollback if not committed
+        if self.state == TxState::Active {
+            self.buffer.clear();
+            self.state = TxState::Aborted;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::transaction::TxIdGenerator;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::storage::wal::{WalConfig, WriteAheadLog};
+    use tempfile::TempDir;
+
+    fn create_test_write_tx() -> (WriteTransaction, TempDir) {
+        let current = Arc::new(CurrentStorage::new());
+        let historical = Arc::new(Mutex::new(HistoricalStorage::new()));
+        let temporal_indexes = Arc::new(Mutex::new(TemporalIndexes::new()));
+
+        // Create WAL with temp directory for tests
+        let temp_dir = TempDir::new().unwrap();
+        let wal_config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            sync_on_write: false, // Faster for tests
+            ..Default::default()
+        };
+        let wal = Arc::new(Mutex::new(WriteAheadLog::new(wal_config).unwrap()));
+
+        let current_timestamp = Arc::new(Mutex::new(time::now()));
+        let node_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
+        let edge_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
+        let version_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
+        let tx_id_gen = TxIdGenerator::new();
+
+        let tx = WriteTransaction::new(
+            tx_id_gen.next(),
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+        );
+
+        (tx, temp_dir)
+    }
+
+    #[test]
+    fn test_write_transaction_creation() {
+        let (tx, _temp_dir) = create_test_write_tx();
+        assert_eq!(tx.state, TxState::Active);
+        let metadata = tx.metadata();
+        assert!(!metadata.is_read_only);
+    }
+
+    #[test]
+    fn test_create_node_buffering() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+
+        let node_id = tx.create_node("Person", props).unwrap();
+        // ID generators start at 0, so first ID is 0
+        assert_eq!(node_id.as_u64(), 0);
+
+        // Node should not be visible until commit
+        assert!(tx.get_node(node_id).is_err());
+    }
+
+    #[test]
+    fn test_create_edge_buffering() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        // First create nodes in current storage (simulating existing nodes)
+        let props = PropertyMapBuilder::new().build();
+        let node1 = tx.current.create_node("Person", props.clone()).unwrap();
+        let node2 = tx.current.create_node("Person", props.clone()).unwrap();
+
+        let edge_props = PropertyMapBuilder::new().insert("since", 2020i64).build();
+
+        let edge_id = tx.create_edge(node1, node2, "KNOWS", edge_props).unwrap();
+        // ID generators start at 0, so first edge ID is 0
+        assert_eq!(edge_id.as_u64(), 0);
+
+        // Edge should not be visible until commit
+        assert!(tx.get_edge(edge_id).is_err());
+    }
+
+    #[test]
+    fn test_commit_applies_changes() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        let props = PropertyMapBuilder::new().insert("name", "Bob").build();
+
+        let node_id = tx.create_node("Person", props).unwrap();
+
+        // Commit the transaction
+        tx.commit().unwrap();
+
+        // Node should now be visible in current storage
+        let node = current.get_node(node_id).unwrap();
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Bob")
+        );
+    }
+
+    #[test]
+    fn test_rollback_discards_changes() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        let props = PropertyMapBuilder::new().insert("name", "Charlie").build();
+
+        let node_id = tx.create_node("Person", props).unwrap();
+
+        // Rollback the transaction
+        tx.rollback().unwrap();
+
+        // Node should not be visible in current storage
+        assert!(current.get_node(node_id).is_err());
+    }
+
+    #[test]
+    fn test_validation_fails_for_invalid_edge() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        let props = PropertyMapBuilder::new().build();
+
+        // Try to create edge with non-existent nodes
+        let node1 = NodeId::new(999);
+        let node2 = NodeId::new(1000);
+
+        tx.create_edge(node1, node2, "KNOWS", props).unwrap();
+
+        // Commit should fail validation
+        let result = tx.commit();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_auto_rollback_on_drop() {
+        let current = Arc::new(CurrentStorage::new());
+        let node_id = {
+            let (mut tx, _temp_dir) = create_test_write_tx();
+            let props = PropertyMapBuilder::new().build();
+            // Transaction dropped here without commit
+            tx.create_node("Person", props).unwrap()
+        };
+
+        // Node should not be visible (auto-rollback)
+        assert!(current.get_node(node_id).is_err());
+    }
+}

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -3,13 +3,16 @@
 //! Write transactions provide full ACID properties:
 //! - **Atomicity**: All-or-nothing commit via write buffering
 //! - **Consistency**: Referential integrity validation before commit
-//! - **Isolation**: Read Committed isolation level
-//! - **Durability**: WAL integration (Phase 4)
+//! - **Isolation**: Snapshot Isolation with write-write conflict detection
+//! - **Durability**: WAL with fsync guarantees
 //!
 //! Write transactions buffer all changes in memory until commit.
 //! On commit, changes are validated and applied atomically.
 
-use super::{ReadOps, TxId, TxMetadata, TxState, WriteBuffer, WriteOps};
+use super::{
+    ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager, WriteBuffer,
+    WriteOps,
+};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
@@ -19,7 +22,7 @@ use crate::index::temporal::TemporalIndexes;
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 use crate::storage::wal::{WalOperation, WriteAheadLog};
-use crate::utils::error::{Result, TransactionError};
+use crate::utils::error::{Result, StorageError, TransactionError};
 use std::sync::{Arc, Mutex};
 
 /// Write transaction with full ACID guarantees.
@@ -40,6 +43,9 @@ pub struct WriteTransaction {
     start_timestamp: Timestamp,
     state: TxState,
 
+    // Snapshot for Snapshot Isolation
+    snapshot: TransactionSnapshot,
+
     // Write buffer for uncommitted changes
     buffer: WriteBuffer,
 
@@ -49,6 +55,7 @@ pub struct WriteTransaction {
     temporal_indexes: Arc<Mutex<TemporalIndexes>>,
     wal: Arc<Mutex<WriteAheadLog>>,
     current_timestamp: Arc<Mutex<Timestamp>>,
+    visibility_manager: Arc<TxVisibilityManager>,
 
     // ID generators (needed for creating new entities)
     node_id_gen: Arc<Mutex<IdGenerator>>,
@@ -61,11 +68,13 @@ impl WriteTransaction {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         tx_id: TxId,
+        snapshot: TransactionSnapshot,
         current: Arc<CurrentStorage>,
         historical: Arc<Mutex<HistoricalStorage>>,
         temporal_indexes: Arc<Mutex<TemporalIndexes>>,
         wal: Arc<Mutex<WriteAheadLog>>,
         current_timestamp: Arc<Mutex<Timestamp>>,
+        visibility_manager: Arc<TxVisibilityManager>,
         node_id_gen: Arc<Mutex<IdGenerator>>,
         edge_id_gen: Arc<Mutex<IdGenerator>>,
         version_id_gen: Arc<Mutex<IdGenerator>>,
@@ -74,12 +83,14 @@ impl WriteTransaction {
             tx_id,
             start_timestamp: time::now(),
             state: TxState::Active,
+            snapshot,
             buffer: WriteBuffer::new(),
             current,
             historical,
             temporal_indexes,
             wal,
             current_timestamp,
+            visibility_manager,
             node_id_gen,
             edge_id_gen,
             version_id_gen,
@@ -123,6 +134,9 @@ impl WriteTransaction {
         // Validate all buffered writes
         self.validate()?;
 
+        // Detect write-write conflicts (Snapshot Isolation)
+        self.detect_conflicts()?;
+
         // Acquire commit timestamp
         let commit_timestamp = {
             let mut ts = self.current_timestamp.lock().unwrap();
@@ -144,6 +158,10 @@ impl WriteTransaction {
         // Apply all changes atomically
         self.apply_changes(commit_timestamp)?;
 
+        // Register commit with visibility manager
+        self.visibility_manager
+            .register_commit(self.tx_id, commit_timestamp);
+
         // Mark as committed
         self.state = TxState::Committed;
 
@@ -164,6 +182,10 @@ impl WriteTransaction {
 
         // Clear the write buffer
         self.buffer.clear();
+
+        // Register abort with visibility manager
+        self.visibility_manager.register_abort(self.tx_id);
+
         self.state = TxState::Aborted;
 
         Ok(())
@@ -201,6 +223,99 @@ impl WriteTransaction {
                 _ => {
                     // Other operations don't need validation
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Detect write-write conflicts for Snapshot Isolation.
+    ///
+    /// Checks if any entity modified by this transaction has been committed
+    /// by another transaction after our snapshot was taken. This implements
+    /// the First-Committer-Wins rule of Snapshot Isolation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SerializationFailure` if a write-write conflict is detected.
+    fn detect_conflicts(&self) -> Result<()> {
+        for write in self.buffer.operations() {
+            match write {
+                // UpdateNode: check if node was modified after our snapshot
+                super::BufferedWrite::UpdateNode { node_id, .. } => {
+                    // Get current version from storage
+                    if let Ok(current_node) = self.current.get_node(*node_id)
+                        && let Some(commit_ts) = current_node.metadata.commit_timestamp
+                        && commit_ts > self.snapshot.snapshot_timestamp
+                    {
+                        return Err(TransactionError::SerializationFailure {
+                            entity: format!("{:?}", node_id),
+                            reason: format!(
+                                "Version committed at {} after snapshot at {}",
+                                commit_ts, self.snapshot.snapshot_timestamp
+                            ),
+                        }
+                        .into());
+                    }
+                }
+
+                // UpdateEdge: check if edge was modified after our snapshot
+                super::BufferedWrite::UpdateEdge { edge_id, .. } => {
+                    // Get current version from storage
+                    if let Ok(current_edge) = self.current.get_edge(*edge_id)
+                        && let Some(commit_ts) = current_edge.metadata.commit_timestamp
+                        && commit_ts > self.snapshot.snapshot_timestamp
+                    {
+                        return Err(TransactionError::SerializationFailure {
+                            entity: format!("{:?}", edge_id),
+                            reason: format!(
+                                "Version committed at {} after snapshot at {}",
+                                commit_ts, self.snapshot.snapshot_timestamp
+                            ),
+                        }
+                        .into());
+                    }
+                }
+
+                // DeleteNode: check if node was modified after our snapshot
+                super::BufferedWrite::DeleteNode { node_id } => {
+                    // Get current version from storage
+                    if let Ok(current_node) = self.current.get_node(*node_id)
+                        && let Some(commit_ts) = current_node.metadata.commit_timestamp
+                        && commit_ts > self.snapshot.snapshot_timestamp
+                    {
+                        return Err(TransactionError::SerializationFailure {
+                            entity: format!("{:?}", node_id),
+                            reason: format!(
+                                "Version committed at {} after snapshot at {}",
+                                commit_ts, self.snapshot.snapshot_timestamp
+                            ),
+                        }
+                        .into());
+                    }
+                }
+
+                // DeleteEdge: check if edge was modified after our snapshot
+                super::BufferedWrite::DeleteEdge { edge_id } => {
+                    // Get current version from storage
+                    if let Ok(current_edge) = self.current.get_edge(*edge_id)
+                        && let Some(commit_ts) = current_edge.metadata.commit_timestamp
+                        && commit_ts > self.snapshot.snapshot_timestamp
+                    {
+                        return Err(TransactionError::SerializationFailure {
+                            entity: format!("{:?}", edge_id),
+                            reason: format!(
+                                "Version committed at {} after snapshot at {}",
+                                commit_ts, self.snapshot.snapshot_timestamp
+                            ),
+                        }
+                        .into());
+                    }
+                }
+
+                // CreateNode and CreateEdge don't need conflict detection
+                // since they're creating new entities that didn't exist before
+                _ => {}
             }
         }
 
@@ -292,18 +407,14 @@ impl WriteTransaction {
                         temporal,
                     }
                 }
-                super::BufferedWrite::DeleteNode { node_id } => {
-                    WalOperation::DeleteNode {
-                        node_id: *node_id,
-                        temporal,
-                    }
-                }
-                super::BufferedWrite::DeleteEdge { edge_id } => {
-                    WalOperation::DeleteEdge {
-                        edge_id: *edge_id,
-                        temporal,
-                    }
-                }
+                super::BufferedWrite::DeleteNode { node_id } => WalOperation::DeleteNode {
+                    node_id: *node_id,
+                    temporal,
+                },
+                super::BufferedWrite::DeleteEdge { edge_id } => WalOperation::DeleteEdge {
+                    edge_id: *edge_id,
+                    temporal,
+                },
             };
 
             // Append to WAL
@@ -472,14 +583,37 @@ impl WriteTransaction {
 
 impl ReadOps for WriteTransaction {
     fn get_node(&self, id: NodeId) -> Result<Node> {
-        // Read Committed: always read latest committed data
+        // Snapshot Isolation: only read versions visible in our snapshot
         // Uncommitted writes in this transaction are not visible
-        // until commit (for simplicity in Phase 3)
-        self.current.get_node(id)
+        // until commit (for simplicity)
+        let node = self.current.get_node(id)?;
+
+        // Check if this version is visible in our snapshot
+        if !self
+            .visibility_manager
+            .is_visible(&self.snapshot, node.metadata.created_by_tx)
+        {
+            // Version not visible - return NodeNotFound
+            return Err(StorageError::NodeNotFound(id).into());
+        }
+
+        Ok(node)
     }
 
     fn get_edge(&self, id: EdgeId) -> Result<Edge> {
-        self.current.get_edge(id)
+        // Snapshot Isolation: only read versions visible in our snapshot
+        let edge = self.current.get_edge(id)?;
+
+        // Check if this version is visible in our snapshot
+        if !self
+            .visibility_manager
+            .is_visible(&self.snapshot, edge.metadata.created_by_tx)
+        {
+            // Version not visible - return EdgeNotFound
+            return Err(StorageError::EdgeNotFound(id).into());
+        }
+
+        Ok(edge)
     }
 
     fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
@@ -682,6 +816,8 @@ impl Drop for WriteTransaction {
         // Auto-rollback if not committed
         if self.state == TxState::Active {
             self.buffer.clear();
+            // Register abort with visibility manager
+            self.visibility_manager.register_abort(self.tx_id);
             self.state = TxState::Aborted;
         }
     }
@@ -715,13 +851,22 @@ mod tests {
         let version_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
         let tx_id_gen = TxIdGenerator::new();
 
+        // Create snapshot and visibility manager for testing
+        let visibility_manager = Arc::new(TxVisibilityManager::new());
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: time::now(),
+            active_transactions: std::collections::HashSet::new(),
+        };
+
         let tx = WriteTransaction::new(
             tx_id_gen.next(),
+            snapshot,
             current,
             historical,
             temporal_indexes,
             wal,
             current_timestamp,
+            visibility_manager,
             node_id_gen,
             edge_id_gen,
             version_id_gen,
@@ -880,7 +1025,9 @@ mod tests {
         let node2 = current.create_node("Person", props).unwrap();
 
         let edge_props = PropertyMapBuilder::new().insert("strength", 5i64).build();
-        let edge_id = current.create_edge(node1, node2, "KNOWS", edge_props).unwrap();
+        let edge_id = current
+            .create_edge(node1, node2, "KNOWS", edge_props)
+            .unwrap();
 
         // Update the edge properties
         let new_props = PropertyMapBuilder::new().insert("strength", 10i64).build();
@@ -1015,9 +1162,7 @@ mod tests {
         let props = PropertyMapBuilder::new().build();
         let node1 = current.create_node("Person", props.clone()).unwrap();
         let node2 = current.create_node("Person", props.clone()).unwrap();
-        current
-            .create_edge(node1, node2, "KNOWS", props)
-            .unwrap();
+        current.create_edge(node1, node2, "KNOWS", props).unwrap();
 
         // Test ReadOps methods on transaction
         assert_eq!(tx.node_count(), 2);

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -7,6 +7,7 @@
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
+use crate::storage::VersionMetadata;
 
 /// A node in the current state of the graph.
 ///
@@ -22,6 +23,8 @@ pub struct Node {
     pub properties: PropertyMap,
     /// ID of the current version in the historical storage.
     pub current_version: VersionId,
+    /// Transaction metadata for Snapshot Isolation.
+    pub metadata: VersionMetadata,
 }
 
 impl Node {
@@ -37,6 +40,24 @@ impl Node {
             label,
             properties,
             current_version,
+            metadata: VersionMetadata::default(),
+        }
+    }
+
+    /// Create a new node with explicit metadata (for transactions).
+    pub fn with_metadata(
+        id: NodeId,
+        label: InternedString,
+        properties: PropertyMap,
+        current_version: VersionId,
+        metadata: VersionMetadata,
+    ) -> Self {
+        Node {
+            id,
+            label,
+            properties,
+            current_version,
+            metadata,
         }
     }
 
@@ -71,6 +92,8 @@ pub struct Edge {
     pub properties: PropertyMap,
     /// ID of the current version in the historical storage.
     pub current_version: VersionId,
+    /// Transaction metadata for Snapshot Isolation.
+    pub metadata: VersionMetadata,
 }
 
 impl Edge {
@@ -90,6 +113,28 @@ impl Edge {
             target,
             properties,
             current_version,
+            metadata: VersionMetadata::default(),
+        }
+    }
+
+    /// Create a new edge with explicit metadata (for transactions).
+    pub fn with_metadata(
+        id: EdgeId,
+        label: InternedString,
+        source: NodeId,
+        target: NodeId,
+        properties: PropertyMap,
+        current_version: VersionId,
+        metadata: VersionMetadata,
+    ) -> Self {
+        Edge {
+            id,
+            label,
+            source,
+            target,
+            properties,
+            current_version,
+            metadata,
         }
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,15 +3,18 @@
 //! This module provides the primary interface to the database, coordinating
 //! between current storage (fast path) and historical storage (temporal path).
 
+use crate::api::transaction::{ReadTransaction, TxIdGenerator, WriteOps, WriteTransaction};
 use crate::core::graph::{Edge, Node};
-use crate::core::id::{EdgeId, NodeId};
+use crate::core::id::{EdgeId, IdGenerator, NodeId};
 use crate::core::property::PropertyMap;
-use crate::core::temporal::{BiTemporalInterval, Timestamp, time};
+use crate::core::temporal::{Timestamp, time};
 use crate::index::temporal::TemporalIndexes;
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 use crate::storage::version::AnchorConfig;
+use crate::storage::wal::{WalConfig, WriteAheadLog};
 use crate::utils::error::{Result, StorageError};
+use std::sync::{Arc, Mutex};
 
 /// Main GallifreyDB database.
 ///
@@ -19,14 +22,22 @@ use crate::utils::error::{Result, StorageError};
 /// It coordinates between current storage (for fast current-state queries)
 /// and historical storage (for temporal queries).
 pub struct GallifreyDB {
-    /// Current state storage (hot path)
-    current: CurrentStorage,
-    /// Historical version storage (temporal path)
-    historical: HistoricalStorage,
-    /// Temporal indexes for efficient time-based queries
-    temporal_indexes: TemporalIndexes,
-    /// Current logical timestamp for transaction time
-    current_timestamp: Timestamp,
+    /// Current state storage (hot path) - Arc-wrapped for sharing across transactions
+    current: Arc<CurrentStorage>,
+    /// Historical version storage (temporal path) - Mutex-protected for write safety
+    historical: Arc<Mutex<HistoricalStorage>>,
+    /// Temporal indexes for efficient time-based queries - Mutex-protected for write safety
+    temporal_indexes: Arc<Mutex<TemporalIndexes>>,
+    /// Write-Ahead Log for durability - Mutex-protected for write safety
+    wal: Arc<Mutex<WriteAheadLog>>,
+    /// Current logical timestamp for transaction time - Mutex-protected for thread-safe increment
+    current_timestamp: Arc<Mutex<Timestamp>>,
+    /// Transaction ID generator for MVCC
+    tx_id_gen: Arc<TxIdGenerator>,
+    /// ID generators for nodes, edges, and versions (shared with transactions)
+    node_id_gen: Arc<Mutex<IdGenerator>>,
+    edge_id_gen: Arc<Mutex<IdGenerator>>,
+    version_id_gen: Arc<Mutex<IdGenerator>>,
 }
 
 impl GallifreyDB {
@@ -37,82 +48,138 @@ impl GallifreyDB {
 
     /// Create a new database with custom anchor configuration.
     pub fn with_config(config: AnchorConfig) -> Self {
+        // Create WAL with default config (can be made configurable later)
+        let wal = WriteAheadLog::new(WalConfig::default()).expect("Failed to create WAL");
+
         GallifreyDB {
-            current: CurrentStorage::new(),
-            historical: HistoricalStorage::with_config(config),
-            temporal_indexes: TemporalIndexes::new(),
-            current_timestamp: time::now(),
+            current: Arc::new(CurrentStorage::new()),
+            historical: Arc::new(Mutex::new(HistoricalStorage::with_config(config))),
+            temporal_indexes: Arc::new(Mutex::new(TemporalIndexes::new())),
+            wal: Arc::new(Mutex::new(wal)),
+            current_timestamp: Arc::new(Mutex::new(time::now())),
+            tx_id_gen: Arc::new(TxIdGenerator::new()),
+            node_id_gen: Arc::new(Mutex::new(IdGenerator::new())),
+            edge_id_gen: Arc::new(Mutex::new(IdGenerator::new())),
+            version_id_gen: Arc::new(Mutex::new(IdGenerator::new())),
         }
+    }
+
+    /// Create a new read-only transaction.
+    ///
+    /// Read-only transactions are lightweight and have zero overhead:
+    /// - No write buffer
+    /// - No WAL logging
+    /// - Direct reads from CurrentStorage
+    /// - No commit overhead
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let tx = db.read_transaction();
+    /// let node = tx.get_node(node_id)?;
+    /// // No commit needed - transaction is read-only
+    /// ```
+    pub fn read_transaction(&self) -> ReadTransaction {
+        let tx_id = self.tx_id_gen.next();
+        ReadTransaction::new(tx_id, Arc::clone(&self.current))
+    }
+
+    /// Execute a read-only operation in a transaction.
+    ///
+    /// This is a closure-based API that automatically manages the transaction lifecycle.
+    /// The transaction is automatically cleaned up after the closure completes.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let name = db.read(|tx| {
+    ///     let node = tx.get_node(node_id)?;
+    ///     Ok(node.get_property("name").cloned())
+    /// })?;
+    /// ```
+    pub fn read<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&ReadTransaction) -> Result<T>,
+    {
+        let tx = self.read_transaction();
+        f(&tx)
+    }
+
+    /// Create a new write transaction.
+    ///
+    /// Write transactions provide full ACID guarantees:
+    /// - **Atomicity**: All-or-nothing commit via write buffering
+    /// - **Consistency**: Referential integrity validation before commit
+    /// - **Isolation**: Read Committed isolation level
+    /// - **Durability**: WAL integration (Phase 4)
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut tx = db.write_transaction();
+    /// let node_id = tx.create_node("Person", props)?;
+    /// tx.create_edge(node_id, other, "KNOWS", edge_props)?;
+    /// tx.commit()?;  // or tx.rollback()
+    /// ```
+    pub fn write_transaction(&self) -> WriteTransaction {
+        let tx_id = self.tx_id_gen.next();
+        WriteTransaction::new(
+            tx_id,
+            Arc::clone(&self.current),
+            Arc::clone(&self.historical),
+            Arc::clone(&self.temporal_indexes),
+            Arc::clone(&self.wal),
+            Arc::clone(&self.current_timestamp),
+            Arc::clone(&self.node_id_gen),
+            Arc::clone(&self.edge_id_gen),
+            Arc::clone(&self.version_id_gen),
+        )
+    }
+
+    /// Execute a write operation in a transaction.
+    ///
+    /// This is a closure-based API that automatically manages the transaction lifecycle.
+    /// The transaction is automatically committed on Ok, or rolled back on Err.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let node_id = db.write(|tx| {
+    ///     let id = tx.create_node("Person", props)?;
+    ///     tx.create_edge(id, other, "KNOWS", edge_props)?;
+    ///     Ok(id)
+    /// })?;
+    /// ```
+    pub fn write<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut WriteTransaction) -> Result<T>,
+    {
+        let mut tx = self.write_transaction();
+        let result = f(&mut tx)?;
+        tx.commit()?;
+        Ok(result)
     }
 
     /// Create a node with the given label and properties.
     ///
-    /// The node is created at the current timestamp in both valid and transaction time.
-    pub fn create_node(&mut self, label: &str, properties: PropertyMap) -> Result<NodeId> {
-        let timestamp = self.next_timestamp();
-        let temporal = BiTemporalInterval::current(timestamp);
-
-        // Create in current storage
-        let node_id = self.current.create_node(label, properties.clone())?;
-
-        // Get the version ID from the current node
-        let node = self.current.get_node(node_id)?;
-        let version_id = node.current_version;
-
-        // Store in historical storage
-        let label_interned = crate::core::interning::GLOBAL_INTERNER.intern(label);
-        self.historical.add_node_version(
-            node_id,
-            version_id,
-            temporal,
-            label_interned,
-            properties,
-        )?;
-
-        // Index in temporal indexes
-        self.temporal_indexes
-            .insert_node_version(node_id, version_id, temporal);
-
-        Ok(node_id)
+    /// This is a convenience method that internally uses a write transaction.
+    /// For multiple operations, prefer using `write()` or `write_transaction()`.
+    pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
+        self.write(|tx| tx.create_node(label, properties))
     }
 
     /// Create an edge between two nodes.
+    ///
+    /// This is a convenience method that internally uses a write transaction.
+    /// For multiple operations, prefer using `write()` or `write_transaction()`.
     pub fn create_edge(
-        &mut self,
+        &self,
         source: NodeId,
         target: NodeId,
         label: &str,
         properties: PropertyMap,
     ) -> Result<EdgeId> {
-        let timestamp = self.next_timestamp();
-        let temporal = BiTemporalInterval::current(timestamp);
-
-        // Create in current storage
-        let edge_id = self
-            .current
-            .create_edge(source, target, label, properties.clone())?;
-
-        // Get the version ID from the current edge
-        let edge = self.current.get_edge(edge_id)?;
-        let version_id = edge.current_version;
-
-        // Store in historical storage
-        let label_interned = crate::core::interning::GLOBAL_INTERNER.intern(label);
-        self.historical.add_edge_version(
-            edge_id,
-            version_id,
-            temporal,
-            label_interned,
-            source,
-            target,
-            properties,
-        )?;
-
-        // Index in temporal indexes
-        self.temporal_indexes
-            .insert_edge_version(edge_id, version_id, temporal);
-
-        Ok(edge_id)
+        self.write(|tx| tx.create_edge(source, target, label, properties))
     }
 
     /// Get the current state of a node.
@@ -151,20 +218,20 @@ impl GallifreyDB {
         valid_time: Timestamp,
         transaction_time: Timestamp,
     ) -> Result<Node> {
+        let historical = self.historical.lock().unwrap();
+
         // Find the version valid at this time
-        let version_id = self
-            .historical
+        let version_id = historical
             .find_node_version_at_time(node_id, valid_time, transaction_time)
             .ok_or(StorageError::NodeNotFound(node_id))?;
 
         // Get the version
-        let version = self
-            .historical
+        let version = historical
             .get_node_version(version_id)
             .ok_or(StorageError::VersionNotFound(version_id))?;
 
         // Reconstruct properties
-        let properties = self.historical.reconstruct_node_properties(version_id)?;
+        let properties = historical.reconstruct_node_properties(version_id)?;
 
         // Build node from version
         Ok(Node::new(
@@ -182,17 +249,17 @@ impl GallifreyDB {
         valid_time: Timestamp,
         transaction_time: Timestamp,
     ) -> Result<Edge> {
-        let version_id = self
-            .historical
+        let historical = self.historical.lock().unwrap();
+
+        let version_id = historical
             .find_edge_version_at_time(edge_id, valid_time, transaction_time)
             .ok_or(StorageError::EdgeNotFound(edge_id))?;
 
-        let version = self
-            .historical
+        let version = historical
             .get_edge_version(version_id)
             .ok_or(StorageError::VersionNotFound(version_id))?;
 
-        let properties = self.historical.reconstruct_edge_properties(version_id)?;
+        let properties = historical.reconstruct_edge_properties(version_id)?;
 
         Ok(Edge::new(
             version.edge_id,
@@ -230,14 +297,7 @@ impl GallifreyDB {
 
     /// Get statistics about the historical storage.
     pub fn historical_stats(&self) -> crate::storage::historical::HistoricalStats {
-        self.historical.stats()
-    }
-
-    /// Get the next timestamp and increment the counter.
-    fn next_timestamp(&mut self) -> Timestamp {
-        let ts = self.current_timestamp;
-        self.current_timestamp += 1;
-        ts
+        self.historical.lock().unwrap().stats()
     }
 }
 
@@ -250,11 +310,12 @@ impl Default for GallifreyDB {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::transaction::ReadOps;
     use crate::core::property::PropertyMapBuilder;
 
     #[test]
     fn test_create_node() {
-        let mut db = GallifreyDB::new();
+        let db = GallifreyDB::new();
 
         let props = PropertyMapBuilder::new()
             .insert("name", "Alice")
@@ -275,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_create_edge() {
-        let mut db = GallifreyDB::new();
+        let db = GallifreyDB::new();
 
         let alice = db
             .create_node("Person", PropertyMapBuilder::new().build())
@@ -302,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_time_travel_query() {
-        let mut db = GallifreyDB::new();
+        let db = GallifreyDB::new();
 
         // Create a node at time T1
         let props_v1 = PropertyMapBuilder::new()
@@ -311,7 +372,7 @@ mod tests {
             .build();
 
         let node_id = db.create_node("Person", props_v1).unwrap();
-        let t1 = db.current_timestamp - 1; // Timestamp when created
+        let t1 = *db.current_timestamp.lock().unwrap() - 1; // Timestamp when created
 
         // In a real implementation, we'd create a second version here with an update_node method
         // For now, just verify we can query at T1
@@ -333,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_graph_traversal() {
-        let mut db = GallifreyDB::new();
+        let db = GallifreyDB::new();
 
         let n0 = db
             .create_node("Person", PropertyMapBuilder::new().build())
@@ -359,7 +420,7 @@ mod tests {
 
     #[test]
     fn test_historical_stats() {
-        let mut db = GallifreyDB::new();
+        let db = GallifreyDB::new();
 
         db.create_node("Person", PropertyMapBuilder::new().build())
             .unwrap();
@@ -369,5 +430,232 @@ mod tests {
         let stats = db.historical_stats();
         assert_eq!(stats.total_node_versions, 2);
         assert_eq!(stats.node_anchor_count, 2); // First versions are always anchors
+    }
+
+    // ==================== Transaction API Tests ====================
+
+    #[test]
+    fn test_closure_based_write_api() {
+        let db = GallifreyDB::new();
+
+        // Use closure-based API for multiple operations
+        let (node_id, edge_id) = db
+            .write(|tx| {
+                let n1 = tx.create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Alice").build(),
+                )?;
+                let n2 = tx.create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Bob").build(),
+                )?;
+                let e = tx.create_edge(
+                    n1,
+                    n2,
+                    "KNOWS",
+                    PropertyMapBuilder::new().insert("since", 2024i64).build(),
+                )?;
+                Ok((n1, e))
+            })
+            .unwrap();
+
+        // Verify changes are visible
+        assert_eq!(db.node_count(), 2);
+        assert_eq!(db.edge_count(), 1);
+
+        let node = db.get_node(node_id).unwrap();
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
+
+        let edge = db.get_edge(edge_id).unwrap();
+        assert_eq!(edge.source, node_id);
+    }
+
+    #[test]
+    fn test_closure_based_read_api() {
+        let db = GallifreyDB::new();
+
+        let node_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Charlie").build(),
+            )
+            .unwrap();
+
+        // Use closure-based read API
+        let name = db
+            .read(|tx| {
+                let node = tx.get_node(node_id)?;
+                Ok(node
+                    .get_property("name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()))
+            })
+            .unwrap();
+
+        assert_eq!(name, Some("Charlie".to_string()));
+    }
+
+    #[test]
+    fn test_explicit_write_transaction() {
+        let db = GallifreyDB::new();
+
+        let mut tx = db.write_transaction();
+        let n1 = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "David").build(),
+            )
+            .unwrap();
+        let n2 = tx
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Eve").build(),
+            )
+            .unwrap();
+        tx.create_edge(n1, n2, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Changes not visible before commit
+        assert_eq!(db.node_count(), 0);
+
+        // Commit
+        tx.commit().unwrap();
+
+        // Now visible
+        assert_eq!(db.node_count(), 2);
+        assert_eq!(db.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_explicit_read_transaction() {
+        let db = GallifreyDB::new();
+
+        let node_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("age", 42i64).build(),
+            )
+            .unwrap();
+
+        let tx = db.read_transaction();
+        let node = tx.get_node(node_id).unwrap();
+        assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(42));
+
+        // Read transactions don't need commit
+    }
+
+    #[test]
+    fn test_transaction_atomicity() {
+        let db = GallifreyDB::new();
+
+        // Create a valid node first
+        let valid_node = db
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Try to create multiple operations, one of which will fail
+        let result = db.write(|tx| {
+            tx.create_node("Person", PropertyMapBuilder::new().build())?;
+            tx.create_node("Person", PropertyMapBuilder::new().build())?;
+            // This should fail validation (non-existent target)
+            tx.create_edge(
+                valid_node,
+                NodeId::new(9999),
+                "KNOWS",
+                PropertyMapBuilder::new().build(),
+            )?;
+            Ok(())
+        });
+
+        // Transaction should fail
+        assert!(result.is_err());
+
+        // No partial changes should be visible (atomicity)
+        // We started with 1 node, should still have 1 node
+        assert_eq!(db.node_count(), 1);
+        assert_eq!(db.edge_count(), 0);
+    }
+
+    #[test]
+    fn test_transaction_rollback_on_error() {
+        let db = GallifreyDB::new();
+
+        // Closure returns an error - should auto-rollback
+        let result: Result<()> = db.write(|tx| {
+            tx.create_node("Person", PropertyMapBuilder::new().build())?;
+            tx.create_node("Person", PropertyMapBuilder::new().build())?;
+            // Manually return an error
+            Err(crate::utils::error::Error::Storage(
+                crate::utils::error::StorageError::InconsistentState {
+                    reason: "test error".to_string(),
+                },
+            ))
+        });
+
+        assert!(result.is_err());
+
+        // All changes rolled back
+        assert_eq!(db.node_count(), 0);
+    }
+
+    #[test]
+    fn test_multiple_transactions() {
+        let db = GallifreyDB::new();
+
+        // Transaction 1
+        let n1 = db
+            .write(|tx| tx.create_node("Person", PropertyMapBuilder::new().build()))
+            .unwrap();
+
+        // Transaction 2
+        let n2 = db
+            .write(|tx| tx.create_node("Person", PropertyMapBuilder::new().build()))
+            .unwrap();
+
+        // Transaction 3
+        db.write(|tx| tx.create_edge(n1, n2, "KNOWS", PropertyMapBuilder::new().build()))
+            .unwrap();
+
+        assert_eq!(db.node_count(), 2);
+        assert_eq!(db.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_read_committed_isolation() {
+        let db = GallifreyDB::new();
+
+        let node_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("version", 1i64).build(),
+            )
+            .unwrap();
+
+        // Start a read transaction
+        let tx1 = db.read_transaction();
+        let node_v1 = tx1.get_node(node_id).unwrap();
+        assert_eq!(
+            node_v1.get_property("version").and_then(|v| v.as_int()),
+            Some(1)
+        );
+
+        // Another write commits a change
+        db.write(|tx| {
+            tx.create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("version", 2i64).build(),
+            )
+        })
+        .unwrap();
+
+        // Read transaction sees the new node (Read Committed)
+        let new_node = tx1.get_node(NodeId::new(1)).unwrap();
+        assert_eq!(
+            new_node.get_property("version").and_then(|v| v.as_int()),
+            Some(2)
+        );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -671,21 +671,26 @@ mod tests {
         );
 
         // Another write commits a change (creates a new node)
-        db.write(|tx| {
-            tx.create_node(
-                "Person",
-                PropertyMapBuilder::new().insert("version", 2i64).build(),
-            )
-        })
-        .unwrap();
+        let new_node_id = db
+            .write(|tx| {
+                tx.create_node(
+                    "Person",
+                    PropertyMapBuilder::new().insert("version", 2i64).build(),
+                )
+            })
+            .unwrap();
 
-        // Snapshot Isolation: tx1 still sees the original node
-        // The new node created after tx1's snapshot is visible because
-        // it has TxId(0) (pre-existing data compatibility)
-        let new_node = tx1.get_node(NodeId::new(1)).unwrap();
+        // Snapshot Isolation: tx1 should NOT see the new node
+        // because it was created and committed after tx1's snapshot
+        assert!(tx1.get_node(new_node_id).is_err());
+
+        // Verify tx1 still sees the original node
+        let node_v1_again = tx1.get_node(node_id).unwrap();
         assert_eq!(
-            new_node.get_property("version").and_then(|v| v.as_int()),
-            Some(2)
+            node_v1_again
+                .get_property("version")
+                .and_then(|v| v.as_int()),
+            Some(1)
         );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,7 +3,9 @@
 //! This module provides the primary interface to the database, coordinating
 //! between current storage (fast path) and historical storage (temporal path).
 
-use crate::api::transaction::{ReadTransaction, TxIdGenerator, WriteOps, WriteTransaction};
+use crate::api::transaction::{
+    ReadTransaction, TxIdGenerator, TxVisibilityManager, WriteOps, WriteTransaction,
+};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, IdGenerator, NodeId};
 use crate::core::property::PropertyMap;
@@ -34,6 +36,8 @@ pub struct GallifreyDB {
     current_timestamp: Arc<Mutex<Timestamp>>,
     /// Transaction ID generator for MVCC
     tx_id_gen: Arc<TxIdGenerator>,
+    /// Transaction visibility manager for Snapshot Isolation
+    visibility_manager: Arc<TxVisibilityManager>,
     /// ID generators for nodes, edges, and versions (shared with transactions)
     node_id_gen: Arc<Mutex<IdGenerator>>,
     edge_id_gen: Arc<Mutex<IdGenerator>>,
@@ -58,6 +62,7 @@ impl GallifreyDB {
             wal: Arc::new(Mutex::new(wal)),
             current_timestamp: Arc::new(Mutex::new(time::now())),
             tx_id_gen: Arc::new(TxIdGenerator::new()),
+            visibility_manager: Arc::new(TxVisibilityManager::new()),
             node_id_gen: Arc::new(Mutex::new(IdGenerator::new())),
             edge_id_gen: Arc::new(Mutex::new(IdGenerator::new())),
             version_id_gen: Arc::new(Mutex::new(IdGenerator::new())),
@@ -69,7 +74,7 @@ impl GallifreyDB {
     /// Read-only transactions are lightweight and have zero overhead:
     /// - No write buffer
     /// - No WAL logging
-    /// - Direct reads from CurrentStorage
+    /// - Snapshot-based reads for consistency
     /// - No commit overhead
     ///
     /// # Example
@@ -81,7 +86,20 @@ impl GallifreyDB {
     /// ```
     pub fn read_transaction(&self) -> ReadTransaction {
         let tx_id = self.tx_id_gen.next();
-        ReadTransaction::new(tx_id, Arc::clone(&self.current))
+        let snapshot_timestamp = *self.current_timestamp.lock().unwrap();
+
+        // Register as active
+        self.visibility_manager.register_active(tx_id);
+
+        // Capture snapshot
+        let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
+
+        ReadTransaction::new(
+            tx_id,
+            snapshot,
+            Arc::clone(&self.current),
+            Arc::clone(&self.visibility_manager),
+        )
     }
 
     /// Execute a read-only operation in a transaction.
@@ -110,8 +128,8 @@ impl GallifreyDB {
     /// Write transactions provide full ACID guarantees:
     /// - **Atomicity**: All-or-nothing commit via write buffering
     /// - **Consistency**: Referential integrity validation before commit
-    /// - **Isolation**: Read Committed isolation level
-    /// - **Durability**: WAL integration (Phase 4)
+    /// - **Isolation**: Snapshot Isolation with write-write conflict detection
+    /// - **Durability**: WAL with fsync for true durability
     ///
     /// # Example
     ///
@@ -123,13 +141,23 @@ impl GallifreyDB {
     /// ```
     pub fn write_transaction(&self) -> WriteTransaction {
         let tx_id = self.tx_id_gen.next();
+        let snapshot_timestamp = *self.current_timestamp.lock().unwrap();
+
+        // Register as active
+        self.visibility_manager.register_active(tx_id);
+
+        // Capture snapshot
+        let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
+
         WriteTransaction::new(
             tx_id,
+            snapshot,
             Arc::clone(&self.current),
             Arc::clone(&self.historical),
             Arc::clone(&self.temporal_indexes),
             Arc::clone(&self.wal),
             Arc::clone(&self.current_timestamp),
+            Arc::clone(&self.visibility_manager),
             Arc::clone(&self.node_id_gen),
             Arc::clone(&self.edge_id_gen),
             Arc::clone(&self.version_id_gen),

--- a/src/db.rs
+++ b/src/db.rs
@@ -652,7 +652,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_committed_isolation() {
+    fn test_snapshot_isolation() {
         let db = GallifreyDB::new();
 
         let node_id = db
@@ -662,7 +662,7 @@ mod tests {
             )
             .unwrap();
 
-        // Start a read transaction
+        // Start a read transaction - captures snapshot
         let tx1 = db.read_transaction();
         let node_v1 = tx1.get_node(node_id).unwrap();
         assert_eq!(
@@ -670,7 +670,7 @@ mod tests {
             Some(1)
         );
 
-        // Another write commits a change
+        // Another write commits a change (creates a new node)
         db.write(|tx| {
             tx.create_node(
                 "Person",
@@ -679,7 +679,9 @@ mod tests {
         })
         .unwrap();
 
-        // Read transaction sees the new node (Read Committed)
+        // Snapshot Isolation: tx1 still sees the original node
+        // The new node created after tx1's snapshot is visible because
+        // it has TxId(0) (pre-existing data compatibility)
         let new_node = tx1.get_node(NodeId::new(1)).unwrap();
         assert_eq!(
             new_node.get_property("version").and_then(|v| v.as_int()),

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -9,7 +9,7 @@ use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
 use crate::index::adjacency::{AdjacencyEntry, AdjacencyIndex};
 use dashmap::DashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 /// Concurrent indexes for current-state graph queries.
 ///
@@ -20,10 +20,10 @@ pub struct CurrentIndexes {
     nodes: DashMap<NodeId, Node>,
     /// Edge ID → Edge (O(1) lookup)
     edges: DashMap<EdgeId, Edge>,
-    /// Outgoing edges: source node → adjacency list
-    outgoing: Arc<AdjacencyIndex>,
-    /// Incoming edges: target node → adjacency list
-    incoming: Arc<AdjacencyIndex>,
+    /// Outgoing edges: source node → adjacency list (RwLock for rebuild)
+    outgoing: Arc<RwLock<AdjacencyIndex>>,
+    /// Incoming edges: target node → adjacency list (RwLock for rebuild)
+    incoming: Arc<RwLock<AdjacencyIndex>>,
 }
 
 impl CurrentIndexes {
@@ -32,8 +32,8 @@ impl CurrentIndexes {
         CurrentIndexes {
             nodes: DashMap::new(),
             edges: DashMap::new(),
-            outgoing: Arc::new(AdjacencyIndex::new()),
-            incoming: Arc::new(AdjacencyIndex::new()),
+            outgoing: Arc::new(RwLock::new(AdjacencyIndex::new())),
+            incoming: Arc::new(RwLock::new(AdjacencyIndex::new())),
         }
     }
 
@@ -96,18 +96,20 @@ impl CurrentIndexes {
 
     /// Get outgoing edges for a node.
     ///
-    /// Returns the adjacency list for efficient traversal.
+    /// Returns a copy of the adjacency list for traversal.
     #[inline]
-    pub fn get_outgoing(&self, source: NodeId) -> &[AdjacencyEntry] {
-        self.outgoing.get_adjacency(source)
+    pub fn get_outgoing(&self, source: NodeId) -> Vec<AdjacencyEntry> {
+        let outgoing = self.outgoing.read().unwrap();
+        outgoing.get_adjacency(source).to_vec()
     }
 
     /// Get incoming edges for a node.
     ///
-    /// Returns the adjacency list for reverse traversal.
+    /// Returns a copy of the adjacency list for reverse traversal.
     #[inline]
-    pub fn get_incoming(&self, target: NodeId) -> &[AdjacencyEntry] {
-        self.incoming.get_adjacency(target)
+    pub fn get_incoming(&self, target: NodeId) -> Vec<AdjacencyEntry> {
+        let incoming = self.incoming.read().unwrap();
+        incoming.get_adjacency(target).to_vec()
     }
 
     /// Get outgoing edges with a specific label.
@@ -115,8 +117,12 @@ impl CurrentIndexes {
         &self,
         source: NodeId,
         label: InternedString,
-    ) -> impl Iterator<Item = &AdjacencyEntry> {
-        self.outgoing.get_adjacency_with_label(source, label)
+    ) -> Vec<AdjacencyEntry> {
+        let outgoing = self.outgoing.read().unwrap();
+        outgoing
+            .get_adjacency_with_label(source, label)
+            .copied()
+            .collect()
     }
 
     /// Get incoming edges with a specific label.
@@ -124,27 +130,33 @@ impl CurrentIndexes {
         &self,
         target: NodeId,
         label: InternedString,
-    ) -> impl Iterator<Item = &AdjacencyEntry> {
-        self.incoming.get_adjacency_with_label(target, label)
+    ) -> Vec<AdjacencyEntry> {
+        let incoming = self.incoming.read().unwrap();
+        incoming
+            .get_adjacency_with_label(target, label)
+            .copied()
+            .collect()
     }
 
     /// Get the out-degree of a node (number of outgoing edges).
     #[inline]
     pub fn out_degree(&self, node: NodeId) -> usize {
-        self.outgoing.degree(node)
+        let outgoing = self.outgoing.read().unwrap();
+        outgoing.degree(node)
     }
 
     /// Get the in-degree of a node (number of incoming edges).
     #[inline]
     pub fn in_degree(&self, node: NodeId) -> usize {
-        self.incoming.degree(node)
+        let incoming = self.incoming.read().unwrap();
+        incoming.degree(node)
     }
 
     /// Rebuild adjacency indexes from current edges.
     ///
     /// This should be called after batch edge insertions/deletions.
     /// It's more efficient to rebuild than to incrementally update for large changes.
-    pub fn rebuild_adjacency(&mut self) {
+    pub fn rebuild_adjacency(&self) {
         let mut outgoing_edges = Vec::new();
         let mut incoming_edges = Vec::new();
 
@@ -155,9 +167,9 @@ impl CurrentIndexes {
             incoming_edges.push((edge.target, edge.source, edge.id, edge.label));
         }
 
-        // Rebuild indexes
-        self.outgoing = Arc::new(AdjacencyIndex::build(outgoing_edges));
-        self.incoming = Arc::new(AdjacencyIndex::build(incoming_edges));
+        // Rebuild indexes with write locks
+        *self.outgoing.write().unwrap() = AdjacencyIndex::build(outgoing_edges);
+        *self.incoming.write().unwrap() = AdjacencyIndex::build(incoming_edges);
     }
 
     /// Iterate over all nodes.
@@ -255,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_adjacency_rebuild() {
-        let mut indexes = CurrentIndexes::new();
+        let indexes = CurrentIndexes::new();
 
         // Add nodes
         indexes.insert_node(create_test_node(0, "Person"));
@@ -286,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_labeled_traversal() {
-        let mut indexes = CurrentIndexes::new();
+        let indexes = CurrentIndexes::new();
 
         let knows = GLOBAL_INTERNER.intern("KNOWS");
         let follows = GLOBAL_INTERNER.intern("FOLLOWS");
@@ -299,15 +311,11 @@ mod tests {
         indexes.rebuild_adjacency();
 
         // Get only KNOWS edges
-        let knows_edges: Vec<_> = indexes
-            .get_outgoing_with_label(NodeId::new(0), knows)
-            .collect();
+        let knows_edges = indexes.get_outgoing_with_label(NodeId::new(0), knows);
         assert_eq!(knows_edges.len(), 2);
 
         // Get only FOLLOWS edges
-        let follows_edges: Vec<_> = indexes
-            .get_outgoing_with_label(NodeId::new(0), follows)
-            .collect();
+        let follows_edges = indexes.get_outgoing_with_label(NodeId::new(0), follows);
         assert_eq!(follows_edges.len(), 1);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+pub mod api;
 pub mod core;
 pub mod db;
 pub mod index;
@@ -60,7 +61,8 @@ pub use core::{
     Timestamp, VersionId,
 };
 
+pub use api::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};
 pub use db::GallifreyDB;
 pub use index::{AdjacencyIndex, CurrentIndexes, TemporalIndexes};
 pub use storage::CurrentStorage;
-pub use utils::{Error, QueryError, Result, StorageError, TemporalError};
+pub use utils::{Error, QueryError, Result, StorageError, TemporalError, TransactionError};

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -6,7 +6,7 @@
 
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
-use crate::core::interning::StringInterner;
+use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyMap;
 use crate::index::current::CurrentIndexes;
 use crate::utils::error::{Result, StorageError};
@@ -34,8 +34,6 @@ pub struct CurrentStorage {
     edge_id_gen: IdGenerator,
     /// ID generator for versions
     version_id_gen: IdGenerator,
-    /// String interner for labels (could use global, but keeping local for now)
-    interner: StringInterner,
 }
 
 impl CurrentStorage {
@@ -46,17 +44,16 @@ impl CurrentStorage {
             node_id_gen: IdGenerator::new(),
             edge_id_gen: IdGenerator::new(),
             version_id_gen: IdGenerator::new(),
-            interner: StringInterner::new(),
         }
     }
 
     /// Create a node with the given label and properties.
     ///
     /// Returns the ID of the newly created node.
-    pub fn create_node(&mut self, label: &str, properties: PropertyMap) -> Result<NodeId> {
+    pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         let node_id = NodeId::new(self.node_id_gen.next());
         let version_id = VersionId::new(self.version_id_gen.next());
-        let label_interned = self.interner.intern(label);
+        let label_interned = GLOBAL_INTERNER.intern(label);
 
         let node = Node::new(node_id, label_interned, properties, version_id);
         self.indexes.insert_node(node);
@@ -68,7 +65,7 @@ impl CurrentStorage {
     ///
     /// Returns the ID of the newly created edge.
     pub fn create_edge(
-        &mut self,
+        &self,
         source: NodeId,
         target: NodeId,
         label: &str,
@@ -84,7 +81,7 @@ impl CurrentStorage {
 
         let edge_id = EdgeId::new(self.edge_id_gen.next());
         let version_id = VersionId::new(self.version_id_gen.next());
-        let label_interned = self.interner.intern(label);
+        let label_interned = GLOBAL_INTERNER.intern(label);
 
         let edge = Edge::new(
             edge_id,
@@ -140,6 +137,56 @@ impl CurrentStorage {
         Ok(edge)
     }
 
+    // Direct insert/update/delete methods for transaction commit
+    // These methods are used by WriteTransaction to apply buffered changes
+
+    /// Insert a node directly (used by WriteTransaction).
+    /// Does not generate IDs - caller must provide them.
+    pub fn insert_node_direct(&self, node: Node) -> Result<()> {
+        self.indexes.insert_node(node);
+        Ok(())
+    }
+
+    /// Insert an edge directly (used by WriteTransaction).
+    /// Does not generate IDs or rebuild adjacency - caller must handle.
+    pub fn insert_edge_direct(&self, edge: Edge) -> Result<()> {
+        self.indexes.insert_edge(edge);
+        self.indexes.rebuild_adjacency();
+        Ok(())
+    }
+
+    /// Update a node directly (used by WriteTransaction).
+    pub fn update_node_direct(&self, node: Node) -> Result<()> {
+        // Remove old version and insert new
+        self.indexes.insert_node(node);
+        Ok(())
+    }
+
+    /// Update an edge directly (used by WriteTransaction).
+    pub fn update_edge_direct(&self, edge: Edge) -> Result<()> {
+        // Remove old version and insert new
+        self.indexes.insert_edge(edge);
+        self.indexes.rebuild_adjacency();
+        Ok(())
+    }
+
+    /// Delete a node directly (used by WriteTransaction).
+    pub fn delete_node_direct(&self, id: NodeId) -> Result<()> {
+        self.indexes
+            .remove_node(id)
+            .ok_or(StorageError::NodeNotFound(id))?;
+        Ok(())
+    }
+
+    /// Delete an edge directly (used by WriteTransaction).
+    pub fn delete_edge_direct(&self, id: EdgeId) -> Result<()> {
+        self.indexes
+            .remove_edge(id)
+            .ok_or(StorageError::EdgeNotFound(id))?;
+        self.indexes.rebuild_adjacency();
+        Ok(())
+    }
+
     /// Get all outgoing edges from a node.
     ///
     /// This is the critical "hot path" operation that must be fast.
@@ -162,26 +209,28 @@ impl CurrentStorage {
 
     /// Get outgoing edges with a specific label.
     pub fn get_outgoing_edges_with_label(&self, source: NodeId, label: &str) -> Vec<EdgeId> {
-        let label_id = match self.interner.get_id(label) {
+        let label_id = match GLOBAL_INTERNER.get_id(label) {
             Some(id) => id,
             None => return Vec::new(), // Label doesn't exist
         };
 
         self.indexes
             .get_outgoing_with_label(source, label_id)
+            .into_iter()
             .map(|entry| entry.edge_id)
             .collect()
     }
 
     /// Get incoming edges with a specific label.
     pub fn get_incoming_edges_with_label(&self, target: NodeId, label: &str) -> Vec<EdgeId> {
-        let label_id = match self.interner.get_id(label) {
+        let label_id = match GLOBAL_INTERNER.get_id(label) {
             Some(id) => id,
             None => return Vec::new(),
         };
 
         self.indexes
             .get_incoming_with_label(target, label_id)
+            .into_iter()
             .map(|entry| entry.edge_id)
             .collect()
     }
@@ -232,7 +281,7 @@ mod tests {
 
     #[test]
     fn test_create_node() {
-        let mut storage = CurrentStorage::new();
+        let storage = CurrentStorage::new();
 
         let props = PropertyMapBuilder::new()
             .insert("name", "Alice")
@@ -253,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_create_edge() {
-        let mut storage = CurrentStorage::new();
+        let storage = CurrentStorage::new();
 
         let alice = storage
             .create_node("Person", PropertyMapBuilder::new().build())
@@ -284,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_create_edge_invalid_nodes() {
-        let mut storage = CurrentStorage::new();
+        let storage = CurrentStorage::new();
 
         let result = storage.create_edge(
             NodeId::new(999),
@@ -298,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_graph_traversal() {
-        let mut storage = CurrentStorage::new();
+        let storage = CurrentStorage::new();
 
         // Create nodes
         let n0 = storage
@@ -337,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_labeled_edges() {
-        let mut storage = CurrentStorage::new();
+        let storage = CurrentStorage::new();
 
         let n0 = storage
             .create_node("Person", PropertyMapBuilder::new().build())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,5 +17,5 @@ pub mod wal;
 pub use current::{CurrentStats, CurrentStorage};
 pub use historical::{HistoricalStats, HistoricalStorage};
 pub use persistence::{Checkpoint, CheckpointConfig, PersistenceManager};
-pub use version::{AnchorConfig, EdgeVersion, NodeVersion, PropertyDelta, VersionData};
+pub use version::{AnchorConfig, EdgeVersion, NodeVersion, PropertyDelta, VersionData, VersionMetadata};
 pub use wal::{LSN, WalConfig, WalEntry, WalOperation, WriteAheadLog};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,5 +17,7 @@ pub mod wal;
 pub use current::{CurrentStats, CurrentStorage};
 pub use historical::{HistoricalStats, HistoricalStorage};
 pub use persistence::{Checkpoint, CheckpointConfig, PersistenceManager};
-pub use version::{AnchorConfig, EdgeVersion, NodeVersion, PropertyDelta, VersionData, VersionMetadata};
+pub use version::{
+    AnchorConfig, EdgeVersion, NodeVersion, PropertyDelta, VersionData, VersionMetadata,
+};
 pub use wal::{LSN, WalConfig, WalEntry, WalOperation, WriteAheadLog};

--- a/src/storage/version.rs
+++ b/src/storage/version.rs
@@ -8,11 +8,57 @@
 //! - Anchors: Full snapshots of state (created periodically)
 //! - Deltas: Only the changed properties since the previous version
 
+use crate::api::transaction::types::TxId;
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::{PropertyMap, PropertyValue};
-use crate::core::temporal::BiTemporalInterval;
+use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use std::collections::{HashMap, HashSet};
+
+/// Metadata about version creation for Snapshot Isolation.
+///
+/// This tracks which transaction created a version and when it was committed,
+/// enabling proper visibility checking for Snapshot Isolation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VersionMetadata {
+    /// Transaction that created this version
+    pub created_by_tx: TxId,
+
+    /// When this version was committed (None if uncommitted)
+    pub commit_timestamp: Option<Timestamp>,
+}
+
+impl VersionMetadata {
+    /// Create new version metadata for a committed version.
+    pub fn new(created_by_tx: TxId, commit_timestamp: Timestamp) -> Self {
+        VersionMetadata {
+            created_by_tx,
+            commit_timestamp: Some(commit_timestamp),
+        }
+    }
+
+    /// Create metadata for an uncommitted version.
+    pub fn uncommitted(created_by_tx: TxId) -> Self {
+        VersionMetadata {
+            created_by_tx,
+            commit_timestamp: None,
+        }
+    }
+
+    /// Create default metadata for existing data (migration helper).
+    pub fn default_for_existing() -> Self {
+        VersionMetadata {
+            created_by_tx: TxId::new(0),
+            commit_timestamp: Some(0),
+        }
+    }
+}
+
+impl Default for VersionMetadata {
+    fn default() -> Self {
+        Self::default_for_existing()
+    }
+}
 
 /// Configuration for anchor creation strategy.
 #[derive(Debug, Clone)]

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -1074,10 +1074,22 @@ mod tests {
         assert_eq!(entries.len(), 4);
 
         // Verify operation types
-        assert!(matches!(entries[0].operation, WalOperation::CreateNode { .. }));
-        assert!(matches!(entries[1].operation, WalOperation::CreateEdge { .. }));
-        assert!(matches!(entries[2].operation, WalOperation::DeleteNode { .. }));
-        assert!(matches!(entries[3].operation, WalOperation::DeleteEdge { .. }));
+        assert!(matches!(
+            entries[0].operation,
+            WalOperation::CreateNode { .. }
+        ));
+        assert!(matches!(
+            entries[1].operation,
+            WalOperation::CreateEdge { .. }
+        ));
+        assert!(matches!(
+            entries[2].operation,
+            WalOperation::DeleteNode { .. }
+        ));
+        assert!(matches!(
+            entries[3].operation,
+            WalOperation::DeleteEdge { .. }
+        ));
 
         Ok(())
     }

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -94,6 +94,20 @@ pub enum WalOperation {
         /// The bi-temporal interval
         temporal: BiTemporalInterval,
     },
+    /// Delete a node
+    DeleteNode {
+        /// The node ID
+        node_id: NodeId,
+        /// The bi-temporal interval
+        temporal: BiTemporalInterval,
+    },
+    /// Delete an edge
+    DeleteEdge {
+        /// The edge ID
+        edge_id: EdgeId,
+        /// The bi-temporal interval
+        temporal: BiTemporalInterval,
+    },
     /// Checkpoint marker - indicates a snapshot was taken
     Checkpoint {
         /// The LSN at checkpoint
@@ -362,6 +376,14 @@ impl WriteAheadLog {
                 buffer.push(4); // operation type
                 buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
                 buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
+            }
+            WalOperation::DeleteNode { node_id, .. } => {
+                buffer.push(6); // operation type
+                buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
+            }
+            WalOperation::DeleteEdge { edge_id, .. } => {
+                buffer.push(7); // operation type
+                buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             }
             WalOperation::Checkpoint { lsn, timestamp } => {
                 buffer.push(5); // operation type
@@ -709,6 +731,56 @@ impl WriteAheadLog {
                         16,
                     )
                 }
+                6 => {
+                    // DeleteNode
+                    if offset + 8 > buffer.len() {
+                        break;
+                    }
+                    let node_id = NodeId::new(u64::from_le_bytes([
+                        buffer[offset],
+                        buffer[offset + 1],
+                        buffer[offset + 2],
+                        buffer[offset + 3],
+                        buffer[offset + 4],
+                        buffer[offset + 5],
+                        buffer[offset + 6],
+                        buffer[offset + 7],
+                    ]));
+                    offset += 8;
+
+                    (
+                        WalOperation::DeleteNode {
+                            node_id,
+                            temporal: BiTemporalInterval::current(timestamp),
+                        },
+                        8,
+                    )
+                }
+                7 => {
+                    // DeleteEdge
+                    if offset + 8 > buffer.len() {
+                        break;
+                    }
+                    let edge_id = EdgeId::new(u64::from_le_bytes([
+                        buffer[offset],
+                        buffer[offset + 1],
+                        buffer[offset + 2],
+                        buffer[offset + 3],
+                        buffer[offset + 4],
+                        buffer[offset + 5],
+                        buffer[offset + 6],
+                        buffer[offset + 7],
+                    ]));
+                    offset += 8;
+
+                    (
+                        WalOperation::DeleteEdge {
+                            edge_id,
+                            temporal: BiTemporalInterval::current(timestamp),
+                        },
+                        8,
+                    )
+                }
                 _ => {
                     // Unknown operation type, skip this entry
                     return Err(StorageError::CorruptedData(format!(
@@ -865,6 +937,136 @@ mod tests {
 
         // Should have rotated to multiple segments
         assert!(wal.current_segment > 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_delete_node_operation() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            sync_on_write: false,
+            ..Default::default()
+        };
+
+        let mut wal = WriteAheadLog::new(config)?;
+
+        // Log a delete node operation
+        let operation = WalOperation::DeleteNode {
+            node_id: NodeId::new(42),
+            temporal: BiTemporalInterval::current(time::now()),
+        };
+
+        let lsn = wal.append(operation)?;
+        assert_eq!(lsn, LSN::initial());
+
+        // Flush to ensure it's written
+        wal.flush()?;
+
+        // Read it back
+        let entries = wal.read_from(LSN::initial())?;
+        assert_eq!(entries.len(), 1);
+
+        match &entries[0].operation {
+            WalOperation::DeleteNode { node_id, .. } => {
+                assert_eq!(node_id.as_u64(), 42);
+            }
+            _ => panic!("Expected DeleteNode operation"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_delete_edge_operation() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            sync_on_write: false,
+            ..Default::default()
+        };
+
+        let mut wal = WriteAheadLog::new(config)?;
+
+        // Log a delete edge operation
+        let operation = WalOperation::DeleteEdge {
+            edge_id: EdgeId::new(99),
+            temporal: BiTemporalInterval::current(time::now()),
+        };
+
+        let lsn = wal.append(operation)?;
+        assert_eq!(lsn, LSN::initial());
+
+        // Flush to ensure it's written
+        wal.flush()?;
+
+        // Read it back
+        let entries = wal.read_from(LSN::initial())?;
+        assert_eq!(entries.len(), 1);
+
+        match &entries[0].operation {
+            WalOperation::DeleteEdge { edge_id, .. } => {
+                assert_eq!(edge_id.as_u64(), 99);
+            }
+            _ => panic!("Expected DeleteEdge operation"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_mixed_operations() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = WalConfig {
+            wal_dir: temp_dir.path().to_path_buf(),
+            sync_on_write: false,
+            ..Default::default()
+        };
+
+        let mut wal = WriteAheadLog::new(config)?;
+
+        // Log a sequence of mixed operations
+        let ops = vec![
+            WalOperation::CreateNode {
+                node_id: NodeId::new(1),
+                label: "Person".to_string(),
+                properties: PropertyMap::new(),
+                temporal: BiTemporalInterval::current(time::now()),
+            },
+            WalOperation::CreateEdge {
+                edge_id: EdgeId::new(1),
+                source: NodeId::new(1),
+                target: NodeId::new(2),
+                label: "KNOWS".to_string(),
+                properties: PropertyMap::new(),
+                temporal: BiTemporalInterval::current(time::now()),
+            },
+            WalOperation::DeleteNode {
+                node_id: NodeId::new(3),
+                temporal: BiTemporalInterval::current(time::now()),
+            },
+            WalOperation::DeleteEdge {
+                edge_id: EdgeId::new(2),
+                temporal: BiTemporalInterval::current(time::now()),
+            },
+        ];
+
+        for op in ops {
+            wal.append(op)?;
+        }
+
+        wal.flush()?;
+
+        // Read all entries back
+        let entries = wal.read_from(LSN::initial())?;
+        assert_eq!(entries.len(), 4);
+
+        // Verify operation types
+        assert!(matches!(entries[0].operation, WalOperation::CreateNode { .. }));
+        assert!(matches!(entries[1].operation, WalOperation::CreateEdge { .. }));
+        assert!(matches!(entries[2].operation, WalOperation::DeleteNode { .. }));
+        assert!(matches!(entries[3].operation, WalOperation::DeleteEdge { .. }));
 
         Ok(())
     }

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -806,12 +806,23 @@ impl WriteAheadLog {
         Ok(entries)
     }
 
-    /// Flush all pending writes
+    /// Flush all pending writes and sync to disk
     pub fn flush(&mut self) -> Result<()> {
         if let Some(writer) = &mut self.writer {
+            // Step 1: Flush BufWriter buffer to OS
             writer
                 .flush()
-                .map_err(|e| StorageError::IoError(format!("Failed to flush WAL: {}", e)))?;
+                .map_err(|e| StorageError::IoError(format!("Failed to flush WAL buffer: {}", e)))?;
+
+            // Step 2: Force OS to sync data to disk (fsync)
+            // SAFETY: sync_data() ensures durability by forcing the OS to write buffered data to disk.
+            // This is critical for WAL correctness - without it, committed transactions could be lost
+            // on crash/power failure. We use sync_data() instead of sync_all() because we only need
+            // to sync file data, not metadata (faster).
+            writer
+                .get_mut() // Get underlying File from BufWriter
+                .sync_data()
+                .map_err(|e| StorageError::IoError(format!("Failed to fsync WAL: {}", e)))?;
         }
         Ok(())
     }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -483,4 +483,188 @@ mod tests {
         assert_eq!(returns_result().unwrap(), 42);
         assert!(returns_error().is_err());
     }
+
+    #[test]
+    fn test_all_storage_error_variants() {
+        // Test EdgeNotFound
+        let err = StorageError::EdgeNotFound(EdgeId::new(1));
+        assert!(format!("{}", err).contains("Edge not found"));
+
+        // Test VersionNotFound
+        let err = StorageError::VersionNotFound(VersionId::new(1));
+        assert!(format!("{}", err).contains("Version not found"));
+
+        // Test DuplicateId
+        let err = StorageError::DuplicateId {
+            id: "42".to_string(),
+            kind: "node".to_string(),
+        };
+        assert!(format!("{}", err).contains("Duplicate"));
+        assert!(format!("{}", err).contains("node"));
+
+        // Test InconsistentState
+        let err = StorageError::InconsistentState {
+            reason: "test".to_string(),
+        };
+        assert!(format!("{}", err).contains("Inconsistent"));
+
+        // Test WalError
+        let err = StorageError::WalError {
+            reason: "flush failed".to_string(),
+        };
+        assert!(format!("{}", err).contains("Write-ahead log"));
+        assert!(format!("{}", err).contains("flush failed"));
+
+        // Test CheckpointError
+        let err = StorageError::CheckpointError {
+            reason: "save failed".to_string(),
+        };
+        assert!(format!("{}", err).contains("Checkpoint"));
+        assert!(format!("{}", err).contains("save failed"));
+
+        // Test IoError
+        let err = StorageError::IoError("file not found".to_string());
+        assert!(format!("{}", err).contains("I/O error"));
+        assert!(format!("{}", err).contains("file not found"));
+
+        // Test CorruptedData
+        let err = StorageError::CorruptedData("bad checksum".to_string());
+        assert!(format!("{}", err).contains("Corrupted data"));
+        assert!(format!("{}", err).contains("bad checksum"));
+    }
+
+    #[test]
+    fn test_all_temporal_error_variants() {
+        // Test InvalidTimeRange
+        let err = TemporalError::InvalidTimeRange {
+            start: 100,
+            end: 50,
+        };
+        assert!(format!("{}", err).contains("Invalid time range"));
+        assert!(format!("{}", err).contains("100"));
+        assert!(format!("{}", err).contains("50"));
+
+        // Test ValidTimeBeforeCreation
+        let err = TemporalError::ValidTimeBeforeCreation {
+            valid_time: 50,
+            creation_time: 100,
+        };
+        assert!(format!("{}", err).contains("precedes creation"));
+
+        // Test VersionAlreadyClosed
+        let err = TemporalError::VersionAlreadyClosed {
+            version_id: VersionId::new(42),
+        };
+        assert!(format!("{}", err).contains("already closed"));
+        assert!(format!("{}", err).contains("42"));
+
+        // Test CorruptedVersionChain
+        let err = TemporalError::CorruptedVersionChain {
+            entity_id: "node-123".to_string(),
+            reason: "missing delta".to_string(),
+        };
+        assert!(format!("{}", err).contains("Corrupted version chain"));
+        assert!(format!("{}", err).contains("node-123"));
+        assert!(format!("{}", err).contains("missing delta"));
+
+        // Test MissingAnchor
+        let err = TemporalError::MissingAnchor {
+            entity_id: "edge-456".to_string(),
+        };
+        assert!(format!("{}", err).contains("Missing anchor"));
+        assert!(format!("{}", err).contains("edge-456"));
+    }
+
+    #[test]
+    fn test_all_query_error_variants() {
+        // Test SyntaxError
+        let err = QueryError::SyntaxError {
+            message: "unexpected token".to_string(),
+        };
+        assert!(format!("{}", err).contains("syntax error"));
+        assert!(format!("{}", err).contains("unexpected token"));
+
+        // Test InvalidParameter
+        let err = QueryError::InvalidParameter {
+            parameter: "limit".to_string(),
+            reason: "must be positive".to_string(),
+        };
+        assert!(format!("{}", err).contains("Invalid query parameter"));
+        assert!(format!("{}", err).contains("limit"));
+        assert!(format!("{}", err).contains("must be positive"));
+
+        // Test LimitExceeded
+        let err = QueryError::LimitExceeded { limit: 1000 };
+        assert!(format!("{}", err).contains("limit"));
+        assert!(format!("{}", err).contains("1000"));
+        assert!(format!("{}", err).contains("exceeded"));
+
+        // Test InvalidTraversal
+        let err = QueryError::InvalidTraversal {
+            reason: "edge doesn't connect nodes".to_string(),
+        };
+        assert!(format!("{}", err).contains("Invalid graph traversal"));
+        assert!(format!("{}", err).contains("edge doesn't connect nodes"));
+    }
+
+    #[test]
+    fn test_all_transaction_error_variants() {
+        // Test InvalidState
+        let err = TransactionError::InvalidState {
+            current: "Committed".to_string(),
+            expected: "Active".to_string(),
+        };
+        assert!(format!("{}", err).contains("invalid state"));
+        assert!(format!("{}", err).contains("Committed"));
+        assert!(format!("{}", err).contains("Active"));
+
+        // Test AlreadyCommitted
+        let err = TransactionError::AlreadyCommitted { tx_id: 123 };
+        assert!(format!("{}", err).contains("already been committed"));
+        assert!(format!("{}", err).contains("123"));
+
+        // Test Aborted
+        let err = TransactionError::Aborted { tx_id: 456 };
+        assert!(format!("{}", err).contains("aborted"));
+        assert!(format!("{}", err).contains("456"));
+
+        // Test WriteConflict
+        let err = TransactionError::WriteConflict {
+            entity_id: "node-789".to_string(),
+            reason: "concurrent modification".to_string(),
+        };
+        assert!(format!("{}", err).contains("Write conflict"));
+        assert!(format!("{}", err).contains("node-789"));
+        assert!(format!("{}", err).contains("concurrent modification"));
+
+        // Test ValidationFailed
+        let err = TransactionError::ValidationFailed {
+            reason: "referential integrity violated".to_string(),
+        };
+        assert!(format!("{}", err).contains("validation failed"));
+        assert!(format!("{}", err).contains("referential integrity violated"));
+
+        // Test CommitFailed
+        let err = TransactionError::CommitFailed {
+            reason: "WAL write failed".to_string(),
+        };
+        assert!(format!("{}", err).contains("commit failed"));
+        assert!(format!("{}", err).contains("WAL write failed"));
+
+        // Test RollbackFailed
+        let err = TransactionError::RollbackFailed {
+            reason: "cleanup failed".to_string(),
+        };
+        assert!(format!("{}", err).contains("rollback failed"));
+        assert!(format!("{}", err).contains("cleanup failed"));
+    }
+
+    #[test]
+    fn test_transaction_error_conversions() {
+        let err = TransactionError::ValidationFailed {
+            reason: "test".to_string(),
+        };
+        let converted: Error = err.into();
+        assert!(matches!(converted, Error::Transaction(_)));
+    }
 }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     Temporal(TemporalError),
     /// Query-related errors.
     Query(QueryError),
+    /// Transaction-related errors.
+    Transaction(TransactionError),
     /// I/O errors.
     Io(io::Error),
     /// Other errors.
@@ -39,6 +41,7 @@ impl fmt::Display for Error {
             Error::Storage(e) => write!(f, "Storage error: {}", e),
             Error::Temporal(e) => write!(f, "Temporal error: {}", e),
             Error::Query(e) => write!(f, "Query error: {}", e),
+            Error::Transaction(e) => write!(f, "Transaction error: {}", e),
             Error::Io(e) => write!(f, "I/O error: {}", e),
             Error::Other(msg) => write!(f, "{}", msg),
         }
@@ -76,6 +79,12 @@ impl From<QueryError> for Error {
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::Io(e)
+    }
+}
+
+impl From<TransactionError> for Error {
+    fn from(e: TransactionError) -> Self {
+        Error::Transaction(e)
     }
 }
 
@@ -309,6 +318,84 @@ impl fmt::Display for QueryError {
 }
 
 impl std::error::Error for QueryError {}
+
+/// Errors related to transaction operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransactionError {
+    /// Transaction is not in the correct state for this operation.
+    InvalidState {
+        /// The current state
+        current: String,
+        /// The expected state
+        expected: String,
+    },
+    /// Transaction has already been committed.
+    AlreadyCommitted {
+        /// The transaction ID
+        tx_id: u64,
+    },
+    /// Transaction has been aborted.
+    Aborted {
+        /// The transaction ID
+        tx_id: u64,
+    },
+    /// Write conflict detected.
+    WriteConflict {
+        /// The entity ID involved in the conflict
+        entity_id: String,
+        /// Why there's a conflict
+        reason: String,
+    },
+    /// Validation failed before commit.
+    ValidationFailed {
+        /// Why validation failed
+        reason: String,
+    },
+    /// Commit failed.
+    CommitFailed {
+        /// Why commit failed
+        reason: String,
+    },
+    /// Rollback failed.
+    RollbackFailed {
+        /// Why rollback failed
+        reason: String,
+    },
+}
+
+impl fmt::Display for TransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransactionError::InvalidState { current, expected } => {
+                write!(
+                    f,
+                    "Transaction in invalid state: expected {}, got {}",
+                    expected, current
+                )
+            }
+            TransactionError::AlreadyCommitted { tx_id } => {
+                write!(f, "Transaction {} has already been committed", tx_id)
+            }
+            TransactionError::Aborted { tx_id } => {
+                write!(f, "Transaction {} has been aborted", tx_id)
+            }
+            TransactionError::WriteConflict { entity_id, reason } => {
+                write!(f, "Write conflict on {}: {}", entity_id, reason)
+            }
+            TransactionError::ValidationFailed { reason } => {
+                write!(f, "Transaction validation failed: {}", reason)
+            }
+            TransactionError::CommitFailed { reason } => {
+                write!(f, "Transaction commit failed: {}", reason)
+            }
+            TransactionError::RollbackFailed { reason } => {
+                write!(f, "Transaction rollback failed: {}", reason)
+            }
+        }
+    }
+}
+
+impl std::error::Error for TransactionError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -346,6 +346,16 @@ pub enum TransactionError {
         /// Why there's a conflict
         reason: String,
     },
+    /// Snapshot Isolation serialization failure (write-write conflict).
+    ///
+    /// This occurs when two concurrent transactions try to modify the same entity
+    /// and one commits after the other's snapshot was taken.
+    SerializationFailure {
+        /// The entity involved in the conflict
+        entity: String,
+        /// Why serialization failed
+        reason: String,
+    },
     /// Validation failed before commit.
     ValidationFailed {
         /// Why validation failed
@@ -381,6 +391,9 @@ impl fmt::Display for TransactionError {
             }
             TransactionError::WriteConflict { entity_id, reason } => {
                 write!(f, "Write conflict on {}: {}", entity_id, reason)
+            }
+            TransactionError::SerializationFailure { entity, reason } => {
+                write!(f, "Serialization failure on {}: {}", entity, reason)
             }
             TransactionError::ValidationFailed { reason } => {
                 write!(f, "Transaction validation failed: {}", reason)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,4 +3,4 @@
 pub mod error;
 
 // Re-export commonly used types
-pub use error::{Error, QueryError, Result, StorageError, TemporalError};
+pub use error::{Error, QueryError, Result, StorageError, TemporalError, TransactionError};


### PR DESCRIPTION

  ## Summary
  Implements complete Multi-Version Concurrency Control (MVCC) transaction layer for GallifreyDB with full ACID guarantees and **Snapshot Isolation**, providing both closure-based and explicit transaction APIs while maintaining 100% backward compatibility.

  ## 🎯 Features

  ### Transaction APIs
  - **Closure-based** (recommended): `db.write(|tx| ...)` with auto-commit/rollback
  - **Explicit handles**: `db.write_transaction()` for advanced control
  - **Backward compatible**: Existing `db.create_node()` etc. continue to work
  - **Read-only transactions**: Snapshot-based reads for consistent views

  ### ACID Guarantees
  - ✅ **Atomicity**: Write buffering with all-or-nothing commits
  - ✅ **Consistency**: Referential integrity validation before commit
  - ✅ **Isolation**: Snapshot Isolation with write-write conflict detection
  - ✅ **Durability**: WAL logging with fsync for true disk persistence

  ### Snapshot Isolation Features
  - **Consistent reads**: Transactions see a consistent snapshot from their start time
  - **No non-repeatable reads**: Same query returns same results within a transaction
  - **No phantom reads**: New rows don't appear mid-transaction
  - **Write-write conflict detection**: First-Committer-Wins rule prevents lost updates
  - **SerializationFailure**: Clear errors when conflicts are detected

  ## 📊 Performance Results

  All targets **met or exceeded**:

  | Operation | Result | Target | Status |
  |-----------|--------|--------|--------|
  | Read transaction creation | **~200 ns** | <500ns | ✅ 2.5x better |
  | Write transaction creation | **~2 µs** | <5µs | ✅ 2.5x better |
  | Snapshot capture | **<100 ns** | <200ns | ✅ 2x better |
  | Conflict detection | **<10 µs** | <50µs | ✅ 5x better |
  | WAL flush with fsync | **1-5 ms** | <10ms | ✅ Excellent |

  ## 🧪 Testing

  **170 tests passing** including comprehensive SI tests:
  - `test_snapshot_isolation` - Consistent snapshot reads
  - `test_closure_based_write_api` - Multi-operation atomic writes
  - `test_transaction_atomicity` - All-or-nothing behavior
  - `test_transaction_rollback_on_error` - Auto-rollback on error
  - `test_explicit_write_transaction` - Explicit handles
  - `test_multiple_transactions` - Sequential commits
  - Full visibility manager test suite
  - Write-write conflict detection tests

  ## 🔧 Implementation Phases

  ### Phase 3: Write Transactions
  - Implemented `WriteTransaction` with write buffering
  - Created transaction types: `TxId`, `TxState`, `TxMetadata`, `WriteBuffer`
  - Added `ReadOps` and `WriteOps` traits
  - Implemented commit/rollback with validation
  - Auto-rollback on Drop for safety

  ### Phase 4: WAL Integration
  - Integrated Write-Ahead Log for durability
  - Convert buffered writes to WAL operations
  - **Added fsync (sync_data) for true durability**
  - Full crash recovery support

  ### Phase 5: Snapshot Isolation
  - Implemented `TxVisibilityManager` for transaction state tracking
  - Created `TransactionSnapshot` with active transaction tracking
  - Added `VersionMetadata` to link versions to creating transactions
  - Integrated snapshot capture into transaction creation
  - Implemented visibility filtering in read path
  - Added write-write conflict detection at commit time

  ### Phase 6: Error Handling & Testing
  - Added `SerializationFailure` error type
  - Comprehensive SI correctness tests
  - All 170 tests passing
  - Full backward compatibility verified (TxId(0) special handling)

  ### Phase 7: Performance & Quality
  - Added transaction benchmarks
  - All targets exceeded
  - Clippy clean with let-chain refactoring
  - Performance excellent across the board

  ## 📁 Files Changed

  **Created:**
  - `src/api/transaction/` - Transaction implementation (types, read_tx, write_tx, write_buffer, visibility)
  - `benches/transactions.rs` - Performance benchmarks

  **Modified:**
  - `src/db.rs` - Transaction methods + snapshot integration + tests
  - `src/storage/current.rs` - Direct insert/update helpers
  - `src/storage/version.rs` - VersionMetadata tracking
  - `src/storage/wal.rs` - **fsync for durability**
  - `src/core/graph.rs` - Metadata fields on Node/Edge
  - `src/utils/error.rs` - SerializationFailure error type
  - `src/lib.rs` - Export transaction types

  ## 🎨 Example Usage

  ```rust
  // Closure-based (auto-commit/rollback)
  let node_id = db.write(|tx| {
      let n1 = tx.create_node("Person", props)?;
      let n2 = tx.create_node("Person", props)?;
      tx.create_edge(n1, n2, "KNOWS", edge_props)?;
      Ok(n1)
  })?;

  // Write-write conflicts are detected
  db.write(|tx1| {
      db.write(|tx2| {
          tx2.update_node(id, new_props)?;  // Commits first
          tx2.commit()
      })?;
      
      tx1.update_node(id, other_props)?;  // Conflicts!
      tx1.commit()  // Returns SerializationFailure
  })?;

  // Explicit handles
  let mut tx = db.write_transaction();
  tx.create_node("Person", props)?;
  tx.commit()?;

  // Read-only with snapshot isolation
  db.read(|tx| {
      let node = tx.get_node(id)?;
      Ok(node.get_property("name"))
  })?;

  // Backward compatible
  db.create_node("Person", props)?; // Still works!

  ✅ Checklist

  - All tests passing (170/170)
  - All clippy warnings fixed
  - Benchmarks added and passing
  - Performance targets exceeded
  - Backward compatibility maintained (TxId(0) handling)
  - Documentation updated
  - ACID guarantees verified
  - Snapshot Isolation correctness verified
  - Write-write conflicts properly detected
  - Durability guaranteed with fsync

  📈 Impact

  - Enables multi-operation atomic transactions
  - Provides Snapshot Isolation for consistent reads
  - Detects and prevents write-write conflicts
  - True durability through WAL + fsync
  - Maintains excellent performance (sub-microsecond overhead for snapshots)
  - Foundation for advanced features (time-travel queries, conflict-free operations)