### PR TITLE
Implement SimilarTo operation for node-based similarity search

### DIFF
--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -278,7 +278,7 @@ impl QueryBuilder<state::HasNodes> {
     /// Cost = O(1) node lookup + O(log N) HNSW search where N = indexed vectors
     ///
     /// # Panics
-    /// Panics in debug mode if k = 0
+    /// Panics if k = 0
     ///
     /// # Example
     ///
@@ -297,7 +297,9 @@ impl QueryBuilder<state::HasNodes> {
         source_node: NodeId,
         k: usize,
     ) -> QueryBuilder<state::HasVectorResults> {
-        assert!(k > 0, "k must be greater than 0");
+        if k == 0 {
+            panic!("k must be greater than 0");
+        }
         self.add_op(QueryOp::SimilarTo {
             source_node,
             k,
@@ -333,7 +335,7 @@ impl QueryBuilder<state::HasNodes> {
     /// ```
     ///
     /// # Panics
-    /// Panics in debug mode if k = 0
+    /// Panics if k = 0
     pub fn similar_to_builder(
         self,
         source_node: NodeId,
@@ -512,7 +514,9 @@ pub struct SimilarToBuilder<S: QueryState> {
 
 impl<S: QueryState> SimilarToBuilder<S> {
     fn new(source_node: NodeId, k: usize, query_builder: QueryBuilder<S>) -> Self {
-        assert!(k > 0, "k must be greater than 0");
+        if k == 0 {
+            panic!("k must be greater than 0");
+        }
         SimilarToBuilder {
             source_node,
             k,

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -246,13 +246,61 @@ impl QueryBuilder<state::HasNodes> {
         source_node: NodeId,
         k: usize,
     ) -> QueryBuilder<state::HasVectorResults> {
-        self.add_op(QueryOp::SimilarTo { source_node, k })
+        self.add_op(QueryOp::SimilarTo {
+            source_node,
+            k,
+            property_key: None,
+            label_filter: None,
+        })
     }
 
-    /// Filter results by predicate
+    /// Find nodes similar to a source node with custom property key
     #[must_use]
-    pub fn filter(self, predicate: Predicate) -> QueryBuilder<state::HasNodes> {
-        self.add_op_same(QueryOp::Filter(predicate))
+    pub fn similar_to_with_property(
+        self,
+        source_node: NodeId,
+        k: usize,
+        property_key: impl Into<String>,
+    ) -> QueryBuilder<state::HasVectorResults> {
+        self.add_op(QueryOp::SimilarTo {
+            source_node,
+            k,
+            property_key: Some(property_key.into()),
+            label_filter: None,
+        })
+    }
+
+    /// Find nodes similar to a source node with label filter
+    #[must_use]
+    pub fn similar_to_with_label(
+        self,
+        source_node: NodeId,
+        k: usize,
+        label_filter: impl Into<String>,
+    ) -> QueryBuilder<state::HasVectorResults> {
+        self.add_op(QueryOp::SimilarTo {
+            source_node,
+            k,
+            property_key: None,
+            label_filter: Some(label_filter.into()),
+        })
+    }
+
+    /// Find nodes similar to a source node with custom property key and label filter
+    #[must_use]
+    pub fn similar_to_with_property_and_label(
+        self,
+        source_node: NodeId,
+        k: usize,
+        property_key: impl Into<String>,
+        label_filter: impl Into<String>,
+    ) -> QueryBuilder<state::HasVectorResults> {
+        self.add_op(QueryOp::SimilarTo {
+            source_node,
+            k,
+            property_key: Some(property_key.into()),
+            label_filter: Some(label_filter.into()),
+        })
     }
 
     /// Filter by label

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -19,6 +19,21 @@
 //!     .as_of(valid_time, tx_time)
 //!     .start(node_id)
 //!     .build();
+//!
+//! // Build a vector similarity query (simple)
+//! let query = QueryBuilder::new()
+//!     .start(alice_id)
+//!     .similar_to(bob_id, 10)
+//!     .build();
+//!
+//! // Build a vector similarity query (advanced with builder)
+//! let query = QueryBuilder::new()
+//!     .start(alice_id)
+//!     .similar_to_builder(bob_id, 10)
+//!         .property("custom_embedding")
+//!         .label_filter("Person")
+//!         .finish()
+//!     .build();
 //! ```
 
 use std::marker::PhantomData;
@@ -239,13 +254,50 @@ impl QueryBuilder<state::HasNodes> {
         })
     }
 
-    /// Find nodes similar to a specific node
+    /// Find nodes similar to a source node's embedding (simple version).
+    ///
+    /// This is a convenience method that uses:
+    /// - Default property key: "embedding"
+    /// - No label filter
+    ///
+    /// For advanced options (custom property, label filtering), use
+    /// [`similar_to_builder()`](Self::similar_to_builder).
+    ///
+    /// # Arguments
+    /// * `source_node` - Node whose embedding to use for similarity search
+    /// * `k` - Number of similar nodes to return (must be > 0)
+    ///
+    /// # Errors
+    /// Returns `QueryError::ExecutionError` if:
+    /// - Source node doesn't exist
+    /// - Source node doesn't have an "embedding" property
+    /// - The "embedding" property is not a vector type
+    /// - No vector index is enabled for "embedding"
+    ///
+    /// # Performance
+    /// Cost = O(1) node lookup + O(log N) HNSW search where N = indexed vectors
+    ///
+    /// # Panics
+    /// Panics in debug mode if k = 0
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let results = db.query()
+    ///     .start(node_id)
+    ///     .similar_to(bob_id, 10)
+    ///     .execute()?;
+    /// ```
+    ///
+    /// # See Also
+    /// - [`similar_to_builder()`](Self::similar_to_builder) - Advanced configuration
     #[must_use]
     pub fn similar_to(
         self,
         source_node: NodeId,
         k: usize,
     ) -> QueryBuilder<state::HasVectorResults> {
+        assert!(k > 0, "k must be greater than 0");
         self.add_op(QueryOp::SimilarTo {
             source_node,
             k,
@@ -254,53 +306,46 @@ impl QueryBuilder<state::HasNodes> {
         })
     }
 
-    /// Find nodes similar to a source node with custom property key
-    #[must_use]
-    pub fn similar_to_with_property(
+    /// Create a builder for advanced SimilarTo configuration.
+    ///
+    /// Use this when you need to:
+    /// - Specify a custom embedding property key
+    /// - Filter results by label
+    /// - (Future) Configure distance metric, exclusions, etc.
+    ///
+    /// For simple cases, use [`similar_to()`](Self::similar_to) instead.
+    ///
+    /// # Arguments
+    /// * `source_node` - Node whose embedding to use for similarity search
+    /// * `k` - Number of similar nodes to return (must be > 0)
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Find similar documents using custom embedding
+    /// let results = db.query()
+    ///     .start(alice_id)
+    ///     .similar_to_builder(bob_id, 10)
+    ///         .property("custom_embedding")
+    ///         .label_filter("Document")
+    ///         .finish()
+    ///     .execute()?;
+    /// ```
+    ///
+    /// # Panics
+    /// Panics in debug mode if k = 0
+    pub fn similar_to_builder(
         self,
         source_node: NodeId,
         k: usize,
-        property_key: impl Into<String>,
-    ) -> QueryBuilder<state::HasVectorResults> {
-        self.add_op(QueryOp::SimilarTo {
-            source_node,
-            k,
-            property_key: Some(property_key.into()),
-            label_filter: None,
-        })
+    ) -> SimilarToBuilder<state::HasNodes> {
+        SimilarToBuilder::new(source_node, k, self)
     }
 
-    /// Find nodes similar to a source node with label filter
+    /// Filter results by predicate
     #[must_use]
-    pub fn similar_to_with_label(
-        self,
-        source_node: NodeId,
-        k: usize,
-        label_filter: impl Into<String>,
-    ) -> QueryBuilder<state::HasVectorResults> {
-        self.add_op(QueryOp::SimilarTo {
-            source_node,
-            k,
-            property_key: None,
-            label_filter: Some(label_filter.into()),
-        })
-    }
-
-    /// Find nodes similar to a source node with custom property key and label filter
-    #[must_use]
-    pub fn similar_to_with_property_and_label(
-        self,
-        source_node: NodeId,
-        k: usize,
-        property_key: impl Into<String>,
-        label_filter: impl Into<String>,
-    ) -> QueryBuilder<state::HasVectorResults> {
-        self.add_op(QueryOp::SimilarTo {
-            source_node,
-            k,
-            property_key: Some(property_key.into()),
-            label_filter: Some(label_filter.into()),
-        })
+    pub fn filter(self, predicate: Predicate) -> QueryBuilder<state::HasNodes> {
+        self.add_op_same(QueryOp::Filter(predicate))
     }
 
     /// Filter by label
@@ -438,6 +483,83 @@ impl<S: QueryState> QueryBuilder<S> {
     fn add_op_same(mut self, op: QueryOp) -> Self {
         self.ops.push(op);
         self
+    }
+}
+
+/// Builder for configuring SimilarTo operations with optional parameters.
+///
+/// Created by calling [`QueryBuilder::similar_to_builder()`].
+///
+/// # Example
+///
+/// ```ignore
+/// let query = QueryBuilder::new()
+///     .start(alice_id)
+///     .similar_to_builder(bob_id, 10)
+///         .property("custom_embedding")
+///         .label_filter("Person")
+///         .finish()
+///     .build();
+/// ```
+#[must_use = "builders do nothing unless you call finish()"]
+pub struct SimilarToBuilder<S: QueryState> {
+    source_node: NodeId,
+    k: usize,
+    property_key: Option<String>,
+    label_filter: Option<String>,
+    query_builder: QueryBuilder<S>,
+}
+
+impl<S: QueryState> SimilarToBuilder<S> {
+    fn new(source_node: NodeId, k: usize, query_builder: QueryBuilder<S>) -> Self {
+        assert!(k > 0, "k must be greater than 0");
+        SimilarToBuilder {
+            source_node,
+            k,
+            property_key: None,
+            label_filter: None,
+            query_builder,
+        }
+    }
+
+    /// Specify which vector property to use for similarity.
+    ///
+    /// Default: "embedding"
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// .similar_to_builder(node_id, 10)
+    ///     .property("custom_embedding")
+    ///     .finish()
+    /// ```
+    pub fn property(mut self, key: impl Into<String>) -> Self {
+        self.property_key = Some(key.into());
+        self
+    }
+
+    /// Filter results to only include nodes with this label.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// .similar_to_builder(node_id, 10)
+    ///     .label_filter("Document")
+    ///     .finish()
+    /// ```
+    pub fn label_filter(mut self, label: impl Into<String>) -> Self {
+        self.label_filter = Some(label.into());
+        self
+    }
+
+    /// Finish building and add the SimilarTo operation to the query.
+    pub fn finish(self) -> QueryBuilder<state::HasVectorResults> {
+        self.query_builder.add_op(QueryOp::SimilarTo {
+            source_node: self.source_node,
+            k: self.k,
+            property_key: self.property_key,
+            label_filter: self.label_filter,
+        })
     }
 }
 
@@ -591,5 +713,127 @@ mod tests {
             .build();
 
         assert_eq!(query.operation_count(), 4);
+    }
+
+    #[test]
+    fn test_similar_to_simple() {
+        let query = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to(test_node_id(), 10)
+            .build();
+
+        assert_eq!(query.operation_count(), 2);
+        match &query.ops[1] {
+            QueryOp::SimilarTo {
+                source_node: _,
+                k,
+                property_key,
+                label_filter,
+            } => {
+                assert_eq!(*k, 10);
+                assert!(property_key.is_none(), "Should use default property");
+                assert!(label_filter.is_none(), "Should have no label filter");
+            }
+            _ => panic!("Expected SimilarTo operation"),
+        }
+    }
+
+    #[test]
+    fn test_similar_to_builder_with_property() {
+        let query = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to_builder(test_node_id(), 10)
+            .property("custom_embedding")
+            .finish()
+            .build();
+
+        match &query.ops[1] {
+            QueryOp::SimilarTo {
+                property_key,
+                label_filter,
+                ..
+            } => {
+                assert_eq!(property_key.as_deref(), Some("custom_embedding"));
+                assert!(label_filter.is_none());
+            }
+            _ => panic!("Expected SimilarTo operation"),
+        }
+    }
+
+    #[test]
+    fn test_similar_to_builder_with_label() {
+        let query = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to_builder(test_node_id(), 10)
+            .label_filter("Document")
+            .finish()
+            .build();
+
+        match &query.ops[1] {
+            QueryOp::SimilarTo {
+                property_key,
+                label_filter,
+                ..
+            } => {
+                assert!(property_key.is_none());
+                assert_eq!(label_filter.as_deref(), Some("Document"));
+            }
+            _ => panic!("Expected SimilarTo operation"),
+        }
+    }
+
+    #[test]
+    fn test_similar_to_builder_with_all_options() {
+        let query = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to_builder(test_node_id(), 10)
+            .property("custom_embedding")
+            .label_filter("Person")
+            .finish()
+            .build();
+
+        match &query.ops[1] {
+            QueryOp::SimilarTo {
+                property_key,
+                label_filter,
+                ..
+            } => {
+                assert_eq!(property_key.as_deref(), Some("custom_embedding"));
+                assert_eq!(label_filter.as_deref(), Some("Person"));
+            }
+            _ => panic!("Expected SimilarTo operation"),
+        }
+    }
+
+    #[test]
+    fn test_similar_to_builder_fluent_chaining() {
+        // Verify builder can be chained with other query operations
+        let query = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to_builder(test_node_id(), 10)
+            .property("embedding")
+            .label_filter("Person")
+            .finish()
+            .filter(Predicate::gt("score", 0.8))
+            .limit(5)
+            .build();
+
+        assert_eq!(query.operation_count(), 4); // start + similar_to + filter + limit
+    }
+
+    #[test]
+    #[should_panic(expected = "k must be greater than 0")]
+    fn test_similar_to_validates_k() {
+        let _ = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to(test_node_id(), 0); // Should panic
+    }
+
+    #[test]
+    #[should_panic(expected = "k must be greater than 0")]
+    fn test_similar_to_builder_validates_k() {
+        let _ = QueryBuilder::new()
+            .start(test_node_id())
+            .similar_to_builder(test_node_id(), 0); // Should panic
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -190,7 +190,31 @@ impl QueryExecutor {
                 k,
                 label_filter,
             } => {
-                // 1. Look up the source node
+                // 1. Validate that property_key matches the indexed property
+                let indexed_property =
+                    self.current.get_indexed_property_name().ok_or_else(|| {
+                        crate::utils::error::Error::Query(
+                            crate::utils::error::QueryError::ExecutionError {
+                                message:
+                                    "No vector index is enabled. Call enable_vector_index() first."
+                                        .to_string(),
+                            },
+                        )
+                    })?;
+
+                if property_key != &indexed_property {
+                    return Err(crate::utils::error::Error::Query(
+                        crate::utils::error::QueryError::ExecutionError {
+                            message: format!(
+                                "Property key '{}' does not match indexed property '{}'. \
+                                 Vector index was built on '{}', so similar_to queries must use the same property.",
+                                property_key, indexed_property, indexed_property
+                            ),
+                        },
+                    ));
+                }
+
+                // 2. Look up the source node
                 let node = self.current.get_node(*source_node).map_err(|_| {
                     crate::utils::error::Error::Query(
                         crate::utils::error::QueryError::ExecutionError {
@@ -199,7 +223,7 @@ impl QueryExecutor {
                     )
                 })?;
 
-                // 2. Extract the embedding from the specified property
+                // 3. Extract the embedding from the specified property
                 let embedding = node
                     .properties
                     .get(property_key)
@@ -215,9 +239,10 @@ impl QueryExecutor {
                         )
                     })?;
 
-                // 3. Perform HNSW search with the extracted embedding
-                // Request k+1 results to account for filtering out the source node
-                let k_with_source = k + 1;
+                // 4. Perform HNSW search with the extracted embedding.
+                // Request k+1 results to account for filtering out the source node.
+                // Use checked_add to prevent overflow (though k=usize::MAX is extremely unlikely).
+                let k_with_source = k.checked_add(1).unwrap_or(*k);
                 let mut results = if let Some(label) = label_filter {
                     self.current.find_similar_by_embedding_with_label(
                         embedding,
@@ -229,7 +254,9 @@ impl QueryExecutor {
                         .find_similar_by_embedding(embedding, k_with_source)?
                 };
 
-                // Filter out the source node itself (a node is always most similar to itself)
+                // Remove source node from results. In vector similarity with cosine distance,
+                // a node has similarity 1.0 with itself, so it's always the first result.
+                // Filtering it out ensures we return k truly *different* nodes.
                 results.retain(|(node_id, _)| node_id != source_node);
 
                 // Trim to requested k results after filtering
@@ -807,7 +834,15 @@ mod tests {
 
     #[test]
     fn test_similar_to_source_node_not_found() {
+        use crate::index::vector::{DistanceMetric, HnswConfig};
+
         let (storage, historical) = create_test_storage();
+
+        // Enable vector index so we can test the "node not found" error
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
+
         let executor = QueryExecutor::new(storage, historical);
 
         let nonexistent_node = NodeId::new(9999).unwrap();
@@ -834,9 +869,15 @@ mod tests {
     #[test]
     fn test_similar_to_missing_vector_property() {
         use crate::core::PropertyMapBuilder;
+        use crate::index::vector::{DistanceMetric, HnswConfig};
 
         let (storage, historical) = create_test_storage();
         let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Enable vector index so we can test the "missing property" error
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
 
         // Create node without vector property
         let node = storage
@@ -967,5 +1008,74 @@ mod tests {
                 error_msg
             );
         }
+    }
+
+    #[test]
+    fn test_similar_to_fewer_results_than_k() {
+        use crate::core::PropertyMapBuilder;
+        use crate::index::vector::{DistanceMetric, HnswConfig};
+
+        let (storage, historical) = create_test_storage();
+        let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Enable vector index
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
+
+        // Create only 3 nodes total
+        let embedding1 = vec![1.0, 0.0, 0.0];
+        let embedding2 = vec![0.9, 0.1, 0.0];
+        let embedding3 = vec![0.8, 0.2, 0.0];
+
+        let node1 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &embedding1)
+                    .build(),
+            )
+            .unwrap();
+
+        let _node2 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &embedding2)
+                    .build(),
+            )
+            .unwrap();
+
+        let _node3 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &embedding3)
+                    .build(),
+            )
+            .unwrap();
+
+        // Request k=10 similar nodes, but only 2 exist (3 total - 1 source)
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: node1,
+                property_key: "embedding".to_string(),
+                k: 10,
+                label_filter: None,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        // Should return only 2 results (3 nodes - source node), not 10
+        assert_eq!(
+            rows.len(),
+            2,
+            "Should return only 2 results when database has fewer nodes than k"
+        );
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -191,9 +191,9 @@ impl QueryExecutor {
                 label_filter,
             } => {
                 // 1. Look up the source node
-                let node = self.current.get_node(*source_node)?.ok_or_else(|| {
+                let node = self.current.get_node(*source_node).map_err(|_| {
                     crate::utils::error::Error::Query(
-                        crate::utils::error::QueryError::SyntaxError {
+                        crate::utils::error::QueryError::ExecutionError {
                             message: format!("Source node {:?} not found", source_node),
                         },
                     )
@@ -201,12 +201,12 @@ impl QueryExecutor {
 
                 // 2. Extract the embedding from the specified property
                 let embedding = node
-                    .properties()
+                    .properties
                     .get(property_key)
-                    .and_then(|v| v.as_vector())
+                    .and_then(|v: &crate::core::PropertyValue| v.as_vector())
                     .ok_or_else(|| {
                         crate::utils::error::Error::Query(
-                            crate::utils::error::QueryError::SyntaxError {
+                            crate::utils::error::QueryError::ExecutionError {
                                 message: format!(
                                     "Node {:?} does not have a vector property '{}'",
                                     source_node, property_key
@@ -216,12 +216,24 @@ impl QueryExecutor {
                     })?;
 
                 // 3. Perform HNSW search with the extracted embedding
-                let results = if let Some(label) = label_filter {
-                    self.current
-                        .find_similar_by_embedding_with_label(embedding, label, *k)?
+                // Request k+1 results to account for filtering out the source node
+                let k_with_source = k + 1;
+                let mut results = if let Some(label) = label_filter {
+                    self.current.find_similar_by_embedding_with_label(
+                        embedding,
+                        label,
+                        k_with_source,
+                    )?
                 } else {
-                    self.current.find_similar_by_embedding(embedding, *k)?
+                    self.current
+                        .find_similar_by_embedding(embedding, k_with_source)?
                 };
+
+                // Filter out the source node itself (a node is always most similar to itself)
+                results.retain(|(node_id, _)| node_id != source_node);
+
+                // Trim to requested k results after filtering
+                results.truncate(*k);
 
                 Ok(Box::new(iterators::VectorResultIterator::new(
                     results,
@@ -665,8 +677,13 @@ mod tests {
         use crate::core::PropertyMapBuilder;
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let (storage, historical) = test_storage();
+        let (storage, historical) = create_test_storage();
         let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Enable vector index first
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
 
         // Create test nodes with embeddings
         let embedding1 = vec![1.0, 0.0, 0.0];
@@ -703,11 +720,6 @@ mod tests {
             )
             .unwrap();
 
-        // Enable vector index
-        storage
-            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
-            .unwrap();
-
         // Execute SimilarTo query
         let plan = PhysicalPlan {
             root: PhysicalOp::SimilarToNode {
@@ -734,8 +746,13 @@ mod tests {
         use crate::core::PropertyMapBuilder;
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let (storage, historical) = test_storage();
+        let (storage, historical) = create_test_storage();
         let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Enable vector index first
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
 
         let embedding = vec![1.0, 0.0, 0.0];
 
@@ -753,7 +770,7 @@ mod tests {
             .create_node(
                 "Other",
                 PropertyMapBuilder::new()
-                    .insert_vector("embedding", &vec![0.9, 0.1, 0.0])
+                    .insert_vector("embedding", &[0.9, 0.1, 0.0])
                     .build(),
             )
             .unwrap();
@@ -763,13 +780,9 @@ mod tests {
             .create_node(
                 "Doc",
                 PropertyMapBuilder::new()
-                    .insert_vector("embedding", &vec![0.95, 0.05, 0.0])
+                    .insert_vector("embedding", &[0.95, 0.05, 0.0])
                     .build(),
             )
-            .unwrap();
-
-        storage
-            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
             .unwrap();
 
         let plan = PhysicalPlan {
@@ -794,7 +807,7 @@ mod tests {
 
     #[test]
     fn test_similar_to_source_node_not_found() {
-        let (storage, historical) = test_storage();
+        let (storage, historical) = create_test_storage();
         let executor = QueryExecutor::new(storage, historical);
 
         let nonexistent_node = NodeId::new(9999).unwrap();
@@ -813,14 +826,16 @@ mod tests {
 
         let result = executor.execute(plan);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Source node"));
+        if let Err(e) = result {
+            assert!(e.to_string().contains("Source node"));
+        }
     }
 
     #[test]
     fn test_similar_to_missing_vector_property() {
         use crate::core::PropertyMapBuilder;
 
-        let (storage, historical) = test_storage();
+        let (storage, historical) = create_test_storage();
         let executor = QueryExecutor::new(Arc::clone(&storage), historical);
 
         // Create node without vector property
@@ -847,12 +862,9 @@ mod tests {
 
         let result = executor.execute(plan);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("does not have a vector property")
-        );
+        if let Err(e) = result {
+            assert!(e.to_string().contains("does not have a vector property"));
+        }
     }
 
     #[test]
@@ -860,8 +872,13 @@ mod tests {
         use crate::core::PropertyMapBuilder;
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let (storage, historical) = test_storage();
+        let (storage, historical) = create_test_storage();
         let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Enable vector index on custom property first
+        storage
+            .enable_vector_index("custom_vector", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
 
         let embedding1 = vec![1.0, 0.0, 0.0];
         let embedding2 = vec![0.9, 0.1, 0.0];
@@ -884,11 +901,6 @@ mod tests {
             )
             .unwrap();
 
-        // Enable vector index on custom property
-        storage
-            .enable_vector_index("custom_vector", HnswConfig::new(3, DistanceMetric::Cosine))
-            .unwrap();
-
         let plan = PhysicalPlan {
             root: PhysicalOp::SimilarToNode {
                 source_node: node1,
@@ -906,5 +918,54 @@ mod tests {
 
         assert!(!rows.is_empty());
         assert_eq!(rows[0].entity.node_id(), Some(node2));
+    }
+
+    #[test]
+    fn test_similar_to_no_vector_index() {
+        use crate::core::PropertyMapBuilder;
+
+        let (storage, historical) = create_test_storage();
+        let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        let embedding = vec![1.0, 0.0, 0.0];
+
+        let node1 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &embedding)
+                    .build(),
+            )
+            .unwrap();
+
+        // NOTE: Vector index NOT enabled for "embedding" property
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: node1,
+                property_key: "embedding".to_string(),
+                k: 5,
+                label_filter: None,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let result = executor.execute(plan);
+        assert!(
+            result.is_err(),
+            "Should return error when vector index is not enabled"
+        );
+
+        // Verify error message indicates index not found
+        if let Err(e) = result {
+            let error_msg = format!("{}", e);
+            assert!(
+                error_msg.contains("index") || error_msg.contains("Index"),
+                "Error should mention missing index: {}",
+                error_msg
+            );
+        }
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -184,6 +184,50 @@ impl QueryExecutor {
             }
 
             PhysicalOp::Empty => Ok(Box::new(iterators::EmptyIterator)),
+            PhysicalOp::SimilarToNode {
+                source_node,
+                property_key,
+                k,
+                label_filter,
+            } => {
+                // 1. Look up the source node
+                let node = self.current.get_node(*source_node)?.ok_or_else(|| {
+                    crate::utils::error::Error::Query(
+                        crate::utils::error::QueryError::SyntaxError {
+                            message: format!("Source node {:?} not found", source_node),
+                        },
+                    )
+                })?;
+
+                // 2. Extract the embedding from the specified property
+                let embedding = node
+                    .properties()
+                    .get(property_key)
+                    .and_then(|v| v.as_vector())
+                    .ok_or_else(|| {
+                        crate::utils::error::Error::Query(
+                            crate::utils::error::QueryError::SyntaxError {
+                                message: format!(
+                                    "Node {:?} does not have a vector property '{}'",
+                                    source_node, property_key
+                                ),
+                            },
+                        )
+                    })?;
+
+                // 3. Perform HNSW search with the extracted embedding
+                let results = if let Some(label) = label_filter {
+                    self.current
+                        .find_similar_by_embedding_with_label(embedding, label, *k)?
+                } else {
+                    self.current.find_similar_by_embedding(embedding, *k)?
+                };
+
+                Ok(Box::new(iterators::VectorResultIterator::new(
+                    results,
+                    Arc::clone(&self.current),
+                )))
+            }
 
             // For unsupported operations, return error
             _ => Err(crate::utils::error::Error::Query(
@@ -612,5 +656,255 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].entity.node_id(), Some(bob));
+    }
+
+    // ==================== SimilarTo Tests ====================
+
+    #[test]
+    fn test_similar_to_node_execution() {
+        use crate::core::PropertyMapBuilder;
+        use crate::index::vector::{DistanceMetric, HnswConfig};
+
+        let (storage, historical) = test_storage();
+        let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Create test nodes with embeddings
+        let embedding1 = vec![1.0, 0.0, 0.0];
+        let embedding2 = vec![0.9, 0.1, 0.0]; // Similar to embedding1
+        let embedding3 = vec![0.0, 1.0, 0.0]; // Different from embedding1
+
+        let node1 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert("title", "Doc1")
+                    .insert_vector("embedding", &embedding1)
+                    .build(),
+            )
+            .unwrap();
+
+        let node2 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert("title", "Doc2")
+                    .insert_vector("embedding", &embedding2)
+                    .build(),
+            )
+            .unwrap();
+
+        let _node3 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert("title", "Doc3")
+                    .insert_vector("embedding", &embedding3)
+                    .build(),
+            )
+            .unwrap();
+
+        // Enable vector index
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
+
+        // Execute SimilarTo query
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: node1,
+                property_key: "embedding".to_string(),
+                k: 5,
+                label_filter: None,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        // Should find node2 as most similar (excluding node1 itself)
+        assert!(!rows.is_empty());
+        assert_eq!(rows[0].entity.node_id(), Some(node2));
+    }
+
+    #[test]
+    fn test_similar_to_with_label_filter() {
+        use crate::core::PropertyMapBuilder;
+        use crate::index::vector::{DistanceMetric, HnswConfig};
+
+        let (storage, historical) = test_storage();
+        let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        let embedding = vec![1.0, 0.0, 0.0];
+
+        let node1 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &embedding)
+                    .build(),
+            )
+            .unwrap();
+
+        // Create similar node with different label
+        let _node2 = storage
+            .create_node(
+                "Other",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &vec![0.9, 0.1, 0.0])
+                    .build(),
+            )
+            .unwrap();
+
+        // Create similar node with same label
+        let node3 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &vec![0.95, 0.05, 0.0])
+                    .build(),
+            )
+            .unwrap();
+
+        storage
+            .enable_vector_index("embedding", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: node1,
+                property_key: "embedding".to_string(),
+                k: 5,
+                label_filter: Some("Doc".to_string()),
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        // Should only find node3 (Doc label), not node2 (Other label)
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].entity.node_id(), Some(node3));
+    }
+
+    #[test]
+    fn test_similar_to_source_node_not_found() {
+        let (storage, historical) = test_storage();
+        let executor = QueryExecutor::new(storage, historical);
+
+        let nonexistent_node = NodeId::new(9999).unwrap();
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: nonexistent_node,
+                property_key: "embedding".to_string(),
+                k: 5,
+                label_filter: None,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let result = executor.execute(plan);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Source node"));
+    }
+
+    #[test]
+    fn test_similar_to_missing_vector_property() {
+        use crate::core::PropertyMapBuilder;
+
+        let (storage, historical) = test_storage();
+        let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        // Create node without vector property
+        let node = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert("title", "No embedding")
+                    .build(),
+            )
+            .unwrap();
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: node,
+                property_key: "embedding".to_string(),
+                k: 5,
+                label_filter: None,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let result = executor.execute(plan);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("does not have a vector property")
+        );
+    }
+
+    #[test]
+    fn test_similar_to_custom_property_key() {
+        use crate::core::PropertyMapBuilder;
+        use crate::index::vector::{DistanceMetric, HnswConfig};
+
+        let (storage, historical) = test_storage();
+        let executor = QueryExecutor::new(Arc::clone(&storage), historical);
+
+        let embedding1 = vec![1.0, 0.0, 0.0];
+        let embedding2 = vec![0.9, 0.1, 0.0];
+
+        let node1 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("custom_vector", &embedding1)
+                    .build(),
+            )
+            .unwrap();
+
+        let node2 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("custom_vector", &embedding2)
+                    .build(),
+            )
+            .unwrap();
+
+        // Enable vector index on custom property
+        storage
+            .enable_vector_index("custom_vector", HnswConfig::new(3, DistanceMetric::Cosine))
+            .unwrap();
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::SimilarToNode {
+                source_node: node1,
+                property_key: "custom_vector".to_string(),
+                k: 5,
+                label_filter: None,
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        assert!(!rows.is_empty());
+        assert_eq!(rows[0].entity.node_id(), Some(node2));
     }
 }

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -88,6 +88,14 @@ pub enum QueryOp {
         label_filter: Option<String>,
     },
 
+    /// Rank current results by similarity to a target embedding
+    RankBySimilarity {
+        /// Target embedding for similarity comparison
+        embedding: Arc<[f32]>,
+        /// Optional limit on results (if None, ranks all)
+        top_k: Option<usize>,
+    },
+
     // === Temporal Operations ===
     /// Query at a specific point in time (bi-temporal)
     AsOf {

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -82,14 +82,10 @@ pub enum QueryOp {
         source_node: NodeId,
         /// Number of results to return
         k: usize,
-    },
-
-    /// Rank/reorder current results by similarity to an embedding
-    RankBySimilarity {
-        /// Target embedding for similarity comparison
-        embedding: Arc<[f32]>,
-        /// Optional limit on results (if None, ranks all)
-        top_k: Option<usize>,
+        /// Property key containing the embedding (default: "embedding")
+        property_key: Option<String>,
+        /// Optional label filter for results
+        label_filter: Option<String>,
     },
 
     // === Temporal Operations ===

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -191,6 +191,17 @@ pub enum ScanOp {
         /// Timestamp for the historical query
         timestamp: Timestamp,
     },
+    /// Find nodes similar to a specific node by extracting its embedding
+    SimilarToNode {
+        /// Source node whose embedding to use
+        source_node: NodeId,
+        /// Property key containing the embedding vector
+        property_key: String,
+        /// Number of results to return
+        k: usize,
+        /// Optional label filter for results
+        label_filter: Option<String>,
+    },
 }
 
 /// Unary operations that transform a single input.

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -276,6 +276,15 @@ impl CostModel {
             | PhysicalOp::Materialize { input }
             | PhysicalOp::TemporalTrack { input, .. } => self.estimate(input, stats),
 
+            PhysicalOp::SimilarToNode {
+                k, label_filter, ..
+            } => {
+                // SimilarToNode = node lookup + HNSW search
+                let lookup_cost = self.estimate_node_lookup(1);
+                let search_cost = self.estimate_hnsw_search(*k, label_filter.is_some(), stats);
+                lookup_cost + search_cost
+            }
+
             PhysicalOp::Empty => Cost::zero(),
         }
     }
@@ -326,6 +335,7 @@ impl CostModel {
             PhysicalOp::Materialize { input } | PhysicalOp::TemporalTrack { input, .. } => {
                 self.estimate_cardinality(input, stats)
             }
+            PhysicalOp::SimilarToNode { k, .. } => *k,
             PhysicalOp::Empty => 0,
         }
     }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -196,18 +196,11 @@ impl QueryPlanner {
             }
 
             QueryOp::SimilarTo { source_node, k } => {
-                // See issue #308: Implement SimilarTo operation
-                // SimilarTo requires multi-step planning:
-                // 1. Lookup source node to extract its embedding
-                // 2. Perform vector search with that embedding
-                // This requires runtime embedding extraction which isn't supported yet.
-                // Return error until properly implemented.
-                Err(Error::Query(QueryError::SyntaxError {
-                    message: format!(
-                        "SimilarTo operation not yet implemented: \
-                         finding {} nodes similar to {:?} requires runtime embedding extraction",
-                        k, source_node
-                    ),
+                Ok(LogicalOp::Scan(ScanOp::SimilarToNode {
+                    source_node: *source_node,
+                    property_key: "embedding".to_string(), // Default property key
+                    k: *k,
+                    label_filter: None,
                 }))
             }
 
@@ -453,6 +446,17 @@ impl QueryPlanner {
                 embedding: embedding.clone(),
                 k: *k,
                 timestamp: *timestamp,
+            }),
+            ScanOp::SimilarToNode {
+                source_node,
+                property_key,
+                k,
+                label_filter,
+            } => Ok(PhysicalOp::SimilarToNode {
+                source_node: *source_node,
+                property_key: property_key.clone(),
+                k: *k,
+                label_filter: label_filter.clone(),
             }),
         }
     }
@@ -845,21 +849,6 @@ mod tests {
         assert!(matches!(plan.root, PhysicalOp::VectorRerank { .. }));
     }
 
-    #[test]
-    fn test_similar_to_not_implemented() {
-        let planner = test_planner();
-        let query = Query {
-            ops: vec![QueryOp::SimilarTo {
-                source_node: NodeId::new(1).unwrap(),
-                k: 10,
-            }],
-            temporal_context: None,
-            hints: QueryHints::default(),
-        };
-
-        // SimilarTo is not yet implemented
-        assert!(planner.plan(query).is_err());
-    }
 
     // ==================== Temporal Tests ====================
 
@@ -1306,5 +1295,65 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("requires a source"));
+    }
+
+    // ==================== SimilarTo Tests ====================
+
+    #[test]
+    fn test_similar_to_planning() {
+        let planner = test_planner();
+        let source_node = NodeId::new(1).unwrap();
+        let query = QueryBuilder::new()
+            .start(source_node)
+            .similar_to(source_node, 10)
+            .build();
+
+        let plan = planner.plan(query).unwrap();
+        assert!(matches!(plan.root, PhysicalOp::SimilarToNode { .. }));
+    }
+
+    #[test]
+    fn test_similar_to_node_parameters() {
+        let planner = test_planner();
+        let source_node = NodeId::new(42).unwrap();
+        let k = 15;
+        let query = Query {
+            ops: vec![QueryOp::SimilarTo { source_node, k }],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        match &plan.root {
+            PhysicalOp::SimilarToNode {
+                source_node: sn,
+                k: result_k,
+                ..
+            } => {
+                assert_eq!(*sn, source_node);
+                assert_eq!(*result_k, k);
+            }
+            _ => panic!("Expected SimilarToNode, got {:?}", plan.root.name()),
+        }
+    }
+
+    #[test]
+    fn test_similar_to_with_property_key() {
+        let planner = test_planner();
+        let source_node = NodeId::new(1).unwrap();
+        let query = Query {
+            ops: vec![QueryOp::SimilarTo { source_node, k: 10 }],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        match &plan.root {
+            PhysicalOp::SimilarToNode { property_key, .. } => {
+                // Default property key should be "embedding"
+                assert_eq!(property_key, "embedding");
+            }
+            _ => panic!("Expected SimilarToNode"),
+        }
     }
 }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -195,23 +195,22 @@ impl QueryPlanner {
                 ))
             }
 
-            QueryOp::SimilarTo { source_node, k } => {
+            QueryOp::SimilarTo {
+                source_node,
+                k,
+                property_key,
+                label_filter,
+            } => {
+                // SimilarTo is a scan operation that looks up a node, extracts its embedding,
+                // and performs k-NN search - all handled by the executor
                 Ok(LogicalOp::Scan(ScanOp::SimilarToNode {
                     source_node: *source_node,
-                    property_key: "embedding".to_string(), // Default property key
+                    property_key: property_key
+                        .clone()
+                        .unwrap_or_else(|| "embedding".to_string()),
                     k: *k,
-                    label_filter: None,
+                    label_filter: label_filter.clone(),
                 }))
-            }
-
-            // Filter operations
-            QueryOp::Filter(predicate) => {
-                let input = current.ok_or_else(|| {
-                    Error::Query(QueryError::SyntaxError {
-                        message: "Filter requires a source".to_string(),
-                    })
-                })?;
-                Ok(LogicalOp::unary(UnaryOp::Filter(predicate.clone()), input))
             }
 
             QueryOp::FilterLabel(label) => {
@@ -849,7 +848,6 @@ mod tests {
         assert!(matches!(plan.root, PhysicalOp::VectorRerank { .. }));
     }
 
-
     // ==================== Temporal Tests ====================
 
     #[test]
@@ -1318,7 +1316,12 @@ mod tests {
         let source_node = NodeId::new(42).unwrap();
         let k = 15;
         let query = Query {
-            ops: vec![QueryOp::SimilarTo { source_node, k }],
+            ops: vec![QueryOp::SimilarTo {
+                source_node,
+                k,
+                property_key: None,
+                label_filter: None,
+            }],
             temporal_context: None,
             hints: QueryHints::default(),
         };
@@ -1342,7 +1345,12 @@ mod tests {
         let planner = test_planner();
         let source_node = NodeId::new(1).unwrap();
         let query = Query {
-            ops: vec![QueryOp::SimilarTo { source_node, k: 10 }],
+            ops: vec![QueryOp::SimilarTo {
+                source_node,
+                k: 10,
+                property_key: None,
+                label_filter: None,
+            }],
             temporal_context: None,
             hints: QueryHints::default(),
         };

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -205,12 +205,19 @@ impl QueryPlanner {
                 // and performs k-NN search - all handled by the executor
                 Ok(LogicalOp::Scan(ScanOp::SimilarToNode {
                     source_node: *source_node,
-                    property_key: property_key
-                        .clone()
-                        .unwrap_or_else(|| "embedding".to_string()),
+                    property_key: property_key.as_deref().unwrap_or("embedding").to_string(),
                     k: *k,
                     label_filter: label_filter.clone(),
                 }))
+            }
+
+            QueryOp::Filter(predicate) => {
+                let input = current.ok_or_else(|| {
+                    Error::Query(QueryError::SyntaxError {
+                        message: "Filter requires a source".to_string(),
+                    })
+                })?;
+                Ok(LogicalOp::unary(UnaryOp::Filter(predicate.clone()), input))
             }
 
             QueryOp::FilterLabel(label) => {

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -95,6 +95,22 @@ pub enum PhysicalOp {
         timestamp: Timestamp,
     },
 
+    /// Find nodes similar to a specific node by extracting its embedding
+    /// and performing k-NN search. This is a compound operation that:
+    /// 1. Looks up the source node
+    /// 2. Extracts the embedding from the specified property
+    /// 3. Performs HNSW k-NN search with that embedding
+    SimilarToNode {
+        /// Source node whose embedding to use
+        source_node: NodeId,
+        /// Property key containing the embedding vector
+        property_key: String,
+        /// Number of results to return
+        k: usize,
+        /// Optional label filter for results
+        label_filter: Option<String>,
+    },
+
     // === Traversal Operators ===
     /// Graph traversal using adjacency index
     IndexedTraversal {
@@ -232,6 +248,7 @@ impl PhysicalOp {
             PhysicalOp::HnswSearch { .. } => "HnswSearch",
             PhysicalOp::TemporalNodeLookup { .. } => "TemporalNodeLookup",
             PhysicalOp::TemporalVectorSearch { .. } => "TemporalVectorSearch",
+            PhysicalOp::SimilarToNode { .. } => "SimilarToNode",
             PhysicalOp::IndexedTraversal { .. } => "IndexedTraversal",
             PhysicalOp::HashJoin { .. } => "HashJoin",
             PhysicalOp::Union { .. } => "Union",
@@ -260,6 +277,7 @@ impl PhysicalOp {
                 | PhysicalOp::HnswSearch { .. }
                 | PhysicalOp::TemporalNodeLookup { .. }
                 | PhysicalOp::TemporalVectorSearch { .. }
+                | PhysicalOp::SimilarToNode { .. }
                 | PhysicalOp::Empty
         )
     }
@@ -273,6 +291,7 @@ impl PhysicalOp {
             | PhysicalOp::HnswSearch { .. }
             | PhysicalOp::TemporalNodeLookup { .. }
             | PhysicalOp::TemporalVectorSearch { .. }
+            | PhysicalOp::SimilarToNode { .. }
             | PhysicalOp::Empty => 1,
 
             PhysicalOp::IndexedTraversal { input, .. }
@@ -330,6 +349,17 @@ impl PhysicalOp {
                 format!(
                     "{prefix}{name} (ids: {:?}, vt: {}, tt: {}, batch: {})",
                     node_ids, valid_time, transaction_time, use_batch
+                )
+            }
+            PhysicalOp::SimilarToNode {
+                source_node,
+                property_key,
+                k,
+                label_filter,
+            } => {
+                format!(
+                    "{prefix}{name} (source: {:?}, prop: {}, k: {}, label: {:?})",
+                    source_node, property_key, k, label_filter
                 )
             }
             PhysicalOp::IndexedTraversal {

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -135,6 +135,14 @@ impl CurrentStorage {
         self.vector_index_state.read().is_enabled()
     }
 
+    /// Get the property name that is currently indexed.
+    ///
+    /// Returns `Some(property_name)` if a vector index is enabled,
+    /// or `None` if no index is configured.
+    pub fn get_indexed_property_name(&self) -> Option<String> {
+        self.vector_index_state.read().property_name.clone()
+    }
+
     /// Get vector index configuration for checkpoint persistence.
     ///
     /// Returns the current vector index configuration if enabled, or disabled

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -469,6 +469,11 @@ pub enum QueryError {
         /// The actual type
         actual: String,
     },
+    /// Query execution error (runtime failure).
+    ExecutionError {
+        /// The error message
+        message: String,
+    },
 }
 
 impl fmt::Display for QueryError {
@@ -491,6 +496,9 @@ impl fmt::Display for QueryError {
             }
             QueryError::TypeMismatch { expected, actual } => {
                 write!(f, "Type mismatch: expected {}, got {}", expected, actual)
+            }
+            QueryError::ExecutionError { message } => {
+                write!(f, "Query execution error: {}", message)
             }
         }
     }


### PR DESCRIPTION
## Summary
## Summary

Implements  to find nodes similar to a source node by extracting its embedding and performing k-NN search.

This was previously unimplemented and returned an error. Now it works as a compound operation that:
1. Looks up the source node
2. Extracts the embedding from a specified property (default: embedding)
3. Performs HNSW k-NN search with the extracted embedding

## Changes

- Added  - a leaf operator that encapsulates the multi-step operation
- Added  - logical plan representation
- Updated query planner to convert  →  → 
- Added cost estimation (node lookup + HNSW search costs)
- Added comprehensive tests for the operation
- Removed obsolete  test

## API Usage



## Test Plan

- [x] Added unit tests for SimilarTo planning
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with cargo fmt

Fixes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Created from worktree workflow.