### PR TITLE
fix: replace lock .expect() with lock_or_err() for graceful error han…

### DIFF
--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -257,7 +257,11 @@ impl WriteTransaction {
             #[cfg(feature = "observability")]
             let ts_lock_start = std::time::Instant::now();
 
-            let mut ts = self.current_timestamp.lock_or_err()?;
+            let mut ts = self.current_timestamp.lock_or_err().map_err(|e| {
+                TransactionError::CommitFailed {
+                    reason: format!("timestamp lock poisoned: {}", e),
+                }
+            })?;
 
             #[cfg(feature = "observability")]
             let ts_lock_acquired = std::time::Instant::now();
@@ -2666,12 +2670,11 @@ mod tests {
 
     // ==================== Lock Poisoning Tests ====================
 
-    #[test]
-    fn test_commit_timestamp_lock_poisoning_returns_error() {
-        // Test that commit returns a proper error if the timestamp lock is poisoned
-        // instead of panicking (Issue #342).
-        use std::thread;
-
+    /// Create a test write transaction with a custom timestamp mutex.
+    /// This allows testing lock poisoning scenarios.
+    fn create_test_write_tx_with_timestamp(
+        current_timestamp: Arc<Mutex<Timestamp>>,
+    ) -> (WriteTransaction, TempDir) {
         let current = Arc::new(CurrentStorage::new());
         let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
         let temporal_indexes = Arc::new(TemporalIndexes::new());
@@ -2680,7 +2683,6 @@ mod tests {
         let wal_config = ConcurrentWalSystemConfig::new(temp_dir.path());
         let wal = Arc::new(ConcurrentWalSystem::new(wal_config).unwrap());
 
-        let current_timestamp = Arc::new(Mutex::new(time::now()));
         let node_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
         let edge_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
         let version_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
@@ -2692,7 +2694,31 @@ mod tests {
             active_transactions: Arc::new(std::collections::HashSet::new()),
         };
 
-        // Clone timestamp mutex for poisoning thread
+        let tx = WriteTransaction::new(
+            tx_id_gen.next(),
+            snapshot,
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            visibility_manager,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+        );
+
+        (tx, temp_dir)
+    }
+
+    #[test]
+    fn test_commit_timestamp_lock_poisoning_returns_error() {
+        // Test that commit returns a proper error if the timestamp lock is poisoned
+        // instead of panicking (Issue #342).
+        use std::thread;
+
+        // Create timestamp mutex that we'll poison
+        let current_timestamp = Arc::new(Mutex::new(time::now()));
         let ts_clone = Arc::clone(&current_timestamp);
 
         // Poison the lock by panicking while holding it
@@ -2704,38 +2730,30 @@ mod tests {
         // Wait for the poisoning thread to complete
         let _ = handle.join();
 
-        // Create the transaction after the lock is poisoned
-        let mut tx = WriteTransaction::new(
-            tx_id_gen.next(),
-            snapshot,
-            current,
-            historical,
-            temporal_indexes,
-            wal,
-            current_timestamp, // This mutex is now poisoned
-            visibility_manager,
-            node_id_gen,
-            edge_id_gen,
-            version_id_gen,
-        );
+        // Create the transaction with the poisoned lock
+        let (mut tx, _temp_dir) = create_test_write_tx_with_timestamp(current_timestamp);
 
         // Create a node so we have something to commit
         let props = PropertyMapBuilder::new().insert("name", "Test").build();
         tx.create_node("TestNode", props).unwrap();
 
-        // Commit should return a LockPoisoned error, not panic
+        // Commit should return a CommitFailed error, not panic
         let result = tx.commit();
         assert!(result.is_err());
 
-        // Verify it's the correct error type
-        if let Err(crate::utils::error::Error::Storage(
-            crate::utils::error::StorageError::LockPoisoned { lock_type },
+        // Verify it's the correct error type (TransactionError::CommitFailed)
+        if let Err(crate::utils::error::Error::Transaction(
+            crate::utils::error::TransactionError::CommitFailed { reason },
         )) = result
         {
-            assert_eq!(lock_type, "Mutex");
+            assert!(
+                reason.contains("timestamp lock poisoned"),
+                "Expected error message to contain 'timestamp lock poisoned', got: {}",
+                reason
+            );
         } else {
             panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
+                "Expected TransactionError::CommitFailed, got {:?}",
                 result.err()
             );
         }

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -257,10 +257,7 @@ impl WriteTransaction {
             #[cfg(feature = "observability")]
             let ts_lock_start = std::time::Instant::now();
 
-            let mut ts = self
-                .current_timestamp
-                .lock()
-                .expect("timestamp lock poisoned - unrecoverable state");
+            let mut ts = self.current_timestamp.lock_or_err()?;
 
             #[cfg(feature = "observability")]
             let ts_lock_acquired = std::time::Instant::now();
@@ -2664,6 +2661,83 @@ mod tests {
         for i in 0..99 {
             assert_eq!(current.out_degree(nodes[i]), 1);
             assert_eq!(current.in_degree(nodes[i + 1]), 1);
+        }
+    }
+
+    // ==================== Lock Poisoning Tests ====================
+
+    #[test]
+    fn test_commit_timestamp_lock_poisoning_returns_error() {
+        // Test that commit returns a proper error if the timestamp lock is poisoned
+        // instead of panicking (Issue #342).
+        use std::thread;
+
+        let current = Arc::new(CurrentStorage::new());
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let temporal_indexes = Arc::new(TemporalIndexes::new());
+
+        let temp_dir = TempDir::new().unwrap();
+        let wal_config = ConcurrentWalSystemConfig::new(temp_dir.path());
+        let wal = Arc::new(ConcurrentWalSystem::new(wal_config).unwrap());
+
+        let current_timestamp = Arc::new(Mutex::new(time::now()));
+        let node_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
+        let edge_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
+        let version_id_gen = Arc::new(Mutex::new(IdGenerator::new()));
+        let tx_id_gen = TxIdGenerator::new();
+
+        let visibility_manager = Arc::new(TxVisibilityManager::new());
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: time::now(),
+            active_transactions: Arc::new(std::collections::HashSet::new()),
+        };
+
+        // Clone timestamp mutex for poisoning thread
+        let ts_clone = Arc::clone(&current_timestamp);
+
+        // Poison the lock by panicking while holding it
+        let handle = thread::spawn(move || {
+            let _guard = ts_clone.lock().unwrap();
+            panic!("intentional panic to poison timestamp lock");
+        });
+
+        // Wait for the poisoning thread to complete
+        let _ = handle.join();
+
+        // Create the transaction after the lock is poisoned
+        let mut tx = WriteTransaction::new(
+            tx_id_gen.next(),
+            snapshot,
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp, // This mutex is now poisoned
+            visibility_manager,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+        );
+
+        // Create a node so we have something to commit
+        let props = PropertyMapBuilder::new().insert("name", "Test").build();
+        tx.create_node("TestNode", props).unwrap();
+
+        // Commit should return a LockPoisoned error, not panic
+        let result = tx.commit();
+        assert!(result.is_err());
+
+        // Verify it's the correct error type
+        if let Err(crate::utils::error::Error::Storage(
+            crate::utils::error::StorageError::LockPoisoned { lock_type },
+        )) = result
+        {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
         }
     }
 }

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -318,9 +318,21 @@ impl ConcurrentWalSystem {
             // transactions register with GroupCommitCoordinator but their entries
             // were already drained by a previous flush iteration.
             let should_mark_flushed = !entries.is_empty()
-                || group_commit
-                    .as_ref()
-                    .is_some_and(|gc| gc.current_batch_size().unwrap_or(0) > 0);
+                || group_commit.as_ref().is_some_and(|gc| {
+                    match gc.current_batch_size() {
+                        Ok(size) => size > 0,
+                        Err(e) => {
+                            // Lock poisoned - coordinator is in unrecoverable state.
+                            // Log error and assume no pending transactions (conservative).
+                            eprintln!(
+                                "CRITICAL: GroupCommitCoordinator lock poisoned during batch size check: {}. \
+                                 Pending transactions may be lost.",
+                                e
+                            );
+                            false
+                        }
+                    }
+                });
 
             if !entries.is_empty() {
                 // Flush to coordinator
@@ -332,9 +344,16 @@ impl ConcurrentWalSystem {
                         // Reset error counter on success
                         error_counter.store(0, Ordering::Relaxed);
                         if let Some(ref gc) = group_commit {
-                            // Ignore mark_flushed error: if lock is poisoned, coordinator is
-                            // corrupt anyway and waiters will fail on their next operation
-                            let _ = gc.mark_flushed(Ok(()));
+                            // If mark_flushed fails due to lock poisoning, the coordinator is
+                            // in an unrecoverable state. Log the error but continue - waiters
+                            // will fail on their next operation anyway.
+                            if let Err(e) = gc.mark_flushed(Ok(())) {
+                                eprintln!(
+                                    "CRITICAL: GroupCommitCoordinator lock poisoned during mark_flushed: {}. \
+                                     Database is in degraded state, transactions may hang.",
+                                    e
+                                );
+                            }
                         }
                     }
                     Err(e) => {
@@ -353,11 +372,15 @@ impl ConcurrentWalSystem {
                         if let Some(ref gc) = group_commit {
                             // Create a new error from the string representation
                             // (Error doesn't implement Clone, but mark_flushed only stores the string)
-                            // Ignore mark_flushed error: if lock is poisoned, coordinator is
-                            // corrupt anyway and waiters will fail on their next operation
-                            let _ = gc.mark_flushed(Err(crate::utils::error::Error::other(
-                                e.to_string(),
-                            )));
+                            if let Err(poison_err) = gc
+                                .mark_flushed(Err(crate::utils::error::Error::other(e.to_string())))
+                            {
+                                eprintln!(
+                                    "CRITICAL: GroupCommitCoordinator lock poisoned during mark_flushed: {}. \
+                                     Database is in degraded state, transactions may hang.",
+                                    poison_err
+                                );
+                            }
                         }
                     }
                 }
@@ -365,9 +388,14 @@ impl ConcurrentWalSystem {
                 // No entries but there are pending transactions - advance epoch anyway
                 // This handles the race where entries were flushed before transactions
                 // called register_transaction()
-                if let Some(ref gc) = group_commit {
-                    // Ignore mark_flushed error: see comment above
-                    let _ = gc.mark_flushed(Ok(()));
+                if let Some(ref gc) = group_commit
+                    && let Err(e) = gc.mark_flushed(Ok(()))
+                {
+                    eprintln!(
+                        "CRITICAL: GroupCommitCoordinator lock poisoned during mark_flushed: {}. \
+                         Database is in degraded state, transactions may hang.",
+                        e
+                    );
                 }
             }
 
@@ -384,17 +412,25 @@ impl ConcurrentWalSystem {
             match result {
                 Ok(_) => {
                     error_counter.store(0, Ordering::Relaxed);
-                    if let Some(ref gc) = group_commit {
-                        // Ignore mark_flushed error: see comment above
-                        let _ = gc.mark_flushed(Ok(()));
+                    if let Some(ref gc) = group_commit
+                        && let Err(e) = gc.mark_flushed(Ok(()))
+                    {
+                        eprintln!(
+                            "CRITICAL: GroupCommitCoordinator lock poisoned during shutdown flush: {}",
+                            e
+                        );
                     }
                 }
                 Err(e) => {
                     error_counter.fetch_add(1, Ordering::Relaxed);
-                    if let Some(ref gc) = group_commit {
-                        // Ignore mark_flushed error: see comment above
-                        let _ =
-                            gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())));
+                    if let Some(ref gc) = group_commit
+                        && let Err(poison_err) =
+                            gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())))
+                    {
+                        eprintln!(
+                            "CRITICAL: GroupCommitCoordinator lock poisoned during shutdown flush: {}",
+                            poison_err
+                        );
                     }
                 }
             }

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -320,7 +320,7 @@ impl ConcurrentWalSystem {
             let should_mark_flushed = !entries.is_empty()
                 || group_commit
                     .as_ref()
-                    .is_some_and(|gc| gc.current_batch_size() > 0);
+                    .is_some_and(|gc| gc.current_batch_size().unwrap_or(0) > 0);
 
             if !entries.is_empty() {
                 // Flush to coordinator
@@ -332,7 +332,9 @@ impl ConcurrentWalSystem {
                         // Reset error counter on success
                         error_counter.store(0, Ordering::Relaxed);
                         if let Some(ref gc) = group_commit {
-                            gc.mark_flushed(Ok(()));
+                            // Ignore mark_flushed error: if lock is poisoned, coordinator is
+                            // corrupt anyway and waiters will fail on their next operation
+                            let _ = gc.mark_flushed(Ok(()));
                         }
                     }
                     Err(e) => {
@@ -351,7 +353,11 @@ impl ConcurrentWalSystem {
                         if let Some(ref gc) = group_commit {
                             // Create a new error from the string representation
                             // (Error doesn't implement Clone, but mark_flushed only stores the string)
-                            gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())));
+                            // Ignore mark_flushed error: if lock is poisoned, coordinator is
+                            // corrupt anyway and waiters will fail on their next operation
+                            let _ = gc.mark_flushed(Err(crate::utils::error::Error::other(
+                                e.to_string(),
+                            )));
                         }
                     }
                 }
@@ -360,7 +366,8 @@ impl ConcurrentWalSystem {
                 // This handles the race where entries were flushed before transactions
                 // called register_transaction()
                 if let Some(ref gc) = group_commit {
-                    gc.mark_flushed(Ok(()));
+                    // Ignore mark_flushed error: see comment above
+                    let _ = gc.mark_flushed(Ok(()));
                 }
             }
 
@@ -378,13 +385,16 @@ impl ConcurrentWalSystem {
                 Ok(_) => {
                     error_counter.store(0, Ordering::Relaxed);
                     if let Some(ref gc) = group_commit {
-                        gc.mark_flushed(Ok(()));
+                        // Ignore mark_flushed error: see comment above
+                        let _ = gc.mark_flushed(Ok(()));
                     }
                 }
                 Err(e) => {
                     error_counter.fetch_add(1, Ordering::Relaxed);
                     if let Some(ref gc) = group_commit {
-                        gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())));
+                        // Ignore mark_flushed error: see comment above
+                        let _ =
+                            gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())));
                     }
                 }
             }
