### PR TITLE
fix: Close previous version transaction_time on deletion for proper time-travel

### DIFF
--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -657,8 +657,7 @@ impl WriteTransaction {
                     // Close the current version's transaction_time in historical storage
                     // This marks the end of this version's visibility
                     let mut historical = self.historical.lock_or_err()?;
-                    if let Some(current_version_id) =
-                        historical.get_current_node_version(*node_id)
+                    if let Some(current_version_id) = historical.get_current_node_version(*node_id)
                     {
                         historical.close_node_version_transaction_time(
                             current_version_id,
@@ -705,8 +704,7 @@ impl WriteTransaction {
                     // Close the current version's transaction_time in historical storage
                     // This marks the end of this version's visibility
                     let mut historical = self.historical.lock_or_err()?;
-                    if let Some(current_version_id) =
-                        historical.get_current_edge_version(*edge_id)
+                    if let Some(current_version_id) = historical.get_current_edge_version(*edge_id)
                     {
                         historical.close_edge_version_transaction_time(
                             current_version_id,

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -651,25 +651,42 @@ impl WriteTransaction {
                     );
                 }
                 super::BufferedWrite::DeleteNode { node_id } => {
-                    // Get the node before deleting to create tombstone
+                    // Get the node before deleting
                     let node = self.current.get_node(*node_id)?;
+
+                    // Close the current version's transaction_time in historical storage
+                    // This marks the end of this version's visibility
+                    let mut historical = self.historical.lock_or_err()?;
+                    if let Some(current_version_id) =
+                        historical.get_current_node_version(*node_id)
+                    {
+                        historical.close_node_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
                         VersionId::new(self.version_id_gen.lock_or_err()?.next());
 
-                    // Create closed temporal interval marking deletion time
+                    // Create tombstone temporal interval
+                    // The tombstone marks when the deletion occurred. Its transaction_time
+                    // starts at commit_timestamp and remains open (we know about the deletion
+                    // from now on). Its valid_time is closed immediately since the entity
+                    // no longer exists.
                     let tombstone_temporal = BiTemporalInterval::current(commit_timestamp)
-                        .close_transaction_time(commit_timestamp);
+                        .close_valid_time(commit_timestamp);
 
                     // Add tombstone version to historical storage
-                    self.historical.lock_or_err()?.add_node_version(
+                    historical.add_node_version(
                         *node_id,
                         tombstone_version_id,
                         tombstone_temporal,
                         node.label,
                         node.properties.clone(),
                     )?;
+                    drop(historical); // Release lock before acquiring temporal_indexes lock
 
                     // Index the tombstone version
                     self.temporal_indexes.lock_or_err()?.insert_node_version(
@@ -682,19 +699,35 @@ impl WriteTransaction {
                     self.current.delete_node_direct(*node_id)?;
                 }
                 super::BufferedWrite::DeleteEdge { edge_id } => {
-                    // Get the edge before deleting to create tombstone
+                    // Get the edge before deleting
                     let edge = self.current.get_edge(*edge_id)?;
+
+                    // Close the current version's transaction_time in historical storage
+                    // This marks the end of this version's visibility
+                    let mut historical = self.historical.lock_or_err()?;
+                    if let Some(current_version_id) =
+                        historical.get_current_edge_version(*edge_id)
+                    {
+                        historical.close_edge_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
                         VersionId::new(self.version_id_gen.lock_or_err()?.next());
 
-                    // Create closed temporal interval marking deletion time
+                    // Create tombstone temporal interval
+                    // The tombstone marks when the deletion occurred. Its transaction_time
+                    // starts at commit_timestamp and remains open (we know about the deletion
+                    // from now on). Its valid_time is closed immediately since the entity
+                    // no longer exists.
                     let tombstone_temporal = BiTemporalInterval::current(commit_timestamp)
-                        .close_transaction_time(commit_timestamp);
+                        .close_valid_time(commit_timestamp);
 
                     // Add tombstone version to historical storage
-                    self.historical.lock_or_err()?.add_edge_version(
+                    historical.add_edge_version(
                         *edge_id,
                         tombstone_version_id,
                         tombstone_temporal,
@@ -703,6 +736,7 @@ impl WriteTransaction {
                         edge.target,
                         edge.properties.clone(),
                     )?;
+                    drop(historical); // Release lock before acquiring temporal_indexes lock
 
                     // Index the tombstone version
                     self.temporal_indexes.lock_or_err()?.insert_edge_version(

--- a/src/db.rs
+++ b/src/db.rs
@@ -471,14 +471,17 @@ mod tests {
         );
 
         // Query BEFORE deletion - should succeed (node existed)
-        let result = db.get_node_at_time(node_id, t_after_create - 1, t_after_create - 1);
+        let result = db.get_node_at_time(node_id, t_after_create, t_after_create);
         assert!(
             result.is_ok(),
             "Expected to find node before deletion, but got: {:?}",
             result
         );
         let node = result.unwrap();
-        assert_eq!(node.get_property("name").and_then(|v| v.as_str()), Some("Alice"));
+        assert_eq!(
+            node.get_property("name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -434,6 +434,54 @@ mod tests {
     }
 
     #[test]
+    fn test_time_travel_after_deletion() {
+        let db = GallifreyDB::new();
+
+        // Create a node
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .build();
+        let node_id = db.create_node("Person", props).unwrap();
+
+        // Record timestamp after creation
+        let t_after_create = *db.current_timestamp.lock().unwrap();
+
+        // Delete the node
+        db.write(|tx| {
+            tx.delete_node(node_id)?;
+            Ok(())
+        })
+        .unwrap();
+
+        // Record timestamp after deletion
+        let t_after_delete = *db.current_timestamp.lock().unwrap();
+
+        // Query BEFORE creation - should fail (node didn't exist)
+        // Note: We can't easily test this without more control over timestamps
+
+        // Query AFTER deletion - should fail (node was deleted)
+        // This is the critical test: time-travel query after deletion should NOT
+        // return the deleted node's data
+        let result = db.get_node_at_time(node_id, t_after_delete, t_after_delete);
+        assert!(
+            result.is_err(),
+            "Expected NodeNotFound after deletion, but got: {:?}",
+            result
+        );
+
+        // Query BEFORE deletion - should succeed (node existed)
+        let result = db.get_node_at_time(node_id, t_after_create - 1, t_after_create - 1);
+        assert!(
+            result.is_ok(),
+            "Expected to find node before deletion, but got: {:?}",
+            result
+        );
+        let node = result.unwrap();
+        assert_eq!(node.get_property("name").and_then(|v| v.as_str()), Some("Alice"));
+    }
+
+    #[test]
     fn test_graph_traversal() {
         let db = GallifreyDB::new();
 

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -13,7 +13,9 @@ use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
-use crate::storage::version::{AnchorConfig, EdgeVersion, NodeVersion, VersionData};
+use crate::storage::version::{
+    AnchorConfig, EdgeVersion, NodeVersion, TemporalVersion, VersionData,
+};
 use crate::utils::error::{Result, StorageError, TemporalError};
 use std::collections::HashMap;
 
@@ -264,7 +266,8 @@ impl HistoricalStorage {
             .get_mut(&version_id)
             .ok_or(StorageError::VersionNotFound(version_id))?;
 
-        version.temporal = version.temporal.close_transaction_time(end_timestamp);
+        // Use TemporalVersion trait method
+        version.close_transaction_time(end_timestamp);
         Ok(())
     }
 
@@ -282,7 +285,8 @@ impl HistoricalStorage {
             .get_mut(&version_id)
             .ok_or(StorageError::VersionNotFound(version_id))?;
 
-        version.temporal = version.temporal.close_transaction_time(end_timestamp);
+        // Use TemporalVersion trait method
+        version.close_transaction_time(end_timestamp);
         Ok(())
     }
 

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -243,6 +243,49 @@ impl HistoricalStorage {
         self.edge_version_heads.get(&edge_id).copied()
     }
 
+    /// Close the transaction time of a node version.
+    ///
+    /// This marks the version as no longer being the "current knowledge" after
+    /// the specified timestamp. Used when a node is deleted or superseded.
+    ///
+    /// # Arguments
+    /// * `version_id` - The version to close
+    /// * `end_timestamp` - The timestamp at which this version is no longer valid
+    ///
+    /// # Returns
+    /// `Ok(())` if successful, `Err` if version not found
+    pub fn close_node_version_transaction_time(
+        &mut self,
+        version_id: VersionId,
+        end_timestamp: Timestamp,
+    ) -> Result<()> {
+        let version = self
+            .node_versions
+            .get_mut(&version_id)
+            .ok_or(StorageError::VersionNotFound(version_id))?;
+
+        version.temporal = version.temporal.close_transaction_time(end_timestamp);
+        Ok(())
+    }
+
+    /// Close the transaction time of an edge version.
+    ///
+    /// This marks the version as no longer being the "current knowledge" after
+    /// the specified timestamp. Used when an edge is deleted or superseded.
+    pub fn close_edge_version_transaction_time(
+        &mut self,
+        version_id: VersionId,
+        end_timestamp: Timestamp,
+    ) -> Result<()> {
+        let version = self
+            .edge_versions
+            .get_mut(&version_id)
+            .ok_or(StorageError::VersionNotFound(version_id))?;
+
+        version.temporal = version.temporal.close_transaction_time(end_timestamp);
+        Ok(())
+    }
+
     /// Find a node version valid at a specific point in time.
     ///
     /// This searches the version chain for a version whose temporal interval

--- a/src/storage/version.rs
+++ b/src/storage/version.rs
@@ -15,6 +15,28 @@ use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use std::collections::{HashMap, HashSet};
 
+/// Trait for version types that have a bi-temporal interval.
+///
+/// This trait provides a common interface for accessing and modifying the
+/// temporal interval of node and edge versions, reducing code duplication
+/// in operations that need to modify temporal properties.
+pub trait TemporalVersion {
+    /// Get a reference to the version's bi-temporal interval.
+    fn temporal(&self) -> &BiTemporalInterval;
+
+    /// Get a mutable reference to the version's bi-temporal interval.
+    fn temporal_mut(&mut self) -> &mut BiTemporalInterval;
+
+    /// Close the transaction time of this version.
+    ///
+    /// This marks the version as no longer being the "current knowledge" after
+    /// the specified timestamp. Used when a version is superseded or deleted.
+    fn close_transaction_time(&mut self, end_timestamp: Timestamp) {
+        let temporal = self.temporal_mut();
+        *temporal = temporal.close_transaction_time(end_timestamp);
+    }
+}
+
 /// Metadata about version creation for Snapshot Isolation.
 ///
 /// This tracks which transaction created a version and when it was committed,
@@ -270,6 +292,16 @@ impl NodeVersion {
     }
 }
 
+impl TemporalVersion for NodeVersion {
+    fn temporal(&self) -> &BiTemporalInterval {
+        &self.temporal
+    }
+
+    fn temporal_mut(&mut self) -> &mut BiTemporalInterval {
+        &mut self.temporal
+    }
+}
+
 /// A version of an edge at a specific point in time.
 #[derive(Debug, Clone)]
 pub struct EdgeVersion {
@@ -353,6 +385,16 @@ impl EdgeVersion {
     #[inline]
     pub fn is_delta(&self) -> bool {
         self.data.is_delta()
+    }
+}
+
+impl TemporalVersion for EdgeVersion {
+    fn temporal(&self) -> &BiTemporalInterval {
+        &self.temporal
+    }
+
+    fn temporal_mut(&mut self) -> &mut BiTemporalInterval {
+        &mut self.temporal
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes time-travel queries returning deleted nodes/edges as if they still existed
- Adds `close_node_version_transaction_time()` and `close_edge_version_transaction_time()` methods to HistoricalStorage
- On deletion, closes the previous version's transaction_time at commit timestamp
- Changes tombstone to close valid_time (represents "we know about this deletion from now on")
- Adds `test_time_travel_after_deletion` test to verify the fix

## The Bug

When deleting a node/edge, the previous version's `transaction_time` was never closed. Time-travel queries use `is_visible_at(valid_time, tx_time)` which checks if timestamps fall within the version's temporal interval. Since the previous version's `transaction_time` remained open `[T, ∞)`, queries after deletion would still find the "deleted" entity.

## The Fix

1. Close the previous version's `transaction_time` at commit_timestamp before creating the tombstone
2. The tombstone closes `valid_time` instead of `transaction_time` - this correctly represents "the entity no longer exists (closed valid_time) and we know about this deletion from now on (open transaction_time)"

## Test plan

- [x] `test_time_travel_after_deletion` - verifies query AFTER deletion returns `NodeNotFound`, query BEFORE deletion returns the node
- [x] All 435 existing tests pass
- [x] Clippy clean

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)