### PR TITLE
perf: Add callback-based string access to avoid Arc clone in StringInterner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,3 +143,9 @@ name = "id_generation"
 harness = false
 path = "benches/id_generation.rs"
 required-features = []
+
+[[bench]]
+name = "string_interning"
+harness = false
+path = "benches/string_interning.rs"
+required-features = []

--- a/benches/string_interning.rs
+++ b/benches/string_interning.rs
@@ -1,0 +1,231 @@
+//! Benchmarks for string interning performance.
+//!
+//! These benchmarks measure the performance difference between `resolve()` and
+//! `with_str()` methods, demonstrating the Arc clone overhead that `with_str()`
+//! avoids through its callback-based API.
+//!
+//! Performance Context:
+//! - `resolve()` clones the Arc on every call (atomic increment/decrement)
+//! - `with_str()` provides direct &str access without Arc cloning
+//! - Performance gain is most significant for frequently accessed strings
+//! - Real-world use cases: serialization, logging, display operations
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use gallifreydb::core::interning::StringInterner;
+use std::sync::Arc;
+
+/// Benchmark single string access using resolve() vs with_str().
+fn bench_single_string_access(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_access_single");
+
+    let interner = StringInterner::new();
+    let id = interner.intern("test_string").unwrap();
+
+    group.bench_function("resolve", |b| {
+        b.iter(|| {
+            let s = interner.resolve(id).unwrap();
+            black_box(s.len())
+        });
+    });
+
+    group.bench_function("with_str", |b| {
+        b.iter(|| interner.with_str(id, |s| black_box(s.len())));
+    });
+
+    group.finish();
+}
+
+/// Benchmark string length computation (common read-only operation).
+fn bench_string_length(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_length");
+
+    let interner = StringInterner::new();
+    let id = interner
+        .intern("this is a test string for benchmarking")
+        .unwrap();
+
+    group.bench_function("resolve", |b| {
+        b.iter(|| {
+            let s = interner.resolve(id).unwrap();
+            black_box(s.len())
+        });
+    });
+
+    group.bench_function("with_str", |b| {
+        b.iter(|| interner.with_str(id, |s| black_box(s.len())));
+    });
+
+    group.finish();
+}
+
+/// Benchmark string comparison (another common read-only operation).
+fn bench_string_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_comparison");
+
+    let interner = StringInterner::new();
+    let id = interner.intern("Person").unwrap();
+
+    group.bench_function("resolve", |b| {
+        b.iter(|| {
+            let s = interner.resolve(id).unwrap();
+            black_box(s.as_ref() == "Person")
+        });
+    });
+
+    group.bench_function("with_str", |b| {
+        b.iter(|| interner.with_str(id, |s| black_box(s == "Person")));
+    });
+
+    group.finish();
+}
+
+/// Benchmark multiple string accesses in a loop (simulates real workload).
+fn bench_multiple_accesses(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multiple_accesses");
+
+    let interner = StringInterner::new();
+    let ids: Vec<_> = (0..100)
+        .map(|i| interner.intern(format!("string_{}", i)).unwrap())
+        .collect();
+
+    group.bench_function("resolve_100", |b| {
+        b.iter(|| {
+            for &id in &ids {
+                let s = interner.resolve(id).unwrap();
+                black_box(s.len());
+            }
+        });
+    });
+
+    group.bench_function("with_str_100", |b| {
+        b.iter(|| {
+            for &id in &ids {
+                interner.with_str(id, |s| black_box(s.len()));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark simulated serialization workload (common use case).
+fn bench_serialization_simulation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serialization_simulation");
+
+    let interner = StringInterner::new();
+    let property_keys: Vec<_> = ["name", "age", "email", "address", "phone"]
+        .iter()
+        .map(|&s| interner.intern(s).unwrap())
+        .collect();
+
+    // Simulate serializing 1000 objects with 5 properties each
+    group.bench_function("resolve", |b| {
+        b.iter(|| {
+            let mut total_len = 0;
+            for _ in 0..1000 {
+                for &key_id in &property_keys {
+                    let key = interner.resolve(key_id).unwrap();
+                    // Simulate serialization by computing length and hashing
+                    total_len += key.len();
+                    black_box(key.as_ref());
+                }
+            }
+            black_box(total_len);
+        });
+    });
+
+    group.bench_function("with_str", |b| {
+        b.iter(|| {
+            let mut total_len = 0;
+            for _ in 0..1000 {
+                for &key_id in &property_keys {
+                    interner.with_str(key_id, |key| {
+                        // Simulate serialization by computing length and hashing
+                        total_len += key.len();
+                        black_box(key);
+                    });
+                }
+            }
+            black_box(total_len);
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark Arc clone overhead isolation (measures just the Arc operations).
+fn bench_arc_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("arc_overhead");
+
+    let interner = StringInterner::new();
+    let id = interner.intern("overhead_test").unwrap();
+
+    // Measure Arc clone + drop overhead
+    group.bench_function("arc_clone_drop", |b| {
+        b.iter(|| {
+            let arc = interner.resolve(id).unwrap();
+            black_box(arc);
+            // Arc is dropped here (atomic decrement)
+        });
+    });
+
+    // Measure direct access without Arc clone
+    group.bench_function("direct_access", |b| {
+        b.iter(|| {
+            interner.with_str(id, |s| {
+                black_box(s);
+            });
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark hot-path scenario: tight loop with repeated accesses.
+fn bench_hot_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hot_path");
+
+    let interner = Arc::new(StringInterner::new());
+    let id = interner.intern("hot_path_string").unwrap();
+
+    for iterations in [100, 1000, 10000] {
+        group.bench_with_input(
+            BenchmarkId::new("resolve", iterations),
+            &iterations,
+            |b, &iterations| {
+                b.iter(|| {
+                    for _ in 0..iterations {
+                        let s = interner.resolve(id).unwrap();
+                        black_box(s.len());
+                    }
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("with_str", iterations),
+            &iterations,
+            |b, &iterations| {
+                b.iter(|| {
+                    for _ in 0..iterations {
+                        interner.with_str(id, |s| black_box(s.len()));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single_string_access,
+    bench_string_length,
+    bench_string_comparison,
+    bench_multiple_accesses,
+    bench_serialization_simulation,
+    bench_arc_overhead,
+    bench_hot_path
+);
+criterion_main!(benches);

--- a/benches/string_interning.rs
+++ b/benches/string_interning.rs
@@ -10,7 +10,7 @@
 //! - Performance gain is most significant for frequently accessed strings
 //! - Real-world use cases: serialization, logging, display operations
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::core::interning::StringInterner;
 use std::sync::Arc;
 

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -507,22 +507,21 @@ mod tests {
         let id = interner.intern("performance test").unwrap();
 
         // Get a baseline Arc to check the strong count.
-        // The count is 2: one in string_to_id map, one in id_to_string map.
+        // We don't hardcode the count because DashMap's internal structure may vary.
         let s_arc = interner.resolve(id).unwrap();
-        let initial_count = Arc::strong_count(&s_arc);
-        assert_eq!(initial_count, 3); // 2 in maps + 1 in s_arc
+        let baseline_count = Arc::strong_count(&s_arc);
 
         // This test verifies that with_str works without cloning by checking the refcount.
         let mut call_count = 0;
         let result = interner.with_str(id, |s| {
             call_count += 1;
             // The count should not increase during the callback.
-            assert_eq!(Arc::strong_count(&s_arc), 3);
+            assert_eq!(Arc::strong_count(&s_arc), baseline_count);
             s.to_string()
         });
 
         // The count should remain unchanged after the call.
-        assert_eq!(Arc::strong_count(&s_arc), 3);
+        assert_eq!(Arc::strong_count(&s_arc), baseline_count);
         assert_eq!(result, Some("performance test".to_string()));
         assert_eq!(call_count, 1);
     }
@@ -579,5 +578,35 @@ mod tests {
 
         let is_empty = interner.with_str(id, |s| s.is_empty()).unwrap();
         assert!(is_empty);
+    }
+
+    #[test]
+    fn test_with_str_panic_safety() {
+        let interner = StringInterner::new();
+        let id = interner.intern("panic test").unwrap();
+
+        // Verify the interner works before panic
+        let before = interner.with_str(id, |s| s.to_string()).unwrap();
+        assert_eq!(before, "panic test");
+
+        // Cause a panic in the callback
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            interner.with_str(id, |_s| {
+                panic!("intentional panic in callback");
+            })
+        }));
+
+        // The panic should be caught
+        assert!(result.is_err());
+
+        // Verify the interner is still usable after the panic
+        // The DashMap entry guard should have been properly dropped
+        let after = interner.with_str(id, |s| s.to_string()).unwrap();
+        assert_eq!(after, "panic test");
+
+        // Verify we can still intern new strings
+        let new_id = interner.intern("after panic").unwrap();
+        let new_str = interner.with_str(new_id, |s| s.to_string()).unwrap();
+        assert_eq!(new_str, "after panic");
     }
 }

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -179,6 +179,9 @@ impl StringInterner {
     /// Get the string as a &str without cloning the Arc.
     ///
     /// This is useful when you just need to read the string temporarily.
+    ///
+    /// **Note:** For read-only access, prefer [`with_str`](Self::with_str) to avoid Arc cloning overhead.
+    /// This method still clones the Arc internally.
     pub fn get(&self, id: InternedString) -> Option<impl AsRef<str> + '_> {
         self.id_to_string.get(&id).map(|entry| {
             let arc: Arc<str> = Arc::clone(entry.value());
@@ -197,6 +200,18 @@ impl StringInterner {
     /// - Serialization
     /// - String comparisons
     /// - Any read-only operation that doesn't need to own the string
+    ///
+    /// # Performance Example
+    ///
+    /// When serializing property keys, this avoids Arc clones:
+    /// ```ignore
+    /// // Instead of:
+    /// let key_str = interner.resolve(key_id)?;
+    /// serializer.serialize_str(key_str.as_ref())?; // Arc clone overhead
+    ///
+    /// // Use:
+    /// interner.with_str(key_id, |s| serializer.serialize_str(s))?;
+    /// ```
     ///
     /// # Examples
     ///
@@ -218,7 +233,9 @@ impl StringInterner {
     where
         F: FnOnce(&str) -> R,
     {
-        self.id_to_string.get(&id).map(|entry| f(entry.value().as_ref()))
+        self.id_to_string
+            .get(&id)
+            .map(|entry| f(entry.value().as_ref()))
     }
 
     /// Check if a string has been interned.
@@ -476,9 +493,11 @@ mod tests {
         assert!(contains);
 
         // Return Vec (must own the data since it outlives the callback)
-        let words: Vec<String> = interner.with_str(id, |s| {
-            s.split_whitespace().map(|w| w.to_string()).collect()
-        }).unwrap();
+        let words: Vec<String> = interner
+            .with_str(id, |s| {
+                s.split_whitespace().map(|w| w.to_string()).collect()
+            })
+            .unwrap();
         assert_eq!(words, vec!["test", "string"]);
     }
 
@@ -487,15 +506,23 @@ mod tests {
         let interner = StringInterner::new();
         let id = interner.intern("performance test").unwrap();
 
-        // This test verifies that with_str works without cloning
-        // While we can't directly measure Arc refcounts in safe code,
-        // we can verify the behavior is correct
+        // Get a baseline Arc to check the strong count.
+        // The count is 2: one in string_to_id map, one in id_to_string map.
+        let s_arc = interner.resolve(id).unwrap();
+        let initial_count = Arc::strong_count(&s_arc);
+        assert_eq!(initial_count, 3); // 2 in maps + 1 in s_arc
+
+        // This test verifies that with_str works without cloning by checking the refcount.
         let mut call_count = 0;
         let result = interner.with_str(id, |s| {
             call_count += 1;
+            // The count should not increase during the callback.
+            assert_eq!(Arc::strong_count(&s_arc), 3);
             s.to_string()
         });
 
+        // The count should remain unchanged after the call.
+        assert_eq!(Arc::strong_count(&s_arc), 3);
         assert_eq!(result, Some("performance test".to_string()));
         assert_eq!(call_count, 1);
     }
@@ -507,22 +534,22 @@ mod tests {
         let interner = Arc::new(StringInterner::new());
         let id = interner.intern("concurrent").unwrap();
 
-        let mut handles = vec![];
-
-        // Spawn 10 threads, each accessing the same string via with_str
-        for i in 0..10 {
-            let interner_clone = Arc::clone(&interner);
-            let handle = thread::spawn(move || {
-                interner_clone.with_str(id, |s| {
-                    assert_eq!(s, "concurrent");
-                    format!("{}-{}", s, i)
-                }).unwrap()
-            });
-            handles.push(handle);
-        }
-
-        // Collect all results
-        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // Spawn 10 threads using a scope to ensure they all complete.
+        let results: Vec<String> = thread::scope(|s| {
+            let mut handles = Vec::new();
+            for i in 0..10 {
+                let interner_clone = Arc::clone(&interner);
+                handles.push(s.spawn(move || {
+                    interner_clone
+                        .with_str(id, |s| {
+                            assert_eq!(s, "concurrent");
+                            format!("{}-{}", s, i)
+                        })
+                        .unwrap()
+                }));
+            }
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
 
         // Verify each thread got the correct result
         for (i, result) in results.iter().enumerate() {

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -186,6 +186,41 @@ impl StringInterner {
         })
     }
 
+    /// Access the interned string via a callback without cloning the Arc.
+    ///
+    /// This is more efficient than `resolve()` or `get()` when you only need
+    /// temporary read access to the string, as it avoids atomic reference
+    /// counting operations.
+    ///
+    /// This is particularly useful for:
+    /// - Display and logging operations
+    /// - Serialization
+    /// - String comparisons
+    /// - Any read-only operation that doesn't need to own the string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gallifreydb::core::interning::StringInterner;
+    ///
+    /// let interner = StringInterner::new();
+    /// let id = interner.intern("hello").unwrap();
+    ///
+    /// // Efficient: no Arc clone
+    /// let len = interner.with_str(id, |s| s.len()).unwrap();
+    /// assert_eq!(len, 5);
+    ///
+    /// // Can return any type from the callback
+    /// let uppercase = interner.with_str(id, |s| s.to_uppercase()).unwrap();
+    /// assert_eq!(uppercase, "HELLO");
+    /// ```
+    pub fn with_str<F, R>(&self, id: InternedString, f: F) -> Option<R>
+    where
+        F: FnOnce(&str) -> R,
+    {
+        self.id_to_string.get(&id).map(|entry| f(entry.value().as_ref()))
+    }
+
     /// Check if a string has been interned.
     pub fn contains<S: AsRef<str>>(&self, string: S) -> bool {
         self.string_to_id.contains_key(string.as_ref())
@@ -398,5 +433,124 @@ mod tests {
 
         let resolved = GLOBAL_INTERNER.resolve(id1).unwrap();
         assert_eq!(resolved.as_ref(), "global");
+    }
+
+    #[test]
+    fn test_with_str_basic() {
+        let interner = StringInterner::new();
+        let id = interner.intern("hello").unwrap();
+
+        // Test basic access
+        let result = interner.with_str(id, |s| {
+            assert_eq!(s, "hello");
+            s.len()
+        });
+
+        assert_eq!(result, Some(5));
+    }
+
+    #[test]
+    fn test_with_str_invalid_id() {
+        let interner = StringInterner::new();
+        let invalid_id = InternedString::from_raw(999);
+
+        let result = interner.with_str(invalid_id, |s| s.len());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_with_str_return_types() {
+        let interner = StringInterner::new();
+        let id = interner.intern("test string").unwrap();
+
+        // Return usize
+        let len = interner.with_str(id, |s| s.len()).unwrap();
+        assert_eq!(len, 11);
+
+        // Return String
+        let uppercase = interner.with_str(id, |s| s.to_uppercase()).unwrap();
+        assert_eq!(uppercase, "TEST STRING");
+
+        // Return bool
+        let contains = interner.with_str(id, |s| s.contains("test")).unwrap();
+        assert!(contains);
+
+        // Return Vec (must own the data since it outlives the callback)
+        let words: Vec<String> = interner.with_str(id, |s| {
+            s.split_whitespace().map(|w| w.to_string()).collect()
+        }).unwrap();
+        assert_eq!(words, vec!["test", "string"]);
+    }
+
+    #[test]
+    fn test_with_str_no_arc_clone() {
+        let interner = StringInterner::new();
+        let id = interner.intern("performance test").unwrap();
+
+        // This test verifies that with_str works without cloning
+        // While we can't directly measure Arc refcounts in safe code,
+        // we can verify the behavior is correct
+        let mut call_count = 0;
+        let result = interner.with_str(id, |s| {
+            call_count += 1;
+            s.to_string()
+        });
+
+        assert_eq!(result, Some("performance test".to_string()));
+        assert_eq!(call_count, 1);
+    }
+
+    #[test]
+    fn test_with_str_concurrent() {
+        use std::thread;
+
+        let interner = Arc::new(StringInterner::new());
+        let id = interner.intern("concurrent").unwrap();
+
+        let mut handles = vec![];
+
+        // Spawn 10 threads, each accessing the same string via with_str
+        for i in 0..10 {
+            let interner_clone = Arc::clone(&interner);
+            let handle = thread::spawn(move || {
+                interner_clone.with_str(id, |s| {
+                    assert_eq!(s, "concurrent");
+                    format!("{}-{}", s, i)
+                }).unwrap()
+            });
+            handles.push(handle);
+        }
+
+        // Collect all results
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Verify each thread got the correct result
+        for (i, result) in results.iter().enumerate() {
+            assert_eq!(result, &format!("concurrent-{}", i));
+        }
+    }
+
+    #[test]
+    fn test_with_str_vs_resolve_equivalence() {
+        let interner = StringInterner::new();
+        let id = interner.intern("equivalence test").unwrap();
+
+        // Both methods should give the same string content
+        let via_with_str = interner.with_str(id, |s| s.to_string()).unwrap();
+        let via_resolve = interner.resolve(id).unwrap();
+
+        assert_eq!(via_with_str, via_resolve.as_ref());
+    }
+
+    #[test]
+    fn test_with_str_empty_string() {
+        let interner = StringInterner::new();
+        let id = interner.intern("").unwrap();
+
+        let len = interner.with_str(id, |s| s.len()).unwrap();
+        assert_eq!(len, 0);
+
+        let is_empty = interner.with_str(id, |s| s.is_empty()).unwrap();
+        assert!(is_empty);
     }
 }


### PR DESCRIPTION
Adds `with_str()` method that allows read-only access to interned strings
without cloning the Arc, avoiding unnecessary atomic reference counting
operations.

Key improvements:
- New `with_str<F, R>(&self, id: InternedString, f: F) -> Option<R>` method
- Callback receives `&str` reference directly from the Arc
- More efficient for display, logging, serialization, and comparison operations
- Comprehensive test coverage (8 new tests)

Performance benefit:
- Eliminates atomic increment/decrement on Arc refcount
- Particularly beneficial for hot paths in serialization and display code

Fixes #184