### PR TITLE
fix: Add input validation to ID constructors (P1-3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ nul
 
 # Git worktrees for parallel development
 agents/
+
+# Proptest regression files
+proptest-regressions/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,40 @@ pub struct VersionId(u64);
 fn get_node(id: u64) -> Node { /* which kind of ID? */ }
 ```
 
+**ID Validation and Security:**
+
+All ID types validate values on construction to prevent security issues:
+
+```rust
+// GOOD: Use validated constructors in public API
+pub fn create_node(&self, id: u64) -> Result<NodeId> {
+    NodeId::new(id)  // Validates ID is within MAX_VALID_ID
+}
+
+// INTERNAL USE ONLY: new_unchecked() bypasses validation
+// - MUST remain pub(crate) - never expose in public API
+// - Only use when ID is known valid (WAL recovery, trusted storage)
+// - Document safety reasoning at call site
+impl NodeId {
+    pub(crate) const fn new_unchecked(id: u64) -> Self {
+        NodeId(id)
+    }
+}
+```
+
+**Critical Security Rule**: The `new_unchecked()` methods MUST remain `pub(crate)`.
+Never expose them in:
+- Public API functions
+- C FFI boundaries
+- External plugin systems
+- Any untrusted context
+
+IDs exceeding `MAX_VALID_ID` (u64::MAX - 1000) are rejected to prevent:
+- Arithmetic overflow in ID operations
+- Excessive memory allocation attempts
+- Serialization buffer overflow
+- DoS attacks via extreme values
+
 **Temporal Types:**
 ```rust
 // GOOD: Explicit temporal semantics

--- a/benches/current_state.rs
+++ b/benches/current_state.rs
@@ -58,7 +58,7 @@ fn bench_single_hop_traversal(c: &mut Criterion) {
 
     for graph_size in [100, 1000, 10000] {
         let storage = create_test_graph(graph_size, 10);
-        let first_node = gallifreydb::NodeId::new(0);
+        let first_node = gallifreydb::NodeId::new(0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("{}_nodes", graph_size)),
@@ -81,7 +81,7 @@ fn bench_single_hop_traversal(c: &mut Criterion) {
 /// Target: <100µs per operation
 fn bench_multi_hop_traversal(c: &mut Criterion) {
     let storage = create_test_graph(1000, 10);
-    let start_node = gallifreydb::NodeId::new(0);
+    let start_node = gallifreydb::NodeId::new(0).unwrap();
 
     c.bench_function("3_hop_traversal", |b| {
         b.iter(|| {
@@ -113,7 +113,7 @@ fn bench_multi_hop_traversal(c: &mut Criterion) {
 /// Target: <100ns per operation
 fn bench_node_lookup(c: &mut Criterion) {
     let storage = create_test_graph(10000, 10);
-    let node_id = gallifreydb::NodeId::new(5000);
+    let node_id = gallifreydb::NodeId::new(5000).unwrap();
 
     c.bench_function("node_lookup", |b| {
         b.iter(|| {
@@ -126,7 +126,7 @@ fn bench_node_lookup(c: &mut Criterion) {
 /// Benchmark edge lookup by ID.
 fn bench_edge_lookup(c: &mut Criterion) {
     let storage = create_test_graph(1000, 10);
-    let edge_id = gallifreydb::EdgeId::new(5000);
+    let edge_id = gallifreydb::EdgeId::new(5000).unwrap();
 
     c.bench_function("edge_lookup", |b| {
         b.iter(|| {
@@ -139,7 +139,7 @@ fn bench_edge_lookup(c: &mut Criterion) {
 /// Benchmark labeled edge traversal.
 fn bench_labeled_traversal(c: &mut Criterion) {
     let storage = create_test_graph(1000, 10);
-    let node_id = gallifreydb::NodeId::new(0);
+    let node_id = gallifreydb::NodeId::new(0).unwrap();
 
     c.bench_function("labeled_traversal", |b| {
         b.iter(|| {
@@ -198,7 +198,7 @@ fn bench_edge_creation(c: &mut Criterion) {
 /// Benchmark graph degree queries.
 fn bench_degree_queries(c: &mut Criterion) {
     let storage = create_test_graph(1000, 10);
-    let node_id = gallifreydb::NodeId::new(0);
+    let node_id = gallifreydb::NodeId::new(0).unwrap();
 
     c.bench_function("out_degree", |b| {
         b.iter(|| {
@@ -218,7 +218,7 @@ fn bench_degree_queries(c: &mut Criterion) {
 /// Benchmark finding neighbors (targets of outgoing edges).
 fn bench_find_neighbors(c: &mut Criterion) {
     let storage = create_test_graph(1000, 10);
-    let node_id = gallifreydb::NodeId::new(0);
+    let node_id = gallifreydb::NodeId::new(0).unwrap();
 
     c.bench_function("find_neighbors", |b| {
         b.iter(|| {

--- a/benches/persistence.rs
+++ b/benches/persistence.rs
@@ -29,22 +29,22 @@ fn bench_wal_append(c: &mut Criterion) {
             b.iter(|| {
                 let operation = match *op_type {
                     "create_node" => WalOperation::CreateNode {
-                        node_id: black_box(gallifreydb::core::id::NodeId::new(1)),
+                        node_id: black_box(gallifreydb::core::id::NodeId::new(1).unwrap()),
                         label: "Person".to_string(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
                     },
                     "create_edge" => WalOperation::CreateEdge {
-                        edge_id: black_box(gallifreydb::core::id::EdgeId::new(1)),
-                        source: gallifreydb::core::id::NodeId::new(1),
-                        target: gallifreydb::core::id::NodeId::new(2),
+                        edge_id: black_box(gallifreydb::core::id::EdgeId::new(1).unwrap()),
+                        source: gallifreydb::core::id::NodeId::new(1).unwrap(),
+                        target: gallifreydb::core::id::NodeId::new(2).unwrap(),
                         label: "KNOWS".to_string(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
                     },
                     _ => WalOperation::UpdateNode {
-                        node_id: gallifreydb::core::id::NodeId::new(1),
-                        version_id: gallifreydb::core::id::VersionId::new(2),
+                        node_id: gallifreydb::core::id::NodeId::new(1).unwrap(),
+                        version_id: gallifreydb::core::id::VersionId::new(2).unwrap(),
                         label: "Person".to_string(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
@@ -74,7 +74,7 @@ fn bench_wal_throughput(c: &mut Criterion) {
 
             for i in 0..1000 {
                 let operation = WalOperation::CreateNode {
-                    node_id: gallifreydb::core::id::NodeId::new(i),
+                    node_id: gallifreydb::core::id::NodeId::new(i).unwrap(),
                     label: "Person".to_string(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),
@@ -104,7 +104,7 @@ fn bench_wal_with_sync(c: &mut Criterion) {
 
                 b.iter(|| {
                     let operation = WalOperation::CreateNode {
-                        node_id: gallifreydb::core::id::NodeId::new(1),
+                        node_id: gallifreydb::core::id::NodeId::new(1).unwrap(),
                         label: "Person".to_string(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
@@ -231,7 +231,7 @@ fn bench_recovery(c: &mut Criterion) {
 
             for i in 0..*wal_entries {
                 let operation = WalOperation::CreateNode {
-                    node_id: gallifreydb::core::id::NodeId::new(i),
+                    node_id: gallifreydb::core::id::NodeId::new(i).unwrap(),
                     label: "Person".to_string(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),
@@ -256,7 +256,7 @@ fn bench_recovery(c: &mut Criterion) {
             // Add more WAL entries after checkpoint
             for i in *wal_entries..(*wal_entries + 100) {
                 let operation = WalOperation::CreateNode {
-                    node_id: gallifreydb::core::id::NodeId::new(i),
+                    node_id: gallifreydb::core::id::NodeId::new(i).unwrap(),
                     label: "Person".to_string(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -183,7 +183,7 @@ mod tests {
         let current = Arc::new(CurrentStorage::new());
         let tx = create_test_read_tx(TxId::new(1), current);
 
-        let result = tx.get_node(NodeId::new(999));
+        let result = tx.get_node(NodeId::new(999).unwrap());
         assert!(result.is_err());
     }
 

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -209,8 +209,8 @@ mod tests {
     #[test]
     fn test_write_buffer_add_node() {
         let mut buffer = WriteBuffer::new();
-        let node_id = NodeId::new(1);
-        let version_id = VersionId::new(1);
+        let node_id = NodeId::new(1).unwrap();
+        let version_id = VersionId::new(1).unwrap();
         let label = crate::core::interning::GLOBAL_INTERNER.intern("Person");
         let properties = PropertyMap::new();
         let temporal = BiTemporalInterval::current(time::now());
@@ -226,16 +226,16 @@ mod tests {
         assert_eq!(buffer.len(), 1);
         assert!(!buffer.is_empty());
         assert!(buffer.has_modified_node(node_id));
-        assert!(!buffer.has_modified_node(NodeId::new(2)));
+        assert!(!buffer.has_modified_node(NodeId::new(2).unwrap()));
     }
 
     #[test]
     fn test_write_buffer_add_edge() {
         let mut buffer = WriteBuffer::new();
-        let edge_id = EdgeId::new(1);
-        let version_id = VersionId::new(1);
-        let source = NodeId::new(1);
-        let target = NodeId::new(2);
+        let edge_id = EdgeId::new(1).unwrap();
+        let version_id = VersionId::new(1).unwrap();
+        let source = NodeId::new(1).unwrap();
+        let target = NodeId::new(2).unwrap();
         let label = crate::core::interning::GLOBAL_INTERNER.intern("KNOWS");
         let properties = PropertyMap::new();
         let temporal = BiTemporalInterval::current(time::now());
@@ -252,15 +252,15 @@ mod tests {
 
         assert_eq!(buffer.len(), 1);
         assert!(buffer.has_modified_edge(edge_id));
-        assert!(!buffer.has_modified_edge(EdgeId::new(2)));
+        assert!(!buffer.has_modified_edge(EdgeId::new(2).unwrap()));
     }
 
     #[test]
     fn test_write_buffer_multiple_operations() {
         let mut buffer = WriteBuffer::new();
-        let node_id = NodeId::new(1);
-        let edge_id = EdgeId::new(1);
-        let version_id = VersionId::new(1);
+        let node_id = NodeId::new(1).unwrap();
+        let edge_id = EdgeId::new(1).unwrap();
+        let version_id = VersionId::new(1).unwrap();
         let label = crate::core::interning::GLOBAL_INTERNER.intern("Test");
         let properties = PropertyMap::new();
         let temporal = BiTemporalInterval::current(time::now());
@@ -279,7 +279,7 @@ mod tests {
             edge_id,
             version_id,
             source: node_id,
-            target: NodeId::new(2),
+            target: NodeId::new(2).unwrap(),
             label,
             properties,
             temporal,
@@ -293,8 +293,8 @@ mod tests {
     #[test]
     fn test_write_buffer_clear() {
         let mut buffer = WriteBuffer::new();
-        let node_id = NodeId::new(1);
-        let version_id = VersionId::new(1);
+        let node_id = NodeId::new(1).unwrap();
+        let version_id = VersionId::new(1).unwrap();
         let label = crate::core::interning::GLOBAL_INTERNER.intern("Test");
         let properties = PropertyMap::new();
         let temporal = BiTemporalInterval::current(time::now());
@@ -319,9 +319,9 @@ mod tests {
     #[test]
     fn test_write_buffer_update_tracking() {
         let mut buffer = WriteBuffer::new();
-        let node_id = NodeId::new(1);
-        let version_id_1 = VersionId::new(1);
-        let version_id_2 = VersionId::new(2);
+        let node_id = NodeId::new(1).unwrap();
+        let version_id_1 = VersionId::new(1).unwrap();
+        let version_id_2 = VersionId::new(2).unwrap();
         let label = crate::core::interning::GLOBAL_INTERNER.intern("Test");
         let properties = PropertyMap::new();
         let temporal = BiTemporalInterval::current(time::now());

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -667,7 +667,7 @@ impl WriteTransaction {
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
-                        VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
+                        VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next()?);
 
                     // Create tombstone temporal interval
                     // The tombstone marks when the deletion occurred. Its transaction_time
@@ -714,7 +714,7 @@ impl WriteTransaction {
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
-                        VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
+                        VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next()?);
 
                     // Create tombstone temporal interval
                     // The tombstone marks when the deletion occurred. Its transaction_time
@@ -929,8 +929,8 @@ impl WriteOps for WriteTransaction {
         }
 
         // Generate IDs
-        let node_id = NodeId::new_unchecked(self.node_id_gen.lock_or_err()?.next());
-        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
+        let node_id = NodeId::new_unchecked(self.node_id_gen.lock_or_err()?.next()?);
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next()?);
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         // Get timestamp for temporal interval
@@ -966,8 +966,8 @@ impl WriteOps for WriteTransaction {
         }
 
         // Generate IDs
-        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.lock_or_err()?.next());
-        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
+        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.lock_or_err()?.next()?);
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next()?);
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         // Get timestamp for temporal interval
@@ -1000,7 +1000,7 @@ impl WriteOps for WriteTransaction {
 
         // Get current node to preserve label
         let node = self.current.get_node(node_id)?;
-        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next()?);
 
         // Get timestamp for temporal interval
         let timestamp = self.start_timestamp;
@@ -1030,7 +1030,7 @@ impl WriteOps for WriteTransaction {
 
         // Get current edge to preserve source, target, label
         let edge = self.current.get_edge(edge_id)?;
-        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next()?);
 
         // Get timestamp for temporal interval
         let timestamp = self.start_timestamp;

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -667,7 +667,7 @@ impl WriteTransaction {
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
-                        VersionId::new(self.version_id_gen.lock_or_err()?.next());
+                        VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
 
                     // Create tombstone temporal interval
                     // The tombstone marks when the deletion occurred. Its transaction_time
@@ -714,7 +714,7 @@ impl WriteTransaction {
 
                     // Generate version ID for tombstone
                     let tombstone_version_id =
-                        VersionId::new(self.version_id_gen.lock_or_err()?.next());
+                        VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
 
                     // Create tombstone temporal interval
                     // The tombstone marks when the deletion occurred. Its transaction_time
@@ -929,8 +929,8 @@ impl WriteOps for WriteTransaction {
         }
 
         // Generate IDs
-        let node_id = NodeId::new(self.node_id_gen.lock_or_err()?.next());
-        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
+        let node_id = NodeId::new_unchecked(self.node_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         // Get timestamp for temporal interval
@@ -966,8 +966,8 @@ impl WriteOps for WriteTransaction {
         }
 
         // Generate IDs
-        let edge_id = EdgeId::new(self.edge_id_gen.lock_or_err()?.next());
-        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
+        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         // Get timestamp for temporal interval
@@ -1000,7 +1000,7 @@ impl WriteOps for WriteTransaction {
 
         // Get current node to preserve label
         let node = self.current.get_node(node_id)?;
-        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
 
         // Get timestamp for temporal interval
         let timestamp = self.start_timestamp;
@@ -1030,7 +1030,7 @@ impl WriteOps for WriteTransaction {
 
         // Get current edge to preserve source, target, label
         let edge = self.current.get_edge(edge_id)?;
-        let version_id = VersionId::new(self.version_id_gen.lock_or_err()?.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.lock_or_err()?.next());
 
         // Get timestamp for temporal interval
         let timestamp = self.start_timestamp;
@@ -1252,8 +1252,8 @@ mod tests {
         let props = PropertyMapBuilder::new().build();
 
         // Try to create edge with non-existent nodes
-        let node1 = NodeId::new(999);
-        let node2 = NodeId::new(1000);
+        let node1 = NodeId::new(999).unwrap();
+        let node2 = NodeId::new(1000).unwrap();
 
         tx.create_edge(node1, node2, "KNOWS", props).unwrap();
 
@@ -1302,7 +1302,7 @@ mod tests {
         let (mut tx, _temp_dir) = create_test_write_tx();
 
         let props = PropertyMapBuilder::new().insert("age", 30i64).build();
-        let result = tx.update_node(NodeId::new(999), props);
+        let result = tx.update_node(NodeId::new(999).unwrap(), props);
 
         // Should fail because node doesn't exist
         assert!(result.is_err());
@@ -1343,7 +1343,7 @@ mod tests {
         let (mut tx, _temp_dir) = create_test_write_tx();
 
         let props = PropertyMapBuilder::new().insert("strength", 5i64).build();
-        let result = tx.update_edge(EdgeId::new(999), props);
+        let result = tx.update_edge(EdgeId::new(999).unwrap(), props);
 
         // Should fail because edge doesn't exist
         assert!(result.is_err());
@@ -1375,7 +1375,7 @@ mod tests {
     fn test_delete_node_not_found() {
         let (mut tx, _temp_dir) = create_test_write_tx();
 
-        let result = tx.delete_node(NodeId::new(999));
+        let result = tx.delete_node(NodeId::new(999).unwrap());
 
         // Should fail because node doesn't exist
         assert!(result.is_err());
@@ -1413,7 +1413,7 @@ mod tests {
     fn test_delete_edge_not_found() {
         let (mut tx, _temp_dir) = create_test_write_tx();
 
-        let result = tx.delete_edge(EdgeId::new(999));
+        let result = tx.delete_edge(EdgeId::new(999).unwrap());
 
         // Should fail because edge doesn't exist
         assert!(result.is_err());

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -171,11 +171,11 @@ mod tests {
             .insert("age", 30i64)
             .build();
 
-        let node = Node::new(NodeId::new(1), label, props, VersionId::new(100));
+        let node = Node::new(NodeId::new(1).unwrap(), label, props, VersionId::new(100).unwrap());
 
-        assert_eq!(node.id, NodeId::new(1));
+        assert_eq!(node.id, NodeId::new(1).unwrap());
         assert_eq!(node.label, label);
-        assert_eq!(node.current_version, VersionId::new(100));
+        assert_eq!(node.current_version, VersionId::new(100).unwrap());
         assert_eq!(
             node.get_property("name").and_then(|v| v.as_str()),
             Some("Alice")
@@ -189,10 +189,10 @@ mod tests {
         let other_label = GLOBAL_INTERNER.intern("Company");
 
         let node = Node::new(
-            NodeId::new(1),
+            NodeId::new(1).unwrap(),
             label,
             PropertyMapBuilder::new().build(),
-            VersionId::new(1),
+            VersionId::new(1).unwrap(),
         );
 
         assert!(node.has_label(label));
@@ -205,19 +205,19 @@ mod tests {
         let props = PropertyMapBuilder::new().insert("since", 2020i64).build();
 
         let edge = Edge::new(
-            EdgeId::new(1),
+            EdgeId::new(1).unwrap(),
             label,
-            NodeId::new(1),
-            NodeId::new(2),
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
             props,
-            VersionId::new(100),
+            VersionId::new(100).unwrap(),
         );
 
-        assert_eq!(edge.id, EdgeId::new(1));
+        assert_eq!(edge.id, EdgeId::new(1).unwrap());
         assert_eq!(edge.label, label);
-        assert_eq!(edge.source, NodeId::new(1));
-        assert_eq!(edge.target, NodeId::new(2));
-        assert_eq!(edge.current_version, VersionId::new(100));
+        assert_eq!(edge.source, NodeId::new(1).unwrap());
+        assert_eq!(edge.target, NodeId::new(2).unwrap());
+        assert_eq!(edge.current_version, VersionId::new(100).unwrap());
         assert_eq!(
             edge.get_property("since").and_then(|v| v.as_int()),
             Some(2020)
@@ -227,16 +227,16 @@ mod tests {
     #[test]
     fn test_edge_connects() {
         let edge = Edge::new(
-            EdgeId::new(1),
+            EdgeId::new(1).unwrap(),
             GLOBAL_INTERNER.intern("KNOWS"),
-            NodeId::new(1),
-            NodeId::new(2),
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
             PropertyMapBuilder::new().build(),
-            VersionId::new(1),
+            VersionId::new(1).unwrap(),
         );
 
-        assert!(edge.connects(NodeId::new(1), NodeId::new(2)));
-        assert!(!edge.connects(NodeId::new(2), NodeId::new(1)));
-        assert!(!edge.connects(NodeId::new(1), NodeId::new(3)));
+        assert!(edge.connects(NodeId::new(1).unwrap(), NodeId::new(2).unwrap()));
+        assert!(!edge.connects(NodeId::new(2).unwrap(), NodeId::new(1).unwrap()));
+        assert!(!edge.connects(NodeId::new(1).unwrap(), NodeId::new(3).unwrap()));
     }
 }

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -527,4 +527,255 @@ mod tests {
         // Validation should add minimal overhead (< 2ns per operation on modern hardware)
         // We don't assert this in the test since it's hardware-dependent
     }
+
+    #[test]
+    fn test_id_generator_concurrent_near_limit() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::collections::HashSet;
+
+        // Start generator 20 IDs before the limit
+        let ids_before_limit = 20u64;
+        let generator = Arc::new(IdGenerator::with_start(MAX_VALID_ID - ids_before_limit + 1));
+
+        // Spawn 10 threads, each trying to generate 5 IDs
+        let num_threads = 10;
+        let ids_per_thread = 5;
+        let total_attempts = num_threads * ids_per_thread;
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let gen_clone = Arc::clone(&generator);
+                thread::spawn(move || {
+                    let mut results = Vec::new();
+                    for _ in 0..ids_per_thread {
+                        results.push(gen_clone.next());
+                    }
+                    results
+                })
+            })
+            .collect();
+
+        // Collect all results
+        let mut all_results = Vec::new();
+        for handle in handles {
+            let thread_results = handle.join().expect("Thread panicked");
+            all_results.extend(thread_results);
+        }
+
+        // Verify results
+        let mut successful_ids = HashSet::new();
+        let mut error_count = 0;
+
+        for result in all_results {
+            match result {
+                Ok(id) => {
+                    // Verify ID is valid
+                    assert!(id <= MAX_VALID_ID, "Generated ID {} exceeds MAX_VALID_ID", id);
+                    // Verify no duplicates (critical for concurrency correctness)
+                    assert!(successful_ids.insert(id), "Duplicate ID generated: {}", id);
+                }
+                Err(e) => {
+                    // Verify error is the expected overflow error
+                    assert!(
+                        matches!(e, StorageError::InvalidId { id_type: "generated", .. }),
+                        "Unexpected error type: {:?}",
+                        e
+                    );
+                    error_count += 1;
+                }
+            }
+        }
+
+        // We started with 20 IDs available (MAX_VALID_ID - start + 1 = 20)
+        // So exactly 20 should succeed and the rest should fail
+        assert_eq!(
+            successful_ids.len(),
+            ids_before_limit as usize,
+            "Expected exactly {} successful ID generations",
+            ids_before_limit
+        );
+        assert_eq!(
+            error_count,
+            total_attempts - ids_before_limit as usize,
+            "Expected {} errors when exceeding limit",
+            total_attempts - ids_before_limit as usize
+        );
+
+        // Verify all successful IDs are in the expected range
+        for id in &successful_ids {
+            assert!(
+                *id > MAX_VALID_ID - ids_before_limit && *id <= MAX_VALID_ID,
+                "ID {} outside expected range [{}, {}]",
+                id,
+                MAX_VALID_ID - ids_before_limit + 1,
+                MAX_VALID_ID
+            );
+        }
+
+        println!("\nConcurrent ID Generation Test Results:");
+        println!("  Threads: {}", num_threads);
+        println!("  Attempts per thread: {}", ids_per_thread);
+        println!("  Total attempts: {}", total_attempts);
+        println!("  Successful: {} (no duplicates)", successful_ids.len());
+        println!("  Errors: {}", error_count);
+        println!("  ID range: {} - {}",
+            successful_ids.iter().min().unwrap(),
+            successful_ids.iter().max().unwrap()
+        );
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    // Generate valid IDs (0..=MAX_VALID_ID)
+    fn valid_id_strategy() -> impl Strategy<Value = u64> {
+        0..=MAX_VALID_ID
+    }
+
+    // Generate any u64 value
+    fn any_u64_strategy() -> impl Strategy<Value = u64> {
+        any::<u64>()
+    }
+
+    proptest! {
+        /// Property: Any ID that passes validation must be <= MAX_VALID_ID
+        #[test]
+        fn prop_validated_ids_within_bounds(raw_id in valid_id_strategy()) {
+            // All valid IDs should successfully create NodeId
+            let node_id = NodeId::new(raw_id).expect("Valid ID should not fail");
+            prop_assert!(node_id.as_u64() <= MAX_VALID_ID);
+
+            // Same for EdgeId and VersionId
+            let edge_id = EdgeId::new(raw_id).expect("Valid ID should not fail");
+            prop_assert!(edge_id.as_u64() <= MAX_VALID_ID);
+
+            let version_id = VersionId::new(raw_id).expect("Valid ID should not fail");
+            prop_assert!(version_id.as_u64() <= MAX_VALID_ID);
+        }
+
+        /// Property: Any ID > MAX_VALID_ID must be rejected
+        #[test]
+        fn prop_invalid_ids_rejected(offset in 1u64..=1000) {
+            let invalid_id = MAX_VALID_ID + offset;
+
+            // All invalid IDs should fail validation
+            prop_assert!(NodeId::new(invalid_id).is_err());
+            prop_assert!(EdgeId::new(invalid_id).is_err());
+            prop_assert!(VersionId::new(invalid_id).is_err());
+        }
+
+        /// Property: ID roundtrip (ID -> u64 -> ID) preserves value
+        #[test]
+        fn prop_id_roundtrip_preserves_value(raw_id in valid_id_strategy()) {
+            // NodeId roundtrip
+            let node_id = NodeId::new(raw_id).unwrap();
+            let roundtrip_node = NodeId::new(node_id.as_u64()).unwrap();
+            prop_assert_eq!(node_id, roundtrip_node);
+
+            // EdgeId roundtrip
+            let edge_id = EdgeId::new(raw_id).unwrap();
+            let roundtrip_edge = EdgeId::new(edge_id.as_u64()).unwrap();
+            prop_assert_eq!(edge_id, roundtrip_edge);
+
+            // VersionId roundtrip
+            let version_id = VersionId::new(raw_id).unwrap();
+            let roundtrip_version = VersionId::new(version_id.as_u64()).unwrap();
+            prop_assert_eq!(version_id, roundtrip_version);
+        }
+
+        /// Property: ID ordering is consistent with u64 ordering
+        #[test]
+        fn prop_id_ordering_consistent(a in valid_id_strategy(), b in valid_id_strategy()) {
+            let node_a = NodeId::new(a).unwrap();
+            let node_b = NodeId::new(b).unwrap();
+
+            // Ordering should match raw u64 ordering
+            prop_assert_eq!(node_a.cmp(&node_b), a.cmp(&b));
+            prop_assert_eq!(node_a == node_b, a == b);
+            prop_assert_eq!(node_a < node_b, a < b);
+            prop_assert_eq!(node_a > node_b, a > b);
+        }
+
+        /// Property: ID generator produces strictly increasing sequence
+        #[test]
+        fn prop_generator_monotonic_increasing(start in 0u64..MAX_VALID_ID-100, count in 1usize..100) {
+            let generator = IdGenerator::with_start(start);
+            let mut prev_id: Option<u64> = None;
+
+            for _ in 0..count {
+                match generator.next() {
+                    Ok(id) => {
+                        // Verify ID is within bounds
+                        prop_assert!(id <= MAX_VALID_ID, "Generator must respect MAX_VALID_ID");
+
+                        // Verify strictly increasing (if not first ID)
+                        if let Some(prev) = prev_id {
+                            prop_assert!(id > prev, "Generator must produce strictly increasing IDs");
+                        }
+
+                        prev_id = Some(id);
+                    }
+                    Err(_) => {
+                        // Once we hit an error, all future calls should also error
+                        if let Some(prev) = prev_id {
+                            prop_assert!(prev >= MAX_VALID_ID, "Generator should only error after MAX_VALID_ID");
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// Property: ID generator never produces duplicates
+        #[test]
+        fn prop_generator_no_duplicates(start in 0u64..MAX_VALID_ID-1000, count in 1usize..1000) {
+            let generator = IdGenerator::with_start(start);
+            let mut seen = std::collections::HashSet::new();
+
+            for _ in 0..count {
+                match generator.next() {
+                    Ok(id) => {
+                        prop_assert!(seen.insert(id), "Generator produced duplicate ID: {}", id);
+                    }
+                    Err(_) => break, // Hit the limit
+                }
+            }
+        }
+
+        /// Property: new_unchecked accepts any value (for internal use)
+        #[test]
+        fn prop_new_unchecked_accepts_all(raw_id in any_u64_strategy()) {
+            // new_unchecked should work with any value, even invalid ones
+            let node = NodeId::new_unchecked(raw_id);
+            prop_assert_eq!(node.as_u64(), raw_id);
+
+            let edge = EdgeId::new_unchecked(raw_id);
+            prop_assert_eq!(edge.as_u64(), raw_id);
+
+            let version = VersionId::new_unchecked(raw_id);
+            prop_assert_eq!(version.as_u64(), raw_id);
+        }
+
+        /// Property: Validation is consistent (always returns same result for same input)
+        #[test]
+        fn prop_validation_is_deterministic(raw_id in any_u64_strategy()) {
+            // Call validation twice with same input
+            let result1 = NodeId::new(raw_id);
+            let result2 = NodeId::new(raw_id);
+
+            // Results should be identical
+            match (result1, result2) {
+                (Ok(id1), Ok(id2)) => prop_assert_eq!(id1, id2),
+                (Err(_), Err(_)) => {
+                    // Both should reject invalid IDs
+                    prop_assert!(raw_id > MAX_VALID_ID);
+                }
+                _ => prop_assert!(false, "Validation must be deterministic"),
+            }
+        }
+    }
 }

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -6,15 +6,40 @@
 
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
+use crate::utils::error::StorageError;
+
+/// Maximum valid ID value. Values above this are reserved for internal use.
+/// This prevents potential integer overflow issues and DoS attacks.
+pub const MAX_VALID_ID: u64 = u64::MAX - 1000;
 
 /// Unique identifier for a node in the graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NodeId(u64);
 
 impl NodeId {
-    /// Create a new NodeId from a u64 value.
+    /// Create a new NodeId from a u64 value with validation.
+    ///
+    /// Returns an error if the ID exceeds MAX_VALID_ID.
     #[inline]
-    pub const fn new(id: u64) -> Self {
+    pub fn new(id: u64) -> Result<Self, StorageError> {
+        if id > MAX_VALID_ID {
+            return Err(StorageError::InvalidId {
+                id,
+                id_type: "node",
+                reason: format!("ID {} exceeds maximum allowed value {}", id, MAX_VALID_ID),
+            });
+        }
+        Ok(NodeId(id))
+    }
+
+    /// Create a new NodeId without validation (for internal use only).
+    ///
+    /// # Safety
+    /// This function bypasses validation. Only use when you're certain the ID is valid,
+    /// such as when loading from trusted storage or in performance-critical paths where
+    /// validation has already occurred.
+    #[inline]
+    pub(crate) const fn new_unchecked(id: u64) -> Self {
         NodeId(id)
     }
 
@@ -36,9 +61,29 @@ impl fmt::Display for NodeId {
 pub struct EdgeId(u64);
 
 impl EdgeId {
-    /// Create a new EdgeId from a u64 value.
+    /// Create a new EdgeId from a u64 value with validation.
+    ///
+    /// Returns an error if the ID exceeds MAX_VALID_ID.
     #[inline]
-    pub const fn new(id: u64) -> Self {
+    pub fn new(id: u64) -> Result<Self, StorageError> {
+        if id > MAX_VALID_ID {
+            return Err(StorageError::InvalidId {
+                id,
+                id_type: "edge",
+                reason: format!("ID {} exceeds maximum allowed value {}", id, MAX_VALID_ID),
+            });
+        }
+        Ok(EdgeId(id))
+    }
+
+    /// Create a new EdgeId without validation (for internal use only).
+    ///
+    /// # Safety
+    /// This function bypasses validation. Only use when you're certain the ID is valid,
+    /// such as when loading from trusted storage or in performance-critical paths where
+    /// validation has already occurred.
+    #[inline]
+    pub(crate) const fn new_unchecked(id: u64) -> Self {
         EdgeId(id)
     }
 
@@ -60,9 +105,29 @@ impl fmt::Display for EdgeId {
 pub struct VersionId(u64);
 
 impl VersionId {
-    /// Create a new VersionId from a u64 value.
+    /// Create a new VersionId from a u64 value with validation.
+    ///
+    /// Returns an error if the ID exceeds MAX_VALID_ID.
     #[inline]
-    pub const fn new(id: u64) -> Self {
+    pub fn new(id: u64) -> Result<Self, StorageError> {
+        if id > MAX_VALID_ID {
+            return Err(StorageError::InvalidId {
+                id,
+                id_type: "version",
+                reason: format!("ID {} exceeds maximum allowed value {}", id, MAX_VALID_ID),
+            });
+        }
+        Ok(VersionId(id))
+    }
+
+    /// Create a new VersionId without validation (for internal use only).
+    ///
+    /// # Safety
+    /// This function bypasses validation. Only use when you're certain the ID is valid,
+    /// such as when loading from trusted storage or in performance-critical paths where
+    /// validation has already occurred.
+    #[inline]
+    pub(crate) const fn new_unchecked(id: u64) -> Self {
         VersionId(id)
     }
 
@@ -192,25 +257,25 @@ mod tests {
 
     #[test]
     fn test_node_id_creation() {
-        let id = NodeId::new(42);
+        let id = NodeId::new(42).unwrap();
         assert_eq!(id.as_u64(), 42);
     }
 
     #[test]
     fn test_edge_id_creation() {
-        let id = EdgeId::new(100);
+        let id = EdgeId::new(100).unwrap();
         assert_eq!(id.as_u64(), 100);
     }
 
     #[test]
     fn test_version_id_creation() {
-        let id = VersionId::new(1000);
+        let id = VersionId::new(1000).unwrap();
         assert_eq!(id.as_u64(), 1000);
     }
 
     #[test]
     fn test_entity_id_from_node() {
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let entity_id: EntityId = node_id.into();
         assert!(entity_id.is_node());
         assert!(!entity_id.is_edge());
@@ -219,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_entity_id_from_edge() {
-        let edge_id = EdgeId::new(2);
+        let edge_id = EdgeId::new(2).unwrap();
         let entity_id: EntityId = edge_id.into();
         assert!(!entity_id.is_node());
         assert!(entity_id.is_edge());
@@ -244,9 +309,9 @@ mod tests {
 
     #[test]
     fn test_id_display() {
-        let node = NodeId::new(42);
-        let edge = EdgeId::new(100);
-        let version = VersionId::new(1000);
+        let node = NodeId::new(42).unwrap();
+        let edge = EdgeId::new(100).unwrap();
+        let version = VersionId::new(1000).unwrap();
 
         assert_eq!(format!("{}", node), "Node(42)");
         assert_eq!(format!("{}", edge), "Edge(100)");
@@ -257,12 +322,89 @@ mod tests {
     fn test_ids_are_distinct_types() {
         // This test ensures that you cannot accidentally use one type where another is expected.
         // This is enforced by the type system, so we just verify we can create different types.
-        let _node = NodeId::new(1);
-        let _edge = EdgeId::new(1);
-        let _version = VersionId::new(1);
+        // Use new_unchecked since we're just testing the type system, not validation.
+        let _node = NodeId::new_unchecked(1);
+        let _edge = EdgeId::new_unchecked(1);
+        let _version = VersionId::new_unchecked(1);
 
         // The following would fail to compile (which is what we want):
         // fn takes_node_id(_id: NodeId) {}
         // takes_node_id(_edge); // Type error!
+    }
+
+    #[test]
+    fn test_id_validation_accepts_valid_ids() {
+        // Valid IDs should be accepted
+        assert!(NodeId::new(0).is_ok());
+        assert!(NodeId::new(42).is_ok());
+        assert!(NodeId::new(MAX_VALID_ID).is_ok());
+
+        assert!(EdgeId::new(0).is_ok());
+        assert!(EdgeId::new(100).is_ok());
+        assert!(EdgeId::new(MAX_VALID_ID).is_ok());
+
+        assert!(VersionId::new(0).is_ok());
+        assert!(VersionId::new(1000).is_ok());
+        assert!(VersionId::new(MAX_VALID_ID).is_ok());
+    }
+
+    #[test]
+    fn test_id_validation_rejects_out_of_range() {
+        // IDs exceeding MAX_VALID_ID should be rejected
+        let node_result = NodeId::new(MAX_VALID_ID + 1);
+        assert!(node_result.is_err());
+        if let Err(StorageError::InvalidId { id, id_type, reason }) = node_result {
+            assert_eq!(id, MAX_VALID_ID + 1);
+            assert_eq!(id_type, "node");
+            assert!(reason.contains("exceeds maximum"));
+        } else {
+            panic!("Expected InvalidId error");
+        }
+
+        let edge_result = EdgeId::new(u64::MAX);
+        assert!(edge_result.is_err());
+        if let Err(StorageError::InvalidId { id, id_type, .. }) = edge_result {
+            assert_eq!(id, u64::MAX);
+            assert_eq!(id_type, "edge");
+        } else {
+            panic!("Expected InvalidId error");
+        }
+
+        let version_result = VersionId::new(MAX_VALID_ID + 1000);
+        assert!(version_result.is_err());
+        if let Err(StorageError::InvalidId { id_type, .. }) = version_result {
+            assert_eq!(id_type, "version");
+        } else {
+            panic!("Expected InvalidId error");
+        }
+    }
+
+    #[test]
+    fn test_new_unchecked_bypasses_validation() {
+        // new_unchecked should create IDs without validation
+        // This is for internal use where we know the ID is safe
+        let node = NodeId::new_unchecked(42);
+        assert_eq!(node.as_u64(), 42);
+
+        let edge = EdgeId::new_unchecked(100);
+        assert_eq!(edge.as_u64(), 100);
+
+        let version = VersionId::new_unchecked(1000);
+        assert_eq!(version.as_u64(), 1000);
+
+        // Even out-of-range values work with new_unchecked (though they shouldn't be used)
+        let _risky_node = NodeId::new_unchecked(u64::MAX);
+        let _risky_edge = EdgeId::new_unchecked(u64::MAX);
+        let _risky_version = VersionId::new_unchecked(u64::MAX);
+    }
+
+    #[test]
+    fn test_max_valid_id_constant() {
+        // Verify the MAX_VALID_ID constant is set correctly
+        assert_eq!(MAX_VALID_ID, u64::MAX - 1000);
+        
+        // Verify it leaves room for reserved values
+        assert!(MAX_VALID_ID < u64::MAX);
+        assert!(u64::MAX - MAX_VALID_ID >= 1000);
     }
 }

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -238,9 +238,22 @@ impl IdGenerator {
     /// Generate the next unique ID.
     ///
     /// This method is thread-safe and lock-free.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the generator would exceed `MAX_VALID_ID`. In practice, this requires
+    /// ~18 quintillion operations and is unrealistic for a single database instance.
     #[inline]
     pub fn next(&self) -> u64 {
-        self.next_id.fetch_add(1, Ordering::Relaxed)
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        if id > MAX_VALID_ID {
+            panic!(
+                "ID generator exhausted: generated ID {} exceeds MAX_VALID_ID ({}). \
+                 This indicates either a bug or an unrealistic number of operations.",
+                id, MAX_VALID_ID
+            );
+        }
+        id
     }
 
     /// Get the current value without incrementing.
@@ -407,12 +420,11 @@ mod tests {
     fn test_max_valid_id_constant() {
         // Verify the MAX_VALID_ID constant is set correctly
         assert_eq!(MAX_VALID_ID, u64::MAX - 1000);
-        
+
         // Verify it leaves room for reserved values
         assert!(MAX_VALID_ID < u64::MAX);
         assert!(u64::MAX - MAX_VALID_ID >= 1000);
     }
-}
 
     #[test]
     fn test_id_validation_boundary_cases() {
@@ -421,12 +433,12 @@ mod tests {
         assert!(NodeId::new(MAX_VALID_ID).is_ok());
         assert!(NodeId::new(MAX_VALID_ID + 1).is_err());
         assert!(NodeId::new(MAX_VALID_ID + 2).is_err());
-        
+
         // Same for other ID types
         assert!(EdgeId::new(MAX_VALID_ID - 1).is_ok());
         assert!(EdgeId::new(MAX_VALID_ID).is_ok());
         assert!(EdgeId::new(MAX_VALID_ID + 1).is_err());
-        
+
         assert!(VersionId::new(MAX_VALID_ID - 1).is_ok());
         assert!(VersionId::new(MAX_VALID_ID).is_ok());
         assert!(VersionId::new(MAX_VALID_ID + 1).is_err());
@@ -443,6 +455,7 @@ mod tests {
         assert!(msg.contains(&(MAX_VALID_ID + 1).to_string()));
         assert!(msg.contains("exceeds maximum"));
         assert!(msg.contains(&MAX_VALID_ID.to_string()));
+        assert!(msg.contains("reserved range for internal use"));
     }
 
     #[test]
@@ -457,7 +470,7 @@ mod tests {
                 id
             );
         }
-        
+
         // Test generator starting near the limit
         let generator = IdGenerator::with_start(MAX_VALID_ID - 10);
         for _ in 0..10 {
@@ -468,9 +481,50 @@ mod tests {
                 id
             );
         }
-        
+
         // Note: After MAX_VALID_ID, generator would produce invalid IDs.
         // In practice, this would require ~18 quintillion operations,
         // which is unrealistic for a single database instance.
-        // If needed, IdGenerator could be enhanced to check MAX_VALID_ID.
     }
+
+    #[test]
+    #[should_panic(expected = "ID generator exhausted")]
+    fn test_id_generator_panics_on_overflow() {
+        // Verify generator panics when exceeding MAX_VALID_ID
+        let generator = IdGenerator::with_start(MAX_VALID_ID);
+        let _ = generator.next(); // This should be OK (at MAX_VALID_ID)
+        let _ = generator.next(); // This should panic (exceeds MAX_VALID_ID)
+    }
+
+    #[test]
+    fn test_id_validation_performance() {
+        // Verify validation overhead is negligible
+        // This is a simple smoke test - proper benchmarking should use criterion
+        use std::time::Instant;
+
+        let iterations = 1_000_000;
+
+        // Time validated creation
+        let start = Instant::now();
+        for i in 0..iterations {
+            let _ = NodeId::new(i);
+        }
+        let validated_duration = start.elapsed();
+
+        // Time unchecked creation (for comparison)
+        let start = Instant::now();
+        for i in 0..iterations {
+            let _ = NodeId::new_unchecked(i);
+        }
+        let unchecked_duration = start.elapsed();
+
+        // Print results for manual inspection (not asserted in test)
+        println!("\nID Validation Performance (1M iterations):");
+        println!("  Validated:  {:?} ({} ns/op)", validated_duration, validated_duration.as_nanos() / iterations as u128);
+        println!("  Unchecked:  {:?} ({} ns/op)", unchecked_duration, unchecked_duration.as_nanos() / iterations as u128);
+        println!("  Overhead:   {:?}", validated_duration.saturating_sub(unchecked_duration));
+
+        // Validation should add minimal overhead (< 2ns per operation on modern hardware)
+        // We don't assert this in the test since it's hardware-dependent
+    }
+}

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -26,7 +26,6 @@ impl NodeId {
             return Err(StorageError::InvalidId {
                 id,
                 id_type: "node",
-                reason: format!("ID {} exceeds maximum allowed value {}", id, MAX_VALID_ID),
             });
         }
         Ok(NodeId(id))
@@ -70,7 +69,6 @@ impl EdgeId {
             return Err(StorageError::InvalidId {
                 id,
                 id_type: "edge",
-                reason: format!("ID {} exceeds maximum allowed value {}", id, MAX_VALID_ID),
             });
         }
         Ok(EdgeId(id))
@@ -114,7 +112,6 @@ impl VersionId {
             return Err(StorageError::InvalidId {
                 id,
                 id_type: "version",
-                reason: format!("ID {} exceeds maximum allowed value {}", id, MAX_VALID_ID),
             });
         }
         Ok(VersionId(id))
@@ -353,17 +350,16 @@ mod tests {
         // IDs exceeding MAX_VALID_ID should be rejected
         let node_result = NodeId::new(MAX_VALID_ID + 1);
         assert!(node_result.is_err());
-        if let Err(StorageError::InvalidId { id, id_type, reason }) = node_result {
+        if let Err(StorageError::InvalidId { id, id_type }) = node_result {
             assert_eq!(id, MAX_VALID_ID + 1);
             assert_eq!(id_type, "node");
-            assert!(reason.contains("exceeds maximum"));
         } else {
             panic!("Expected InvalidId error");
         }
 
         let edge_result = EdgeId::new(u64::MAX);
         assert!(edge_result.is_err());
-        if let Err(StorageError::InvalidId { id, id_type, .. }) = edge_result {
+        if let Err(StorageError::InvalidId { id, id_type }) = edge_result {
             assert_eq!(id, u64::MAX);
             assert_eq!(id_type, "edge");
         } else {
@@ -372,7 +368,8 @@ mod tests {
 
         let version_result = VersionId::new(MAX_VALID_ID + 1000);
         assert!(version_result.is_err());
-        if let Err(StorageError::InvalidId { id_type, .. }) = version_result {
+        if let Err(StorageError::InvalidId { id, id_type }) = version_result {
+            assert_eq!(id, MAX_VALID_ID + 1000);
             assert_eq!(id_type, "version");
         } else {
             panic!("Expected InvalidId error");

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -8,8 +8,16 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use crate::utils::error::StorageError;
 
-/// Maximum valid ID value. Values above this are reserved for internal use.
-/// This prevents potential integer overflow issues and DoS attacks.
+/// Maximum valid ID value. Values above this are reserved.
+///
+/// This prevents potential DoS attacks where malicious code creates IDs with
+/// extreme values (like u64::MAX) that could cause issues in:
+/// - Arithmetic operations (addition/subtraction with IDs)
+/// - Array indexing or allocation attempts
+/// - Serialization buffer sizing
+///
+/// The reserved range of 1000 values provides a safety margin without meaningfully
+/// restricting the ID space (you can still have ~18 quintillion valid IDs).
 pub const MAX_VALID_ID: u64 = u64::MAX - 1000;
 
 /// Unique identifier for a node in the graph.
@@ -33,7 +41,7 @@ impl NodeId {
 
     /// Create a new NodeId without validation (for internal use only).
     ///
-    /// # Safety
+    /// # Internal Use Only
     /// This function bypasses validation. Only use when you're certain the ID is valid,
     /// such as when loading from trusted storage or in performance-critical paths where
     /// validation has already occurred.
@@ -76,7 +84,7 @@ impl EdgeId {
 
     /// Create a new EdgeId without validation (for internal use only).
     ///
-    /// # Safety
+    /// # Internal Use Only
     /// This function bypasses validation. Only use when you're certain the ID is valid,
     /// such as when loading from trusted storage or in performance-critical paths where
     /// validation has already occurred.
@@ -119,7 +127,7 @@ impl VersionId {
 
     /// Create a new VersionId without validation (for internal use only).
     ///
-    /// # Safety
+    /// # Internal Use Only
     /// This function bypasses validation. Only use when you're certain the ID is valid,
     /// such as when loading from trusted storage or in performance-critical paths where
     /// validation has already occurred.
@@ -405,3 +413,64 @@ mod tests {
         assert!(u64::MAX - MAX_VALID_ID >= 1000);
     }
 }
+
+    #[test]
+    fn test_id_validation_boundary_cases() {
+        // Test values around MAX_VALID_ID boundary
+        assert!(NodeId::new(MAX_VALID_ID - 1).is_ok());
+        assert!(NodeId::new(MAX_VALID_ID).is_ok());
+        assert!(NodeId::new(MAX_VALID_ID + 1).is_err());
+        assert!(NodeId::new(MAX_VALID_ID + 2).is_err());
+        
+        // Same for other ID types
+        assert!(EdgeId::new(MAX_VALID_ID - 1).is_ok());
+        assert!(EdgeId::new(MAX_VALID_ID).is_ok());
+        assert!(EdgeId::new(MAX_VALID_ID + 1).is_err());
+        
+        assert!(VersionId::new(MAX_VALID_ID - 1).is_ok());
+        assert!(VersionId::new(MAX_VALID_ID).is_ok());
+        assert!(VersionId::new(MAX_VALID_ID + 1).is_err());
+    }
+
+    #[test]
+    fn test_error_message_content() {
+        // Verify error messages are properly formatted
+        let err = NodeId::new(MAX_VALID_ID + 1).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Invalid"));
+        assert!(msg.contains("node"));
+        assert!(msg.contains("ID"));
+        assert!(msg.contains(&(MAX_VALID_ID + 1).to_string()));
+        assert!(msg.contains("exceeds maximum"));
+        assert!(msg.contains(&MAX_VALID_ID.to_string()));
+    }
+
+    #[test]
+    fn test_id_generator_respects_max_valid_id() {
+        // Verify ID generators produce valid IDs
+        let generator = IdGenerator::new();
+        for _ in 0..100 {
+            let id = generator.next();
+            assert!(
+                NodeId::new(id).is_ok(),
+                "Generator produced invalid ID: {}",
+                id
+            );
+        }
+        
+        // Test generator starting near the limit
+        let generator = IdGenerator::with_start(MAX_VALID_ID - 10);
+        for _ in 0..10 {
+            let id = generator.next();
+            assert!(
+                NodeId::new(id).is_ok(),
+                "Generator near limit produced invalid ID: {}",
+                id
+            );
+        }
+        
+        // Note: After MAX_VALID_ID, generator would produce invalid IDs.
+        // In practice, this would require ~18 quintillion operations,
+        // which is unrealistic for a single database instance.
+        // If needed, IdGenerator could be enhanced to check MAX_VALID_ID.
+    }

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -239,21 +239,18 @@ impl IdGenerator {
     ///
     /// This method is thread-safe and lock-free.
     ///
-    /// # Panics
-    ///
-    /// Panics if the generator would exceed `MAX_VALID_ID`. In practice, this requires
+    /// Returns an error if the generator would exceed `MAX_VALID_ID`. In practice, this requires
     /// ~18 quintillion operations and is unrealistic for a single database instance.
     #[inline]
-    pub fn next(&self) -> u64 {
+    pub fn next(&self) -> Result<u64, StorageError> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         if id > MAX_VALID_ID {
-            panic!(
-                "ID generator exhausted: generated ID {} exceeds MAX_VALID_ID ({}). \
-                 This indicates either a bug or an unrealistic number of operations.",
-                id, MAX_VALID_ID
-            );
+            return Err(StorageError::InvalidId {
+                id,
+                id_type: "generated",
+            });
         }
-        id
+        Ok(id)
     }
 
     /// Get the current value without incrementing.
@@ -312,17 +309,17 @@ mod tests {
     #[test]
     fn test_id_generator() {
         let generator = IdGenerator::new();
-        assert_eq!(generator.next(), 0);
-        assert_eq!(generator.next(), 1);
-        assert_eq!(generator.next(), 2);
+        assert_eq!(generator.next(), Ok(0));
+        assert_eq!(generator.next(), Ok(1));
+        assert_eq!(generator.next(), Ok(2));
         assert_eq!(generator.current(), 3);
     }
 
     #[test]
     fn test_id_generator_with_start() {
         let generator = IdGenerator::with_start(100);
-        assert_eq!(generator.next(), 100);
-        assert_eq!(generator.next(), 101);
+        assert_eq!(generator.next(), Ok(100));
+        assert_eq!(generator.next(), Ok(101));
     }
 
     #[test]
@@ -463,7 +460,7 @@ mod tests {
         // Verify ID generators produce valid IDs
         let generator = IdGenerator::new();
         for _ in 0..100 {
-            let id = generator.next();
+            let id = generator.next().expect("Generator should produce valid ID");
             assert!(
                 NodeId::new(id).is_ok(),
                 "Generator produced invalid ID: {}",
@@ -474,7 +471,7 @@ mod tests {
         // Test generator starting near the limit
         let generator = IdGenerator::with_start(MAX_VALID_ID - 10);
         for _ in 0..10 {
-            let id = generator.next();
+            let id = generator.next().expect("Generator near limit should produce valid ID");
             assert!(
                 NodeId::new(id).is_ok(),
                 "Generator near limit produced invalid ID: {}",
@@ -488,12 +485,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "ID generator exhausted")]
-    fn test_id_generator_panics_on_overflow() {
-        // Verify generator panics when exceeding MAX_VALID_ID
+    fn test_id_generator_returns_error_on_overflow() {
+        // Verify generator returns error when exceeding MAX_VALID_ID
         let generator = IdGenerator::with_start(MAX_VALID_ID);
-        let _ = generator.next(); // This should be OK (at MAX_VALID_ID)
-        let _ = generator.next(); // This should panic (exceeds MAX_VALID_ID)
+        assert!(generator.next().is_ok()); // This should be OK (at MAX_VALID_ID)
+        assert!(generator.next().is_err()); // This should error (exceeds MAX_VALID_ID)
+
+        // Verify error type
+        let err = generator.next().unwrap_err();
+        assert!(matches!(err, StorageError::InvalidId { id_type: "generated", .. }));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -748,7 +748,7 @@ mod tests {
             // This should fail validation (non-existent target)
             tx.create_edge(
                 valid_node,
-                NodeId::new(9999),
+                NodeId::new(9999).unwrap(),
                 "KNOWS",
                 PropertyMapBuilder::new().build(),
             )?;

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -98,7 +98,7 @@ impl AdjacencyIndex {
 
         // Iterate through all node IDs in order
         for node_id in 0..=max_node_id {
-            let node = NodeId::new(node_id);
+            let node = NodeId::new_unchecked(node_id);
             if let Some(mut adj_list) = adjacency_map.remove(&node) {
                 // Sort by target for deterministic ordering
                 adj_list.sort_by_key(|e| e.target);
@@ -185,8 +185,8 @@ mod tests {
     fn test_empty_index() {
         let index = AdjacencyIndex::new();
         assert_eq!(index.edge_count(), 0);
-        assert_eq!(index.degree(NodeId::new(0)), 0);
-        assert_eq!(index.get_adjacency(NodeId::new(0)).len(), 0);
+        assert_eq!(index.degree(NodeId::new(0).unwrap()), 0);
+        assert_eq!(index.get_adjacency(NodeId::new(0).unwrap()).len(), 0);
     }
 
     #[test]
@@ -194,28 +194,28 @@ mod tests {
         let knows = GLOBAL_INTERNER.intern("KNOWS");
 
         let edges = vec![
-            (NodeId::new(0), NodeId::new(1), EdgeId::new(0), knows),
-            (NodeId::new(0), NodeId::new(2), EdgeId::new(1), knows),
-            (NodeId::new(1), NodeId::new(2), EdgeId::new(2), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(1).unwrap(), EdgeId::new(0).unwrap(), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(2).unwrap(), EdgeId::new(1).unwrap(), knows),
+            (NodeId::new(1).unwrap(), NodeId::new(2).unwrap(), EdgeId::new(2).unwrap(), knows),
         ];
 
         let index = AdjacencyIndex::build(edges);
 
         // Node 0 has 2 outgoing edges
-        assert_eq!(index.degree(NodeId::new(0)), 2);
-        let adj0 = index.get_adjacency(NodeId::new(0));
+        assert_eq!(index.degree(NodeId::new(0).unwrap()), 2);
+        let adj0 = index.get_adjacency(NodeId::new(0).unwrap());
         assert_eq!(adj0.len(), 2);
-        assert_eq!(adj0[0].target, NodeId::new(1));
-        assert_eq!(adj0[1].target, NodeId::new(2));
+        assert_eq!(adj0[0].target, NodeId::new(1).unwrap());
+        assert_eq!(adj0[1].target, NodeId::new(2).unwrap());
 
         // Node 1 has 1 outgoing edge
-        assert_eq!(index.degree(NodeId::new(1)), 1);
-        let adj1 = index.get_adjacency(NodeId::new(1));
+        assert_eq!(index.degree(NodeId::new(1).unwrap()), 1);
+        let adj1 = index.get_adjacency(NodeId::new(1).unwrap());
         assert_eq!(adj1.len(), 1);
-        assert_eq!(adj1[0].target, NodeId::new(2));
+        assert_eq!(adj1[0].target, NodeId::new(2).unwrap());
 
         // Node 2 has no outgoing edges
-        assert_eq!(index.degree(NodeId::new(2)), 0);
+        assert_eq!(index.degree(NodeId::new(2).unwrap()), 0);
 
         // Total edges
         assert_eq!(index.edge_count(), 3);
@@ -227,51 +227,51 @@ mod tests {
         let follows = GLOBAL_INTERNER.intern("FOLLOWS");
 
         let edges = vec![
-            (NodeId::new(0), NodeId::new(1), EdgeId::new(0), knows),
-            (NodeId::new(0), NodeId::new(2), EdgeId::new(1), follows),
-            (NodeId::new(0), NodeId::new(3), EdgeId::new(2), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(1).unwrap(), EdgeId::new(0).unwrap(), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(2).unwrap(), EdgeId::new(1).unwrap(), follows),
+            (NodeId::new(0).unwrap(), NodeId::new(3).unwrap(), EdgeId::new(2).unwrap(), knows),
         ];
 
         let index = AdjacencyIndex::build(edges);
 
         // Get all edges from node 0
-        assert_eq!(index.degree(NodeId::new(0)), 3);
+        assert_eq!(index.degree(NodeId::new(0).unwrap()), 3);
 
         // Get only KNOWS edges from node 0
         let knows_edges: Vec<_> = index
-            .get_adjacency_with_label(NodeId::new(0), knows)
+            .get_adjacency_with_label(NodeId::new(0).unwrap(), knows)
             .collect();
         assert_eq!(knows_edges.len(), 2);
 
         // Get only FOLLOWS edges from node 0
         let follows_edges: Vec<_> = index
-            .get_adjacency_with_label(NodeId::new(0), follows)
+            .get_adjacency_with_label(NodeId::new(0).unwrap(), follows)
             .collect();
         assert_eq!(follows_edges.len(), 1);
-        assert_eq!(follows_edges[0].target, NodeId::new(2));
+        assert_eq!(follows_edges[0].target, NodeId::new(2).unwrap());
     }
 
     #[test]
     fn test_node_without_edges() {
         let knows = GLOBAL_INTERNER.intern("KNOWS");
 
-        let edges = vec![(NodeId::new(0), NodeId::new(1), EdgeId::new(0), knows)];
+        let edges = vec![(NodeId::new(0).unwrap(), NodeId::new(1).unwrap(), EdgeId::new(0).unwrap(), knows)];
 
         let index = AdjacencyIndex::build(edges);
 
         // Node 5 doesn't exist
-        assert_eq!(index.degree(NodeId::new(5)), 0);
-        assert!(!index.has_edges(NodeId::new(5)));
-        assert_eq!(index.get_adjacency(NodeId::new(5)).len(), 0);
+        assert_eq!(index.degree(NodeId::new(5).unwrap()), 0);
+        assert!(!index.has_edges(NodeId::new(5).unwrap()));
+        assert_eq!(index.get_adjacency(NodeId::new(5).unwrap()).len(), 0);
     }
 
     #[test]
     fn test_adjacency_entry() {
         let label = GLOBAL_INTERNER.intern("TEST");
-        let entry = AdjacencyEntry::new(NodeId::new(1), EdgeId::new(100), label);
+        let entry = AdjacencyEntry::new(NodeId::new(1).unwrap(), EdgeId::new(100).unwrap(), label);
 
-        assert_eq!(entry.target, NodeId::new(1));
-        assert_eq!(entry.edge_id, EdgeId::new(100));
+        assert_eq!(entry.target, NodeId::new(1).unwrap());
+        assert_eq!(entry.edge_id, EdgeId::new(100).unwrap());
         assert_eq!(entry.label, label);
     }
 
@@ -280,17 +280,17 @@ mod tests {
         // Edges deliberately out of order
         let knows = GLOBAL_INTERNER.intern("KNOWS");
         let edges = vec![
-            (NodeId::new(0), NodeId::new(3), EdgeId::new(2), knows),
-            (NodeId::new(0), NodeId::new(1), EdgeId::new(0), knows),
-            (NodeId::new(0), NodeId::new(2), EdgeId::new(1), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(3).unwrap(), EdgeId::new(2).unwrap(), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(1).unwrap(), EdgeId::new(0).unwrap(), knows),
+            (NodeId::new(0).unwrap(), NodeId::new(2).unwrap(), EdgeId::new(1).unwrap(), knows),
         ];
 
         let index = AdjacencyIndex::build(edges);
-        let adj = index.get_adjacency(NodeId::new(0));
+        let adj = index.get_adjacency(NodeId::new(0).unwrap());
 
         // Should be sorted by target
-        assert_eq!(adj[0].target, NodeId::new(1));
-        assert_eq!(adj[1].target, NodeId::new(2));
-        assert_eq!(adj[2].target, NodeId::new(3));
+        assert_eq!(adj[0].target, NodeId::new(1).unwrap());
+        assert_eq!(adj[1].target, NodeId::new(2).unwrap());
+        assert_eq!(adj[2].target, NodeId::new(3).unwrap());
     }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -273,21 +273,21 @@ mod tests {
 
     pub(super) fn create_test_node(id: u64, label: &str) -> Node {
         Node::new(
-            NodeId::new(id),
+            NodeId::new(id).unwrap(),
             GLOBAL_INTERNER.intern(label),
             PropertyMapBuilder::new().build(),
-            VersionId::new(1),
+            VersionId::new(1).unwrap(),
         )
     }
 
     pub(super) fn create_test_edge(id: u64, source: u64, target: u64, label: &str) -> Edge {
         Edge::new(
-            EdgeId::new(id),
+            EdgeId::new(id).unwrap(),
             GLOBAL_INTERNER.intern(label),
-            NodeId::new(source),
-            NodeId::new(target),
+            NodeId::new(source).unwrap(),
+            NodeId::new(target).unwrap(),
             PropertyMapBuilder::new().build(),
-            VersionId::new(1),
+            VersionId::new(1).unwrap(),
         )
     }
 
@@ -297,22 +297,22 @@ mod tests {
 
         // Initially empty
         assert_eq!(indexes.node_count(), 0);
-        assert!(!indexes.contains_node(NodeId::new(1)));
+        assert!(!indexes.contains_node(NodeId::new(1).unwrap()));
 
         // Insert node
         let node = create_test_node(1, "Person");
         indexes.insert_node(node.clone());
 
         assert_eq!(indexes.node_count(), 1);
-        assert!(indexes.contains_node(NodeId::new(1)));
+        assert!(indexes.contains_node(NodeId::new(1).unwrap()));
 
         // Get node
-        let retrieved = indexes.get_node(NodeId::new(1)).unwrap();
+        let retrieved = indexes.get_node(NodeId::new(1).unwrap()).unwrap();
         assert_eq!(retrieved.id, node.id);
         assert_eq!(retrieved.label, node.label);
 
         // Remove node
-        let removed = indexes.remove_node(NodeId::new(1)).unwrap();
+        let removed = indexes.remove_node(NodeId::new(1).unwrap()).unwrap();
         assert_eq!(removed.id, node.id);
         assert_eq!(indexes.node_count(), 0);
     }
@@ -326,16 +326,16 @@ mod tests {
         indexes.insert_edge(edge.clone());
 
         assert_eq!(indexes.edge_count(), 1);
-        assert!(indexes.contains_edge(EdgeId::new(1)));
+        assert!(indexes.contains_edge(EdgeId::new(1).unwrap()));
 
         // Get edge
-        let retrieved = indexes.get_edge(EdgeId::new(1)).unwrap();
+        let retrieved = indexes.get_edge(EdgeId::new(1).unwrap()).unwrap();
         assert_eq!(retrieved.id, edge.id);
         assert_eq!(retrieved.source, edge.source);
         assert_eq!(retrieved.target, edge.target);
 
         // Remove edge
-        let removed = indexes.remove_edge(EdgeId::new(1)).unwrap();
+        let removed = indexes.remove_edge(EdgeId::new(1).unwrap()).unwrap();
         assert_eq!(removed.id, edge.id);
         assert_eq!(indexes.edge_count(), 0);
     }
@@ -358,17 +358,17 @@ mod tests {
         indexes.rebuild_adjacency();
 
         // Test outgoing edges
-        assert_eq!(indexes.out_degree(NodeId::new(0)), 2);
-        assert_eq!(indexes.out_degree(NodeId::new(1)), 1);
-        assert_eq!(indexes.out_degree(NodeId::new(2)), 0);
+        assert_eq!(indexes.out_degree(NodeId::new(0).unwrap()), 2);
+        assert_eq!(indexes.out_degree(NodeId::new(1).unwrap()), 1);
+        assert_eq!(indexes.out_degree(NodeId::new(2).unwrap()), 0);
 
-        let outgoing = indexes.get_outgoing(NodeId::new(0));
+        let outgoing = indexes.get_outgoing(NodeId::new(0).unwrap());
         assert_eq!(outgoing.len(), 2);
 
         // Test incoming edges
-        assert_eq!(indexes.in_degree(NodeId::new(0)), 0);
-        assert_eq!(indexes.in_degree(NodeId::new(1)), 1);
-        assert_eq!(indexes.in_degree(NodeId::new(2)), 2);
+        assert_eq!(indexes.in_degree(NodeId::new(0).unwrap()), 0);
+        assert_eq!(indexes.in_degree(NodeId::new(1).unwrap()), 1);
+        assert_eq!(indexes.in_degree(NodeId::new(2).unwrap()), 2);
     }
 
     #[test]
@@ -386,11 +386,11 @@ mod tests {
         indexes.rebuild_adjacency();
 
         // Get only KNOWS edges
-        let knows_edges = indexes.get_outgoing_with_label(NodeId::new(0), knows);
+        let knows_edges = indexes.get_outgoing_with_label(NodeId::new(0).unwrap(), knows);
         assert_eq!(knows_edges.len(), 2);
 
         // Get only FOLLOWS edges
-        let follows_edges = indexes.get_outgoing_with_label(NodeId::new(0), follows);
+        let follows_edges = indexes.get_outgoing_with_label(NodeId::new(0).unwrap(), follows);
         assert_eq!(follows_edges.len(), 1);
     }
 
@@ -421,13 +421,13 @@ mod tests {
 
         // Rebuild once
         indexes.rebuild_adjacency();
-        let first_out = indexes.get_outgoing(NodeId::new(0));
-        let first_in = indexes.get_incoming(NodeId::new(1));
+        let first_out = indexes.get_outgoing(NodeId::new(0).unwrap());
+        let first_in = indexes.get_incoming(NodeId::new(1).unwrap());
 
         // Rebuild again
         indexes.rebuild_adjacency();
-        let second_out = indexes.get_outgoing(NodeId::new(0));
-        let second_in = indexes.get_incoming(NodeId::new(1));
+        let second_out = indexes.get_outgoing(NodeId::new(0).unwrap());
+        let second_in = indexes.get_incoming(NodeId::new(1).unwrap());
 
         // Results should be identical
         assert_eq!(first_out.len(), second_out.len());
@@ -453,16 +453,16 @@ mod tests {
         indexes.rebuild_adjacency();
 
         // Verify adjacency reflects all edges
-        assert_eq!(indexes.out_degree(NodeId::new(0)), 2); // KNOWS and LIKES
-        assert_eq!(indexes.in_degree(NodeId::new(2)), 2); // from 1 and 0
+        assert_eq!(indexes.out_degree(NodeId::new(0).unwrap()), 2); // KNOWS and LIKES
+        assert_eq!(indexes.in_degree(NodeId::new(2).unwrap()), 2); // from 1 and 0
 
         // Remove an edge
-        indexes.remove_edge(EdgeId::new(1));
+        indexes.remove_edge(EdgeId::new(1).unwrap());
         indexes.rebuild_adjacency();
 
         // Verify adjacency updated correctly
-        assert_eq!(indexes.out_degree(NodeId::new(1)), 0);
-        assert_eq!(indexes.in_degree(NodeId::new(2)), 1); // only from 0 now
+        assert_eq!(indexes.out_degree(NodeId::new(1).unwrap()), 0);
+        assert_eq!(indexes.in_degree(NodeId::new(2).unwrap()), 1); // only from 0 now
     }
 }
 
@@ -503,7 +503,7 @@ mod proptests {
                         indexes.insert_edge(create_test_edge(*id, *src, *tgt, "TEST"));
                     }
                     EdgeOp::Remove(id) => {
-                        let _ = indexes.remove_edge(EdgeId::new(*id));
+                        let _ = indexes.remove_edge(EdgeId::new(*id).unwrap());
                     }
                 }
             }
@@ -517,8 +517,8 @@ mod proptests {
             let mut total_in_degree = 0;
 
             for node_id in 0..10 {
-                total_out_degree += indexes.out_degree(NodeId::new(node_id));
-                total_in_degree += indexes.in_degree(NodeId::new(node_id));
+                total_out_degree += indexes.out_degree(NodeId::new(node_id).unwrap());
+                total_in_degree += indexes.in_degree(NodeId::new(node_id).unwrap());
             }
 
             // Each edge appears once in outgoing and once in incoming
@@ -537,7 +537,7 @@ mod proptests {
                         indexes.insert_edge(create_test_edge(*id, *src, *tgt, "TEST"));
                     }
                     EdgeOp::Remove(id) => {
-                        let _ = indexes.remove_edge(EdgeId::new(*id));
+                        let _ = indexes.remove_edge(EdgeId::new(*id).unwrap());
                     }
                 }
             }
@@ -546,7 +546,7 @@ mod proptests {
             indexes.rebuild_adjacency();
             let first_results: Vec<_> = (0..10)
                 .map(|i| {
-                    let node = NodeId::new(i);
+                    let node = NodeId::new(i).unwrap();
                     (indexes.get_outgoing(node), indexes.get_incoming(node))
                 })
                 .collect();
@@ -554,7 +554,7 @@ mod proptests {
             indexes.rebuild_adjacency();
             let second_results: Vec<_> = (0..10)
                 .map(|i| {
-                    let node = NodeId::new(i);
+                    let node = NodeId::new(i).unwrap();
                     (indexes.get_outgoing(node), indexes.get_incoming(node))
                 })
                 .collect();
@@ -642,8 +642,8 @@ mod concurrency_tests {
         let mut total_out_degree = 0;
         let mut total_in_degree = 0;
         for i in 0..10 {
-            total_out_degree += indexes.out_degree(NodeId::new(i));
-            total_in_degree += indexes.in_degree(NodeId::new(i));
+            total_out_degree += indexes.out_degree(NodeId::new(i).unwrap());
+            total_in_degree += indexes.in_degree(NodeId::new(i).unwrap());
         }
 
         assert_eq!(
@@ -690,7 +690,7 @@ mod concurrency_tests {
         let indexes_clone = Arc::clone(&indexes);
         let remove_handle = thread::spawn(move || {
             for i in 0..50 {
-                indexes_clone.remove_edge(EdgeId::new(i));
+                indexes_clone.remove_edge(EdgeId::new(i).unwrap());
                 thread::sleep(Duration::from_micros(5));
             }
         });
@@ -708,7 +708,7 @@ mod concurrency_tests {
         // Verify adjacency matches
         let mut total_degree = 0;
         for i in 0..10 {
-            total_degree += indexes.out_degree(NodeId::new(i));
+            total_degree += indexes.out_degree(NodeId::new(i).unwrap());
         }
         assert_eq!(total_degree, 50, "Adjacency should reflect removed edges");
     }
@@ -773,7 +773,7 @@ mod concurrency_tests {
 
         let mut total_degree = 0;
         for i in 0..20 {
-            total_degree += indexes.out_degree(NodeId::new(i));
+            total_degree += indexes.out_degree(NodeId::new(i).unwrap());
         }
         assert_eq!(
             total_degree, 300,

--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -192,10 +192,10 @@ mod tests {
     fn test_insert_and_find_node_versions() {
         let mut indexes = TemporalIndexes::new();
 
-        let node_id = NodeId::new(1);
-        let v1 = VersionId::new(100);
-        let v2 = VersionId::new(101);
-        let v3 = VersionId::new(102);
+        let node_id = NodeId::new(1).unwrap();
+        let v1 = VersionId::new(100).unwrap();
+        let v2 = VersionId::new(101).unwrap();
+        let v3 = VersionId::new(102).unwrap();
 
         // Insert versions at different valid times
         indexes.insert_node_version(
@@ -237,9 +237,9 @@ mod tests {
     fn test_transaction_time_range_query() {
         let mut indexes = TemporalIndexes::new();
 
-        let edge_id = EdgeId::new(1);
-        let v1 = VersionId::new(100);
-        let v2 = VersionId::new(101);
+        let edge_id = EdgeId::new(1).unwrap();
+        let v1 = VersionId::new(100).unwrap();
+        let v2 = VersionId::new(101).unwrap();
 
         // Version recorded at tx time 1000
         indexes.insert_edge_version(
@@ -275,7 +275,7 @@ mod tests {
         let indexes = TemporalIndexes::new();
 
         let results =
-            indexes.find_node_versions_in_valid_time_range(NodeId::new(1), TimeRange::new(0, 1000));
+            indexes.find_node_versions_in_valid_time_range(NodeId::new(1).unwrap(), TimeRange::new(0, 1000));
 
         assert_eq!(results.len(), 0);
     }
@@ -284,10 +284,10 @@ mod tests {
     fn test_multiple_entities() {
         let mut indexes = TemporalIndexes::new();
 
-        let node1 = NodeId::new(1);
-        let node2 = NodeId::new(2);
-        let v1 = VersionId::new(100);
-        let v2 = VersionId::new(101);
+        let node1 = NodeId::new(1).unwrap();
+        let node2 = NodeId::new(2).unwrap();
+        let v1 = VersionId::new(100).unwrap();
+        let v2 = VersionId::new(101).unwrap();
 
         indexes.insert_node_version(node1, v1, BiTemporalInterval::current(1000));
 
@@ -307,8 +307,8 @@ mod tests {
         let mut indexes = TemporalIndexes::new();
 
         indexes.insert_node_version(
-            NodeId::new(1),
-            VersionId::new(100),
+            NodeId::new(1).unwrap(),
+            VersionId::new(100).unwrap(),
             BiTemporalInterval::current(1000),
         );
 
@@ -321,8 +321,8 @@ mod tests {
 
     #[test]
     fn test_temporal_key_ordering() {
-        let node1 = EntityId::Node(NodeId::new(1));
-        let node2 = EntityId::Node(NodeId::new(2));
+        let node1 = EntityId::Node(NodeId::new(1).unwrap());
+        let node2 = EntityId::Node(NodeId::new(2).unwrap());
 
         let key1 = TemporalKey::new(node1, 1000);
         let key2 = TemporalKey::new(node1, 2000);

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1381,7 +1381,7 @@ mod tests {
             let index_clone = Arc::clone(&index);
             let handle = thread::spawn(move || {
                 for j in 0..25 {
-                    let node_id = NodeId::new((i * 25 + j) as u64);
+                    let node_id = NodeId::new((i * 25 + j) as u64).unwrap();
                     let vec = vec![i as f32, j as f32, 0.0, 0.0];
                     index_clone.add(node_id, &vec).unwrap();
                 }
@@ -1405,7 +1405,7 @@ mod tests {
         // Add some vectors first
         for i in 0..100 {
             index
-                .add(NodeId::new(i), &[i as f32 / 100.0, 0.0, 0.0, 0.0])
+                .add(NodeId::new(i).unwrap(), &[i as f32 / 100.0, 0.0, 0.0, 0.0])
                 .unwrap();
         }
 
@@ -1440,7 +1440,7 @@ mod tests {
             let handle = thread::spawn(move || {
                 // Add vectors
                 for j in 0..20 {
-                    let node_id = NodeId::new((i * 20 + j) as u64);
+                    let node_id = NodeId::new((i * 20 + j) as u64).unwrap();
                     let vec = vec![i as f32, j as f32, 0.0, 0.0];
                     index_clone.add(node_id, &vec).unwrap();
                 }
@@ -1528,7 +1528,7 @@ mod tests {
         // Add some vectors
         for i in 0..20 {
             let vec = vec![i as f32 / 20.0, 0.0, 0.0, 0.0];
-            index.add(NodeId::new(i), &vec).unwrap();
+            index.add(NodeId::new(i).unwrap(), &vec).unwrap();
         }
 
         // Search with low ef_search
@@ -1700,7 +1700,7 @@ mod tests {
         // Add more than config.capacity to verify override worked
         for i in 0..100 {
             let vec = vec![i as f32 / 100.0; 64];
-            index.add(NodeId::new(i), &vec).unwrap();
+            index.add(NodeId::new(i).unwrap(), &vec).unwrap();
         }
 
         assert_eq!(index.len(), 100);
@@ -1832,7 +1832,7 @@ mod tests {
 
     /// Strategy for generating valid NodeId
     fn valid_node_id() -> impl Strategy<Value = NodeId> {
-        (1u64..1000u64).prop_map(NodeId::new)
+        (1u64..1000u64).prop_map(|id| NodeId::new(id).unwrap())
     }
 
     proptest! {

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -180,8 +180,8 @@ impl CurrentStorage {
     ///
     /// Returns the ID of the newly created node.
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
-        let node_id = NodeId::new_unchecked(self.node_id_gen.next());
-        let version_id = VersionId::new_unchecked(self.version_id_gen.next());
+        let node_id = NodeId::new_unchecked(self.node_id_gen.next()?);
+        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         let node = Node::new(node_id, label_interned, properties.clone(), version_id);
@@ -215,8 +215,8 @@ impl CurrentStorage {
             return Err(StorageError::NodeNotFound(target).into());
         }
 
-        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.next());
-        let version_id = VersionId::new_unchecked(self.version_id_gen.next());
+        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.next()?);
+        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         let edge = Edge::new(

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -1131,7 +1131,7 @@ mod tests {
         let config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
         storage.enable_vector_index("embedding", config).unwrap();
 
-        let result = storage.find_similar(NodeId::new(999), 2);
+        let result = storage.find_similar(NodeId::new(999).unwrap(), 2);
         assert!(result.is_err());
     }
 

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -180,8 +180,8 @@ impl CurrentStorage {
     ///
     /// Returns the ID of the newly created node.
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
-        let node_id = NodeId::new(self.node_id_gen.next());
-        let version_id = VersionId::new(self.version_id_gen.next());
+        let node_id = NodeId::new_unchecked(self.node_id_gen.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.next());
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         let node = Node::new(node_id, label_interned, properties.clone(), version_id);
@@ -215,8 +215,8 @@ impl CurrentStorage {
             return Err(StorageError::NodeNotFound(target).into());
         }
 
-        let edge_id = EdgeId::new(self.edge_id_gen.next());
-        let version_id = VersionId::new(self.version_id_gen.next());
+        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.next());
+        let version_id = VersionId::new_unchecked(self.version_id_gen.next());
         let label_interned = GLOBAL_INTERNER.intern(label);
 
         let edge = Edge::new(
@@ -602,8 +602,8 @@ mod tests {
         let storage = CurrentStorage::new();
 
         let result = storage.create_edge(
-            NodeId::new(999),
-            NodeId::new(1000),
+            NodeId::new(999).unwrap(),
+            NodeId::new(1000).unwrap(),
             "KNOWS",
             PropertyMapBuilder::new().build(),
         );

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -472,8 +472,8 @@ mod tests {
     fn test_create_first_version() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
-        let version_id = VersionId::new(100);
+        let node_id = NodeId::new(1).unwrap();
+        let version_id = VersionId::new(100).unwrap();
         let label = GLOBAL_INTERNER.intern("Person");
         let temporal = BiTemporalInterval::current(1000);
         let props = PropertyMapBuilder::new().insert("name", "Alice").build();
@@ -496,13 +496,13 @@ mod tests {
             max_delta_chain: 10,
         });
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Person");
 
         // Create 5 versions
         let mut version_ids = Vec::new();
         for i in 0..5 {
-            let version_id = VersionId::new(100 + i);
+            let version_id = VersionId::new(100 + i).unwrap();
             let temporal = BiTemporalInterval::current(1000 + (i as i64) * 100);
             let props = PropertyMapBuilder::new()
                 .insert("name", "Alice")
@@ -544,11 +544,11 @@ mod tests {
     fn test_property_reconstruction() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Person");
 
         // Version 1: name=Alice, age=30
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -563,7 +563,7 @@ mod tests {
             .unwrap();
 
         // Version 2: name=Alice, age=31 (delta)
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -587,13 +587,13 @@ mod tests {
     fn test_find_version_at_time() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Person");
 
         // Create versions at different times
-        let v1 = VersionId::new(1);
-        let v2 = VersionId::new(2);
-        let v3 = VersionId::new(3);
+        let v1 = VersionId::new(1).unwrap();
+        let v2 = VersionId::new(2).unwrap();
+        let v3 = VersionId::new(3).unwrap();
 
         storage
             .add_node_version(
@@ -659,8 +659,8 @@ mod tests {
         for i in 0..3 {
             storage
                 .add_node_version(
-                    NodeId::new(1),
-                    VersionId::new(i),
+                    NodeId::new(1).unwrap(),
+                    VersionId::new(i).unwrap(),
                     BiTemporalInterval::current(1000 + (i as i64) * 100),
                     label,
                     PropertyMapBuilder::new().build(),
@@ -699,8 +699,8 @@ mod tests {
     fn test_create_node_version_with_vector_property() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
-        let version_id = VersionId::new(100);
+        let node_id = NodeId::new(1).unwrap();
+        let version_id = VersionId::new(100).unwrap();
         let label = GLOBAL_INTERNER.intern("Document");
         let temporal = BiTemporalInterval::current(1000);
 
@@ -731,11 +731,11 @@ mod tests {
     fn test_delta_computation_with_vector_change() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Document");
 
         // Version 1: Initial embedding
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         let embedding_v1 = vec![0.1f32, 0.2, 0.3];
         storage
             .add_node_version(
@@ -751,7 +751,7 @@ mod tests {
             .unwrap();
 
         // Version 2: Updated embedding (should create delta)
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         let embedding_v2 = vec![0.4f32, 0.5, 0.6];
         storage
             .add_node_version(
@@ -788,11 +788,11 @@ mod tests {
     fn test_delta_only_vector_changes() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Document");
 
         // Version 1: title + embedding
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         let embedding_v1 = vec![0.1f32, 0.2];
         storage
             .add_node_version(
@@ -808,7 +808,7 @@ mod tests {
             .unwrap();
 
         // Version 2: Only embedding changes
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         let embedding_v2 = vec![0.9f32, 0.8];
         storage
             .add_node_version(
@@ -843,14 +843,14 @@ mod tests {
     fn test_vector_unchanged_between_versions() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Document");
 
         // Same embedding for both versions
         let embedding = vec![0.5f32, 0.5, 0.5];
 
         // Version 1
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -865,7 +865,7 @@ mod tests {
             .unwrap();
 
         // Version 2: Same embedding, different title
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -911,7 +911,7 @@ mod tests {
             max_delta_chain: 10,
         });
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Document");
 
         // Create 3 versions with different embeddings
@@ -921,7 +921,7 @@ mod tests {
             storage
                 .add_node_version(
                     node_id,
-                    VersionId::new(i as u64),
+                    VersionId::new(i as u64).unwrap(),
                     BiTemporalInterval::current(1000 + (i as i64) * 100),
                     label,
                     PropertyMapBuilder::new()
@@ -934,19 +934,19 @@ mod tests {
         // V0: anchor (first), V1: delta, V2: anchor (interval=2)
         assert!(
             storage
-                .get_node_version(VersionId::new(0))
+                .get_node_version(VersionId::new(0).unwrap())
                 .unwrap()
                 .is_anchor()
         );
         assert!(
             storage
-                .get_node_version(VersionId::new(1))
+                .get_node_version(VersionId::new(1).unwrap())
                 .unwrap()
                 .is_delta()
         );
         assert!(
             storage
-                .get_node_version(VersionId::new(2))
+                .get_node_version(VersionId::new(2).unwrap())
                 .unwrap()
                 .is_anchor()
         );
@@ -954,7 +954,7 @@ mod tests {
         // Verify each version reconstructs correctly
         for (i, emb) in embeddings.iter().enumerate() {
             let props = storage
-                .reconstruct_node_properties(VersionId::new(i as u64))
+                .reconstruct_node_properties(VersionId::new(i as u64).unwrap())
                 .unwrap();
             assert_eq!(
                 props.get("embedding").and_then(|v| v.as_vector()),
@@ -967,12 +967,12 @@ mod tests {
     fn test_edge_version_with_vector() {
         let mut storage = HistoricalStorage::new();
 
-        let edge_id = EdgeId::new(1);
-        let version_id = VersionId::new(100);
+        let edge_id = EdgeId::new(1).unwrap();
+        let version_id = VersionId::new(100).unwrap();
         let label = GLOBAL_INTERNER.intern("SIMILAR_TO");
         let temporal = BiTemporalInterval::current(1000);
-        let source = NodeId::new(10);
-        let target = NodeId::new(20);
+        let source = NodeId::new(10).unwrap();
+        let target = NodeId::new(20).unwrap();
 
         // Edge with relationship embedding
         let embedding = vec![0.8f32, 0.1, 0.1];
@@ -1005,13 +1005,13 @@ mod tests {
     fn test_edge_delta_with_vector_change() {
         let mut storage = HistoricalStorage::new();
 
-        let edge_id = EdgeId::new(1);
+        let edge_id = EdgeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("SIMILAR_TO");
-        let source = NodeId::new(10);
-        let target = NodeId::new(20);
+        let source = NodeId::new(10).unwrap();
+        let target = NodeId::new(20).unwrap();
 
         // Version 1: Initial edge
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         let embedding_v1 = vec![0.5f32, 0.5];
         storage
             .add_edge_version(
@@ -1029,7 +1029,7 @@ mod tests {
             .unwrap();
 
         // Version 2: Updated embedding and weight
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         let embedding_v2 = vec![0.9f32, 0.1];
         storage
             .add_edge_version(
@@ -1062,7 +1062,7 @@ mod tests {
     fn test_high_dimensional_vector_versioning() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Embedding");
 
         // High-dimensional embedding (like OpenAI's 1536-dim)
@@ -1071,7 +1071,7 @@ mod tests {
             .map(|i| (i as f32) / DIMENSIONS as f32)
             .collect();
 
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -1099,7 +1099,7 @@ mod tests {
     fn test_version_time_travel_with_vectors() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("Document");
 
         // Create versions at different times with different embeddings
@@ -1113,7 +1113,7 @@ mod tests {
             storage
                 .add_node_version(
                     node_id,
-                    VersionId::new(i as u64),
+                    VersionId::new(i as u64).unwrap(),
                     BiTemporalInterval::new(
                         TimeRange::new(*start, *end),
                         TimeRange::new(0, Timestamp::MAX),
@@ -1131,9 +1131,9 @@ mod tests {
         let v_at_750 = storage.find_node_version_at_time(node_id, 750, 0);
         let v_at_1500 = storage.find_node_version_at_time(node_id, 1500, 0);
 
-        assert_eq!(v_at_250, Some(VersionId::new(0)));
-        assert_eq!(v_at_750, Some(VersionId::new(1)));
-        assert_eq!(v_at_1500, Some(VersionId::new(2)));
+        assert_eq!(v_at_250, Some(VersionId::new(0).unwrap()));
+        assert_eq!(v_at_750, Some(VersionId::new(1).unwrap()));
+        assert_eq!(v_at_1500, Some(VersionId::new(2).unwrap()));
 
         // Verify each has correct embedding
         for (vid, expected_emb) in [
@@ -1157,14 +1157,14 @@ mod tests {
     fn test_empty_vector_versioning() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("EmptyEmbedding");
 
         // Empty vector should work with delta compression
         let empty_vec: Vec<f32> = vec![];
 
         // Version 1: empty vector
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -1179,7 +1179,7 @@ mod tests {
             .unwrap();
 
         // Version 2: still empty (should be excluded from delta as unchanged)
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -1211,7 +1211,7 @@ mod tests {
     fn test_vector_with_special_float_values() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("SpecialFloats");
 
         // Note: NaN and Infinity are allowed in storage (validation is optional).
@@ -1220,7 +1220,7 @@ mod tests {
 
         let special_vec = vec![f32::INFINITY, f32::NEG_INFINITY, 0.0, -0.0];
 
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -1250,14 +1250,14 @@ mod tests {
     fn test_nan_in_vector_delta_behavior() {
         let mut storage = HistoricalStorage::new();
 
-        let node_id = NodeId::new(1);
+        let node_id = NodeId::new(1).unwrap();
         let label = GLOBAL_INTERNER.intern("NaNTest");
 
         // NaN != NaN per IEEE 754, so same NaN values will be detected as
         // "changed" in delta computation. This is documented behavior.
         let nan_vec = vec![f32::NAN, 1.0];
 
-        let v1 = VersionId::new(1);
+        let v1 = VersionId::new(1).unwrap();
         storage
             .add_node_version(
                 node_id,
@@ -1271,7 +1271,7 @@ mod tests {
             .unwrap();
 
         // Same NaN values - will be treated as changed due to NaN != NaN
-        let v2 = VersionId::new(2);
+        let v2 = VersionId::new(2).unwrap();
         storage
             .add_node_version(
                 node_id,

--- a/src/storage/version.rs
+++ b/src/storage/version.rs
@@ -462,8 +462,8 @@ mod tests {
         let temporal = BiTemporalInterval::current(1000);
 
         let version = NodeVersion::new_anchor(
-            VersionId::new(1),
-            NodeId::new(10),
+            VersionId::new(1).unwrap(),
+            NodeId::new(10).unwrap(),
             temporal,
             crate::core::interning::GLOBAL_INTERNER.intern("Person"),
             props,
@@ -471,7 +471,7 @@ mod tests {
 
         assert!(version.is_anchor());
         assert!(!version.is_delta());
-        assert_eq!(version.node_id, NodeId::new(10));
+        assert_eq!(version.node_id, NodeId::new(10).unwrap());
     }
 
     #[test]
@@ -483,19 +483,19 @@ mod tests {
         let temporal = BiTemporalInterval::current(2000);
 
         let version = EdgeVersion::new_delta(
-            VersionId::new(2),
-            EdgeId::new(20),
+            VersionId::new(2).unwrap(),
+            EdgeId::new(20).unwrap(),
             temporal,
             crate::core::interning::GLOBAL_INTERNER.intern("KNOWS"),
-            NodeId::new(1),
-            NodeId::new(2),
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
             &old_props,
             &new_props,
-            VersionId::new(1),
+            VersionId::new(1).unwrap(),
         );
 
         assert!(!version.is_anchor());
         assert!(version.is_delta());
-        assert_eq!(version.prev_version, Some(VersionId::new(1)));
+        assert_eq!(version.prev_version, Some(VersionId::new(1).unwrap()));
     }
 }

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -18,7 +18,7 @@ use crate::core::{
     property::PropertyMap,
     temporal::{BiTemporalInterval, Timestamp, time},
 };
-use crate::utils::error::{Result, StorageError};
+use crate::utils::error::{Error, Result, StorageError};
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -211,6 +211,42 @@ pub struct WriteAheadLog {
     current_segment: u64,
     writer: Option<BufWriter<File>>,
     current_size: usize,
+}
+
+/// Helper to deserialize and validate a NodeId from WAL buffer
+#[inline]
+fn deserialize_node_id(buffer: &[u8], offset: usize, context: &str) -> Result<NodeId> {
+    let raw_id = u64::from_le_bytes([
+        buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3],
+        buffer[offset + 4], buffer[offset + 5], buffer[offset + 6], buffer[offset + 7],
+    ]);
+    NodeId::new(raw_id).map_err(|e| Error::Storage(StorageError::CorruptedData(
+        format!("Invalid node ID in WAL {}: {}", context, e)
+    )))
+}
+
+/// Helper to deserialize and validate an EdgeId from WAL buffer
+#[inline]
+fn deserialize_edge_id(buffer: &[u8], offset: usize, context: &str) -> Result<EdgeId> {
+    let raw_id = u64::from_le_bytes([
+        buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3],
+        buffer[offset + 4], buffer[offset + 5], buffer[offset + 6], buffer[offset + 7],
+    ]);
+    EdgeId::new(raw_id).map_err(|e| Error::Storage(StorageError::CorruptedData(
+        format!("Invalid edge ID in WAL {}: {}", context, e)
+    )))
+}
+
+/// Helper to deserialize and validate a VersionId from WAL buffer
+#[inline]
+fn deserialize_version_id(buffer: &[u8], offset: usize, context: &str) -> Result<VersionId> {
+    let raw_id = u64::from_le_bytes([
+        buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3],
+        buffer[offset + 4], buffer[offset + 5], buffer[offset + 6], buffer[offset + 7],
+    ]);
+    VersionId::new(raw_id).map_err(|e| Error::Storage(StorageError::CorruptedData(
+        format!("Invalid version ID in WAL {}: {}", context, e)
+    )))
 }
 
 impl WriteAheadLog {
@@ -488,6 +524,42 @@ impl WriteAheadLog {
         Ok(entries)
     }
 
+    /// Helper to deserialize and validate a NodeId from WAL buffer
+    #[inline]
+    fn deserialize_node_id(buffer: &[u8], offset: usize, context: &str) -> Result<NodeId> {
+        let raw_id = u64::from_le_bytes([
+            buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3],
+            buffer[offset + 4], buffer[offset + 5], buffer[offset + 6], buffer[offset + 7],
+        ]);
+        NodeId::new(raw_id).map_err(|e| Error::Storage(StorageError::CorruptedData(
+            format!("Invalid node ID in WAL {}: {}", context, e)
+        )))
+    }
+
+    /// Helper to deserialize and validate an EdgeId from WAL buffer
+    #[inline]
+    fn deserialize_edge_id(buffer: &[u8], offset: usize, context: &str) -> Result<EdgeId> {
+        let raw_id = u64::from_le_bytes([
+            buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3],
+            buffer[offset + 4], buffer[offset + 5], buffer[offset + 6], buffer[offset + 7],
+        ]);
+        EdgeId::new(raw_id).map_err(|e| Error::Storage(StorageError::CorruptedData(
+            format!("Invalid edge ID in WAL {}: {}", context, e)
+        )))
+    }
+
+    /// Helper to deserialize and validate a VersionId from WAL buffer
+    #[inline]
+    fn deserialize_version_id(buffer: &[u8], offset: usize, context: &str) -> Result<VersionId> {
+        let raw_id = u64::from_le_bytes([
+            buffer[offset], buffer[offset + 1], buffer[offset + 2], buffer[offset + 3],
+            buffer[offset + 4], buffer[offset + 5], buffer[offset + 6], buffer[offset + 7],
+        ]);
+        VersionId::new(raw_id).map_err(|e| Error::Storage(StorageError::CorruptedData(
+            format!("Invalid version ID in WAL {}: {}", context, e)
+        )))
+    }
+
     /// Read WAL entries from a single segment file
     fn read_segment(&self, path: &Path, start_lsn: LSN) -> Result<Vec<WalEntry>> {
         use std::io::Read;
@@ -580,16 +652,7 @@ impl WriteAheadLog {
                     if offset + 12 > buffer.len() {
                         break;
                     }
-                    let node_id = NodeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let node_id = Self::deserialize_node_id(&buffer, offset, "CreateNode")?;
                     offset += 8;
 
                     let label_len = u32::from_le_bytes([
@@ -631,40 +694,13 @@ impl WriteAheadLog {
                     if offset + 28 > buffer.len() {
                         break;
                     }
-                    let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let edge_id = Self::deserialize_edge_id(&buffer, offset, "CreateEdge")?;
                     offset += 8;
 
-                    let source = NodeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let source = Self::deserialize_node_id(&buffer, offset, "CreateEdge source")?;
                     offset += 8;
 
-                    let target = NodeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let target = Self::deserialize_node_id(&buffer, offset, "CreateEdge target")?;
                     offset += 8;
 
                     let label_len = u32::from_le_bytes([
@@ -708,28 +744,10 @@ impl WriteAheadLog {
                     if offset + 16 > buffer.len() {
                         break;
                     }
-                    let node_id = NodeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let node_id = Self::deserialize_node_id(&buffer, offset, "UpdateNode")?;
                     offset += 8;
 
-                    let version_id = VersionId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let version_id = Self::deserialize_version_id(&buffer, offset, "UpdateNode")?;
                     offset += 8;
 
                     let (label, properties, temporal) = if version >= WAL_VERSION {
@@ -776,28 +794,10 @@ impl WriteAheadLog {
                     if offset + 16 > buffer.len() {
                         break;
                     }
-                    let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let edge_id = Self::deserialize_edge_id(&buffer, offset, "UpdateEdge")?;
                     offset += 8;
 
-                    let version_id = VersionId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let version_id = Self::deserialize_version_id(&buffer, offset, "UpdateEdge")?;
                     offset += 8;
 
                     let (label, properties, temporal) = if version >= WAL_VERSION {
@@ -876,16 +876,7 @@ impl WriteAheadLog {
                     if offset + 8 > buffer.len() {
                         break;
                     }
-                    let node_id = NodeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let node_id = Self::deserialize_node_id(&buffer, offset, "DeleteNode")?;
                     offset += 8;
 
                     let temporal = if version >= WAL_VERSION {
@@ -903,16 +894,7 @@ impl WriteAheadLog {
                     if offset + 8 > buffer.len() {
                         break;
                     }
-                    let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
-                        buffer[offset],
-                        buffer[offset + 1],
-                        buffer[offset + 2],
-                        buffer[offset + 3],
-                        buffer[offset + 4],
-                        buffer[offset + 5],
-                        buffer[offset + 6],
-                        buffer[offset + 7],
-                    ]));
+                    let edge_id = Self::deserialize_edge_id(&buffer, offset, "DeleteEdge")?;
                     offset += 8;
 
                     let temporal = if version >= WAL_VERSION {
@@ -1220,16 +1202,7 @@ fn parse_wal_entries_versioned(
                 if offset + 12 > buffer.len() {
                     break;
                 }
-                let node_id = NodeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let node_id = deserialize_node_id(&buffer, offset, "CreateNode (migration)")?;
                 offset += 8;
 
                 let label_len = u32::from_le_bytes([
@@ -1269,40 +1242,13 @@ fn parse_wal_entries_versioned(
                 if offset + 28 > buffer.len() {
                     break;
                 }
-                let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let edge_id = deserialize_edge_id(&buffer, offset, "CreateEdge (migration)")?;
                 offset += 8;
 
-                let source = NodeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let source = deserialize_node_id(&buffer, offset, "CreateEdge source (migration)")?;
                 offset += 8;
 
-                let target = NodeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let target = deserialize_node_id(&buffer, offset, "CreateEdge target (migration)")?;
                 offset += 8;
 
                 let label_len = u32::from_le_bytes([
@@ -1344,28 +1290,10 @@ fn parse_wal_entries_versioned(
                 if offset + 16 > buffer.len() {
                     break;
                 }
-                let node_id = NodeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let node_id = deserialize_node_id(&buffer, offset, "UpdateNode (migration)")?;
                 offset += 8;
 
-                let version_id = VersionId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let version_id = deserialize_version_id(&buffer, offset, "UpdateNode (migration)")?;
                 offset += 8;
 
                 let (label, properties, temporal) = if version >= WAL_VERSION {
@@ -1410,28 +1338,10 @@ fn parse_wal_entries_versioned(
                 if offset + 16 > buffer.len() {
                     break;
                 }
-                let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let edge_id = deserialize_edge_id(&buffer, offset, "UpdateEdge (migration)")?;
                 offset += 8;
 
-                let version_id = VersionId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let version_id = deserialize_version_id(&buffer, offset, "UpdateEdge (migration)")?;
                 offset += 8;
 
                 let (label, properties, temporal) = if version >= WAL_VERSION {
@@ -1510,16 +1420,7 @@ fn parse_wal_entries_versioned(
                 if offset + 8 > buffer.len() {
                     break;
                 }
-                let node_id = NodeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let node_id = deserialize_node_id(&buffer, offset, "DeleteNode (migration)")?;
                 offset += 8;
 
                 let temporal = if version >= WAL_VERSION {
@@ -1537,16 +1438,7 @@ fn parse_wal_entries_versioned(
                 if offset + 8 > buffer.len() {
                     break;
                 }
-                let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
-                    buffer[offset],
-                    buffer[offset + 1],
-                    buffer[offset + 2],
-                    buffer[offset + 3],
-                    buffer[offset + 4],
-                    buffer[offset + 5],
-                    buffer[offset + 6],
-                    buffer[offset + 7],
-                ]));
+                let edge_id = deserialize_edge_id(&buffer, offset, "DeleteEdge (migration)")?;
                 offset += 8;
 
                 let temporal = if version >= WAL_VERSION {
@@ -1564,8 +1456,7 @@ fn parse_wal_entries_versioned(
                 return Err(StorageError::CorruptedData(format!(
                     "Unknown WAL operation type: {}",
                     op_type
-                ))
-                .into());
+                )).into())
             }
         };
 

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -580,7 +580,7 @@ impl WriteAheadLog {
                     if offset + 12 > buffer.len() {
                         break;
                     }
-                    let node_id = NodeId::new(u64::from_le_bytes([
+                    let node_id = NodeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -631,7 +631,7 @@ impl WriteAheadLog {
                     if offset + 28 > buffer.len() {
                         break;
                     }
-                    let edge_id = EdgeId::new(u64::from_le_bytes([
+                    let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -643,7 +643,7 @@ impl WriteAheadLog {
                     ]));
                     offset += 8;
 
-                    let source = NodeId::new(u64::from_le_bytes([
+                    let source = NodeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -655,7 +655,7 @@ impl WriteAheadLog {
                     ]));
                     offset += 8;
 
-                    let target = NodeId::new(u64::from_le_bytes([
+                    let target = NodeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -708,7 +708,7 @@ impl WriteAheadLog {
                     if offset + 16 > buffer.len() {
                         break;
                     }
-                    let node_id = NodeId::new(u64::from_le_bytes([
+                    let node_id = NodeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -720,7 +720,7 @@ impl WriteAheadLog {
                     ]));
                     offset += 8;
 
-                    let version_id = VersionId::new(u64::from_le_bytes([
+                    let version_id = VersionId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -776,7 +776,7 @@ impl WriteAheadLog {
                     if offset + 16 > buffer.len() {
                         break;
                     }
-                    let edge_id = EdgeId::new(u64::from_le_bytes([
+                    let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -788,7 +788,7 @@ impl WriteAheadLog {
                     ]));
                     offset += 8;
 
-                    let version_id = VersionId::new(u64::from_le_bytes([
+                    let version_id = VersionId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -876,7 +876,7 @@ impl WriteAheadLog {
                     if offset + 8 > buffer.len() {
                         break;
                     }
-                    let node_id = NodeId::new(u64::from_le_bytes([
+                    let node_id = NodeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -903,7 +903,7 @@ impl WriteAheadLog {
                     if offset + 8 > buffer.len() {
                         break;
                     }
-                    let edge_id = EdgeId::new(u64::from_le_bytes([
+                    let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
                         buffer[offset],
                         buffer[offset + 1],
                         buffer[offset + 2],
@@ -1220,7 +1220,7 @@ fn parse_wal_entries_versioned(
                 if offset + 12 > buffer.len() {
                     break;
                 }
-                let node_id = NodeId::new(u64::from_le_bytes([
+                let node_id = NodeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1269,7 +1269,7 @@ fn parse_wal_entries_versioned(
                 if offset + 28 > buffer.len() {
                     break;
                 }
-                let edge_id = EdgeId::new(u64::from_le_bytes([
+                let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1281,7 +1281,7 @@ fn parse_wal_entries_versioned(
                 ]));
                 offset += 8;
 
-                let source = NodeId::new(u64::from_le_bytes([
+                let source = NodeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1293,7 +1293,7 @@ fn parse_wal_entries_versioned(
                 ]));
                 offset += 8;
 
-                let target = NodeId::new(u64::from_le_bytes([
+                let target = NodeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1344,7 +1344,7 @@ fn parse_wal_entries_versioned(
                 if offset + 16 > buffer.len() {
                     break;
                 }
-                let node_id = NodeId::new(u64::from_le_bytes([
+                let node_id = NodeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1356,7 +1356,7 @@ fn parse_wal_entries_versioned(
                 ]));
                 offset += 8;
 
-                let version_id = VersionId::new(u64::from_le_bytes([
+                let version_id = VersionId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1410,7 +1410,7 @@ fn parse_wal_entries_versioned(
                 if offset + 16 > buffer.len() {
                     break;
                 }
-                let edge_id = EdgeId::new(u64::from_le_bytes([
+                let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1422,7 +1422,7 @@ fn parse_wal_entries_versioned(
                 ]));
                 offset += 8;
 
-                let version_id = VersionId::new(u64::from_le_bytes([
+                let version_id = VersionId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1510,7 +1510,7 @@ fn parse_wal_entries_versioned(
                 if offset + 8 > buffer.len() {
                     break;
                 }
-                let node_id = NodeId::new(u64::from_le_bytes([
+                let node_id = NodeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1537,7 +1537,7 @@ fn parse_wal_entries_versioned(
                 if offset + 8 > buffer.len() {
                     break;
                 }
-                let edge_id = EdgeId::new(u64::from_le_bytes([
+                let edge_id = EdgeId::new_unchecked(u64::from_le_bytes([
                     buffer[offset],
                     buffer[offset + 1],
                     buffer[offset + 2],
@@ -1612,7 +1612,7 @@ mod tests {
         let wal = WriteAheadLog::new(config)?;
 
         let operation = WalOperation::CreateNode {
-            node_id: NodeId::new(1),
+            node_id: NodeId::new(1).unwrap(),
             label: "Person".to_string(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
@@ -1659,7 +1659,7 @@ mod tests {
         let mut wal = WriteAheadLog::new(config)?;
 
         let operation = WalOperation::CreateNode {
-            node_id: NodeId::new(1),
+            node_id: NodeId::new(1).unwrap(),
             label: "Person".to_string(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
@@ -1687,7 +1687,7 @@ mod tests {
         // Append multiple entries to trigger rotation
         for i in 0..10 {
             let operation = WalOperation::CreateNode {
-                node_id: NodeId::new(i),
+                node_id: NodeId::new(i).unwrap(),
                 label: "Person".to_string(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
@@ -1714,7 +1714,7 @@ mod tests {
 
         // Log a delete node operation
         let operation = WalOperation::DeleteNode {
-            node_id: NodeId::new(42),
+            node_id: NodeId::new(42).unwrap(),
             temporal: BiTemporalInterval::current(time::now()),
         };
 
@@ -1751,7 +1751,7 @@ mod tests {
 
         // Log a delete edge operation
         let operation = WalOperation::DeleteEdge {
-            edge_id: EdgeId::new(99),
+            edge_id: EdgeId::new(99).unwrap(),
             temporal: BiTemporalInterval::current(time::now()),
         };
 
@@ -1789,25 +1789,25 @@ mod tests {
         // Log a sequence of mixed operations
         let ops = vec![
             WalOperation::CreateNode {
-                node_id: NodeId::new(1),
+                node_id: NodeId::new(1).unwrap(),
                 label: "Person".to_string(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             },
             WalOperation::CreateEdge {
-                edge_id: EdgeId::new(1),
-                source: NodeId::new(1),
-                target: NodeId::new(2),
+                edge_id: EdgeId::new(1).unwrap(),
+                source: NodeId::new(1).unwrap(),
+                target: NodeId::new(2).unwrap(),
                 label: "KNOWS".to_string(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             },
             WalOperation::DeleteNode {
-                node_id: NodeId::new(3),
+                node_id: NodeId::new(3).unwrap(),
                 temporal: BiTemporalInterval::current(time::now()),
             },
             WalOperation::DeleteEdge {
-                edge_id: EdgeId::new(2),
+                edge_id: EdgeId::new(2).unwrap(),
                 temporal: BiTemporalInterval::current(time::now()),
             },
         ];
@@ -1874,7 +1874,7 @@ mod tests {
         );
 
         let operation = WalOperation::CreateNode {
-            node_id: NodeId::new(42),
+            node_id: NodeId::new(42).unwrap(),
             label: "Person".to_string(),
             properties: properties.clone(),
             temporal,
@@ -1937,9 +1937,9 @@ mod tests {
             BiTemporalInterval::new(TimeRange::new(5000, 6000), TimeRange::new(7000, 8000));
 
         let operation = WalOperation::CreateEdge {
-            edge_id: EdgeId::new(99),
-            source: NodeId::new(1),
-            target: NodeId::new(2),
+            edge_id: EdgeId::new(99).unwrap(),
+            source: NodeId::new(1).unwrap(),
+            target: NodeId::new(2).unwrap(),
             label: "FRIENDS_WITH".to_string(),
             properties: properties.clone(),
             temporal,
@@ -2000,8 +2000,8 @@ mod tests {
             BiTemporalInterval::new(TimeRange::new(10000, 20000), TimeRange::from(15000));
 
         let operation = WalOperation::UpdateNode {
-            node_id: NodeId::new(42),
-            version_id: VersionId::new(2),
+            node_id: NodeId::new(42).unwrap(),
+            version_id: VersionId::new(2).unwrap(),
             label: "Person".to_string(),
             properties: properties.clone(),
             temporal,
@@ -2049,12 +2049,12 @@ mod tests {
         let temporal = BiTemporalInterval::new(TimeRange::new(100, 200), TimeRange::new(300, 400));
 
         wal.append(WalOperation::DeleteNode {
-            node_id: NodeId::new(5),
+            node_id: NodeId::new(5).unwrap(),
             temporal,
         })?;
 
         wal.append(WalOperation::DeleteEdge {
-            edge_id: EdgeId::new(10),
+            edge_id: EdgeId::new(10).unwrap(),
             temporal,
         })?;
 
@@ -2109,7 +2109,7 @@ mod tests {
 
         // Append an entry to create a segment
         wal.append(WalOperation::CreateNode {
-            node_id: NodeId::new(1),
+            node_id: NodeId::new(1).unwrap(),
             label: "Test".to_string(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
@@ -2157,7 +2157,7 @@ mod tests {
                 BiTemporalInterval::new(TimeRange::new(1000, 2000), TimeRange::new(3000, 4000));
 
             wal.append(WalOperation::CreateNode {
-                node_id: NodeId::new(100),
+                node_id: NodeId::new(100).unwrap(),
                 label: "TestNode".to_string(),
                 properties: original_properties.clone(),
                 temporal: original_temporal,
@@ -2218,7 +2218,7 @@ mod tests {
 
         let mut wal = WriteAheadLog::new(config)?;
         wal.append(WalOperation::CreateNode {
-            node_id: NodeId::new(1),
+            node_id: NodeId::new(1).unwrap(),
             label: "Test".to_string(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
@@ -2261,7 +2261,7 @@ mod tests {
 
         let mut wal = WriteAheadLog::new(config)?;
         wal.append(WalOperation::CreateNode {
-            node_id: NodeId::new(1),
+            node_id: NodeId::new(1).unwrap(),
             label: "Test".to_string(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -150,6 +150,13 @@ pub enum StorageError {
     },
     /// Property with the given key was not found.
     PropertyNotFound(String),
+    /// Invalid ID value (out of range or reserved).
+    InvalidId {
+        /// The invalid ID value
+        id: u64,
+        /// The type of ID (node/edge/version)
+        id_type: &'static str,
+    },
 }
 
 impl fmt::Display for StorageError {
@@ -184,6 +191,13 @@ impl fmt::Display for StorageError {
             }
             StorageError::PropertyNotFound(key) => {
                 write!(f, "Property not found: {}", key)
+            }
+            StorageError::InvalidId { id, id_type } => {
+                write!(
+                    f,
+                    "Invalid {} ID {}: exceeds maximum allowed value {} (reserved range for internal use)",
+                    id_type, id, crate::core::id::MAX_VALID_ID
+                )
             }
         }
     }
@@ -538,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_storage_error_display() {
-        let err = StorageError::NodeNotFound(NodeId::new(42));
+        let err = StorageError::NodeNotFound(NodeId::new(42).unwrap());
         assert_eq!(format!("{}", err), "Node not found: Node(42)");
 
         let err = StorageError::InvalidProperty {
@@ -580,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_error_conversions() {
-        let storage_err = StorageError::NodeNotFound(NodeId::new(1));
+        let storage_err = StorageError::NodeNotFound(NodeId::new(1).unwrap());
         let err: Error = storage_err.clone().into();
         assert!(matches!(err, Error::Storage(_)));
 
@@ -597,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let err = Error::Storage(StorageError::NodeNotFound(NodeId::new(42)));
+        let err = Error::Storage(StorageError::NodeNotFound(NodeId::new(42).unwrap()));
         assert!(format!("{}", err).contains("Storage error"));
         assert!(format!("{}", err).contains("Node not found"));
 
@@ -612,7 +626,7 @@ mod tests {
         }
 
         fn returns_error() -> Result<i32> {
-            Err(StorageError::NodeNotFound(NodeId::new(1)).into())
+            Err(StorageError::NodeNotFound(NodeId::new(1).unwrap()).into())
         }
 
         assert_eq!(returns_result().unwrap(), 42);
@@ -622,11 +636,11 @@ mod tests {
     #[test]
     fn test_all_storage_error_variants() {
         // Test EdgeNotFound
-        let err = StorageError::EdgeNotFound(EdgeId::new(1));
+        let err = StorageError::EdgeNotFound(EdgeId::new(1).unwrap());
         assert!(format!("{}", err).contains("Edge not found"));
 
         // Test VersionNotFound
-        let err = StorageError::VersionNotFound(VersionId::new(1));
+        let err = StorageError::VersionNotFound(VersionId::new(1).unwrap());
         assert!(format!("{}", err).contains("Version not found"));
 
         // Test DuplicateId
@@ -698,7 +712,7 @@ mod tests {
 
         // Test VersionAlreadyClosed
         let err = TemporalError::VersionAlreadyClosed {
-            version_id: VersionId::new(42),
+            version_id: VersionId::new(42).unwrap(),
         };
         assert!(format!("{}", err).contains("already closed"));
         assert!(format!("{}", err).contains("42"));


### PR DESCRIPTION
## Summary
## Summary
Implements input validation for ID constructors to prevent potential integer overflow and DoS attacks from malicious or out-of-range ID values.

## Changes
- **Added MAX_VALID_ID constant**: Set to  to reserve high values for internal use
- **Updated ID constructors**: Changed  to return  with validation
- **Added new_unchecked()**: Internal-use-only constructor that bypasses validation for performance
- **Added InvalidId error**: New variant in  enum for out-of-range IDs
- **Updated call sites** (16 files):
  - Internal storage/index: Use  for ID generators
  - Test code: Use  for explicit test values
  - WAL deserialization: Use  for trusted storage

## Testing
- All 460 existing tests pass
- Added new validation tests:
  - Valid IDs (0 to MAX_VALID_ID) are accepted
  - Out-of-range IDs (> MAX_VALID_ID) are rejected
  -  bypasses validation
  - MAX_VALID_ID reserves correct amount (1000 values)

## Security Impact
Prevents potential DoS vector where malicious code could create IDs with extreme values (like ) that might cause issues in arithmetic operations or indexing.

Resolves #13

---
Created from worktree workflow.