### PR TITLE
fix(ci): Add verification for benchmark output directory

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,9 +61,26 @@ jobs:
 
       - name: Run all benchmarks once
         run: |
+          set -o pipefail  # Ensure piped commands propagate failures
           echo "Running all benchmarks..."
           # Run benchmarks and capture output for github-action-benchmark 'cargo' tool support
           cargo bench --all-features --bench concurrent_reads --bench current_state --bench gallifreydb --bench hnsw_index --bench id_generation --bench persistence --bench string_interning --bench temporal_vector --bench transactions --bench vector_similarity -- --quick | tee output.txt
+
+          # Verify that Criterion generated output
+          if [ ! -d "target/criterion" ]; then
+            echo "ERROR: target/criterion directory not found after running benchmarks"
+            echo "Benchmark execution may have failed. Check output.txt for details."
+            exit 1
+          fi
+
+          # Verify that we have some benchmark results
+          BENCH_COUNT=$(find target/criterion -name "estimates.json" | wc -l)
+          echo "Found $BENCH_COUNT benchmark results in target/criterion"
+          if [ "$BENCH_COUNT" -eq 0 ]; then
+            echo "ERROR: No benchmark results (estimates.json files) found in target/criterion"
+            echo "Benchmarks may have failed to run properly. Check output.txt for details."
+            exit 1
+          fi
 
       - name: Generate benchmark JSON
         run: |

--- a/benches/temporal_vector.rs
+++ b/benches/temporal_vector.rs
@@ -461,7 +461,7 @@ fn bench_semantic_evolution_memory_overhead(c: &mut Criterion) {
                 let all_snapshots_vectors: Vec<Vec<Vec<f32>>> = (0..10)
                     .map(|snapshot_idx| {
                         (0..vector_count)
-                            .map(|i| gen_vector(384, (snapshot_idx + i) as usize))
+                            .map(|i| gen_vector(384, snapshot_idx + i))
                             .collect()
                     })
                     .collect();


### PR DESCRIPTION
## Summary
## Problem

The benchmark CI workflow was failing with:


This occurred because the workflow continued even when benchmarks failed to generate output, due to the pipe to  not propagating failures properly.

## Solution

This PR adds robust verification to the benchmark workflow:

1. **Enable pipefail**: Use  to ensure piped commands fail properly
2. **Verify directory**: Check that  exists after running benchmarks
3. **Count results**: Verify that benchmark results ( files) were actually generated
4. **Fail fast**: Exit with error code 1 if any verification fails

## Testing

- ✅ Verified the find command works locally (found 773 benchmark results)
- ✅ Verified the logic is sound
- ✅ CI will now fail early with clear error messages if benchmarks don't run properly

## Impact

- Prevents silent failures in the benchmark workflow
- Provides clear error messages when benchmarks fail
- Stops the workflow early instead of cascading failures in downstream steps

---
Created from worktree workflow.