### PR TITLE
fix: validate TimeRange in release builds (issue #18)

### DIFF
--- a/benches/temporal_query.rs
+++ b/benches/temporal_query.rs
@@ -44,7 +44,7 @@ fn bench_valid_at_query(c: &mut Criterion) {
                                     node_id,
                                     v_id,
                                     BiTemporalInterval::new(
-                                        TimeRange::new(start, end),
+                                        TimeRange::new(start, end).unwrap(),
                                         TimeRange::from(0), // Tx time is irrelevant for this test
                                     ),
                                 )
@@ -59,7 +59,7 @@ fn bench_valid_at_query(c: &mut Criterion) {
                         // Benchmark: Query operation only
                         // New efficient query: "valid at time T"
                         // Since the index now supports overlaps, we can just query the point interval.
-                        let range = TimeRange::new(time, time + 1);
+                        let range = TimeRange::new(time, time + 1).unwrap();
                         black_box(indexes.find_node_versions_in_valid_time_range(node_id, range))
                     },
                     criterion::BatchSize::SmallInput,
@@ -95,7 +95,7 @@ fn bench_insert_performance(c: &mut Criterion) {
                                     node_id,
                                     v_id,
                                     BiTemporalInterval::new(
-                                        TimeRange::new(start, end),
+                                        TimeRange::new(start, end).unwrap(),
                                         TimeRange::from(0),
                                     ),
                                 )
@@ -135,7 +135,7 @@ fn bench_insert_performance(c: &mut Criterion) {
                                     node_id,
                                     v_id,
                                     BiTemporalInterval::new(
-                                        TimeRange::new(start, end),
+                                        TimeRange::new(start, end).unwrap(),
                                         TimeRange::from(0),
                                     ),
                                 )
@@ -179,7 +179,8 @@ fn bench_concurrent_write_throughput(c: &mut Criterion) {
                                                 TimeRange::new(
                                                     (v * 1000) as i64,
                                                     ((v + 1) * 1000) as i64,
-                                                ),
+                                                )
+                                                .unwrap(),
                                                 TimeRange::from(0),
                                             ),
                                         )
@@ -224,7 +225,8 @@ fn bench_concurrent_write_throughput(c: &mut Criterion) {
                                                 TimeRange::new(
                                                     ((thread_id * 100 + v) * 1000) as i64,
                                                     (((thread_id * 100 + v) + 1) * 1000) as i64,
-                                                ),
+                                                )
+                                                .unwrap(),
                                                 TimeRange::from(0),
                                             ),
                                         )
@@ -267,7 +269,7 @@ fn bench_read_latency_under_write_contention(c: &mut Criterion) {
                             node_id,
                             version_id,
                             BiTemporalInterval::new(
-                                TimeRange::new((i * 1000) as i64, ((i + 1) * 1000) as i64),
+                                TimeRange::new((i * 1000) as i64, ((i + 1) * 1000) as i64).unwrap(),
                                 TimeRange::from(0),
                             ),
                         )
@@ -275,7 +277,7 @@ fn bench_read_latency_under_write_contention(c: &mut Criterion) {
                 }
 
                 // Query range in the middle
-                let query_range = TimeRange::new(5_000_000, 5_001_000);
+                let query_range = TimeRange::new(5_000_000, 5_001_000).unwrap();
 
                 b.iter_batched(
                     || {
@@ -295,7 +297,8 @@ fn bench_read_latency_under_write_contention(c: &mut Criterion) {
                                                 TimeRange::new(
                                                     ((thread_id * 100 + v) * 1000) as i64,
                                                     (((thread_id * 100 + v) + 1) * 1000) as i64,
-                                                ),
+                                                )
+                                                .unwrap(),
                                                 TimeRange::from(0),
                                             ),
                                         )
@@ -349,7 +352,7 @@ fn bench_concurrent_read_same_entity(c: &mut Criterion) {
                     node_id,
                     version_id,
                     BiTemporalInterval::new(
-                        TimeRange::new((i * 1000) as i64, ((i + 1) * 1000) as i64),
+                        TimeRange::new((i * 1000) as i64, ((i + 1) * 1000) as i64).unwrap(),
                         TimeRange::from(0),
                     ),
                 )
