### PR TITLE
Fix benchmark baseline comparisons and historical data tracking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,6 +53,18 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          # Note: This cache excludes target/criterion, which is cached separately below
+
+      - name: Cache Criterion baselines
+        uses: actions/cache@v4
+        with:
+          path: target/criterion
+          # Use branch-based key so baselines persist across dependency changes
+          # For PRs: uses head branch name, for trunk: uses 'trunk'
+          key: ${{ runner.os }}-criterion-${{ github.head_ref || github.ref_name }}
+          restore-keys: |
+            ${{ runner.os }}-criterion-trunk
+            ${{ runner.os }}-criterion-
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -119,9 +131,9 @@ jobs:
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false
-          # Store in dev/bench for historical charts
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: dev/bench
+          # Use external JSON file instead of gh-pages branch
+          # This creates data.js file locally that we can deploy
+          external-data-json-path: dev/bench/data.js
           save-data-file: true
           # Generate the benchmark data file locally instead of pushing
           # We'll deploy it with peaceiris/actions-gh-pages in a later step


### PR DESCRIPTION
## Summary
This PR fixes two issues with the benchmark CI workflow:

## Issue 1: Base vs New Always Identical

**Root Cause:** Criterion's baseline data in  was cached with a -based key. When dependencies changed, the cache was invalidated and Criterion created fresh baselines, making base and new identical.

**Fix:** Added separate cache for  with branch-based key that persists across dependency changes.

## Issue 2: Missing Historical Benchmark Data

**Root Cause:**  with  and  creates git commits in a local branch, not files in the working directory. The workflow tried to deploy  files that never existed.

**Fix:** Changed to use  which creates the file locally for deployment via .

## Expected Results

After this PR merges:
- Criterion will show meaningful base vs new comparisons
- Historical benchmark data will be tracked at 
- PR comments will show performance regressions/improvements when historical data exists

---
Created from worktree workflow.