### PR TITLE
Claude/fix issue 343 tdd 3jx hp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Cargo.lock
 # Test artifacts
 *.log
 /test_data
+/data
 
 # Backup files
 *.bak

--- a/benches/durability_modes.rs
+++ b/benches/durability_modes.rs
@@ -47,7 +47,7 @@ fn create_db_with_mode(mode: DurabilityMode) -> (GallifreyDB, TempDir) {
         .unwrap()
         .durability_mode(mode)
         .build();
-    let db = GallifreyDB::with_wal_config(config);
+    let db = GallifreyDB::with_wal_config(config).unwrap();
     (db, temp_dir)
 }
 

--- a/benches/gallifreydb.rs
+++ b/benches/gallifreydb.rs
@@ -23,7 +23,7 @@ fn create_benchmark_db() -> GallifreyDB {
             flush_interval_ms: 100,
         })
         .build();
-    GallifreyDB::with_wal_config(wal_config)
+    GallifreyDB::with_wal_config(wal_config).unwrap()
 }
 
 /// Create a test database with versioned history.
@@ -314,7 +314,7 @@ fn bench_batch_operations(c: &mut Criterion) {
             &batch_size,
             |b, &size| {
                 b.iter_batched(
-                    GallifreyDB::new,
+                    || GallifreyDB::new().unwrap(),
                     |db| {
                         for i in 0..size {
                             let props = PropertyMapBuilder::new().insert("id", i as i64).build();

--- a/benches/hybrid_query.rs
+++ b/benches/hybrid_query.rs
@@ -59,7 +59,7 @@ fn gen_clustered_vector(dim: usize, cluster_id: usize, variance: f32) -> Vec<f32
 /// connectivity, representing knowledge graphs or databases with
 /// predictable relationship patterns.
 fn build_uniform_graph(node_count: usize, fan_out: usize, dim: usize) -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(dim, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config).unwrap();
 
@@ -97,7 +97,7 @@ fn build_uniform_graph(node_count: usize, fan_out: usize, dim: usize) -> Gallifr
 ///
 /// Uses clustered embeddings to simulate semantic similarity within communities.
 fn build_power_law_graph(node_count: usize, dim: usize) -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(dim, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config).unwrap();
 
@@ -144,7 +144,7 @@ fn build_power_law_graph(node_count: usize, dim: usize) -> GallifreyDB {
 /// This represents minimalist graphs where connections are selective,
 /// such as expert networks or curated knowledge bases.
 fn build_sparse_graph(node_count: usize, dim: usize) -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(dim, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config).unwrap();
 
@@ -183,7 +183,7 @@ fn build_temporal_graph_core(
     snapshot_count: usize,
     dim: usize,
 ) -> (GallifreyDB, Vec<i64>) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let hnsw_config = HnswConfig::new(dim, DistanceMetric::Cosine);
     let temporal_config = TemporalVectorConfig {
         snapshot_strategy: SnapshotStrategy::TransactionInterval(1),

--- a/benches/performance_targets.rs
+++ b/benches/performance_targets.rs
@@ -151,7 +151,7 @@ fn bench_time_travel_at_anchor(c: &mut Criterion) {
     let mut group = c.benchmark_group("target_time_travel");
 
     // Setup: Create database with anchored versions
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let node_id = db
         .create_node(
             "Person",
@@ -210,7 +210,7 @@ fn bench_time_travel_with_deltas(c: &mut Criterion) {
 
     // Setup: Create database with 15 updates
     // Anchors at updates 1, 11 (default anchor_interval = 10)
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let node_id = db
         .create_node(
             "Person",
@@ -271,7 +271,7 @@ fn bench_time_travel_worst_case(c: &mut Criterion) {
 
     // Setup: Create database with 19 updates
     // Anchors at updates 1, 11 (default anchor_interval = 10)
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let node_id = db
         .create_node(
             "Person",

--- a/benches/temporal_query.rs
+++ b/benches/temporal_query.rs
@@ -615,7 +615,7 @@ fn bench_cache_miss(c: &mut Criterion) {
 
 /// Setup helper: Create a database with `count` versioned nodes.
 fn setup_database_with_versions(count: usize) -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Batch writes if possible, otherwise individual
     for i in 0..count {

--- a/benches/transactions.rs
+++ b/benches/transactions.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::thread;
 
 fn bench_read_transaction_creation(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     c.bench_function("read_transaction_creation", |b| {
         b.iter(|| {
@@ -21,7 +21,7 @@ fn bench_read_transaction_creation(c: &mut Criterion) {
 }
 
 fn bench_write_transaction_creation(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     c.bench_function("write_transaction_creation", |b| {
         b.iter(|| {
@@ -31,7 +31,7 @@ fn bench_write_transaction_creation(c: &mut Criterion) {
 }
 
 fn bench_closure_based_write_empty(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     c.bench_function("closure_write_empty_commit", |b| {
         b.iter(|| {
@@ -41,7 +41,7 @@ fn bench_closure_based_write_empty(c: &mut Criterion) {
 }
 
 fn bench_closure_based_write_single_node(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     c.bench_function("closure_write_single_node", |b| {
         b.iter(|| {
@@ -60,7 +60,7 @@ fn bench_closure_based_write_single_node(c: &mut Criterion) {
 }
 
 fn bench_closure_based_write_10_ops(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     c.bench_function("closure_write_10_operations", |b| {
         b.iter(|| {
@@ -91,7 +91,7 @@ fn bench_closure_based_write_10_ops(c: &mut Criterion) {
 }
 
 fn bench_explicit_transaction_commit(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     c.bench_function("explicit_transaction_commit", |b| {
         b.iter(|| {
@@ -107,7 +107,7 @@ fn bench_explicit_transaction_commit(c: &mut Criterion) {
 }
 
 fn bench_implicit_vs_explicit(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let mut group = c.benchmark_group("implicit_vs_explicit");
 
@@ -137,7 +137,7 @@ fn bench_implicit_vs_explicit(c: &mut Criterion) {
 }
 
 fn bench_read_transaction_overhead(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create a node to read
     let node_id = db
@@ -178,7 +178,7 @@ fn bench_batch_edge_insertions(c: &mut Criterion) {
     for batch_size in [100, 1000, 10000] {
         group.bench_function(format!("batch_{}_edges", batch_size), |b| {
             b.iter(|| {
-                let db = GallifreyDB::new();
+                let db = GallifreyDB::new().unwrap();
 
                 db.write(|tx| {
                     // Create nodes first
@@ -217,7 +217,7 @@ fn bench_batch_edge_updates(c: &mut Criterion) {
         b.iter_batched(
             || {
                 // Setup: Create DB with 1000 edges
-                let db = GallifreyDB::new();
+                let db = GallifreyDB::new().unwrap();
                 let edge_ids: Vec<_> = db
                     .write(|tx| {
                         let mut nodes = Vec::new();
@@ -270,7 +270,7 @@ fn bench_batch_edge_deletions(c: &mut Criterion) {
         b.iter_batched(
             || {
                 // Setup: create DB with 1000 edges
-                let db = GallifreyDB::new();
+                let db = GallifreyDB::new().unwrap();
                 let edge_ids: Vec<_> = db
                     .write(|tx| {
                         let mut nodes = Vec::new();
@@ -326,7 +326,7 @@ fn bench_batch_insertions_with_prepopulated_graph(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     // Setup: create DB with existing edges
-                    let db = GallifreyDB::new();
+                    let db = GallifreyDB::new().unwrap();
 
                     // Pre-populate with existing edges
                     db.write(|tx| {
@@ -395,7 +395,7 @@ fn bench_read_during_rebuild(c: &mut Criterion) {
     // Pre-populate a database with 4K nodes + 4K edges
     // Note: stays under DEFAULT_MAX_OPERATIONS (50K) limit defined in
     // src/api/transaction/write_buffer.rs for DoS protection
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let node_ids: Vec<_> = db
         .write(|tx| {
             let mut nodes = Vec::new();
@@ -444,7 +444,7 @@ fn bench_concurrent_visibility_checks(c: &mut Criterion) {
     // Pre-populate database with committed data (500 nodes)
     // Note: stays under DEFAULT_MAX_OPERATIONS (50K) limit defined in
     // src/api/transaction/write_buffer.rs for DoS protection
-    let db = Arc::new(GallifreyDB::new());
+    let db = Arc::new(GallifreyDB::new().unwrap());
     let node_ids: Vec<_> = db
         .write(|tx| {
             let mut nodes = Vec::new();
@@ -489,7 +489,7 @@ fn bench_concurrent_visibility_checks(c: &mut Criterion) {
 
 /// Benchmark single-threaded visibility check performance (baseline).
 fn bench_sequential_visibility_checks(c: &mut Criterion) {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Pre-populate with 500 nodes
     // Note: stays under DEFAULT_MAX_OPERATIONS (50K) limit defined in
@@ -536,7 +536,7 @@ fn bench_concurrent_transaction_creation_with_active_txs(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     // Setup: create DB and start many active write transactions
-                    let db = Arc::new(GallifreyDB::new());
+                    let db = Arc::new(GallifreyDB::new().unwrap());
                     let mut active_txs = Vec::new();
 
                     for _ in 0..active_count {
@@ -580,7 +580,7 @@ fn bench_apply_changes_large_tx(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     // Setup: create DB with some existing data for updates/deletes
-                    let db = GallifreyDB::new();
+                    let db = GallifreyDB::new().unwrap();
                     let (nodes, edges) = db
                         .write(|tx| {
                             let mut nodes = Vec::new();
@@ -659,7 +659,7 @@ fn bench_apply_changes_large_tx(c: &mut Criterion) {
         // Create-heavy workload
         group.bench_function(format!("creates_{}_ops", size), |b| {
             b.iter(|| {
-                let db = GallifreyDB::new();
+                let db = GallifreyDB::new().unwrap();
                 db.write(|tx| {
                     for i in 0..size {
                         tx.create_node(
@@ -681,7 +681,7 @@ fn bench_apply_changes_large_tx(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     // Setup: create DB with nodes and edges to delete
-                    let db = GallifreyDB::new();
+                    let db = GallifreyDB::new().unwrap();
                     let (nodes, edges) = db
                         .write(|tx| {
                             let mut nodes = Vec::new();
@@ -756,7 +756,7 @@ fn bench_commit_vector_vs_nonvector(c: &mut Criterion) {
     // Benchmark 1: Non-vector transaction (should be optimized)
     group.bench_function("commit_without_vectors", |b| {
         b.iter(|| {
-            let db = GallifreyDB::new();
+            let db = GallifreyDB::new().unwrap();
             db.write(|tx| {
                 // Create nodes with scalar properties only (no vectors)
                 for i in 0..10 {
@@ -778,7 +778,7 @@ fn bench_commit_vector_vs_nonvector(c: &mut Criterion) {
     // Benchmark 2: Vector transaction (will call vector notification)
     group.bench_function("commit_with_vectors", |b| {
         b.iter(|| {
-            let db = GallifreyDB::new();
+            let db = GallifreyDB::new().unwrap();
             db.write(|tx| {
                 // Create nodes with vector properties
                 let embedding = vec![0.1f32, 0.2, 0.3, 0.4];
@@ -800,7 +800,7 @@ fn bench_commit_vector_vs_nonvector(c: &mut Criterion) {
     // Benchmark 3: Large non-vector transaction (amplifies the optimization benefit)
     group.bench_function("commit_100_ops_without_vectors", |b| {
         b.iter(|| {
-            let db = GallifreyDB::new();
+            let db = GallifreyDB::new().unwrap();
             db.write(|tx| {
                 // Create 100 nodes with scalar properties only
                 for i in 0..100 {
@@ -821,7 +821,7 @@ fn bench_commit_vector_vs_nonvector(c: &mut Criterion) {
     // Benchmark 4: Large vector transaction
     group.bench_function("commit_100_ops_with_vectors", |b| {
         b.iter(|| {
-            let db = GallifreyDB::new();
+            let db = GallifreyDB::new().unwrap();
             db.write(|tx| {
                 let embedding = vec![0.1f32; 128]; // Realistic embedding size
                 for i in 0..100 {

--- a/examples/doctor_who_demo.rs
+++ b/examples/doctor_who_demo.rs
@@ -108,13 +108,13 @@ struct DemoData {
 }
 
 impl DemoData {
-    fn new() -> Self {
-        Self {
+    fn new() -> Result<Self> {
+        Ok(Self {
             nodes: HashMap::new(),
-            db: GallifreyDB::new(),
+            db: GallifreyDB::new()?,
             regenerations: Vec::new(),
             creation_time: now_timestamp(),
-        }
+        })
     }
 
     fn get(&self, name: &str) -> Option<NodeId> {
@@ -1012,7 +1012,7 @@ fn main() -> Result<()> {
 "#
     );
 
-    let mut demo = DemoData::new();
+    let mut demo = DemoData::new()?;
     populate_database(&mut demo)?;
 
     print_help();

--- a/examples/embedding_huggingface.rs
+++ b/examples/embedding_huggingface.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Store in GallifreyDB
     println!("💾 Storing in GallifreyDB...");
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new()?;
 
     for (doc, embedding) in documents.iter().zip(embeddings.iter()) {
         db.create_node(

--- a/examples/embedding_ollama.rs
+++ b/examples/embedding_ollama.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Store in GallifreyDB
     println!("💾 Storing in GallifreyDB...");
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new()?;
 
     for (doc, embedding) in documents.iter().zip(embeddings.iter()) {
         db.create_node(

--- a/examples/embedding_onnx.rs
+++ b/examples/embedding_onnx.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Store in GallifreyDB
     println!("💾 Storing in GallifreyDB...");
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new()?;
 
     for (doc, embedding) in documents.iter().zip(embeddings.iter()) {
         db.create_node(

--- a/examples/embedding_openai.rs
+++ b/examples/embedding_openai.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Store in GallifreyDB
     println!("💾 Storing in GallifreyDB...");
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new()?;
 
     let mut node_ids = Vec::new();
     for (doc, embedding) in documents.iter().zip(embeddings.iter()) {

--- a/examples/observability_demo.rs
+++ b/examples/observability_demo.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("ℹ️  Running without observability (zero overhead mode)");
 
     println!("\n🚀 Creating GallifreyDB instance...");
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new()?;
 
     println!("📝 Creating sample nodes and edges...");
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -827,18 +827,30 @@ pub struct GallifreyDB {
 
 impl GallifreyDB {
     /// Create a new empty database with default configuration.
-    pub fn new() -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
+    pub fn new() -> Result<Self> {
         Self::with_config(AnchorConfig::default())
     }
 
     /// Create a new database with custom anchor configuration.
-    pub fn with_config(config: AnchorConfig) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
+    pub fn with_config(config: AnchorConfig) -> Result<Self> {
         Self::with_full_config(config, crate::config::WalConfig::default())
     }
 
     /// Create a new database with custom WAL configuration.
     ///
     /// This allows configuring the durability mode and other WAL settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
     ///
     /// # Example
     ///
@@ -849,15 +861,15 @@ impl GallifreyDB {
     /// let wal_config = WalConfigBuilder::new()
     ///     .durability_mode(DurabilityMode::group_commit(10, 200))
     ///     .build();
-    /// let db = GallifreyDB::with_wal_config(wal_config);
+    /// let db = GallifreyDB::with_wal_config(wal_config)?;
     ///
     /// // Bulk loading mode with async durability
     /// let wal_config = WalConfigBuilder::new()
     ///     .durability_mode(DurabilityMode::async_mode(100))
     ///     .build();
-    /// let db = GallifreyDB::with_wal_config(wal_config);
+    /// let db = GallifreyDB::with_wal_config(wal_config)?;
     /// ```
-    pub fn with_wal_config(wal_config: crate::config::WalConfig) -> Self {
+    pub fn with_wal_config(wal_config: crate::config::WalConfig) -> Result<Self> {
         Self::with_full_config(AnchorConfig::default(), wal_config)
     }
 
@@ -865,6 +877,10 @@ impl GallifreyDB {
     ///
     /// This method accepts a [`GallifreyDBConfig`] which consolidates all configuration
     /// settings for the database, including WAL, historical storage, and vector indexes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
     ///
     /// # Example
     ///
@@ -877,9 +893,9 @@ impl GallifreyDB {
     ///         .build())
     ///     .build();
     ///
-    /// let db = GallifreyDB::with_unified_config(config);
+    /// let db = GallifreyDB::with_unified_config(config)?;
     /// ```
-    pub fn with_unified_config(config: GallifreyDBConfig) -> Self {
+    pub fn with_unified_config(config: GallifreyDBConfig) -> Result<Self> {
         let durability_mode = config.wal.durability_mode;
 
         // Create ConcurrentWalSystem config from unified WalConfig
@@ -899,7 +915,7 @@ impl GallifreyDB {
             write_buffer_size: config.wal.write_buffer_size,
         };
 
-        let wal = ConcurrentWalSystem::new(wal_system_config).expect("Failed to create WAL");
+        let wal = ConcurrentWalSystem::new(wal_system_config)?;
         let wal = Arc::new(wal);
 
         // Create persistence manager if enabled
@@ -1276,17 +1292,21 @@ impl GallifreyDB {
             );
         }
 
-        db
+        Ok(db)
     }
 
     /// Create a new database with both anchor and WAL configuration.
     ///
     /// This maintains backward compatibility with the old API.
     /// For new code, prefer using [`with_unified_config`](Self::with_unified_config).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
     pub fn with_full_config(
         anchor_config: AnchorConfig,
         wal_config: crate::config::WalConfig,
-    ) -> Self {
+    ) -> Result<Self> {
         let durability_mode = wal_config.durability_mode;
 
         // Create ConcurrentWalSystem config from unified WalConfig
@@ -1306,10 +1326,10 @@ impl GallifreyDB {
             write_buffer_size: wal_config.write_buffer_size,
         };
 
-        let wal = ConcurrentWalSystem::new(wal_system_config).expect("Failed to create WAL");
+        let wal = ConcurrentWalSystem::new(wal_system_config)?;
         let wal = Arc::new(wal);
 
-        GallifreyDB {
+        Ok(GallifreyDB {
             current: Arc::new(CurrentStorage::new()),
             historical: Arc::new(RwLock::new(HistoricalStorage::with_config(anchor_config))),
             temporal_indexes: Arc::new(TemporalIndexes::new()),
@@ -1326,7 +1346,7 @@ impl GallifreyDB {
             persistence_manager: None,
             persistence_tracker: None,
             persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        }
+        })
     }
 
     /// Get the default durability mode for this database.
@@ -1363,7 +1383,7 @@ impl GallifreyDB {
         let checkpoint = Checkpoint::load(checkpoint_path.as_ref())?;
 
         // Create new database with default config
-        let db = Self::new();
+        let db = Self::new()?;
 
         // Restore vector index if it was enabled
         if let Some(ref vector_config) = checkpoint.metadata.vector_index_config
@@ -3257,11 +3277,10 @@ impl Drop for GallifreyDB {
     }
 }
 
-impl Default for GallifreyDB {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// Note: Default is intentionally NOT implemented for GallifreyDB because:
+// 1. Construction can fail (WAL initialization may fail)
+// 2. Users should explicitly call GallifreyDB::new()? to handle potential errors
+// 3. This follows CODING_STANDARDS.md which prohibits .expect() in production code
 
 /// Builder for configuring and enabling a vector index on a property.
 ///
@@ -3410,7 +3429,7 @@ mod tests {
 
     #[test]
     fn test_create_node() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let props = PropertyMapBuilder::new()
             .insert("name", "Alice")
@@ -3431,7 +3450,7 @@ mod tests {
 
     #[test]
     fn test_create_edge() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let alice = db
             .create_node("Person", PropertyMapBuilder::new().build())
@@ -3458,7 +3477,7 @@ mod tests {
 
     #[test]
     fn test_time_travel_query() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create a node at time T1
         let props_v1 = PropertyMapBuilder::new()
@@ -3492,7 +3511,7 @@ mod tests {
 
     #[test]
     fn test_time_travel_after_deletion() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create a node
         let props = PropertyMapBuilder::new()
@@ -3546,7 +3565,7 @@ mod tests {
 
     #[test]
     fn test_graph_traversal() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let n0 = db
             .create_node("Person", PropertyMapBuilder::new().build())
@@ -3572,7 +3591,7 @@ mod tests {
 
     #[test]
     fn test_historical_stats() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         db.create_node("Person", PropertyMapBuilder::new().build())
             .unwrap();
@@ -3588,7 +3607,7 @@ mod tests {
 
     #[test]
     fn test_closure_based_write_api() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Use closure-based API for multiple operations
         let (node_id, edge_id) = db
@@ -3627,7 +3646,7 @@ mod tests {
 
     #[test]
     fn test_closure_based_read_api() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let node_id = db
             .create_node(
@@ -3652,7 +3671,7 @@ mod tests {
 
     #[test]
     fn test_explicit_write_transaction() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let mut tx = db.write_transaction().unwrap();
         let n1 = tx
@@ -3683,7 +3702,7 @@ mod tests {
 
     #[test]
     fn test_explicit_read_transaction() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let node_id = db
             .create_node(
@@ -3701,7 +3720,7 @@ mod tests {
 
     #[test]
     fn test_transaction_atomicity() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create a valid node first
         let valid_node = db
@@ -3733,7 +3752,7 @@ mod tests {
 
     #[test]
     fn test_transaction_rollback_on_error() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Closure returns an error - should auto-rollback
         let result: Result<()> = db.write(|tx| {
@@ -3755,7 +3774,7 @@ mod tests {
 
     #[test]
     fn test_multiple_transactions() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Transaction 1
         let n1 = db
@@ -3777,7 +3796,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_isolation() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let node_id = db
             .create_node(
@@ -3824,7 +3843,7 @@ mod tests {
     fn test_enable_vector_index() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -3839,7 +3858,7 @@ mod tests {
     fn test_find_similar_basic() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -3895,7 +3914,7 @@ mod tests {
     fn test_find_similar_with_label() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -3940,7 +3959,7 @@ mod tests {
 
     #[test]
     fn test_vector_index_not_enabled() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create node with vector
         let node_id = db
@@ -3960,7 +3979,7 @@ mod tests {
     fn test_vector_index_with_euclidean_distance() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index with Euclidean distance
         let config = HnswConfig::new(3, DistanceMetric::Euclidean).with_capacity(100);
@@ -4008,7 +4027,7 @@ mod tests {
     fn test_vector_index_with_large_k() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4045,7 +4064,7 @@ mod tests {
     fn test_transaction_nodes_are_indexed() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4090,7 +4109,7 @@ mod tests {
     fn test_find_similar_by_embedding() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4142,7 +4161,7 @@ mod tests {
     fn test_find_similar_by_embedding_with_label() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4193,7 +4212,7 @@ mod tests {
     fn test_find_similar_by_embedding_dimension_mismatch() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index with 3 dimensions
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4220,7 +4239,7 @@ mod tests {
     fn test_find_similar_empty_database() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index but don't add any nodes
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4237,7 +4256,7 @@ mod tests {
     fn test_find_similar_k_zero() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index and add some nodes
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4264,7 +4283,7 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        let db = Arc::new(GallifreyDB::new());
+        let db = Arc::new(GallifreyDB::new().unwrap());
 
         // Enable vector index
         let config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(1000);
@@ -4328,7 +4347,7 @@ mod tests {
 
     #[test]
     fn test_get_nodes_at_time_basic() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create multiple nodes at time T1
         let props1 = PropertyMapBuilder::new()
@@ -4392,7 +4411,7 @@ mod tests {
 
     #[test]
     fn test_get_nodes_at_time_mixed_results() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create two nodes
         let node1 = db
@@ -4433,7 +4452,7 @@ mod tests {
 
     #[test]
     fn test_get_nodes_at_time_empty_batch() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let t1 = *db.current_timestamp.lock().unwrap();
 
@@ -4446,7 +4465,7 @@ mod tests {
 
     #[test]
     fn test_get_nodes_at_time_after_deletion() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create nodes
         let node1 = db
@@ -4495,7 +4514,7 @@ mod tests {
 
     #[test]
     fn test_get_edges_at_time_basic() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create nodes
         let alice = db
@@ -4584,7 +4603,7 @@ mod tests {
 
     #[test]
     fn test_get_edges_at_time_mixed_results() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create nodes and edges
         let alice = db
@@ -4624,7 +4643,7 @@ mod tests {
 
     #[test]
     fn test_get_edges_at_time_empty_batch() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let t1 = *db.current_timestamp.lock().unwrap();
 
@@ -4637,7 +4656,7 @@ mod tests {
 
     #[test]
     fn test_get_edges_at_time_after_deletion() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create nodes and edges
         let alice = db
@@ -4687,7 +4706,7 @@ mod tests {
 
     #[test]
     fn test_get_nodes_at_time_large_batch() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create 100 nodes
         let node_ids: Vec<_> = (0..100)
@@ -4717,7 +4736,7 @@ mod tests {
 
     #[test]
     fn test_get_nodes_at_time_duplicate_ids() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let node1 = db
             .create_node(
@@ -4743,7 +4762,7 @@ mod tests {
 
     #[test]
     fn test_get_edges_at_time_large_batch() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Create nodes
         let source = db
@@ -4783,7 +4802,7 @@ mod tests {
 
     #[test]
     fn test_get_edges_at_time_duplicate_ids() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         let source = db
             .create_node("Node", PropertyMapBuilder::new().build())
@@ -4815,7 +4834,7 @@ mod tests {
     fn test_find_similar_with_missing_property() {
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index on "embedding" property
         let config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(100);
@@ -4866,7 +4885,7 @@ mod tests {
     fn test_vector_index_builder_basic() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Builder pattern API
         db.vector_index("embedding")
@@ -4883,7 +4902,7 @@ mod tests {
     fn test_vector_index_builder_multiple_properties() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable two indexes via builder
         db.vector_index("title_embedding")
@@ -4908,7 +4927,7 @@ mod tests {
     /// Test builder pattern without calling hnsw() fails.
     #[test]
     fn test_vector_index_builder_missing_hnsw_fails() {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Calling enable() without hnsw() should fail
         let result = db.vector_index("embedding").enable();
@@ -4926,7 +4945,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         // Single call enables both current and temporal indexing
@@ -4954,7 +4973,7 @@ mod tests {
     fn test_vector_index_builder_functional() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         db.vector_index("embedding")
             .hnsw(HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100))
@@ -4992,7 +5011,7 @@ mod tests {
     fn test_vector_index_builder_same_property_twice_fails() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         db.vector_index("embedding")
             .hnsw(HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100))
@@ -5020,7 +5039,7 @@ mod tests {
     fn test_find_similar_in_explicit_property() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable two different indexes
         db.vector_index("title_embedding")
@@ -5073,7 +5092,7 @@ mod tests {
     fn test_search_vectors_in_explicit_property() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         db.vector_index("embedding")
             .hnsw(HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100))
@@ -5111,7 +5130,7 @@ mod tests {
     fn test_find_similar_in_nonexistent_property_fails() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         db.vector_index("embedding")
             .hnsw(HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100))
@@ -5145,7 +5164,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         // Enable temporal vector index for a specific property
@@ -5193,7 +5212,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         // Enable temporal index for "embedding" property
@@ -5225,7 +5244,7 @@ mod tests {
     fn test_find_similar_as_of_in_no_temporal_index() {
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Only enable regular HNSW index, not temporal
         db.vector_index("embedding")
@@ -5253,7 +5272,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         // Enable temporal vector index for a specific property
@@ -5302,7 +5321,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         // Enable temporal index for "embedding" property
@@ -5336,7 +5355,7 @@ mod tests {
         use crate::core::temporal::TimeRange;
         use crate::index::vector::DistanceMetric;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Only enable regular HNSW index, not temporal
         db.vector_index("embedding")
@@ -5365,7 +5384,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         db.vector_index("content_embedding")
@@ -5405,7 +5424,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         db.vector_index("embedding")
@@ -5439,7 +5458,7 @@ mod tests {
             DriftMetric, RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         db.vector_index("content_embedding")
@@ -5479,7 +5498,7 @@ mod tests {
             DriftMetric, RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
 
         db.vector_index("embedding")
@@ -5517,7 +5536,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable temporal index for FIRST property
         let hnsw_config1 = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
@@ -5613,7 +5632,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable temporal index for one property
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
@@ -5653,7 +5672,7 @@ mod tests {
         use crate::index::vector::temporal::TemporalVectorConfig;
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Enable vector index first
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
@@ -5675,7 +5694,7 @@ mod tests {
         // when no vector index exists
         use crate::index::vector::temporal::TemporalVectorConfig;
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Try to enable temporal vector index WITHOUT providing hnsw_config
         // AND without an existing vector index - this should fail
@@ -5714,7 +5733,7 @@ mod tests {
         };
         use crate::index::vector::{DistanceMetric, HnswConfig};
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
 
         // Initially empty
         assert!(db.list_temporal_vector_indexes().is_empty());
@@ -5766,7 +5785,7 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        let db = Arc::new(GallifreyDB::new());
+        let db = Arc::new(GallifreyDB::new().unwrap());
 
         // Enable two vector indexes for different properties
         let hnsw_config1 = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
@@ -5851,13 +5870,128 @@ mod tests {
         let _ = node_ids; // Use node_ids to suppress unused warning
     }
 
+    // ==================== Constructor Error Handling Tests ====================
+    // These tests verify that database constructors return Result and properly
+    // propagate WAL creation errors (Issue #343)
+
+    #[test]
+    fn test_new_returns_result() {
+        // GallifreyDB::new() should return Result<Self> and succeed with default config
+        let result = GallifreyDB::new();
+        assert!(result.is_ok(), "new() should succeed with default config");
+    }
+
+    #[test]
+    fn test_with_config_returns_result() {
+        // GallifreyDB::with_config() should return Result<Self>
+        let result = GallifreyDB::with_config(crate::storage::version::AnchorConfig::default());
+        assert!(
+            result.is_ok(),
+            "with_config() should succeed with default config"
+        );
+    }
+
+    #[test]
+    fn test_with_wal_config_returns_result() {
+        // GallifreyDB::with_wal_config() should return Result<Self>
+        let wal_config = crate::config::WalConfig::default();
+        let result = GallifreyDB::with_wal_config(wal_config);
+        assert!(
+            result.is_ok(),
+            "with_wal_config() should succeed with default config"
+        );
+    }
+
+    #[test]
+    fn test_with_full_config_returns_result() {
+        // GallifreyDB::with_full_config() should return Result<Self>
+        let result = GallifreyDB::with_full_config(
+            crate::storage::version::AnchorConfig::default(),
+            crate::config::WalConfig::default(),
+        );
+        assert!(
+            result.is_ok(),
+            "with_full_config() should succeed with default config"
+        );
+    }
+
+    #[test]
+    fn test_with_unified_config_returns_result() {
+        // GallifreyDB::with_unified_config() should return Result<Self>
+        let config = crate::config::GallifreyDBConfig::default();
+        let result = GallifreyDB::with_unified_config(config);
+        assert!(
+            result.is_ok(),
+            "with_unified_config() should succeed with default config"
+        );
+    }
+
+    #[test]
+    fn test_wal_creation_failure_propagates_error() {
+        // When WAL creation fails, the error should be propagated instead of panicking
+        use std::path::PathBuf;
+
+        // Use /dev/null/wal - /dev/null is a character device, not a directory,
+        // so any attempt to create subdirectories under it will fail
+        let invalid_wal_dir = PathBuf::from("/dev/null/wal");
+
+        let wal_config = crate::config::WalConfigBuilder::new()
+            .wal_dir(invalid_wal_dir)
+            .build();
+
+        let result = GallifreyDB::with_wal_config(wal_config);
+
+        // Should return Err instead of panicking
+        assert!(
+            result.is_err(),
+            "with_wal_config() should return Err when WAL directory cannot be created"
+        );
+
+        // Error should mention an I/O issue
+        let err = result.err().expect("Expected an error");
+        let err_msg = err.to_string().to_lowercase();
+        assert!(
+            err_msg.contains("i/o")
+                || err_msg.contains("directory")
+                || err_msg.contains("not a directory"),
+            "Error message should indicate I/O issue, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_unified_config_wal_failure_propagates_error() {
+        // When WAL creation fails in with_unified_config, the error should be propagated
+        use std::path::PathBuf;
+
+        // Use /dev/null/wal - /dev/null is a character device, not a directory,
+        // so any attempt to create subdirectories under it will fail
+        let invalid_wal_dir = PathBuf::from("/dev/null/wal");
+
+        let config = crate::config::GallifreyDBConfigBuilder::new()
+            .wal(
+                crate::config::WalConfigBuilder::new()
+                    .wal_dir(invalid_wal_dir)
+                    .build(),
+            )
+            .build();
+
+        let result = GallifreyDB::with_unified_config(config);
+
+        // Should return Err instead of panicking
+        assert!(
+            result.is_err(),
+            "with_unified_config() should return Err when WAL directory cannot be created"
+        );
+    }
+
     #[test]
     fn test_max_vector_properties_limit() {
         // Test that the maximum number of vector properties is enforced
         use crate::index::vector::{DistanceMetric, HnswConfig};
         use crate::storage::current::DEFAULT_MAX_VECTOR_PROPERTIES;
 
-        let db = crate::GallifreyDB::new();
+        let db = crate::GallifreyDB::new().unwrap();
 
         // Enable indexes up to the limit
         for i in 0..DEFAULT_MAX_VECTOR_PROPERTIES {

--- a/src/db.rs
+++ b/src/db.rs
@@ -5926,6 +5926,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_wal_creation_failure_propagates_error() {
         // When WAL creation fails, the error should be propagated instead of panicking
@@ -5959,6 +5960,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_unified_config_wal_failure_propagates_error() {
         // When WAL creation fails in with_unified_config, the error should be propagated

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -267,7 +267,7 @@ mod tests {
 
     /// Helper to create a test database with vector indexing enabled.
     fn create_test_db() -> GallifreyDB {
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let config = HnswConfig::new(4, DistanceMetric::Cosine);
         db.enable_vector_index("embedding", config)
             .expect("Failed to enable vector index");
@@ -703,7 +703,7 @@ mod tests {
             RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
         };
 
-        let db = GallifreyDB::new();
+        let db = GallifreyDB::new().unwrap();
         let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);
         let temporal_config = TemporalVectorConfig {
             snapshot_strategy: SnapshotStrategy::TransactionInterval(1),

--- a/tests/benchmark_validation.rs
+++ b/tests/benchmark_validation.rs
@@ -20,7 +20,7 @@ use gallifreydb::{GallifreyDB, PropertyMapBuilder};
 /// - Verifying correct historical state reconstruction
 #[test]
 fn test_anchor_creation_matches_benchmark_assumptions() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create initial node
     let node_id = db
@@ -85,7 +85,7 @@ fn test_anchor_creation_matches_benchmark_assumptions() {
 /// validation requires deeper investigation of get_node_at_time semantics.
 #[test]
 fn test_delta_reconstruction_produces_correct_state() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let node_id = db
         .create_node(
@@ -186,7 +186,7 @@ fn test_delta_reconstruction_produces_correct_state() {
 /// which requires explicit closing of previous versions before adding new ones.
 #[test]
 fn test_multiple_updates_same_transaction() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let node_id = db
         .create_node(
@@ -263,7 +263,7 @@ fn test_performance_targets_benchmark_runtime() {
     let start = Instant::now();
 
     // Simulate the benchmark setup (without criterion overhead)
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let node_id = db
         .create_node(
             "Person",

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -32,7 +32,7 @@ fn create_db_with_mode(mode: DurabilityMode) -> GallifreyDB {
         .unwrap()
         .durability_mode(mode)
         .build();
-    GallifreyDB::with_wal_config(config)
+    GallifreyDB::with_wal_config(config).unwrap()
 }
 
 // =============================================================================
@@ -41,7 +41,7 @@ fn create_db_with_mode(mode: DurabilityMode) -> GallifreyDB {
 
 #[test]
 fn test_synchronous_mode_is_default() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Default mode should be Synchronous
     let node_id = db
@@ -516,7 +516,7 @@ fn test_async_data_flushed_on_shutdown() {
                 flush_interval_ms: 60000, // Very long - won't naturally flush
             })
             .build();
-        let db = GallifreyDB::with_wal_config(config);
+        let db = GallifreyDB::with_wal_config(config).unwrap();
 
         let options = WriteOptions {
             durability_mode: Some(DurabilityMode::Async {
@@ -559,7 +559,7 @@ fn test_write_options_default() {
 
 #[test]
 fn test_write_with_options_closure_semantics() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Test that closure can access outer scope
     let prefix = "test_";
@@ -587,7 +587,7 @@ fn test_write_with_options_closure_semantics() {
 
 #[test]
 fn test_write_options_bulk_import_preset_integration() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Use bulk_import preset for fast loading - all writes in ONE transaction
     let node_ids = db
@@ -621,7 +621,7 @@ fn test_write_options_bulk_import_preset_integration() {
 
 #[test]
 fn test_write_options_critical_preset_integration() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Use critical preset for important data
     let node_id = db
@@ -649,7 +649,7 @@ fn test_write_options_critical_preset_integration() {
 
 #[test]
 fn test_preset_methods_mixed_usage() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Use bulk_import for initial data
     let bulk_node = db
@@ -688,7 +688,7 @@ fn test_preset_methods_mixed_usage() {
 
 #[test]
 fn test_error_in_write_with_options_propagates() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let result: Result<(), gallifreydb::Error> =
         db.write_with_options(WriteOptions::default(), |_tx| {
@@ -796,7 +796,7 @@ fn test_segment_rotation_with_background_thread() {
         })
         .build();
 
-    let db = GallifreyDB::with_wal_config(config);
+    let db = GallifreyDB::with_wal_config(config).unwrap();
 
     // Write enough data to trigger multiple segment rotations
     // Each node with properties is ~100-200 bytes
@@ -1066,7 +1066,7 @@ fn test_async_batched_graceful_shutdown() {
                 max_batch_size: 10000,
             })
             .build();
-        let db = GallifreyDB::with_wal_config(config);
+        let db = GallifreyDB::with_wal_config(config).unwrap();
 
         let options = WriteOptions {
             durability_mode: Some(DurabilityMode::AsyncBatched {
@@ -1210,7 +1210,7 @@ fn test_async_batched_with_segment_rotation() {
         })
         .build();
 
-    let db = GallifreyDB::with_wal_config(config);
+    let db = GallifreyDB::with_wal_config(config).unwrap();
 
     let options = WriteOptions {
         durability_mode: Some(DurabilityMode::AsyncBatched {

--- a/tests/hybrid_query.rs
+++ b/tests/hybrid_query.rs
@@ -51,7 +51,7 @@ const TEST_VECTOR_DIM: usize = 4;
 
 /// Helper to create a test database with vector indexing enabled.
 fn create_test_db() -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(TEST_VECTOR_DIM, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
@@ -63,7 +63,8 @@ fn create_temporal_test_db() -> GallifreyDB {
     let db = GallifreyDB::with_config(AnchorConfig {
         anchor_interval: 3,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
     let config = HnswConfig::new(TEST_VECTOR_DIM, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 /// Helper to create a test database with vector indexing enabled.
 fn create_test_db() -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(4, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
@@ -432,7 +432,8 @@ fn test_temporal_context_preserved() {
     let db = GallifreyDB::with_config(AnchorConfig {
         anchor_interval: 3,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
     let config = HnswConfig::new(4, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
@@ -487,7 +488,8 @@ fn test_full_hybrid_temporal_graph_vector() {
     let db = GallifreyDB::with_config(AnchorConfig {
         anchor_interval: 3,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
     let config = HnswConfig::new(4, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
@@ -868,7 +870,8 @@ fn test_execute_temporal_node_lookup_returns_historical_state() {
     let db = GallifreyDB::with_config(AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
     let config = HnswConfig::new(4, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
@@ -1170,7 +1173,8 @@ fn test_temporal_vector_query() {
     let db = GallifreyDB::with_config(AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);
     let temporal_config = TemporalVectorConfig {
@@ -1243,7 +1247,7 @@ fn test_temporal_vector_query() {
 
 #[test]
 fn test_query_with_missing_vector_index() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     // Note: NOT enabling vector index
 
     // Create a node
@@ -1358,7 +1362,8 @@ fn test_all_query_dimension_combinations() {
     let db = GallifreyDB::with_config(AnchorConfig {
         anchor_interval: 3,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
     let config = HnswConfig::new(4, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -261,7 +261,7 @@ fn test_db_persist_indexes_mvp() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Add some nodes
         let node1_id = db
@@ -371,7 +371,7 @@ fn test_full_persistence_lifecycle() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Add nodes with properties
         node1_id = db
@@ -431,7 +431,7 @@ fn test_full_persistence_lifecycle() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Verify counts
         assert_eq!(db.node_count(), 2, "Should have restored 2 nodes from disk");
@@ -553,7 +553,7 @@ fn test_automatic_persistence_integration() {
         .persistence(persistence_config)
         .build();
 
-    let db = GallifreyDB::with_unified_config(config);
+    let db = GallifreyDB::with_unified_config(config).unwrap();
 
     // Create test data - enough to trigger automatic persistence
     println!("Creating 10 nodes to trigger automatic persistence...");
@@ -631,7 +631,7 @@ fn test_automatic_persistence_integration() {
         .persistence(persistence_config)
         .build();
 
-    let db2 = GallifreyDB::with_unified_config(config);
+    let db2 = GallifreyDB::with_unified_config(config).unwrap();
 
     // Verify all nodes were restored
     println!("Verifying restored data...");
@@ -676,7 +676,7 @@ fn test_automatic_persistence_integration() {
         .build();
 
     // This should not panic - should start with empty database
-    let db3 = GallifreyDB::with_unified_config(config);
+    let db3 = GallifreyDB::with_unified_config(config).unwrap();
 
     // Verify database started (even if empty due to corruption)
     let test_node = db3
@@ -1412,7 +1412,7 @@ fn test_invalid_id_detection() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Add node
         db.create_node(
@@ -1458,7 +1458,7 @@ fn test_invalid_id_detection() {
         .build();
 
     // Should not panic, may log warnings
-    let _db = GallifreyDB::with_unified_config(config);
+    let _db = GallifreyDB::with_unified_config(config).unwrap();
 
     println!("✓ Invalid ID detection test passed");
 }
@@ -1485,7 +1485,7 @@ fn test_missing_interner_entries() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         db.create_node(
             "Person",
@@ -1512,7 +1512,7 @@ fn test_missing_interner_entries() {
         .build();
 
     // Should not panic - may start with empty DB or skip invalid entries
-    let db = GallifreyDB::with_unified_config(config);
+    let db = GallifreyDB::with_unified_config(config).unwrap();
 
     // Verify database is functional even if data was lost
     let node_id = db
@@ -1604,7 +1604,7 @@ fn test_multiple_restoration_errors() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Add several nodes
         for i in 0..10 {
@@ -1663,7 +1663,7 @@ fn test_multiple_restoration_errors() {
         })
         .build();
 
-    let db = GallifreyDB::with_unified_config(config);
+    let db = GallifreyDB::with_unified_config(config).unwrap();
 
     // Should have loaded the valid nodes (10) and skipped the invalid ones (2)
     // Note: Exact count may vary depending on restoration logic
@@ -1720,7 +1720,7 @@ fn test_vector_index_persistence() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Enable vector index for "embedding" property
         db.vector_index("embedding")
@@ -1855,7 +1855,7 @@ fn test_vector_index_persistence() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         println!("✓ Database restarted, loading indexes...");
 
@@ -2118,7 +2118,7 @@ fn test_temporal_persistence_with_database() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         // Create nodes (each node creation creates a temporal version)
         node1_id = db
@@ -2219,7 +2219,7 @@ fn test_temporal_persistence_with_database() {
             })
             .build();
 
-        let db = GallifreyDB::with_unified_config(config);
+        let db = GallifreyDB::with_unified_config(config).unwrap();
 
         println!("✓ Database restarted with load_on_startup=true");
 
@@ -2564,7 +2564,7 @@ fn test_persist_indexes_uses_actual_wal_lsn() {
         })
         .build();
 
-    let db = GallifreyDB::with_unified_config(config);
+    let db = GallifreyDB::with_unified_config(config).unwrap();
 
     // Create multiple nodes and edges to advance WAL LSN significantly
     let mut node_ids = Vec::new();

--- a/tests/quick_perf_test.rs
+++ b/tests/quick_perf_test.rs
@@ -20,7 +20,7 @@ fn create_db_with_mode(mode: DurabilityMode) -> (GallifreyDB, TempDir) {
         .unwrap()
         .durability_mode(mode)
         .build();
-    let db = GallifreyDB::with_wal_config(config);
+    let db = GallifreyDB::with_wal_config(config).unwrap();
     (db, temp_dir)
 }
 

--- a/tests/repro_phantom_delete.rs
+++ b/tests/repro_phantom_delete.rs
@@ -6,7 +6,7 @@ use std::thread;
 #[test]
 fn test_phantom_delete_violation() {
     // 1. Setup: Create DB and a "Doctor" node
-    let db = Arc::new(GallifreyDB::new());
+    let db = Arc::new(GallifreyDB::new().unwrap());
 
     let node_id = {
         let mut tx = db.write_transaction().unwrap();

--- a/tests/temporal_debug.rs
+++ b/tests/temporal_debug.rs
@@ -9,7 +9,8 @@ fn test_temporal_lookup_directly() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Create a node and get the timestamp AFTER it's committed
     let node_id = db

--- a/tests/temporal_edge_tests.rs
+++ b/tests/temporal_edge_tests.rs
@@ -15,7 +15,8 @@ fn test_temporal_edge_lookup_basic() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Increased delay to ensure background flush thread has started (fixes CI race condition)
     // On heavily loaded CI systems, the default 10ms may not be sufficient for thread scheduling.
@@ -155,7 +156,8 @@ fn test_temporal_edge_multiple_updates() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 3,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Increased delay to ensure background flush thread has started (fixes CI race condition)
     // On heavily loaded CI systems, the default 10ms may not be sufficient for thread scheduling.
@@ -260,7 +262,8 @@ fn test_temporal_edge_interval_closing() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Increased delay to ensure background flush thread has started (fixes CI race condition)
     // On heavily loaded CI systems, the default 10ms may not be sufficient for thread scheduling.
@@ -377,7 +380,8 @@ fn test_temporal_edge_version_chain_integrity() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Create nodes
     let alice = db
@@ -466,7 +470,8 @@ fn test_temporal_edge_anchor_delta_pattern() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 3, // Create anchor every 3 versions
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Increased delay to ensure background flush thread has started (fixes CI race condition)
     // On heavily loaded CI systems, the default 10ms may not be sufficient for thread scheduling.
@@ -552,7 +557,8 @@ fn test_temporal_edge_with_vector_properties() {
     let db = GallifreyDB::with_config(storage::version::AnchorConfig {
         anchor_interval: 2,
         max_delta_chain: 10,
-    });
+    })
+    .unwrap();
 
     // Create nodes
     let alice = db

--- a/tests/temporal_vector_integration.rs
+++ b/tests/temporal_vector_integration.rs
@@ -362,7 +362,7 @@ fn test_vector_snapshot_id_stored_in_anchors() {
 /// is identical, and this avoids the complexity of temporal snapshot infrastructure.
 #[test]
 fn test_multi_property_temporal_vector_search_execution() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Enable vector indexing for TWO different properties (non-temporal for simplicity)
     let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);

--- a/tests/temporal_vector_integration.rs
+++ b/tests/temporal_vector_integration.rs
@@ -15,7 +15,7 @@ fn test_full_temporal_vector_lifecycle() {
         anchor_interval: 3,
         max_delta_chain: 10,
     };
-    let db = GallifreyDB::with_config(anchor_config);
+    let db = GallifreyDB::with_config(anchor_config).unwrap();
 
     // Enable temporal vector indexing
     let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);
@@ -75,7 +75,7 @@ fn test_multiple_nodes_with_temporal_vectors() {
         anchor_interval: 2,
         max_delta_chain: 10,
     };
-    let db = GallifreyDB::with_config(anchor_config);
+    let db = GallifreyDB::with_config(anchor_config).unwrap();
 
     // Enable temporal vector indexing
     let hnsw_config = HnswConfig::new(3, DistanceMetric::Cosine);
@@ -133,7 +133,7 @@ fn test_multiple_nodes_with_temporal_vectors() {
 #[test]
 fn test_temporal_vector_index_without_anchors() {
     // Test that temporal vector indexing works even when no anchors are created
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);
     let temporal_config = TemporalVectorConfig::default_with_hnsw(hnsw_config);
@@ -172,7 +172,7 @@ fn test_observer_graceful_degradation() {
         anchor_interval: 2,
         max_delta_chain: 10,
     };
-    let db = GallifreyDB::with_config(anchor_config);
+    let db = GallifreyDB::with_config(anchor_config).unwrap();
 
     // Enable temporal vector indexing with default config
     let hnsw_config = HnswConfig::new(3, DistanceMetric::Cosine).with_capacity(5); // Small capacity
@@ -209,7 +209,7 @@ fn test_edge_versions_with_temporal_vectors() {
         anchor_interval: 2,
         max_delta_chain: 10,
     };
-    let db = GallifreyDB::with_config(anchor_config);
+    let db = GallifreyDB::with_config(anchor_config).unwrap();
 
     let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);
     let temporal_config = TemporalVectorConfig::default_with_hnsw(hnsw_config);
@@ -277,7 +277,7 @@ fn test_vector_snapshot_id_stored_in_anchors() {
         anchor_interval: 3,
         max_delta_chain: 10,
     };
-    let db = GallifreyDB::with_config(anchor_config);
+    let db = GallifreyDB::with_config(anchor_config).unwrap();
 
     // Enable temporal vector indexing
     let hnsw_config = HnswConfig::new(4, DistanceMetric::Cosine);

--- a/tests/vector_storage.rs
+++ b/tests/vector_storage.rs
@@ -40,7 +40,7 @@ fn advance_time() {
 /// use approximate equality with an epsilon tolerance.
 #[test]
 fn test_create_node_with_vector_and_retrieve() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create node with embedding
     let embedding = vec![0.1f32, 0.2, 0.3, 0.4, 0.5];
@@ -65,7 +65,7 @@ fn test_create_node_with_vector_and_retrieve() {
 
 #[test]
 fn test_update_vector_property_creates_version() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create node with initial embedding
     let embedding_v1 = vec![0.1f32, 0.2, 0.3];
@@ -113,7 +113,7 @@ fn test_update_vector_property_creates_version() {
 
 #[test]
 fn test_multiple_nodes_with_vectors_isolation() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create multiple nodes with different embeddings
     let embedding_a = vec![1.0f32, 0.0, 0.0];
@@ -220,7 +220,7 @@ fn test_multiple_nodes_with_vectors_isolation() {
 
 #[test]
 fn test_edge_with_vector_property() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create two nodes
     let node_a = db
@@ -266,7 +266,7 @@ fn test_edge_with_vector_property() {
 
 #[test]
 fn test_update_edge_vector_property() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let node_a = db
         .create_node("Entity", PropertyMapBuilder::new().build())
@@ -331,7 +331,7 @@ fn test_update_edge_vector_property() {
 
 #[test]
 fn test_large_vector_1000_dimensions() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     const DIMENSIONS: usize = 1000;
     let large_embedding = generate_embedding(DIMENSIONS, 0.0);
@@ -357,7 +357,7 @@ fn test_large_vector_1000_dimensions() {
 
 #[test]
 fn test_very_large_vector_4096_dimensions() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // 4096 dimensions (larger than typical embedding models)
     const DIMENSIONS: usize = 4096;
@@ -392,7 +392,7 @@ macro_rules! test_embedding_dimension {
     ($test_name:ident, $dim:expr, $model:expr, $label:expr) => {
         #[test]
         fn $test_name() {
-            let db = GallifreyDB::new();
+            let db = GallifreyDB::new().unwrap();
             const DIMENSIONS: usize = $dim;
             let embedding = generate_embedding(DIMENSIONS, 0.0);
 
@@ -459,7 +459,7 @@ test_embedding_dimension!(
 
 #[test]
 fn test_multiple_vector_updates_version_chain() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create node with initial embedding
     let embedding_v1 = vec![0.1f32, 0.2, 0.3];
@@ -527,7 +527,7 @@ fn test_multiple_vector_updates_version_chain() {
 
 #[test]
 fn test_historical_stats_with_vectors() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create node and update it multiple times
     let node_id = db
@@ -576,7 +576,7 @@ fn test_historical_stats_with_vectors() {
 
 #[test]
 fn test_empty_vector() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     let empty_vec: Vec<f32> = vec![];
     let node_id = db
@@ -597,7 +597,7 @@ fn test_empty_vector() {
 
 #[test]
 fn test_node_with_multiple_embeddings() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Node with multiple embedding fields (e.g., from different models)
     let text_embedding = vec![0.1f32, 0.2, 0.3, 0.4];
@@ -637,7 +637,7 @@ fn test_node_with_multiple_embeddings() {
 
 #[test]
 fn test_graph_with_mixed_properties_and_vectors() {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Create a small knowledge graph with embeddings
     let alice = db
@@ -698,7 +698,7 @@ fn test_graph_with_mixed_properties_and_vectors() {
 fn setup_indexed_db(dimensions: usize) -> GallifreyDB {
     use gallifreydb::index::vector::{DistanceMetric, HnswConfig};
 
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(dimensions, DistanceMetric::Cosine).with_capacity(100);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");
@@ -713,7 +713,7 @@ fn setup_indexed_db(dimensions: usize) -> GallifreyDB {
 fn test_enable_vector_index() {
     use gallifreydb::index::vector::{DistanceMetric, HnswConfig};
 
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Index should not be enabled initially
     assert!(!db.is_vector_index_enabled());
@@ -730,7 +730,7 @@ fn test_enable_vector_index() {
 fn test_double_enable_vector_index_fails() {
     use gallifreydb::index::vector::{DistanceMetric, HnswConfig};
 
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
 
     // Enable index once
     let config = HnswConfig::new(384, DistanceMetric::Cosine);
@@ -952,7 +952,7 @@ fn test_node_without_vector_property_not_indexed() {
 fn test_find_similar_on_non_indexed_db_fails() {
     use gallifreydb::core::id::NodeId;
 
-    let db = GallifreyDB::new(); // No index enabled
+    let db = GallifreyDB::new().unwrap(); // No index enabled
 
     let node_id = NodeId::new(1).unwrap();
     let result = db.find_similar(node_id, 10);

--- a/tests/vs_069_public_api_acceptance.rs
+++ b/tests/vs_069_public_api_acceptance.rs
@@ -23,7 +23,7 @@ use gallifreydb::{
 
 /// Helper to create a test database with vector indexing enabled.
 fn create_test_db() -> GallifreyDB {
-    let db = GallifreyDB::new();
+    let db = GallifreyDB::new().unwrap();
     let config = HnswConfig::new(4, DistanceMetric::Cosine);
     db.enable_vector_index("embedding", config)
         .expect("Failed to enable vector index");


### PR DESCRIPTION
fix: replace .expect() with Result propagation in database constructors
This fixes issue https://github.com/madmax983/GallifreyDB/issues/343 by changing all GallifreyDB constructor methods
to return Result<Self> instead of Self, enabling proper error propagation
when WAL initialization fails.

Changes:
- new(), with_config(), with_wal_config(), with_full_config(), and
  with_unified_config() now return Result<Self>
- Replace .expect("Failed to create WAL") with the ? operator
- Remove Default implementation (cannot return Result, and expect()
  violates CODING_STANDARDS.md)
- Update open() method to use new()? for proper error propagation
- Add comprehensive tests for error propagation behavior
- Update all test call sites to use .unwrap() as appropriate

This change follows the project's coding standards which prohibit
.expect() in production code, enabling callers to catch and handle
WAL creation failures gracefully instead of panicking.