### PR TITLE
feat: Add git worktree workflow for parallel Claude development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Cargo.lock
 
 settings.local.json
 nul
+
+# Git worktrees for parallel development
+agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,6 +535,37 @@ pub struct Metadata {
 
 ## Development Workflow
 
+### IMPORTANT: Worktree-First Development
+
+**When starting ANY implementation task, Claude instances MUST:**
+
+1. **Create a worktree first** before making any code changes:
+   ```bash
+   just worktree-new feature/descriptive-name   # For new features
+   just worktree-new fix/descriptive-name       # For bug fixes
+   ```
+
+2. **Navigate to the worktree** and work there:
+   ```bash
+   cd agents/feature-descriptive-name
+   ```
+
+3. **After completing work**, commit, create PR, and clean up:
+   ```bash
+   git add . && git commit -m "feat: description"
+   just worktree-pr "PR Title" "Description"
+   # After merge: just worktree-remove feature/descriptive-name
+   ```
+
+This enables multiple Claude instances to work in parallel without conflicts. Each instance gets an isolated copy of the codebase.
+
+**Skip worktree creation only if:**
+- You're already in a worktree (check with `git worktree list`)
+- The task is read-only (exploration, answering questions)
+- The user explicitly asks you to work in the main repo
+
+See `WORKTREE_WORKFLOW.md` for complete documentation.
+
 ### Feature Development
 
 1. **Design First**: Document design in issue/PR description

--- a/WORKTREE_WORKFLOW.md
+++ b/WORKTREE_WORKFLOW.md
@@ -1,0 +1,232 @@
+# Git Worktree Workflow for Parallel Development
+
+This document describes how to use git worktrees for parallel development, enabling multiple Claude instances (or developers) to work simultaneously on different features.
+
+## For Claude Instances
+
+**IMPORTANT**: When you start working on ANY implementation task:
+
+1. **Check if you're in a worktree**:
+   ```bash
+   git worktree list
+   ```
+   If you see only one entry (the main repo), you need to create a worktree.
+
+2. **Create a worktree for your task**:
+   ```bash
+   just worktree-new feature/task-name   # or fix/task-name
+   cd agents/feature-task-name
+   ```
+
+3. **Work in the worktree**, then commit and create PR:
+   ```bash
+   # After making changes
+   git add . && git commit -m "feat: description"
+   just worktree-pr "PR Title" "Description"
+   ```
+
+The worktree automatically includes your Claude settings (`.claude/settings.local.json`).
+
+## Quick Start
+
+```bash
+# Create a new worktree for your feature
+just worktree-new feature/my-feature
+
+# Navigate to the worktree
+cd agents/feature-my-feature
+
+# Make your changes, then commit
+git add .
+git commit -m "feat: add my feature"
+
+# Create a PR to trunk
+just worktree-pr "Add my feature" "Description of changes"
+
+# After PR is merged, clean up
+just worktree-remove feature/my-feature
+```
+
+## Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `just worktree-new <branch>` | Create new worktree with feature/fix branch |
+| `just worktree-list` | List all worktrees with status |
+| `just worktree-remove <branch>` | Remove worktree and clean up branches |
+| `just worktree-pr "<title>" "<body>"` | Push and create PR to trunk |
+
+## Branch Naming Convention
+
+Use the following prefixes:
+
+- `feature/` - New features (e.g., `feature/vector-search`, `feature/add-auth`)
+- `fix/` - Bug fixes (e.g., `fix/memory-leak`, `fix/query-timeout`)
+
+Examples:
+```bash
+just worktree-new feature/temporal-indexes
+just worktree-new fix/version-chain-ordering
+```
+
+## Directory Structure
+
+Worktrees are created in the `agents/` directory:
+
+```
+gallifreydb/
+├── agents/
+│   ├── feature-my-feature/     # Worktree for feature/my-feature
+│   ├── fix-memory-leak/        # Worktree for fix/memory-leak
+│   └── ...
+├── src/
+├── ...
+```
+
+The `agents/` directory is gitignored, so worktrees won't be committed.
+
+## Complete Workflow Example
+
+### 1. Start a new feature
+
+```bash
+# From the main repository
+just worktree-new feature/add-compression
+
+# Output:
+# Setting up worktree for branch: feature/add-compression
+# Location: /path/to/gallifreydb/agents/feature-add-compression
+# Fetching latest from origin...
+# Creating worktree and branch...
+# Worktree created successfully!
+```
+
+### 2. Work on the feature
+
+```bash
+cd agents/feature-add-compression
+
+# Open in your editor
+code .
+
+# Make changes...
+# Run tests
+just test
+
+# Commit your work
+git add .
+git commit -m "feat: implement compression for historical storage"
+```
+
+### 3. Create a Pull Request
+
+```bash
+# From within the worktree
+just worktree-pr "Implement compression for historical storage" "Adds anchor+delta compression reducing storage by 5-6X"
+
+# This will:
+# 1. Push the branch to origin
+# 2. Create a PR targeting trunk
+# 3. Open the PR in your browser
+```
+
+### 4. Clean up after merge
+
+After your PR is merged:
+
+```bash
+# From the main repository (or any worktree)
+just worktree-remove feature/add-compression
+
+# This will:
+# 1. Remove the worktree directory
+# 2. Optionally delete the local branch
+# 3. Optionally delete the remote branch
+```
+
+## Working with Multiple Features
+
+You can have multiple worktrees active simultaneously:
+
+```bash
+# Terminal 1 - Claude instance working on feature A
+just worktree-new feature/vector-search
+cd agents/feature-vector-search
+# ... work on vector search
+
+# Terminal 2 - Claude instance working on feature B
+just worktree-new feature/query-optimizer
+cd agents/feature-query-optimizer
+# ... work on query optimizer
+
+# Terminal 3 - Claude instance fixing a bug
+just worktree-new fix/memory-leak
+cd agents/fix-memory-leak
+# ... fix the bug
+```
+
+All three can work independently without conflicts.
+
+## Best Practices
+
+1. **Always create from fresh trunk**: The `worktree-new` script fetches the latest trunk before creating your branch.
+
+2. **Keep worktrees focused**: Each worktree should focus on a single feature or fix.
+
+3. **Clean up promptly**: Remove worktrees after PRs are merged to avoid clutter.
+
+4. **Don't modify the main worktree**: Use `agents/` worktrees for all development work.
+
+5. **Commit frequently**: Make small, focused commits within your worktree.
+
+## Troubleshooting
+
+### Worktree already exists
+
+```
+Error: Worktree already exists at /path/to/agents/feature-name
+```
+
+Either use a different branch name, or remove the existing worktree:
+```bash
+just worktree-remove feature/name
+```
+
+### Branch already exists
+
+```
+Error: Branch 'feature/name' already exists
+```
+
+The branch might exist from a previous attempt. Delete it:
+```bash
+git branch -D feature/name
+```
+
+### Uncommitted changes warning
+
+When removing a worktree with uncommitted changes:
+```
+Warning: 5 uncommitted change(s) in worktree!
+Continue anyway? (y/N)
+```
+
+Either commit your changes first, or confirm to discard them.
+
+### Cannot push to origin
+
+If `gh` CLI isn't authenticated:
+```bash
+gh auth login
+```
+
+## Scripts Location
+
+The worktree scripts are located in `scripts/`:
+
+- `scripts/worktree-new.ps1` / `scripts/worktree-new.sh`
+- `scripts/worktree-list.ps1` / `scripts/worktree-list.sh`
+- `scripts/worktree-remove.ps1` / `scripts/worktree-remove.sh`
+- `scripts/worktree-pr.ps1` / `scripts/worktree-pr.sh`
+
+The `just` commands automatically select the appropriate script based on your environment.

--- a/justfile
+++ b/justfile
@@ -143,3 +143,45 @@ outdated:
 # Audit dependencies for security issues
 audit:
     cargo audit
+
+# === Git Worktree Commands ===
+# These commands enable parallel development with multiple Claude instances
+
+# Create new worktree with feature/fix branch
+# Usage: just worktree-new feature/my-feature
+worktree-new NAME:
+    #!/usr/bin/env bash
+    if command -v pwsh &> /dev/null; then
+        pwsh -File scripts/worktree-new.ps1 {{NAME}}
+    else
+        bash scripts/worktree-new.sh {{NAME}}
+    fi
+
+# List all worktrees with status
+worktree-list:
+    #!/usr/bin/env bash
+    if command -v pwsh &> /dev/null; then
+        pwsh -File scripts/worktree-list.ps1
+    else
+        bash scripts/worktree-list.sh
+    fi
+
+# Remove worktree and clean up branches
+# Usage: just worktree-remove feature/my-feature
+worktree-remove NAME:
+    #!/usr/bin/env bash
+    if command -v pwsh &> /dev/null; then
+        pwsh -File scripts/worktree-remove.ps1 {{NAME}}
+    else
+        bash scripts/worktree-remove.sh {{NAME}}
+    fi
+
+# Push current branch and create PR to trunk
+# Usage: just worktree-pr "PR Title" "Optional description"
+worktree-pr TITLE BODY="":
+    #!/usr/bin/env bash
+    if command -v pwsh &> /dev/null; then
+        pwsh -File scripts/worktree-pr.ps1 "{{TITLE}}" "{{BODY}}"
+    else
+        bash scripts/worktree-pr.sh "{{TITLE}}" "{{BODY}}"
+    fi

--- a/scripts/worktree-list.ps1
+++ b/scripts/worktree-list.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Lists all git worktrees with their status.
+
+.DESCRIPTION
+    Shows all active worktrees, their branches, and status information
+    including uncommitted changes and unpushed commits.
+
+.EXAMPLE
+    .\worktree-list.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+# Colors for output
+function Write-Success { param($msg) Write-Host $msg -ForegroundColor Green }
+function Write-Info { param($msg) Write-Host $msg -ForegroundColor Cyan }
+function Write-Warn { param($msg) Write-Host $msg -ForegroundColor Yellow }
+function Write-Err { param($msg) Write-Host $msg -ForegroundColor Red }
+
+# Get the repo root
+$RepoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $RepoRoot) {
+    Write-Err "Error: Not in a git repository"
+    exit 1
+}
+
+Write-Info "Git Worktrees:"
+Write-Host ""
+
+# Get worktree list
+$Worktrees = git worktree list --porcelain | Out-String
+
+# Parse and display each worktree
+$CurrentWorktree = $null
+$CurrentBranch = $null
+
+foreach ($line in (git worktree list --porcelain) -split "`n") {
+    if ($line -match "^worktree (.+)$") {
+        if ($CurrentWorktree) {
+            # Output previous worktree info
+            Write-WorktreeInfo $CurrentWorktree $CurrentBranch
+        }
+        $CurrentWorktree = $Matches[1]
+        $CurrentBranch = $null
+    }
+    elseif ($line -match "^branch refs/heads/(.+)$") {
+        $CurrentBranch = $Matches[1]
+    }
+}
+
+# Output last worktree
+if ($CurrentWorktree) {
+    Write-WorktreeInfo $CurrentWorktree $CurrentBranch
+}
+
+function Write-WorktreeInfo {
+    param($Path, $Branch)
+
+    $IsMain = $Path -eq $RepoRoot
+    $Prefix = if ($IsMain) { "[MAIN]" } else { "      " }
+
+    Write-Host "$Prefix $Branch" -NoNewline
+    Write-Host " -> " -NoNewline -ForegroundColor DarkGray
+    Write-Host $Path -ForegroundColor DarkGray
+
+    # Check for uncommitted changes
+    Push-Location $Path
+    try {
+        $Status = git status --porcelain 2>$null
+        if ($Status) {
+            $Count = ($Status -split "`n").Count
+            Write-Warn "        ! $Count uncommitted change(s)"
+        }
+
+        # Check for unpushed commits (only for non-main worktrees)
+        if (-not $IsMain -and $Branch) {
+            $Unpushed = git log "origin/$Branch..$Branch" --oneline 2>$null
+            if ($LASTEXITCODE -eq 0 -and $Unpushed) {
+                $Count = ($Unpushed -split "`n").Count
+                Write-Warn "        ^ $Count unpushed commit(s)"
+            }
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Host ""
+}
+
+# Simple list view (git worktree list already gives good output)
+git worktree list
+
+Write-Host ""
+Write-Info "Use 'just worktree-new <branch>' to create a new worktree"
+Write-Info "Use 'just worktree-remove <branch>' to remove a worktree"

--- a/scripts/worktree-list.sh
+++ b/scripts/worktree-list.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Lists all git worktrees with their status.
+#
+# Usage:
+#   ./worktree-list.sh
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+GRAY='\033[0;90m'
+NC='\033[0m' # No Color
+
+success() { echo -e "${GREEN}$1${NC}"; }
+info() { echo -e "${CYAN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+err() { echo -e "${RED}$1${NC}"; }
+
+# Get the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+    err "Error: Not in a git repository"
+    exit 1
+fi
+
+info "Git Worktrees:"
+echo ""
+
+# Show basic worktree list first
+git worktree list
+
+echo ""
+
+# Show detailed status for each worktree
+while IFS= read -r line; do
+    # Parse worktree path from the output
+    WORKTREE_PATH=$(echo "$line" | awk '{print $1}')
+    BRANCH=$(echo "$line" | awk '{print $3}' | tr -d '[]')
+
+    if [ -d "$WORKTREE_PATH" ]; then
+        # Check for uncommitted changes
+        CHANGES=$(cd "$WORKTREE_PATH" && git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$CHANGES" -gt 0 ]; then
+            warn "  ! $WORKTREE_PATH: $CHANGES uncommitted change(s)"
+        fi
+
+        # Check for unpushed commits (skip if branch doesn't track remote)
+        if [ -n "$BRANCH" ] && [ "$BRANCH" != "(bare)" ]; then
+            UNPUSHED=$(cd "$WORKTREE_PATH" && git log "origin/$BRANCH..$BRANCH" --oneline 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+            if [ "$UNPUSHED" -gt 0 ]; then
+                warn "  ^ $WORKTREE_PATH: $UNPUSHED unpushed commit(s)"
+            fi
+        fi
+    fi
+done < <(git worktree list)
+
+echo ""
+info "Use 'just worktree-new <branch>' to create a new worktree"
+info "Use 'just worktree-remove <branch>' to remove a worktree"

--- a/scripts/worktree-new.ps1
+++ b/scripts/worktree-new.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+    Creates a new git worktree with a feature or fix branch.
+
+.DESCRIPTION
+    This script creates a new git worktree for parallel development.
+    It fetches the latest trunk, creates a new branch, and sets up
+    a worktree in the agents/ directory.
+
+.PARAMETER BranchName
+    The name of the branch to create (e.g., feature/my-feature or fix/bug-name)
+
+.EXAMPLE
+    .\worktree-new.ps1 feature/add-vector-search
+    .\worktree-new.ps1 fix/memory-leak
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$BranchName
+)
+
+$ErrorActionPreference = "Stop"
+
+# Colors for output
+function Write-Success { param($msg) Write-Host $msg -ForegroundColor Green }
+function Write-Info { param($msg) Write-Host $msg -ForegroundColor Cyan }
+function Write-Warn { param($msg) Write-Host $msg -ForegroundColor Yellow }
+function Write-Err { param($msg) Write-Host $msg -ForegroundColor Red }
+
+# Get the repo root (where .git is)
+$RepoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $RepoRoot) {
+    Write-Err "Error: Not in a git repository"
+    exit 1
+}
+
+# Validate branch name format
+if (-not ($BranchName -match "^(feature|fix)/[\w\-]+$")) {
+    Write-Err "Error: Branch name must be in format 'feature/<name>' or 'fix/<name>'"
+    Write-Err "  Examples: feature/add-auth, fix/memory-leak"
+    exit 1
+}
+
+# Sanitize branch name for directory (replace / with -)
+$DirName = $BranchName -replace "/", "-"
+$WorktreePath = Join-Path $RepoRoot "agents" $DirName
+
+# Check if worktree already exists
+if (Test-Path $WorktreePath) {
+    Write-Err "Error: Worktree already exists at $WorktreePath"
+    Write-Info "Use 'just worktree-list' to see existing worktrees"
+    exit 1
+}
+
+# Check if branch already exists
+$BranchExists = git show-ref --verify --quiet "refs/heads/$BranchName" 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Err "Error: Branch '$BranchName' already exists"
+    Write-Info "Use a different name or delete the existing branch first"
+    exit 1
+}
+
+Write-Info "Setting up worktree for branch: $BranchName"
+Write-Info "Location: $WorktreePath"
+Write-Host ""
+
+# Fetch latest from origin
+Write-Info "Fetching latest from origin..."
+git fetch origin trunk
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Error: Failed to fetch from origin"
+    exit 1
+}
+
+# Create agents directory if it doesn't exist
+$AgentsDir = Join-Path $RepoRoot "agents"
+if (-not (Test-Path $AgentsDir)) {
+    New-Item -ItemType Directory -Path $AgentsDir | Out-Null
+}
+
+# Create the worktree with a new branch from trunk
+Write-Info "Creating worktree and branch..."
+git worktree add -b $BranchName $WorktreePath origin/trunk
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Error: Failed to create worktree"
+    exit 1
+}
+
+# Copy .claude/settings.local.json to the new worktree
+$SourceSettings = Join-Path $RepoRoot ".claude" "settings.local.json"
+if (Test-Path $SourceSettings) {
+    Write-Info "Copying Claude settings to worktree..."
+    $TargetClaudeDir = Join-Path $WorktreePath ".claude"
+    New-Item -ItemType Directory -Path $TargetClaudeDir -Force | Out-Null
+    Copy-Item $SourceSettings -Destination $TargetClaudeDir
+    Write-Success "Claude settings copied!"
+}
+
+Write-Host ""
+Write-Success "Worktree created successfully!"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. cd $WorktreePath"
+Write-Host "  2. Make your changes"
+Write-Host "  3. git add . && git commit -m 'Your message'"
+Write-Host "  4. just worktree-pr 'PR Title' 'PR Description'"
+Write-Host ""
+Write-Host "Or run directly:"
+Write-Host "  cd $WorktreePath && code ."

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Creates a new git worktree with a feature or fix branch.
+#
+# Usage:
+#   ./worktree-new.sh feature/my-feature
+#   ./worktree-new.sh fix/bug-name
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+success() { echo -e "${GREEN}$1${NC}"; }
+info() { echo -e "${CYAN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+err() { echo -e "${RED}$1${NC}"; }
+
+# Check argument
+if [ $# -lt 1 ]; then
+    err "Usage: $0 <branch-name>"
+    err "  Example: $0 feature/add-vector-search"
+    err "  Example: $0 fix/memory-leak"
+    exit 1
+fi
+
+BRANCH_NAME="$1"
+
+# Get the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+    err "Error: Not in a git repository"
+    exit 1
+fi
+
+# Validate branch name format
+if ! [[ "$BRANCH_NAME" =~ ^(feature|fix)/[a-zA-Z0-9_-]+$ ]]; then
+    err "Error: Branch name must be in format 'feature/<name>' or 'fix/<name>'"
+    err "  Examples: feature/add-auth, fix/memory-leak"
+    exit 1
+fi
+
+# Sanitize branch name for directory (replace / with -)
+DIR_NAME="${BRANCH_NAME//\//-}"
+WORKTREE_PATH="$REPO_ROOT/agents/$DIR_NAME"
+
+# Check if worktree already exists
+if [ -d "$WORKTREE_PATH" ]; then
+    err "Error: Worktree already exists at $WORKTREE_PATH"
+    info "Use 'just worktree-list' to see existing worktrees"
+    exit 1
+fi
+
+# Check if branch already exists
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
+    err "Error: Branch '$BRANCH_NAME' already exists"
+    info "Use a different name or delete the existing branch first"
+    exit 1
+fi
+
+info "Setting up worktree for branch: $BRANCH_NAME"
+info "Location: $WORKTREE_PATH"
+echo ""
+
+# Fetch latest from origin
+info "Fetching latest from origin..."
+git fetch origin trunk
+
+# Create agents directory if it doesn't exist
+mkdir -p "$REPO_ROOT/agents"
+
+# Create the worktree with a new branch from trunk
+info "Creating worktree and branch..."
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" origin/trunk
+
+# Copy .claude/settings.local.json to the new worktree
+SOURCE_SETTINGS="$REPO_ROOT/.claude/settings.local.json"
+if [ -f "$SOURCE_SETTINGS" ]; then
+    info "Copying Claude settings to worktree..."
+    mkdir -p "$WORKTREE_PATH/.claude"
+    cp "$SOURCE_SETTINGS" "$WORKTREE_PATH/.claude/"
+    success "Claude settings copied!"
+fi
+
+echo ""
+success "Worktree created successfully!"
+echo ""
+echo "Next steps:"
+echo "  1. cd $WORKTREE_PATH"
+echo "  2. Make your changes"
+echo "  3. git add . && git commit -m 'Your message'"
+echo "  4. just worktree-pr 'PR Title' 'PR Description'"
+echo ""
+echo "Or run directly:"
+echo "  cd $WORKTREE_PATH && code ."

--- a/scripts/worktree-pr.ps1
+++ b/scripts/worktree-pr.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Pushes the current branch and creates a PR to trunk.
+
+.DESCRIPTION
+    Ensures all changes are committed, pushes to origin, and creates
+    a pull request to trunk using the GitHub CLI (gh).
+
+.PARAMETER Title
+    The title for the pull request
+
+.PARAMETER Body
+    The body/description for the pull request (optional)
+
+.EXAMPLE
+    .\worktree-pr.ps1 "Add vector search feature"
+    .\worktree-pr.ps1 "Fix memory leak" "Fixes issue #123"
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$Title,
+
+    [Parameter(Position=1)]
+    [string]$Body = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+# Colors for output
+function Write-Success { param($msg) Write-Host $msg -ForegroundColor Green }
+function Write-Info { param($msg) Write-Host $msg -ForegroundColor Cyan }
+function Write-Warn { param($msg) Write-Host $msg -ForegroundColor Yellow }
+function Write-Err { param($msg) Write-Host $msg -ForegroundColor Red }
+
+# Check if gh is installed
+$GhExists = Get-Command gh -ErrorAction SilentlyContinue
+if (-not $GhExists) {
+    Write-Err "Error: GitHub CLI (gh) is not installed"
+    Write-Info "Install it from: https://cli.github.com/"
+    exit 1
+}
+
+# Get current branch
+$CurrentBranch = git branch --show-current 2>$null
+if (-not $CurrentBranch) {
+    Write-Err "Error: Could not determine current branch"
+    exit 1
+}
+
+# Don't allow PRs from trunk or main
+if ($CurrentBranch -eq "trunk" -or $CurrentBranch -eq "main" -or $CurrentBranch -eq "master") {
+    Write-Err "Error: Cannot create PR from '$CurrentBranch'"
+    Write-Info "Create a feature branch first with 'just worktree-new feature/name'"
+    exit 1
+}
+
+Write-Info "Creating PR for branch: $CurrentBranch"
+Write-Host ""
+
+# Check for uncommitted changes
+$Status = git status --porcelain 2>$null
+if ($Status) {
+    Write-Err "Error: You have uncommitted changes"
+    Write-Info "Commit your changes first:"
+    Write-Host "  git add . && git commit -m 'Your message'"
+    exit 1
+}
+
+# Push to origin
+Write-Info "Pushing to origin..."
+git push -u origin $CurrentBranch
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Error: Failed to push to origin"
+    exit 1
+}
+
+Write-Success "Pushed to origin/$CurrentBranch"
+Write-Host ""
+
+# Create PR
+Write-Info "Creating pull request..."
+
+# Build the PR body
+$FullBody = @"
+## Summary
+$Body
+
+---
+Created from worktree workflow.
+"@
+
+if ([string]::IsNullOrWhiteSpace($Body)) {
+    $FullBody = "Created from worktree workflow."
+}
+
+# Create the PR
+$PrOutput = gh pr create --base trunk --title $Title --body $FullBody 2>&1
+if ($LASTEXITCODE -ne 0) {
+    # Check if PR already exists
+    if ($PrOutput -match "already exists") {
+        Write-Warn "A pull request already exists for this branch"
+        gh pr view --web
+        exit 0
+    }
+    Write-Err "Error: Failed to create PR"
+    Write-Err $PrOutput
+    exit 1
+}
+
+Write-Host ""
+Write-Success "Pull request created!"
+Write-Host $PrOutput
+
+# Open in browser
+Write-Host ""
+Write-Info "Opening PR in browser..."
+gh pr view --web

--- a/scripts/worktree-pr.sh
+++ b/scripts/worktree-pr.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Pushes the current branch and creates a PR to trunk.
+#
+# Usage:
+#   ./worktree-pr.sh "PR Title"
+#   ./worktree-pr.sh "PR Title" "PR Description"
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+success() { echo -e "${GREEN}$1${NC}"; }
+info() { echo -e "${CYAN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+err() { echo -e "${RED}$1${NC}"; }
+
+# Check arguments
+if [ $# -lt 1 ]; then
+    err "Usage: $0 <title> [body]"
+    err "  Example: $0 'Add vector search feature'"
+    err "  Example: $0 'Fix memory leak' 'Fixes issue #123'"
+    exit 1
+fi
+
+TITLE="$1"
+BODY="${2:-}"
+
+# Check if gh is installed
+if ! command -v gh &> /dev/null; then
+    err "Error: GitHub CLI (gh) is not installed"
+    info "Install it from: https://cli.github.com/"
+    exit 1
+fi
+
+# Get current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+if [ -z "$CURRENT_BRANCH" ]; then
+    err "Error: Could not determine current branch"
+    exit 1
+fi
+
+# Don't allow PRs from trunk or main
+if [ "$CURRENT_BRANCH" = "trunk" ] || [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+    err "Error: Cannot create PR from '$CURRENT_BRANCH'"
+    info "Create a feature branch first with 'just worktree-new feature/name'"
+    exit 1
+fi
+
+info "Creating PR for branch: $CURRENT_BRANCH"
+echo ""
+
+# Check for uncommitted changes
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    err "Error: You have uncommitted changes"
+    info "Commit your changes first:"
+    echo "  git add . && git commit -m 'Your message'"
+    exit 1
+fi
+
+# Push to origin
+info "Pushing to origin..."
+git push -u origin "$CURRENT_BRANCH"
+
+success "Pushed to origin/$CURRENT_BRANCH"
+echo ""
+
+# Create PR
+info "Creating pull request..."
+
+# Build the PR body
+if [ -n "$BODY" ]; then
+    FULL_BODY=$(cat <<EOF
+## Summary
+$BODY
+
+---
+Created from worktree workflow.
+EOF
+)
+else
+    FULL_BODY="Created from worktree workflow."
+fi
+
+# Create the PR
+if ! PR_OUTPUT=$(gh pr create --base trunk --title "$TITLE" --body "$FULL_BODY" 2>&1); then
+    # Check if PR already exists
+    if echo "$PR_OUTPUT" | grep -q "already exists"; then
+        warn "A pull request already exists for this branch"
+        gh pr view --web
+        exit 0
+    fi
+    err "Error: Failed to create PR"
+    err "$PR_OUTPUT"
+    exit 1
+fi
+
+echo ""
+success "Pull request created!"
+echo "$PR_OUTPUT"
+
+# Open in browser
+echo ""
+info "Opening PR in browser..."
+gh pr view --web

--- a/scripts/worktree-remove.ps1
+++ b/scripts/worktree-remove.ps1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+    Removes a git worktree and optionally cleans up branches.
+
+.DESCRIPTION
+    Removes a worktree from the agents/ directory and offers to delete
+    the local and remote branches. Warns about uncommitted changes.
+
+.PARAMETER BranchName
+    The name of the branch whose worktree to remove (e.g., feature/my-feature)
+
+.PARAMETER Force
+    Skip confirmation prompts and force removal
+
+.EXAMPLE
+    .\worktree-remove.ps1 feature/add-vector-search
+    .\worktree-remove.ps1 fix/memory-leak -Force
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$BranchName,
+
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+# Colors for output
+function Write-Success { param($msg) Write-Host $msg -ForegroundColor Green }
+function Write-Info { param($msg) Write-Host $msg -ForegroundColor Cyan }
+function Write-Warn { param($msg) Write-Host $msg -ForegroundColor Yellow }
+function Write-Err { param($msg) Write-Host $msg -ForegroundColor Red }
+
+# Get the repo root
+$RepoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $RepoRoot) {
+    Write-Err "Error: Not in a git repository"
+    exit 1
+}
+
+# Sanitize branch name for directory (replace / with -)
+$DirName = $BranchName -replace "/", "-"
+$WorktreePath = Join-Path $RepoRoot "agents" $DirName
+
+# Check if worktree exists
+if (-not (Test-Path $WorktreePath)) {
+    Write-Err "Error: Worktree not found at $WorktreePath"
+    Write-Info "Use 'just worktree-list' to see existing worktrees"
+    exit 1
+}
+
+Write-Info "Removing worktree for branch: $BranchName"
+Write-Info "Location: $WorktreePath"
+Write-Host ""
+
+# Check for uncommitted changes
+Push-Location $WorktreePath
+try {
+    $Status = git status --porcelain 2>$null
+    if ($Status) {
+        $Count = ($Status -split "`n").Count
+        Write-Warn "Warning: $Count uncommitted change(s) in worktree!"
+        if (-not $Force) {
+            $Response = Read-Host "Continue anyway? (y/N)"
+            if ($Response -ne "y" -and $Response -ne "Y") {
+                Write-Info "Aborted"
+                exit 0
+            }
+        }
+    }
+
+    # Check for unpushed commits
+    $Unpushed = git log "origin/$BranchName..$BranchName" --oneline 2>$null
+    if ($LASTEXITCODE -eq 0 -and $Unpushed) {
+        $Count = ($Unpushed -split "`n").Count
+        Write-Warn "Warning: $Count unpushed commit(s)!"
+        if (-not $Force) {
+            $Response = Read-Host "Continue anyway? (y/N)"
+            if ($Response -ne "y" -and $Response -ne "Y") {
+                Write-Info "Aborted"
+                exit 0
+            }
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+
+# Remove the worktree
+Write-Info "Removing worktree..."
+git worktree remove $WorktreePath --force
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Error: Failed to remove worktree"
+    exit 1
+}
+
+Write-Success "Worktree removed!"
+
+# Offer to delete local branch
+if (-not $Force) {
+    $Response = Read-Host "Delete local branch '$BranchName'? (Y/n)"
+    if ($Response -eq "" -or $Response -eq "y" -or $Response -eq "Y") {
+        git branch -D $BranchName 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Local branch deleted"
+        }
+    }
+}
+else {
+    git branch -D $BranchName 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Success "Local branch deleted"
+    }
+}
+
+# Offer to delete remote branch
+$RemoteExists = git ls-remote --heads origin $BranchName 2>$null
+if ($RemoteExists) {
+    if (-not $Force) {
+        $Response = Read-Host "Delete remote branch 'origin/$BranchName'? (y/N)"
+        if ($Response -eq "y" -or $Response -eq "Y") {
+            git push origin --delete $BranchName 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "Remote branch deleted"
+            }
+        }
+    }
+}
+
+Write-Host ""
+Write-Success "Cleanup complete!"

--- a/scripts/worktree-remove.sh
+++ b/scripts/worktree-remove.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Removes a git worktree and optionally cleans up branches.
+#
+# Usage:
+#   ./worktree-remove.sh feature/my-feature
+#   ./worktree-remove.sh fix/bug-name --force
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+success() { echo -e "${GREEN}$1${NC}"; }
+info() { echo -e "${CYAN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+err() { echo -e "${RED}$1${NC}"; }
+
+# Parse arguments
+FORCE=false
+BRANCH_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force|-f)
+            FORCE=true
+            shift
+            ;;
+        *)
+            BRANCH_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$BRANCH_NAME" ]; then
+    err "Usage: $0 <branch-name> [--force]"
+    err "  Example: $0 feature/add-vector-search"
+    exit 1
+fi
+
+# Get the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+    err "Error: Not in a git repository"
+    exit 1
+fi
+
+# Sanitize branch name for directory (replace / with -)
+DIR_NAME="${BRANCH_NAME//\//-}"
+WORKTREE_PATH="$REPO_ROOT/agents/$DIR_NAME"
+
+# Check if worktree exists
+if [ ! -d "$WORKTREE_PATH" ]; then
+    err "Error: Worktree not found at $WORKTREE_PATH"
+    info "Use 'just worktree-list' to see existing worktrees"
+    exit 1
+fi
+
+info "Removing worktree for branch: $BRANCH_NAME"
+info "Location: $WORKTREE_PATH"
+echo ""
+
+# Check for uncommitted changes
+CHANGES=$(cd "$WORKTREE_PATH" && git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+if [ "$CHANGES" -gt 0 ]; then
+    warn "Warning: $CHANGES uncommitted change(s) in worktree!"
+    if [ "$FORCE" = false ]; then
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            info "Aborted"
+            exit 0
+        fi
+    fi
+fi
+
+# Check for unpushed commits
+UNPUSHED=$(cd "$WORKTREE_PATH" && git log "origin/$BRANCH_NAME..$BRANCH_NAME" --oneline 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+if [ "$UNPUSHED" -gt 0 ]; then
+    warn "Warning: $UNPUSHED unpushed commit(s)!"
+    if [ "$FORCE" = false ]; then
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            info "Aborted"
+            exit 0
+        fi
+    fi
+fi
+
+# Remove the worktree
+info "Removing worktree..."
+git worktree remove "$WORKTREE_PATH" --force
+
+success "Worktree removed!"
+
+# Offer to delete local branch
+if [ "$FORCE" = false ]; then
+    read -p "Delete local branch '$BRANCH_NAME'? (Y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]?$ ]]; then
+        git branch -D "$BRANCH_NAME" 2>/dev/null && success "Local branch deleted" || true
+    fi
+else
+    git branch -D "$BRANCH_NAME" 2>/dev/null && success "Local branch deleted" || true
+fi
+
+# Offer to delete remote branch
+if git ls-remote --heads origin "$BRANCH_NAME" 2>/dev/null | grep -q .; then
+    if [ "$FORCE" = false ]; then
+        read -p "Delete remote branch 'origin/$BRANCH_NAME'? (y/N) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            git push origin --delete "$BRANCH_NAME" 2>/dev/null && success "Remote branch deleted" || true
+        fi
+    fi
+fi
+
+echo ""
+success "Cleanup complete!"


### PR DESCRIPTION
## Summary

Enables multiple Claude instances to work simultaneously on different features by using git worktrees. Each instance gets an isolated copy of the codebase with its own branch.

### Added
- `scripts/worktree-new.ps1/.sh` - Create worktree with feature/fix branch
- `scripts/worktree-list.ps1/.sh` - List all worktrees with status  
- `scripts/worktree-remove.ps1/.sh` - Clean up worktree after PR merge
- `scripts/worktree-pr.ps1/.sh` - Push and create PR to trunk
- `WORKTREE_WORKFLOW.md` - Complete workflow documentation

### Updated
- `justfile` - Added `worktree-*` commands
- `CLAUDE.md` - Added worktree-first development instructions
- `.gitignore` - Exclude `agents/` directory (worktree location)

## Usage

```bash
# Create a worktree for your feature
just worktree-new feature/my-feature
cd agents/feature-my-feature

# Work, commit, create PR
git add . && git commit -m "feat: description"
just worktree-pr "PR Title" "Description"

# After merge, clean up
just worktree-remove feature/my-feature
```

## Key Features

- **Automatic settings copy**: `.claude/settings.local.json` is copied to new worktrees
- **Cross-platform**: PowerShell scripts for Windows, bash for Unix
- **Integration with just**: All commands available via `just worktree-*`
- **Claude-aware**: CLAUDE.md instructs Claude instances to use worktrees

## Test plan

- [ ] Create test worktree: `just worktree-new feature/test`
- [ ] Verify settings copied: `cat agents/feature-test/.claude/settings.local.json`
- [ ] List worktrees: `just worktree-list`
- [ ] Clean up: `just worktree-remove feature/test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)