### PR TITLE
docs: add wraparound, overflow, and mutex recovery documentation

### DIFF
--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -38,6 +38,33 @@
 //! - **Append latency**: ~50-100ns (lock-free)
 //! - **Throughput**: 500K+ entries/sec with 16+ stripes
 //! - **Scalability**: Linear up to 64 concurrent writers
+//!
+//! # Buffer Exhaustion / Backpressure
+//!
+//! When all stripes fill up faster than the flush coordinator can drain them:
+//!
+//! 1. **Non-blocking append (`try_append`)**: Returns `Err(entry)` immediately
+//!    after exponential spin backoff. The caller can retry, drop, or queue the
+//!    entry externally.
+//!
+//! 2. **Blocking append (`append_blocking`)**: Spins briefly, then sleeps with
+//!    exponential backoff (1µs → 2µs → 4µs → ... → 1ms) until space is available.
+//!    This provides automatic backpressure but may block the calling thread.
+//!
+//! 3. **Async append (`append_async`)**: Uses `append_blocking` internally, so
+//!    it will block until space is available. This is intentional - async here
+//!    means "no durability wait", not "non-blocking".
+//!
+//! **Sizing guidance**: With default settings (16 stripes × 1024 capacity), the
+//! WAL can buffer 16,384 entries. At 500K entries/sec with 10ms flush interval,
+//! ~5,000 entries accumulate per interval. The default sizing provides ~3x
+//! headroom for burst traffic.
+//!
+//! **Monitoring**: Use `stripe_metrics()` to detect high buffer utilization.
+//! If `entries_pending` consistently exceeds 50% of capacity, consider:
+//! - Increasing `stripe_capacity`
+//! - Increasing `num_stripes`
+//! - Reducing flush interval
 
 use std::cell::{Cell, RefCell};
 use std::path::{Path, PathBuf};

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -108,6 +108,28 @@ pub struct FlushStats {
 ///
 /// This struct manages segment files and coordinates flushing entries
 /// from the concurrent WAL stripes to disk.
+///
+/// # Mutex Poisoning Recovery
+///
+/// The coordinator uses `unwrap_or_else(|e| e.into_inner())` when acquiring
+/// mutex locks on `writer` and `sync_handle`. This pattern recovers from
+/// poisoned mutexes because:
+///
+/// 1. **Single-threaded access**: The flush coordinator is accessed by only
+///    one flush thread at a time. Mutex poisoning would only occur if the
+///    flush thread itself panicked during a previous operation.
+///
+/// 2. **File handle recovery**: If a panic occurred while holding the writer
+///    or sync_handle lock, the underlying file handles are still valid. The
+///    OS will have either completed or rolled back any in-progress writes.
+///
+/// 3. **Idempotent operations**: Flush operations are designed to be safe
+///    to retry. Re-acquiring a poisoned lock and continuing is preferable
+///    to propagating a panic to the caller.
+///
+/// 4. **Crash consistency**: The WAL already handles crash recovery at the
+///    entry level via checksums. A panic during flush is treated the same
+///    as a crash - entries are either fully written or not.
 pub struct FlushCoordinator {
     /// Configuration.
     config: FlushCoordinatorConfig,

--- a/src/storage/wal/lsn_allocator.rs
+++ b/src/storage/wal/lsn_allocator.rs
@@ -14,6 +14,24 @@
 //!
 //! The allocator is `Send` and `Sync`. Multiple threads can allocate LSNs
 //! concurrently without any locking.
+//!
+//! # LSN Overflow (Theoretical Limitation)
+//!
+//! The allocator uses a `u64` counter with `fetch_add`, which will wrap around
+//! to 0 after 2^64 allocations. This is a theoretical limitation:
+//!
+//! - At 1 million LSNs/second: overflow in ~584,542 years
+//! - At 10 million LSNs/second: overflow in ~58,454 years
+//! - At 100 million LSNs/second: overflow in ~5,845 years
+//!
+//! **Consequences of overflow**: LSN wraparound would cause duplicate LSNs,
+//! breaking the uniqueness guarantee. Recovery would become ambiguous as
+//! entries with "older" LSNs might actually be newer.
+//!
+//! **Mitigation**: For systems requiring true infinite operation, a database
+//! restart with LSN reset (after full checkpoint) would be needed before
+//! overflow. Monitoring `current()` against a threshold (e.g., `u64::MAX / 2`)
+//! can provide early warning.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -30,6 +30,27 @@
 //!
 //! When the buffer is full, writers spin briefly then yield. This provides
 //! natural backpressure without blocking the flush thread.
+//!
+//! # Position Counter Wraparound
+//!
+//! The ring buffer uses `u64` counters for `write_pos` and `read_pos`, which
+//! wrap around after 2^64 operations using `wrapping_add`. At 500K operations
+//! per second, overflow would occur after approximately 1.2 million years.
+//!
+//! **Theoretical limitation**: The sequence-based slot availability logic uses
+//! direct integer comparison (`==`, `<`, `>`). After position counter wraparound,
+//! these comparisons would produce incorrect results, causing the buffer to
+//! become unusable. This is a documented theoretical limitation rather than a
+//! practical concern.
+//!
+//! **Sequence number lifecycle**:
+//! 1. Initially: `sequence[i] = i` for each slot
+//! 2. After write: `sequence = pos + 1` (signals data ready)
+//! 3. After read: `sequence = pos + capacity` (signals slot available)
+//!
+//! The comparison `current_seq < expected_seq` at line 526 assumes monotonic
+//! growth, which breaks after u64 wraparound. For systems requiring true
+//! infinite operation, a restart-based reset mechanism would be needed.
 
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -182,6 +203,26 @@ enum CompletionState {
 /// Writers that need durability guarantees create a `CompletionNotifier`
 /// and wait on it after appending their entry. The flush coordinator
 /// notifies all pending entries after fsync completes.
+///
+/// # Mutex Poisoning Recovery
+///
+/// This type uses `unwrap_or_else(|e| e.into_inner())` when acquiring mutex
+/// locks. This pattern intentionally recovers from poisoned mutexes because:
+///
+/// 1. **Single-threaded notification**: The flush coordinator is the only
+///    thread that notifies completion. If it panics, the mutex may be poisoned,
+///    but the notification data (`error` string) is still valid.
+///
+/// 2. **Wait semantics are unchanged**: A waiting thread should either receive
+///    the completion signal or an error. Mutex poisoning indicates the flush
+///    thread panicked, which is itself an error condition we can report.
+///
+/// 3. **No invariant protection**: These mutexes protect coordination state
+///    (error strings, condvar), not data invariants. Recovering the lock's
+///    contents is safe because the state transitions are well-defined.
+///
+/// 4. **Fail-safe default**: If we can't determine the error, we return
+///    "Unknown error" rather than propagating the panic.
 #[derive(Debug)]
 pub struct CompletionNotifier {
     /// Current state (Pending, Complete, or Error).
@@ -880,7 +921,10 @@ mod tests {
     }
 
     #[test]
-    fn test_ring_buffer_wrap_around() {
+    fn test_ring_buffer_slot_reuse() {
+        // Note: This tests SLOT reuse (cycling through buffer slots), NOT position
+        // counter wraparound (u64 overflow). See module docs for position overflow
+        // limitations.
         let buf = WalRingBuffer::new(4);
 
         // First cycle - fill and drain
@@ -901,6 +945,43 @@ mod tests {
 
         for (i, entry) in entries.iter().enumerate() {
             assert_eq!(entry.lsn, LSN((i + 4) as u64));
+        }
+    }
+
+    #[test]
+    fn test_ring_buffer_many_cycles() {
+        // Test extensive slot reuse to verify sequence number progression is correct
+        // over many cycles. This doesn't test u64 position overflow (which would
+        // require 2^64 operations), but validates the sequence logic works for
+        // realistic long-running scenarios.
+        let buf = WalRingBuffer::new(4);
+
+        // Run 1000 cycles (4000 operations total)
+        for cycle in 0..1000u64 {
+            for i in 0..4 {
+                let lsn = LSN(cycle * 4 + i);
+                let entry = PendingEntry::new_async(lsn, vec![(lsn.0 % 256) as u8]);
+                assert!(
+                    buf.try_append(entry).is_ok(),
+                    "Failed at cycle {}, entry {}",
+                    cycle,
+                    i
+                );
+            }
+
+            let entries = buf.drain();
+            assert_eq!(entries.len(), 4, "Drain failed at cycle {}", cycle);
+
+            // Verify LSNs are correct
+            for (i, entry) in entries.iter().enumerate() {
+                assert_eq!(
+                    entry.lsn,
+                    LSN(cycle * 4 + i as u64),
+                    "Wrong LSN at cycle {}, entry {}",
+                    cycle,
+                    i
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Address code review feedback with comprehensive documentation:

- Ring buffer: Document position counter wraparound limitation (u64)
- Ring buffer: Add test for extensive slot reuse (1000 cycles)
- LSN allocator: Document overflow theoretical limitation with timing
- CompletionNotifier: Explain mutex poisoning recovery pattern
- FlushCoordinator: Document mutex unwrap_or_else usage rationale
- ConcurrentWal: Add buffer exhaustion/backpressure documentation

All items are theoretical limitations that won't occur in practice (e.g., u64 overflow requires ~1.2M years at 500K ops/sec).