### PR TITLE
Add test coverage for persist_indexes() WAL LSN usage

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -3135,6 +3135,32 @@ impl GallifreyDB {
         &self.current
     }
 
+    /// Get the current WAL LSN (test-only helper).
+    ///
+    /// This method provides access to the current WAL Log Sequence Number for
+    /// test verification purposes. This is particularly useful for testing index
+    /// persistence where LSN coordination with the WAL is critical for correctness.
+    ///
+    /// **Warning**: This method exposes internal implementation details and
+    /// should only be used in tests.
+    ///
+    /// # Returns
+    ///
+    /// The current LSN from the WAL system.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let db = GallifreyDB::new();
+    /// db.create_node("Person", properties)?;
+    /// let lsn = db.__test_current_wal_lsn();
+    /// assert!(lsn > 0); // LSN advances after operations
+    /// ```
+    #[doc(hidden)]
+    pub fn __test_current_wal_lsn(&self) -> u64 {
+        self.wal.current_lsn().0
+    }
+
     /// Access the internal HistoricalStorage for testing purposes.
     ///
     /// This method provides access to the internal HistoricalStorage for

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2531,3 +2531,96 @@ fn test_version_chain_reconstruction() {
     println!("✓ Version head correctly points to latest version");
     println!("✓ Version chain reconstruction test passed!");
 }
+
+/// Test that persist_indexes() uses actual WAL LSN instead of hardcoded LSN=0.
+///
+/// This test verifies the fix for issue #410: The public persist_indexes() method
+/// must use the actual LSN from the WAL, not a hardcoded value of 0.
+///
+/// Test strategy:
+/// 1. Create database with persistence enabled
+/// 2. Create several nodes/edges to advance WAL LSN beyond 0
+/// 3. Get the current WAL LSN before persisting
+/// 4. Call persist_indexes()
+/// 5. Load manifest and verify LSN matches WAL LSN (not 0)
+#[test]
+fn test_persist_indexes_uses_actual_wal_lsn() {
+    use gallifreydb::GallifreyDB;
+    use gallifreydb::config::GallifreyDBConfig;
+    use gallifreydb::storage::index_persistence::PersistenceConfig;
+
+    // Acquire mutex to prevent race conditions with GLOBAL_INTERNER
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().to_path_buf();
+
+    let config = GallifreyDBConfig::builder()
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: data_dir.clone(),
+            load_on_startup: false,
+            ..Default::default()
+        })
+        .build();
+
+    let db = GallifreyDB::with_unified_config(config);
+
+    // Create multiple nodes and edges to advance WAL LSN significantly
+    let mut node_ids = Vec::new();
+    for i in 0..10 {
+        let node_id = db
+            .create_node(
+                "TestNode",
+                PropertyMapBuilder::new()
+                    .insert("index", i as i64)
+                    .insert("name", format!("Node_{}", i))
+                    .build(),
+            )
+            .unwrap();
+        node_ids.push(node_id);
+    }
+
+    // Create edges to further advance WAL LSN
+    for i in 0..9 {
+        db.create_edge(
+            node_ids[i],
+            node_ids[i + 1],
+            "LINKS_TO",
+            PropertyMapBuilder::new()
+                .insert("weight", (i + 1) as i64)
+                .build(),
+        )
+        .unwrap();
+    }
+
+    // Get current WAL LSN before persisting
+    // We need to access the WAL through the DB's internal structure
+    // Since this is a test, we'll verify the manifest LSN is > 0
+
+    // Persist indexes - this should capture the current WAL LSN
+    db.persist_indexes().unwrap();
+
+    // Load the manifest and verify LSN
+    let manager = IndexPersistenceManager::new(&data_dir);
+    let manifest = manager.load_manifest_and_strings().unwrap();
+
+    // The critical assertion: LSN should NOT be 0 (the old hardcoded value)
+    assert_ne!(
+        manifest.lsn, 0,
+        "LSN should not be hardcoded to 0 - it should reflect actual WAL position"
+    );
+
+    // Additionally, verify LSN is reasonable (should be > 0 after creating 10 nodes + 9 edges)
+    assert!(
+        manifest.lsn > 0,
+        "LSN should be greater than 0 after database operations. Got: {}",
+        manifest.lsn
+    );
+
+    println!(
+        "✓ persist_indexes() correctly uses actual WAL LSN: {}",
+        manifest.lsn
+    );
+    println!("✓ Issue #410 fix verified: No hardcoded LSN=0");
+}

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2594,9 +2594,8 @@ fn test_persist_indexes_uses_actual_wal_lsn() {
         .unwrap();
     }
 
