### PR TITLE
fix: add index validation during query planning (issue #309)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1156,7 +1156,7 @@ impl GallifreyDB {
 
         // Use cached statistics for cost-based optimization
         // Statistics are shared across all queries for this database instance
-        let planner = QueryPlanner::new(Arc::clone(&self.stats));
+        let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));
         let physical_plan = planner.plan(query)?;
 
         // Execute the plan

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 #[cfg(feature = "observability")]
 use tracing;
 
+use crate::storage::CurrentStorage;
 use crate::utils::error::{Error, QueryError, Result};
 
 use super::builder::Query;
@@ -33,16 +34,22 @@ pub struct QueryPlanner {
     cost_model: CostModel,
     /// Optimization rules to apply
     rules: Vec<Box<dyn OptimizationRule>>,
+    /// Reference to current storage for index validation
+    storage: Arc<CurrentStorage>,
 }
 
 impl QueryPlanner {
-    /// Create a new query planner with the given statistics
+    /// Create a new query planner with the given statistics and storage
+    ///
+    /// The storage reference is used to validate that required indexes exist during
+    /// query planning, providing earlier and more informative error messages.
     #[must_use]
-    pub fn new(stats: Arc<Statistics>) -> Self {
+    pub fn new(stats: Arc<Statistics>, storage: Arc<CurrentStorage>) -> Self {
         QueryPlanner {
             stats,
             cost_model: CostModel::default(),
             rules: rules::default_rules(),
+            storage,
         }
     }
 
@@ -373,12 +380,11 @@ impl QueryPlanner {
 
     /// Convert a scan operation to physical
     ///
-    /// # Limitations
+    /// # Index Validation
     ///
-    /// See issue #309: This function does not validate that required indexes exist (e.g., vector index
-    /// for HnswSearch). Validation happens at execution time in the executor. For better
-    /// error messages, the planner should receive a reference to CurrentStorage to check
-    /// index availability during planning.
+    /// This function validates that required indexes exist before generating physical
+    /// operations. If a vector index is required but not enabled, it returns an
+    /// `IndexNotFound` error with a helpful hint on how to enable the index.
     fn scan_to_physical(
         &self,
         scan: &ScanOp,
@@ -414,6 +420,21 @@ impl QueryPlanner {
                 label_filter,
                 metric: _,
             } => {
+                // Validate that vector index is enabled
+                if !self.storage.is_vector_index_enabled() {
+                    let property_name = self
+                        .storage
+                        .get_indexed_property_name()
+                        .unwrap_or_else(|| "embedding".to_string());
+                    return Err(Error::Query(QueryError::IndexNotFound {
+                        index_type: "vector".to_string(),
+                        property_name,
+                        hint: Some(
+                            "Call db.enable_vector_index(\"embedding\", config) first".to_string(),
+                        ),
+                    }));
+                }
+
                 if let Some((_, tx_time)) = temporal.as_ref().and_then(|ctx| ctx.as_of) {
                     return Ok(PhysicalOp::TemporalVectorSearch {
                         embedding: embedding.clone(),
@@ -448,22 +469,53 @@ impl QueryPlanner {
                 embedding,
                 k,
                 timestamp,
-            } => Ok(PhysicalOp::TemporalVectorSearch {
-                embedding: embedding.clone(),
-                k: *k,
-                timestamp: *timestamp,
-            }),
+            } => {
+                // Validate that vector index is enabled for temporal search
+                if !self.storage.is_vector_index_enabled() {
+                    let property_name = self
+                        .storage
+                        .get_indexed_property_name()
+                        .unwrap_or_else(|| "embedding".to_string());
+                    return Err(Error::Query(QueryError::IndexNotFound {
+                        index_type: "vector".to_string(),
+                        property_name,
+                        hint: Some(
+                            "Call db.enable_vector_index(\"embedding\", config) first".to_string(),
+                        ),
+                    }));
+                }
+
+                Ok(PhysicalOp::TemporalVectorSearch {
+                    embedding: embedding.clone(),
+                    k: *k,
+                    timestamp: *timestamp,
+                })
+            }
             ScanOp::SimilarToNode {
                 source_node,
                 property_key,
                 k,
                 label_filter,
-            } => Ok(PhysicalOp::SimilarToNode {
-                source_node: *source_node,
-                property_key: property_key.clone(),
-                k: *k,
-                label_filter: label_filter.clone(),
-            }),
+            } => {
+                // Validate that vector index is enabled for SimilarTo queries
+                if !self.storage.is_vector_index_enabled() {
+                    let property_name = property_key.clone();
+                    return Err(Error::Query(QueryError::IndexNotFound {
+                        index_type: "vector".to_string(),
+                        property_name,
+                        hint: Some(
+                            "Call db.enable_vector_index(\"embedding\", config) first".to_string(),
+                        ),
+                    }));
+                }
+
+                Ok(PhysicalOp::SimilarToNode {
+                    source_node: *source_node,
+                    property_key: property_key.clone(),
+                    k: *k,
+                    label_filter: label_filter.clone(),
+                })
+            }
         }
     }
 
@@ -503,11 +555,28 @@ impl QueryPlanner {
                 depth: depth.max_depth().unwrap_or(10),
             }),
 
-            UnaryOp::VectorRank { embedding, top_k } => Ok(PhysicalOp::VectorRerank {
-                input: Box::new(input),
-                embedding: embedding.clone(),
-                k: top_k.unwrap_or(10),
-            }),
+            UnaryOp::VectorRank { embedding, top_k } => {
+                // Validate that vector index is enabled for reranking
+                if !self.storage.is_vector_index_enabled() {
+                    let property_name = self
+                        .storage
+                        .get_indexed_property_name()
+                        .unwrap_or_else(|| "embedding".to_string());
+                    return Err(Error::Query(QueryError::IndexNotFound {
+                        index_type: "vector".to_string(),
+                        property_name,
+                        hint: Some(
+                            "Call db.enable_vector_index(\"embedding\", config) first".to_string(),
+                        ),
+                    }));
+                }
+
+                Ok(PhysicalOp::VectorRerank {
+                    input: Box::new(input),
+                    embedding: embedding.clone(),
+                    k: top_k.unwrap_or(10),
+                })
+            }
 
             UnaryOp::Sort { key, descending } => Ok(PhysicalOp::Sort {
                 input: Box::new(input),
@@ -580,32 +649,50 @@ mod tests {
     use crate::query::plan::QueryHints;
 
     fn test_planner() -> QueryPlanner {
-        QueryPlanner::new(Arc::new(Statistics::default()))
+        use crate::index::vector::DistanceMetric;
+        use crate::index::vector::hnsw::HnswConfig;
+        use crate::storage::CurrentStorage;
+
+        // Create storage with vector index enabled for most tests
+        let storage = Arc::new(CurrentStorage::new());
+        let config = HnswConfig::new(4, DistanceMetric::Cosine);
+        storage.enable_vector_index("embedding", config).unwrap();
+
+        QueryPlanner::new(Arc::new(Statistics::default()), storage)
     }
 
     // ==================== Basic Planner Tests ====================
 
     #[test]
     fn test_planner_new() {
+        use crate::storage::CurrentStorage;
+
         let stats = Arc::new(Statistics::default());
-        let planner = QueryPlanner::new(Arc::clone(&stats));
+        let storage = Arc::new(CurrentStorage::new());
+        let planner = QueryPlanner::new(Arc::clone(&stats), storage);
         // Verify the planner was created (no public fields to check)
         let _ = planner;
     }
 
     #[test]
     fn test_planner_with_cost_model() {
+        use crate::storage::CurrentStorage;
+
         let stats = Arc::new(Statistics::default());
+        let storage = Arc::new(CurrentStorage::new());
         let custom_cost = CostModel::default();
-        let planner = QueryPlanner::new(stats).with_cost_model(custom_cost);
+        let planner = QueryPlanner::new(stats, storage).with_cost_model(custom_cost);
         let _ = planner;
     }
 
     #[test]
     fn test_planner_with_rules() {
+        use crate::storage::CurrentStorage;
+
         let stats = Arc::new(Statistics::default());
+        let storage = Arc::new(CurrentStorage::new());
         let custom_rules: Vec<Box<dyn OptimizationRule>> = vec![];
-        let planner = QueryPlanner::new(stats).with_rules(custom_rules);
+        let planner = QueryPlanner::new(stats, storage).with_rules(custom_rules);
         let _ = planner;
     }
 
@@ -1370,5 +1457,97 @@ mod tests {
             }
             _ => panic!("Expected SimilarToNode"),
         }
+    }
+
+    // ==================== Index Validation Tests (Issue #309) ====================
+
+    #[test]
+    fn test_vector_search_without_index_error() {
+        use crate::storage::CurrentStorage;
+
+        // Create planner with storage (no vector index enabled)
+        let storage = Arc::new(CurrentStorage::new());
+        let planner = QueryPlanner::new(Arc::new(Statistics::default()), storage);
+
+        let embedding = [0.1f32; 4];
+        let query = QueryBuilder::new().find_similar(&embedding, 10).build();
+
+        // Should fail during planning with IndexNotFound error
+        let result = planner.plan(query);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let err_msg = format!("{}", err);
+        assert!(err_msg.contains("index"));
+        assert!(err_msg.contains("embedding"));
+        assert!(
+            err_msg.contains("enable_vector_index"),
+            "Error message should provide hint to enable index: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_vector_rerank_without_index_error() {
+        use crate::storage::CurrentStorage;
+
+        let storage = Arc::new(CurrentStorage::new());
+        let planner = QueryPlanner::new(Arc::new(Statistics::default()), storage);
+
+        let embedding = [0.1f32; 4];
+        let query = QueryBuilder::new()
+            .start(NodeId::new(1).unwrap())
+            .rank_by_similarity(&embedding, 10)
+            .build();
+
+        let result = planner.plan(query);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let err_msg = format!("{}", err).to_lowercase();
+        assert!(err_msg.contains("vector"));
+        assert!(err_msg.contains("index"));
+        assert!(err_msg.contains("embedding"));
+    }
+
+    #[test]
+    fn test_similar_to_without_index_error() {
+        use crate::storage::CurrentStorage;
+
+        let storage = Arc::new(CurrentStorage::new());
+        let planner = QueryPlanner::new(Arc::new(Statistics::default()), storage);
+
+        let source_node = NodeId::new(1).unwrap();
+        let query = QueryBuilder::new()
+            .start(source_node)
+            .similar_to(source_node, 10)
+            .build();
+
+        let result = planner.plan(query);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let err_msg = format!("{}", err);
+        assert!(err_msg.contains("index"));
+    }
+
+    #[test]
+    fn test_temporal_vector_search_without_index_error() {
+        use crate::storage::CurrentStorage;
+
+        let storage = Arc::new(CurrentStorage::new());
+        let planner = QueryPlanner::new(Arc::new(Statistics::default()), storage);
+
+        let embedding = [0.1f32; 4];
+        let query = QueryBuilder::new()
+            .as_of(1000, 2000)
+            .find_similar(&embedding, 10)
+            .build();
+
+        let result = planner.plan(query);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, crate::utils::error::Error::Query(_)));
     }
 }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -474,6 +474,15 @@ pub enum QueryError {
         /// The error message
         message: String,
     },
+    /// Required index not found during query planning.
+    IndexNotFound {
+        /// The type of index required (e.g., "vector")
+        index_type: String,
+        /// The property name being indexed
+        property_name: String,
+        /// Optional hint on how to fix the issue
+        hint: Option<String>,
+    },
 }
 
 impl fmt::Display for QueryError {
@@ -499,6 +508,21 @@ impl fmt::Display for QueryError {
             }
             QueryError::ExecutionError { message } => {
                 write!(f, "Query execution error: {}", message)
+            }
+            QueryError::IndexNotFound {
+                index_type,
+                property_name,
+                hint,
+            } => {
+                write!(
+                    f,
+                    "Query requires {} index on '{}' property which is not enabled",
+                    index_type, property_name
+                )?;
+                if let Some(hint_msg) = hint {
+                    write!(f, ". Hint: {}", hint_msg)?;
+                }
+                Ok(())
             }
         }
     }