@@ -376,7 +379,7 @@ fn bench_concurrent_read_same_entity(c: &mut Criterion) {
                                     for q in 0..50 {
                                         // Query different time points across the history
                                         let time = ((reader_id * 50 + q) * 1000) as i64;
-                                        let range = TimeRange::new(time, time + 1);
+                                        let range = TimeRange::new(time, time + 1).unwrap();
                                         let r = idx_clone
                                             .find_node_versions_in_valid_time_range(node_id, range);
                                         results.push(r);
@@ -421,7 +424,7 @@ fn bench_mixed_read_write_same_entity(c: &mut Criterion) {
                         node_id,
                         version_id,
                         BiTemporalInterval::new(
-                            TimeRange::new((i * 1000) as i64, ((i + 1) * 1000) as i64),
+                            TimeRange::new((i * 1000) as i64, ((i + 1) * 1000) as i64).unwrap(),
                             TimeRange::from(0),
                         ),
                     )
@@ -446,7 +449,7 @@ fn bench_mixed_read_write_same_entity(c: &mut Criterion) {
                                 let mut results = Vec::new();
                                 for q in 0..25 {
                                     let time = ((reader_id * 25 + q) * 1000) as i64;
-                                    let range = TimeRange::new(time, time + 1);
+                                    let range = TimeRange::new(time, time + 1).unwrap();
                                     let r = idx_clone
                                         .find_node_versions_in_valid_time_range(node_id, range);
                                     results.push(r);
@@ -470,7 +473,8 @@ fn bench_mixed_read_write_same_entity(c: &mut Criterion) {
                                                 TimeRange::new(
                                                     ((1000 + writer_id * 10 + w) * 1000) as i64,
                                                     ((1001 + writer_id * 10 + w) * 1000) as i64,
-                                                ),
+                                                )
+                                                .unwrap(),
                                                 TimeRange::from(0),
                                             ),
                                         )

--- a/benches/temporal_vector.rs
+++ b/benches/temporal_vector.rs
@@ -146,7 +146,7 @@ fn bench_time_range_queries(c: &mut Criterion) {
                 }
 
                 let query_vector = gen_vector(128, 0);
-                let time_range = TimeRange::between(0, (snapshot_count * 10000) as i64);
+                let time_range = TimeRange::between(0, (snapshot_count * 10000) as i64).unwrap();
 
                 b.iter(|| {
                     let _ = index.find_similar_in_range(
@@ -342,7 +342,7 @@ fn bench_semantic_evolution(c: &mut Criterion) {
                     let _ = index.on_transaction();
                 }
 
-                let time_range = TimeRange::between(0, snapshot_count as i64 * 1000);
+                let time_range = TimeRange::between(0, snapshot_count as i64 * 1000).unwrap();
 
                 b.iter(|| {
                     let _ = index.semantic_evolution(black_box(node_id), black_box(time_range));
@@ -391,7 +391,7 @@ fn bench_track_semantic_drift(c: &mut Criterion) {
                     v[0] = 1.0;
                     v
                 };
-                let time_range = TimeRange::between(0, snapshot_count as i64 * 1000);
+                let time_range = TimeRange::between(0, snapshot_count as i64 * 1000).unwrap();
 
                 b.iter(|| {
                     let _ = index.track_semantic_drift(
@@ -438,7 +438,7 @@ fn bench_calculate_consecutive_drift(c: &mut Criterion) {
                     let _ = index.on_transaction();
                 }
 
-                let time_range = TimeRange::between(0, snapshot_count as i64 * 1000);
+                let time_range = TimeRange::between(0, snapshot_count as i64 * 1000).unwrap();
 
                 b.iter(|| {
                     let _ = index
@@ -490,7 +490,7 @@ fn bench_semantic_evolution_memory_overhead(c: &mut Criterion) {
                     |index| {
                         // Measure semantic evolution retrieval
                         let node_id = NodeId::new(vector_count as u64 / 2).unwrap();
-                        let time_range = TimeRange::between(0, 10000);
+                        let time_range = TimeRange::between(0, 10000).unwrap();
                         let _ = index.semantic_evolution(node_id, time_range);
                     },
                     criterion::BatchSize::SmallInput,

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -593,15 +593,13 @@ mod tests {
     fn test_time_range_invalid_returns_error() {
         // TimeRange::new should return an error for invalid ranges (start > end)
         let result = TimeRange::new(200, 100);
-        assert!(result.is_err());
-
-        match result {
-            Err(crate::utils::error::TemporalError::InvalidTimeRange { start, end }) => {
-                assert_eq!(start, 200);
-                assert_eq!(end, 100);
-            }
-            _ => panic!("Expected InvalidTimeRange error"),
-        }
+        assert!(matches!(
+            result,
+            Err(crate::utils::error::TemporalError::InvalidTimeRange {
+                start: 200,
+                end: 100
+            })
+        ));
     }
 
     #[test]

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-use crate::utils::error::StorageError;
+use crate::utils::error::{StorageError, TemporalError};
 
 /// Timestamp represented as microseconds since Unix epoch (1970-01-01 00:00:00 UTC).
 ///
@@ -47,17 +47,14 @@ pub struct TimeRange {
 impl TimeRange {
     /// Create a new time range.
     ///
-    /// # Panics
-    /// Panics in debug mode if start > end.
+    /// # Errors
+    /// Returns `TemporalError::InvalidTimeRange` if start > end.
     #[inline]
-    pub fn new(start: Timestamp, end: Timestamp) -> Self {
-        debug_assert!(
-            start <= end,
-            "TimeRange start ({}) must be <= end ({})",
-            start,
-            end
-        );
-        TimeRange { start, end }
+    pub fn new(start: Timestamp, end: Timestamp) -> Result<Self, TemporalError> {
+        if start > end {
+            return Err(TemporalError::InvalidTimeRange { start, end });
+        }
+        Ok(TimeRange { start, end })
     }
 
     /// Create a time range that starts at the given timestamp and is still current.
@@ -71,7 +68,7 @@ impl TimeRange {
 
     /// Create a time range that is bounded on both ends.
     #[inline]
-    pub fn between(start: Timestamp, end: Timestamp) -> Self {
+    pub fn between(start: Timestamp, end: Timestamp) -> Result<Self, TemporalError> {
         Self::new(start, end)
     }
 
@@ -452,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_time_range_creation() {
-        let range = TimeRange::new(100, 200);
+        let range = TimeRange::new(100, 200).unwrap();
         assert_eq!(range.start(), 100);
         assert_eq!(range.end(), 200);
         assert!(!range.is_current());
@@ -470,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_time_range_contains() {
-        let range = TimeRange::new(100, 200);
+        let range = TimeRange::new(100, 200).unwrap();
         assert!(!range.contains(99));
         assert!(range.contains(100));
         assert!(range.contains(150));
@@ -480,10 +477,10 @@ mod tests {
 
     #[test]
     fn test_time_range_overlaps() {
-        let r1 = TimeRange::new(100, 200);
-        let r2 = TimeRange::new(150, 250);
-        let r3 = TimeRange::new(200, 300);
-        let r4 = TimeRange::new(50, 75);
+        let r1 = TimeRange::new(100, 200).unwrap();
+        let r2 = TimeRange::new(150, 250).unwrap();
+        let r3 = TimeRange::new(200, 300).unwrap();
+        let r4 = TimeRange::new(50, 75).unwrap();
 
         assert!(r1.overlaps(&r2));
         assert!(r2.overlaps(&r1));
@@ -493,9 +490,9 @@ mod tests {
 
     #[test]
     fn test_time_range_contains_range() {
-        let outer = TimeRange::new(100, 300);
-        let inner = TimeRange::new(150, 250);
-        let overlapping = TimeRange::new(150, 350);
+        let outer = TimeRange::new(100, 300).unwrap();
+        let inner = TimeRange::new(150, 250).unwrap();
+        let overlapping = TimeRange::new(150, 350).unwrap();
 
         assert!(outer.contains_range(&inner));
         assert!(!inner.contains_range(&outer));
@@ -515,7 +512,7 @@ mod tests {
 
     #[test]
     fn test_time_range_duration() {
-        let range = TimeRange::new(100, 500);
+        let range = TimeRange::new(100, 500).unwrap();
         assert_eq!(range.duration_micros(), Some(400));
 
         let open = TimeRange::from(100);
@@ -542,8 +539,8 @@ mod tests {
     #[test]
     fn test_bitemporal_visibility() {
         let interval = BiTemporalInterval::new(
-            TimeRange::new(1000, 2000), // Valid from 1000 to 2000
-            TimeRange::new(3000, 4000), // Recorded from 3000 to 4000
+            TimeRange::new(1000, 2000).unwrap(), // Valid from 1000 to 2000
+            TimeRange::new(3000, 4000).unwrap(), // Recorded from 3000 to 4000
         );
 
         // Visible if both dimensions are in range
@@ -593,10 +590,38 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_time_range_invalid_in_debug() {
-        // This should panic in debug mode when start > end
-        TimeRange::new(200, 100);
+    fn test_time_range_invalid_returns_error() {
+        // TimeRange::new should return an error for invalid ranges (start > end)
+        let result = TimeRange::new(200, 100);
+        assert!(result.is_err());
+
+        match result {
+            Err(crate::utils::error::TemporalError::InvalidTimeRange { start, end }) => {
+                assert_eq!(start, 200);
+                assert_eq!(end, 100);
+            }
+            _ => panic!("Expected InvalidTimeRange error"),
+        }
+    }
+
+    #[test]
+    fn test_time_range_valid_returns_ok() {
+        // TimeRange::new should return Ok for valid ranges
+        let result = TimeRange::new(100, 200);
+        assert!(result.is_ok());
+        let range = result.unwrap();
+        assert_eq!(range.start(), 100);
+        assert_eq!(range.end(), 200);
+    }
+
+    #[test]
+    fn test_time_range_equal_start_end_returns_ok() {
+        // TimeRange::new should return Ok when start == end (point-in-time)
+        let result = TimeRange::new(100, 100);
+        assert!(result.is_ok());
+        let range = result.unwrap();
+        assert_eq!(range.start(), 100);
+        assert_eq!(range.end(), 100);
     }
 
     // Serialization tests
@@ -604,11 +629,11 @@ mod tests {
     #[test]
     fn test_timerange_serialize_roundtrip() {
         let ranges = [
-            TimeRange::new(100, 200),
+            TimeRange::new(100, 200).unwrap(),
             TimeRange::from(1000),
             TimeRange::at(500),
-            TimeRange::new(i64::MIN, i64::MAX),
-            TimeRange::new(0, 0),
+            TimeRange::new(i64::MIN, i64::MAX).unwrap(),
+            TimeRange::new(0, 0).unwrap(),
         ];
         for range in ranges {
             let bytes = range.serialize();
@@ -621,7 +646,7 @@ mod tests {
 
     #[test]
     fn test_timerange_serialize_into() {
-        let range = TimeRange::new(100, 200);
+        let range = TimeRange::new(100, 200).unwrap();
         let mut buffer = Vec::new();
         range.serialize_into(&mut buffer);
         assert_eq!(buffer.len(), 16);
@@ -640,7 +665,10 @@ mod tests {
         let intervals = [
             BiTemporalInterval::current(1000),
             BiTemporalInterval::now(500, 600),
-            BiTemporalInterval::new(TimeRange::new(100, 200), TimeRange::new(300, 400)),
+            BiTemporalInterval::new(
+                TimeRange::new(100, 200).unwrap(),
+                TimeRange::new(300, 400).unwrap(),
+            ),
             BiTemporalInterval::new(TimeRange::from(0), TimeRange::from(0)),
         ];
         for interval in intervals {
@@ -654,7 +682,10 @@ mod tests {
 
     #[test]
     fn test_bitemporal_serialize_into() {
-        let interval = BiTemporalInterval::new(TimeRange::new(100, 200), TimeRange::new(300, 400));
+        let interval = BiTemporalInterval::new(
+            TimeRange::new(100, 200).unwrap(),
+            TimeRange::new(300, 400).unwrap(),
+        );
         let mut buffer = Vec::new();
         interval.serialize_into(&mut buffer);
         assert_eq!(buffer.len(), 32);
@@ -671,7 +702,7 @@ mod tests {
     #[test]
     fn test_serialization_endianness() {
         // Verify little-endian format
-        let range = TimeRange::new(0x0102030405060708i64, 0x1112131415161718i64);
+        let range = TimeRange::new(0x0102030405060708i64, 0x1112131415161718i64).unwrap();
         let bytes = range.serialize();
         // Little-endian: least significant byte first
         assert_eq!(bytes[0], 0x08);

--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -451,7 +451,10 @@ mod tests {
             .insert_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(0, 1000), TimeRange::new(0, Timestamp::MAX)),
+                BiTemporalInterval::new(
+                    TimeRange::new(0, 1000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
+                ),
             )
             .unwrap();
 
@@ -461,8 +464,8 @@ mod tests {
                 node_id,
                 v2,
                 BiTemporalInterval::new(
-                    TimeRange::new(1000, 2000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(1000, 2000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
@@ -473,8 +476,8 @@ mod tests {
                 node_id,
                 v3,
                 BiTemporalInterval::new(
-                    TimeRange::new(2000, 3000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(2000, 3000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
@@ -482,8 +485,8 @@ mod tests {
         // Test overlap logic: Query [500, 1500)
         // v1 overlaps (500 to 1000)
         // v2 overlaps (1000 to 1500)
-        let results =
-            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(500, 1500));
+        let results = indexes
+            .find_node_versions_in_valid_time_range(node_id, TimeRange::new(500, 1500).unwrap());
 
         assert_eq!(results.len(), 2);
         assert!(results.contains(&v1));
@@ -503,14 +506,14 @@ mod tests {
             .insert_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(0, 2000), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(0, 2000).unwrap(), TimeRange::from(0)),
             )
             .unwrap();
         indexes
             .insert_node_version(
                 node_id,
                 v2,
-                BiTemporalInterval::new(TimeRange::new(1000, 3000), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(1000, 3000).unwrap(), TimeRange::from(0)),
             )
             .unwrap();
 
@@ -543,27 +546,27 @@ mod tests {
             .insert_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(0, 1000), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(0, 1000).unwrap(), TimeRange::from(0)),
             )
             .unwrap();
         indexes
             .insert_node_version(
                 node_id,
                 v2,
-                BiTemporalInterval::new(TimeRange::new(1000, 2000), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(1000, 2000).unwrap(), TimeRange::from(0)),
             )
             .unwrap();
 
         // Query point at 1000 (only v2 because [start, end) is inclusive-exclusive)
         // Use [1000, 1001) to represent the point 1000
-        let results =
-            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(1000, 1001));
+        let results = indexes
+            .find_node_versions_in_valid_time_range(node_id, TimeRange::new(1000, 1001).unwrap());
         assert_eq!(results.len(), 1);
         assert!(results.contains(&v2));
 
         // Query range [500, 1000) (only v1 because 1000 is exclusive)
-        let results =
-            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(500, 1000));
+        let results = indexes
+            .find_node_versions_in_valid_time_range(node_id, TimeRange::new(500, 1000).unwrap());
         assert_eq!(results.len(), 1);
         assert!(results.contains(&v1));
     }
@@ -576,15 +579,15 @@ mod tests {
         let versions = vec![
             (
                 VersionId::new(1).unwrap(),
-                BiTemporalInterval::new(TimeRange::new(0, 10), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(0, 10).unwrap(), TimeRange::from(0)),
             ),
             (
                 VersionId::new(3).unwrap(),
-                BiTemporalInterval::new(TimeRange::new(20, 30), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(20, 30).unwrap(), TimeRange::from(0)),
             ),
             (
                 VersionId::new(2).unwrap(),
-                BiTemporalInterval::new(TimeRange::new(10, 20), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(10, 20).unwrap(), TimeRange::from(0)),
             ),
         ];
 
@@ -593,7 +596,7 @@ mod tests {
             .unwrap();
 
         let results =
-            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(5, 25));
+            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(5, 25).unwrap());
         assert_eq!(results.len(), 3);
 
         // Verify sort order internally (though opaque to API)
@@ -617,8 +620,8 @@ mod tests {
                 edge_id,
                 v1,
                 BiTemporalInterval::new(
-                    TimeRange::new(0, Timestamp::MAX),
-                    TimeRange::new(1000, Timestamp::MAX),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
+                    TimeRange::new(1000, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
@@ -629,15 +632,17 @@ mod tests {
                 edge_id,
                 v2,
                 BiTemporalInterval::new(
-                    TimeRange::new(0, Timestamp::MAX),
-                    TimeRange::new(2000, Timestamp::MAX),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
+                    TimeRange::new(2000, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
 
         // Query: [1500, 2500)
-        let results = indexes
-            .find_edge_versions_in_transaction_time_range(edge_id, TimeRange::new(1500, 2500));
+        let results = indexes.find_edge_versions_in_transaction_time_range(
+            edge_id,
+            TimeRange::new(1500, 2500).unwrap(),
+        );
 
         assert_eq!(results.len(), 2);
         assert!(results.contains(&v1));
@@ -661,7 +666,7 @@ mod tests {
             .unwrap();
 
         let results =
-            indexes.find_node_versions_in_valid_time_range(node1, TimeRange::new(0, 2000));
+            indexes.find_node_versions_in_valid_time_range(node1, TimeRange::new(0, 2000).unwrap());
 
         assert_eq!(results.len(), 1);
         assert!(results.contains(&v1));
@@ -693,8 +698,8 @@ mod tests {
         let node_id = NodeId::new(1).unwrap();
 
         // Query an entity with no versions
-        let results =
-            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(0, 1000));
+        let results = indexes
+            .find_node_versions_in_valid_time_range(node_id, TimeRange::new(0, 1000).unwrap());
 
         assert_eq!(results.len(), 0, "Empty timeline should return no results");
     }
@@ -713,7 +718,10 @@ mod tests {
             .insert_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(0, 1000), TimeRange::new(0, Timestamp::MAX)),
+                BiTemporalInterval::new(
+                    TimeRange::new(0, 1000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
+                ),
             )
             .unwrap();
 
@@ -723,8 +731,8 @@ mod tests {
                 node_id,
                 v3,
                 BiTemporalInterval::new(
-                    TimeRange::new(20000, 21000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(20000, 21000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
@@ -735,8 +743,8 @@ mod tests {
                 node_id,
                 v2,
                 BiTemporalInterval::new(
-                    TimeRange::new(10000, 11000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(10000, 11000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
@@ -772,8 +780,8 @@ mod tests {
         );
 
         // Verify queries work correctly with retroactively inserted versions
-        let results =
-            indexes.find_node_versions_in_valid_time_range(node_id, TimeRange::new(9000, 11000));
+        let results = indexes
+            .find_node_versions_in_valid_time_range(node_id, TimeRange::new(9000, 11000).unwrap());
         assert_eq!(results.len(), 1, "Should find 1 version in range");
         assert_eq!(results[0], v2, "Should find v2 in the middle");
     }
@@ -790,7 +798,10 @@ mod tests {
             .insert_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(0, 1000), TimeRange::new(0, Timestamp::MAX)),
+                BiTemporalInterval::new(
+                    TimeRange::new(0, 1000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
+                ),
             )
             .unwrap();
 
@@ -800,8 +811,8 @@ mod tests {
                 node_id,
                 v2,
                 BiTemporalInterval::new(
-                    TimeRange::new(1000, 2000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(1000, 2000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             )
             .unwrap();
@@ -875,8 +886,8 @@ mod tests {
                             node_id,
                             version_id,
                             BiTemporalInterval::new(
-                                TimeRange::new((v * 1000) as i64, ((v + 1) * 1000) as i64),
-                                TimeRange::new(0, Timestamp::MAX),
+                                TimeRange::new((v * 1000) as i64, ((v + 1) * 1000) as i64).unwrap(),
+                                TimeRange::new(0, Timestamp::MAX).unwrap(),
                             ),
                         )
                         .unwrap();
@@ -895,7 +906,7 @@ mod tests {
             let node_id = NodeId::new(thread_id + 1).unwrap();
             let results = indexes.find_node_versions_in_valid_time_range(
                 node_id,
-                TimeRange::new(0, (versions_per_thread * 1000) as i64),
+                TimeRange::new(0, (versions_per_thread * 1000) as i64).unwrap(),
             );
             assert_eq!(
                 results.len(),
@@ -942,8 +953,9 @@ mod tests {
                                 TimeRange::new(
                                     ((thread_id * versions_per_thread + v) * 100) as i64,
                                     (((thread_id * versions_per_thread + v) + 1) * 100) as i64,
-                                ),
-                                TimeRange::new(0, Timestamp::MAX),
+                                )
+                                .unwrap(),
+                                TimeRange::new(0, Timestamp::MAX).unwrap(),
                             ),
                         )
                         .unwrap();
@@ -962,7 +974,7 @@ mod tests {
         // Verify all versions were indexed correctly
         let results = indexes.find_node_versions_in_valid_time_range(
             node_id,
-            TimeRange::new(0, ((num_threads * versions_per_thread) * 100) as i64),
+            TimeRange::new(0, ((num_threads * versions_per_thread) * 100) as i64).unwrap(),
         );
 
         assert_eq!(
@@ -1006,16 +1018,18 @@ mod tests {
                     node_id,
                     version_id,
                     BiTemporalInterval::new(
-                        TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                        TimeRange::new(0, Timestamp::MAX),
+                        TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                        TimeRange::new(0, Timestamp::MAX).unwrap(),
                     ),
                 )
                 .unwrap();
         }
 
         // Query a small range in the middle - should be fast
-        let results = indexes
-            .find_node_versions_in_valid_time_range(node_id, TimeRange::new(5_000_000, 5_001_000));
+        let results = indexes.find_node_versions_in_valid_time_range(
+            node_id,
+            TimeRange::new(5_000_000, 5_001_000).unwrap(),
+        );
 
         // Should find ~10 versions in this range
         assert!(
@@ -1027,7 +1041,7 @@ mod tests {
         // Query the entire timeline - should return all versions
         let all_results = indexes.find_node_versions_in_valid_time_range(
             node_id,
-            TimeRange::new(0, (version_count * 100) as i64),
+            TimeRange::new(0, (version_count * 100) as i64).unwrap(),
         );
 
         assert_eq!(
@@ -1049,14 +1063,14 @@ mod tests {
             .insert_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(1000, 2000), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(1000, 2000).unwrap(), TimeRange::from(0)),
             )
             .unwrap();
         indexes
             .insert_node_version(
                 node_id,
                 v2,
-                BiTemporalInterval::new(TimeRange::new(1000, 3000), TimeRange::from(0)),
+                BiTemporalInterval::new(TimeRange::new(1000, 3000).unwrap(), TimeRange::from(0)),
             )
             .unwrap();
 
@@ -1099,8 +1113,8 @@ mod tests {
                 node_id,
                 version_id,
                 BiTemporalInterval::new(
-                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             );
             assert!(result.is_ok(), "Insert {} should succeed", i);
@@ -1112,8 +1126,8 @@ mod tests {
             node_id,
             version_id,
             BiTemporalInterval::new(
-                TimeRange::new(1000, 1100),
-                TimeRange::new(0, Timestamp::MAX),
+                TimeRange::new(1000, 1100).unwrap(),
+                TimeRange::new(0, Timestamp::MAX).unwrap(),
             ),
         );
 
@@ -1157,8 +1171,8 @@ mod tests {
                 edge_id,
                 version_id,
                 BiTemporalInterval::new(
-                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             );
             assert!(result.is_ok(), "Insert {} should succeed", i);
@@ -1169,7 +1183,10 @@ mod tests {
         let result = indexes.insert_edge_version(
             edge_id,
             version_id,
-            BiTemporalInterval::new(TimeRange::new(500, 600), TimeRange::new(0, Timestamp::MAX)),
+            BiTemporalInterval::new(
+                TimeRange::new(500, 600).unwrap(),
+                TimeRange::new(0, Timestamp::MAX).unwrap(),
+            ),
         );
 
         assert!(result.is_err(), "Insert beyond limit should fail");
@@ -1199,8 +1216,8 @@ mod tests {
                     node1,
                     VersionId::new(i).unwrap(),
                     BiTemporalInterval::new(
-                        TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                        TimeRange::new(0, Timestamp::MAX),
+                        TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                        TimeRange::new(0, Timestamp::MAX).unwrap(),
                     ),
                 )
                 .unwrap();
@@ -1212,8 +1229,8 @@ mod tests {
                 node2,
                 VersionId::new(100 + i).unwrap(),
                 BiTemporalInterval::new(
-                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             );
             assert!(
@@ -1227,7 +1244,10 @@ mod tests {
         let result = indexes.insert_node_version(
             node1,
             VersionId::new(10).unwrap(),
-            BiTemporalInterval::new(TimeRange::new(500, 600), TimeRange::new(0, Timestamp::MAX)),
+            BiTemporalInterval::new(
+                TimeRange::new(500, 600).unwrap(),
+                TimeRange::new(0, Timestamp::MAX).unwrap(),
+            ),
         );
         assert!(result.is_err(), "node1 should still be at limit");
     }
@@ -1247,8 +1267,8 @@ mod tests {
                     node_id,
                     VersionId::new(i).unwrap(),
                     BiTemporalInterval::new(
-                        TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                        TimeRange::new(0, Timestamp::MAX),
+                        TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                        TimeRange::new(0, Timestamp::MAX).unwrap(),
                     ),
                 )
                 .unwrap();
@@ -1259,22 +1279,22 @@ mod tests {
             (
                 VersionId::new(8).unwrap(),
                 BiTemporalInterval::new(
-                    TimeRange::new(800, 900),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(800, 900).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             ),
             (
                 VersionId::new(9).unwrap(),
                 BiTemporalInterval::new(
-                    TimeRange::new(900, 1000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(900, 1000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             ),
             (
                 VersionId::new(10).unwrap(),
                 BiTemporalInterval::new(
-                    TimeRange::new(1000, 1100),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(1000, 1100).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             ),
         ];
@@ -1319,8 +1339,8 @@ mod tests {
                 node_id,
                 VersionId::new(i).unwrap(),
                 BiTemporalInterval::new(
-                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new((i * 100) as i64, ((i + 1) * 100) as i64).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
             );
             assert!(
@@ -1353,8 +1373,8 @@ mod tests {
                 (
                     VersionId::new(vid).unwrap(),
                     BiTemporalInterval::new(
-                        TimeRange::new(start, end),
-                        TimeRange::new(0, Timestamp::MAX),
+                        TimeRange::new(start, end).unwrap(),
+                        TimeRange::new(0, Timestamp::MAX).unwrap(),
                     ),
                 )
             })
@@ -1420,7 +1440,7 @@ mod tests {
                 }
 
                 // Query the range
-                let query_time_range = TimeRange::new(query_range.0, query_range.1);
+                let query_time_range = TimeRange::new(query_range.0, query_range.1).unwrap();
                 let results = indexes.find_node_versions_in_valid_time_range(node_id, query_time_range);
 
                 // Manually compute expected results
@@ -1520,13 +1540,13 @@ mod tests {
                 // Point query
                 let point_results = indexes.find_node_versions_in_valid_time_range(
                     node_id,
-                    TimeRange::new(point, point + 1)
+                    TimeRange::new(point, point + 1).unwrap()
                 );
 
                 // Range query covering the point
                 let range_results = indexes.find_node_versions_in_valid_time_range(
                     node_id,
-                    TimeRange::new(point - 1000, point + 1000)
+                    TimeRange::new(point - 1000, point + 1000).unwrap()
                 );
 
                 // Every version from point query should be in range query

--- a/src/index/vector/temporal.rs
+++ b/src/index/vector/temporal.rs
@@ -60,7 +60,7 @@
 //! // Track semantic drift over time
 //! let node_id = NodeId::new(42).unwrap();
 //! let reference_embedding = vec![0.5f32; 384];
-//! let time_range = TimeRange::new(1000000, 2000000);
+//! let time_range = TimeRange::new(1000000, 2000000).unwrap();
 //! let drift = index.track_semantic_drift(node_id, &reference_embedding, time_range)?;
 //! # Ok(())
 //! # }
@@ -1613,7 +1613,7 @@ impl TemporalVectorIndex {
     ///
     /// # fn example(index: &TemporalVectorIndex) -> gallifreydb::utils::Result<()> {
     /// let query = vec![0.1f32; 384];
-    /// let time_range = TimeRange::new(1672531200000000, 1704067200000000); // 2023-2024
+    /// let time_range = TimeRange::new(1672531200000000, 1704067200000000).unwrap(); // 2023-2024
     ///
     /// let results = index.find_similar_in_range(&query, 10, time_range)?;
     ///
@@ -1714,7 +1714,7 @@ impl TemporalVectorIndex {
     /// # fn example(index: &TemporalVectorIndex) -> gallifreydb::utils::Result<()> {
     /// let node_id = NodeId::new(42).unwrap();
     /// let reference = vec![0.5f32; 384];
-    /// let time_range = TimeRange::new(1000000, 2000000);
+    /// let time_range = TimeRange::new(1000000, 2000000).unwrap();
     ///
     /// let drift_timeline = index.track_semantic_drift(node_id, &reference, time_range)?;
     ///
@@ -1808,7 +1808,7 @@ impl TemporalVectorIndex {
     /// use gallifreydb::core::temporal::TimeRange;
     ///
     /// # fn example(index: &TemporalVectorIndex) -> gallifreydb::utils::Result<()> {
-    /// let time_range = TimeRange::new(1000000, 2000000);
+    /// let time_range = TimeRange::new(1000000, 2000000).unwrap();
     ///
     /// // Find documents that changed significantly (cosine distance > 0.3)
     /// let drifted = index.find_semantic_drift(0.3, time_range, DriftMetric::Cosine)?;
@@ -2346,7 +2346,7 @@ mod tests {
         index.on_transaction_at(3000)?;
 
         let query = vec![1.0, 0.0, 0.0, 0.0];
-        let time_range = TimeRange::new(1000, 3000);
+        let time_range = TimeRange::new(1000, 3000).unwrap();
         let results = index.find_similar_in_range(&query, 5, time_range)?;
 
         assert!(!results.is_empty());
@@ -2589,7 +2589,7 @@ mod tests {
         index.on_transaction_at(3000)?;
         assert_eq!(index.snapshot_count(), 3);
 
-        let time_range = TimeRange::new(1000, 3000);
+        let time_range = TimeRange::new(1000, 3000).unwrap();
         let evolution = index.semantic_evolution(node_id, time_range)?;
 
         assert_eq!(evolution.len(), 3);
@@ -2620,7 +2620,7 @@ mod tests {
             index.on_transaction_at(timestamp)?;
         }
 
-        let time_range = TimeRange::new(2000, 4000);
+        let time_range = TimeRange::new(2000, 4000).unwrap();
         let evolution = index.semantic_evolution(node_id, time_range)?;
 
         assert_eq!(evolution.len(), 3);
@@ -2647,7 +2647,7 @@ mod tests {
         index.on_transaction_at(1000)?;
 
         let node_id = NodeId::new(42).unwrap();
-        let time_range = TimeRange::new(1000, 2000);
+        let time_range = TimeRange::new(1000, 2000).unwrap();
         let evolution = index.semantic_evolution(node_id, time_range)?;
 
         assert_eq!(evolution.len(), 0);
@@ -2678,7 +2678,7 @@ mod tests {
         index.on_transaction_at(3000)?;
 
         let reference = vec![1.0, 0.0, 0.0, 0.0];
-        let time_range = TimeRange::new(1000, 3000);
+        let time_range = TimeRange::new(1000, 3000).unwrap();
         let drift = index.track_semantic_drift(node_id, &reference, time_range)?;
 
         assert_eq!(drift.len(), 3);
@@ -2714,7 +2714,7 @@ mod tests {
         index.add(node_id, &[0.0, 1.0, 0.0, 0.0], 4000)?;
         index.on_transaction_at(4000)?;
 
-        let time_range = TimeRange::new(1000, 4000);
+        let time_range = TimeRange::new(1000, 4000).unwrap();
         let drift = index.calculate_consecutive_drift(node_id, time_range)?;
 
         assert_eq!(drift.len(), 3);
@@ -2741,7 +2741,7 @@ mod tests {
         index.add(node_id, &[1.0, 0.0, 0.0, 0.0], 1000)?;
         index.on_transaction_at(1000)?;
 
-        let time_range = TimeRange::new(1000, 2000);
+        let time_range = TimeRange::new(1000, 2000).unwrap();
         let drift = index.calculate_consecutive_drift(node_id, time_range)?;
 
         assert_eq!(drift.len(), 0);
@@ -2768,7 +2768,7 @@ mod tests {
         index.add(node_id, &[0.0, 1.0, 0.0, 0.0], 2000)?;
         index.on_transaction_at(2000)?;
 
-        let time_range = TimeRange::new(1000, 2000);
+        let time_range = TimeRange::new(1000, 2000).unwrap();
         let evolution = index.semantic_evolution(node_id, time_range)?;
 
         assert_eq!(evolution.len(), 2);
@@ -2799,7 +2799,7 @@ mod tests {
 
         assert_eq!(index.snapshot_count(), 3);
 
-        let time_range = TimeRange::new(1000, 5000);
+        let time_range = TimeRange::new(1000, 5000).unwrap();
         let evolution = index.semantic_evolution(node_id, time_range)?;
 
         assert_eq!(evolution.len(), 3);
@@ -2827,7 +2827,7 @@ mod tests {
         index.on_transaction_at(1000)?;
 
         let wrong_dimension_ref = vec![1.0, 0.0, 0.0];
-        let time_range = TimeRange::new(1000, 2000);
+        let time_range = TimeRange::new(1000, 2000).unwrap();
 
         let result = index.track_semantic_drift(node_id, &wrong_dimension_ref, time_range);
 
@@ -2894,7 +2894,7 @@ mod tests {
         )?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, i64::MAX);
+        let time_range = TimeRange::new(0, i64::MAX).unwrap();
 
         let results = index.find_semantic_drift(0.2, time_range, DriftMetric::Cosine)?;
 
@@ -2956,7 +2956,7 @@ mod tests {
         )?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, i64::MAX);
+        let time_range = TimeRange::new(0, i64::MAX).unwrap();
         let results = index.find_semantic_drift(0.0, time_range, DriftMetric::Cosine)?;
 
         assert_eq!(results.len(), 3);
@@ -2995,7 +2995,7 @@ mod tests {
         index.add(node2, &[0.0, 1.0, 0.0, 0.0], ts)?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, i64::MAX);
+        let time_range = TimeRange::new(0, i64::MAX).unwrap();
         let results = index.find_semantic_drift(0.0, time_range, DriftMetric::Cosine)?;
 
         assert_eq!(results.len(), 1);
@@ -3021,7 +3021,7 @@ mod tests {
         index.add(node1, &[1.0, 0.0, 0.0, 0.0], ts)?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, 100);
+        let time_range = TimeRange::new(0, 100).unwrap();
         let results = index.find_semantic_drift(0.0, time_range, DriftMetric::Cosine)?;
 
         assert_eq!(results.len(), 0);
@@ -3050,7 +3050,7 @@ mod tests {
         index.add(node1, &[0.9, 0.1, 0.0, 0.0], ts)?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, i64::MAX);
+        let time_range = TimeRange::new(0, i64::MAX).unwrap();
 
         let results = index.find_semantic_drift(0.0, time_range, DriftMetric::Cosine)?;
         assert_eq!(results.len(), 1);
@@ -3082,7 +3082,7 @@ mod tests {
         index.add(node1, &[0.0, 1.0, 0.0, 0.0], ts)?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, i64::MAX);
+        let time_range = TimeRange::new(0, i64::MAX).unwrap();
 
         let cosine_results = index.find_semantic_drift(0.5, time_range, DriftMetric::Cosine)?;
         assert_eq!(cosine_results.len(), 1);
@@ -3118,7 +3118,7 @@ mod tests {
         index.add(node1, &[0.0, 1.0, 0.0, 0.0], ts)?;
         index.on_transaction_at(ts)?;
 
-        let time_range = TimeRange::new(0, i64::MAX);
+        let time_range = TimeRange::new(0, i64::MAX).unwrap();
 
         let cosine_results = index.find_semantic_drift(0.0, time_range, DriftMetric::Cosine)?;
         assert_eq!(cosine_results[0].1, 1.0);
@@ -4061,7 +4061,7 @@ mod tests {
         // With full_snapshot_interval=10, we get full snapshots at 0 and 10,
         // so max delta chain is 5 (snapshots 11-15), well under MAX_DELTA_CHAIN_DEPTH
         use crate::core::temporal::TimeRange;
-        let time_range = TimeRange::new(1000, 2500);
+        let time_range = TimeRange::new(1000, 2500).unwrap();
         let result = index.find_semantic_drift(
             0.1, // threshold
             time_range,

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -1224,7 +1224,10 @@ mod tests {
             .add_node_version(
                 node_id,
                 v1,
-                BiTemporalInterval::new(TimeRange::new(0, 1000), TimeRange::new(0, Timestamp::MAX)),
+                BiTemporalInterval::new(
+                    TimeRange::new(0, 1000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
+                ),
                 label,
                 PropertyMapBuilder::new().insert("age", 30i64).build(),
             )
@@ -1235,8 +1238,8 @@ mod tests {
                 node_id,
                 v2,
                 BiTemporalInterval::new(
-                    TimeRange::new(1000, 2000),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(1000, 2000).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
                 label,
                 PropertyMapBuilder::new().insert("age", 31i64).build(),
@@ -1248,8 +1251,8 @@ mod tests {
                 node_id,
                 v3,
                 BiTemporalInterval::new(
-                    TimeRange::new(2000, Timestamp::MAX),
-                    TimeRange::new(0, Timestamp::MAX),
+                    TimeRange::new(2000, Timestamp::MAX).unwrap(),
+                    TimeRange::new(0, Timestamp::MAX).unwrap(),
                 ),
                 label,
                 PropertyMapBuilder::new().insert("age", 32i64).build(),
@@ -1842,8 +1845,8 @@ mod tests {
                     node_id,
                     VersionId::new(i as u64).unwrap(),
                     BiTemporalInterval::new(
-                        TimeRange::new(*start, *end),
-                        TimeRange::new(0, Timestamp::MAX),
+                        TimeRange::new(*start, *end).unwrap(),
+                        TimeRange::new(0, Timestamp::MAX).unwrap(),
                     ),
                     label,
                     PropertyMapBuilder::new()

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -2228,8 +2228,8 @@ mod tests {
 
         // Create specific temporal interval
         let temporal = BiTemporalInterval::new(
-            TimeRange::new(1000, 2000),
-            TimeRange::new(3000, crate::core::temporal::TIMESTAMP_MAX),
+            TimeRange::new(1000, 2000).unwrap(),
+            TimeRange::new(3000, crate::core::temporal::TIMESTAMP_MAX).unwrap(),
         );
 
         let operation = WalOperation::CreateNode {
@@ -2291,8 +2291,10 @@ mod tests {
             .insert("weight", 0.85f64)
             .build();
 
-        let temporal =
-            BiTemporalInterval::new(TimeRange::new(5000, 6000), TimeRange::new(7000, 8000));
+        let temporal = BiTemporalInterval::new(
+            TimeRange::new(5000, 6000).unwrap(),
+            TimeRange::new(7000, 8000).unwrap(),
+        );
 
         let operation = WalOperation::CreateEdge {
             edge_id: EdgeId::new(99).unwrap(),
@@ -2353,8 +2355,10 @@ mod tests {
             .insert("age", 31i64) // Updated age
             .build();
 
-        let temporal =
-            BiTemporalInterval::new(TimeRange::new(10000, 20000), TimeRange::from(15000));
+        let temporal = BiTemporalInterval::new(
+            TimeRange::new(10000, 20000).unwrap(),
+            TimeRange::from(15000),
+        );
 
         let operation = WalOperation::UpdateNode {
             node_id: NodeId::new(42).unwrap(),
@@ -2402,7 +2406,10 @@ mod tests {
 
         let mut wal = WriteAheadLog::new(config)?;
 
-        let temporal = BiTemporalInterval::new(TimeRange::new(100, 200), TimeRange::new(300, 400));
+        let temporal = BiTemporalInterval::new(
+            TimeRange::new(100, 200).unwrap(),
+            TimeRange::new(300, 400).unwrap(),
+        );
 
         wal.append(WalOperation::DeleteNode {
             node_id: NodeId::new(5).unwrap(),
@@ -2507,8 +2514,10 @@ mod tests {
                 .insert("key", "value")
                 .insert("count", 42i64)
                 .build();
-            original_temporal =
-                BiTemporalInterval::new(TimeRange::new(1000, 2000), TimeRange::new(3000, 4000));
+            original_temporal = BiTemporalInterval::new(
+                TimeRange::new(1000, 2000).unwrap(),
+                TimeRange::new(3000, 4000).unwrap(),
+            );
 
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(100).unwrap(),

--- a/tests/semantic_drift_detection.rs
+++ b/tests/semantic_drift_detection.rs
@@ -121,7 +121,7 @@ fn test_semantic_drift_detection_realistic_scenario() -> Result<()> {
     index.on_transaction_at(ts)?;
 
     // Query with threshold 0.3 - should get docs 4-9
-    let time_range = TimeRange::new(0, i64::MAX);
+    let time_range = TimeRange::new(0, i64::MAX).unwrap();
     let results = index.find_semantic_drift(0.3, time_range, DriftMetric::Cosine)?;
 
     // Verify results
@@ -235,7 +235,7 @@ fn test_semantic_drift_with_multiple_snapshots() -> Result<()> {
     }
 
     // Query for drift - should find the node
-    let time_range = TimeRange::new(0, i64::MAX);
+    let time_range = TimeRange::new(0, i64::MAX).unwrap();
     let results = index.find_semantic_drift(0.05, time_range, DriftMetric::Cosine)?;
 
     assert!(
@@ -296,7 +296,7 @@ fn test_semantic_drift_different_metrics() -> Result<()> {
     index.add(node_id, &embedding2, ts)?;
     index.on_transaction_at(ts)?;
 
-    let time_range = TimeRange::new(0, i64::MAX);
+    let time_range = TimeRange::new(0, i64::MAX).unwrap();
 
     // Test all three metrics
     let cosine_results = index.find_semantic_drift(0.0, time_range, DriftMetric::Cosine)?;

--- a/tests/temporal_vector.rs
+++ b/tests/temporal_vector.rs
@@ -116,7 +116,7 @@ fn test_time_range_vector_query() -> Result<()> {
 
     // Query across time range
     let query = vec![1.0, 0.0, 0.0, 0.0];
-    let time_range = TimeRange::between(base_time, base_time + 3000);
+    let time_range = TimeRange::between(base_time, base_time + 3000).unwrap();
     let results = index.find_similar_in_range(&query, 5, time_range)?;
 
     // Should have results for multiple snapshots
@@ -350,7 +350,7 @@ fn test_semantic_evolution_end_to_end() -> Result<()> {
 
     // Get semantic evolution
     // Use a very wide time range to capture all snapshots (which use real timestamps)
-    let time_range = TimeRange::between(0, i64::MAX);
+    let time_range = TimeRange::between(0, i64::MAX).unwrap();
     let evolution = index.semantic_evolution(node_id, time_range)?;
 
     // Verify we captured all changes
@@ -395,7 +395,7 @@ fn test_track_semantic_drift_over_time() -> Result<()> {
     // Track drift from original vector
     let reference = vec![1.0, 0.0, 0.0, 0.0];
     // Use wide time range to capture all snapshots
-    let time_range = TimeRange::between(0, i64::MAX);
+    let time_range = TimeRange::between(0, i64::MAX).unwrap();
     let drift = index.track_semantic_drift(node_id, &reference, time_range)?;
 
     // Should have 4 measurements
@@ -433,7 +433,7 @@ fn test_calculate_consecutive_drift_end_to_end() -> Result<()> {
 
     // Calculate consecutive drift
     // Use wide time range to capture all snapshots
-    let time_range = TimeRange::between(0, i64::MAX);
+    let time_range = TimeRange::between(0, i64::MAX).unwrap();
     let drift = index.calculate_consecutive_drift(node_id, time_range)?;
 
     // Should have 3 drift measurements (4 vectors -> 3 pairs)
@@ -476,7 +476,7 @@ fn test_semantic_evolution_with_gaps() -> Result<()> {
 
     // Get evolution for node1
     // Use wide time range to capture all snapshots
-    let time_range = TimeRange::between(0, i64::MAX);
+    let time_range = TimeRange::between(0, i64::MAX).unwrap();
     let evolution = index.semantic_evolution(node1, time_range)?;
 
     // Node1 appears in all 3 snapshots:
@@ -504,7 +504,7 @@ fn test_empty_evolution_for_nonexistent_node() -> Result<()> {
 
     // Query for non-existent node
     let nonexistent = NodeId::new(999).unwrap();
-    let time_range = TimeRange::between(base_time, base_time + 1000);
+    let time_range = TimeRange::between(base_time, base_time + 1000).unwrap();
     let evolution = index.semantic_evolution(nonexistent, time_range)?;
 
     // Should return empty, not error
@@ -541,7 +541,7 @@ fn test_drift_calculation_with_normalized_vectors() -> Result<()> {
 
     // Calculate consecutive drift
     // Use wide time range to capture all snapshots
-    let time_range = TimeRange::between(0, i64::MAX);
+    let time_range = TimeRange::between(0, i64::MAX).unwrap();
     let drift = index.calculate_consecutive_drift(node_id, time_range)?;
 
     // Should have 2 drift measurements

--- a/tests/temporal_vector_tests.rs
+++ b/tests/temporal_vector_tests.rs
@@ -114,7 +114,7 @@ fn test_find_similar_in_range() -> Result<()> {
 
     // Query range from 1500 to 2500
     let query = vec![1.0, 0.0, 0.0, 0.0];
-    let time_range = TimeRange::new(1500, 2500);
+    let time_range = TimeRange::new(1500, 2500).unwrap();
     let results = index.find_similar_in_range(&query, 5, time_range)?;
 
     // Should have results for timestamps in range


### PR DESCRIPTION
## Summary
- `TimeRange::new()` and `TimeRange::between()` now return `Result<Self, TemporalError>` instead of `Self`
- Validation is now performed in both debug and release builds
- Invalid time ranges (start > end) return `TemporalError::InvalidTimeRange`

## Problem
Previously, `TimeRange::new()` used `debug_assert!` for validation, meaning invalid ranges could be created in release builds. This is a correctness issue as documented in issue #18.

## Solution
Changed `TimeRange::new()` and `TimeRange::between()` to return `Result` types that validate the range and return an error for invalid inputs. Updated all callers throughout the codebase to handle the `Result`.

## Test plan
- [x] Added tests for valid range creation (`test_time_range_valid_returns_ok`)
- [x] Added tests for invalid range creation (`test_time_range_invalid_returns_error`)
- [x] Added tests for equal start/end (`test_time_range_equal_start_end_returns_ok`)
- [x] All existing tests pass (738 tests)
- [x] Clippy passes with no warnings
- [x] Code formatted with `cargo fmt`

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)