### PR TITLE
docs: Verify issue #202 already resolved (duplicate of #16)

### DIFF
--- a/ISSUE_202_COMMENT.md
+++ b/ISSUE_202_COMMENT.md
@@ -1,0 +1,50 @@
+# Issue #202 - Already Resolved ✅
+
+This issue has already been fixed! The changes were implemented in commit [`9df8517`](https://github.com/madmax983/GallifreyDB/commit/9df8517) on January 5, 2026, as part of issue #16 (P2-1: PropertyKey not using string interning).
+
+## Current Status
+
+`PropertyKey` is now defined as `InternedString` in `src/core/property.rs:56`:
+
+```rust
+/// Property key type.
+///
+/// Uses interned strings for memory efficiency and O(1) equality comparisons.
+/// Common keys like "name", "age", and "id" are deduplicated in memory.
+pub type PropertyKey = InternedString;
+```
+
+## Implementation Complete
+
+✅ **Type Definition**: PropertyKey = InternedString
+✅ **Automatic Interning**: PropertyMap methods auto-intern string keys
+✅ **Serialization**: Properly resolves InternedString ↔ String
+✅ **Deserialization**: Interns keys when loading from bytes
+✅ **Tests**: All 550 library tests passing
+✅ **Documentation**: Comprehensive inline documentation
+
+## Benefits Achieved
+
+- **Memory Savings**: ~200 bytes per entity (~20 bytes per key)
+- **Performance**: O(1) key comparisons instead of O(n) string comparisons
+- **Deduplication**: Common keys like "name", "age", "id", "embedding" stored once
+
+## Verification
+
+A comprehensive verification document has been created: [`ISSUE_202_VERIFICATION.md`](https://github.com/madmax983/GallifreyDB/blob/claude/fix-issue-202-Z0PXB/ISSUE_202_VERIFICATION.md)
+
+All test cases pass, including:
+- Property key interning serialization round-trips
+- Memory efficiency verification
+- Concurrent access patterns
+- Invalid key handling
+
+## Recommendation
+
+This issue can be **closed as a duplicate of #16**.
+
+## Related Issues
+
+- #183: Implement string interning (✅ Closed)
+- #16: Use string interning for PropertyKey (✅ Closed Jan 5, 2026)
+- #184, #185: Follow-up optimizations (if applicable)

--- a/ISSUE_202_VERIFICATION.md
+++ b/ISSUE_202_VERIFICATION.md
@@ -1,0 +1,127 @@
+# Issue #202 Verification: PropertyKey Using InternedString
+
+## Status: ✅ ALREADY RESOLVED
+
+Issue #202 has already been fixed by commit `9df8517` which implemented the same changes as part of issue #16.
+
+## Summary
+
+**Issue #202**: PropertyKey should use InternedString instead of String
+**Resolution**: Implemented in commit `9df8517` on January 5, 2026
+**Related Issue**: Duplicate of #16 (P2-1: PropertyKey not using string interning)
+
+## Implementation Details
+
+### 1. PropertyKey Type Definition
+
+**Location**: `src/core/property.rs:56`
+
+```rust
+/// Property key type.
+///
+/// Uses interned strings for memory efficiency and O(1) equality comparisons.
+/// Common keys like "name", "age", and "id" are deduplicated in memory.
+pub type PropertyKey = InternedString;
+```
+
+### 2. Automatic Key Interning
+
+The PropertyMap implementation automatically interns string keys:
+
+**PropertyMap::get()** (`src/core/property.rs:721-724`):
+```rust
+pub fn get(&self, key: &str) -> Option<&PropertyValue> {
+    let interned_key = GLOBAL_INTERNER.intern(key).ok()?;
+    self.get_by_interned_key(&interned_key)
+}
+```
+
+**PropertyMap::contains_key()** (`src/core/property.rs:740-745`):
+```rust
+pub fn contains_key(&self, key: &str) -> bool {
+    let Ok(interned_key) = GLOBAL_INTERNER.intern(key) else {
+        return false;
+    };
+    self.contains_interned_key(&interned_key)
+}
+```
+
+### 3. Optimized Methods for Performance-Critical Paths
+
+For code that already has an `InternedString`, optimized methods skip re-interning:
+
+- `get_by_interned_key()` - Direct lookup with interned key
+- `contains_interned_key()` - Direct existence check with interned key
+- `PropertyMapBuilder::insert_by_key()` - Direct insertion with interned key
+
+### 4. Serialization/Deserialization
+
+**Serialization** (`src/core/property.rs:828-848`):
+- Resolves `InternedString` keys to actual strings before serializing
+- Returns error if key cannot be resolved (indicates data corruption)
+
+**Deserialization** (`src/core/property.rs:853-905`):
+- Interns string keys when loading from bytes
+- Stores keys as `InternedString` in the PropertyMap
+
+## Benefits Achieved
+
+### Memory Efficiency
+- **Before**: 24 bytes per key (String type)
+- **After**: 4 bytes per key (InternedString type)
+- **Savings**: ~20 bytes per property key
+- **Impact**: ~200 bytes per entity (typical entity has ~10 properties)
+
+### Performance Improvements
+- **Key Comparison**: O(1) integer comparison vs O(n) string comparison
+- **Memory Locality**: Better cache performance with smaller keys
+- **Deduplication**: Common keys like "name", "age", "id", "embedding" stored once
+
+## Test Coverage
+
+All 550 library tests pass, including comprehensive tests for:
+
+1. Property value types and conversions
+2. PropertyMap creation and manipulation
+3. Copy-on-write semantics
+4. Serialization/deserialization round-trips
+5. PropertyKey interning (lines 1729-1910)
+6. Concurrent access patterns
+7. Memory efficiency verification
+
+**Key Test Cases**:
+- `test_property_key_interning_serialization_round_trip` (line 1730)
+- `test_property_key_memory_efficiency` (line 1770)
+- `test_invalid_interned_string_serialization` (line 1824)
+- `test_concurrent_property_key_access` (line 1856)
+- `test_property_key_get_efficiency` (line 1892)
+
+## Verification Commands
+
+```bash
+# Run all library tests
+cargo test --lib
+
+# Run property-specific tests
+cargo test --lib property::tests
+
+# Check PropertyKey definition
+grep -n "pub type PropertyKey" src/core/property.rs
+```
+
+## Related Work
+
+- Issue #183: Implement string interning system (✅ Closed)
+- Issue #16: Use string interning for PropertyKey (✅ Closed Jan 5, 2026)
+- Issue #202: PropertyKey should use InternedString (⚠️ Duplicate - can be closed)
+
+## Recommendation
+
+Issue #202 can be closed as a duplicate of issue #16, which has already been fully implemented and tested.
+
+---
+
+**Verified by**: Claude (automated verification)
+**Date**: 2026-01-06
+**Branch**: claude/fix-issue-202-Z0PXB
+**Tests**: ✅ All 550 tests passing


### PR DESCRIPTION
Issue #202 requested changing PropertyKey from String to InternedString,
which was already implemented in commit 9df8517 as part of issue #16.

Verification confirms:
- PropertyKey is defined as InternedString (src/core/property.rs:56)
- All PropertyMap methods properly handle key interning
- Serialization/deserialization works correctly
- All 550 library tests pass
- Memory savings: ~200 bytes per entity
- Performance: O(1) key comparisons vs O(n)

Issue #202 can be closed as duplicate of #16.

Related: #16, #183, #202