### PR TITLE
perf: optimize adjacency dirty flag checking with Relaxed ordering (f…

### DIFF
--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -233,6 +233,13 @@ impl CurrentIndexes {
     /// This optimization saves ~0.5-2ns per adjacency access by avoiding
     /// the acquire fence on the fast path. See Issue #336 for details.
     ///
+    /// # Safety Justification
+    ///
+    /// Even if we miss `dirty=true` due to Relaxed ordering, the subsequent
+    /// `ArcSwap::load_full()` uses Acquire ordering internally, which synchronizes
+    /// with the Release store from `rebuild_adjacency_internal()`. This guarantees
+    /// we see a consistent (though possibly pre-rebuild) adjacency snapshot.
+    ///
     /// # Race Window (Acceptable)
     ///
     /// There's a benign race where:
@@ -1529,8 +1536,9 @@ mod dirty_flag_optimization_tests {
                     assert_eq!(len, iter_count, "Snapshot should be internally consistent");
 
                     // Each entry should have valid data
+                    // Targets are created as (i + 1) % 10, so always < 10
                     for entry in guard.iter() {
-                        assert!(entry.target.as_u64() < 100);
+                        assert!(entry.target.as_u64() < 10);
                         assert!(entry.edge_id.as_u64() < 100);
                     }
                 }
@@ -1613,7 +1621,7 @@ mod dirty_flag_optimization_tests {
         });
 
         writer.join().expect("Writer should complete");
-        let _saw_new = reader.join().expect("Reader should complete");
+        let _ = reader.join().expect("Reader should complete");
 
         // Eventually, the new edge must be visible
         let final_guard = indexes.get_outgoing(NodeId::new(0).unwrap());
@@ -1651,7 +1659,7 @@ mod dirty_flag_optimization_tests {
             let running_clone = Arc::clone(&running);
             reader_handles.push(thread::spawn(move || {
                 let mut reads = 0u64;
-                while running_clone.load(Ordering::Relaxed) {
+                while running_clone.load(Ordering::Acquire) {
                     for node_id in 0..20 {
                         let guard = indexes_clone.get_outgoing(NodeId::new(node_id).unwrap());
                         // Verify data consistency
@@ -1686,8 +1694,8 @@ mod dirty_flag_optimization_tests {
             handle.join().expect("Writer should complete");
         }
 
-        // Stop readers
-        running.store(false, Ordering::Relaxed);
+        // Stop readers (Release synchronizes with Acquire loads in reader threads)
+        running.store(false, Ordering::Release);
 
         // Wait for readers and collect stats
         let mut total_reads = 0u64;

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -1493,7 +1493,7 @@ mod dirty_flag_optimization_tests {
         // Multiple reads should all use the fast path
         for _ in 0..100 {
             let outgoing = indexes.get_outgoing(NodeId::new(0).unwrap());
-            assert!(outgoing.len() >= 1);
+            assert!(!outgoing.is_empty());
 
             // Dirty flag should remain false (no modifications)
             assert!(!indexes.adjacency_dirty.load(Ordering::Relaxed));

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -210,19 +210,28 @@ impl CurrentIndexes {
     /// This is called before any adjacency access to ensure correctness.
     ///
     /// Uses double-checked locking pattern to minimize overhead:
-    /// 1. Quick check of dirty flag (no lock, just atomic read with Acquire)
+    /// 1. Quick check of dirty flag (no lock, just atomic read with Relaxed)
     /// 2. If dirty, acquire write lock and check again with Relaxed
     /// 3. Rebuild only if still dirty after acquiring lock
     ///
     /// This ensures only one thread rebuilds even if multiple threads
     /// detect the dirty flag simultaneously.
     ///
-    /// # Memory Ordering
+    /// # Memory Ordering (Issue #336 Optimization)
     ///
-    /// - First check uses `Acquire` to synchronize with the `Release` in
-    ///   `insert_edge`/`remove_edge` that set the flag
-    /// - Second check uses `Relaxed` because the lock acquisition provides
-    ///   full synchronization guarantees (no additional ordering needed)
+    /// Both checks use `Relaxed` ordering because:
+    /// - **ArcSwap provides synchronization**: The actual adjacency data is accessed
+    ///   through `ArcSwap::load()` which provides its own memory ordering guarantees.
+    ///   When we load the Arc, we're guaranteed to see a consistent snapshot.
+    /// - **Lock provides synchronization for slow path**: When we detect dirty=true
+    ///   and acquire the write lock, the lock provides full synchronization.
+    /// - **Dirty flag is a hint, not a guard**: The flag indicates whether we
+    ///   *might* need to rebuild, not whether the data is valid. Even if we
+    ///   miss a dirty=true due to Relaxed ordering, we'll see a consistent
+    ///   (though potentially stale) adjacency snapshot via ArcSwap.
+    ///
+    /// This optimization saves ~0.5-2ns per adjacency access by avoiding
+    /// the acquire fence on the fast path. See Issue #336 for details.
     ///
     /// # Race Window (Acceptable)
     ///
@@ -241,8 +250,8 @@ impl CurrentIndexes {
     /// performance (avoiding locks on every read) over strict linearizability.
     #[inline]
     fn ensure_adjacency_current(&self) {
-        // Fast path: adjacency is already current
-        if !self.adjacency_dirty.load(Ordering::Acquire) {
+        // Fast path: adjacency is already current (Relaxed is safe - see docs above)
+        if !self.adjacency_dirty.load(Ordering::Relaxed) {
             return;
         }
 
@@ -1351,5 +1360,354 @@ mod concurrency_tests {
             total_in_degree, 150,
             "Lazy rebuild should make all edges accessible via incoming adjacency"
         );
+    }
+}
+
+/// Tests specifically for the dirty flag optimization (Issue #336).
+///
+/// These tests verify that using Relaxed ordering on the fast path dirty flag
+/// check is safe and maintains correctness. The key insight is that ArcSwap
+/// already provides the necessary synchronization for the actual data access.
+#[cfg(test)]
+mod dirty_flag_optimization_tests {
+    use super::tests::{create_test_edge, create_test_node};
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+    use std::thread;
+
+    /// Test that dirty flag is correctly set on edge insertion.
+    #[test]
+    fn test_dirty_flag_set_on_insert() {
+        let indexes = CurrentIndexes::new();
+
+        // Initially not dirty (empty graph)
+        assert!(
+            !indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "New indexes should not be dirty"
+        );
+
+        // Insert an edge
+        indexes.insert_edge(create_test_edge(0, 0, 1, "KNOWS"));
+
+        // Should now be dirty
+        assert!(
+            indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be set after insert"
+        );
+    }
+
+    /// Test that dirty flag is correctly set on edge removal.
+    #[test]
+    fn test_dirty_flag_set_on_remove() {
+        let indexes = CurrentIndexes::new();
+
+        // Insert and rebuild to clear dirty flag
+        indexes.insert_edge(create_test_edge(0, 0, 1, "KNOWS"));
+        indexes.rebuild_adjacency();
+
+        assert!(
+            !indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be cleared after rebuild"
+        );
+
+        // Remove the edge
+        indexes.remove_edge(EdgeId::new(0).unwrap());
+
+        // Should be dirty again
+        assert!(
+            indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be set after remove"
+        );
+    }
+
+    /// Test that dirty flag is cleared after rebuild.
+    #[test]
+    fn test_dirty_flag_cleared_after_rebuild() {
+        let indexes = CurrentIndexes::new();
+
+        // Insert edges to set dirty flag
+        indexes.insert_edge(create_test_edge(0, 0, 1, "KNOWS"));
+        indexes.insert_edge(create_test_edge(1, 1, 2, "KNOWS"));
+
+        assert!(
+            indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be set after inserts"
+        );
+
+        // Rebuild should clear the flag
+        indexes.rebuild_adjacency();
+
+        assert!(
+            !indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be cleared after rebuild"
+        );
+    }
+
+    /// Test that adjacency access triggers lazy rebuild when dirty.
+    #[test]
+    fn test_lazy_rebuild_clears_dirty_flag() {
+        let indexes = CurrentIndexes::new();
+
+        // Insert edge (sets dirty flag)
+        indexes.insert_edge(create_test_edge(0, 0, 1, "KNOWS"));
+
+        assert!(
+            indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be set"
+        );
+
+        // Access adjacency - should trigger lazy rebuild
+        let _outgoing = indexes.get_outgoing(NodeId::new(0).unwrap());
+
+        assert!(
+            !indexes.adjacency_dirty.load(Ordering::Relaxed),
+            "Dirty flag should be cleared after lazy rebuild"
+        );
+    }
+
+    /// Test that multiple reads don't unnecessarily check/rebuild when not dirty.
+    ///
+    /// This test verifies the fast path behavior: when dirty flag is false,
+    /// subsequent reads should skip the rebuild entirely.
+    #[test]
+    fn test_fast_path_no_rebuild_when_clean() {
+        let indexes = CurrentIndexes::new();
+
+        // Setup: insert edges and trigger initial rebuild
+        for i in 0..10 {
+            indexes.insert_edge(create_test_edge(i, i % 5, (i + 1) % 5, "LINK"));
+        }
+        indexes.rebuild_adjacency();
+
+        // Dirty flag should be false
+        assert!(!indexes.adjacency_dirty.load(Ordering::Relaxed));
+
+        // Multiple reads should all use the fast path
+        for _ in 0..100 {
+            let outgoing = indexes.get_outgoing(NodeId::new(0).unwrap());
+            assert!(outgoing.len() >= 1);
+
+            // Dirty flag should remain false (no modifications)
+            assert!(!indexes.adjacency_dirty.load(Ordering::Relaxed));
+        }
+    }
+
+    /// Test that ArcSwap provides consistent snapshots even with Relaxed ordering.
+    ///
+    /// This is the key test for the optimization: even if we use Relaxed ordering
+    /// on the dirty flag check, ArcSwap ensures we always see a consistent
+    /// (though potentially stale) snapshot of the adjacency data.
+    #[test]
+    fn test_arcswap_provides_consistent_snapshots() {
+        let indexes = Arc::new(CurrentIndexes::new());
+
+        // Add initial nodes and edges
+        for i in 0..10 {
+            indexes.insert_node(create_test_node(i, "Node"));
+        }
+        for i in 0..50 {
+            indexes.insert_edge(create_test_edge(i, i % 10, (i + 1) % 10, "LINK"));
+        }
+        indexes.rebuild_adjacency();
+
+        let mut handles = Vec::new();
+
+        // Spawn readers that access adjacency repeatedly
+        for _ in 0..4 {
+            let indexes_clone = Arc::clone(&indexes);
+            handles.push(thread::spawn(move || {
+                for _ in 0..100 {
+                    // Get a snapshot via ArcSwap
+                    let guard = indexes_clone.get_outgoing(NodeId::new(0).unwrap());
+
+                    // The snapshot should be internally consistent:
+                    // - All entries should be valid
+                    // - Length should match what we iterate over
+                    let len = guard.len();
+                    let iter_count = guard.iter().count();
+                    assert_eq!(len, iter_count, "Snapshot should be internally consistent");
+
+                    // Each entry should have valid data
+                    for entry in guard.iter() {
+                        assert!(entry.target.as_u64() < 100);
+                        assert!(entry.edge_id.as_u64() < 100);
+                    }
+                }
+            }));
+        }
+
+        // Spawn a writer that modifies edges
+        let indexes_clone = Arc::clone(&indexes);
+        handles.push(thread::spawn(move || {
+            for i in 50..100 {
+                indexes_clone.insert_edge(create_test_edge(i, i % 10, (i + 1) % 10, "NEW"));
+            }
+        }));
+
+        // All threads should complete without panics or data corruption
+        for handle in handles {
+            handle.join().expect("Thread should complete without panic");
+        }
+
+        // Final verification
+        assert_eq!(indexes.edge_count(), 100);
+    }
+
+    /// Test the "benign race" scenario documented in ensure_adjacency_current.
+    ///
+    /// This test exercises the race window where:
+    /// 1. Thread A checks dirty=false
+    /// 2. Thread B inserts edge, sets dirty=true
+    /// 3. Thread A proceeds with potentially stale adjacency
+    ///
+    /// The key assertion is that this is safe because:
+    /// - Thread A sees a consistent (older) snapshot via ArcSwap
+    /// - No data corruption occurs
+    /// - Next access will see the new data
+    #[test]
+    fn test_benign_race_eventual_consistency() {
+        let indexes = Arc::new(CurrentIndexes::new());
+
+        // Setup initial state
+        for i in 0..5 {
+            indexes.insert_node(create_test_node(i, "Node"));
+        }
+        indexes.insert_edge(create_test_edge(0, 0, 1, "INITIAL"));
+        indexes.rebuild_adjacency();
+
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+
+        // Thread A: Reader that may see stale data
+        let indexes_a = Arc::clone(&indexes);
+        let barrier_a = Arc::clone(&barrier);
+        let reader = thread::spawn(move || {
+            // Wait for both threads to be ready
+            barrier_a.wait();
+
+            // Read multiple times
+            let mut saw_new_edge = false;
+            for _ in 0..1000 {
+                let guard = indexes_a.get_outgoing(NodeId::new(0).unwrap());
+                // May or may not see the new edge depending on timing
+                if guard.len() > 1 {
+                    saw_new_edge = true;
+                }
+                // Should never see corrupted data
+                for entry in guard.iter() {
+                    assert!(entry.target.as_u64() < 10);
+                }
+            }
+            saw_new_edge
+        });
+
+        // Thread B: Writer that adds a new edge
+        let indexes_b = Arc::clone(&indexes);
+        let barrier_b = Arc::clone(&barrier);
+        let writer = thread::spawn(move || {
+            // Wait for both threads to be ready
+            barrier_b.wait();
+
+            // Add a new edge
+            indexes_b.insert_edge(create_test_edge(1, 0, 2, "NEW"));
+        });
+
+        writer.join().expect("Writer should complete");
+        let _saw_new = reader.join().expect("Reader should complete");
+
+        // Eventually, the new edge must be visible
+        let final_guard = indexes.get_outgoing(NodeId::new(0).unwrap());
+        assert_eq!(
+            final_guard.len(),
+            2,
+            "New edge should be visible after final access"
+        );
+    }
+
+    /// Stress test for the Relaxed ordering optimization under high contention.
+    ///
+    /// This test creates many concurrent readers and writers to verify that
+    /// the Relaxed ordering doesn't cause correctness issues.
+    #[test]
+    fn test_relaxed_ordering_stress() {
+        let indexes = Arc::new(CurrentIndexes::new());
+
+        // Setup initial graph
+        for i in 0..20 {
+            indexes.insert_node(create_test_node(i, "Node"));
+        }
+        for i in 0..100 {
+            indexes.insert_edge(create_test_edge(i, i % 20, (i + 1) % 20, "INIT"));
+        }
+        indexes.rebuild_adjacency();
+
+        let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let mut reader_handles = Vec::new();
+        let mut writer_handles = Vec::new();
+
+        // Spawn 8 reader threads
+        for _ in 0..8 {
+            let indexes_clone = Arc::clone(&indexes);
+            let running_clone = Arc::clone(&running);
+            reader_handles.push(thread::spawn(move || {
+                let mut reads = 0u64;
+                while running_clone.load(Ordering::Relaxed) {
+                    for node_id in 0..20 {
+                        let guard = indexes_clone.get_outgoing(NodeId::new(node_id).unwrap());
+                        // Verify data consistency
+                        let len = guard.len();
+                        let actual_len = guard.iter().count();
+                        assert_eq!(len, actual_len, "Data should be consistent");
+                        reads += 1;
+                    }
+                }
+                reads
+            }));
+        }
+
+        // Spawn 2 writer threads
+        for thread_id in 0..2 {
+            let indexes_clone = Arc::clone(&indexes);
+            writer_handles.push(thread::spawn(move || {
+                for i in 0..50 {
+                    let edge_id = 100 + thread_id * 100 + i;
+                    indexes_clone.insert_edge(create_test_edge(
+                        edge_id,
+                        edge_id % 20,
+                        (edge_id + 1) % 20,
+                        "STRESS",
+                    ));
+                }
+            }));
+        }
+
+        // Let writers finish
+        for handle in writer_handles {
+            handle.join().expect("Writer should complete");
+        }
+
+        // Stop readers
+        running.store(false, Ordering::Relaxed);
+
+        // Wait for readers and collect stats
+        let mut total_reads = 0u64;
+        for handle in reader_handles {
+            total_reads += handle.join().expect("Reader should complete");
+        }
+
+        // Verify final state
+        assert_eq!(indexes.edge_count(), 200, "All edges should be present");
+
+        // Final consistency check
+        let _outgoing = indexes.get_outgoing(NodeId::new(0).unwrap());
+
+        let mut total_degree = 0;
+        for i in 0..20 {
+            total_degree += indexes.out_degree(NodeId::new(i).unwrap());
+        }
+        assert_eq!(total_degree, 200, "Adjacency should reflect all edges");
+
+        // Sanity check that readers actually did work
+        assert!(total_reads > 1000, "Should have performed many reads");
     }
 }


### PR DESCRIPTION
…ixes #336)

Change the fast path dirty flag check from Acquire to Relaxed memory ordering. This saves ~0.5-2ns per adjacency access.

This optimization is safe because:
- ArcSwap provides its own memory ordering guarantees when loading the adjacency data, ensuring consistent snapshots
- The write lock provides full synchronization on the slow path
- The dirty flag is a hint, not a guard - missing a true value just means we use a slightly stale but consistent snapshot

Added comprehensive tests to verify the optimization maintains correctness under concurrent access patterns.