### PR TITLE
feat(storage): Add vector property support for CurrentStorage (VS-011)

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -847,6 +847,31 @@ impl PropertyMapBuilder {
         self
     }
 
+    /// Insert a vector property (convenience method for embeddings).
+    ///
+    /// This is a convenience wrapper around `insert()` for vector properties,
+    /// commonly used for storing embeddings in nodes and edges.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::core::property::PropertyMapBuilder;
+    ///
+    /// let embedding = vec![0.1f32, 0.2, 0.3, 0.4];
+    /// let props = PropertyMapBuilder::new()
+    ///     .insert("name", "Document")
+    ///     .insert_vector("embedding", &embedding)
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     props.get("embedding").and_then(|v| v.as_vector()),
+    ///     Some(&embedding[..])
+    /// );
+    /// ```
+    pub fn insert_vector<K: Into<PropertyKey>>(self, key: K, vector: &[f32]) -> Self {
+        self.insert(key, PropertyValue::vector(vector))
+    }
+
     /// Remove a property.
     pub fn remove(mut self, key: &str) -> Self {
         self.map.remove(key);

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -507,9 +507,10 @@ mod tests {
             Some("Document")
         );
 
-        let retrieved_embedding = node.get_property("embedding").and_then(|v| v.as_vector());
-        assert!(retrieved_embedding.is_some());
-        assert_eq!(retrieved_embedding.unwrap(), &embedding[..]);
+        assert_eq!(
+            node.get_property("embedding").and_then(|v| v.as_vector()),
+            Some(&embedding[..])
+        );
     }
 
     #[test]
@@ -525,13 +526,10 @@ mod tests {
         let node_id = storage.create_node("Embedding", props).unwrap();
 
         let node = storage.get_node(node_id).unwrap();
-        let retrieved = node
-            .get_property("embedding")
-            .and_then(|v| v.as_vector())
-            .unwrap();
-
-        assert_eq!(retrieved.len(), 384);
-        assert_eq!(retrieved, &embedding[..]);
+        assert_eq!(
+            node.get_property("embedding").and_then(|v| v.as_vector()),
+            Some(&embedding[..])
+        );
     }
 
     #[test]
@@ -562,9 +560,10 @@ mod tests {
             Some(0.95)
         );
 
-        let retrieved = edge.get_property("embedding").and_then(|v| v.as_vector());
-        assert!(retrieved.is_some());
-        assert_eq!(retrieved.unwrap(), &edge_embedding[..]);
+        assert_eq!(
+            edge.get_property("embedding").and_then(|v| v.as_vector()),
+            Some(&edge_embedding[..])
+        );
     }
 
     #[test]
@@ -595,11 +594,12 @@ mod tests {
 
         // Verify update
         let updated_node = storage.get_node(node_id).unwrap();
-        let retrieved = updated_node
-            .get_property("embedding")
-            .and_then(|v| v.as_vector())
-            .unwrap();
-        assert_eq!(retrieved, &updated_embedding[..]);
+        assert_eq!(
+            updated_node
+                .get_property("embedding")
+                .and_then(|v| v.as_vector()),
+            Some(&updated_embedding[..])
+        );
     }
 
     #[test]
@@ -632,11 +632,12 @@ mod tests {
 
         // Verify
         let updated_edge = storage.get_edge(edge_id).unwrap();
-        let retrieved = updated_edge
-            .get_property("embedding")
-            .and_then(|v| v.as_vector())
-            .unwrap();
-        assert_eq!(retrieved, &updated_embedding[..]);
+        assert_eq!(
+            updated_edge
+                .get_property("embedding")
+                .and_then(|v| v.as_vector()),
+            Some(&updated_embedding[..])
+        );
     }
 
     #[test]
@@ -680,11 +681,10 @@ mod tests {
         let node_id = storage.create_node("EmptyVec", props).unwrap();
 
         let node = storage.get_node(node_id).unwrap();
-        let retrieved = node
-            .get_property("embedding")
-            .and_then(|v| v.as_vector())
-            .unwrap();
-        assert!(retrieved.is_empty());
+        assert_eq!(
+            node.get_property("embedding").and_then(|v| v.as_vector()),
+            Some(&empty_embedding[..])
+        );
     }
 
     #[test]
