### PR TITLE
fix(ci): add permissions for benchmark workflow PR comments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Permissions needed for benchmark actions
+permissions:
+  contents: write      # For pushing benchmark results to gh-pages
+  pull-requests: write # For commenting on PRs
+  issues: write        # For creating comments
+
 jobs:
   benchmark:
     name: Run Benchmarks
@@ -101,13 +107,20 @@ jobs:
       - name: Comment benchmark results on PR
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
+        continue-on-error: true  # Don't fail the workflow if commenting fails (e.g., fork PRs)
         with:
           script: |
             const fs = require('fs');
-            const summary = fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## 🚀 Benchmark Results\n\n${summary}`
-            });
+            try {
+              const summary = fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, 'utf8');
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `## 🚀 Benchmark Results\n\n${summary}`
+              });
+              console.log('Successfully posted benchmark results as PR comment');
+            } catch (error) {
+              console.log('Could not post PR comment (this is expected for fork PRs):', error.message);
+              console.log('Benchmark results are available in the workflow summary above.');
+            }


### PR DESCRIPTION
## Summary
- Fix "Resource not accessible by integration" error in benchmark-pr job
- Add explicit workflow-level permissions for `contents`, `pull-requests`, and `issues`
- Add graceful error handling for fork PRs where permissions may still be restricted

## Problem
The benchmark-pr job was failing when trying to post comments on PRs because the `GITHUB_TOKEN` lacked explicit permissions. This caused the workflow to fail with:
> HttpError: Resource not accessible by integration

## Solution
1. Added explicit `permissions` block at the workflow level
2. Added `continue-on-error: true` to the comment step
3. Wrapped the comment logic in try-catch with informative logging

For fork PRs where GitHub restricts permissions for security, the workflow will now succeed and benchmark results remain available in the workflow summary.

## Test plan
- [ ] Verify workflow passes on this PR
- [ ] Verify PR comment is posted (for same-repo PRs)
- [ ] Verify workflow summary contains benchmark results

🤖 Generated with [Claude Code](https://claude.com/claude-code)