@@ -917,6 +941,28 @@ mod tests {
         };
         assert!(format!("{}", err).contains("Invalid graph traversal"));
         assert!(format!("{}", err).contains("edge doesn't connect nodes"));
+
+        // Test IndexNotFound without hint
+        let err = QueryError::IndexNotFound {
+            index_type: "vector".to_string(),
+            property_name: "embedding".to_string(),
+            hint: None,
+        };
+        let display = format!("{}", err);
+        assert!(display.contains("vector index"));
+        assert!(display.contains("embedding"));
+        assert!(display.contains("not enabled"));
+
+        // Test IndexNotFound with hint
+        let err = QueryError::IndexNotFound {
+            index_type: "vector".to_string(),
+            property_name: "embedding".to_string(),
+            hint: Some("Call db.enable_vector_index(\"embedding\", config) first".to_string()),
+        };
+        let display = format!("{}", err);
+        assert!(display.contains("vector index"));
+        assert!(display.contains("embedding"));
+        assert!(display.contains("enable_vector_index"));
     }
 
     #[test]

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -6,7 +6,7 @@
 use gallifreydb::{
     DistanceMetric, GallifreyDB, HnswConfig, NodeId, PropertyMapBuilder, WriteOps,
     query::{QueryBuilder, QueryPlanner},
-    storage::version::AnchorConfig,
+    storage::{CurrentStorage, version::AnchorConfig},
 };
 use std::sync::Arc;
 
