### PR TITLE
Add configurable benchmark timing via environment variables

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,6 +60,10 @@ jobs:
           python-version: '3.11'
 
       - name: Run benchmarks
+        env:
+          BENCH_SAMPLE_SIZE: 10
+          BENCH_MEASUREMENT_TIME: 1
+          BENCH_WARMUP_TIME: 1
         run: |
           set -o pipefail  # Ensure piped commands propagate failures
 
@@ -75,9 +79,9 @@ jobs:
             BENCH_TARGETS="--bench current_state --bench gallifreydb --bench transactions"
           fi
 
-          # Run benchmarks and capture output for github-action-benchmark 'cargo' tool support
-          # Use --sample-size 10 for balance between CI speed and statistical validity
-          cargo bench --all-features $BENCH_TARGETS -- --sample-size 10 | tee output.txt
+          # Run benchmarks with configured timing parameters
+          # BENCH_SAMPLE_SIZE, BENCH_MEASUREMENT_TIME, and BENCH_WARMUP_TIME are read from env
+          cargo bench --all-features $BENCH_TARGETS | tee output.txt
 
           # Verify that Criterion generated output
           if [ ! -d "target/criterion" ]; then

--- a/benches/async_wal_writer.rs
+++ b/benches/async_wal_writer.rs
@@ -23,6 +23,8 @@
 //! - Smaller buffer → lower latency to disk, less memory, more frequent fsync
 //! - Optimal buffer size depends on workload (typically 1000-10000)
 
+mod common;
+
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gallifreydb::core::id::NodeId;
 use gallifreydb::core::property::PropertyMap;
@@ -156,8 +158,9 @@ fn bench_async_write_batching(c: &mut Criterion) {
 }
 
 criterion_group!(
-    benches,
-    bench_async_write_latency,
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_async_write_latency,
     bench_async_write_throughput,
     bench_async_write_batching
 );

