### PR TITLE
fix: add recursion depth limit to version reconstruction (issue #17)

### DIFF
--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -32,6 +32,13 @@ pub const DEFAULT_MAX_VERSIONS_PER_ENTITY: usize = 1_000;
 /// Default maximum age for versions in milliseconds (365 days)
 pub const DEFAULT_MAX_VERSION_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
 
+/// Maximum recursion depth for version reconstruction (DoS protection).
+///
+/// This limit prevents stack overflow from corrupted version chains or cycles.
+/// A depth of 100 is sufficient for any legitimate use case since anchors are
+/// typically created every 10-20 versions.
+pub const MAX_RECONSTRUCTION_DEPTH: usize = 100;
+
 /// Retention policy for version history (DoS protection).
 ///
 /// Controls how many versions are kept and for how long to prevent
@@ -624,7 +631,41 @@ impl HistoricalStorage {
     /// immutable per version and temporal visibility is checked separately in
     /// `find_node_version_at_time()`, cached properties are always valid and don't
     /// require invalidation when temporal intervals are modified.
+    ///
+    /// **Depth Limit**: Returns `TemporalError::MaxDepthExceeded` if the delta
+    /// chain exceeds `MAX_RECONSTRUCTION_DEPTH` (100). This protects against
+    /// stack overflow from corrupted version chains or cycles.
     pub fn reconstruct_node_properties(&self, version_id: VersionId) -> Result<PropertyMap> {
+        self.reconstruct_node_properties_with_depth(version_id, 0)
+    }
+
+    /// Internal helper for node property reconstruction with depth tracking.
+    ///
+    /// The depth parameter tracks how many delta versions have been traversed.
+    /// If depth exceeds MAX_RECONSTRUCTION_DEPTH, returns an error to prevent
+    /// stack overflow from corrupted version chains or cycles.
+    fn reconstruct_node_properties_with_depth(
+        &self,
+        version_id: VersionId,
+        depth: usize,
+    ) -> Result<PropertyMap> {
+        // Check depth limit first (DoS protection)
+        // Using >= for clarity: depth is 0-indexed, so this limits to exactly
+        // MAX_RECONSTRUCTION_DEPTH recursive calls (depths 0..99 = 100 calls)
+        if depth >= MAX_RECONSTRUCTION_DEPTH {
+            // Get the node ID for error reporting
+            let entity_id = self
+                .node_versions
+                .get(&version_id)
+                .map(|v| v.node_id.to_string())
+                .unwrap_or_else(|| format!("version {}", version_id));
+            return Err(TemporalError::MaxDepthExceeded {
+                max_depth: MAX_RECONSTRUCTION_DEPTH,
+                entity_id,
+            }
+            .into());
+        }
+
         // Check cache first (fast path for concurrent reads)
         if let Some(cached) = self.node_property_cache.get(&version_id) {
             return Ok(cached.as_ref().clone());
@@ -647,8 +688,9 @@ impl HistoricalStorage {
                         reason: "Delta version has no previous version".to_string(),
                     })?;
 
-                // Recursively reconstruct previous version (may hit cache)
-                let base_properties = self.reconstruct_node_properties(prev_id)?;
+                // Recursively reconstruct previous version with incremented depth
+                let base_properties =
+                    self.reconstruct_node_properties_with_depth(prev_id, depth + 1)?;
 
                 // Apply this delta
                 delta.apply(&base_properties)
@@ -666,7 +708,41 @@ impl HistoricalStorage {
     ///
     /// **Cache Behavior**: Same as `reconstruct_node_properties()` - properties are
     /// immutable per VersionId, so caching doesn't require invalidation.
+    ///
+    /// **Depth Limit**: Returns `TemporalError::MaxDepthExceeded` if the delta
+    /// chain exceeds `MAX_RECONSTRUCTION_DEPTH` (100). This protects against
+    /// stack overflow from corrupted version chains or cycles.
     pub fn reconstruct_edge_properties(&self, version_id: VersionId) -> Result<PropertyMap> {
+        self.reconstruct_edge_properties_with_depth(version_id, 0)
+    }
+
+    /// Internal helper for edge property reconstruction with depth tracking.
+    ///
+    /// The depth parameter tracks how many delta versions have been traversed.
+    /// If depth exceeds MAX_RECONSTRUCTION_DEPTH, returns an error to prevent
+    /// stack overflow from corrupted version chains or cycles.
+    fn reconstruct_edge_properties_with_depth(
+        &self,
+        version_id: VersionId,
+        depth: usize,
+    ) -> Result<PropertyMap> {
+        // Check depth limit first (DoS protection)
+        // Using >= for clarity: depth is 0-indexed, so this limits to exactly
+        // MAX_RECONSTRUCTION_DEPTH recursive calls (depths 0..99 = 100 calls)
+        if depth >= MAX_RECONSTRUCTION_DEPTH {
+            // Get the edge ID for error reporting
+            let entity_id = self
+                .edge_versions
+                .get(&version_id)
+                .map(|v| v.edge_id.to_string())
+                .unwrap_or_else(|| format!("version {}", version_id));
+            return Err(TemporalError::MaxDepthExceeded {
+                max_depth: MAX_RECONSTRUCTION_DEPTH,
+                entity_id,
+            }
+            .into());
+        }
+
         // Check cache first (fast path for concurrent reads)
         if let Some(cached) = self.edge_property_cache.get(&version_id) {
             return Ok(cached.as_ref().clone());
@@ -688,8 +764,9 @@ impl HistoricalStorage {
                         reason: "Delta version has no previous version".to_string(),
                     })?;
 
-                // Recursively reconstruct previous version (may hit cache)
-                let base_properties = self.reconstruct_edge_properties(prev_id)?;
+                // Recursively reconstruct previous version with incremented depth
+                let base_properties =
+                    self.reconstruct_edge_properties_with_depth(prev_id, depth + 1)?;
                 delta.apply(&base_properties)
             }
         };
@@ -2782,5 +2859,261 @@ mod tests {
             .unwrap();
         assert_eq!(node_version.data.get_vector_snapshot_id(), Some(1));
         assert_eq!(edge_version.data.get_vector_snapshot_id(), Some(2));
+    }
+
+    // ========================================================================
+    // Tests for Issue #17: Recursion depth limit in version reconstruction
+    // ========================================================================
+
+    use super::{MAX_RECONSTRUCTION_DEPTH, RetentionPolicy};
+
+    #[test]
+    fn test_reconstruction_depth_limit_exceeded_for_nodes() {
+        // Create storage with very high anchor interval to force delta creation
+        // and cache_size=0 to prevent caching from defeating the depth test
+        let mut storage = HistoricalStorage::with_config_retention_and_cache_size(
+            AnchorConfig {
+                anchor_interval: 200, // Won't create anchors until 200 versions
+                max_delta_chain: 200,
+            },
+            RetentionPolicy::default(),
+            0, // Disable cache to test full depth traversal
+        );
+
+        let node_id = NodeId::new(1).unwrap();
+        let label = GLOBAL_INTERNER.intern("Test").unwrap();
+
+        // Create first version (anchor)
+        let v0 = VersionId::new(0).unwrap();
+        storage
+            .add_node_version(
+                node_id,
+                v0,
+                BiTemporalInterval::current(0),
+                label,
+                PropertyMapBuilder::new().insert("counter", 0i64).build(),
+            )
+            .unwrap();
+
+        // Create 100 more versions (deltas) to exceed the depth limit
+        // With >= check, depth 100 triggers error, so 100 deltas will exceed
+        for i in 1..=MAX_RECONSTRUCTION_DEPTH {
+            let vid = VersionId::new(i as u64).unwrap();
+            storage
+                .add_node_version(
+                    node_id,
+                    vid,
+                    BiTemporalInterval::current(i as i64 * 1000),
+                    label,
+                    PropertyMapBuilder::new()
+                        .insert("counter", i as i64)
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        // Reconstruction should fail with MaxDepthExceeded
+        let last_version_id = VersionId::new(MAX_RECONSTRUCTION_DEPTH as u64).unwrap();
+        let result = storage.reconstruct_node_properties(last_version_id);
+
+        assert!(result.is_err(), "Expected MaxDepthExceeded error");
+        let err = result.unwrap_err();
+        match err {
+            crate::utils::error::Error::Temporal(
+                crate::utils::error::TemporalError::MaxDepthExceeded { max_depth, .. },
+            ) => {
+                assert_eq!(max_depth, MAX_RECONSTRUCTION_DEPTH);
+            }
+            other => panic!("Expected MaxDepthExceeded error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_reconstruction_within_depth_limit_works_for_nodes() {
+        // Create storage with high anchor interval to force delta creation
+        // and cache_size=0 to test full depth traversal
+        let mut storage = HistoricalStorage::with_config_retention_and_cache_size(
+            AnchorConfig {
+                anchor_interval: 200,
+                max_delta_chain: 200,
+            },
+            RetentionPolicy::default(),
+            0, // Disable cache to test full depth traversal
+        );
+
+        let node_id = NodeId::new(1).unwrap();
+        let label = GLOBAL_INTERNER.intern("Test").unwrap();
+
+        // Create first version (anchor)
+        let v0 = VersionId::new(0).unwrap();
+        storage
+            .add_node_version(
+                node_id,
+                v0,
+                BiTemporalInterval::current(0),
+                label,
+                PropertyMapBuilder::new().insert("counter", 0i64).build(),
+            )
+            .unwrap();
+
+        // Create exactly MAX_RECONSTRUCTION_DEPTH - 1 versions (should be within limit)
+        // With >= check, 99 deltas means max depth of 99 which is < 100
+        for i in 1..MAX_RECONSTRUCTION_DEPTH {
+            let vid = VersionId::new(i as u64).unwrap();
+            storage
+                .add_node_version(
+                    node_id,
+                    vid,
+                    BiTemporalInterval::current(i as i64 * 1000),
+                    label,
+                    PropertyMapBuilder::new()
+                        .insert("counter", i as i64)
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        // Reconstruction should succeed for version at depth limit
+        let last_version_id = VersionId::new((MAX_RECONSTRUCTION_DEPTH - 1) as u64).unwrap();
+        let result = storage.reconstruct_node_properties(last_version_id);
+
+        assert!(
+            result.is_ok(),
+            "Expected successful reconstruction within depth limit"
+        );
+        let props = result.unwrap();
+        assert_eq!(
+            props.get("counter").and_then(|v| v.as_int()),
+            Some((MAX_RECONSTRUCTION_DEPTH - 1) as i64)
+        );
+    }
+
+    #[test]
+    fn test_reconstruction_depth_limit_exceeded_for_edges() {
+        // Create storage with very high anchor interval to force delta creation
+        // and cache_size=0 to prevent caching from defeating the depth test
+        let mut storage = HistoricalStorage::with_config_retention_and_cache_size(
+            AnchorConfig {
+                anchor_interval: 200,
+                max_delta_chain: 200,
+            },
+            RetentionPolicy::default(),
+            0, // Disable cache to test full depth traversal
+        );
+
+        let edge_id = EdgeId::new(1).unwrap();
+        let source = NodeId::new(100).unwrap();
+        let target = NodeId::new(200).unwrap();
+        let label = GLOBAL_INTERNER.intern("TestEdge").unwrap();
+
+        // Create first version (anchor)
+        let v0 = VersionId::new(0).unwrap();
+        storage
+            .add_edge_version(
+                edge_id,
+                v0,
+                BiTemporalInterval::current(0),
+                label,
+                source,
+                target,
+                PropertyMapBuilder::new().insert("weight", 0.0f64).build(),
+            )
+            .unwrap();
+
+        // Create 100 more versions (deltas) to exceed the depth limit
+        // With >= check, depth 100 triggers error, so 100 deltas will exceed
+        for i in 1..=MAX_RECONSTRUCTION_DEPTH {
+            let vid = VersionId::new(i as u64).unwrap();
+            storage
+                .add_edge_version(
+                    edge_id,
+                    vid,
+                    BiTemporalInterval::current(i as i64 * 1000),
+                    label,
+                    source,
+                    target,
+                    PropertyMapBuilder::new().insert("weight", i as f64).build(),
+                )
+                .unwrap();
+        }
+
+        // Reconstruction should fail with MaxDepthExceeded
+        let last_version_id = VersionId::new(MAX_RECONSTRUCTION_DEPTH as u64).unwrap();
+        let result = storage.reconstruct_edge_properties(last_version_id);
+
+        assert!(result.is_err(), "Expected MaxDepthExceeded error");
+        let err = result.unwrap_err();
+        match err {
+            crate::utils::error::Error::Temporal(
+                crate::utils::error::TemporalError::MaxDepthExceeded { max_depth, .. },
+            ) => {
+                assert_eq!(max_depth, MAX_RECONSTRUCTION_DEPTH);
+            }
+            other => panic!("Expected MaxDepthExceeded error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_reconstruction_within_depth_limit_works_for_edges() {
+        // Create storage with high anchor interval to force delta creation
+        // and cache_size=0 to test full depth traversal
+        let mut storage = HistoricalStorage::with_config_retention_and_cache_size(
+            AnchorConfig {
+                anchor_interval: 200,
+                max_delta_chain: 200,
+            },
+            RetentionPolicy::default(),
+            0, // Disable cache to test full depth traversal
+        );
+
+        let edge_id = EdgeId::new(1).unwrap();
+        let source = NodeId::new(100).unwrap();
+        let target = NodeId::new(200).unwrap();
+        let label = GLOBAL_INTERNER.intern("TestEdge").unwrap();
+
+        // Create first version (anchor)
+        let v0 = VersionId::new(0).unwrap();
+        storage
+            .add_edge_version(
+                edge_id,
+                v0,
+                BiTemporalInterval::current(0),
+                label,
+                source,
+                target,
+                PropertyMapBuilder::new().insert("weight", 0.0f64).build(),
+            )
+            .unwrap();
+
+        // Create exactly MAX_RECONSTRUCTION_DEPTH - 1 versions (should be within limit)
+        // With >= check, 99 deltas means max depth of 99 which is < 100
+        for i in 1..MAX_RECONSTRUCTION_DEPTH {
+            let vid = VersionId::new(i as u64).unwrap();
+            storage
+                .add_edge_version(
+                    edge_id,
+                    vid,
+                    BiTemporalInterval::current(i as i64 * 1000),
+                    label,
+                    source,
+                    target,
+                    PropertyMapBuilder::new().insert("weight", i as f64).build(),
+                )
+                .unwrap();
+        }
+
+        // Reconstruction should succeed for version at depth limit
+        let last_version_id = VersionId::new((MAX_RECONSTRUCTION_DEPTH - 1) as u64).unwrap();
+        let result = storage.reconstruct_edge_properties(last_version_id);
+
+        assert!(
+            result.is_ok(),
+            "Expected successful reconstruction within depth limit"
+        );
+        let props = result.unwrap();
+        assert_eq!(
+            props.get("weight").and_then(|v| v.as_float()),
+            Some((MAX_RECONSTRUCTION_DEPTH - 1) as f64)
+        );
     }
 }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -338,6 +338,16 @@ pub enum TemporalError {
         /// The entity ID
         entity_id: String,
     },
+    /// Maximum recursion depth exceeded during version reconstruction.
+    ///
+    /// This error indicates either a corrupted version chain (possible cycle)
+    /// or an unusually long delta chain that exceeds the safety limit.
+    MaxDepthExceeded {
+        /// The maximum depth that was exceeded
+        max_depth: usize,
+        /// The entity ID being reconstructed
+        entity_id: String,
+    },
 }
 
 impl fmt::Display for TemporalError {
@@ -380,6 +390,16 @@ impl fmt::Display for TemporalError {
             }
             TemporalError::MissingAnchor { entity_id } => {
                 write!(f, "Missing anchor in version chain for {}", entity_id)
+            }
+            TemporalError::MaxDepthExceeded {
+                max_depth,
+                entity_id,
+            } => {
+                write!(
+                    f,
+                    "Maximum recursion depth ({}) exceeded while reconstructing {}: possible corrupted version chain or cycle",
+                    max_depth, entity_id
+                )
             }
         }
     }
@@ -822,6 +842,16 @@ mod tests {
         };
         assert!(format!("{}", err).contains("Missing anchor"));
         assert!(format!("{}", err).contains("edge-456"));
+
+        // Test MaxDepthExceeded
+        let err = TemporalError::MaxDepthExceeded {
+            max_depth: 100,
+            entity_id: "node-789".to_string(),
+        };
+        assert!(format!("{}", err).contains("Maximum recursion depth"));
+        assert!(format!("{}", err).contains("100"));
+        assert!(format!("{}", err).contains("node-789"));
+        assert!(format!("{}", err).contains("corrupted version chain"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a maximum recursion depth of 100 for version chain traversal during property reconstruction
- Prevents stack overflow from corrupted version chains, cycles, or unusually long delta chains
- Implements depth-tracking wrapper functions with zero overhead for normal operations
- Adds comprehensive TDD tests for both depth limit exceeded and within-limit scenarios

## Changes

1. **New error variant**: `TemporalError::MaxDepthExceeded { max_depth, entity_id }` for clear error reporting
2. **Depth-limited reconstruction**: Internal helper functions track recursion depth and return error when limit exceeded
3. **Constant export**: `MAX_RECONSTRUCTION_DEPTH` (100) exported for documentation
4. **Tests**: 4 new tests covering nodes/edges for both exceeded and within-limit cases

## Test plan

- [x] New tests verify depth limit works for nodes (`test_reconstruction_depth_limit_exceeded_for_nodes`)
- [x] New tests verify depth limit works for edges (`test_reconstruction_depth_limit_exceeded_for_edges`)
- [x] New tests verify normal chains still work (`test_reconstruction_within_depth_limit_works_for_*`)
- [x] All existing 736 library tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with cargo fmt

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)