### PR TITLE
feat: Use string interning for PropertyKey (P2-1)

### DIFF
--- a/examples/doctor_who_demo.rs
+++ b/examples/doctor_who_demo.rs
@@ -578,10 +578,19 @@ fn print_node_details(demo: &DemoData, name: &str) -> Result<()> {
 
         // Sort properties for consistent display
         let mut props: Vec<_> = node.properties.iter().collect();
-        props.sort_by_key(|(k, _)| k.as_str());
+        props.sort_by_key(|(k, _)| {
+            GLOBAL_INTERNER
+                .resolve(**k)
+                .map(|s| s.to_string())
+                .unwrap_or_default()
+        });
 
         for (key, value) in props {
-            println!("  {}: {}", key, format_value(value));
+            let key_str = GLOBAL_INTERNER
+                .resolve(*key)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("{:?}", key));
+            println!("  {}: {}", key_str, format_value(value));
         }
 
         // Show relationships

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -47,6 +47,25 @@ impl fmt::Display for InternedString {
     }
 }
 
+// Convenient From implementations for use as PropertyKey
+impl From<&str> for InternedString {
+    fn from(s: &str) -> Self {
+        GLOBAL_INTERNER.intern(s)
+    }
+}
+
+impl From<String> for InternedString {
+    fn from(s: String) -> Self {
+        GLOBAL_INTERNER.intern(s)
+    }
+}
+
+impl From<&String> for InternedString {
+    fn from(s: &String) -> Self {
+        GLOBAL_INTERNER.intern(s)
+    }
+}
+
 /// Thread-safe string interner.
 ///
 /// This interner maintains a bidirectional mapping between strings and IDs:

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -113,38 +113,30 @@ impl StringInterner {
     pub fn intern<S: AsRef<str>>(&self, string: S) -> InternedString {
         let string = string.as_ref();
 
-        // Fast path: check if already interned
-        if let Some(id) = self.string_to_id.get(string) {
-            return *id;
-        }
-
-        // Check capacity before interning (DoS protection)
-        let current_count = self.string_to_id.len();
-        if current_count >= self.max_capacity {
-            panic!(
-                "String interner capacity exceeded: current={}, limit={} (DoS protection). \
-                 This prevents unbounded memory growth from malicious or buggy clients.",
-                current_count, self.max_capacity
-            );
-        }
-
-        // Slow path: need to intern a new string
+        // Use entry API for atomic check-and-insert
+        // This prevents race conditions where two threads could assign different IDs
+        // to the same string
         let arc_str: Arc<str> = Arc::from(string);
 
-        // Double-check to handle race conditions
-        // Another thread might have interned it while we were creating the Arc
-        if let Some(id) = self.string_to_id.get(arc_str.as_ref()) {
-            return *id;
-        }
+        *self.string_to_id.entry(arc_str.clone()).or_insert_with(|| {
+            // Check capacity before interning (DoS protection)
+            let current_count = self.string_to_id.len();
+            if current_count >= self.max_capacity {
+                panic!(
+                    "String interner capacity exceeded: current={}, limit={} (DoS protection). \
+                     This prevents unbounded memory growth from malicious or buggy clients.",
+                    current_count, self.max_capacity
+                );
+            }
 
-        // Assign a new ID
-        let id = InternedString(self.next_id.fetch_add(1, Ordering::Relaxed));
+            // Assign a new ID atomically
+            let id = InternedString(self.next_id.fetch_add(1, Ordering::Relaxed));
 
-        // Store in both directions
-        self.string_to_id.insert(Arc::clone(&arc_str), id);
-        self.id_to_string.insert(id, arc_str);
+            // Store the reverse mapping
+            self.id_to_string.insert(id, arc_str.clone());
 
-        id
+            id
+        })
     }
 
     /// Resolve an interned string ID back to the original string.

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -371,9 +371,6 @@ mod tests {
 
     #[test]
     fn test_global_interner() {
-        // Clear to ensure clean state
-        GLOBAL_INTERNER.clear();
-
         let id1 = GLOBAL_INTERNER.intern("global");
         let id2 = GLOBAL_INTERNER.intern("global");
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1031,14 +1031,6 @@ macro_rules! properties {
 mod tests {
     use super::*;
 
-    /// Test helper to clear the global interner before each test.
-    ///
-    /// This ensures test isolation when tests run in parallel, preventing
-    /// state from one test affecting another.
-    fn setup_test() {
-        GLOBAL_INTERNER.clear();
-    }
-
     #[test]
     fn test_property_value_types() {
         assert!(PropertyValue::Null.is_null());

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -804,26 +804,42 @@ impl PropertyMap {
     /// Note: HashMap ordering is not guaranteed, so serialization order
     /// may vary. This is acceptable for correctness but may affect
     /// byte-for-byte reproducibility.
-    pub fn serialize(&self) -> Vec<u8> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any PropertyKey cannot be resolved from the interner.
+    /// This should never happen in practice as all keys are created via interning.
+    pub fn serialize(&self) -> Result<Vec<u8>> {
         let mut buffer = Vec::new();
-        self.serialize_into(&mut buffer);
-        buffer
+        self.serialize_into(&mut buffer)?;
+        Ok(buffer)
     }
 
     /// Serialize this PropertyMap into an existing buffer.
-    pub fn serialize_into(&self, buffer: &mut Vec<u8>) {
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::InconsistentState` if any PropertyKey cannot be
+    /// resolved from the interner, indicating data corruption.
+    pub fn serialize_into(&self, buffer: &mut Vec<u8>) -> Result<()> {
         buffer.extend_from_slice(&(self.inner.len() as u32).to_le_bytes());
         for (key, value) in self.inner.iter() {
             // Serialize key: resolve InternedString to actual string
-            let key_str = GLOBAL_INTERNER
-                .resolve(*key)
-                .expect("PropertyKey should always resolve to a valid string");
+            let key_str = GLOBAL_INTERNER.resolve(*key).ok_or_else(|| {
+                StorageError::InconsistentState {
+                    reason: format!(
+                        "PropertyKey {} not found in interner - data corruption detected",
+                        key.as_u32()
+                    ),
+                }
+            })?;
             let key_bytes = key_str.as_bytes();
             buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
             buffer.extend_from_slice(key_bytes);
             // Serialize value
             value.serialize_into(buffer);
         }
+        Ok(())
     }
 
     /// Deserialize a PropertyMap from bytes.
@@ -1015,6 +1031,14 @@ macro_rules! properties {
 mod tests {
     use super::*;
 
+    /// Test helper to clear the global interner before each test.
+    ///
+    /// This ensures test isolation when tests run in parallel, preventing
+    /// state from one test affecting another.
+    fn setup_test() {
+        GLOBAL_INTERNER.clear();
+    }
+
     #[test]
     fn test_property_value_types() {
         assert!(PropertyValue::Null.is_null());
@@ -1085,6 +1109,8 @@ mod tests {
 
     #[test]
     fn test_property_map_iteration() {
+        setup_test();
+
         let map = PropertyMapBuilder::new()
             .insert("a", 1i64)
             .insert("b", 2i64)
@@ -1509,7 +1535,7 @@ mod tests {
     #[test]
     fn test_serialize_property_map_empty() {
         let map = PropertyMap::new();
-        let bytes = map.serialize();
+        let bytes = map.serialize().expect("Serialization should succeed");
 
         // Empty map: just count (4 bytes) = [0, 0, 0, 0]
         assert_eq!(bytes, vec![0, 0, 0, 0]);
@@ -1528,7 +1554,7 @@ mod tests {
             .insert("score", 98.5)
             .build();
 
-        let bytes = map.serialize();
+        let bytes = map.serialize().expect("Serialization should succeed");
         let (deserialized, _) = PropertyMap::deserialize(&bytes).unwrap();
 
         // Check all values match
@@ -1556,7 +1582,7 @@ mod tests {
             .insert("embedding", PropertyValue::vector(&embedding))
             .build();
 
-        let bytes = map.serialize();
+        let bytes = map.serialize().expect("Serialization should succeed");
         let (deserialized, _) = PropertyMap::deserialize(&bytes).unwrap();
 
         assert_eq!(deserialized.len(), 2);
@@ -1582,7 +1608,7 @@ mod tests {
             )
             .build();
 
-        let bytes = map.serialize();
+        let bytes = map.serialize().expect("Serialization should succeed");
         let (deserialized, _) = PropertyMap::deserialize(&bytes).unwrap();
 
         let tags = deserialized.get("tags").and_then(|v| v.as_array()).unwrap();
@@ -1686,5 +1712,177 @@ mod tests {
         assert_eq!(bytes[6], 0x03);
         assert_eq!(bytes[7], 0x02);
         assert_eq!(bytes[8], 0x01);
+    }
+
+    // ========================================================================
+    // PropertyKey Interning Tests (Issue #16)
+    // ========================================================================
+
+    #[test]
+    fn test_property_key_interning_serialization_round_trip() {
+        setup_test();
+
+        // Create a property map with interned keys
+        let map = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .insert("active", true)
+            .build();
+
+        // Serialize
+        let bytes = map.serialize().expect("Serialization should succeed");
+
+        // Deserialize
+        let (deserialized, _) = PropertyMap::deserialize(&bytes).expect("Deserialization should succeed");
+
+        // Verify all values match
+        assert_eq!(deserialized.get("name").and_then(|v| v.as_str()), Some("Alice"));
+        assert_eq!(deserialized.get("age").and_then(|v| v.as_int()), Some(30));
+        assert_eq!(deserialized.get("active").and_then(|v| v.as_bool()), Some(true));
+
+        // Verify keys are interned (same ID as original)
+        let original_keys: Vec<_> = map.keys().cloned().collect();
+        let deserialized_keys: Vec<_> = deserialized.keys().cloned().collect();
+
+        assert_eq!(original_keys.len(), deserialized_keys.len());
+        for key in &original_keys {
+            assert!(deserialized_keys.contains(key), "Key should be interned with same ID");
+        }
+    }
+
+    #[test]
+    fn test_property_key_memory_efficiency() {
+        use std::mem::size_of;
+
+        // Verify InternedString is indeed smaller than String
+        assert_eq!(size_of::<InternedString>(), 4, "InternedString should be 4 bytes");
+        assert_eq!(size_of::<String>(), 24, "String should be 24 bytes");
+
+        // Record interner size before creating maps
+        let interner_size_before = GLOBAL_INTERNER.len();
+
+        // Create multiple maps with the same keys
+        let maps: Vec<_> = (0..100)
+            .map(|i| {
+                PropertyMapBuilder::new()
+                    .insert("test_mem_name", format!("Person{}", i))
+                    .insert("test_mem_age", i as i64)
+                    .insert("test_mem_id", i as i64)
+                    .build()
+            })
+            .collect();
+
+        // Verify all maps use the same interned key IDs (order may vary)
+        use std::collections::HashSet;
+        let first_keys: HashSet<_> = maps[0].keys().cloned().collect();
+        for map in &maps[1..] {
+            let map_keys: HashSet<_> = map.keys().cloned().collect();
+            assert_eq!(
+                first_keys, map_keys,
+                "All maps should share the same interned key IDs"
+            );
+        }
+
+        // Verify we only added 3 unique keys (deduplication works)
+        // Note: Using test-specific key names to avoid conflicts with other parallel tests
+        let interner_size_after = GLOBAL_INTERNER.len();
+        assert_eq!(
+            interner_size_after - interner_size_before,
+            3,
+            "Should have added exactly 3 unique keys to interner"
+        );
+    }
+
+    #[test]
+    fn test_invalid_interned_string_serialization() {
+        setup_test();
+
+        // Create an InternedString with a raw ID that doesn't exist in the interner
+        let invalid_key = InternedString::from_raw(999999);
+
+        // Create a property map and manually insert with invalid key
+        let mut inner_map = HashMap::new();
+        inner_map.insert(invalid_key, PropertyValue::Int(42));
+        let map = PropertyMap {
+            inner: Arc::new(inner_map),
+        };
+
+        // Serialization should return an error, not panic
+        let result = map.serialize();
+        assert!(
+            result.is_err(),
+            "Serialization should fail for invalid InternedString"
+        );
+
+        match result {
+            Err(crate::utils::error::Error::Storage(StorageError::InconsistentState { reason })) => {
+                assert!(
+                    reason.contains("not found in interner"),
+                    "Error message should indicate missing key in interner"
+                );
+            }
+            _ => panic!("Expected StorageError::InconsistentState"),
+        }
+    }
+
+    #[test]
+    fn test_concurrent_property_key_access() {
+        setup_test();
+
+        use std::sync::Arc;
+        use std::thread;
+
+        // Create a property map
+        let map = Arc::new(
+            PropertyMapBuilder::new()
+                .insert("shared_key", "value")
+                .insert("count", 0i64)
+                .build()
+        );
+
+        // Spawn multiple threads accessing the same property keys
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let map_clone = Arc::clone(&map);
+                thread::spawn(move || {
+                    // Each thread accesses properties multiple times
+                    for _ in 0..100 {
+                        assert_eq!(
+                            map_clone.get("shared_key").and_then(|v| v.as_str()),
+                            Some("value")
+                        );
+                        assert!(map_clone.contains_key("count"));
+                    }
+                })
+            })
+            .collect();
+
+        // Wait for all threads to complete
+        for handle in handles {
+            handle.join().expect("Thread should complete successfully");
+        }
+    }
+
+    #[test]
+    fn test_property_key_get_efficiency() {
+        setup_test();
+
+        // Pre-populate interner with a key
+        let interned_key = GLOBAL_INTERNER.intern("test_key");
+
+        let map = PropertyMapBuilder::new()
+            .insert("test_key", "value")
+            .build();
+
+        // get() should auto-intern the key
+        let value1 = map.get("test_key");
+        assert_eq!(value1.and_then(|v| v.as_str()), Some("value"));
+
+        // get_by_interned_key() should be more efficient for repeated lookups
+        let value2 = map.get_by_interned_key(&interned_key);
+        assert_eq!(value2.and_then(|v| v.as_str()), Some("value"));
+
+        // Both methods should return the same result
+        assert_eq!(value1, value2);
     }
 }

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1109,8 +1109,6 @@ mod tests {
 
     #[test]
     fn test_property_map_iteration() {
-        setup_test();
-
         let map = PropertyMapBuilder::new()
             .insert("a", 1i64)
             .insert("b", 2i64)
@@ -1720,8 +1718,6 @@ mod tests {
 
     #[test]
     fn test_property_key_interning_serialization_round_trip() {
-        setup_test();
-
         // Create a property map with interned keys
         let map = PropertyMapBuilder::new()
             .insert("name", "Alice")
@@ -1802,8 +1798,6 @@ mod tests {
 
     #[test]
     fn test_invalid_interned_string_serialization() {
-        setup_test();
-
         // Create an InternedString with a raw ID that doesn't exist in the interner
         let invalid_key = InternedString::from_raw(999999);
 
@@ -1834,8 +1828,6 @@ mod tests {
 
     #[test]
     fn test_concurrent_property_key_access() {
-        setup_test();
-
         use std::sync::Arc;
         use std::thread;
 
@@ -1872,8 +1864,6 @@ mod tests {
 
     #[test]
     fn test_property_key_get_efficiency() {
-        setup_test();
-
         // Pre-populate interner with a key
         let interned_key = GLOBAL_INTERNER.intern("test_key");
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1758,9 +1758,6 @@ mod tests {
         assert_eq!(size_of::<InternedString>(), 4, "InternedString should be 4 bytes");
         assert_eq!(size_of::<String>(), 24, "String should be 24 bytes");
 
-        // Record interner size before creating maps
-        let interner_size_before = GLOBAL_INTERNER.len();
-
         // Create multiple maps with the same keys
         let maps: Vec<_> = (0..100)
             .map(|i| {
@@ -1783,14 +1780,24 @@ mod tests {
             );
         }
 
-        // Verify we only added 3 unique keys (deduplication works)
-        // Note: Using test-specific key names to avoid conflicts with other parallel tests
-        let interner_size_after = GLOBAL_INTERNER.len();
+        // Verify we have exactly 3 unique keys across all maps
         assert_eq!(
-            interner_size_after - interner_size_before,
+            first_keys.len(),
             3,
-            "Should have added exactly 3 unique keys to interner"
+            "Should have exactly 3 unique keys"
         );
+
+        // Verify the specific keys exist and can be resolved
+        let expected_keys = ["test_mem_name", "test_mem_age", "test_mem_id"];
+        for key_str in &expected_keys {
+            let exists = first_keys.iter().any(|key| {
+                GLOBAL_INTERNER
+                    .resolve(*key)
+                    .map(|s| s.as_ref() == *key_str)
+                    .unwrap_or(false)
+            });
+            assert!(exists, "Key '{}' should exist in the property maps", key_str);
+        }
     }
 
     #[test]

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
+use crate::core::interning::{InternedString, GLOBAL_INTERNER};
 use crate::utils::error::{Result, StorageError};
 
 // ============================================================================
@@ -50,9 +51,9 @@ pub const MAX_VECTOR_DIMENSIONS: usize = 100_000;
 
 /// Property key type.
 ///
-/// TODO: Replace with InternedString once string interning is implemented.
-/// For now, using String directly.
-pub type PropertyKey = String;
+/// Uses interned strings for memory efficiency and O(1) equality comparisons.
+/// Common keys like "name", "age", and "id" are deduplicated in memory.
+pub type PropertyKey = InternedString;
 
 /// A value that can be stored as a property.
 ///
@@ -713,14 +714,38 @@ impl PropertyMap {
     }
 
     /// Get a property value by key.
+    ///
+    /// The key is automatically interned before lookup for efficient comparison.
     #[inline]
     pub fn get(&self, key: &str) -> Option<&PropertyValue> {
+        let interned_key = GLOBAL_INTERNER.intern(key);
+        self.get_by_interned_key(&interned_key)
+    }
+
+    /// Get a property value by an already-interned key.
+    ///
+    /// This is more efficient than `get()` when you already have an InternedString.
+    /// For internal use and performance-critical paths.
+    #[inline]
+    pub fn get_by_interned_key(&self, key: &PropertyKey) -> Option<&PropertyValue> {
         self.inner.get(key)
     }
 
     /// Check if a property exists.
+    ///
+    /// The key is automatically interned before lookup for efficient comparison.
     #[inline]
     pub fn contains_key(&self, key: &str) -> bool {
+        let interned_key = GLOBAL_INTERNER.intern(key);
+        self.contains_interned_key(&interned_key)
+    }
+
+    /// Check if a property exists by an already-interned key.
+    ///
+    /// This is more efficient than `contains_key()` when you already have an InternedString.
+    /// For internal use and performance-critical paths.
+    #[inline]
+    pub fn contains_interned_key(&self, key: &PropertyKey) -> bool {
         self.inner.contains_key(key)
     }
 
@@ -789,8 +814,11 @@ impl PropertyMap {
     pub fn serialize_into(&self, buffer: &mut Vec<u8>) {
         buffer.extend_from_slice(&(self.inner.len() as u32).to_le_bytes());
         for (key, value) in self.inner.iter() {
-            // Serialize key
-            let key_bytes = key.as_bytes();
+            // Serialize key: resolve InternedString to actual string
+            let key_str = GLOBAL_INTERNER
+                .resolve(*key)
+                .expect("PropertyKey should always resolve to a valid string");
+            let key_bytes = key_str.as_bytes();
             buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
             buffer.extend_from_slice(key_bytes);
             // Serialize value
@@ -833,11 +861,12 @@ impl PropertyMap {
                 )
                 .into());
             }
-            let key = std::str::from_utf8(&bytes[offset..offset + key_len])
+            let key_str = std::str::from_utf8(&bytes[offset..offset + key_len])
                 .map_err(|e| {
                     StorageError::CorruptedData(format!("Invalid UTF-8 in property key: {}", e))
-                })?
-                .to_string();
+                })?;
+            // Intern the key for efficient storage and comparison
+            let key = GLOBAL_INTERNER.intern(key_str);
             offset += key_len;
 
             // Read value
@@ -928,7 +957,18 @@ impl PropertyMapBuilder {
     }
 
     /// Remove a property.
-    pub fn remove(mut self, key: &str) -> Self {
+    ///
+    /// The key is automatically interned before removal.
+    pub fn remove(self, key: &str) -> Self {
+        let interned_key = GLOBAL_INTERNER.intern(key);
+        self.remove_by_key(&interned_key)
+    }
+
+    /// Remove a property by an already-interned key.
+    ///
+    /// This is more efficient than `remove()` when you already have an InternedString.
+    /// For internal use and performance-critical paths.
+    pub fn remove_by_key(mut self, key: &PropertyKey) -> Self {
         self.map.remove(key);
         self
     }
@@ -1053,9 +1093,9 @@ mod tests {
 
         let keys: Vec<_> = map.keys().cloned().collect();
         assert_eq!(keys.len(), 3);
-        assert!(keys.contains(&"a".to_string()));
-        assert!(keys.contains(&"b".to_string()));
-        assert!(keys.contains(&"c".to_string()));
+        assert!(keys.contains(&GLOBAL_INTERNER.intern("a")));
+        assert!(keys.contains(&GLOBAL_INTERNER.intern("b")));
+        assert!(keys.contains(&GLOBAL_INTERNER.intern("c")));
 
         let values: Vec<_> = map.values().cloned().collect();
         assert_eq!(values.len(), 3);

--- a/src/storage/version.rs
+++ b/src/storage/version.rs
@@ -10,8 +10,8 @@
 
 use crate::api::transaction::types::TxId;
 use crate::core::id::{EdgeId, NodeId, VersionId};
-use crate::core::interning::InternedString;
-use crate::core::property::{PropertyMap, PropertyValue};
+use crate::core::interning::{InternedString, GLOBAL_INTERNER};
+use crate::core::property::{PropertyKey, PropertyMap, PropertyValue};
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use std::collections::{HashMap, HashSet};
 
@@ -107,9 +107,9 @@ impl Default for AnchorConfig {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PropertyDelta {
     /// Properties that were added or modified
-    pub changed: HashMap<String, PropertyValue>,
+    pub changed: HashMap<PropertyKey, PropertyValue>,
     /// Properties that were removed
-    pub removed: HashSet<String>,
+    pub removed: HashSet<PropertyKey>,
 }
 
 impl PropertyDelta {
@@ -129,7 +129,7 @@ impl PropertyDelta {
 
         // Find added and modified properties
         for (key, new_value) in new.iter() {
-            match old.get(key) {
+            match old.get_by_interned_key(key) {
                 Some(old_value) if old_value == new_value => {
                     // Unchanged, skip
                 }
@@ -142,7 +142,7 @@ impl PropertyDelta {
 
         // Find removed properties
         for key in old.keys() {
-            if !new.contains_key(key) {
+            if !new.contains_interned_key(key) {
                 delta.removed.insert(key.clone());
             }
         }
@@ -162,7 +162,7 @@ impl PropertyDelta {
 
         // Apply removals
         for key in &self.removed {
-            builder = builder.remove(key);
+            builder = builder.remove_by_key(key);
         }
 
         builder.build()
@@ -422,7 +422,7 @@ mod tests {
 
         assert_eq!(delta.changed.len(), 2); // age modified, country added
         assert_eq!(delta.removed.len(), 1); // city removed
-        assert!(delta.removed.contains("city"));
+        assert!(delta.removed.contains(&GLOBAL_INTERNER.intern("city")));
     }
 
     #[test]
@@ -435,10 +435,10 @@ mod tests {
         let mut delta = PropertyDelta::new();
         delta
             .changed
-            .insert("age".to_string(), PropertyValue::Int(31));
+            .insert(GLOBAL_INTERNER.intern("age"), PropertyValue::Int(31));
         delta
             .changed
-            .insert("city".to_string(), PropertyValue::string("NYC"));
+            .insert(GLOBAL_INTERNER.intern("city"), PropertyValue::string("NYC"));
 
         let result = delta.apply(&base);
 

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -441,7 +441,7 @@ impl WriteAheadLog {
                 buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
                 buffer.extend_from_slice(&(label.len() as u32).to_le_bytes());
                 buffer.extend_from_slice(label.as_bytes());
-                properties.serialize_into(&mut buffer);
+                properties.serialize_into(&mut buffer)?;
                 temporal.serialize_into(&mut buffer);
             }
             WalOperation::CreateEdge {
@@ -458,7 +458,7 @@ impl WriteAheadLog {
                 buffer.extend_from_slice(&target.as_u64().to_le_bytes());
                 buffer.extend_from_slice(&(label.len() as u32).to_le_bytes());
                 buffer.extend_from_slice(label.as_bytes());
-                properties.serialize_into(&mut buffer);
+                properties.serialize_into(&mut buffer)?;
                 temporal.serialize_into(&mut buffer);
             }
             WalOperation::UpdateNode {
@@ -473,7 +473,7 @@ impl WriteAheadLog {
                 buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
                 buffer.extend_from_slice(&(label.len() as u32).to_le_bytes());
                 buffer.extend_from_slice(label.as_bytes());
-                properties.serialize_into(&mut buffer);
+                properties.serialize_into(&mut buffer)?;
                 temporal.serialize_into(&mut buffer);
             }
             WalOperation::UpdateEdge {
@@ -488,7 +488,7 @@ impl WriteAheadLog {
                 buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
                 buffer.extend_from_slice(&(label.len() as u32).to_le_bytes());
                 buffer.extend_from_slice(label.as_bytes());
-                properties.serialize_into(&mut buffer);
+                properties.serialize_into(&mut buffer)?;
                 temporal.serialize_into(&mut buffer);
             }
             WalOperation::DeleteNode { node_id, temporal } => {


### PR DESCRIPTION
Replace PropertyKey type alias from String to InternedString to improve memory efficiency and property lookup performance.

Changes:
- Update PropertyKey from String to InternedString type alias
- Add From<&str>, From<String> implementations for InternedString
- Update PropertyMap::get() and contains_key() to auto-intern keys
- Add *_by_interned_key() methods for performance-critical paths
- Update PropertyDelta to use PropertyKey instead of String
- Update serialization to resolve InternedString to string
- Update deserialization to intern strings before storage
- Fix all tests to use InternedString

Benefits:
- Memory savings: ~200 bytes per entity (24 → 4 bytes per key)
- Faster comparisons: O(1) integer comparison vs O(n) string comparison
- Common keys like 'name', 'age', 'id' deduplicated across entities

Fixes #16