### PR TITLE
perf(temporal-vector): reduce default max_snapshots to mitigate memor…

### DIFF
--- a/benches/temporal_vector.rs
+++ b/benches/temporal_vector.rs
@@ -22,6 +22,8 @@ fn create_temporal_index(dimensions: usize) -> TemporalVectorIndex {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(10),
         retention_policy: RetentionPolicy::KeepN(100),
+        // Higher limit for benchmarks to measure performance under load
+        // Production default is 20 (see issue #230)
         max_snapshots: 100,
         hnsw_config,
     };
@@ -51,7 +53,7 @@ fn bench_snapshot_creation(c: &mut Criterion) {
                 let config = TemporalVectorConfig {
                     snapshot_strategy: snapshot_strategy.clone(),
                     retention_policy: RetentionPolicy::KeepN(10),
-                    max_snapshots: 100,
+                    max_snapshots: 100,  // Higher for benchmarking
                     hnsw_config,
                 };
                 let index = TemporalVectorIndex::new(config).unwrap();

--- a/benches/temporal_vector.rs
+++ b/benches/temporal_vector.rs
@@ -53,7 +53,7 @@ fn bench_snapshot_creation(c: &mut Criterion) {
                 let config = TemporalVectorConfig {
                     snapshot_strategy: snapshot_strategy.clone(),
                     retention_policy: RetentionPolicy::KeepN(10),
-                    max_snapshots: 100,  // Higher for benchmarking
+                    max_snapshots: 100, // Higher for benchmarking
                     hnsw_config,
                 };
                 let index = TemporalVectorIndex::new(config).unwrap();

--- a/docs/adr/0017-temporal-vector-strategy.md
+++ b/docs/adr/0017-temporal-vector-strategy.md
@@ -82,7 +82,9 @@ pub struct TemporalVectorConfig {
     pub snapshot_strategy: SnapshotStrategy,
 
     /// Maximum number of snapshots to retain
-    pub max_snapshots: usize,  // Default: 100
+    /// Default reduced from 100 to 20 (issue #230) to prevent excessive memory usage
+    /// Each snapshot creates full HNSW index copy (~200MB for 100K vectors, 384 dims)
+    pub max_snapshots: usize,  // Default: 20 (was 100)
 
     /// Base HNSW configuration
     pub hnsw_config: HnswConfig,
@@ -477,24 +479,34 @@ pub fn create_checkpoint(&self) -> Result<()> {
 
 ### Recommended Default Configuration
 
+**Updated 2024**: Default `max_snapshots` reduced from 100 to 20 due to memory concerns (see issue #230).
+
 ```rust
 pub fn default_temporal_vector_config() -> TemporalVectorConfig {
     TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(10),  // Mirror anchor interval
-        max_snapshots: 100,  // ~100 anchors for 1000 versions
+        max_snapshots: 20,  // Reduced from 100 to prevent OOM (issue #230)
         hnsw_config: HnswConfig::default(),
     }
 }
 ```
 
+**Note**: Each snapshot creates a full copy of the HNSW index. For 100K vectors at 384 dimensions, each snapshot uses ~200MB (150MB vectors + 50-100MB HNSW graph). With 20 snapshots, total memory = ~4GB. The old default of 100 snapshots used ~20GB, causing OOM issues.
+
 ### Memory Budget Analysis
 
-| Scenario | Vectors | Snapshots | Memory per Snapshot | Total Memory |
-|----------|---------|-----------|---------------------|--------------|
-| Small DB | 10K | 10 | ~10MB | ~100MB |
-| Medium DB | 100K | 50 | ~100MB | ~5GB |
-| Large DB | 1M | 100 | ~1GB | ~100GB |
-| Very Large | 10M | 100 | ~10GB | ~1TB |
+**Current Implementation** (Full Snapshot - Phase 3.1):
+
+| Scenario | Vectors | Dims | Snapshots | Memory/Snapshot | Total Memory | Recommendation |
+|----------|---------|------|-----------|-----------------|--------------|----------------|
+| Small DB | 10K | 384 | 20 | ~20MB | ~400MB | Default (20) |
+| Medium DB | 100K | 384 | 20 | ~200MB | ~4GB | Default (20) |
+| Large DB | 100K | 384 | 50 | ~200MB | ~10GB | Increase if RAM available |
+| Large DB | 1M | 384 | 10 | ~2GB | ~20GB | Reduce snapshots |
+
+**Future with Anchor+Delta** (Phase 3.2 - Planned):
+- Memory reduction: ~9X (20GB → ~2.2GB for 100 snapshots)
+- Enables higher `max_snapshots` without memory penalty
 
 **Mitigation strategies**:
 1. **Lazy loading**: Load snapshots on-demand, evict LRU
@@ -619,7 +631,7 @@ let config = TemporalVectorConfig {
         time_interval: Duration::from_secs(3600),  // Hourly
         change_threshold: 0.1,  // 10% changed
     },
-    max_snapshots: 100,
+    max_snapshots: 20,  // Conservative default (was 100, see issue #230)
     hnsw_config: HnswConfig::new(384, DistanceMetric::Cosine),
 };
 db.enable_temporal_vector_index("embedding", config)?;
@@ -692,6 +704,13 @@ for (timestamp, results) in history {
 - Temporal indexing is opt-in via `enable_temporal_vector_index()`
 - Databases without temporal indexing continue to work
 - Can enable temporal indexing on existing database (creates first snapshot)
+
+**Configuration Default Change (2024)**:
+- Default `max_snapshots` reduced from 100 to 20 (issue #230)
+- **Existing databases**: Configurations are stored per-database. Existing databases retain their configured `max_snapshots` value (likely 100 if created before this change)
+- **New databases**: Will use new default of 20 snapshots
+- **Migration**: Users with existing databases can manually reduce `max_snapshots` if experiencing memory pressure, or keep existing value if RAM is sufficient
+- **Rationale**: Each snapshot creates full HNSW index copy (~200MB for 100K vectors, 384 dims). Old default of 100 snapshots = ~20GB, causing OOM issues. New default of 20 = ~4GB, suitable for most deployments.
 
 ### Future Enhancements (Phase 4+)
 

--- a/src/index/vector/temporal.rs
+++ b/src/index/vector/temporal.rs
@@ -1332,7 +1332,9 @@ mod tests {
         let hnsw_config = HnswConfig::new(384, DistanceMetric::Cosine);
         let config = TemporalVectorConfig::default_with_hnsw(hnsw_config.clone());
 
-        assert_eq!(config.max_snapshots, 100);
+        // Verify new conservative defaults (reduced from 100 to 20, see issue #230)
+        assert_eq!(config.max_snapshots, 20);
+        assert_eq!(config.retention_policy, RetentionPolicy::KeepN(20));
         assert!(matches!(
             config.snapshot_strategy,
             SnapshotStrategy::TransactionInterval(10)
@@ -1534,7 +1536,7 @@ mod tests {
         let hnsw_config = HnswConfig::new(384, DistanceMetric::Cosine);
         let config = TemporalVectorConfig::default_with_hnsw(hnsw_config);
 
-        // Verify default config has retention policy
-        assert_eq!(config.retention_policy, RetentionPolicy::KeepN(100));
+        // Verify default config has retention policy (reduced from 100 to 20, see issue #230)
+        assert_eq!(config.retention_policy, RetentionPolicy::KeepN(20));
     }
 }

--- a/src/index/vector/temporal.rs
+++ b/src/index/vector/temporal.rs
@@ -131,10 +131,24 @@ pub struct TemporalVectorConfig {
     /// Snapshot retention policy (default: KeepN(100))
     pub retention_policy: RetentionPolicy,
 
-    /// Maximum number of snapshots to retain (default: 100)
+    /// Maximum number of snapshots to retain (default: 20, reduced from 100)
     ///
     /// When this limit is exceeded, the oldest snapshots are removed.
     /// This prevents unbounded storage growth.
+    ///
+    /// **CRITICAL - Memory Usage**: Each snapshot creates a full copy of the HNSW index.
+    /// With 100K vectors at 384 dimensions:
+    /// - Per snapshot: ~200MB (150MB vectors + 50-100MB HNSW graph)
+    /// - 20 snapshots: ~4GB total memory
+    /// - 100 snapshots: ~20GB total memory (NOT RECOMMENDED)
+    ///
+    /// **Recommended values**:
+    /// - Development/testing: 5-10 snapshots
+    /// - Production with limited memory (<16GB): 10-20 snapshots
+    /// - Production with ample memory (32GB+): 20-50 snapshots
+    ///
+    /// **Note**: This will be optimized in a future release using anchor+delta compression
+    /// (see GitHub issue #230), which will reduce memory usage by ~9X.
     pub max_snapshots: usize,
 
     /// Base HNSW configuration for all indexes (current + snapshots)
@@ -146,13 +160,16 @@ impl TemporalVectorConfig {
     ///
     /// Defaults:
     /// - Strategy: TransactionInterval(10) - mirrors anchor+delta pattern
-    /// - Retention: KeepN(100)
-    /// - Max snapshots: 100
+    /// - Retention: KeepN(20) - conservative for memory
+    /// - Max snapshots: 20 - reduced from 100 to prevent excessive memory usage
+    ///
+    /// **Note**: Default reduced to 20 snapshots (~4GB for 100K vectors) to prevent
+    /// out-of-memory issues. Increase max_snapshots if you have sufficient RAM.
     pub fn default_with_hnsw(hnsw_config: HnswConfig) -> Self {
         TemporalVectorConfig {
             snapshot_strategy: SnapshotStrategy::TransactionInterval(10),
-            retention_policy: RetentionPolicy::KeepN(100),
-            max_snapshots: 100,
+            retention_policy: RetentionPolicy::KeepN(20),
+            max_snapshots: 20,
             hnsw_config,
         }
     }
@@ -161,8 +178,8 @@ impl TemporalVectorConfig {
     pub fn with_time_interval(hnsw_config: HnswConfig, interval_secs: u64) -> Self {
         TemporalVectorConfig {
             snapshot_strategy: SnapshotStrategy::TimeInterval(interval_secs),
-            retention_policy: RetentionPolicy::KeepN(100),
-            max_snapshots: 100,
+            retention_policy: RetentionPolicy::KeepN(20),
+            max_snapshots: 20,
             hnsw_config,
         }
     }
@@ -171,8 +188,8 @@ impl TemporalVectorConfig {
     pub fn with_change_threshold(hnsw_config: HnswConfig, threshold: f64) -> Self {
         TemporalVectorConfig {
             snapshot_strategy: SnapshotStrategy::ChangeThreshold(threshold),
-            retention_policy: RetentionPolicy::KeepN(100),
-            max_snapshots: 100,
+            retention_policy: RetentionPolicy::KeepN(20),
+            max_snapshots: 20,
             hnsw_config,
         }
     }

--- a/src/index/vector/temporal.rs
+++ b/src/index/vector/temporal.rs
@@ -30,12 +30,13 @@
 //! use gallifreydb::core::temporal::TimeRange;
 //!
 //! # fn example() -> gallifreydb::utils::Result<()> {
-//! // Create temporal index configuration
+//! // Create temporal index configuration with defaults
+//! // Or use: TemporalVectorConfig::default_with_hnsw(hnsw_config)
 //! let hnsw_config = HnswConfig::new(384, DistanceMetric::Cosine);
 //! let config = TemporalVectorConfig {
 //!     snapshot_strategy: SnapshotStrategy::TransactionInterval(10),
-//!     retention_policy: RetentionPolicy::KeepN(100),
-//!     max_snapshots: 100,
+//!     retention_policy: RetentionPolicy::KeepN(20),  // Conservative default
+//!     max_snapshots: 20,  // Reduced from 100, see issue #230
 //!     hnsw_config,
 //! };
 //!
@@ -92,7 +93,9 @@ pub enum RetentionPolicy {
 
 impl Default for RetentionPolicy {
     fn default() -> Self {
-        RetentionPolicy::KeepN(100)
+        // Reduced from 100 to 20 to prevent excessive memory usage (see issue #230)
+        // Each snapshot uses ~200MB for 100K vectors at 384 dimensions
+        RetentionPolicy::KeepN(20)
     }
 }
 
@@ -1526,9 +1529,9 @@ mod tests {
 
     #[test]
     fn test_retention_policy_default() {
-        // Verify RetentionPolicy has correct default
+        // Verify RetentionPolicy has correct default (reduced from 100 to 20, see issue #230)
         let default_policy = RetentionPolicy::default();
-        assert_eq!(default_policy, RetentionPolicy::KeepN(100));
+        assert_eq!(default_policy, RetentionPolicy::KeepN(20));
     }
 
     #[test]

--- a/tests/temporal_vector.rs
+++ b/tests/temporal_vector.rs
@@ -22,7 +22,7 @@ fn create_test_index() -> Result<TemporalVectorIndex> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(2),
         retention_policy: RetentionPolicy::KeepN(10),
-        max_snapshots: 20,  // Conservative default, see issue #230
+        max_snapshots: 20, // Conservative default, see issue #230
         hnsw_config,
     };
     TemporalVectorIndex::new(config)
@@ -136,7 +136,7 @@ fn test_snapshot_pruning_with_keep_n() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
         retention_policy: RetentionPolicy::KeepN(3),
-        max_snapshots: 100,  // High limit to test retention policy enforcement
+        max_snapshots: 100, // High limit to test retention policy enforcement
         hnsw_config,
     };
     let index = TemporalVectorIndex::new(config)?;
@@ -164,7 +164,7 @@ fn test_snapshot_pruning_with_keep_duration() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
         retention_policy: RetentionPolicy::KeepDuration(Duration::from_secs(10)),
-        max_snapshots: 100,  // High limit to test retention policy enforcement
+        max_snapshots: 100, // High limit to test retention policy enforcement
         hnsw_config,
     };
     let index = TemporalVectorIndex::new(config)?;
@@ -214,7 +214,7 @@ fn test_temporal_vector_with_different_strategies() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TimeInterval(1), // 1 second
         retention_policy: RetentionPolicy::KeepN(10),
-        max_snapshots: 20,  // Conservative default, see issue #230
+        max_snapshots: 20, // Conservative default, see issue #230
         hnsw_config: hnsw_config.clone(),
     };
 
@@ -234,7 +234,7 @@ fn test_temporal_vector_with_different_strategies() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::ChangeThreshold(0.5), // 50% changed
         retention_policy: RetentionPolicy::KeepN(10),
-        max_snapshots: 20,  // Conservative default, see issue #230
+        max_snapshots: 20, // Conservative default, see issue #230
         hnsw_config,
     };
     let change_threshold_index = TemporalVectorIndex::new_at(config, 1000)?;

--- a/tests/temporal_vector.rs
+++ b/tests/temporal_vector.rs
@@ -22,7 +22,7 @@ fn create_test_index() -> Result<TemporalVectorIndex> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(2),
         retention_policy: RetentionPolicy::KeepN(10),
-        max_snapshots: 100,
+        max_snapshots: 20,  // Conservative default, see issue #230
         hnsw_config,
     };
     TemporalVectorIndex::new(config)
@@ -136,7 +136,7 @@ fn test_snapshot_pruning_with_keep_n() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
         retention_policy: RetentionPolicy::KeepN(3),
-        max_snapshots: 100,
+        max_snapshots: 100,  // High limit to test retention policy enforcement
         hnsw_config,
     };
     let index = TemporalVectorIndex::new(config)?;
@@ -164,7 +164,7 @@ fn test_snapshot_pruning_with_keep_duration() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
         retention_policy: RetentionPolicy::KeepDuration(Duration::from_secs(10)),
-        max_snapshots: 100,
+        max_snapshots: 100,  // High limit to test retention policy enforcement
         hnsw_config,
     };
     let index = TemporalVectorIndex::new(config)?;
@@ -214,7 +214,7 @@ fn test_temporal_vector_with_different_strategies() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TimeInterval(1), // 1 second
         retention_policy: RetentionPolicy::KeepN(10),
-        max_snapshots: 100,
+        max_snapshots: 20,  // Conservative default, see issue #230
         hnsw_config: hnsw_config.clone(),
     };
 
@@ -234,7 +234,7 @@ fn test_temporal_vector_with_different_strategies() -> Result<()> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::ChangeThreshold(0.5), // 50% changed
         retention_policy: RetentionPolicy::KeepN(10),
-        max_snapshots: 100,
+        max_snapshots: 20,  // Conservative default, see issue #230
         hnsw_config,
     };
     let change_threshold_index = TemporalVectorIndex::new_at(config, 1000)?;

--- a/tests/temporal_vector_tests.rs
+++ b/tests/temporal_vector_tests.rs
@@ -9,7 +9,7 @@ fn create_test_index() -> Result<TemporalVectorIndex> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1000),
         retention_policy: RetentionPolicy::KeepN(20),
-        max_snapshots: 20,  // Conservative default, see issue #230
+        max_snapshots: 20, // Conservative default, see issue #230
         hnsw_config: HnswConfig::new(4, DistanceMetric::Cosine),
     };
     TemporalVectorIndex::new(config)

--- a/tests/temporal_vector_tests.rs
+++ b/tests/temporal_vector_tests.rs
@@ -8,8 +8,8 @@ use gallifreydb::utils::Result;
 fn create_test_index() -> Result<TemporalVectorIndex> {
     let config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1000),
-        retention_policy: RetentionPolicy::KeepN(100),
-        max_snapshots: 100,
+        retention_policy: RetentionPolicy::KeepN(20),
+        max_snapshots: 20,  // Conservative default, see issue #230
         hnsw_config: HnswConfig::new(4, DistanceMetric::Cosine),
     };
     TemporalVectorIndex::new(config)


### PR DESCRIPTION
…y usage

Address issue #230 by documenting snapshot memory costs and reducing defaults:

**Problem**:
- Each snapshot creates full HNSW index copy (~200MB for 100K vectors)
- Default of 100 snapshots = ~20GB memory usage
- Causes OOM issues in production environments

**Changes**:
- Reduce default max_snapshots from 100 to 20 (~4GB instead of ~20GB)
- Add comprehensive documentation of memory usage per snapshot
- Provide configuration recommendations based on available RAM
- Reference issue #230 for future anchor+delta compression work

**Impact**:
- 5X reduction in default memory usage (20GB → 4GB)
- Prevents OOM errors in most production environments
- Users can still increase max_snapshots if they have sufficient RAM

**Future Work**:
Full anchor+delta compression implementation (issue #230) will reduce memory usage by ~9X, but requires significant refactoring. This change provides immediate relief while that work is in progress.

Fixes #230