--- a/benches/checkpoints.rs
+++ b/benches/checkpoints.rs
@@ -1,5 +1,7 @@
 //! Benchmarks for checkpoint creation, loading, and recovery operations
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::core::{
     property::PropertyMapBuilder,
@@ -184,17 +186,9 @@ fn bench_recovery(c: &mut Criterion) {
     group.finish();
 }
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = benches;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_checkpoint_creation,
     bench_checkpoint_load,
     bench_recovery

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,0 +1,58 @@
+//! Common utilities for benchmarks.
+//!
+//! This module provides shared configuration and helper functions
+//! used across all benchmark suites.
+
+use criterion::Criterion;
+use std::time::Duration;
+
+/// Configure Criterion with environment variable overrides.
+///
+/// This function reads the following environment variables:
+/// - `BENCH_SAMPLE_SIZE`: Number of samples per benchmark (default: 50)
+/// - `BENCH_MEASUREMENT_TIME`: Measurement time in seconds (default: 5)
+/// - `BENCH_WARMUP_TIME`: Warm-up time in seconds (default: 3)
+///
+/// # Examples
+///
+/// ```ignore
+/// // In your benchmark file
+/// mod common;
+///
+/// criterion_group!(
+///     name = my_benches;
+///     config = common::configure_criterion();
+///     targets = my_benchmark_function
+/// );
+/// ```
+///
+/// # Environment Variable Usage
+///
+/// ```bash
+/// # Fast CI benchmarks
+/// BENCH_SAMPLE_SIZE=10 BENCH_MEASUREMENT_TIME=1 BENCH_WARMUP_TIME=1 cargo bench
+///
+/// # Production benchmarks
+/// BENCH_SAMPLE_SIZE=100 BENCH_MEASUREMENT_TIME=10 BENCH_WARMUP_TIME=5 cargo bench
+/// ```
+pub fn configure_criterion() -> Criterion {
+    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+
+    let measurement_time_secs = std::env::var("BENCH_MEASUREMENT_TIME")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+
+    let warmup_time_secs = std::env::var("BENCH_WARMUP_TIME")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+
+    Criterion::default()
+        .sample_size(sample_size)
+        .measurement_time(Duration::from_secs(measurement_time_secs))
+        .warm_up_time(Duration::from_secs(warmup_time_secs))
+}

--- a/benches/current_state.rs
+++ b/benches/current_state.rs
@@ -12,6 +12,8 @@
 //! - Node lookup: <100ns
 //! - Edge creation: <10µs
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::core::id::IdGenerator;
 use gallifreydb::core::interning::StringInterner;
@@ -548,17 +550,9 @@ fn bench_string_hot_path(c: &mut Criterion) {
     group.finish();
 }
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = benches;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_single_hop_traversal,
     bench_multi_hop_traversal,
     bench_node_lookup,

--- a/benches/durability_modes.rs
+++ b/benches/durability_modes.rs
@@ -11,6 +11,8 @@
 //! - WAL throughput (batch operations)
 //! - Sync vs async WAL modes
 
+mod common;
+
 use criterion::{
     BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
@@ -769,8 +771,9 @@ fn bench_wal_with_sync(c: &mut Criterion) {
 }
 
 criterion_group!(
-    benches,
-    bench_single_transaction_latency,
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_single_transaction_latency,
     bench_batch_throughput,
     bench_concurrent_writes,
     bench_group_commit_batch_sizes,

--- a/benches/gallifreydb.rs
+++ b/benches/gallifreydb.rs
@@ -8,6 +8,8 @@
 //! NOTE: These benchmarks use Async durability mode to isolate graph performance
 //! from WAL flush overhead. See durability_modes.rs for durability-focused benchmarks.
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::{
     GallifreyDB, NodeId, PropertyMapBuilder, WriteOps,
@@ -330,17 +332,9 @@ fn bench_batch_operations(c: &mut Criterion) {
     group.finish();
 }
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = benches;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_node_creation_with_versioning,
     bench_edge_creation_with_versioning,
     bench_current_state_queries,

--- a/benches/hnsw_index.rs
+++ b/benches/hnsw_index.rs
@@ -7,6 +7,8 @@
 //! - Filtered search (by label)
 //! - HNSW parameter tuning (M, ef_construction, ef_search)
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gallifreydb::core::id::NodeId;
 use gallifreydb::index::vector::hnsw::{HnswConfig, HnswIndex};
@@ -330,17 +332,9 @@ fn bench_distance_metrics(c: &mut Criterion) {
 // Benchmark Groups
 // ============================================================================
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = index_ops;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_index_creation,
     bench_vector_addition_single,
     bench_vector_addition_batch,
@@ -348,14 +342,14 @@ criterion_group!(
 
 criterion_group!(
     name = search_ops;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_knn_search,
     bench_knn_search_index_size,
 );
 
 criterion_group!(
     name = tuning_ops;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_hnsw_parameter_m,
     bench_hnsw_parameter_ef_construction,
     bench_hnsw_parameter_ef_search,

--- a/benches/temporal_query.rs
+++ b/benches/temporal_query.rs
@@ -6,6 +6,8 @@
 //! - Concurrent read/write patterns
 //! - Cache effectiveness
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::GallifreyDB;
 use gallifreydb::api::transaction::WriteOps;
@@ -645,8 +647,9 @@ fn setup_database_with_versions(count: usize) -> GallifreyDB {
 }
 
 criterion_group!(
-    benches,
-    bench_valid_at_query,
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_valid_at_query,
     bench_insert_performance,
     bench_concurrent_write_throughput,
     bench_read_latency_under_write_contention,

--- a/benches/temporal_vector.rs
+++ b/benches/temporal_vector.rs
@@ -7,6 +7,8 @@
 //! - Snapshot pruning
 //! - Temporal vector index overhead vs current-only index
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gallifreydb::core::id::NodeId;
 use gallifreydb::core::temporal::TimeRange;
@@ -502,17 +504,9 @@ fn bench_semantic_evolution_memory_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = benches;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_snapshot_creation,
     bench_point_in_time_queries,
     bench_time_range_queries,

--- a/benches/transactions.rs
+++ b/benches/transactions.rs
@@ -3,6 +3,8 @@
 //! These benchmarks measure the overhead introduced by the transaction layer
 //! compared to direct operations.
 
+mod common;
+
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::{GallifreyDB, PropertyMapBuilder, ReadOps, WriteOps};
 use std::sync::Arc;
@@ -840,17 +842,9 @@ fn bench_commit_vector_vs_nonvector(c: &mut Criterion) {
     group.finish();
 }
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = benches;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_read_transaction_creation,
     bench_write_transaction_creation,
     bench_closure_based_write_empty,

--- a/benches/vector_similarity.rs
+++ b/benches/vector_similarity.rs
@@ -11,6 +11,8 @@
 //! - 1536: OpenAI text-embedding-3-small
 //! - 3072: OpenAI text-embedding-3-large
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gallifreydb::core::vector::{
     cosine_similarity, cosine_similarity_normalized, dot_product, euclidean_distance,
@@ -439,17 +441,9 @@ fn bench_dot_product_batch(c: &mut Criterion) {
     group.finish();
 }
 
-fn configure_criterion() -> Criterion {
-    let sample_size = std::env::var("BENCH_SAMPLE_SIZE")
-        .map(|s| s.parse().unwrap_or(50))
-        .unwrap_or(50);
-
-    Criterion::default().sample_size(sample_size)
-}
-
 criterion_group!(
     name = benches;
-    config = configure_criterion();
+    config = common::configure_criterion();
     targets = bench_cosine_similarity_dimensions,
     bench_cosine_similarity_openai,
     bench_cosine_similarity_normalized,


### PR DESCRIPTION
Adds support for configuring Criterion benchmark timing parameters via environment variables for faster CI runs and flexible local profiling.