### PR TITLE
fix: implement temporal edge traversal for as_of() queries (#400)

### DIFF
--- a/benches/query_optimization.rs
+++ b/benches/query_optimization.rs
@@ -149,6 +149,7 @@ fn bench_cost_estimation(c: &mut Criterion) {
             direction: gallifreydb::query::ir::Direction::Outgoing,
             label: Some("KNOWS".to_string()),
             depth: 2,
+            temporal_context: None,
         }),
         predicate: gallifreydb::query::ir::Predicate::eq("active", true),
     };

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -387,6 +387,10 @@ pub struct TraversalIterator {
     label: Option<String>,
     depth: usize,
     current: Arc<CurrentStorage>,
+    historical: Arc<RwLock<HistoricalStorage>>,
+    /// Optional temporal context (valid_time, transaction_time) for edge filtering.
+    /// When present, only edges that existed at the specified point in time are traversed.
+    temporal_context: Option<(Timestamp, Timestamp)>,
     // BFS state - reset for each input node (see doc comment above)
     frontier: VecDeque<(NodeId, Vec<EntityId>, usize)>,
     visited: HashSet<NodeId>,
@@ -400,6 +404,8 @@ impl TraversalIterator {
         label: Option<String>,
         depth: usize,
         current: Arc<CurrentStorage>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+        temporal_context: Option<(Timestamp, Timestamp)>,
     ) -> Self {
         TraversalIterator {
             input,
@@ -407,13 +413,40 @@ impl TraversalIterator {
             label,
             depth,
             current,
+            historical,
+            temporal_context,
             frontier: VecDeque::new(),
             visited: HashSet::new(),
             input_exhausted: false,
         }
     }
 
+    /// Check if an edge existed at the specified temporal context using a pre-acquired lock guard.
+    /// Returns true if no temporal context is set (current state query).
+    #[inline]
+    fn edge_visible_at_time(
+        &self,
+        edge_id: crate::core::EdgeId,
+        historical_guard: &Option<parking_lot::RwLockReadGuard<'_, HistoricalStorage>>,
+    ) -> bool {
+        match self.temporal_context {
+            Some((valid_time, tx_time)) => {
+                // Use the pre-acquired guard to avoid per-edge lock acquisition
+                historical_guard
+                    .as_ref()
+                    .expect("historical_guard must be Some when temporal_context is Some")
+                    .find_edge_version_at_time(edge_id, valid_time, tx_time)
+                    .is_some()
+            }
+            None => true, // No temporal context, use current state
+        }
+    }
+
     fn get_neighbors(&self, node_id: NodeId) -> Vec<(NodeId, crate::core::EdgeId)> {
+        // Acquire historical lock ONCE for all edge checks in this call.
+        // This avoids the performance regression of acquiring per-edge locks.
+        let historical_guard = self.temporal_context.map(|_| self.historical.read());
+
         match self.direction {
             Direction::Outgoing => {
                 let edges = if let Some(ref label) = self.label {
@@ -425,6 +458,9 @@ impl TraversalIterator {
                 edges
                     .into_iter()
                     .filter_map(|edge_id| {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            return None;
+                        }
                         self.current
                             .get_edge(edge_id)
                             .ok()
@@ -442,6 +478,9 @@ impl TraversalIterator {
                 edges
                     .into_iter()
                     .filter_map(|edge_id| {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            return None;
+                        }
                         self.current
                             .get_edge(edge_id)
                             .ok()
@@ -459,6 +498,9 @@ impl TraversalIterator {
                 };
 
                 for edge_id in out_edges {
+                    if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                        continue;
+                    }
                     if let Ok(e) = self.current.get_edge(edge_id) {
                         neighbors.push((e.target, edge_id));
                     }
@@ -471,6 +513,9 @@ impl TraversalIterator {
                 };
 
                 for edge_id in in_edges {
+                    if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                        continue;
+                    }
                     if let Ok(e) = self.current.get_edge(edge_id) {
                         neighbors.push((e.source, edge_id));
                     }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -144,6 +144,7 @@ impl QueryExecutor {
                 direction,
                 label,
                 depth,
+                temporal_context,
             } => {
                 let input_iter = self.execute_op(input)?;
                 Ok(Box::new(iterators::TraversalIterator::new(
@@ -152,6 +153,8 @@ impl QueryExecutor {
                     label.clone(),
                     *depth,
                     Arc::clone(&self.current),
+                    Arc::clone(&self.historical),
+                    *temporal_context,
                 )))
             }
 
@@ -513,6 +516,7 @@ mod tests {
                 direction: crate::query::ir::Direction::Outgoing,
                 label: Some("KNOWS".to_string()),
                 depth: 1,
+                temporal_context: None,
             },
             estimated_cost: Default::default(),
             temporal_context: None,
@@ -695,6 +699,7 @@ mod tests {
                         direction: crate::query::ir::Direction::Outgoing,
                         label: Some("KNOWS".to_string()),
                         depth: 1,
+                        temporal_context: None,
                     }),
                     predicate: crate::query::Predicate::eq("name", "Bob"),
                 }),

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -583,6 +583,7 @@ mod tests {
             direction: crate::query::ir::Direction::Outgoing,
             label: None,
             depth: 2,
+            temporal_context: None,
         };
 
         let cost = model.estimate(&op, &stats);

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -366,7 +366,7 @@ impl QueryPlanner {
 
             LogicalOp::Unary { op, input } => {
                 let physical_input = self.to_physical_op(input, temporal)?;
-                self.unary_to_physical(op, physical_input)
+                self.unary_to_physical(op, physical_input, temporal)
             }
 
             LogicalOp::Binary { op, left, right } => {
@@ -521,7 +521,12 @@ impl QueryPlanner {
     }
 
     /// Convert a unary operation to physical
-    fn unary_to_physical(&self, op: &UnaryOp, input: PhysicalOp) -> Result<PhysicalOp> {
+    fn unary_to_physical(
+        &self,
+        op: &UnaryOp,
+        input: PhysicalOp,
+        temporal: &Option<TemporalContext>,
+    ) -> Result<PhysicalOp> {
         match op {
             UnaryOp::Filter(predicate) => Ok(PhysicalOp::Filter {
                 input: Box::new(input),
@@ -549,12 +554,17 @@ impl QueryPlanner {
                 direction,
                 label,
                 depth,
-            } => Ok(PhysicalOp::IndexedTraversal {
-                input: Box::new(input),
-                direction: *direction,
-                label: label.clone(),
-                depth: depth.max_depth().unwrap_or(10),
-            }),
+            } => {
+                // Extract temporal context for edge filtering during traversal
+                let temporal_ctx = temporal.as_ref().and_then(|ctx| ctx.as_of);
+                Ok(PhysicalOp::IndexedTraversal {
+                    input: Box::new(input),
+                    direction: *direction,
+                    label: label.clone(),
+                    depth: depth.max_depth().unwrap_or(10),
+                    temporal_context: temporal_ctx,
+                })
+            }
 
             UnaryOp::VectorRank { embedding, top_k } => {
                 // Validate that vector index is enabled for reranking

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -314,6 +314,9 @@ pub enum PhysicalOp {
         label: Option<String>,
         /// Maximum depth
         depth: usize,
+        /// Optional temporal context (valid_time, transaction_time) for edge filtering.
+        /// When present, only edges that existed at the specified point in time are traversed.
+        temporal_context: Option<(Timestamp, Timestamp)>,
     },
 
     // === Join Operators ===
@@ -559,12 +562,19 @@ impl PhysicalOp {
                 direction,
                 label,
                 depth,
+                temporal_context,
             } => {
+                let temporal_str = if let Some((vt, tt)) = temporal_context {
+                    format!(", as_of: ({}, {})", vt, tt)
+                } else {
+                    String::new()
+                };
                 format!(
-                    "{prefix}{name} (dir: {:?}, label: {:?}, depth: {})\n{}",
+                    "{prefix}{name} (dir: {:?}, label: {:?}, depth: {}{})\n{}",
                     direction,
                     label,
                     depth,
+                    temporal_str,
                     input.explain_indent(indent + 1)
                 )
             }
@@ -777,7 +787,8 @@ mod tests {
                 input: Box::new(PhysicalOp::Empty),
                 direction: Direction::Outgoing,
                 label: None,
-                depth: 1
+                depth: 1,
+                temporal_context: None,
             }
             .name(),
             "IndexedTraversal"
@@ -961,7 +972,8 @@ mod tests {
                 input: Box::new(PhysicalOp::Empty),
                 direction: Direction::Outgoing,
                 label: None,
-                depth: 1
+                depth: 1,
+                temporal_context: None,
             }
             .is_leaf()
         );
@@ -1241,6 +1253,7 @@ mod tests {
             direction: Direction::Outgoing,
             label: Some("KNOWS".to_string()),
             depth: 2,
+            temporal_context: None,
         };
 
         let explain = plan.explain();
@@ -1577,6 +1590,7 @@ mod tests {
                     direction: Direction::Outgoing,
                     label: Some("KNOWS".to_string()),
                     depth: 2,
+                    temporal_context: None,
                 }),
                 predicate: Predicate::eq("age", 25i64),
             },

--- a/tests/hybrid_query.rs
+++ b/tests/hybrid_query.rs
@@ -596,24 +596,13 @@ mod temporal_vector_tests {
             .collect_all()
             .expect("Failed to collect query results");
 
-        // BUG: Temporal edge traversal is NOT implemented (issue #400)
-        // https://github.com/madmax983/GallifreyDB/issues/400
-        //
-        // EXPECTED: At the historical timestamp, Alice only knew Bob.
-        //           Carol was added AFTER the timestamp, so she should NOT appear.
-        //           This test SHOULD pass with rows.len() == 1.
-        //
-        // ACTUAL: The TraversalIterator only queries CurrentStorage, ignoring
-        //         temporal context entirely. Both Bob AND Carol are returned.
-        //
-        // This test is INTENTIONALLY left failing to ensure this bug gets fixed.
-        // When issue #400 is resolved, this assertion will pass.
+        // At the historical timestamp, Alice only knew Bob.
+        // Carol was added AFTER the timestamp, so she should NOT appear.
+        // Issue #400 fixed: Temporal edge traversal is now implemented.
         assert_eq!(
             rows.len(),
             1,
-            "BUG #400: At historical timestamp, Alice should only know Bob (not Carol). \
-             Temporal edge traversal is not implemented - edges are queried from current \
-             state instead of historical state. See: https://github.com/madmax983/GallifreyDB/issues/400"
+            "At historical timestamp, Alice should only know Bob (not Carol)"
         );
 
         // Verify Bob is the one result


### PR DESCRIPTION
## Summary
- Fixes issue #400: `as_of()` queries now correctly filter edges by timestamp during graph traversal
- Previously, temporal queries filtered nodes but returned edges from current state
- Now both nodes AND edges respect the temporal context

## Changes
- Added `temporal_context` field to `PhysicalOp::IndexedTraversal` to carry `(valid_time, tx_time)`
- Updated `TraversalIterator` to:
  - Accept `HistoricalStorage` reference and temporal context
  - Implement `edge_exists_at_time()` using `find_edge_version_at_time()` from HistoricalStorage
  - Filter edges in `get_neighbors()` when temporal context is present
- Updated query planner to propagate temporal context to traversal operators
- Updated test comment now that bug is fixed

## Test plan
- [x] Verified `test_temporal_traverse_and_rank` now passes (was intentionally failing)
- [x] Ran full test suite (1197+ tests pass)
- [x] Clippy passes with no warnings
- [x] Code formatted with `cargo fmt`

## Example
```rust
// Query at historical timestamp - only returns edges that existed at that time
let results = db.query()
    .as_of(timestamp_2023, timestamp_2023)
    .start(alice)
    .traverse("KNOWS")
    .rank_by_similarity(&embedding, 10)
    .execute();
// Now correctly returns only friends Alice had at timestamp_2023
```

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)