-    // Get current WAL LSN before persisting
-    // We need to access the WAL through the DB's internal structure
-    // Since this is a test, we'll verify the manifest LSN is > 0
+    // Get current WAL LSN before persisting to verify exact match
+    let expected_lsn = db.__test_current_wal_lsn();
 
     // Persist indexes - this should capture the current WAL LSN
     db.persist_indexes().unwrap();
@@ -2605,22 +2604,23 @@ fn test_persist_indexes_uses_actual_wal_lsn() {
     let manager = IndexPersistenceManager::new(&data_dir);
     let manifest = manager.load_manifest_and_strings().unwrap();
 
-    // The critical assertion: LSN should NOT be 0 (the old hardcoded value)
+    // Critical assertion: LSN should NOT be hardcoded to 0 (the old bug)
     assert_ne!(
         manifest.lsn, 0,
         "LSN should not be hardcoded to 0 - it should reflect actual WAL position"
     );
 
-    // Additionally, verify LSN is reasonable (should be > 0 after creating 10 nodes + 9 edges)
-    assert!(
-        manifest.lsn > 0,
-        "LSN should be greater than 0 after database operations. Got: {}",
-        manifest.lsn
+    // Enhanced assertion: LSN should exactly match WAL LSN at persist time
+    // This is the strongest verification - catches ANY hardcoded value (0, 1, 100, etc.)
+    assert_eq!(
+        manifest.lsn, expected_lsn,
+        "Manifest LSN should exactly match WAL LSN at persist time. Expected: {}, Got: {}",
+        expected_lsn, manifest.lsn
     );
 
     println!(
-        "✓ persist_indexes() correctly uses actual WAL LSN: {}",
-        manifest.lsn
+        "✓ persist_indexes() correctly uses actual WAL LSN: {} (expected: {})",
+        manifest.lsn, expected_lsn
     );
-    println!("✓ Issue #410 fix verified: No hardcoded LSN=0");
+    println!("✓ Issue #410 fix verified: No hardcoded LSN, exact match confirmed");
 }


### PR DESCRIPTION
## Summary

Fixes #410: Adds comprehensive test coverage to verify that `persist_indexes()` uses the actual WAL LSN instead of a hardcoded value.

## Changes

### Test Implementation (`tests/index_persistence.rs`)
- ✅ Added `test_persist_indexes_uses_actual_wal_lsn()` 
- Creates 10 nodes + 9 edges to advance WAL LSN significantly
- Calls `persist_indexes()` and verifies manifest LSN
- **Dual verification:**
  - `assert_ne!(lsn, 0)` - Catches hardcoded 0 (the original bug)
  - `assert_eq!(lsn, expected_lsn)` - Exact match verification (stronger)

### Test Helper (`src/db.rs`)
- ✅ Added `__test_current_wal_lsn()` helper method
- Follows project pattern (`__test_` prefix, `#[doc(hidden)]`)
- Enables exact LSN comparison in tests

## Verification

The implementation was already correct (lines 3119-3120 in `src/db.rs`):
```rust
let current_lsn = self.wal.current_lsn().0;
let manifest = IndexManifest::new(current_lsn);
```

This PR adds **regression protection** through comprehensive test coverage.

## Test Results

```
✓ persist_indexes() correctly uses actual WAL LSN: 20 (expected: 20)
✓ Issue #410 fix verified: No hardcoded LSN, exact match confirmed
test test_persist_indexes_uses_actual_wal_lsn ... ok
```

**All checks passed:**
- ✅ All 23 index_persistence tests pass
- ✅ All 1278 library tests pass
- ✅ Clippy clean (no warnings)
- ✅ Code formatted

## Design Decisions

1. **Exact LSN comparison:** Stronger than just `> 0` - catches ANY hardcoded value
2. **Test helper method:** Follows `__test_` pattern used elsewhere in codebase
3. **Sufficient WAL advancement:** 19 operations ensure LSN advances beyond initial state

## Related

- Related to #408, #409 (index persistence hardening)
- Implements verification for ADR-0023 (WAL coordination requirement)

## Test Plan

- [x] Test passes with exact LSN match
- [x] Full test suite passes (no regressions)
- [x] Clippy passes
- [x] Code formatted

🤖 Generated with TDD workflow and code review feedback