@@ -703,7 +703,7 @@ mod tests {
         let retrieved = node
             .get_property("embedding")
             .and_then(|v| v.as_vector())
-            .unwrap();
+            .expect("Embedding property should exist and be a vector");
 
         // Verify magnitude is approximately 1.0
         let magnitude: f32 = retrieved.iter().map(|x| x * x).sum::<f32>().sqrt();

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -641,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn test_node_with_multiple_vector_properties() {
+    fn test_create_node_with_multiple_vector_properties() {
         let storage = CurrentStorage::new();
 
         // Node with multiple embeddings (e.g., different model embeddings)
@@ -669,7 +669,7 @@ mod tests {
     }
 
     #[test]
-    fn test_node_with_empty_vector() {
+    fn test_create_node_with_empty_vector() {
         let storage = CurrentStorage::new();
 
         // Empty vector should be allowed
@@ -688,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn test_node_vector_with_special_values() {
+    fn test_create_node_with_normalized_vector() {
         let storage = CurrentStorage::new();
 
         // Vector with normalized values (common for embeddings)

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -482,4 +482,231 @@ mod tests {
         assert_eq!(storage.edge_count(), 0);
         assert_eq!(storage.out_degree(n0), 0);
     }
+
+    // ========================================================================
+    // Vector Property Tests (VS-011)
+    // ========================================================================
+
+    #[test]
+    fn test_create_node_with_vector_property() {
+        let storage = CurrentStorage::new();
+
+        // Create a node with an embedding vector
+        let embedding = vec![0.1f32, 0.2, 0.3, 0.4, 0.5];
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Document")
+            .insert_vector("embedding", &embedding)
+            .build();
+
+        let node_id = storage.create_node("Document", props).unwrap();
+
+        // Retrieve and verify
+        let node = storage.get_node(node_id).unwrap();
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Document")
+        );
+
+        let retrieved_embedding = node.get_property("embedding").and_then(|v| v.as_vector());
+        assert!(retrieved_embedding.is_some());
+        assert_eq!(retrieved_embedding.unwrap(), &embedding[..]);
+    }
+
+    #[test]
+    fn test_create_node_with_high_dimensional_vector() {
+        let storage = CurrentStorage::new();
+
+        // Create a 384-dimensional vector (common embedding size)
+        let embedding: Vec<f32> = (0..384).map(|i| i as f32 / 384.0).collect();
+        let props = PropertyMapBuilder::new()
+            .insert_vector("embedding", &embedding)
+            .build();
+
+        let node_id = storage.create_node("Embedding", props).unwrap();
+
+        let node = storage.get_node(node_id).unwrap();
+        let retrieved = node
+            .get_property("embedding")
+            .and_then(|v| v.as_vector())
+            .unwrap();
+
+        assert_eq!(retrieved.len(), 384);
+        assert_eq!(retrieved, &embedding[..]);
+    }
+
+    #[test]
+    fn test_create_edge_with_vector_property() {
+        let storage = CurrentStorage::new();
+
+        // Create nodes
+        let n1 = storage
+            .create_node("Entity", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Entity", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create edge with a relationship embedding
+        let edge_embedding = vec![0.5f32, -0.3, 0.8];
+        let props = PropertyMapBuilder::new()
+            .insert("weight", 0.95f64)
+            .insert_vector("embedding", &edge_embedding)
+            .build();
+
+        let edge_id = storage.create_edge(n1, n2, "RELATES_TO", props).unwrap();
+
+        // Retrieve and verify
+        let edge = storage.get_edge(edge_id).unwrap();
+        assert_eq!(
+            edge.get_property("weight").and_then(|v| v.as_float()),
+            Some(0.95)
+        );
+
+        let retrieved = edge.get_property("embedding").and_then(|v| v.as_vector());
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap(), &edge_embedding[..]);
+    }
+
+    #[test]
+    fn test_update_node_vector_property() {
+        let storage = CurrentStorage::new();
+
+        // Create node with initial embedding
+        let initial_embedding = vec![0.1f32, 0.2, 0.3];
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Document")
+            .insert_vector("embedding", &initial_embedding)
+            .build();
+
+        let node_id = storage.create_node("Document", props).unwrap();
+
+        // Get node, update embedding, and save
+        let mut node = storage.get_node(node_id).unwrap();
+
+        // Update with new embedding
+        let updated_embedding = vec![0.9f32, 0.8, 0.7];
+        let new_props = PropertyMapBuilder::new()
+            .insert("name", "Document")
+            .insert_vector("embedding", &updated_embedding)
+            .build();
+        node.properties = new_props;
+
+        storage.update_node_direct(node).unwrap();
+
+        // Verify update
+        let updated_node = storage.get_node(node_id).unwrap();
+        let retrieved = updated_node
+            .get_property("embedding")
+            .and_then(|v| v.as_vector())
+            .unwrap();
+        assert_eq!(retrieved, &updated_embedding[..]);
+    }
+
+    #[test]
+    fn test_update_edge_vector_property() {
+        let storage = CurrentStorage::new();
+
+        let n1 = storage
+            .create_node("Entity", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Entity", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create edge with initial embedding
+        let initial_embedding = vec![1.0f32, 0.0];
+        let props = PropertyMapBuilder::new()
+            .insert_vector("embedding", &initial_embedding)
+            .build();
+
+        let edge_id = storage.create_edge(n1, n2, "RELATES_TO", props).unwrap();
+
+        // Update edge embedding
+        let mut edge = storage.get_edge(edge_id).unwrap();
+        let updated_embedding = vec![0.0f32, 1.0];
+        edge.properties = PropertyMapBuilder::new()
+            .insert_vector("embedding", &updated_embedding)
+            .build();
+
+        storage.update_edge_direct(edge).unwrap();
+
+        // Verify
+        let updated_edge = storage.get_edge(edge_id).unwrap();
+        let retrieved = updated_edge
+            .get_property("embedding")
+            .and_then(|v| v.as_vector())
+            .unwrap();
+        assert_eq!(retrieved, &updated_embedding[..]);
+    }
+
+    #[test]
+    fn test_node_with_multiple_vector_properties() {
+        let storage = CurrentStorage::new();
+
+        // Node with multiple embeddings (e.g., different model embeddings)
+        let text_embedding = vec![0.1f32, 0.2, 0.3, 0.4];
+        let image_embedding = vec![0.5f32, 0.6, 0.7, 0.8];
+        let props = PropertyMapBuilder::new()
+            .insert("content", "multimodal content")
+            .insert_vector("text_embedding", &text_embedding)
+            .insert_vector("image_embedding", &image_embedding)
+            .build();
+
+        let node_id = storage.create_node("MultimodalDoc", props).unwrap();
+
+        let node = storage.get_node(node_id).unwrap();
+        assert_eq!(
+            node.get_property("text_embedding")
+                .and_then(|v| v.as_vector()),
+            Some(&text_embedding[..])
+        );
+        assert_eq!(
+            node.get_property("image_embedding")
+                .and_then(|v| v.as_vector()),
+            Some(&image_embedding[..])
+        );
+    }
+
+    #[test]
+    fn test_node_with_empty_vector() {
+        let storage = CurrentStorage::new();
+
+        // Empty vector should be allowed
+        let empty_embedding: Vec<f32> = vec![];
+        let props = PropertyMapBuilder::new()
+            .insert_vector("embedding", &empty_embedding)
+            .build();
+
+        let node_id = storage.create_node("EmptyVec", props).unwrap();
+
+        let node = storage.get_node(node_id).unwrap();
+        let retrieved = node
+            .get_property("embedding")
+            .and_then(|v| v.as_vector())
+            .unwrap();
+        assert!(retrieved.is_empty());
+    }
+
+    #[test]
+    fn test_node_vector_with_special_values() {
+        let storage = CurrentStorage::new();
+
+        // Vector with normalized values (common for embeddings)
+        let normalized_embedding = vec![0.5773503f32, 0.5773503, 0.5773503]; // unit vector
+        let props = PropertyMapBuilder::new()
+            .insert_vector("embedding", &normalized_embedding)
+            .build();
+
+        let node_id = storage.create_node("NormalizedDoc", props).unwrap();
+
+        let node = storage.get_node(node_id).unwrap();
+        let retrieved = node
+            .get_property("embedding")
+            .and_then(|v| v.as_vector())
+            .unwrap();
+
+        // Verify magnitude is approximately 1.0
+        let magnitude: f32 = retrieved.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((magnitude - 1.0).abs() < 1e-5);
+    }
 }


### PR DESCRIPTION
## Summary

Verifies and documents vector property support for nodes and edges in CurrentStorage.

**Key additions:**
- `PropertyMapBuilder::insert_vector()` - convenience method for embedding properties
- 8 comprehensive integration tests for vector property operations

## Changes

- **src/core/property.rs**: Added `insert_vector()` helper with documentation
- **src/storage/current.rs**: Added 8 integration tests for vector properties

## Test Coverage

| Test | Description |
|------|-------------|
| `test_create_node_with_vector_property` | Basic node creation with embedding |
| `test_create_node_with_high_dimensional_vector` | 384-dimensional vector (sentence transformers) |
| `test_create_edge_with_vector_property` | Edge with relationship embedding |
| `test_update_node_vector_property` | Vector property update via update_node_direct |
| `test_update_edge_vector_property` | Vector property update via update_edge_direct |
| `test_node_with_multiple_vector_properties` | Multimodal (text + image embeddings) |
| `test_node_with_empty_vector` | Empty vector edge case |
| `test_node_vector_with_special_values` | Normalized (unit) vectors |

## Usage Example

```rust
let embedding = vec![0.1f32, 0.2, 0.3, 0.4];
let props = PropertyMapBuilder::new()
    .insert("name", "Document")
    .insert_vector("embedding", &embedding)
    .build();

let node_id = storage.create_node("Document", props)?;
```

## Test Plan

- [x] `cargo test --lib -- storage::current::tests` (15 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)