### PR TITLE
Query Planner: Migrate HistoricalStorage to parking_lot::RwLock

### DIFF
--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -15,7 +15,8 @@ use crate::storage::historical::HistoricalStorage;
 use crate::storage::version::VersionMetadata;
 use crate::utils::error::{Result, StorageError};
 use crate::utils::lock::RwLockExt;
-use std::sync::{Arc, RwLock};
+use parking_lot::RwLock;
+use std::sync::Arc;
 
 /// Read-only transaction
 ///
@@ -277,6 +278,7 @@ mod tests {
     use super::*;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::time;
+    use parking_lot::RwLock;
     use std::collections::HashSet;
     use std::sync::Arc;
 

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -25,7 +25,8 @@ use crate::storage::historical::HistoricalStorage;
 use crate::storage::wal::{DurabilityMode, WalOperation, WriteAheadLog};
 use crate::utils::error::{Result, StorageError, TransactionError};
 use crate::utils::lock::{MutexExt, RwLockExt};
-use std::sync::{Arc, Mutex, RwLock};
+use parking_lot::RwLock;
+use std::sync::{Arc, Mutex};
 
 /// Write transaction with full ACID guarantees.
 ///
@@ -1721,7 +1722,7 @@ mod tests {
         assert!(current.get_node(node_id).is_err());
 
         // Verify tombstone version was created in historical storage
-        let historical = historical.read().unwrap();
+        let historical = historical.read();
         let stats = historical.stats();
         assert!(
             stats.total_node_versions > 0,
@@ -1761,7 +1762,7 @@ mod tests {
         assert!(current.get_edge(edge_id).is_err());
 
         // Verify tombstone version was created in historical storage
-        let historical = historical.read().unwrap();
+        let historical = historical.read();
         let stats = historical.stats();
         assert!(
             stats.total_edge_versions > 0,

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,7 +22,8 @@ use crate::storage::version::AnchorConfig;
 use crate::storage::wal::{DurabilityMode, WalConfig, WriteAheadLog, WriteOptions};
 use crate::utils::error::{Result, StorageError};
 use crate::utils::lock::{MutexExt, RwLockExt};
-use std::sync::{Arc, Mutex, RwLock};
+use parking_lot::RwLock;
+use std::sync::{Arc, Mutex};
 
 /// Main GallifreyDB database.
 ///
@@ -843,13 +844,7 @@ impl GallifreyDB {
         let node_hook = Arc::clone(&hook);
         let edge_hook = hook;
 
-        let mut historical = self.historical.write().map_err(|_| {
-            crate::utils::error::Error::Storage(
-                crate::utils::error::StorageError::InconsistentState {
-                    reason: "Historical storage lock poisoned".to_string(),
-                },
-            )
-        })?;
+        let mut historical = self.historical.write();
 
         historical.register_pre_node_anchor_hook(node_hook);
         historical.register_pre_edge_anchor_hook(edge_hook);

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -3,8 +3,9 @@
 //! Pull-based iterators for query execution. Each physical operator
 //! has a corresponding iterator that lazily produces results.
 
+use parking_lot::RwLock;
 use std::collections::{HashSet, VecDeque};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[cfg(feature = "observability")]
 use tracing;
@@ -233,11 +234,7 @@ impl ResultIterator for TemporalNodeIterator {
         self.node_ids.next().map(|id| {
             // Acquire read lock on historical storage (per-node)
             // For bulk queries, use BatchTemporalNodeIterator instead
-            let historical = self.historical.read().map_err(|_| {
-                crate::utils::error::StorageError::LockPoisoned {
-                    lock_type: "historical_storage_read",
-                }
-            })?;
+            let historical = self.historical.read();
 
             // Find the version valid at the requested time
             let version_id =
@@ -308,12 +305,7 @@ impl BatchTemporalNodeIterator {
         historical: Arc<RwLock<HistoricalStorage>>,
     ) -> Result<Self> {
         // Acquire lock once for all nodes
-        let guard =
-            historical
-                .read()
-                .map_err(|_| crate::utils::error::StorageError::LockPoisoned {
-                    lock_type: "historical_storage_read",
-                })?;
+        let guard = historical.read();
 
         // Reconstruct all nodes while holding the lock
         let results: Vec<Result<QueryRow>> = node_ids
@@ -1993,7 +1985,7 @@ mod tests {
             .intern("Person")
             .unwrap();
         {
-            let mut hist = historical.write().unwrap();
+            let mut hist = historical.write();
             hist.add_node_version(
                 node,
                 crate::core::id::VersionId::new(1).unwrap(),
@@ -2037,7 +2029,7 @@ mod tests {
         use crate::storage::historical::HistoricalStorage;
 
         let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
-        let mut hist = historical.write().unwrap();
+        let mut hist = historical.write();
 
         // Add 3 nodes
         for i in 1..=3 {

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -7,12 +7,8 @@
 mod iterators;
 mod results;
 
-// TODO: Consider migrating to parking_lot::RwLock for consistency with CurrentStorage
-// and other performance-critical components. Currently using std::sync::RwLock to match
-// the type used in db.rs for HistoricalStorage. A dedicated PR should migrate all
-// historical storage access (db.rs, read_tx.rs, write_tx.rs) to parking_lot::RwLock.
-// See: CurrentStorage, HnswIndex, TemporalVectorIndex which already use parking_lot.
-use std::sync::{Arc, RwLock};
+use parking_lot::RwLock;
+use std::sync::Arc;
 
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
@@ -259,7 +255,7 @@ mod tests {
             .unwrap();
         let bob_label = alice_label;
         {
-            let mut hist = historical.write().unwrap();
+            let mut hist = historical.write();
             hist.add_node_version(
                 alice,
                 crate::core::id::VersionId::new(1).unwrap(),

--- a/src/utils/lock.rs
+++ b/src/utils/lock.rs
@@ -25,6 +25,12 @@ use std::sync::{Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockW
 
 use super::error::{Error, StorageError};
 
+// Import parking_lot types for the implementation
+use parking_lot::{
+    RwLock as ParkingLotRwLock, RwLockReadGuard as ParkingLotRwLockReadGuard,
+    RwLockWriteGuard as ParkingLotRwLockWriteGuard,
+};
+
 /// Extension trait for `Mutex` providing graceful error handling.
 pub trait MutexExt<T> {
     /// Acquire the lock, returning an error if the lock is poisoned.
@@ -90,6 +96,18 @@ impl<T> MutexExt<T> for Mutex<T> {
 
 /// Extension trait for `RwLock` providing graceful error handling.
 pub trait RwLockExt<T> {
+    /// The type of the read guard returned by this lock
+    type ReadGuard<'a>
+    where
+        Self: 'a,
+        T: 'a;
+
+    /// The type of the write guard returned by this lock
+    type WriteGuard<'a>
+    where
+        Self: 'a,
+        T: 'a;
+
     /// Acquire a read lock, returning an error if the lock is poisoned.
     ///
     /// This method is equivalent to `read().unwrap()` but returns a `Result`
@@ -99,7 +117,7 @@ pub trait RwLockExt<T> {
     ///
     /// Returns `Error::Storage(StorageError::LockPoisoned)` if the lock has been
     /// poisoned by a panicking thread.
-    fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error>;
+    fn read_or_err(&self) -> Result<Self::ReadGuard<'_>, Error>;
 
     /// Acquire a write lock, returning an error if the lock is poisoned.
     ///
@@ -110,20 +128,29 @@ pub trait RwLockExt<T> {
     ///
     /// Returns `Error::Storage(StorageError::LockPoisoned)` if the lock has been
     /// poisoned by a panicking thread.
-    fn write_or_err(&self) -> Result<RwLockWriteGuard<'_, T>, Error>;
+    fn write_or_err(&self) -> Result<Self::WriteGuard<'_>, Error>;
 
     /// Acquire a read lock, recovering even if poisoned.
     ///
     /// Use with caution - see `MutexExt::lock_or_recover` for safety considerations.
-    fn read_or_recover(&self) -> RwLockReadGuard<'_, T>;
+    fn read_or_recover(&self) -> Self::ReadGuard<'_>;
 
     /// Acquire a write lock, recovering even if poisoned.
     ///
     /// Use with caution - see `MutexExt::lock_or_recover` for safety considerations.
-    fn write_or_recover(&self) -> RwLockWriteGuard<'_, T>;
+    fn write_or_recover(&self) -> Self::WriteGuard<'_>;
 }
 
 impl<T> RwLockExt<T> for RwLock<T> {
+    type ReadGuard<'a>
+        = RwLockReadGuard<'a, T>
+    where
+        T: 'a;
+    type WriteGuard<'a>
+        = RwLockWriteGuard<'a, T>
+    where
+        T: 'a;
+
     fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
         // Debug-only: Track read lock acquisitions
         #[cfg(all(debug_assertions, feature = "observability"))]
@@ -192,6 +219,65 @@ impl<T> RwLockExt<T> for RwLock<T> {
 
     fn write_or_recover(&self) -> RwLockWriteGuard<'_, T> {
         self.write().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Implementation of `RwLockExt` for `parking_lot::RwLock`.
+///
+/// Since `parking_lot::RwLock` doesn't have lock poisoning, these methods
+/// simply acquire the lock and return it. This provides a consistent API
+/// across both lock types while maintaining the performance benefits of
+/// `parking_lot`.
+impl<T> RwLockExt<T> for ParkingLotRwLock<T> {
+    type ReadGuard<'a>
+        = ParkingLotRwLockReadGuard<'a, T>
+    where
+        T: 'a;
+    type WriteGuard<'a>
+        = ParkingLotRwLockWriteGuard<'a, T>
+    where
+        T: 'a;
+
+    fn read_or_err(&self) -> Result<ParkingLotRwLockReadGuard<'_, T>, Error> {
+        // Debug-only: Track read lock acquisitions
+        #[cfg(all(debug_assertions, feature = "observability"))]
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static READ_LOCK_COUNT: AtomicU64 = AtomicU64::new(0);
+            let count = READ_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
+            if count.is_multiple_of(10000) {
+                tracing::debug!(count, "parking_lot::RwLock read acquisition count");
+            }
+        }
+
+        // parking_lot::RwLock doesn't have poisoning, so we just acquire the lock
+        Ok(self.read())
+    }
+
+    fn write_or_err(&self) -> Result<ParkingLotRwLockWriteGuard<'_, T>, Error> {
+        // Debug-only: Track write lock acquisitions
+        #[cfg(all(debug_assertions, feature = "observability"))]
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static WRITE_LOCK_COUNT: AtomicU64 = AtomicU64::new(0);
+            let count = WRITE_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
+            if count.is_multiple_of(10000) {
+                tracing::debug!(count, "parking_lot::RwLock write acquisition count");
+            }
+        }
+
+        // parking_lot::RwLock doesn't have poisoning, so we just acquire the lock
+        Ok(self.write())
+    }
+
+    fn read_or_recover(&self) -> ParkingLotRwLockReadGuard<'_, T> {
+        // No poisoning in parking_lot, so just acquire the lock
+        self.read()
+    }
+
+    fn write_or_recover(&self) -> ParkingLotRwLockWriteGuard<'_, T> {
+        // No poisoning in parking_lot, so just acquire the lock
+        self.write()
     }
 }
 

--- a/src/utils/lock.rs
+++ b/src/utils/lock.rs
@@ -31,6 +31,24 @@ use parking_lot::{
     RwLockWriteGuard as ParkingLotRwLockWriteGuard,
 };
 
+/// Macro to track lock acquisitions for debugging and observability.
+///
+/// This macro is used to reduce code duplication across different lock
+/// implementations while maintaining debug-only tracking.
+macro_rules! track_lock_acquisition {
+    ($counter:ident, $lock_name:expr) => {
+        #[cfg(all(debug_assertions, feature = "observability"))]
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static $counter: AtomicU64 = AtomicU64::new(0);
+            let count = $counter.fetch_add(1, Ordering::Relaxed);
+            if count.is_multiple_of(10000) {
+                tracing::debug!(count, concat!($lock_name, " acquisition count"));
+            }
+        }
+    };
+}
+
 /// Extension trait for `Mutex` providing graceful error handling.
 pub trait MutexExt<T> {
     /// Acquire the lock, returning an error if the lock is poisoned.
@@ -152,16 +170,7 @@ impl<T> RwLockExt<T> for RwLock<T> {
         T: 'a;
 
     fn read_or_err(&self) -> Result<RwLockReadGuard<'_, T>, Error> {
-        // Debug-only: Track read lock acquisitions
-        #[cfg(all(debug_assertions, feature = "observability"))]
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            static READ_LOCK_COUNT: AtomicU64 = AtomicU64::new(0);
-            let count = READ_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
-            if count.is_multiple_of(10000) {
-                tracing::debug!(count, "RwLock read acquisition count");
-            }
-        }
+        track_lock_acquisition!(READ_LOCK_COUNT, "std::sync::RwLock read");
 
         self.read().map_err(|_| {
             #[cfg(feature = "observability")]
@@ -183,16 +192,7 @@ impl<T> RwLockExt<T> for RwLock<T> {
     }
 
     fn write_or_err(&self) -> Result<RwLockWriteGuard<'_, T>, Error> {
-        // Debug-only: Track write lock acquisitions
-        #[cfg(all(debug_assertions, feature = "observability"))]
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            static WRITE_LOCK_COUNT: AtomicU64 = AtomicU64::new(0);
-            let count = WRITE_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
-            if count.is_multiple_of(10000) {
-                tracing::debug!(count, "RwLock write acquisition count");
-            }
-        }
+        track_lock_acquisition!(WRITE_LOCK_COUNT, "std::sync::RwLock write");
 
         self.write().map_err(|_| {
             #[cfg(feature = "observability")]
@@ -239,32 +239,14 @@ impl<T> RwLockExt<T> for ParkingLotRwLock<T> {
         T: 'a;
 
     fn read_or_err(&self) -> Result<ParkingLotRwLockReadGuard<'_, T>, Error> {
-        // Debug-only: Track read lock acquisitions
-        #[cfg(all(debug_assertions, feature = "observability"))]
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            static READ_LOCK_COUNT: AtomicU64 = AtomicU64::new(0);
-            let count = READ_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
-            if count.is_multiple_of(10000) {
-                tracing::debug!(count, "parking_lot::RwLock read acquisition count");
-            }
-        }
+        track_lock_acquisition!(PARKING_LOT_READ_LOCK_COUNT, "parking_lot::RwLock read");
 
         // parking_lot::RwLock doesn't have poisoning, so we just acquire the lock
         Ok(self.read())
     }
 
     fn write_or_err(&self) -> Result<ParkingLotRwLockWriteGuard<'_, T>, Error> {
-        // Debug-only: Track write lock acquisitions
-        #[cfg(all(debug_assertions, feature = "observability"))]
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            static WRITE_LOCK_COUNT: AtomicU64 = AtomicU64::new(0);
-            let count = WRITE_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
-            if count.is_multiple_of(10000) {
-                tracing::debug!(count, "parking_lot::RwLock write acquisition count");
-            }
-        }
+        track_lock_acquisition!(PARKING_LOT_WRITE_LOCK_COUNT, "parking_lot::RwLock write");
 
         // parking_lot::RwLock doesn't have poisoning, so we just acquire the lock
         Ok(self.write())

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -895,7 +895,7 @@ fn test_execute_temporal_node_lookup_returns_historical_state() {
     // (after the first version starts but before the second version starts)
     let historical_timestamp = {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let current_version_id = hist_guard.get_current_node_version(node_id).unwrap();
         let current_version = hist_guard.get_node_version(current_version_id).unwrap();
         let prev_version_id = current_version.prev_version.unwrap();
@@ -938,7 +938,7 @@ fn test_execute_temporal_node_lookup_returns_historical_state() {
     println!("\n=== Version chain at query time ===");
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         if let Some(head_version_id) = hist_guard.get_current_node_version(node_id) {
             let mut current_id = head_version_id;
             let mut index = 0;

--- a/tests/temporal_debug.rs
+++ b/tests/temporal_debug.rs
@@ -23,7 +23,7 @@ fn test_temporal_lookup_directly() {
     // Get the timestamp of the first version from HistoricalStorage
     let t1 = {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let version_id = hist_guard.get_current_node_version(node_id).unwrap();
         let version = hist_guard.get_node_version(version_id).unwrap();
         // Use a timestamp between this version's start and the next update
@@ -57,7 +57,7 @@ fn test_temporal_lookup_directly() {
     println!("\n=== Dumping version chain ===");
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         if let Some(head_version_id) = hist_guard.get_current_node_version(node_id) {
             println!("Head version: {:?}", head_version_id);
             let mut current_id = head_version_id;
@@ -88,7 +88,7 @@ fn test_temporal_lookup_directly() {
     println!("\n=== Manual version lookup ===");
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         match hist_guard.find_node_version_at_time(node_id, t1, t1) {
             Some(version_id) => {
                 let version = hist_guard.get_node_version(version_id).unwrap();

--- a/tests/temporal_edge_tests.rs
+++ b/tests/temporal_edge_tests.rs
@@ -51,7 +51,7 @@ fn test_temporal_edge_lookup_basic() {
     // Get the timestamp of the first version from HistoricalStorage
     let t1 = {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let version_id = hist_guard.get_current_edge_version(edge_id).unwrap();
         let version = hist_guard.get_edge_version(version_id).unwrap();
         version.temporal.valid_time().start() + 1
@@ -85,7 +85,7 @@ fn test_temporal_edge_lookup_basic() {
     println!("\n=== Dumping edge version chain ===");
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         if let Some(head_version_id) = hist_guard.get_current_edge_version(edge_id) {
             println!("Head version: {:?}", head_version_id);
             let mut current_id = head_version_id;
@@ -116,7 +116,7 @@ fn test_temporal_edge_lookup_basic() {
     println!("\n=== Verifying temporal edge lookup at t1={} ===", t1);
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         match hist_guard.find_edge_version_at_time(edge_id, t1, t1) {
             Some(version_id) => {
                 let version = hist_guard.get_edge_version(version_id).unwrap();
@@ -182,7 +182,7 @@ fn test_temporal_edge_multiple_updates() {
     // Get timestamp of first version
     timestamps.push({
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let version_id = hist_guard.get_current_edge_version(edge_id).unwrap();
         let version = hist_guard.get_edge_version(version_id).unwrap();
         version.temporal.valid_time().start() + 1
@@ -205,7 +205,7 @@ fn test_temporal_edge_multiple_updates() {
         // Capture timestamp after each update
         timestamps.push({
             let historical = db.__test_historical_storage();
-            let hist_guard = historical.read().unwrap();
+            let hist_guard = historical.read();
             let version_id = hist_guard.get_current_edge_version(edge_id).unwrap();
             let version = hist_guard.get_edge_version(version_id).unwrap();
             version.temporal.valid_time().start() + 1
@@ -220,7 +220,7 @@ fn test_temporal_edge_multiple_updates() {
 
     // Verify we can retrieve each historical state
     let historical = db.__test_historical_storage();
-    let hist_guard = historical.read().unwrap();
+    let hist_guard = historical.read();
 
     for (i, &timestamp) in timestamps[..timestamps.len() - 1].iter().enumerate() {
         let version_id = hist_guard
@@ -273,7 +273,7 @@ fn test_temporal_edge_interval_closing() {
     // Get first version
     let (v1_id, v1_start) = {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let version_id = hist_guard.get_current_edge_version(edge_id).unwrap();
         let version = hist_guard.get_edge_version(version_id).unwrap();
         (version_id, version.temporal.valid_time().start())
@@ -293,7 +293,7 @@ fn test_temporal_edge_interval_closing() {
     // Get second version
     let v2_start = {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let version_id = hist_guard.get_current_edge_version(edge_id).unwrap();
         let version = hist_guard.get_edge_version(version_id).unwrap();
         version.temporal.valid_time().start()
@@ -302,7 +302,7 @@ fn test_temporal_edge_interval_closing() {
     // Verify first version interval was closed
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let v1 = hist_guard.get_edge_version(v1_id).unwrap();
 
         assert!(
@@ -323,7 +323,7 @@ fn test_temporal_edge_interval_closing() {
 
     // Verify temporal queries work correctly for both periods
     let historical = db.__test_historical_storage();
-    let hist_guard = historical.read().unwrap();
+    let hist_guard = historical.read();
 
     // Query at t1 (during v1)
     let t1 = v1_start + 1;
@@ -397,7 +397,7 @@ fn test_temporal_edge_version_chain_integrity() {
     // Verify version chain integrity
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
 
         let mut current_id = hist_guard.get_current_edge_version(edge_id).unwrap();
         let mut version_count = 0;
@@ -484,7 +484,7 @@ fn test_temporal_edge_anchor_delta_pattern() {
     // Verify anchor/delta pattern: v0(A), v1(D), v2(D), v3(A), v4(D), v5(D)
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
 
         let mut version_ids = vec![];
         let mut current_id = hist_guard.get_current_edge_version(edge_id).unwrap();
@@ -559,7 +559,7 @@ fn test_temporal_edge_with_vector_properties() {
     // Capture timestamp
     let t1 = {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
         let version_id = hist_guard.get_current_edge_version(edge_id).unwrap();
         let version = hist_guard.get_edge_version(version_id).unwrap();
         version.temporal.valid_time().start() + 1
@@ -583,7 +583,7 @@ fn test_temporal_edge_with_vector_properties() {
     // Verify temporal lookup returns correct vector
     {
         let historical = db.__test_historical_storage();
-        let hist_guard = historical.read().unwrap();
+        let hist_guard = historical.read();
 
         let version_id = hist_guard
             .find_edge_version_at_time(edge_id, t1, t1)

--- a/tests/temporal_vector_integration.rs
+++ b/tests/temporal_vector_integration.rs
@@ -316,7 +316,7 @@ fn test_vector_snapshot_id_stored_in_anchors() {
 
     // Access historical storage to verify snapshot IDs
     let historical = db.__test_historical_storage();
-    let historical_read = historical.read().expect("Failed to acquire read lock");
+    let historical_read = historical.read();
 
     // Check all node versions
     let mut anchor_count = 0;


### PR DESCRIPTION
## Summary
## Summary

Migrates all  access from  to  for consistency with other performance-critical components like , , and .

## Changes

- **src/db.rs**: Updated  field to use 
- **src/api/transaction/{read_tx,write_tx}.rs**: Updated imports and usage patterns
- **src/query/executor/{mod,iterators}.rs**: Updated imports and removed TODO comment
- **src/utils/lock.rs**: Added  trait implementation for  with associated types to support both std and parking_lot locks
- **tests/***: Removed / calls on lock acquisition since parking_lot doesn't return 

## Benefits

- **Consistent lock implementation** across the codebase
- **Better performance**: No lock poisoning overhead
- **Improved API ergonomics**: No need for  on lock acquisition

## Testing

- All existing tests pass (1013 tests)
- Clippy passes with all warnings as errors
- Code formatted with 

Resolves #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Created from worktree workflow.