@@ -17,6 +17,15 @@ fn create_test_db() -> GallifreyDB {
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
     db
+}
+
+/// Helper to create a test planner with vector index enabled.
+fn create_test_planner() -> QueryPlanner {
+    let storage = Arc::new(CurrentStorage::new());
+    let config = HnswConfig::new(4, DistanceMetric::Cosine);
+    storage.enable_vector_index("embedding", config).unwrap();
+    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
+    QueryPlanner::new(stats, storage)
 }
 
 /// Helper to create a social graph for testing.
@@ -87,8 +96,7 @@ fn test_query_builder_basic() {
     let query = QueryBuilder::new().start(alice).build();
 
     // Verify by planning - if planning succeeds, the query is valid
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     assert!(planner.plan(query).is_ok());
     println!("✓ Query builder creates valid query");
 }
@@ -105,8 +113,7 @@ fn test_query_builder_with_filter() {
         .build();
 
     // Verify by planning
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     assert!(planner.plan(query).is_ok());
     println!("✓ Query builder with filter works");
 }
@@ -120,8 +127,7 @@ fn test_query_builder_traverse() {
     let query = QueryBuilder::new().start(alice).traverse("KNOWS").build();
 
     // Verify by planning
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     assert!(planner.plan(query).is_ok());
     println!("✓ Query builder with traversal works");
 }
