### PR TITLE
chore: convert TODO comments to GitHub issues

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1345,7 +1345,8 @@ impl GallifreyDB {
 
         // Calculate average delta chain length from historical storage
         // (using default estimate if historical storage is empty)
-        let avg_delta_chain = 5.0; // TODO: Calculate from historical storage
+        // See issue #366: Calculate from historical storage instead of hardcoding
+        let avg_delta_chain = 5.0;
 
         self.stats.refresh(
             node_count,

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -196,7 +196,8 @@ impl QueryPlanner {
             }
 
             QueryOp::SimilarTo { source_node, k } => {
-                // TODO: SimilarTo requires multi-step planning:
+                // See issue #308: Implement SimilarTo operation
+                // SimilarTo requires multi-step planning:
                 // 1. Lookup source node to extract its embedding
                 // 2. Perform vector search with that embedding
                 // This requires runtime embedding extraction which isn't supported yet.
@@ -375,10 +376,10 @@ impl QueryPlanner {
     ///
     /// # Limitations
     ///
-    /// TODO: This function does not validate that required indexes exist (e.g., vector index
+    /// See issue #309: This function does not validate that required indexes exist (e.g., vector index
     /// for HnswSearch). Validation happens at execution time in the executor. For better
     /// error messages, the planner should receive a reference to CurrentStorage to check
-    /// index availability during planning. See issue for future improvement.
+    /// index availability during planning.
     fn scan_to_physical(
         &self,
         scan: &ScanOp,

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -298,7 +298,7 @@ impl CurrentStorage {
     /// Delete a node.
     ///
     /// Note: This does not delete edges connected to the node.
-    /// TODO: Add cascade delete option.
+    /// See issue #364 for cascade delete option.
     pub fn delete_node(&self, id: NodeId) -> Result<Node> {
         self.indexes
             .remove_node(id)

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -449,7 +449,8 @@ impl PersistenceManager {
         let wal_entries = wal.read_from(start_lsn)?;
 
         for _entry in wal_entries {
-            // TODO: Implement WAL operation replay
+            // See issue #287: Implement basic WAL replay loop
+            // See issue #290: Implement DeleteNode/DeleteEdge replay with correct bi-temporal semantics
             //
             // IMPORTANT: When implementing replay for DeleteNode/DeleteEdge operations,
             // you MUST close the previous version's transaction_time BEFORE creating

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -829,7 +829,7 @@ fn test_segment_rotation_with_background_thread() {
     // Drop database to trigger final flush and ensure proper cleanup
     drop(db);
 
-    // TODO: Add recovery test once GallifreyDB supports WAL replay on open
+    // See issue #365: Add recovery test once GallifreyDB supports WAL replay on open
     // For now, this test verifies:
     // 1. Writes succeed across segment rotation
     // 2. Background thread doesn't crash when segment rotates

--- a/tests/vector_storage.rs
+++ b/tests/vector_storage.rs
@@ -911,7 +911,7 @@ fn test_update_node_updates_index() {
 }
 
 // Note: test_delete_node_removes_from_index skipped - delete_node not yet implemented
-// TODO: Add this test when delete_node is implemented in GallifreyDB
+// See issue #367: Add test when delete_node is implemented in GallifreyDB
 
 #[test]
 fn test_node_without_vector_property_not_indexed() {


### PR DESCRIPTION
## Summary
## Summary

This PR addresses issue #353 by converting all TODO comments in the codebase to GitHub issues for better tracking and discoverability.

## Changes

Replaced 7 TODO comments with GitHub issue references:

1.  → #367 (Add test for delete_node in vector storage)
2.  → #364 (Add cascade delete option)
3.  → #365 (Add WAL recovery integration test)
4.  → #287, #290 (WAL replay implementation)
5.  → #308 (Implement SimilarTo operation)
6.  → #309 (Add index validation during planning)
7.  → #366 (Calculate avg_delta_chain from historical storage)

## New Issues Created

- #364: Feature: Add cascade delete option for delete_node
- #365: Testing: Add WAL recovery integration test
- #366: Feature: Calculate avg_delta_chain from historical storage
- #367: Testing: Add test for delete_node in vector storage

## Existing Issues Referenced

- #287: Implement Basic WAL Replay Loop
- #290: Implement DeleteNode/DeleteEdge Replay
- #308: Query Planner: Implement SimilarTo operation
- #309: Query Planner: Add index validation during planning

## Testing

- ✅ All library tests passing
- ✅ All integration tests passing
- ✅ Clippy check passed
- ✅ Code formatted with cargo fmt

## Impact

- No functional changes
- Documentation/comment updates only
- All TODOs now tracked in GitHub issues for better visibility and management

Closes #353


---
Created from worktree workflow.