@@ -489,7 +499,7 @@ impl ConcurrentWalSystem {
             DurabilityMode::GroupCommit { .. } | DurabilityMode::AsyncBatched { .. } => {
                 // Register with coordinator and return epoch to wait for
                 if let Some(ref gc) = self.group_commit {
-                    let (epoch, should_trigger) = gc.register_transaction();
+                    let (epoch, should_trigger) = gc.register_transaction()?;
 
                     // If batch is full, signal flush thread to wake up immediately
                     if should_trigger {

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -317,21 +317,15 @@ impl ConcurrentWalSystem {
             // group commit has pending transactions. This handles the race where
             // transactions register with GroupCommitCoordinator but their entries
             // were already drained by a previous flush iteration.
+            //
+            // LOCK POISONING: If current_batch_size() fails, the coordinator lock is
+            // poisoned and the system is in an unrecoverable state. Panicking is correct
+            // here - continuing would leave waiting transactions hanging indefinitely.
             let should_mark_flushed = !entries.is_empty()
                 || group_commit.as_ref().is_some_and(|gc| {
-                    match gc.current_batch_size() {
-                        Ok(size) => size > 0,
-                        Err(e) => {
-                            // Lock poisoned - coordinator is in unrecoverable state.
-                            // Log error and assume no pending transactions (conservative).
-                            eprintln!(
-                                "CRITICAL: GroupCommitCoordinator lock poisoned during batch size check: {}. \
-                                 Pending transactions may be lost.",
-                                e
-                            );
-                            false
-                        }
-                    }
+                    gc.current_batch_size().expect(
+                        "GroupCommitCoordinator lock poisoned - flush thread cannot continue",
+                    ) > 0
                 });
 
             if !entries.is_empty() {
@@ -339,21 +333,19 @@ impl ConcurrentWalSystem {
                 let result = coordinator.flush(entries, sync_on_flush);
 
                 // Notify group commit waiters and handle errors
+                //
+                // LOCK POISONING: If mark_flushed() fails due to lock poisoning, we panic.
+                // This is an unrecoverable state - waiting transactions would hang forever.
+                // Panicking the flush thread ensures fail-fast behavior rather than silent
+                // degradation.
                 match result {
                     Ok(_) => {
                         // Reset error counter on success
                         error_counter.store(0, Ordering::Relaxed);
                         if let Some(ref gc) = group_commit {
-                            // If mark_flushed fails due to lock poisoning, the coordinator is
-                            // in an unrecoverable state. Log the error but continue - waiters
-                            // will fail on their next operation anyway.
-                            if let Err(e) = gc.mark_flushed(Ok(())) {
-                                eprintln!(
-                                    "CRITICAL: GroupCommitCoordinator lock poisoned during mark_flushed: {}. \
-                                     Database is in degraded state, transactions may hang.",
-                                    e
-                                );
-                            }
+                            gc.mark_flushed(Ok(())).expect(
+                                "GroupCommitCoordinator lock poisoned - flush thread cannot continue",
+                            );
                         }
                     }
                     Err(e) => {
@@ -372,15 +364,10 @@ impl ConcurrentWalSystem {
                         if let Some(ref gc) = group_commit {
                             // Create a new error from the string representation
                             // (Error doesn't implement Clone, but mark_flushed only stores the string)
-                            if let Err(poison_err) = gc
-                                .mark_flushed(Err(crate::utils::error::Error::other(e.to_string())))
-                            {
-                                eprintln!(
-                                    "CRITICAL: GroupCommitCoordinator lock poisoned during mark_flushed: {}. \
-                                     Database is in degraded state, transactions may hang.",
-                                    poison_err
+                            gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())))
+                                .expect(
+                                    "GroupCommitCoordinator lock poisoned - flush thread cannot continue",
                                 );
-                            }
                         }
                     }
                 }
@@ -388,13 +375,9 @@ impl ConcurrentWalSystem {
                 // No entries but there are pending transactions - advance epoch anyway
                 // This handles the race where entries were flushed before transactions
                 // called register_transaction()
-                if let Some(ref gc) = group_commit
-                    && let Err(e) = gc.mark_flushed(Ok(()))
-                {
-                    eprintln!(
-                        "CRITICAL: GroupCommitCoordinator lock poisoned during mark_flushed: {}. \
-                         Database is in degraded state, transactions may hang.",
-                        e
+                if let Some(ref gc) = group_commit {
+                    gc.mark_flushed(Ok(())).expect(
+                        "GroupCommitCoordinator lock poisoned - flush thread cannot continue",
                     );
                 }
             }
@@ -412,25 +395,16 @@ impl ConcurrentWalSystem {
             match result {
                 Ok(_) => {
                     error_counter.store(0, Ordering::Relaxed);
-                    if let Some(ref gc) = group_commit
-                        && let Err(e) = gc.mark_flushed(Ok(()))
-                    {
-                        eprintln!(
-                            "CRITICAL: GroupCommitCoordinator lock poisoned during shutdown flush: {}",
-                            e
-                        );
+                    if let Some(ref gc) = group_commit {
+                        gc.mark_flushed(Ok(()))
+                            .expect("GroupCommitCoordinator lock poisoned during shutdown");
                     }
                 }
                 Err(e) => {
                     error_counter.fetch_add(1, Ordering::Relaxed);
-                    if let Some(ref gc) = group_commit
-                        && let Err(poison_err) =
-                            gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())))
-                    {
-                        eprintln!(
-                            "CRITICAL: GroupCommitCoordinator lock poisoned during shutdown flush: {}",
-                            poison_err
-                        );
+                    if let Some(ref gc) = group_commit {
+                        gc.mark_flushed(Err(crate::utils::error::Error::other(e.to_string())))
+                            .expect("GroupCommitCoordinator lock poisoned during shutdown");
                     }
                 }
             }

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -106,12 +106,13 @@ impl GroupCommitCoordinator {
     ///
     /// A tuple of (epoch_to_wait_for, should_trigger_flush)
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the coordinator lock is poisoned. This is an unrecoverable state
-    /// indicating the coordinator is broken and cannot safely coordinate commits.
-    pub fn register_transaction(&self) -> (u64, bool) {
-        let mut state = self.state.lock().expect("group commit lock poisoned");
+    /// Returns `StorageError::LockPoisoned` if the coordinator lock was poisoned
+    /// by a panicking thread. This indicates the coordinator is in an inconsistent
+    /// state and cannot safely coordinate commits.
+    pub fn register_transaction(&self) -> Result<(u64, bool), Error> {
+        let mut state = self.state.lock_or_err()?;
 
         state.batch_count += 1;
         let epoch = state.current_epoch;
@@ -119,7 +120,7 @@ impl GroupCommitCoordinator {
         // Check if we should trigger immediate flush (batch full)
         let should_flush = state.batch_count >= self.config.max_batch_size;
 
-        (epoch, should_flush)
+        Ok((epoch, should_flush))
     }
 
     /// Wait for the specified epoch to be flushed.
@@ -161,7 +162,7 @@ impl GroupCommitCoordinator {
             let (new_state, timeout_result) = self
                 .flush_complete
                 .wait_timeout(state, timeout)
-                .expect("group commit lock poisoned");
+                .map_err(|_| StorageError::LockPoisoned { lock_type: "Mutex" })?;
 
             state = new_state;
 
@@ -197,8 +198,13 @@ impl GroupCommitCoordinator {
     ///
     /// * `result` - The result of the flush operation. If `Err`, the error
     ///   is stored and propagated to all waiters.
-    pub fn mark_flushed(&self, result: Result<(), Error>) {
-        let mut state = self.state.lock().expect("group commit lock poisoned");
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::LockPoisoned` if the coordinator lock was poisoned
+    /// by a panicking thread.
+    pub fn mark_flushed(&self, result: Result<(), Error>) -> Result<(), Error> {
+        let mut state = self.state.lock_or_err()?;
 
         // Store any error for propagation
         state.last_flush_error = result.err().map(|e| e.to_string());
@@ -214,44 +220,53 @@ impl GroupCommitCoordinator {
 
         // Wake all waiting transactions
         self.flush_complete.notify_all();
+
+        Ok(())
     }
 
     /// Get the current batch size.
     ///
     /// Useful for monitoring and testing.
-    pub fn current_batch_size(&self) -> usize {
-        self.state
-            .lock()
-            .expect("group commit lock poisoned")
-            .batch_count
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::LockPoisoned` if the coordinator lock was poisoned.
+    pub fn current_batch_size(&self) -> Result<usize, Error> {
+        Ok(self.state.lock_or_err()?.batch_count)
     }
 
     /// Get the current epoch.
     ///
     /// Useful for monitoring and testing.
-    pub fn current_epoch(&self) -> u64 {
-        self.state
-            .lock()
-            .expect("group commit lock poisoned")
-            .current_epoch
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::LockPoisoned` if the coordinator lock was poisoned.
+    pub fn current_epoch(&self) -> Result<u64, Error> {
+        Ok(self.state.lock_or_err()?.current_epoch)
     }
 
     /// Get the last flushed epoch.
     ///
     /// Useful for monitoring and testing.
-    pub fn flushed_epoch(&self) -> u64 {
-        self.state
-            .lock()
-            .expect("group commit lock poisoned")
-            .flushed_epoch
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::LockPoisoned` if the coordinator lock was poisoned.
+    pub fn flushed_epoch(&self) -> Result<u64, Error> {
+        Ok(self.state.lock_or_err()?.flushed_epoch)
     }
 
     /// Check if a flush should be triggered based on batch size.
     ///
     /// Called by the flush thread to check if the batch is full.
-    pub fn should_flush(&self) -> bool {
-        let state = self.state.lock().expect("group commit lock poisoned");
-        state.batch_count >= self.config.max_batch_size
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::LockPoisoned` if the coordinator lock was poisoned.
+    pub fn should_flush(&self) -> Result<bool, Error> {
+        let state = self.state.lock_or_err()?;
+        Ok(state.batch_count >= self.config.max_batch_size)
     }
 
     /// Get the maximum delay for this coordinator.
@@ -266,12 +281,255 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
+    // ==================== TDD Tests for Lock Poisoning Error Handling ====================
+    // These tests verify that methods return proper errors instead of panicking
+    // when mutex locks are poisoned.
+
+    #[test]
+    fn test_register_transaction_returns_result() {
+        // Test that register_transaction returns Result instead of panicking
+        let coord = GroupCommitCoordinator::new(10, 200);
+        let result = coord.register_transaction();
+        assert!(result.is_ok());
+        let (epoch, should_flush) = result.unwrap();
+        assert_eq!(epoch, 0);
+        assert!(!should_flush);
+    }
+
+    #[test]
+    fn test_register_transaction_with_poisoned_lock() {
+        // Test that register_transaction returns LockPoisoned error instead of panicking
+        let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
+        let coord_clone = Arc::clone(&coord);
+
+        // Poison the lock by panicking while holding it
+        let handle = thread::spawn(move || {
+            // We need to access the inner state to poison it
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join(); // This will return Err since the thread panicked
+
+        // Now register_transaction should return an error, not panic
+        let result = coord.register_transaction();
+        assert!(result.is_err());
+
+        // Verify it's the correct error type
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_mark_flushed_returns_result() {
+        // Test that mark_flushed returns Result instead of panicking
+        let coord = GroupCommitCoordinator::new(10, 100);
+        let _ = coord.register_transaction().unwrap();
+        let result = coord.mark_flushed(Ok(()));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_mark_flushed_with_poisoned_lock() {
+        // Test that mark_flushed returns LockPoisoned error instead of panicking
+        let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
+        let coord_clone = Arc::clone(&coord);
+
+        // Poison the lock
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        // mark_flushed should return an error, not panic
+        let result = coord.mark_flushed(Ok(()));
+        assert!(result.is_err());
+
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_current_batch_size_returns_result() {
+        // Test that current_batch_size returns Result
+        let coord = GroupCommitCoordinator::new(10, 200);
+        let result = coord.current_batch_size();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_current_batch_size_with_poisoned_lock() {
+        let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
+        let coord_clone = Arc::clone(&coord);
+
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let result = coord.current_batch_size();
+        assert!(result.is_err());
+
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_current_epoch_returns_result() {
+        // Test that current_epoch returns Result
+        let coord = GroupCommitCoordinator::new(10, 200);
+        let result = coord.current_epoch();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_current_epoch_with_poisoned_lock() {
+        let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
+        let coord_clone = Arc::clone(&coord);
+
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let result = coord.current_epoch();
+        assert!(result.is_err());
+
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_flushed_epoch_returns_result() {
+        // Test that flushed_epoch returns Result
+        let coord = GroupCommitCoordinator::new(10, 200);
+        let result = coord.flushed_epoch();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_flushed_epoch_with_poisoned_lock() {
+        let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
+        let coord_clone = Arc::clone(&coord);
+
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let result = coord.flushed_epoch();
+        assert!(result.is_err());
+
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_should_flush_returns_result() {
+        // Test that should_flush returns Result
+        let coord = GroupCommitCoordinator::new(10, 200);
+        let result = coord.should_flush();
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_should_flush_with_poisoned_lock() {
+        let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
+        let coord_clone = Arc::clone(&coord);
+
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        let result = coord.should_flush();
+        assert!(result.is_err());
+
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, "Mutex");
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned, got {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_wait_for_flush_condvar_poisoned_lock() {
+        // Test that wait_for_flush returns error if lock is poisoned during wait
+        let coord = Arc::new(GroupCommitCoordinator::new(100, 200));
+
+        // Register a transaction first
+        let (epoch, _) = coord.register_transaction().unwrap();
+        let coord_clone = Arc::clone(&coord);
+
+        // Spawn thread to poison the lock
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+
+        let _ = handle.join();
+
+        // wait_for_flush should return error, not panic
+        // Note: This tests that acquiring the lock after condvar wakeup handles poisoning
+        let result = coord.wait_for_flush(epoch);
+        assert!(result.is_err());
+    }
+
+    // ==================== Original Tests (Updated for Result-based API) ====================
+
     #[test]
     fn test_new_coordinator() {
         let coord = GroupCommitCoordinator::new(10, 200);
-        assert_eq!(coord.current_epoch(), 0);
-        assert_eq!(coord.flushed_epoch(), 0);
-        assert_eq!(coord.current_batch_size(), 0);
+        assert_eq!(coord.current_epoch().unwrap(), 0);
+        assert_eq!(coord.flushed_epoch().unwrap(), 0);
+        assert_eq!(coord.current_batch_size().unwrap(), 0);
     }
 
     #[test]
@@ -280,13 +538,13 @@ mod tests {
 
         // Register transactions
         for i in 0..4 {
-            let (epoch, should_flush) = coord.register_transaction();
+            let (epoch, should_flush) = coord.register_transaction().unwrap();
             assert_eq!(epoch, 0);
             assert!(!should_flush, "should not flush at batch size {}", i + 1);
         }
 
         // Fifth transaction should trigger flush
-        let (epoch, should_flush) = coord.register_transaction();
+        let (epoch, should_flush) = coord.register_transaction().unwrap();
         assert_eq!(epoch, 0);
         assert!(should_flush, "should flush when batch is full");
     }
@@ -295,17 +553,17 @@ mod tests {
     fn test_mark_flushed_advances_epoch() {
         let coord = GroupCommitCoordinator::new(10, 100);
 
-        coord.register_transaction();
-        coord.register_transaction();
+        coord.register_transaction().unwrap();
+        coord.register_transaction().unwrap();
 
-        assert_eq!(coord.current_epoch(), 0);
-        assert_eq!(coord.current_batch_size(), 2);
+        assert_eq!(coord.current_epoch().unwrap(), 0);
+        assert_eq!(coord.current_batch_size().unwrap(), 2);
 
-        coord.mark_flushed(Ok(()));
+        coord.mark_flushed(Ok(())).unwrap();
 
-        assert_eq!(coord.current_epoch(), 1);
-        assert_eq!(coord.flushed_epoch(), 1);
-        assert_eq!(coord.current_batch_size(), 0);
+        assert_eq!(coord.current_epoch().unwrap(), 1);
+        assert_eq!(coord.flushed_epoch().unwrap(), 1);
+        assert_eq!(coord.current_batch_size().unwrap(), 0);
     }
 
     #[test]
@@ -313,12 +571,12 @@ mod tests {
         let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
         let coord_clone = Arc::clone(&coord);
 
-        let (epoch, _) = coord.register_transaction();
+        let (epoch, _) = coord.register_transaction().unwrap();
 
         // Spawn a thread to mark flushed after a short delay
         let handle = thread::spawn(move || {
             thread::sleep(Duration::from_millis(10));
-            coord_clone.mark_flushed(Ok(()));
+            coord_clone.mark_flushed(Ok(())).unwrap();
         });
 
         // Wait should succeed
@@ -333,14 +591,16 @@ mod tests {
         let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
         let coord_clone = Arc::clone(&coord);
 
-        let (epoch, _) = coord.register_transaction();
+        let (epoch, _) = coord.register_transaction().unwrap();
 
         // Spawn a thread to mark flushed with error
         let handle = thread::spawn(move || {
             thread::sleep(Duration::from_millis(10));
-            coord_clone.mark_flushed(Err(Error::Storage(StorageError::WalError {
-                reason: "disk full".to_string(),
-            })));
+            coord_clone
+                .mark_flushed(Err(Error::Storage(StorageError::WalError {
+                    reason: "disk full".to_string(),
+                })))
+                .unwrap();
         });
 
         // Wait should return the error
@@ -356,7 +616,7 @@ mod tests {
     fn test_wait_for_flush_timeout() {
         let coord = GroupCommitCoordinator::new(10, 100); // 10ms max delay
 
-        let (epoch, _) = coord.register_transaction();
+        let (epoch, _) = coord.register_transaction().unwrap();
 
         // Wait without anyone calling mark_flushed - should timeout
         let result = coord.wait_for_flush(epoch);
@@ -372,7 +632,7 @@ mod tests {
         // Register multiple transactions
         let mut epochs = Vec::new();
         for _ in 0..5 {
-            let (epoch, _) = coord.register_transaction();
+            let (epoch, _) = coord.register_transaction().unwrap();
             epochs.push(epoch);
         }
 
@@ -390,7 +650,7 @@ mod tests {
         thread::sleep(Duration::from_millis(10));
 
         // Mark flushed
-        coord.mark_flushed(Ok(()));
+        coord.mark_flushed(Ok(())).unwrap();
 
         // All should succeed
         for handle in handles {
@@ -404,34 +664,34 @@ mod tests {
         let coord = GroupCommitCoordinator::new(10, 100);
 
         // First batch
-        coord.register_transaction();
-        coord.register_transaction();
-        coord.mark_flushed(Ok(()));
+        coord.register_transaction().unwrap();
+        coord.register_transaction().unwrap();
+        coord.mark_flushed(Ok(())).unwrap();
 
-        assert_eq!(coord.current_epoch(), 1);
+        assert_eq!(coord.current_epoch().unwrap(), 1);
 
         // Second batch
-        let (epoch, _) = coord.register_transaction();
+        let (epoch, _) = coord.register_transaction().unwrap();
         assert_eq!(epoch, 1);
 
-        coord.mark_flushed(Ok(()));
-        assert_eq!(coord.current_epoch(), 2);
+        coord.mark_flushed(Ok(())).unwrap();
+        assert_eq!(coord.current_epoch().unwrap(), 2);
     }
 
     #[test]
     fn test_should_flush() {
         let coord = GroupCommitCoordinator::new(10, 3);
 
-        assert!(!coord.should_flush());
+        assert!(!coord.should_flush().unwrap());
 
-        coord.register_transaction();
-        assert!(!coord.should_flush());
+        coord.register_transaction().unwrap();
+        assert!(!coord.should_flush().unwrap());
 
-        coord.register_transaction();
-        assert!(!coord.should_flush());
+        coord.register_transaction().unwrap();
+        assert!(!coord.should_flush().unwrap());
 
-        coord.register_transaction();
-        assert!(coord.should_flush());
+        coord.register_transaction().unwrap();
+        assert!(coord.should_flush().unwrap());
     }
 
     #[test]

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -2,6 +2,30 @@
 //!
 //! This module provides [`GroupCommitCoordinator`], which manages the epoch-based
 //! waiting mechanism for [`GroupCommit`](super::DurabilityMode::GroupCommit) mode.
+//!
+//! # Error Handling Strategy
+//!
+//! All public methods return `Result` types to handle lock poisoning gracefully.
+//! Lock poisoning occurs when a thread panics while holding the coordinator's mutex.
+//!
+//! ## For Callers
+//!
+//! When a `StorageError::LockPoisoned` error is returned:
+//! - **Flush thread**: Should panic immediately. Continuing would leave waiting
+//!   transactions hanging indefinitely. This is an unrecoverable state.
+//! - **Transaction threads**: Should propagate the error to the caller. The
+//!   transaction cannot complete and must be rolled back.
+//!
+//! ## Rationale
+//!
+//! Lock poisoning in the coordinator indicates severe corruption. The alternatives
+//! are:
+//! 1. **Panic everywhere** (too aggressive for transaction threads)
+//! 2. **Continue silently** (leaves transactions hanging - worse than panicking)
+//! 3. **Return Result** (chosen approach - lets callers decide appropriate action)
+//!
+//! The flush thread uses `.expect()` to panic on lock poisoning because silent
+//! degradation is worse than fail-fast behavior for background infrastructure.
 
 use std::sync::{Condvar, Mutex};
 use std::time::Duration;
@@ -163,7 +187,9 @@ impl GroupCommitCoordinator {
                 .flush_complete
                 .wait_timeout(state, timeout)
                 .map_err(|_| StorageError::LockPoisoned {
-                    lock_type: "Condvar",
+                    // Note: Condvar::wait_timeout() returns PoisonError when the MUTEX
+                    // is poisoned, not the Condvar. Condvars cannot be poisoned.
+                    lock_type: "Mutex",
                 })?;
 
             state = new_state;
@@ -314,6 +340,13 @@ mod tests {
     // ==================== TDD Tests for Lock Poisoning Error Handling ====================
     // These tests verify that methods return proper errors instead of panicking
     // when mutex locks are poisoned.
+    //
+    // TEST GAP: The wait_timeout() path in wait_for_flush() (line ~164) cannot be
+    // reliably tested for poisoning during the actual condvar wait. This would
+    // require poisoning the lock WHILE another thread is blocked in wait_timeout(),
+    // which is inherently racy. The current test (test_wait_for_flush_with_poisoned_lock)
+    // only tests the initial lock acquisition path. The implementation does handle
+    // the condvar poisoning case, but it's not covered by tests.
 
     #[test]
     fn test_register_transaction_returns_result() {

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -162,7 +162,9 @@ impl GroupCommitCoordinator {
             let (new_state, timeout_result) = self
                 .flush_complete
                 .wait_timeout(state, timeout)
-                .map_err(|_| StorageError::LockPoisoned { lock_type: "Mutex" })?;
+                .map_err(|_| StorageError::LockPoisoned {
+                    lock_type: "Condvar",
+                })?;
 
             state = new_state;
 
@@ -281,13 +283,40 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
+    // ==================== Test Helpers for Lock Poisoning ====================
+
+    /// Poison the coordinator's internal lock by panicking while holding it.
+    /// After this function returns, any lock acquisition will fail with PoisonError.
+    fn poison_coordinator_lock(coord: &Arc<GroupCommitCoordinator>) {
+        let coord_clone = Arc::clone(coord);
+        let handle = thread::spawn(move || {
+            let _guard = coord_clone.state.lock().unwrap();
+            panic!("intentional panic to poison lock");
+        });
+        // Thread panicked, so join returns Err - this is expected
+        assert!(handle.join().is_err(), "Poisoning thread should panic");
+    }
+
+    /// Assert that a Result contains a LockPoisoned error with the expected lock_type.
+    fn assert_is_lock_poisoned<T: std::fmt::Debug>(result: Result<T, Error>, expected_type: &str) {
+        assert!(result.is_err(), "Expected error, got {:?}", result);
+        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
+            assert_eq!(lock_type, expected_type);
+        } else {
+            panic!(
+                "Expected StorageError::LockPoisoned {{ lock_type: \"{}\" }}, got {:?}",
+                expected_type,
+                result.err()
+            );
+        }
+    }
+
     // ==================== TDD Tests for Lock Poisoning Error Handling ====================
     // These tests verify that methods return proper errors instead of panicking
     // when mutex locks are poisoned.
 
     #[test]
     fn test_register_transaction_returns_result() {
-        // Test that register_transaction returns Result instead of panicking
         let coord = GroupCommitCoordinator::new(10, 200);
         let result = coord.register_transaction();
         assert!(result.is_ok());
@@ -298,37 +327,13 @@ mod tests {
 
     #[test]
     fn test_register_transaction_with_poisoned_lock() {
-        // Test that register_transaction returns LockPoisoned error instead of panicking
         let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
-        let coord_clone = Arc::clone(&coord);
-
-        // Poison the lock by panicking while holding it
-        let handle = thread::spawn(move || {
-            // We need to access the inner state to poison it
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-
-        let _ = handle.join(); // This will return Err since the thread panicked
-
-        // Now register_transaction should return an error, not panic
-        let result = coord.register_transaction();
-        assert!(result.is_err());
-
-        // Verify it's the correct error type
-        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
-            assert_eq!(lock_type, "Mutex");
-        } else {
-            panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
-                result.err()
-            );
-        }
+        poison_coordinator_lock(&coord);
+        assert_is_lock_poisoned(coord.register_transaction(), "Mutex");
     }
 
     #[test]
     fn test_mark_flushed_returns_result() {
-        // Test that mark_flushed returns Result instead of panicking
         let coord = GroupCommitCoordinator::new(10, 100);
         let _ = coord.register_transaction().unwrap();
         let result = coord.mark_flushed(Ok(()));
@@ -337,35 +342,13 @@ mod tests {
 
     #[test]
     fn test_mark_flushed_with_poisoned_lock() {
-        // Test that mark_flushed returns LockPoisoned error instead of panicking
         let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
-        let coord_clone = Arc::clone(&coord);
-
-        // Poison the lock
-        let handle = thread::spawn(move || {
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-
-        let _ = handle.join();
-
-        // mark_flushed should return an error, not panic
-        let result = coord.mark_flushed(Ok(()));
-        assert!(result.is_err());
-
-        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
-            assert_eq!(lock_type, "Mutex");
-        } else {
-            panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
-                result.err()
-            );
-        }
+        poison_coordinator_lock(&coord);
+        assert_is_lock_poisoned(coord.mark_flushed(Ok(())), "Mutex");
     }
 
     #[test]
     fn test_current_batch_size_returns_result() {
-        // Test that current_batch_size returns Result
         let coord = GroupCommitCoordinator::new(10, 200);
         let result = coord.current_batch_size();
         assert!(result.is_ok());
@@ -375,31 +358,12 @@ mod tests {
     #[test]
     fn test_current_batch_size_with_poisoned_lock() {
         let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
-        let coord_clone = Arc::clone(&coord);
-
-        let handle = thread::spawn(move || {
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-
-        let _ = handle.join();
-
-        let result = coord.current_batch_size();
-        assert!(result.is_err());
-
-        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
-            assert_eq!(lock_type, "Mutex");
-        } else {
-            panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
-                result.err()
-            );
-        }
+        poison_coordinator_lock(&coord);
+        assert_is_lock_poisoned(coord.current_batch_size(), "Mutex");
     }
 
     #[test]
     fn test_current_epoch_returns_result() {
-        // Test that current_epoch returns Result
         let coord = GroupCommitCoordinator::new(10, 200);
         let result = coord.current_epoch();
         assert!(result.is_ok());
@@ -409,31 +373,12 @@ mod tests {
     #[test]
     fn test_current_epoch_with_poisoned_lock() {
         let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
-        let coord_clone = Arc::clone(&coord);
-
-        let handle = thread::spawn(move || {
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-
-        let _ = handle.join();
-
-        let result = coord.current_epoch();
-        assert!(result.is_err());
-
-        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
-            assert_eq!(lock_type, "Mutex");
-        } else {
-            panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
-                result.err()
-            );
-        }
+        poison_coordinator_lock(&coord);
+        assert_is_lock_poisoned(coord.current_epoch(), "Mutex");
     }
 
     #[test]
     fn test_flushed_epoch_returns_result() {
-        // Test that flushed_epoch returns Result
         let coord = GroupCommitCoordinator::new(10, 200);
         let result = coord.flushed_epoch();
         assert!(result.is_ok());
@@ -443,31 +388,12 @@ mod tests {
     #[test]
     fn test_flushed_epoch_with_poisoned_lock() {
         let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
-        let coord_clone = Arc::clone(&coord);
-
-        let handle = thread::spawn(move || {
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-
-        let _ = handle.join();
-
-        let result = coord.flushed_epoch();
-        assert!(result.is_err());
-
-        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
-            assert_eq!(lock_type, "Mutex");
-        } else {
-            panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
-                result.err()
-            );
-        }
+        poison_coordinator_lock(&coord);
+        assert_is_lock_poisoned(coord.flushed_epoch(), "Mutex");
     }
 
     #[test]
     fn test_should_flush_returns_result() {
-        // Test that should_flush returns Result
         let coord = GroupCommitCoordinator::new(10, 200);
         let result = coord.should_flush();
         assert!(result.is_ok());
@@ -477,47 +403,23 @@ mod tests {
     #[test]
     fn test_should_flush_with_poisoned_lock() {
         let coord = Arc::new(GroupCommitCoordinator::new(10, 200));
-        let coord_clone = Arc::clone(&coord);
-
-        let handle = thread::spawn(move || {
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-
-        let _ = handle.join();
-
-        let result = coord.should_flush();
-        assert!(result.is_err());
-
-        if let Err(Error::Storage(StorageError::LockPoisoned { lock_type })) = result {
-            assert_eq!(lock_type, "Mutex");
-        } else {
-            panic!(
-                "Expected StorageError::LockPoisoned, got {:?}",
-                result.err()
-            );
-        }
+        poison_coordinator_lock(&coord);
+        assert_is_lock_poisoned(coord.should_flush(), "Mutex");
     }
 
     #[test]
-    fn test_wait_for_flush_condvar_poisoned_lock() {
-        // Test that wait_for_flush returns error if lock is poisoned during wait
+    fn test_wait_for_flush_with_poisoned_lock() {
+        // Test that wait_for_flush returns an error if the lock is already poisoned on entry.
+        // This tests the initial lock_or_err() call, not the condvar wait_timeout path.
         let coord = Arc::new(GroupCommitCoordinator::new(100, 200));
 
-        // Register a transaction first
+        // Register a transaction first (before poisoning)
         let (epoch, _) = coord.register_transaction().unwrap();
-        let coord_clone = Arc::clone(&coord);
 
-        // Spawn thread to poison the lock
-        let handle = thread::spawn(move || {
-            let _guard = coord_clone.state.lock().unwrap();
-            panic!("intentional panic to poison lock");
-        });
+        // Now poison the lock
+        poison_coordinator_lock(&coord);
 
-        let _ = handle.join();
-
-        // wait_for_flush should return error, not panic
-        // Note: This tests that acquiring the lock after condvar wakeup handles poisoning
+        // wait_for_flush should return error on initial lock acquisition, not panic
         let result = coord.wait_for_flush(epoch);
         assert!(result.is_err());
     }


### PR DESCRIPTION
…dling

Replace panic-inducing .expect() calls during mutex acquisition with the existing lock_or_err() utility to return proper Result types.

Changes:
- group_commit.rs: Update register_transaction(), mark_flushed(), current_batch_size(), current_epoch(), flushed_epoch(), and should_flush() to return Result<T, Error>
- group_commit.rs: Handle wait_timeout poisoning in wait_for_flush()
- write_tx.rs: Use lock_or_err() for timestamp lock in commit
- concurrent_system.rs: Update callers to handle new Result types

Testing:
- Add TDD tests that verify LockPoisoned error is returned when mutex is poisoned (rather than panicking)
- All existing tests updated to use new Result-based API

Closes #342