### PR TITLE
perf(visibility): Replace Mutex with RwLock to eliminate read contention

### DIFF
--- a/benches/transactions.rs
+++ b/benches/transactions.rs
@@ -401,7 +401,9 @@ fn bench_batch_insertions_with_prepopulated_graph(c: &mut Criterion) {
 /// Benchmark concurrent read operations during adjacency rebuild.
 /// This tests the impact of rebuild on read performance.
 fn bench_read_during_rebuild(c: &mut Criterion) {
-    // Pre-populate a database with 4K nodes + 4K edges (stay under 10K transaction limit)
+    // Pre-populate a database with 4K nodes + 4K edges
+    // Note: stays under DEFAULT_MAX_OPERATIONS (10K) limit defined in
+    // src/api/transaction/write_buffer.rs for DoS protection
     let db = GallifreyDB::new();
     let node_ids: Vec<_> = db
         .write(|tx| {
@@ -448,7 +450,9 @@ fn bench_read_during_rebuild(c: &mut Criterion) {
 fn bench_concurrent_visibility_checks(c: &mut Criterion) {
     let mut group = c.benchmark_group("concurrent_visibility");
 
-    // Pre-populate database with committed data (500 nodes to stay under transaction limit)
+    // Pre-populate database with committed data (500 nodes)
+    // Note: stays under DEFAULT_MAX_OPERATIONS (10K) limit defined in
+    // src/api/transaction/write_buffer.rs for DoS protection
     let db = Arc::new(GallifreyDB::new());
     let node_ids: Vec<_> = db
         .write(|tx| {
@@ -496,7 +500,9 @@ fn bench_concurrent_visibility_checks(c: &mut Criterion) {
 fn bench_sequential_visibility_checks(c: &mut Criterion) {
     let db = GallifreyDB::new();
 
-    // Pre-populate with 500 nodes (stay under transaction limit)
+    // Pre-populate with 500 nodes
+    // Note: stays under DEFAULT_MAX_OPERATIONS (10K) limit defined in
+    // src/api/transaction/write_buffer.rs for DoS protection
     let node_ids: Vec<_> = db
         .write(|tx| {
             let mut nodes = Vec::new();

--- a/benches/transactions.rs
+++ b/benches/transactions.rs
@@ -5,6 +5,8 @@
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::{GallifreyDB, PropertyMapBuilder, ReadOps, WriteOps};
+use std::sync::Arc;
+use std::thread;
 
 fn bench_read_transaction_creation(c: &mut Criterion) {
     let db = GallifreyDB::new();
@@ -399,12 +401,12 @@ fn bench_batch_insertions_with_prepopulated_graph(c: &mut Criterion) {
 /// Benchmark concurrent read operations during adjacency rebuild.
 /// This tests the impact of rebuild on read performance.
 fn bench_read_during_rebuild(c: &mut Criterion) {
-    // Pre-populate a database with 10K edges
+    // Pre-populate a database with 4K nodes + 4K edges (stay under 10K transaction limit)
     let db = GallifreyDB::new();
     let node_ids: Vec<_> = db
         .write(|tx| {
             let mut nodes = Vec::new();
-            for i in 0..10000 {
+            for i in 0..4000 {
                 let node = tx.create_node(
                     "Node",
                     PropertyMapBuilder::new().insert("id", i as i64).build(),
@@ -412,7 +414,7 @@ fn bench_read_during_rebuild(c: &mut Criterion) {
                 nodes.push(node);
             }
 
-            for i in 0..9999 {
+            for i in 0..3999 {
                 tx.create_edge(
                     nodes[i],
                     nodes[i + 1],
@@ -435,6 +437,90 @@ fn bench_read_during_rebuild(c: &mut Criterion) {
     });
 }
 
+/// Benchmark concurrent read operations to measure visibility check performance.
+///
+/// This benchmark demonstrates the RwLock optimization in TxVisibilityManager (issue #222).
+/// Every read operation (get_node, get_edge) performs a visibility check, which previously
+/// used a Mutex causing read contention. With RwLock, concurrent readers can proceed
+/// without serialization.
+///
+/// Performance target from CLAUDE.md: <1µs single-hop traversal includes visibility checks.
+fn bench_concurrent_visibility_checks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_visibility");
+
+    // Pre-populate database with committed data (500 nodes to stay under transaction limit)
+    let db = Arc::new(GallifreyDB::new());
+    let node_ids: Vec<_> = db
+        .write(|tx| {
+            let mut nodes = Vec::new();
+            for i in 0..500 {
+                let node = tx.create_node(
+                    "Node",
+                    PropertyMapBuilder::new().insert("id", i as i64).build(),
+                )?;
+                nodes.push(node);
+            }
+            Ok(nodes)
+        })
+        .unwrap();
+
+    // Benchmark with different thread counts to show scalability
+    for thread_count in [1, 2, 4, 8] {
+        group.bench_function(format!("{}_threads", thread_count), |b| {
+            b.iter(|| {
+                let handles: Vec<_> = (0..thread_count)
+                    .map(|_| {
+                        let db_clone = Arc::clone(&db);
+                        let nodes = node_ids.clone();
+                        thread::spawn(move || {
+                            // Each thread performs 100 read operations
+                            // Each read triggers a visibility check via is_visible()
+                            for node_id in nodes.iter().take(100) {
+                                let _ = db_clone.get_node(black_box(*node_id));
+                            }
+                        })
+                    })
+                    .collect();
+
+                for handle in handles {
+                    handle.join().unwrap();
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark single-threaded visibility check performance (baseline).
+fn bench_sequential_visibility_checks(c: &mut Criterion) {
+    let db = GallifreyDB::new();
+
+    // Pre-populate with 500 nodes (stay under transaction limit)
+    let node_ids: Vec<_> = db
+        .write(|tx| {
+            let mut nodes = Vec::new();
+            for i in 0..500 {
+                let node = tx.create_node(
+                    "Node",
+                    PropertyMapBuilder::new().insert("id", i as i64).build(),
+                )?;
+                nodes.push(node);
+            }
+            Ok(nodes)
+        })
+        .unwrap();
+
+    c.bench_function("sequential_get_node_500", |b| {
+        b.iter(|| {
+            // Sequential reads - each triggers visibility check
+            for node_id in &node_ids {
+                let _ = db.get_node(black_box(*node_id));
+            }
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_read_transaction_creation,
@@ -451,6 +537,8 @@ criterion_group!(
     bench_batch_edge_deletions,
     bench_batch_insertions_with_prepopulated_graph,
     bench_read_during_rebuild,
+    bench_concurrent_visibility_checks,
+    bench_sequential_visibility_checks,
 );
 
 criterion_main!(benches);

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -6,9 +6,9 @@
 
 use crate::api::transaction::types::TxId;
 use crate::core::temporal::Timestamp;
-use crate::utils::lock::MutexExt;
+use crate::utils::lock::{MutexExt, RwLockExt};
 use std::collections::{BTreeMap, HashSet};
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 /// Snapshot of transaction visibility at a point in time.
 ///
@@ -66,13 +66,21 @@ impl TransactionSnapshot {
 ///
 /// # Lock Recovery Safety
 ///
-/// This struct uses `lock_or_recover()` for all lock acquisitions. This is safe
-/// because the protected data structures (`HashSet<TxId>` and `BTreeMap<TxId, Timestamp>`)
-/// have no complex invariants that could be violated by a mid-operation panic:
+/// This struct uses `lock_or_recover()`, `read_or_recover()`, and `write_or_recover()`
+/// for all lock acquisitions. This is safe because the protected data structures
+/// (`HashSet<TxId>` and `BTreeMap<TxId, Timestamp>`) have no complex invariants that
+/// could be violated by a mid-operation panic:
 ///
 /// - **Worst case**: A transaction ID may be missing from the active/committed sets
 /// - **Behavior**: This fails safe by being conservative (treating as uncommitted/not visible)
 /// - **No corruption**: Standard library collections remain valid after partial operations
+///
+/// # Concurrency
+///
+/// The `committed` map uses an `RwLock` instead of `Mutex` to allow concurrent readers.
+/// This eliminates read contention in `is_visible()`, which is called during every
+/// read operation (get_node, get_edge). Multiple transactions can check visibility
+/// simultaneously, while commits still acquire exclusive write access.
 pub struct TxVisibilityManager {
     /// Currently active transactions
     active: Mutex<HashSet<TxId>>,
@@ -95,7 +103,7 @@ pub struct TxVisibilityManager {
     /// **Future optimizations** (tracked in separate issues):
     /// - Epoch-based compression for 10-100x memory savings
     /// - Embedding timestamps in versions (architectural refactor)
-    committed: Mutex<BTreeMap<TxId, Timestamp>>,
+    committed: RwLock<BTreeMap<TxId, Timestamp>>,
 }
 
 impl TxVisibilityManager {
@@ -103,7 +111,7 @@ impl TxVisibilityManager {
     pub fn new() -> Self {
         TxVisibilityManager {
             active: Mutex::new(HashSet::new()),
-            committed: Mutex::new(BTreeMap::new()),
+            committed: RwLock::new(BTreeMap::new()),
         }
     }
 
@@ -156,7 +164,7 @@ impl TxVisibilityManager {
         let mut active = self.active.lock_or_recover();
         active.remove(&tx_id);
 
-        let mut committed = self.committed.lock_or_recover();
+        let mut committed = self.committed.write_or_recover();
         committed.insert(tx_id, commit_timestamp);
     }
 
@@ -191,7 +199,7 @@ impl TxVisibilityManager {
         }
 
         // Check if transaction committed
-        let committed = self.committed.lock_or_recover();
+        let committed = self.committed.read_or_recover();
 
         match committed.get(&created_by_tx) {
             None => false, // Not committed - not visible
@@ -216,7 +224,7 @@ impl TxVisibilityManager {
     /// This is primarily useful for testing and monitoring.
     #[allow(dead_code)]
     pub fn committed_count(&self) -> usize {
-        let committed = self.committed.lock_or_recover();
+        let committed = self.committed.read_or_recover();
         committed.len()
     }
 }

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -161,8 +161,11 @@ impl TxVisibilityManager {
     /// * `tx_id` - The ID of the committing transaction
     /// * `commit_timestamp` - When the transaction committed
     pub fn register_commit(&self, tx_id: TxId, commit_timestamp: Timestamp) {
-        let mut active = self.active.lock_or_recover();
-        active.remove(&tx_id);
+        // Drop active lock before acquiring committed write lock to reduce contention
+        {
+            let mut active = self.active.lock_or_recover();
+            active.remove(&tx_id);
+        } // active lock released here
 
         let mut committed = self.committed.write_or_recover();
         committed.insert(tx_id, commit_timestamp);
@@ -437,5 +440,47 @@ mod tests {
         manager.register_abort(TxId::new(2));
         assert_eq!(manager.active_count(), 0);
         assert_eq!(manager.committed_count(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_visibility_checks() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let manager = Arc::new(TxVisibilityManager::new());
+
+        // Setup: commit several transactions
+        for i in 1..=10 {
+            manager.register_active(TxId::new(i));
+            manager.register_commit(TxId::new(i), (i * 10) as i64);
+        }
+
+        // Take snapshot after all commits (timestamp 100 is the last commit)
+        let snapshot = manager.capture_snapshot(101);
+
+        // Spawn multiple threads doing concurrent visibility checks
+        // This test demonstrates that RwLock allows concurrent readers
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let mgr = Arc::clone(&manager);
+                let snap = snapshot.clone();
+                thread::spawn(move || {
+                    // Each thread performs many visibility checks
+                    for _ in 0..1000 {
+                        let tx_id = TxId::new((i % 10) + 1);
+                        // All these transactions were committed before snapshot time
+                        assert!(mgr.is_visible(&snap, tx_id));
+                    }
+                })
+            })
+            .collect();
+
+        // Wait for all threads to complete
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Verify the manager is still in a valid state
+        assert_eq!(manager.committed_count(), 10);
     }
 }


### PR DESCRIPTION
Replace Mutex with RwLock for the committed transactions map in
TxVisibilityManager to allow concurrent read operations. This
eliminates unnecessary serialization during visibility checks,
which occur on every read operation (get_node, get_edge).

Changes:
- Updated committed field from Mutex to RwLock
- Changed is_visible() to use read_or_recover() for shared access
- Changed committed_count() to use read_or_recover() for shared access
- Changed register_commit() to use write_or_recover() for exclusive access
- Added documentation about concurrency benefits

Impact:
- Multiple transactions can now check visibility concurrently
- Commits still acquire exclusive write access as needed
- All 550 tests pass successfully

Fixes #222