### PR TITLE
fix: Benchmark PR comments now show actual results

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -96,13 +96,23 @@ jobs:
 
       - name: Run benchmarks on PR
         run: |
-          echo "## Benchmark Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Current State Benchmarks" >> $GITHUB_STEP_SUMMARY
-          cargo bench --bench current_state 2>&1 | tee -a $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### GallifreyDB Benchmarks" >> $GITHUB_STEP_SUMMARY
-          cargo bench --bench gallifreydb 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          echo "## 🚀 Benchmark Results" > benchmark_results.md
+          echo "" >> benchmark_results.md
+          echo "### Current State Benchmarks" >> benchmark_results.md
+          echo '```' >> benchmark_results.md
+          cargo bench --bench current_state 2>&1 | grep -E "(test|time:|ns/iter)" | head -n 50 >> benchmark_results.md || echo "No benchmark output captured" >> benchmark_results.md
+          echo '```' >> benchmark_results.md
+          echo "" >> benchmark_results.md
+          echo "### GallifreyDB Benchmarks" >> benchmark_results.md
+          echo '```' >> benchmark_results.md
+          cargo bench --bench gallifreydb 2>&1 | grep -E "(test|time:|ns/iter)" | head -n 50 >> benchmark_results.md || echo "No benchmark output captured" >> benchmark_results.md
+          echo '```' >> benchmark_results.md
+          echo "" >> benchmark_results.md
+          echo "---" >> benchmark_results.md
+          echo "*Benchmarks run on ubuntu-latest*" >> benchmark_results.md
+
+          # Also output to step summary
+          cat benchmark_results.md >> $GITHUB_STEP_SUMMARY
 
       - name: Comment benchmark results on PR
         uses: actions/github-script@v7
@@ -112,15 +122,15 @@ jobs:
           script: |
             const fs = require('fs');
             try {
-              const summary = fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, 'utf8');
+              const summary = fs.readFileSync('benchmark_results.md', 'utf8');
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `## 🚀 Benchmark Results\n\n${summary}`
+                body: summary
               });
               console.log('Successfully posted benchmark results as PR comment');
             } catch (error) {
-              console.log('Could not post PR comment (this is expected for fork PRs):', error.message);
+              console.log('Could not post PR comment:', error.message);
               console.log('Benchmark results are available in the workflow summary above.');
             }


### PR DESCRIPTION
The benchmark-pr workflow was posting empty comments because it was trying to read from $GITHUB_STEP_SUMMARY in a later step, but that file gets cleared between steps.

Fixed by:
- Save benchmark output to benchmark_results.md file
- Filter output to show only relevant benchmark lines (test names, times)
- Limit output to 50 lines per benchmark to avoid huge comments
- Read from the persistent file instead of GITHUB_STEP_SUMMARY
- Still output to GITHUB_STEP_SUMMARY for workflow UI

Now PR comments will show formatted benchmark results with actual timings!

🤖 Generated with [Claude Code](https://claude.com/claude-code)