### PR TITLE
feat(vector): Add DistanceMetric enum for unified metric dispatch (VS-008)

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -18,6 +18,7 @@ pub use property::{PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue};
 pub use temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp};
 pub use vector::{
     // Types and constants
+    DistanceMetric,
     NORMALIZATION_TOLERANCE,
     VectorDimension,
     // Similarity functions

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -1536,6 +1536,237 @@ pub fn is_normalized_default(v: &[f32]) -> bool {
 }
 
 // ============================================================================
+// Distance Metric Enum
+// ============================================================================
+
+/// Specifies which distance or similarity metric to use for vector operations.
+///
+/// This enum provides a unified interface for computing distances and similarities
+/// between vectors, dispatching to the appropriate underlying function based on the
+/// selected metric.
+///
+/// # Choosing a Metric
+///
+/// | Metric | Best For | Range | Notes |
+/// |--------|----------|-------|-------|
+/// | [`Cosine`](DistanceMetric::Cosine) | Semantic similarity, text embeddings | [-1, 1] similarity, [0, 2] distance | Scale-invariant, most common for embeddings |
+/// | [`Euclidean`](DistanceMetric::Euclidean) | Spatial data, image features | [0, ∞) distance | Sensitive to vector magnitude |
+/// | [`DotProduct`](DistanceMetric::DotProduct) | Pre-normalized vectors, MaxIP search | (-∞, ∞) | Fastest; requires normalized vectors for cosine-like behavior |
+///
+/// # Example
+///
+/// ```rust
+/// use gallifreydb::core::vector::DistanceMetric;
+///
+/// let a = vec![1.0, 0.0, 0.0];
+/// let b = vec![0.0, 1.0, 0.0];
+///
+/// // Using cosine similarity (orthogonal vectors = 0 similarity)
+/// let similarity = DistanceMetric::Cosine.compute_similarity(&a, &b).unwrap();
+/// assert!((similarity - 0.0).abs() < 1e-6);
+///
+/// // Using euclidean distance
+/// let distance = DistanceMetric::Euclidean.compute_distance(&a, &b).unwrap();
+/// assert!((distance - std::f32::consts::SQRT_2).abs() < 1e-6);
+/// ```
+///
+/// # Performance
+///
+/// All metrics use SIMD acceleration (AVX2/SSE2) when available. For maximum
+/// performance with large-scale similarity search:
+///
+/// 1. Pre-normalize vectors with [`normalize`] or [`normalize_in_place`]
+/// 2. Use [`DotProduct`](DistanceMetric::DotProduct) metric (single SIMD operation)
+/// 3. Store normalized vectors to avoid repeated normalization
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum DistanceMetric {
+    /// Cosine similarity/distance.
+    ///
+    /// Measures the cosine of the angle between two vectors, making it
+    /// **scale-invariant** (only direction matters, not magnitude).
+    ///
+    /// - **Similarity**: Range [-1, 1] where 1 = identical direction,
+    ///   0 = orthogonal, -1 = opposite direction
+    /// - **Distance**: Computed as `1 - similarity`, range [0, 2]
+    ///
+    /// # When to Use
+    ///
+    /// - Text embeddings (word2vec, BERT, OpenAI embeddings)
+    /// - Semantic similarity where magnitude doesn't matter
+    /// - When vectors may have different scales
+    ///
+    /// # Implementation Note
+    ///
+    /// Uses [`cosine_similarity`] internally, which handles zero vectors
+    /// by returning 0.0 similarity.
+    #[default]
+    Cosine,
+
+    /// Euclidean (L2) distance.
+    ///
+    /// Measures the straight-line distance between two points in vector space.
+    /// Also known as the L2 norm of the difference vector.
+    ///
+    /// - **Distance**: Range [0, ∞) where 0 = identical vectors
+    /// - **Similarity**: Computed as `1 / (1 + distance)`, range (0, 1]
+    ///
+    /// # When to Use
+    ///
+    /// - Spatial data (coordinates, positions)
+    /// - Image feature vectors
+    /// - When absolute magnitude differences matter
+    /// - K-means clustering (uses squared Euclidean internally)
+    ///
+    /// # Implementation Note
+    ///
+    /// Uses [`euclidean_distance`] internally, which uses SIMD-accelerated
+    /// squared difference computation.
+    Euclidean,
+
+    /// Inner (dot) product.
+    ///
+    /// Computes the sum of element-wise products. For normalized vectors,
+    /// this equals cosine similarity but is faster (single SIMD operation).
+    ///
+    /// - **Raw value**: Range (-∞, ∞)
+    /// - **Similarity**: Raw dot product value (higher = more similar)
+    /// - **Distance**: Computed as `1 - dot_product`, which is meaningful
+    ///   only for normalized vectors
+    ///
+    /// # When to Use
+    ///
+    /// - **Maximum Inner Product Search (MIPS)**: When you want the highest
+    ///   dot product, not necessarily the closest vector
+    /// - **Pre-normalized vectors**: Equivalent to cosine but faster
+    /// - **Learned embeddings**: Some models are trained with dot product loss
+    ///
+    /// # Important
+    ///
+    /// For non-normalized vectors, dot product is **not** a proper distance
+    /// metric (doesn't satisfy triangle inequality). Use [`Cosine`](DistanceMetric::Cosine)
+    /// for general similarity or ensure vectors are normalized first.
+    DotProduct,
+}
+
+impl DistanceMetric {
+    /// Computes the distance between two vectors using this metric.
+    ///
+    /// Lower values indicate more similar vectors.
+    ///
+    /// # Returns
+    ///
+    /// - [`Cosine`](DistanceMetric::Cosine): `1 - cosine_similarity`, range [0, 2]
+    /// - [`Euclidean`](DistanceMetric::Euclidean): L2 distance, range [0, ∞)
+    /// - [`DotProduct`](DistanceMetric::DotProduct): `1 - dot_product` (meaningful only for normalized vectors)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vectors have different lengths.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::core::vector::DistanceMetric;
+    ///
+    /// let a = vec![1.0, 0.0];
+    /// let b = vec![1.0, 0.0];
+    ///
+    /// // Identical vectors have zero distance
+    /// assert!((DistanceMetric::Cosine.compute_distance(&a, &b).unwrap() - 0.0).abs() < 1e-6);
+    /// assert!((DistanceMetric::Euclidean.compute_distance(&a, &b).unwrap() - 0.0).abs() < 1e-6);
+    /// ```
+    #[inline]
+    pub fn compute_distance(&self, a: &[f32], b: &[f32]) -> Result<f32> {
+        match self {
+            DistanceMetric::Cosine => cosine_similarity(a, b).map(|sim| 1.0 - sim),
+            DistanceMetric::Euclidean => euclidean_distance(a, b),
+            DistanceMetric::DotProduct => dot_product(a, b).map(|dp| 1.0 - dp),
+        }
+    }
+
+    /// Computes the similarity between two vectors using this metric.
+    ///
+    /// Higher values indicate more similar vectors.
+    ///
+    /// # Returns
+    ///
+    /// - [`Cosine`](DistanceMetric::Cosine): Cosine similarity, range [-1, 1]
+    /// - [`Euclidean`](DistanceMetric::Euclidean): `1 / (1 + distance)`, range (0, 1]
+    /// - [`DotProduct`](DistanceMetric::DotProduct): Raw dot product, range (-∞, ∞)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vectors have different lengths.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::core::vector::DistanceMetric;
+    ///
+    /// let a = vec![1.0, 0.0];
+    /// let b = vec![1.0, 0.0];
+    ///
+    /// // Identical vectors have maximum similarity
+    /// assert!((DistanceMetric::Cosine.compute_similarity(&a, &b).unwrap() - 1.0).abs() < 1e-6);
+    /// assert!((DistanceMetric::Euclidean.compute_similarity(&a, &b).unwrap() - 1.0).abs() < 1e-6);
+    /// ```
+    #[inline]
+    pub fn compute_similarity(&self, a: &[f32], b: &[f32]) -> Result<f32> {
+        match self {
+            DistanceMetric::Cosine => cosine_similarity(a, b),
+            DistanceMetric::Euclidean => euclidean_distance(a, b).map(|dist| 1.0 / (1.0 + dist)),
+            DistanceMetric::DotProduct => dot_product(a, b),
+        }
+    }
+
+    /// Returns a human-readable name for this metric.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::core::vector::DistanceMetric;
+    ///
+    /// assert_eq!(DistanceMetric::Cosine.name(), "cosine");
+    /// assert_eq!(DistanceMetric::Euclidean.name(), "euclidean");
+    /// assert_eq!(DistanceMetric::DotProduct.name(), "dot_product");
+    /// ```
+    #[inline]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            DistanceMetric::Cosine => "cosine",
+            DistanceMetric::Euclidean => "euclidean",
+            DistanceMetric::DotProduct => "dot_product",
+        }
+    }
+
+    /// Returns whether this metric requires normalized vectors for optimal results.
+    ///
+    /// - [`Cosine`](DistanceMetric::Cosine): No (handles normalization internally)
+    /// - [`Euclidean`](DistanceMetric::Euclidean): No (works with any vectors)
+    /// - [`DotProduct`](DistanceMetric::DotProduct): Yes (otherwise not a proper similarity)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::core::vector::DistanceMetric;
+    ///
+    /// assert!(!DistanceMetric::Cosine.requires_normalized_vectors());
+    /// assert!(!DistanceMetric::Euclidean.requires_normalized_vectors());
+    /// assert!(DistanceMetric::DotProduct.requires_normalized_vectors());
+    /// ```
+    #[inline]
+    pub const fn requires_normalized_vectors(&self) -> bool {
+        matches!(self, DistanceMetric::DotProduct)
+    }
+}
+
+impl fmt::Display for DistanceMetric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -2812,6 +3043,285 @@ mod tests {
         let c = 1.0 / 3.0_f32.sqrt();
         let v = vec![c, c, c];
         assert!(is_normalized(&v, 1e-6));
+    }
+
+    // ========================================================================
+    // DistanceMetric Tests
+    // ========================================================================
+
+    #[test]
+    fn test_distance_metric_default() {
+        let metric = DistanceMetric::default();
+        assert_eq!(metric, DistanceMetric::Cosine);
+    }
+
+    #[test]
+    fn test_distance_metric_cosine_identical_vectors() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![1.0, 2.0, 3.0];
+
+        // Identical vectors: similarity = 1, distance = 0
+        let similarity = DistanceMetric::Cosine.compute_similarity(&a, &b).unwrap();
+        let distance = DistanceMetric::Cosine.compute_distance(&a, &b).unwrap();
+
+        assert!((similarity - 1.0).abs() < 1e-6);
+        assert!((distance - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_cosine_opposite_vectors() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![-1.0, 0.0, 0.0];
+
+        // Opposite vectors: similarity = -1, distance = 2
+        let similarity = DistanceMetric::Cosine.compute_similarity(&a, &b).unwrap();
+        let distance = DistanceMetric::Cosine.compute_distance(&a, &b).unwrap();
+
+        assert!((similarity - (-1.0)).abs() < 1e-6);
+        assert!((distance - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_cosine_orthogonal_vectors() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+
+        // Orthogonal vectors: similarity = 0, distance = 1
+        let similarity = DistanceMetric::Cosine.compute_similarity(&a, &b).unwrap();
+        let distance = DistanceMetric::Cosine.compute_distance(&a, &b).unwrap();
+
+        assert!((similarity - 0.0).abs() < 1e-6);
+        assert!((distance - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_euclidean_identical_vectors() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![1.0, 2.0, 3.0];
+
+        // Identical vectors: distance = 0, similarity = 1
+        let distance = DistanceMetric::Euclidean.compute_distance(&a, &b).unwrap();
+        let similarity = DistanceMetric::Euclidean
+            .compute_similarity(&a, &b)
+            .unwrap();
+
+        assert!((distance - 0.0).abs() < 1e-6);
+        assert!((similarity - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_euclidean_unit_distance() {
+        let a = vec![0.0, 0.0];
+        let b = vec![1.0, 0.0];
+
+        // Distance = 1, similarity = 1/(1+1) = 0.5
+        let distance = DistanceMetric::Euclidean.compute_distance(&a, &b).unwrap();
+        let similarity = DistanceMetric::Euclidean
+            .compute_similarity(&a, &b)
+            .unwrap();
+
+        assert!((distance - 1.0).abs() < 1e-6);
+        assert!((similarity - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_euclidean_3_4_5_triangle() {
+        let a = vec![0.0, 0.0];
+        let b = vec![3.0, 4.0];
+
+        // Distance = 5, similarity = 1/(1+5) = 1/6
+        let distance = DistanceMetric::Euclidean.compute_distance(&a, &b).unwrap();
+        let similarity = DistanceMetric::Euclidean
+            .compute_similarity(&a, &b)
+            .unwrap();
+
+        assert!((distance - 5.0).abs() < 1e-6);
+        assert!((similarity - (1.0 / 6.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_dot_product_identical_unit_vectors() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![1.0, 0.0, 0.0];
+
+        // Unit vectors: dot = 1, distance = 0
+        let similarity = DistanceMetric::DotProduct
+            .compute_similarity(&a, &b)
+            .unwrap();
+        let distance = DistanceMetric::DotProduct.compute_distance(&a, &b).unwrap();
+
+        assert!((similarity - 1.0).abs() < 1e-6);
+        assert!((distance - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_dot_product_orthogonal_vectors() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+
+        // Orthogonal: dot = 0, distance = 1
+        let similarity = DistanceMetric::DotProduct
+            .compute_similarity(&a, &b)
+            .unwrap();
+        let distance = DistanceMetric::DotProduct.compute_distance(&a, &b).unwrap();
+
+        assert!((similarity - 0.0).abs() < 1e-6);
+        assert!((distance - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_dot_product_opposite_vectors() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![-1.0, 0.0, 0.0];
+
+        // Opposite: dot = -1, distance = 2
+        let similarity = DistanceMetric::DotProduct
+            .compute_similarity(&a, &b)
+            .unwrap();
+        let distance = DistanceMetric::DotProduct.compute_distance(&a, &b).unwrap();
+
+        assert!((similarity - (-1.0)).abs() < 1e-6);
+        assert!((distance - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_distance_metric_dimension_mismatch() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![1.0, 2.0];
+
+        // All metrics should return an error for mismatched dimensions
+        assert!(DistanceMetric::Cosine.compute_distance(&a, &b).is_err());
+        assert!(DistanceMetric::Cosine.compute_similarity(&a, &b).is_err());
+        assert!(DistanceMetric::Euclidean.compute_distance(&a, &b).is_err());
+        assert!(
+            DistanceMetric::Euclidean
+                .compute_similarity(&a, &b)
+                .is_err()
+        );
+        assert!(DistanceMetric::DotProduct.compute_distance(&a, &b).is_err());
+        assert!(
+            DistanceMetric::DotProduct
+                .compute_similarity(&a, &b)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_distance_metric_name() {
+        assert_eq!(DistanceMetric::Cosine.name(), "cosine");
+        assert_eq!(DistanceMetric::Euclidean.name(), "euclidean");
+        assert_eq!(DistanceMetric::DotProduct.name(), "dot_product");
+    }
+
+    #[test]
+    fn test_distance_metric_display() {
+        assert_eq!(format!("{}", DistanceMetric::Cosine), "cosine");
+        assert_eq!(format!("{}", DistanceMetric::Euclidean), "euclidean");
+        assert_eq!(format!("{}", DistanceMetric::DotProduct), "dot_product");
+    }
+
+    #[test]
+    fn test_distance_metric_requires_normalized() {
+        assert!(!DistanceMetric::Cosine.requires_normalized_vectors());
+        assert!(!DistanceMetric::Euclidean.requires_normalized_vectors());
+        assert!(DistanceMetric::DotProduct.requires_normalized_vectors());
+    }
+
+    #[test]
+    fn test_distance_metric_clone_copy() {
+        let metric = DistanceMetric::Cosine;
+        // Both Clone and Copy traits work - use Copy (implicit)
+        let copied1 = metric;
+        let copied2 = metric;
+
+        assert_eq!(metric, copied1);
+        assert_eq!(metric, copied2);
+    }
+
+    #[test]
+    fn test_distance_metric_debug() {
+        assert_eq!(format!("{:?}", DistanceMetric::Cosine), "Cosine");
+        assert_eq!(format!("{:?}", DistanceMetric::Euclidean), "Euclidean");
+        assert_eq!(format!("{:?}", DistanceMetric::DotProduct), "DotProduct");
+    }
+
+    #[test]
+    fn test_distance_metric_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(DistanceMetric::Cosine);
+        set.insert(DistanceMetric::Euclidean);
+        set.insert(DistanceMetric::DotProduct);
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn test_distance_metric_consistency() {
+        // For normalized vectors, cosine similarity should equal dot product
+        let a = normalize(&[3.0, 4.0]);
+        let b = normalize(&[1.0, 0.0]);
+
+        let cosine_sim = DistanceMetric::Cosine.compute_similarity(&a, &b).unwrap();
+        let dot_sim = DistanceMetric::DotProduct
+            .compute_similarity(&a, &b)
+            .unwrap();
+
+        assert!(
+            (cosine_sim - dot_sim).abs() < 1e-5,
+            "For normalized vectors, cosine ({}) should equal dot product ({})",
+            cosine_sim,
+            dot_sim
+        );
+    }
+
+    #[test]
+    fn test_distance_metric_all_metrics_same_order() {
+        // All metrics should agree on which of two vectors is more similar to a query
+        let query = vec![1.0, 0.5, 0.0];
+        let closer = vec![0.9, 0.4, 0.1];
+        let farther = vec![0.1, 0.9, 0.8];
+
+        // Cosine
+        let cosine_closer = DistanceMetric::Cosine
+            .compute_similarity(&query, &closer)
+            .unwrap();
+        let cosine_farther = DistanceMetric::Cosine
+            .compute_similarity(&query, &farther)
+            .unwrap();
+        assert!(
+            cosine_closer > cosine_farther,
+            "Cosine: {} should be > {}",
+            cosine_closer,
+            cosine_farther
+        );
+
+        // Euclidean
+        let eucl_closer = DistanceMetric::Euclidean
+            .compute_distance(&query, &closer)
+            .unwrap();
+        let eucl_farther = DistanceMetric::Euclidean
+            .compute_distance(&query, &farther)
+            .unwrap();
+        assert!(
+            eucl_closer < eucl_farther,
+            "Euclidean: {} should be < {}",
+            eucl_closer,
+            eucl_farther
+        );
+
+        // Dot Product
+        let dot_closer = DistanceMetric::DotProduct
+            .compute_similarity(&query, &closer)
+            .unwrap();
+        let dot_farther = DistanceMetric::DotProduct
+            .compute_similarity(&query, &farther)
+            .unwrap();
+        assert!(
+            dot_closer > dot_farther,
+            "DotProduct: {} should be > {}",
+            dot_closer,
+            dot_farther
+        );
     }
 }
 

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -1578,6 +1578,13 @@ pub fn is_normalized_default(v: &[f32]) -> bool {
 /// 1. Pre-normalize vectors with [`normalize`] or [`normalize_in_place`]
 /// 2. Use [`DotProduct`](DistanceMetric::DotProduct) metric (single SIMD operation)
 /// 3. Store normalized vectors to avoid repeated normalization
+///
+/// # Future Enhancements
+///
+/// - **Serialization**: When serde is added as a dependency, this enum will
+///   support `#[serde(rename_all = "snake_case")]` for JSON/config serialization
+/// - **Batch operations**: `compute_distances_batch()` for SIMD-optimized
+///   multi-vector distance computation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum DistanceMetric {
     /// Cosine similarity/distance.


### PR DESCRIPTION
## Summary

- Implements `DistanceMetric` enum with `Cosine`, `Euclidean`, and `DotProduct` variants
- Provides unified interface for computing distances and similarities between vectors
- Adds comprehensive documentation on when to use each metric

## API

```rust
pub enum DistanceMetric {
    Cosine,      // Default - scale-invariant, best for embeddings
    Euclidean,   // L2 distance, for spatial data
    DotProduct,  // Fastest for pre-normalized vectors
}

impl DistanceMetric {
    pub fn compute_distance(&self, a: &[f32], b: &[f32]) -> Result<f32>;
    pub fn compute_similarity(&self, a: &[f32], b: &[f32]) -> Result<f32>;
    pub fn name(&self) -> &'static str;
    pub fn requires_normalized_vectors(&self) -> bool;
}
```

## Metric Comparison

| Metric | Best For | Similarity Range | Distance Range |
|--------|----------|-----------------|----------------|
| Cosine | Text embeddings | [-1, 1] | [0, 2] |
| Euclidean | Spatial data | (0, 1] | [0, ∞) |
| DotProduct | Pre-normalized vectors | (-∞, ∞) | N/A |

## Test plan

- [x] 19 unit tests for all dispatch paths
- [x] Dimension mismatch error handling test
- [x] Metric consistency test (cosine ≈ dot product for normalized vectors)
- [x] All trait implementations tested (Default, Display, Debug, Clone, Copy, Hash, Eq)
- [x] Clippy and format checks pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)