@@ -135,8 +141,7 @@ fn test_query_builder_vector_search() {
     let query = QueryBuilder::new().find_similar(&embedding, 5).build();
 
     // Verify by planning
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     assert!(planner.plan(query).is_ok());
     println!("✓ Query builder for vector search works");
 }
@@ -155,8 +160,7 @@ fn test_query_builder_hybrid() {
         .build();
 
     // Verify by planning
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     assert!(planner.plan(query).is_ok());
     println!("✓ Query builder for hybrid query works");
 }
@@ -184,8 +188,7 @@ fn test_planner_node_lookup() {
 
     let query = QueryBuilder::new().start(alice).build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Should produce a NodeLookup physical op
@@ -203,8 +206,7 @@ fn test_planner_traversal() {
 
     let query = QueryBuilder::new().start(alice).traverse("KNOWS").build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Should produce an IndexedTraversal
@@ -222,8 +224,7 @@ fn test_planner_vector_search() {
     let embedding = [1.0f32, 0.0, 0.0, 0.0];
     let query = QueryBuilder::new().find_similar(&embedding, 5).build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Should produce an HnswSearch
@@ -246,8 +247,7 @@ fn test_planner_hybrid_graph_vector() {
         .rank_by_similarity(&embedding, 10)
         .build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Should produce VectorRerank(IndexedTraversal(NodeLookup))
@@ -265,8 +265,7 @@ fn test_planner_temporal_lookup() {
 
     let query = QueryBuilder::new().as_of(1000, 1000).start(alice).build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Should produce TemporalNodeLookup
@@ -310,8 +309,7 @@ fn test_plan_explain() {
         .limit(5)
         .build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Get explain output from the root operation
@@ -328,8 +326,7 @@ fn test_plan_depth() {
 
     // Simple query - shallow plan
     let simple = QueryBuilder::new().start(alice).build();
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats.clone());
+    let planner = create_test_planner();
     let simple_plan = planner.plan(simple).expect("Planning failed");
     assert_eq!(simple_plan.root.depth(), 1);
 
@@ -359,8 +356,7 @@ fn test_minimal_query() {
     let fake_id = NodeId::new(99999).expect("valid id");
     let query = QueryBuilder::new().start(fake_id).build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
 
     // Planning should succeed (execution would return empty results)
     let result = planner.plan(query);
@@ -379,8 +375,7 @@ fn test_multi_hop_traversal_query() {
         .traverse_n("KNOWS", 2)
         .build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     assert!(matches!(
@@ -398,8 +393,7 @@ fn test_scan_all_nodes() {
     // Scan all nodes with label
     let query = QueryBuilder::new().scan(Some("Person")).build();
 
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     assert!(matches!(
@@ -498,8 +492,7 @@ fn test_full_hybrid_temporal_graph_vector() {
     assert!(query.operation_count() >= 3);
 
     // Plan should work
-    let stats = Arc::new(gallifreydb::query::planner::Statistics::default());
-    let planner = QueryPlanner::new(stats);
+    let planner = create_test_planner();
     let plan = planner.plan(query).expect("Planning failed");
 
     // Should be a VectorRerank over something


### PR DESCRIPTION
Implement index validation in QueryPlanner to detect missing indexes during planning rather than at execution time, providing better error messages and earlier failure detection.

**Changes:**
- Add IndexNotFound error variant to QueryError with helpful hints
- Modify QueryPlanner to accept Arc<CurrentStorage> for index validation
- Add validation in scan_to_physical() for vector operations:
  * HnswSearch (vector search)
  * TemporalVectorSearch (temporal vector search)
  * SimilarToNode (similar-to queries)
- Add validation in unary_to_physical() for VectorRerank operations
- Add comprehensive tests for index validation behavior
- Update all QueryPlanner::new() call sites (db.rs, tests)

**Benefits:**
- Earlier error detection at planning time vs execution time
- Clear, actionable error messages with hints (e.g., "Call db.enable_vector_index(...) first")
- Single validation pass during planning instead of per-row checks
- Enables future query plan caching with upfront validation

**Testing:**
- Added 4 new tests for index validation scenarios
- All existing tests updated and passing (1113 library tests)
- Clippy passes with -D warnings
- Code formatted with cargo fmt

Fixes #309