### PR TITLE
fix: Handle lock poisoning gracefully (Issue #11)

### DIFF
--- a/benches/transactions.rs
+++ b/benches/transactions.rs
@@ -11,7 +11,7 @@ fn bench_read_transaction_creation(c: &mut Criterion) {
 
     c.bench_function("read_transaction_creation", |b| {
         b.iter(|| {
-            let _tx = db.read_transaction();
+            let _tx = db.read_transaction().unwrap();
         });
     });
 }
@@ -21,7 +21,7 @@ fn bench_write_transaction_creation(c: &mut Criterion) {
 
     c.bench_function("write_transaction_creation", |b| {
         b.iter(|| {
-            let _tx = db.write_transaction();
+            let _tx = db.write_transaction().unwrap();
         });
     });
 }
@@ -91,7 +91,7 @@ fn bench_explicit_transaction_commit(c: &mut Criterion) {
 
     c.bench_function("explicit_transaction_commit", |b| {
         b.iter(|| {
-            let mut tx = db.write_transaction();
+            let mut tx = db.write_transaction().unwrap();
             tx.create_node(
                 "Person",
                 PropertyMapBuilder::new().insert("name", "Test").build(),
@@ -119,7 +119,7 @@ fn bench_implicit_vs_explicit(c: &mut Criterion) {
 
     group.bench_function("explicit_create_node", |b| {
         b.iter(|| {
-            let mut tx = db.write_transaction();
+            let mut tx = db.write_transaction().unwrap();
             tx.create_node(
                 "Person",
                 PropertyMapBuilder::new().insert("name", "Test").build(),

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -6,6 +6,7 @@
 
 use crate::api::transaction::types::TxId;
 use crate::core::temporal::Timestamp;
+use crate::utils::lock::MutexExt;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Mutex;
 
@@ -85,8 +86,13 @@ impl TxVisibilityManager {
     ///
     /// # Arguments
     /// * `tx_id` - The ID of the transaction being started
+    ///
+    /// # Note
+    ///
+    /// Uses lock recovery to prevent cascade panics if the lock was poisoned
+    /// by a panicking thread. The transaction set can safely be used after recovery.
     pub fn register_active(&self, tx_id: TxId) {
-        let mut active = self.active.lock().unwrap();
+        let mut active = self.active.lock_or_recover();
         active.insert(tx_id);
     }
 
@@ -102,7 +108,7 @@ impl TxVisibilityManager {
     /// # Returns
     /// A `TransactionSnapshot` capturing the current visibility state
     pub fn capture_snapshot(&self, snapshot_timestamp: Timestamp) -> TransactionSnapshot {
-        let active = self.active.lock().unwrap();
+        let active = self.active.lock_or_recover();
         TransactionSnapshot {
             snapshot_timestamp,
             active_transactions: active.clone(),
@@ -119,10 +125,10 @@ impl TxVisibilityManager {
     /// * `tx_id` - The ID of the committing transaction
     /// * `commit_timestamp` - When the transaction committed
     pub fn register_commit(&self, tx_id: TxId, commit_timestamp: Timestamp) {
-        let mut active = self.active.lock().unwrap();
+        let mut active = self.active.lock_or_recover();
         active.remove(&tx_id);
 
-        let mut committed = self.committed.lock().unwrap();
+        let mut committed = self.committed.lock_or_recover();
         committed.insert(tx_id, commit_timestamp);
     }
 
@@ -134,7 +140,7 @@ impl TxVisibilityManager {
     /// # Arguments
     /// * `tx_id` - The ID of the aborting transaction
     pub fn register_abort(&self, tx_id: TxId) {
-        let mut active = self.active.lock().unwrap();
+        let mut active = self.active.lock_or_recover();
         active.remove(&tx_id);
     }
 
@@ -157,7 +163,7 @@ impl TxVisibilityManager {
         }
 
         // Check if transaction committed
-        let committed = self.committed.lock().unwrap();
+        let committed = self.committed.lock_or_recover();
 
         match committed.get(&created_by_tx) {
             None => false, // Not committed - not visible
@@ -173,7 +179,7 @@ impl TxVisibilityManager {
     /// This is primarily useful for testing and monitoring.
     #[allow(dead_code)]
     pub fn active_count(&self) -> usize {
-        let active = self.active.lock().unwrap();
+        let active = self.active.lock_or_recover();
         active.len()
     }
 
@@ -182,7 +188,7 @@ impl TxVisibilityManager {
     /// This is primarily useful for testing and monitoring.
     #[allow(dead_code)]
     pub fn committed_count(&self) -> usize {
-        let committed = self.committed.lock().unwrap();
+        let committed = self.committed.lock_or_recover();
         committed.len()
     }
 }

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -63,6 +63,16 @@ impl TransactionSnapshot {
 /// - Transactions don't see uncommitted changes from other transactions
 /// - Transactions don't see changes committed after their snapshot time
 /// - Write-write conflicts are detected at commit time
+///
+/// # Lock Recovery Safety
+///
+/// This struct uses `lock_or_recover()` for all lock acquisitions. This is safe
+/// because the protected data structures (`HashSet<TxId>` and `BTreeMap<TxId, Timestamp>`)
+/// have no complex invariants that could be violated by a mid-operation panic:
+///
+/// - **Worst case**: A transaction ID may be missing from the active/committed sets
+/// - **Behavior**: This fails safe by being conservative (treating as uncommitted/not visible)
+/// - **No corruption**: Standard library collections remain valid after partial operations
 pub struct TxVisibilityManager {
     /// Currently active transactions
     active: Mutex<HashSet<TxId>>,

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -24,6 +24,7 @@ use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 use crate::storage::wal::{WalOperation, WriteAheadLog};
 use crate::utils::error::{Result, StorageError, TransactionError};
+use crate::utils::lock::MutexExt;
 use std::sync::{Arc, Mutex};
 
 /// Write transaction with full ACID guarantees.
@@ -520,7 +521,7 @@ impl WriteTransaction {
                     self.current.insert_node_direct(node)?;
 
                     // Store in historical storage
-                    self.historical.lock().unwrap().add_node_version(
+                    self.historical.lock_or_err()?.add_node_version(
                         *node_id,
                         *version_id,
                         temporal,
@@ -529,7 +530,7 @@ impl WriteTransaction {
                     )?;
 
                     // Index in temporal indexes
-                    self.temporal_indexes.lock().unwrap().insert_node_version(
+                    self.temporal_indexes.lock_or_err()?.insert_node_version(
                         *node_id,
                         *version_id,
                         temporal,
@@ -558,7 +559,7 @@ impl WriteTransaction {
                     self.current.insert_edge_direct(edge)?;
 
                     // Store in historical storage
-                    self.historical.lock().unwrap().add_edge_version(
+                    self.historical.lock_or_err()?.add_edge_version(
                         *edge_id,
                         *version_id,
                         temporal,
@@ -569,7 +570,7 @@ impl WriteTransaction {
                     )?;
 
                     // Index in temporal indexes
-                    self.temporal_indexes.lock().unwrap().insert_edge_version(
+                    self.temporal_indexes.lock_or_err()?.insert_edge_version(
                         *edge_id,
                         *version_id,
                         temporal,
@@ -594,7 +595,7 @@ impl WriteTransaction {
                     self.current.update_node_direct(node)?;
 
                     // Add new version to historical storage
-                    self.historical.lock().unwrap().add_node_version(
+                    self.historical.lock_or_err()?.add_node_version(
                         *node_id,
                         *version_id,
                         temporal,
@@ -603,7 +604,7 @@ impl WriteTransaction {
                     )?;
 
                     // Index in temporal indexes
-                    self.temporal_indexes.lock().unwrap().insert_node_version(
+                    self.temporal_indexes.lock_or_err()?.insert_node_version(
                         *node_id,
                         *version_id,
                         temporal,
@@ -632,7 +633,7 @@ impl WriteTransaction {
                     self.current.update_edge_direct(edge)?;
 
                     // Add new version to historical storage
-                    self.historical.lock().unwrap().add_edge_version(
+                    self.historical.lock_or_err()?.add_edge_version(
                         *edge_id,
                         *version_id,
                         temporal,
@@ -643,7 +644,7 @@ impl WriteTransaction {
                     )?;
 
                     // Index in temporal indexes
-                    self.temporal_indexes.lock().unwrap().insert_edge_version(
+                    self.temporal_indexes.lock_or_err()?.insert_edge_version(
                         *edge_id,
                         *version_id,
                         temporal,
@@ -655,14 +656,14 @@ impl WriteTransaction {
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
-                        VersionId::new(self.version_id_gen.lock().unwrap().next());
+                        VersionId::new(self.version_id_gen.lock_or_err()?.next());
 
                     // Create closed temporal interval marking deletion time
                     let tombstone_temporal = BiTemporalInterval::current(commit_timestamp)
                         .close_transaction_time(commit_timestamp);
 
                     // Add tombstone version to historical storage
-                    self.historical.lock().unwrap().add_node_version(
+                    self.historical.lock_or_err()?.add_node_version(
                         *node_id,
                         tombstone_version_id,
                         tombstone_temporal,
@@ -671,7 +672,7 @@ impl WriteTransaction {
                     )?;
 
                     // Index the tombstone version
-                    self.temporal_indexes.lock().unwrap().insert_node_version(
+                    self.temporal_indexes.lock_or_err()?.insert_node_version(
                         *node_id,
                         tombstone_version_id,
                         tombstone_temporal,
@@ -686,14 +687,14 @@ impl WriteTransaction {
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
-                        VersionId::new(self.version_id_gen.lock().unwrap().next());
+                        VersionId::new(self.version_id_gen.lock_or_err()?.next());
 
                     // Create closed temporal interval marking deletion time
                     let tombstone_temporal = BiTemporalInterval::current(commit_timestamp)
                         .close_transaction_time(commit_timestamp);
 
                     // Add tombstone version to historical storage
-                    self.historical.lock().unwrap().add_edge_version(
+                    self.historical.lock_or_err()?.add_edge_version(
                         *edge_id,
                         tombstone_version_id,
                         tombstone_temporal,
@@ -704,7 +705,7 @@ impl WriteTransaction {
                     )?;
 
                     // Index the tombstone version
-                    self.temporal_indexes.lock().unwrap().insert_edge_version(
+                    self.temporal_indexes.lock_or_err()?.insert_edge_version(
                         *edge_id,
                         tombstone_version_id,
                         tombstone_temporal,
@@ -896,8 +897,8 @@ impl WriteOps for WriteTransaction {
         }
 
         // Generate IDs
-        let node_id = NodeId::new(self.node_id_gen.lock().unwrap().next());
-        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+        let node_id = NodeId::new(self.node_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         // Get timestamp for temporal interval
@@ -933,8 +934,8 @@ impl WriteOps for WriteTransaction {
         }
 
         // Generate IDs
-        let edge_id = EdgeId::new(self.edge_id_gen.lock().unwrap().next());
-        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+        let edge_id = EdgeId::new(self.edge_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         // Get timestamp for temporal interval
@@ -967,7 +968,7 @@ impl WriteOps for WriteTransaction {
 
         // Get current node to preserve label
         let node = self.current.get_node(node_id)?;
-        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
 
         // Get timestamp for temporal interval
         let timestamp = self.start_timestamp;
@@ -997,7 +998,7 @@ impl WriteOps for WriteTransaction {
 
         // Get current edge to preserve source, target, label
         let edge = self.current.get_edge(edge_id)?;
-        let version_id = VersionId::new(self.version_id_gen.lock().unwrap().next());
+        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
 
         // Get timestamp for temporal interval
         let timestamp = self.start_timestamp;

--- a/src/db.rs
+++ b/src/db.rs
@@ -16,6 +16,7 @@ use crate::storage::historical::HistoricalStorage;
 use crate::storage::version::AnchorConfig;
 use crate::storage::wal::{WalConfig, WriteAheadLog};
 use crate::utils::error::{Result, StorageError};
+use crate::utils::lock::MutexExt;
 use std::sync::{Arc, Mutex};
 
 /// Main GallifreyDB database.
@@ -77,16 +78,20 @@ impl GallifreyDB {
     /// - Snapshot-based reads for consistency
     /// - No commit overhead
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the timestamp lock is poisoned.
+    ///
     /// # Example
     ///
     /// ```ignore
-    /// let tx = db.read_transaction();
+    /// let tx = db.read_transaction()?;
     /// let node = tx.get_node(node_id)?;
     /// // No commit needed - transaction is read-only
     /// ```
-    pub fn read_transaction(&self) -> ReadTransaction {
+    pub fn read_transaction(&self) -> Result<ReadTransaction> {
         let tx_id = self.tx_id_gen.next();
-        let snapshot_timestamp = *self.current_timestamp.lock().unwrap();
+        let snapshot_timestamp = *self.current_timestamp.lock_or_err()?;
 
         // Register as active
         self.visibility_manager.register_active(tx_id);
@@ -94,12 +99,12 @@ impl GallifreyDB {
         // Capture snapshot
         let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-        ReadTransaction::new(
+        Ok(ReadTransaction::new(
             tx_id,
             snapshot,
             Arc::clone(&self.current),
             Arc::clone(&self.visibility_manager),
-        )
+        ))
     }
 
     /// Execute a read-only operation in a transaction.
@@ -119,7 +124,7 @@ impl GallifreyDB {
     where
         F: FnOnce(&ReadTransaction) -> Result<T>,
     {
-        let tx = self.read_transaction();
+        let tx = self.read_transaction()?;
         f(&tx)
     }
 
@@ -131,17 +136,21 @@ impl GallifreyDB {
     /// - **Isolation**: Snapshot Isolation with write-write conflict detection
     /// - **Durability**: WAL with fsync for true durability
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the timestamp lock is poisoned.
+    ///
     /// # Example
     ///
     /// ```ignore
-    /// let mut tx = db.write_transaction();
+    /// let mut tx = db.write_transaction()?;
     /// let node_id = tx.create_node("Person", props)?;
     /// tx.create_edge(node_id, other, "KNOWS", edge_props)?;
     /// tx.commit()?;  // or tx.rollback()
     /// ```
-    pub fn write_transaction(&self) -> WriteTransaction {
+    pub fn write_transaction(&self) -> Result<WriteTransaction> {
         let tx_id = self.tx_id_gen.next();
-        let snapshot_timestamp = *self.current_timestamp.lock().unwrap();
+        let snapshot_timestamp = *self.current_timestamp.lock_or_err()?;
 
         // Register as active
         self.visibility_manager.register_active(tx_id);
@@ -149,7 +158,7 @@ impl GallifreyDB {
         // Capture snapshot
         let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-        WriteTransaction::new(
+        Ok(WriteTransaction::new(
             tx_id,
             snapshot,
             Arc::clone(&self.current),
@@ -161,7 +170,7 @@ impl GallifreyDB {
             Arc::clone(&self.node_id_gen),
             Arc::clone(&self.edge_id_gen),
             Arc::clone(&self.version_id_gen),
-        )
+        ))
     }
 
     /// Execute a write operation in a transaction.
@@ -182,7 +191,7 @@ impl GallifreyDB {
     where
         F: FnOnce(&mut WriteTransaction) -> Result<T>,
     {
-        let mut tx = self.write_transaction();
+        let mut tx = self.write_transaction()?;
         let result = f(&mut tx)?;
         tx.commit()?;
         Ok(result)
@@ -246,7 +255,7 @@ impl GallifreyDB {
         valid_time: Timestamp,
         transaction_time: Timestamp,
     ) -> Result<Node> {
-        let historical = self.historical.lock().unwrap();
+        let historical = self.historical.lock_or_err()?;
 
         // Find the version valid at this time
         let version_id = historical
@@ -277,7 +286,7 @@ impl GallifreyDB {
         valid_time: Timestamp,
         transaction_time: Timestamp,
     ) -> Result<Edge> {
-        let historical = self.historical.lock().unwrap();
+        let historical = self.historical.lock_or_err()?;
 
         let version_id = historical
             .find_edge_version_at_time(edge_id, valid_time, transaction_time)
@@ -324,8 +333,12 @@ impl GallifreyDB {
     }
 
     /// Get statistics about the historical storage.
-    pub fn historical_stats(&self) -> crate::storage::historical::HistoricalStats {
-        self.historical.lock().unwrap().stats()
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the historical storage lock is poisoned.
+    pub fn historical_stats(&self) -> Result<crate::storage::historical::HistoricalStats> {
+        Ok(self.historical.lock_or_err()?.stats())
     }
 }
 
@@ -455,7 +468,7 @@ mod tests {
         db.create_node("Person", PropertyMapBuilder::new().build())
             .unwrap();
 
-        let stats = db.historical_stats();
+        let stats = db.historical_stats().unwrap();
         assert_eq!(stats.total_node_versions, 2);
         assert_eq!(stats.node_anchor_count, 2); // First versions are always anchors
     }
@@ -530,7 +543,7 @@ mod tests {
     fn test_explicit_write_transaction() {
         let db = GallifreyDB::new();
 
-        let mut tx = db.write_transaction();
+        let mut tx = db.write_transaction().unwrap();
         let n1 = tx
             .create_node(
                 "Person",
@@ -568,7 +581,7 @@ mod tests {
             )
             .unwrap();
 
-        let tx = db.read_transaction();
+        let tx = db.read_transaction().unwrap();
         let node = tx.get_node(node_id).unwrap();
         assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(42));
 
@@ -663,7 +676,7 @@ mod tests {
             .unwrap();
 
         // Start a read transaction - captures snapshot
-        let tx1 = db.read_transaction();
+        let tx1 = db.read_transaction().unwrap();
         let node_v1 = tx1.get_node(node_id).unwrap();
         assert_eq!(
             node_v1.get_property("version").and_then(|v| v.as_int()),

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -8,6 +8,7 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
 use crate::index::adjacency::{AdjacencyEntry, AdjacencyIndex};
+use crate::utils::lock::RwLockExt;
 use dashmap::DashMap;
 use std::sync::{Arc, RwLock};
 
@@ -64,7 +65,7 @@ impl CurrentIndexes {
     /// Acquires `rebuild_lock` in read mode to coordinate with concurrent
     /// adjacency rebuilds (which hold write lock).
     pub fn insert_edge(&self, edge: Edge) {
-        let _guard = self.rebuild_lock.read().unwrap();
+        let _guard = self.rebuild_lock.read_or_recover();
         self.edges.insert(edge.id, edge);
     }
 
@@ -88,7 +89,7 @@ impl CurrentIndexes {
     /// Acquires `rebuild_lock` in read mode to coordinate with concurrent
     /// adjacency rebuilds (which hold write lock).
     pub fn remove_edge(&self, id: EdgeId) -> Option<Edge> {
-        let _guard = self.rebuild_lock.read().unwrap();
+        let _guard = self.rebuild_lock.read_or_recover();
         self.edges.remove(&id).map(|(_, edge)| edge)
     }
 
@@ -121,7 +122,7 @@ impl CurrentIndexes {
     /// Returns a copy of the adjacency list for traversal.
     #[inline]
     pub fn get_outgoing(&self, source: NodeId) -> Vec<AdjacencyEntry> {
-        let outgoing = self.outgoing.read().unwrap();
+        let outgoing = self.outgoing.read_or_recover();
         outgoing.get_adjacency(source).to_vec()
     }
 
@@ -130,7 +131,7 @@ impl CurrentIndexes {
     /// Returns a copy of the adjacency list for reverse traversal.
     #[inline]
     pub fn get_incoming(&self, target: NodeId) -> Vec<AdjacencyEntry> {
-        let incoming = self.incoming.read().unwrap();
+        let incoming = self.incoming.read_or_recover();
         incoming.get_adjacency(target).to_vec()
     }
 
@@ -140,7 +141,7 @@ impl CurrentIndexes {
         source: NodeId,
         label: InternedString,
     ) -> Vec<AdjacencyEntry> {
-        let outgoing = self.outgoing.read().unwrap();
+        let outgoing = self.outgoing.read_or_recover();
         outgoing
             .get_adjacency_with_label(source, label)
             .copied()
@@ -153,7 +154,7 @@ impl CurrentIndexes {
         target: NodeId,
         label: InternedString,
     ) -> Vec<AdjacencyEntry> {
-        let incoming = self.incoming.read().unwrap();
+        let incoming = self.incoming.read_or_recover();
         incoming
             .get_adjacency_with_label(target, label)
             .copied()
@@ -163,14 +164,14 @@ impl CurrentIndexes {
     /// Get the out-degree of a node (number of outgoing edges).
     #[inline]
     pub fn out_degree(&self, node: NodeId) -> usize {
-        let outgoing = self.outgoing.read().unwrap();
+        let outgoing = self.outgoing.read_or_recover();
         outgoing.degree(node)
     }
 
     /// Get the in-degree of a node (number of incoming edges).
     #[inline]
     pub fn in_degree(&self, node: NodeId) -> usize {
-        let incoming = self.incoming.read().unwrap();
+        let incoming = self.incoming.read_or_recover();
         incoming.degree(node)
     }
 
@@ -219,7 +220,7 @@ impl CurrentIndexes {
         // Acquire write lock to block concurrent edge modifications.
         // This ensures all edges in the DashMap at iteration start will
         // be present in the rebuilt indexes.
-        let _guard = self.rebuild_lock.write().unwrap();
+        let _guard = self.rebuild_lock.write_or_recover();
 
         let mut outgoing_edges = Vec::new();
         let mut incoming_edges = Vec::new();
@@ -232,8 +233,8 @@ impl CurrentIndexes {
         }
 
         // Rebuild indexes with write locks
-        *self.outgoing.write().unwrap() = AdjacencyIndex::build(outgoing_edges);
-        *self.incoming.write().unwrap() = AdjacencyIndex::build(incoming_edges);
+        *self.outgoing.write_or_recover() = AdjacencyIndex::build(outgoing_edges);
+        *self.incoming.write_or_recover() = AdjacencyIndex::build(incoming_edges);
     }
 
     /// Iterate over all nodes.

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -26,6 +26,16 @@ use std::sync::{Arc, RwLock};
 ///
 /// This prevents the race condition where edges inserted during a rebuild
 /// could be lost from the adjacency indexes.
+///
+/// # Lock Recovery Safety
+///
+/// This struct uses `read_or_recover()`/`write_or_recover()` for adjacency index
+/// access. This is safe because:
+///
+/// - **AdjacencyIndex**: Contains `Vec<AdjacencyEntry>` with no complex invariants
+/// - **Worst case**: An adjacency list may be incomplete after a panic
+/// - **Recovery**: `rebuild_adjacency()` can always reconstruct correct state from edges
+/// - **Hot path**: Recovery avoids cascade panics on the performance-critical traversal path
 pub struct CurrentIndexes {
     /// Node ID → Node (O(1) lookup)
     nodes: DashMap<NodeId, Node>,

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -137,7 +137,7 @@ pub enum StorageError {
     /// error instead of panicking.
     LockPoisoned {
         /// The type of lock that was poisoned (e.g., "Mutex", "RwLock")
-        lock_type: String,
+        lock_type: &'static str,
     },
 }
 
@@ -562,9 +562,7 @@ mod tests {
         assert!(format!("{}", err).contains("bad checksum"));
 
         // Test LockPoisoned
-        let err = StorageError::LockPoisoned {
-            lock_type: "Mutex".to_string(),
-        };
+        let err = StorageError::LockPoisoned { lock_type: "Mutex" };
         assert!(format!("{}", err).contains("Mutex"));
         assert!(format!("{}", err).contains("lock poisoned"));
         assert!(format!("{}", err).contains("panicked"));

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -130,6 +130,15 @@ pub enum StorageError {
     IoError(String),
     /// Corrupted data detected.
     CorruptedData(String),
+    /// A lock was poisoned by a panicking thread.
+    ///
+    /// This occurs when a thread panics while holding a lock, causing subsequent
+    /// lock acquisitions to fail. This prevents cascade panics by returning an
+    /// error instead of panicking.
+    LockPoisoned {
+        /// The type of lock that was poisoned (e.g., "Mutex", "RwLock")
+        lock_type: String,
+    },
 }
 
 impl fmt::Display for StorageError {
@@ -155,6 +164,13 @@ impl fmt::Display for StorageError {
             }
             StorageError::IoError(msg) => write!(f, "I/O error: {}", msg),
             StorageError::CorruptedData(msg) => write!(f, "Corrupted data: {}", msg),
+            StorageError::LockPoisoned { lock_type } => {
+                write!(
+                    f,
+                    "{} lock poisoned: a thread panicked while holding this lock",
+                    lock_type
+                )
+            }
         }
     }
 }
@@ -544,6 +560,14 @@ mod tests {
         let err = StorageError::CorruptedData("bad checksum".to_string());
         assert!(format!("{}", err).contains("Corrupted data"));
         assert!(format!("{}", err).contains("bad checksum"));
+
+        // Test LockPoisoned
+        let err = StorageError::LockPoisoned {
+            lock_type: "Mutex".to_string(),
+        };
+        assert!(format!("{}", err).contains("Mutex"));
+        assert!(format!("{}", err).contains("lock poisoned"));
+        assert!(format!("{}", err).contains("panicked"));
     }
 
     #[test]

--- a/src/utils/lock.rs
+++ b/src/utils/lock.rs
@@ -56,9 +56,8 @@ pub trait MutexExt<T> {
 
 impl<T> MutexExt<T> for Mutex<T> {
     fn lock_or_err(&self) -> Result<MutexGuard<'_, T>, Error> {
-        self.lock().map_err(|_| {
-            StorageError::LockPoisoned { lock_type: "Mutex" }.into()
-        })
+        self.lock()
+            .map_err(|_| StorageError::LockPoisoned { lock_type: "Mutex" }.into())
     }
 
     fn lock_or_recover(&self) -> MutexGuard<'_, T> {
@@ -104,13 +103,19 @@ pub trait RwLockExt<T> {
 impl<T> RwLockExt<T> for RwLock<T> {
     fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
         self.read().map_err(|_| {
-            StorageError::LockPoisoned { lock_type: "RwLock" }.into()
+            StorageError::LockPoisoned {
+                lock_type: "RwLock",
+            }
+            .into()
         })
     }
 
     fn write_or_err(&self) -> Result<RwLockWriteGuard<'_, T>, Error> {
         self.write().map_err(|_| {
-            StorageError::LockPoisoned { lock_type: "RwLock" }.into()
+            StorageError::LockPoisoned {
+                lock_type: "RwLock",
+            }
+            .into()
         })
     }
 

--- a/src/utils/lock.rs
+++ b/src/utils/lock.rs
@@ -1,0 +1,279 @@
+//! Lock utility extensions for graceful error handling.
+//!
+//! This module provides extension traits for `Mutex` and `RwLock` that return
+//! `Result` types instead of panicking on lock poisoning. This prevents cascade
+//! failures where a single panicking thread causes all subsequent lock acquisitions
+//! to panic.
+//!
+//! # Lock Poisoning
+//!
+//! In Rust, when a thread panics while holding a lock, the lock becomes "poisoned".
+//! By default, attempting to acquire a poisoned lock will panic. This module provides
+//! methods that return errors instead, allowing callers to handle the situation
+//! gracefully.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use gallifreydb::utils::lock::LockExt;
+//!
+//! let mutex = Mutex::new(42);
+//! let guard = mutex.lock_or_err()?;
+//! ```
+
+use std::sync::{Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use super::error::{Error, StorageError};
+
+/// Extension trait for `Mutex` providing graceful error handling.
+pub trait MutexExt<T> {
+    /// Acquire the lock, returning an error if the lock is poisoned.
+    ///
+    /// This method is equivalent to `lock().unwrap()` but returns a `Result`
+    /// instead of panicking, allowing callers to handle lock poisoning gracefully.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Storage(StorageError::LockPoisoned)` if the lock has been
+    /// poisoned by a panicking thread.
+    fn lock_or_err(&self) -> Result<MutexGuard<'_, T>, Error>;
+
+    /// Acquire the lock, recovering the data even if poisoned.
+    ///
+    /// This method acquires the lock regardless of whether it's poisoned,
+    /// using `into_inner()` to extract the data. Use with caution - the
+    /// protected data may be in an inconsistent state if a thread panicked
+    /// while modifying it.
+    ///
+    /// # Safety Considerations
+    ///
+    /// Only use this method when:
+    /// - The protected data has no invariants that could be violated
+    /// - You can validate/repair the data after acquisition
+    /// - Availability is more important than consistency
+    fn lock_or_recover(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> MutexExt<T> for Mutex<T> {
+    fn lock_or_err(&self) -> Result<MutexGuard<'_, T>, Error> {
+        self.lock().map_err(|_| {
+            StorageError::LockPoisoned {
+                lock_type: "Mutex".to_string(),
+            }
+            .into()
+        })
+    }
+
+    fn lock_or_recover(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Extension trait for `RwLock` providing graceful error handling.
+pub trait RwLockExt<T> {
+    /// Acquire a read lock, returning an error if the lock is poisoned.
+    ///
+    /// This method is equivalent to `read().unwrap()` but returns a `Result`
+    /// instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Storage(StorageError::LockPoisoned)` if the lock has been
+    /// poisoned by a panicking thread.
+    fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error>;
+
+    /// Acquire a write lock, returning an error if the lock is poisoned.
+    ///
+    /// This method is equivalent to `write().unwrap()` but returns a `Result`
+    /// instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Storage(StorageError::LockPoisoned)` if the lock has been
+    /// poisoned by a panicking thread.
+    fn write_or_err(&self) -> Result<RwLockWriteGuard<'_, T>, Error>;
+
+    /// Acquire a read lock, recovering even if poisoned.
+    ///
+    /// Use with caution - see `MutexExt::lock_or_recover` for safety considerations.
+    fn read_or_recover(&self) -> RwLockReadGuard<'_, T>;
+
+    /// Acquire a write lock, recovering even if poisoned.
+    ///
+    /// Use with caution - see `MutexExt::lock_or_recover` for safety considerations.
+    fn write_or_recover(&self) -> RwLockWriteGuard<'_, T>;
+}
+
+impl<T> RwLockExt<T> for RwLock<T> {
+    fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
+        self.read().map_err(|_| {
+            StorageError::LockPoisoned {
+                lock_type: "RwLock".to_string(),
+            }
+            .into()
+        })
+    }
+
+    fn write_or_err(&self) -> Result<RwLockWriteGuard<'_, T>, Error> {
+        self.write().map_err(|_| {
+            StorageError::LockPoisoned {
+                lock_type: "RwLock".to_string(),
+            }
+            .into()
+        })
+    }
+
+    fn read_or_recover(&self) -> RwLockReadGuard<'_, T> {
+        self.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn write_or_recover(&self) -> RwLockWriteGuard<'_, T> {
+        self.write().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn test_mutex_lock_or_err_success() {
+        let mutex = Mutex::new(42);
+        let guard = mutex.lock_or_err().unwrap();
+        assert_eq!(*guard, 42);
+    }
+
+    #[test]
+    fn test_rwlock_read_or_err_success() {
+        let rwlock = RwLock::new(42);
+        let guard = rwlock.read_or_err().unwrap();
+        assert_eq!(*guard, 42);
+    }
+
+    #[test]
+    fn test_rwlock_write_or_err_success() {
+        let rwlock = RwLock::new(42);
+        let mut guard = rwlock.write_or_err().unwrap();
+        *guard = 100;
+        drop(guard);
+        assert_eq!(*rwlock.read_or_err().unwrap(), 100);
+    }
+
+    #[test]
+    fn test_mutex_lock_or_err_poisoned() {
+        let mutex = Arc::new(Mutex::new(42));
+        let mutex_clone = Arc::clone(&mutex);
+
+        // Panic while holding the lock to poison it
+        let handle = thread::spawn(move || {
+            let _guard = mutex_clone.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        // Wait for the thread to finish (it will panic)
+        let _ = handle.join();
+
+        // Now try to acquire the poisoned lock
+        let result = mutex.lock_or_err();
+        assert!(result.is_err());
+
+        // Verify it's the right error type
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!("Expected LockPoisoned error");
+        }
+    }
+
+    #[test]
+    fn test_mutex_lock_or_recover_poisoned() {
+        let mutex = Arc::new(Mutex::new(42));
+        let mutex_clone = Arc::clone(&mutex);
+
+        // Panic while holding the lock to poison it
+        let handle = thread::spawn(move || {
+            let mut guard = mutex_clone.lock().unwrap();
+            *guard = 100; // Modify before panic
+            panic!("intentional panic to poison lock");
+        });
+
+        // Wait for the thread to finish (it will panic)
+        let _ = handle.join();
+
+        // Should be able to recover the data
+        let guard = mutex.lock_or_recover();
+        assert_eq!(*guard, 100);
+    }
+
+    #[test]
+    fn test_rwlock_read_or_err_poisoned() {
+        let rwlock = Arc::new(RwLock::new(42));
+        let rwlock_clone = Arc::clone(&rwlock);
+
+        // Panic while holding a write lock to poison it
+        let handle = thread::spawn(move || {
+            let _guard = rwlock_clone.write().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let result = rwlock.read_or_err();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rwlock_write_or_err_poisoned() {
+        let rwlock = Arc::new(RwLock::new(42));
+        let rwlock_clone = Arc::clone(&rwlock);
+
+        let handle = thread::spawn(move || {
+            let _guard = rwlock_clone.write().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let result = rwlock.write_or_err();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rwlock_read_or_recover_poisoned() {
+        let rwlock = Arc::new(RwLock::new(42));
+        let rwlock_clone = Arc::clone(&rwlock);
+
+        let handle = thread::spawn(move || {
+            let mut guard = rwlock_clone.write().unwrap();
+            *guard = 100;
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let guard = rwlock.read_or_recover();
+        assert_eq!(*guard, 100);
+    }
+
+    #[test]
+    fn test_rwlock_write_or_recover_poisoned() {
+        let rwlock = Arc::new(RwLock::new(42));
+        let rwlock_clone = Arc::clone(&rwlock);
+
+        let handle = thread::spawn(move || {
+            let mut guard = rwlock_clone.write().unwrap();
+            *guard = 100;
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let mut guard = rwlock.write_or_recover();
+        assert_eq!(*guard, 100);
+        *guard = 200;
+        drop(guard);
+        assert_eq!(*rwlock.read_or_recover(), 200);
+    }
+}

--- a/src/utils/lock.rs
+++ b/src/utils/lock.rs
@@ -57,10 +57,7 @@ pub trait MutexExt<T> {
 impl<T> MutexExt<T> for Mutex<T> {
     fn lock_or_err(&self) -> Result<MutexGuard<'_, T>, Error> {
         self.lock().map_err(|_| {
-            StorageError::LockPoisoned {
-                lock_type: "Mutex".to_string(),
-            }
-            .into()
+            StorageError::LockPoisoned { lock_type: "Mutex" }.into()
         })
     }
 
@@ -107,19 +104,13 @@ pub trait RwLockExt<T> {
 impl<T> RwLockExt<T> for RwLock<T> {
     fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
         self.read().map_err(|_| {
-            StorageError::LockPoisoned {
-                lock_type: "RwLock".to_string(),
-            }
-            .into()
+            StorageError::LockPoisoned { lock_type: "RwLock" }.into()
         })
     }
 
     fn write_or_err(&self) -> Result<RwLockWriteGuard<'_, T>, Error> {
         self.write().map_err(|_| {
-            StorageError::LockPoisoned {
-                lock_type: "RwLock".to_string(),
-            }
-            .into()
+            StorageError::LockPoisoned { lock_type: "RwLock" }.into()
         })
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,8 @@
 //! Utility modules for GallifreyDB.
 
 pub mod error;
+pub mod lock;
 
 // Re-export commonly used types
 pub use error::{Error, QueryError, Result, StorageError, TemporalError, TransactionError};
+pub use lock::{MutexExt, RwLockExt};


### PR DESCRIPTION
## Summary
- Implements `MutexExt` and `RwLockExt` traits for graceful lock error handling
- Replaces all `.unwrap()` calls on lock acquisitions with safe alternatives
- Prevents cascade panics when a thread panics while holding a lock

## Changes

### New `src/utils/lock.rs`
Extension traits with two strategies for handling poisoned locks:
- **`lock_or_err()`**: Returns `Result<Guard, Error>` for operations that should propagate the error
- **`lock_or_recover()`**: Uses `PoisonError::into_inner()` to recover the data (safe for many internal operations)

### API Changes
- `db.read_transaction()` → `Result<ReadTransaction>`
- `db.write_transaction()` → `Result<WriteTransaction>`
- `db.historical_stats()` → `Result<HistoricalStats>`

### Internal Changes
- **visibility.rs**: Uses `lock_or_recover()` for internal state management
- **write_tx.rs**: Uses `lock_or_err()?` for transactional operations
- **current.rs**: Uses `read_or_recover()`/`write_or_recover()` for index operations

## Test plan
- [x] All 408 existing tests pass
- [x] New tests for lock poisoning scenarios:
  - `test_mutex_lock_or_err_poisoned`
  - `test_mutex_lock_or_recover_poisoned`
  - `test_rwlock_read_or_err_poisoned`
  - `test_rwlock_write_or_err_poisoned`
  - `test_rwlock_read_or_recover_poisoned`
  - `test_rwlock_write_or_recover_poisoned`
- [x] Clippy passes with no warnings

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)