### PR TITLE
docs: Document WAL replay requirement for deletion bi-temporal semantics

### DIFF
--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -380,9 +380,24 @@ impl PersistenceManager {
         let wal_entries = wal.read_from(start_lsn)?;
 
         for _entry in wal_entries {
-            // Apply WAL operation to storage
-            // In production, would have apply_operation methods
-            // For now, operations are already in storage
+            // TODO: Implement WAL operation replay
+            //
+            // IMPORTANT: When implementing replay for DeleteNode/DeleteEdge operations,
+            // you MUST close the previous version's transaction_time BEFORE creating
+            // the tombstone. This is critical for correct bi-temporal semantics.
+            //
+            // The tombstone's temporal.transaction_time().start() contains the
+            // commit_timestamp that should be used to close the previous version.
+            //
+            // Example for DeleteNode:
+            //   let commit_timestamp = temporal.transaction_time().start();
+            //   if let Some(prev_version_id) = historical.get_current_node_version(node_id) {
+            //       historical.close_node_version_transaction_time(prev_version_id, commit_timestamp)?;
+            //   }
+            //   // Then create the tombstone...
+            //
+            // See: write_tx.rs apply_changes() for the reference implementation.
+            // Related: Issue #12 - Time-travel queries returning deleted entities.
         }
 
         let final_lsn = wal.current_lsn();


### PR DESCRIPTION
## Summary

Documents the critical requirement for WAL replay to maintain correct bi-temporal semantics after crash recovery.

## Context

PR #143 fixed time-travel queries returning deleted entities by closing the previous version's `transaction_time` before creating the tombstone. This fix works correctly for in-memory operations, but the same logic must be applied during WAL replay.

## Changes

Added detailed documentation in `PersistenceManager::recover()` explaining:

1. When replaying `DeleteNode`/`DeleteEdge` operations, the previous version's `transaction_time` MUST be closed
2. The tombstone's `temporal.transaction_time().start()` provides the correct `commit_timestamp`
3. Reference to `write_tx.rs::apply_changes()` for the implementation pattern

## Why This Matters

Without this fix during WAL replay:
- After a crash and recovery, deleted entities would reappear in time-travel queries
- The bug from issue #12 would manifest again after any crash

## Note

WAL replay is currently a stub (not fully implemented). This documentation ensures that when replay is implemented, the correct bi-temporal deletion semantics will be followed.

Related: Issue #12, PR #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)