### PR TITLE
feat(error): Add remaining VectorError variants (VS-010)

### DIFF
--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -825,21 +825,23 @@ mod tests {
         assert!(format!("{}", err).contains("100000"));
 
         let err = VectorError::IndexOutOfBounds { index: 10, len: 5 };
-        assert!(format!("{}", err).contains("index"));
-        assert!(format!("{}", err).contains("10"));
-        assert!(format!("{}", err).contains("5"));
+        assert_eq!(
+            format!("{}", err),
+            "Vector index 10 out of bounds for length 5"
+        );
 
         let err = VectorError::NotFound {
             id: "vec_12345".to_string(),
         };
-        assert!(format!("{}", err).contains("not found"));
-        assert!(format!("{}", err).contains("vec_12345"));
+        assert_eq!(format!("{}", err), "Vector not found: vec_12345");
 
         let err = VectorError::InvalidVector {
             reason: "empty vector not allowed".to_string(),
         };
-        assert!(format!("{}", err).contains("Invalid vector"));
-        assert!(format!("{}", err).contains("empty vector not allowed"));
+        assert_eq!(
+            format!("{}", err),
+            "Invalid vector: empty vector not allowed"
+        );
     }
 
     #[test]

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -462,6 +462,23 @@ pub enum VectorError {
         /// The maximum allowed dimension
         max_allowed: usize,
     },
+    /// Index is out of bounds for the vector or index structure.
+    IndexOutOfBounds {
+        /// The index that was accessed
+        index: usize,
+        /// The valid range (0..len)
+        len: usize,
+    },
+    /// Vector not found in storage or index.
+    NotFound {
+        /// Identifier or description of the vector that was not found
+        id: String,
+    },
+    /// Vector is invalid for the requested operation.
+    InvalidVector {
+        /// Description of why the vector is invalid
+        reason: String,
+    },
 }
 
 impl fmt::Display for VectorError {
@@ -489,6 +506,15 @@ impl fmt::Display for VectorError {
                     "Vector dimension {} exceeds maximum allowed {}",
                     dimension, max_allowed
                 )
+            }
+            VectorError::IndexOutOfBounds { index, len } => {
+                write!(f, "Vector index {} out of bounds for length {}", index, len)
+            }
+            VectorError::NotFound { id } => {
+                write!(f, "Vector not found: {}", id)
+            }
+            VectorError::InvalidVector { reason } => {
+                write!(f, "Invalid vector: {}", reason)
             }
         }
     }
@@ -797,6 +823,23 @@ mod tests {
         };
         assert!(format!("{}", err).contains("200000"));
         assert!(format!("{}", err).contains("100000"));
+
+        let err = VectorError::IndexOutOfBounds { index: 10, len: 5 };
+        assert!(format!("{}", err).contains("index"));
+        assert!(format!("{}", err).contains("10"));
+        assert!(format!("{}", err).contains("5"));
+
+        let err = VectorError::NotFound {
+            id: "vec_12345".to_string(),
+        };
+        assert!(format!("{}", err).contains("not found"));
+        assert!(format!("{}", err).contains("vec_12345"));
+
+        let err = VectorError::InvalidVector {
+            reason: "empty vector not allowed".to_string(),
+        };
+        assert!(format!("{}", err).contains("Invalid vector"));
+        assert!(format!("{}", err).contains("empty vector not allowed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the VectorError type as specified in issue #39, adding the remaining error variants.

**New variants added:**
- `IndexOutOfBounds { index, len }` - for out-of-bounds vector/index access
- `NotFound { id }` - for vectors not found in storage or index
- `InvalidVector { reason }` - generic validation errors

**Previously implemented in VS-009 (#139):**
- `DimensionMismatch { expected, actual }`
- `ContainsNaN { count }`
- `ContainsInfinity { count }`
- `DimensionTooLarge { dimension, max_allowed }`

## Changes

- **src/utils/error.rs**: Added 3 new VectorError variants with Display implementations and tests

## VectorError Variants Complete List

| Variant | Use Case |
|---------|----------|
| `DimensionMismatch` | Vector operations with incompatible dimensions |
| `ContainsNaN` | Validation detected NaN values |
| `ContainsInfinity` | Validation detected Infinity values |
| `DimensionTooLarge` | Vector exceeds maximum allowed dimension |
| `IndexOutOfBounds` | Index out of range for vector/index structure |
| `NotFound` | Vector not found in storage or index |
| `InvalidVector` | Generic validation failure |

## Test Plan

- [x] `cargo test --lib -- utils::error::tests::test_vector_error` (2 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)