### PR TITLE
fix: Documentation publishing now works on trunk branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
     name: Publish Documentation
     needs: build-docs
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
     steps:
       - name: Download documentation artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The publish-docs job was checking for 'refs/heads/main' but the repo uses 'trunk' as the main branch, so it was always skipped.

Changed condition from:
  if: github.ref == 'refs/heads/main'
To:
  if: github.ref == 'refs/heads/trunk'

Now docs will actually publish to GitHub Pages when pushed to trunk!

🤖 Generated with [Claude Code](https://claude.com/claude-code)