### PR TITLE
feat(checkpoint): integrate index persistence with checkpoint system

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,9 @@
 
 #[cfg(feature = "config-toml")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "config-toml")]
 use std::fs;
+#[cfg(feature = "config-toml")]
 use std::path::Path;
 
 use crate::storage::index_persistence::PersistenceConfig;

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -304,18 +304,33 @@ impl IdGenerator {
     /// sources (e.g., current storage and historical storage) without overwriting
     /// a higher value that was already set.
     ///
+    /// # Thread Safety
+    ///
+    /// This method uses compare-and-swap (CAS) in a loop to atomically ensure
+    /// the value is at least `min_value`, avoiding check-then-act race conditions
+    /// that could occur with separate load/store operations.
+    ///
     /// # Arguments
     ///
     /// * `min_value` - The minimum next ID to generate
     ///
     /// # Memory Ordering
     ///
-    /// Uses `Ordering::SeqCst` for both load and store to ensure consistency.
+    /// Uses `Ordering::SeqCst` for compare_exchange to ensure all threads observe
+    /// a globally consistent order of operations.
     #[inline]
     pub(crate) fn ensure_at_least(&self, min_value: u64) {
-        let current = self.next_id.load(Ordering::SeqCst);
-        if min_value > current {
-            self.next_id.store(min_value, Ordering::SeqCst);
+        let mut current = self.next_id.load(Ordering::SeqCst);
+        while min_value > current {
+            match self.next_id.compare_exchange(
+                current,
+                min_value,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,                  // Successfully updated
+                Err(actual) => current = actual, // Retry with actual current value
+            }
         }
     }
 }

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -297,6 +297,27 @@ impl IdGenerator {
     pub(crate) fn reset_to(&self, value: u64) {
         self.next_id.store(value, Ordering::SeqCst);
     }
+
+    /// Ensure the generator's next value is at least the specified minimum.
+    ///
+    /// This is used during recovery when we need to account for IDs from multiple
+    /// sources (e.g., current storage and historical storage) without overwriting
+    /// a higher value that was already set.
+    ///
+    /// # Arguments
+    ///
+    /// * `min_value` - The minimum next ID to generate
+    ///
+    /// # Memory Ordering
+    ///
+    /// Uses `Ordering::SeqCst` for both load and store to ensure consistency.
+    #[inline]
+    pub(crate) fn ensure_at_least(&self, min_value: u64) {
+        let current = self.next_id.load(Ordering::SeqCst);
+        if min_value > current {
+            self.next_id.store(min_value, Ordering::SeqCst);
+        }
+    }
 }
 
 impl Default for IdGenerator {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1226,31 +1226,14 @@ impl GallifreyDB {
                 use crate::storage::index_persistence::temporal::{
                     load_temporal_index, restore_into_historical_storage,
                 };
-                use std::collections::HashMap;
 
                 match load_temporal_index(&temporal_path) {
                     Ok(temporal_data) => {
-                        // Build label maps from current storage (nodes/edges were just loaded)
-                        let node_labels: HashMap<u64, crate::core::InternedString> = db
-                            .current
-                            .all_nodes()
-                            .map(|node| (node.id.as_u64(), node.label))
-                            .collect();
-
-                        let edge_labels: HashMap<u64, crate::core::InternedString> = db
-                            .current
-                            .all_edges()
-                            .map(|edge| (edge.id.as_u64(), edge.label))
-                            .collect();
-
                         // Restore versions into historical storage
+                        // Labels are now stored directly in the persisted entries
                         let mut historical_guard = db.historical.write();
-                        match restore_into_historical_storage(
-                            &temporal_data,
-                            &mut historical_guard,
-                            &node_labels,
-                            &edge_labels,
-                        ) {
+                        match restore_into_historical_storage(&temporal_data, &mut historical_guard)
+                        {
                             Ok(()) => {
                                 eprintln!(
                                     "Temporal index restored: {} node versions, {} edge versions",

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -128,8 +128,21 @@ impl CheckpointManager {
     ///
     /// # Errors
     ///
-    /// Returns an error if the data directory cannot be created.
+    /// Returns an error if:
+    /// - The data directory cannot be created
+    /// - The compression level is invalid (must be 1-22 for zstd)
     pub fn new(config: CheckpointConfig) -> Result<Self> {
+        // Validate compression level (zstd supports 1-22)
+        if config.enable_compression && !(1..=22).contains(&config.compression_level) {
+            return Err(StorageError::CheckpointError {
+                reason: format!(
+                    "Invalid compression level {}: must be 1-22 for zstd",
+                    config.compression_level
+                ),
+            }
+            .into());
+        }
+
         let persistence_manager = IndexPersistenceManager::new(&config.data_dir);
         persistence_manager
             .ensure_directories()
@@ -309,6 +322,20 @@ impl CheckpointManager {
             .map_err(persistence_err)?;
         let checkpoint_lsn = LSN(manifest.lsn);
 
+        // Validate checkpoint LSN is consistent with WAL
+        // The checkpoint LSN should not exceed the WAL's current LSN
+        let wal_current_lsn = wal.current_lsn();
+        if checkpoint_lsn.0 > wal_current_lsn.0 {
+            return Err(StorageError::CheckpointError {
+                reason: format!(
+                    "Checkpoint LSN {} is ahead of WAL current LSN {}, \
+                     checkpoint may be from a different WAL or corrupted",
+                    checkpoint_lsn.0, wal_current_lsn.0
+                ),
+            }
+            .into());
+        }
+
         // Load graph index
         let current = self.load_current_storage(&manifest)?;
 
@@ -319,9 +346,20 @@ impl CheckpointManager {
         // The current storage's generator was initialized from the count of restored entities,
         // but historical storage may have higher version IDs that we need to account for
         if historical_max_version_id > 0 {
-            // Get current generator's next value and update if historical has higher
-            // We need to ensure no collisions with existing version IDs
-            current.ensure_version_id_generator_at_least(historical_max_version_id + 1);
+            use crate::core::id::MAX_VALID_ID;
+
+            // Use saturating_add to prevent overflow, then validate against MAX_VALID_ID
+            let next_version_id = historical_max_version_id.saturating_add(1);
+            if next_version_id > MAX_VALID_ID {
+                return Err(StorageError::CheckpointError {
+                    reason: format!(
+                        "Historical max version ID {} would overflow MAX_VALID_ID on recovery",
+                        historical_max_version_id
+                    ),
+                }
+                .into());
+            }
+            current.ensure_version_id_generator_at_least(next_version_id);
         }
 
         // Replay WAL entries after checkpoint LSN
@@ -1166,6 +1204,10 @@ mod tests {
         let wal_dir = temp_dir.path().join("wal");
         let data_dir = temp_dir.path().join("data");
 
+        // Create WAL first so we have a valid LSN for the checkpoint
+        let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+        let wal = ConcurrentWalSystem::new(wal_config)?;
+
         // Phase 1: Create checkpoint with data
         {
             let config = CheckpointConfig::with_data_dir(&data_dir);
@@ -1191,17 +1233,14 @@ mod tests {
             }
 
             let historical = HistoricalStorage::new();
-            manager.create_checkpoint(LSN(25), &current, &historical)?;
+            // Use LSN(0) which is valid for an empty WAL
+            manager.create_checkpoint(LSN(0), &current, &historical)?;
         }
 
-        // Phase 2: Recover from checkpoint
+        // Phase 2: Recover from checkpoint using the same WAL
         {
             let config = CheckpointConfig::with_data_dir(&data_dir);
             let mut manager = CheckpointManager::new(config)?;
-
-            // Create empty WAL (no entries after checkpoint)
-            let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
-            let wal = ConcurrentWalSystem::new(wal_config)?;
 
             let (recovered_current, _recovered_historical, lsn) = manager.recover(&wal)?;
 

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1063,10 +1063,17 @@ impl CheckpointManager {
 
         let final_lsn = wal.current_lsn();
 
-        // Initialize ID generators
-        current.init_node_id_generator(max_node_id + 1);
-        current.init_edge_id_generator(max_edge_id + 1);
-        current.init_version_id_generator(max_version_id + 1);
+        // Only update ID generators if we replayed entries with higher IDs
+        // This preserves the values set during load_current_storage if no WAL replay happened
+        if max_node_id > 0 {
+            current.init_node_id_generator(max_node_id + 1);
+        }
+        if max_edge_id > 0 {
+            current.init_edge_id_generator(max_edge_id + 1);
+        }
+        if max_version_id > 0 {
+            current.init_version_id_generator(max_version_id + 1);
+        }
 
         Ok((current, historical, final_lsn))
     }
@@ -1092,12 +1099,11 @@ pub struct CheckpointStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PropertyMapBuilder;
     use crate::core::id::NodeId;
-    use crate::core::property::PropertyMap;
     use crate::core::temporal::{BiTemporalInterval, time};
     use crate::storage::wal::WalOperation;
     use crate::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
-    use crate::{PropertyMapBuilder, api::transaction::types::TxId};
     use tempfile::TempDir;
 
     // ========================================================================
@@ -1487,7 +1493,7 @@ mod tests {
             let props = PropertyMapBuilder::new()
                 .insert("string_prop", "hello")
                 .insert("int_prop", 42i64)
-                .insert("float_prop", 3.14f64)
+                .insert("float_prop", 3.15f64)
                 .insert("bool_prop", true)
                 .build();
 
@@ -1523,7 +1529,7 @@ mod tests {
             );
             assert_eq!(node.get_property("int_prop").unwrap().as_int().unwrap(), 42);
             assert!(
-                (node.get_property("float_prop").unwrap().as_float().unwrap() - 3.14).abs() < 0.001
+                (node.get_property("float_prop").unwrap().as_float().unwrap() - 3.15).abs() < 0.001
             );
             assert!(node.get_property("bool_prop").unwrap().as_bool().unwrap());
         }

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -313,7 +313,16 @@ impl CheckpointManager {
         let current = self.load_current_storage(&manifest)?;
 
         // Load temporal index
-        let historical = self.load_historical_storage(&manifest)?;
+        let (historical, historical_max_version_id) = self.load_historical_storage(&manifest)?;
+
+        // Ensure version ID generator accounts for historical versions
+        // The current storage's generator was initialized from the count of restored entities,
+        // but historical storage may have higher version IDs that we need to account for
+        if historical_max_version_id > 0 {
+            // Get current generator's next value and update if historical has higher
+            // We need to ensure no collisions with existing version IDs
+            current.ensure_version_id_generator_at_least(historical_max_version_id + 1);
+        }
 
         // Replay WAL entries after checkpoint LSN
         let start_lsn = checkpoint_lsn.next();
@@ -448,6 +457,7 @@ impl CheckpointManager {
             let entry = NodeVersionEntry {
                 version_id: version_id.as_u64(),
                 node_id: version.node_id.as_u64(),
+                label_idx: version.label.as_u32(),
                 valid_from: valid_time.start().wallclock(),
                 valid_to: if valid_time.is_current() {
                     None
@@ -502,6 +512,7 @@ impl CheckpointManager {
                 edge_id: version.edge_id.as_u64(),
                 source_id: version.source.as_u64(),
                 target_id: version.target.as_u64(),
+                label_idx: version.label.as_u32(),
                 valid_from: valid_time.start().wallclock(),
                 valid_to: if valid_time.is_current() {
                     None
@@ -585,10 +596,17 @@ impl CheckpointManager {
     }
 
     /// Load HistoricalStorage from persisted temporal index.
-    fn load_historical_storage(&self, manifest: &IndexManifest) -> Result<HistoricalStorage> {
+    ///
+    /// Returns the loaded HistoricalStorage and the maximum version ID found,
+    /// which is needed to properly initialize the version ID generator.
+    fn load_historical_storage(
+        &self,
+        manifest: &IndexManifest,
+    ) -> Result<(HistoricalStorage, u64)> {
         use crate::storage::version::PropertyDelta;
 
         let mut historical = HistoricalStorage::new();
+        let mut max_version_id: u64 = 0;
 
         if let Some(ref temporal_entry) = manifest.temporal_index {
             let temporal_path = self
@@ -605,12 +623,9 @@ impl CheckpointManager {
                 temporal_data.edge_versions.len(),
             );
 
-            // Track max version ID for generator initialization
-            let mut _max_version_id: u64 = 0;
-
             // Restore node versions
             for entry in &temporal_data.node_versions {
-                _max_version_id = _max_version_id.max(entry.version_id);
+                max_version_id = max_version_id.max(entry.version_id);
 
                 let version_id = VersionId::new(entry.version_id)?;
                 let node_id = NodeId::new(entry.node_id)?;
@@ -636,7 +651,7 @@ impl CheckpointManager {
 
                 let properties =
                     restore_property_map(&entry.properties).map_err(persistence_err)?;
-                let label = self.find_node_label_from_anchors(&temporal_data, entry.node_id)?;
+                let label = InternedString::from_raw(entry.label_idx);
 
                 let data = match &entry.version_type {
                     crate::storage::index_persistence::formats::PersistedVersionType::Anchor => {
@@ -677,7 +692,7 @@ impl CheckpointManager {
 
             // Restore edge versions
             for entry in &temporal_data.edge_versions {
-                _max_version_id = _max_version_id.max(entry.version_id);
+                max_version_id = max_version_id.max(entry.version_id);
 
                 let version_id = VersionId::new(entry.version_id)?;
                 let edge_id = EdgeId::new(entry.edge_id)?;
@@ -705,7 +720,7 @@ impl CheckpointManager {
 
                 let properties =
                     restore_property_map(&entry.properties).map_err(persistence_err)?;
-                let label = self.find_edge_label(&temporal_data, entry.edge_id)?;
+                let label = InternedString::from_raw(entry.label_idx);
 
                 let data = match &entry.version_type {
                     crate::storage::index_persistence::formats::PersistedVersionType::Anchor => {
@@ -746,37 +761,7 @@ impl CheckpointManager {
             }
         }
 
-        Ok(historical)
-    }
-
-    /// Find node label from anchors (needed for version restoration).
-    fn find_node_label_from_anchors(
-        &self,
-        _temporal_data: &TemporalIndexData,
-        _node_id: u64,
-    ) -> Result<InternedString> {
-        // TODO: Store labels in temporal data or look up from graph data
-        // For now, use a placeholder - this should be fixed in a follow-up
-        Ok(GLOBAL_INTERNER
-            .intern("unknown")
-            .map_err(|e| StorageError::WalError {
-                reason: e.to_string(),
-            })?)
-    }
-
-    /// Find edge label (needed for version restoration).
-    fn find_edge_label(
-        &self,
-        _temporal_data: &TemporalIndexData,
-        _edge_id: u64,
-    ) -> Result<InternedString> {
-        // TODO: Store labels in temporal data
-        // For now, use a placeholder - this should be fixed in a follow-up
-        Ok(GLOBAL_INTERNER
-            .intern("unknown")
-            .map_err(|e| StorageError::WalError {
-                reason: e.to_string(),
-            })?)
+        Ok((historical, max_version_id))
     }
 
     /// Recover from WAL only (no persisted state).

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1,0 +1,1533 @@
+//! Checkpoint system with full state snapshot via index persistence.
+//!
+//! This module integrates the checkpoint system with index persistence to enable:
+//! - Full state snapshots (not just metadata)
+//! - Fast recovery by loading indexes from disk instead of replaying WAL
+//! - LSN consistency between WAL, checkpoints, and persisted indexes
+//!
+//! # Architecture
+//!
+//! ```text
+//! Checkpoint Creation:
+//!   CurrentStorage ──┬── IndexPersistenceManager.save_graph()
+//!   HistoricalStorage ├── IndexPersistenceManager.save_temporal()
+//!   StringInterner ───┴── IndexPersistenceManager.save_strings()
+//!                        │
+//!                        └── Manifest (with LSN)
+//!
+//! Recovery:
+//!   Manifest (LSN) ──────► Determine WAL replay start
+//!   IndexPersistenceManager ──► Load full state
+//!   WAL.read_from(manifest.lsn + 1) ──► Apply incremental changes
+//! ```
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use gallifreydb::storage::checkpoint::{CheckpointManager, CheckpointConfig};
+//!
+//! // Create checkpoint manager
+//! let config = CheckpointConfig::default().data_dir("data/mydb");
+//! let mut manager = CheckpointManager::new(config)?;
+//!
+//! // Create checkpoint (persists full state)
+//! manager.create_checkpoint(current_lsn, &current, &historical)?;
+//!
+//! // Recover from checkpoint
+//! let (current, historical, lsn) = manager.recover(&wal)?;
+//! ```
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::core::GLOBAL_INTERNER;
+use crate::core::graph::{Edge, Node};
+use crate::core::id::{EdgeId, NodeId, VersionId};
+use crate::core::interning::InternedString;
+use crate::storage::current::CurrentStorage;
+use crate::storage::historical::HistoricalStorage;
+use crate::storage::index_persistence::{
+    GRAPH_MAGIC, IndexPersistenceError, IndexPersistenceManager, MANIFEST_VERSION, TEMPORAL_MAGIC,
+    formats::{
+        GraphIndexData, GraphIndexManifestEntry, IndexManifest, PersistedEdge, PersistedNode,
+        StringInternerManifestEntry, TemporalIndexData, TemporalIndexManifestEntry,
+    },
+    graph::{persist_property_map, restore_property_map},
+};
+use crate::storage::version::VersionData;
+use crate::storage::wal::LSN;
+use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
+use crate::utils::error::{Result, StorageError};
+
+/// Convert IndexPersistenceError to our Result type.
+fn persistence_err(e: IndexPersistenceError) -> crate::utils::error::Error {
+    StorageError::CheckpointError {
+        reason: e.to_string(),
+    }
+    .into()
+}
+
+/// Configuration for checkpoint behavior.
+#[derive(Debug, Clone)]
+pub struct CheckpointConfig {
+    /// Base data directory for persistence
+    pub data_dir: PathBuf,
+    /// Minimum time between checkpoints
+    pub checkpoint_interval: Duration,
+    /// Minimum WAL entries before checkpoint
+    pub min_wal_entries: u64,
+    /// Whether to compress persisted indexes
+    pub enable_compression: bool,
+    /// Compression level (0-22, default 3)
+    pub compression_level: i32,
+}
+
+impl Default for CheckpointConfig {
+    fn default() -> Self {
+        Self {
+            data_dir: PathBuf::from("data"),
+            checkpoint_interval: Duration::from_secs(300), // 5 minutes
+            min_wal_entries: 1000,
+            enable_compression: true,
+            compression_level: 3,
+        }
+    }
+}
+
+impl CheckpointConfig {
+    /// Create configuration with a specific data directory.
+    pub fn with_data_dir(data_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            data_dir: data_dir.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Manages checkpoints with full state persistence via index persistence.
+///
+/// This is the main coordinator between checkpoints and index persistence,
+/// enabling fast recovery by loading indexes from disk instead of replaying WAL.
+pub struct CheckpointManager {
+    /// Configuration for checkpoint behavior
+    config: CheckpointConfig,
+    /// Index persistence manager for disk I/O
+    persistence_manager: IndexPersistenceManager,
+    /// Last checkpoint time
+    last_checkpoint_time: SystemTime,
+    /// Last checkpoint LSN
+    last_checkpoint_lsn: LSN,
+}
+
+impl CheckpointManager {
+    /// Create a new checkpoint manager.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Checkpoint configuration
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data directory cannot be created.
+    pub fn new(config: CheckpointConfig) -> Result<Self> {
+        let persistence_manager = IndexPersistenceManager::new(&config.data_dir);
+        persistence_manager
+            .ensure_directories()
+            .map_err(persistence_err)?;
+
+        Ok(Self {
+            config,
+            persistence_manager,
+            last_checkpoint_time: UNIX_EPOCH,
+            last_checkpoint_lsn: LSN::initial(),
+        })
+    }
+
+    /// Check if a checkpoint should be created.
+    ///
+    /// Returns true if:
+    /// - Time since last checkpoint exceeds `checkpoint_interval`
+    /// - Number of WAL entries since last checkpoint exceeds `min_wal_entries`
+    pub fn should_checkpoint(&self, current_lsn: LSN) -> bool {
+        // Check time threshold
+        let time_elapsed = SystemTime::now()
+            .duration_since(self.last_checkpoint_time)
+            .unwrap_or(Duration::MAX);
+
+        if time_elapsed >= self.config.checkpoint_interval {
+            return true;
+        }
+
+        // Check LSN threshold
+        let lsn_diff = current_lsn.0.saturating_sub(self.last_checkpoint_lsn.0);
+        lsn_diff >= self.config.min_wal_entries
+    }
+
+    /// Create a checkpoint with full state persistence.
+    ///
+    /// This persists:
+    /// - String interner (all interned strings)
+    /// - Graph index (all nodes and edges with properties)
+    /// - Temporal index (all version chains)
+    /// - Manifest (LSN and metadata)
+    ///
+    /// # Arguments
+    ///
+    /// * `lsn` - Current LSN for consistency tracking
+    /// * `current` - Current storage to persist
+    /// * `historical` - Historical storage to persist
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if persistence fails.
+    pub fn create_checkpoint(
+        &mut self,
+        lsn: LSN,
+        current: &CurrentStorage,
+        historical: &HistoricalStorage,
+    ) -> Result<CheckpointStats> {
+        let start_time = std::time::Instant::now();
+        let mut bytes_written = 0u64;
+
+        // 1. Save string interner first (other indexes depend on it)
+        self.persistence_manager
+            .save_string_interner()
+            .map_err(persistence_err)?;
+        bytes_written += std::fs::metadata(self.persistence_manager.interner_path())
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        // 2. Save graph index (current state)
+        let graph_data = self.extract_graph_data(current)?;
+        let graph_path = self.persistence_manager.graph_path().join("adjacency.idx");
+        if self.config.enable_compression {
+            crate::storage::index_persistence::graph::save_graph_index_compressed(
+                &graph_data,
+                &graph_path,
+                self.config.compression_level,
+            )
+            .map_err(persistence_err)?;
+        } else {
+            crate::storage::index_persistence::graph::save_graph_index(&graph_data, &graph_path)
+                .map_err(persistence_err)?;
+        }
+        bytes_written += std::fs::metadata(&graph_path).map(|m| m.len()).unwrap_or(0);
+
+        // 3. Save temporal index (historical versions)
+        let temporal_data = self.extract_temporal_data(historical)?;
+        let temporal_path = self
+            .persistence_manager
+            .temporal_path()
+            .join("versions.idx");
+        crate::storage::index_persistence::temporal::save_temporal_index(
+            &temporal_data,
+            &temporal_path,
+        )
+        .map_err(persistence_err)?;
+        bytes_written += std::fs::metadata(&temporal_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        // 4. Build and save manifest
+        let mut manifest = IndexManifest::new(lsn.0);
+
+        // Add graph index entry
+        manifest.graph_index = Some(GraphIndexManifestEntry {
+            adjacency_file: "graph/adjacency.idx".to_string(),
+            node_count: graph_data.node_count,
+            edge_count: graph_data.edge_count,
+        });
+
+        // Add temporal index entry
+        manifest.temporal_index = Some(TemporalIndexManifestEntry {
+            node_versions_file: "temporal/versions.idx".to_string(),
+            edge_versions_file: "temporal/versions.idx".to_string(),
+            version_count: (temporal_data.node_versions.len() + temporal_data.edge_versions.len())
+                as u64,
+        });
+
+        // Add string interner entry
+        let string_count = GLOBAL_INTERNER.len() as u64;
+        manifest.string_interner = Some(StringInternerManifestEntry {
+            interner_file: "strings/interner.idx".to_string(),
+            string_count,
+        });
+
+        self.persistence_manager
+            .save_manifest(&manifest)
+            .map_err(persistence_err)?;
+        bytes_written += std::fs::metadata(self.persistence_manager.manifest_path())
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        // Update tracking
+        self.last_checkpoint_time = SystemTime::now();
+        self.last_checkpoint_lsn = lsn;
+
+        Ok(CheckpointStats {
+            duration: start_time.elapsed(),
+            bytes_written,
+            lsn,
+            node_count: graph_data.node_count as usize,
+            edge_count: graph_data.edge_count as usize,
+            version_count: temporal_data.node_versions.len() + temporal_data.edge_versions.len(),
+        })
+    }
+
+    /// Recover database state from persisted indexes and WAL.
+    ///
+    /// Recovery process:
+    /// 1. Check if persisted indexes exist
+    /// 2. If yes: Load indexes from disk, then replay WAL from manifest LSN + 1
+    /// 3. If no: Start with empty storage, replay entire WAL
+    ///
+    /// # Arguments
+    ///
+    /// * `wal` - WAL system for replaying entries after checkpoint
+    ///
+    /// # Returns
+    ///
+    /// Tuple of (CurrentStorage, HistoricalStorage, final_lsn)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if loading or WAL replay fails.
+    pub fn recover(
+        &mut self,
+        wal: &ConcurrentWalSystem,
+    ) -> Result<(CurrentStorage, HistoricalStorage, LSN)> {
+        // Check if persisted indexes exist
+        if !self.persistence_manager.indexes_exist() {
+            // No persisted state - use legacy recovery (WAL replay from start)
+            return self.recover_from_wal_only(wal);
+        }
+
+        // Load manifest and strings
+        let manifest = self
+            .persistence_manager
+            .load_manifest_and_strings()
+            .map_err(persistence_err)?;
+        let checkpoint_lsn = LSN(manifest.lsn);
+
+        // Load graph index
+        let current = self.load_current_storage(&manifest)?;
+
+        // Load temporal index
+        let historical = self.load_historical_storage(&manifest)?;
+
+        // Replay WAL entries after checkpoint LSN
+        let start_lsn = checkpoint_lsn.next();
+        let (current, historical, final_lsn) =
+            self.replay_wal(wal, current, historical, start_lsn)?;
+
+        // Update tracking
+        self.last_checkpoint_lsn = checkpoint_lsn;
+
+        Ok((current, historical, final_lsn))
+    }
+
+    /// Check if persisted indexes exist.
+    pub fn has_persisted_state(&self) -> bool {
+        self.persistence_manager.indexes_exist()
+    }
+
+    /// Get the LSN from the persisted manifest.
+    ///
+    /// Returns None if no manifest exists.
+    pub fn get_persisted_lsn(&self) -> Option<LSN> {
+        if !self.persistence_manager.indexes_exist() {
+            return None;
+        }
+
+        self.persistence_manager
+            .load_manifest_and_strings()
+            .ok()
+            .map(|m| LSN(m.lsn))
+    }
+
+    // ========================================================================
+    // Private Helper Methods
+    // ========================================================================
+
+    /// Extract graph data from CurrentStorage for persistence.
+    fn extract_graph_data(&self, current: &CurrentStorage) -> Result<GraphIndexData> {
+        let mut nodes = Vec::new();
+        let mut edges = Vec::new();
+
+        // Extract all nodes
+        for node in current.all_nodes() {
+            let persisted = PersistedNode {
+                id: node.id.as_u64(),
+                label_idx: node.label.as_u32(),
+                properties: persist_property_map(&node.properties).map_err(persistence_err)?,
+            };
+            nodes.push(persisted);
+        }
+
+        // Extract all edges
+        for edge in current.all_edges() {
+            let persisted = PersistedEdge {
+                id: edge.id.as_u64(),
+                source_id: edge.source.as_u64(),
+                target_id: edge.target.as_u64(),
+                label_idx: edge.label.as_u32(),
+                properties: persist_property_map(&edge.properties).map_err(persistence_err)?,
+            };
+            edges.push(persisted);
+        }
+
+        Ok(GraphIndexData {
+            magic: GRAPH_MAGIC,
+            version: MANIFEST_VERSION,
+            node_count: nodes.len() as u64,
+            edge_count: edges.len() as u64,
+            nodes,
+            edges,
+            // CSR adjacency will be rebuilt during loading
+            outgoing_offsets: Vec::new(),
+            outgoing_neighbors: Vec::new(),
+            incoming_offsets: Vec::new(),
+            incoming_neighbors: Vec::new(),
+        })
+    }
+
+    /// Extract temporal data from HistoricalStorage for persistence.
+    fn extract_temporal_data(&self, historical: &HistoricalStorage) -> Result<TemporalIndexData> {
+        use crate::core::property::PropertyMapBuilder;
+        use crate::storage::index_persistence::formats::{
+            EdgeAnchorEntry, EdgeVersionEntry, NodeAnchorEntry, NodeVersionEntry,
+            PersistedVersionType,
+        };
+
+        let mut node_versions = Vec::new();
+        let mut node_anchors = Vec::new();
+        let mut edge_versions = Vec::new();
+        let mut edge_anchors = Vec::new();
+
+        // Extract node versions
+        for (version_id, version) in historical.get_node_versions() {
+            let (version_type, properties, vector_snapshot_id) = match &version.data {
+                VersionData::Anchor {
+                    properties,
+                    vector_snapshot_id,
+                } => {
+                    // Also add to anchors list
+                    node_anchors.push(NodeAnchorEntry {
+                        node_id: version.node_id.as_u64(),
+                        anchor_tx_time: version.temporal.transaction_time().start().wallclock(),
+                        full_state: persist_property_map(properties).map_err(persistence_err)?,
+                        vector_snapshot_id: vector_snapshot_id.map(|id| id as u64),
+                    });
+                    (
+                        PersistedVersionType::Anchor,
+                        persist_property_map(properties).map_err(persistence_err)?,
+                        vector_snapshot_id.map(|id| id as u64),
+                    )
+                }
+                VersionData::Delta { delta } => {
+                    // Convert delta to PropertyMap for persistence
+                    let mut builder = PropertyMapBuilder::new();
+                    for (key, value) in &delta.changed {
+                        builder = builder.insert_by_key(*key, value.clone());
+                    }
+                    let changed_props = builder.build();
+                    let removed_keys: Vec<u32> = delta.removed.iter().map(|k| k.as_u32()).collect();
+
+                    (
+                        PersistedVersionType::Delta {
+                            base_anchor_tx: version.temporal.transaction_time().start().wallclock(),
+                            removed_keys,
+                        },
+                        persist_property_map(&changed_props).map_err(persistence_err)?,
+                        None,
+                    )
+                }
+            };
+
+            let valid_time = version.temporal.valid_time();
+            let entry = NodeVersionEntry {
+                version_id: version_id.as_u64(),
+                node_id: version.node_id.as_u64(),
+                valid_from: valid_time.start().wallclock(),
+                valid_to: if valid_time.is_current() {
+                    None
+                } else {
+                    Some(valid_time.end().wallclock())
+                },
+                tx_time: version.temporal.transaction_time().start().wallclock(),
+                version_type,
+                properties,
+                vector_snapshot_id,
+            };
+            node_versions.push(entry);
+        }
+
+        // Extract edge versions
+        for (version_id, version) in historical.get_edge_versions() {
+            let (version_type, properties) = match &version.data {
+                VersionData::Anchor { properties, .. } => {
+                    // Also add to anchors list
+                    edge_anchors.push(EdgeAnchorEntry {
+                        edge_id: version.edge_id.as_u64(),
+                        anchor_tx_time: version.temporal.transaction_time().start().wallclock(),
+                        full_state: persist_property_map(properties).map_err(persistence_err)?,
+                    });
+                    (
+                        PersistedVersionType::Anchor,
+                        persist_property_map(properties).map_err(persistence_err)?,
+                    )
+                }
+                VersionData::Delta { delta } => {
+                    // Convert delta to PropertyMap for persistence
+                    let mut builder = PropertyMapBuilder::new();
+                    for (key, value) in &delta.changed {
+                        builder = builder.insert_by_key(*key, value.clone());
+                    }
+                    let changed_props = builder.build();
+                    let removed_keys: Vec<u32> = delta.removed.iter().map(|k| k.as_u32()).collect();
+
+                    (
+                        PersistedVersionType::Delta {
+                            base_anchor_tx: version.temporal.transaction_time().start().wallclock(),
+                            removed_keys,
+                        },
+                        persist_property_map(&changed_props).map_err(persistence_err)?,
+                    )
+                }
+            };
+
+            let valid_time = version.temporal.valid_time();
+            let entry = EdgeVersionEntry {
+                version_id: version_id.as_u64(),
+                edge_id: version.edge_id.as_u64(),
+                source_id: version.source.as_u64(),
+                target_id: version.target.as_u64(),
+                valid_from: valid_time.start().wallclock(),
+                valid_to: if valid_time.is_current() {
+                    None
+                } else {
+                    Some(valid_time.end().wallclock())
+                },
+                tx_time: version.temporal.transaction_time().start().wallclock(),
+                version_type,
+                properties,
+            };
+            edge_versions.push(entry);
+        }
+
+        Ok(TemporalIndexData {
+            magic: TEMPORAL_MAGIC,
+            version: MANIFEST_VERSION,
+            node_versions,
+            node_anchors,
+            edge_versions,
+            edge_anchors,
+        })
+    }
+
+    /// Load CurrentStorage from persisted graph index.
+    fn load_current_storage(&self, manifest: &IndexManifest) -> Result<CurrentStorage> {
+        let current = CurrentStorage::new();
+
+        if let Some(ref graph_entry) = manifest.graph_index {
+            let graph_path = self
+                .persistence_manager
+                .indexes_path()
+                .join(&graph_entry.adjacency_file);
+            let graph_data =
+                crate::storage::index_persistence::graph::load_graph_index(&graph_path)
+                    .map_err(persistence_err)?;
+
+            // Track next version ID for restored entities
+            let mut next_version_id: u64 = 1;
+
+            // Restore nodes
+            for persisted_node in &graph_data.nodes {
+                let node_id = NodeId::new(persisted_node.id)?;
+                let label = InternedString::from_raw(persisted_node.label_idx);
+                let properties =
+                    restore_property_map(&persisted_node.properties).map_err(persistence_err)?;
+                let version_id = VersionId::new(next_version_id)?;
+                next_version_id += 1;
+
+                let node = Node::new(node_id, label, properties, version_id);
+                current.insert_node_direct(node, crate::core::temporal::time::now())?;
+            }
+
+            // Restore edges
+            for persisted_edge in &graph_data.edges {
+                let edge_id = EdgeId::new(persisted_edge.id)?;
+                let source = NodeId::new(persisted_edge.source_id)?;
+                let target = NodeId::new(persisted_edge.target_id)?;
+                let label = InternedString::from_raw(persisted_edge.label_idx);
+                let properties =
+                    restore_property_map(&persisted_edge.properties).map_err(persistence_err)?;
+                let version_id = VersionId::new(next_version_id)?;
+                next_version_id += 1;
+
+                let edge = Edge::new(edge_id, label, source, target, properties, version_id);
+                current.insert_edge_direct(edge)?;
+            }
+
+            // Initialize version ID generator
+            current.init_version_id_generator(next_version_id);
+
+            // Initialize ID generators to continue from max IDs
+            if let Some(max_node_id) = graph_data.nodes.iter().map(|n| n.id).max() {
+                current.init_node_id_generator(max_node_id + 1);
+            }
+            if let Some(max_edge_id) = graph_data.edges.iter().map(|e| e.id).max() {
+                current.init_edge_id_generator(max_edge_id + 1);
+            }
+        }
+
+        Ok(current)
+    }
+
+    /// Load HistoricalStorage from persisted temporal index.
+    fn load_historical_storage(&self, manifest: &IndexManifest) -> Result<HistoricalStorage> {
+        use crate::storage::version::PropertyDelta;
+
+        let mut historical = HistoricalStorage::new();
+
+        if let Some(ref temporal_entry) = manifest.temporal_index {
+            let temporal_path = self
+                .persistence_manager
+                .indexes_path()
+                .join(&temporal_entry.node_versions_file);
+            let temporal_data =
+                crate::storage::index_persistence::temporal::load_temporal_index(&temporal_path)
+                    .map_err(persistence_err)?;
+
+            // Reserve capacity for efficient bulk insertion
+            historical.reserve_restoration_capacity(
+                temporal_data.node_versions.len(),
+                temporal_data.edge_versions.len(),
+            );
+
+            // Track max version ID for generator initialization
+            let mut _max_version_id: u64 = 0;
+
+            // Restore node versions
+            for entry in &temporal_data.node_versions {
+                _max_version_id = _max_version_id.max(entry.version_id);
+
+                let version_id = VersionId::new(entry.version_id)?;
+                let node_id = NodeId::new(entry.node_id)?;
+
+                use crate::core::hlc::HybridTimestamp;
+                use crate::core::temporal::{TIMESTAMP_MAX, TimeRange};
+
+                let valid_start = HybridTimestamp::new_unchecked(entry.valid_from, 0);
+                let valid_end = entry
+                    .valid_to
+                    .map(|t| HybridTimestamp::new_unchecked(t, 0))
+                    .unwrap_or(TIMESTAMP_MAX);
+                let valid_time = TimeRange::new(valid_start, valid_end).map_err(|e| {
+                    StorageError::CheckpointError {
+                        reason: format!("Invalid valid time range: {}", e),
+                    }
+                })?;
+
+                let tx_start = HybridTimestamp::new_unchecked(entry.tx_time, 0);
+                let tx_time = TimeRange::from(tx_start);
+
+                let temporal = crate::core::temporal::BiTemporalInterval::new(valid_time, tx_time);
+
+                let properties =
+                    restore_property_map(&entry.properties).map_err(persistence_err)?;
+                let label = self.find_node_label_from_anchors(&temporal_data, entry.node_id)?;
+
+                let data = match &entry.version_type {
+                    crate::storage::index_persistence::formats::PersistedVersionType::Anchor => {
+                        let vector_snapshot_id = entry.vector_snapshot_id.map(|id| id as usize);
+                        VersionData::Anchor {
+                            properties,
+                            vector_snapshot_id,
+                        }
+                    }
+                    crate::storage::index_persistence::formats::PersistedVersionType::Delta {
+                        removed_keys,
+                        ..
+                    } => {
+                        // Convert properties to PropertyDelta
+                        let mut delta = PropertyDelta::new();
+                        for (key, value) in properties.iter() {
+                            delta.changed.insert(*key, value.clone());
+                        }
+                        for key_idx in removed_keys {
+                            delta.removed.insert(InternedString::from_raw(*key_idx));
+                        }
+                        VersionData::Delta { delta }
+                    }
+                };
+
+                let version = crate::storage::version::NodeVersion {
+                    id: version_id,
+                    node_id,
+                    label,
+                    temporal,
+                    data,
+                    next_version: None,
+                    prev_version: None,
+                };
+
+                historical.insert_restored_node_version(version)?;
+            }
+
+            // Restore edge versions
+            for entry in &temporal_data.edge_versions {
+                _max_version_id = _max_version_id.max(entry.version_id);
+
+                let version_id = VersionId::new(entry.version_id)?;
+                let edge_id = EdgeId::new(entry.edge_id)?;
+                let source = NodeId::new(entry.source_id)?;
+                let target = NodeId::new(entry.target_id)?;
+
+                use crate::core::hlc::HybridTimestamp;
+                use crate::core::temporal::{TIMESTAMP_MAX, TimeRange};
+
+                let valid_start = HybridTimestamp::new_unchecked(entry.valid_from, 0);
+                let valid_end = entry
+                    .valid_to
+                    .map(|t| HybridTimestamp::new_unchecked(t, 0))
+                    .unwrap_or(TIMESTAMP_MAX);
+                let valid_time = TimeRange::new(valid_start, valid_end).map_err(|e| {
+                    StorageError::CheckpointError {
+                        reason: format!("Invalid valid time range: {}", e),
+                    }
+                })?;
+
+                let tx_start = HybridTimestamp::new_unchecked(entry.tx_time, 0);
+                let tx_time = TimeRange::from(tx_start);
+
+                let temporal = crate::core::temporal::BiTemporalInterval::new(valid_time, tx_time);
+
+                let properties =
+                    restore_property_map(&entry.properties).map_err(persistence_err)?;
+                let label = self.find_edge_label(&temporal_data, entry.edge_id)?;
+
+                let data = match &entry.version_type {
+                    crate::storage::index_persistence::formats::PersistedVersionType::Anchor => {
+                        VersionData::Anchor {
+                            properties,
+                            vector_snapshot_id: None,
+                        }
+                    }
+                    crate::storage::index_persistence::formats::PersistedVersionType::Delta {
+                        removed_keys,
+                        ..
+                    } => {
+                        // Convert properties to PropertyDelta
+                        let mut delta = PropertyDelta::new();
+                        for (key, value) in properties.iter() {
+                            delta.changed.insert(*key, value.clone());
+                        }
+                        for key_idx in removed_keys {
+                            delta.removed.insert(InternedString::from_raw(*key_idx));
+                        }
+                        VersionData::Delta { delta }
+                    }
+                };
+
+                let version = crate::storage::version::EdgeVersion {
+                    id: version_id,
+                    edge_id,
+                    source,
+                    target,
+                    label,
+                    temporal,
+                    data,
+                    next_version: None,
+                    prev_version: None,
+                };
+
+                historical.insert_restored_edge_version(version)?;
+            }
+        }
+
+        Ok(historical)
+    }
+
+    /// Find node label from anchors (needed for version restoration).
+    fn find_node_label_from_anchors(
+        &self,
+        _temporal_data: &TemporalIndexData,
+        _node_id: u64,
+    ) -> Result<InternedString> {
+        // TODO: Store labels in temporal data or look up from graph data
+        // For now, use a placeholder - this should be fixed in a follow-up
+        Ok(GLOBAL_INTERNER
+            .intern("unknown")
+            .map_err(|e| StorageError::WalError {
+                reason: e.to_string(),
+            })?)
+    }
+
+    /// Find edge label (needed for version restoration).
+    fn find_edge_label(
+        &self,
+        _temporal_data: &TemporalIndexData,
+        _edge_id: u64,
+    ) -> Result<InternedString> {
+        // TODO: Store labels in temporal data
+        // For now, use a placeholder - this should be fixed in a follow-up
+        Ok(GLOBAL_INTERNER
+            .intern("unknown")
+            .map_err(|e| StorageError::WalError {
+                reason: e.to_string(),
+            })?)
+    }
+
+    /// Recover from WAL only (no persisted state).
+    fn recover_from_wal_only(
+        &mut self,
+        wal: &ConcurrentWalSystem,
+    ) -> Result<(CurrentStorage, HistoricalStorage, LSN)> {
+        // Create fresh storage
+        let current = CurrentStorage::new();
+        let historical = HistoricalStorage::new();
+
+        // Replay entire WAL
+        self.replay_wal(wal, current, historical, LSN::initial())
+    }
+
+    /// Replay WAL entries starting from a given LSN.
+    fn replay_wal(
+        &self,
+        wal: &ConcurrentWalSystem,
+        current: CurrentStorage,
+        mut historical: HistoricalStorage,
+        start_lsn: LSN,
+    ) -> Result<(CurrentStorage, HistoricalStorage, LSN)> {
+        use crate::api::transaction::types::TxId;
+        use crate::storage::version::VersionMetadata;
+        use crate::storage::wal::WalOperation;
+
+        const RECOVERY_TX_ID: u64 = 0;
+
+        let mut max_node_id: u64 = 0;
+        let mut max_edge_id: u64 = 0;
+        let mut max_version_id: u64 = 0;
+        let mut next_version_id: u64 = 1;
+
+        let wal_entries = wal.read_from(start_lsn)?;
+
+        for entry in wal_entries {
+            match entry.operation {
+                WalOperation::CreateNode {
+                    node_id,
+                    label,
+                    properties,
+                    temporal,
+                } => {
+                    max_node_id = max_node_id.max(node_id.as_u64());
+
+                    let interned_label =
+                        GLOBAL_INTERNER
+                            .intern(&label)
+                            .map_err(|e| StorageError::WalError {
+                                reason: format!("Failed to intern label: {}", e),
+                            })?;
+
+                    let commit_timestamp = temporal.transaction_time().start();
+                    let metadata =
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+                    let version_id = VersionId::new(next_version_id)?;
+                    next_version_id += 1;
+
+                    let node = Node::with_metadata(
+                        node_id,
+                        interned_label,
+                        properties.clone(),
+                        version_id,
+                        metadata,
+                    );
+
+                    current.insert_node_direct(node, commit_timestamp)?;
+                    historical.add_node_version(
+                        node_id,
+                        version_id,
+                        temporal,
+                        interned_label,
+                        properties,
+                    )?;
+
+                    max_version_id = max_version_id.max(next_version_id - 1);
+                }
+                WalOperation::CreateEdge {
+                    edge_id,
+                    source,
+                    target,
+                    label,
+                    properties,
+                    temporal,
+                } => {
+                    max_edge_id = max_edge_id.max(edge_id.as_u64());
+
+                    let interned_label =
+                        GLOBAL_INTERNER
+                            .intern(&label)
+                            .map_err(|e| StorageError::WalError {
+                                reason: format!("Failed to intern label: {}", e),
+                            })?;
+
+                    let commit_timestamp = temporal.transaction_time().start();
+                    let metadata =
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+                    let version_id = VersionId::new(next_version_id)?;
+                    next_version_id += 1;
+
+                    let edge = Edge::with_metadata(
+                        edge_id,
+                        interned_label,
+                        source,
+                        target,
+                        properties.clone(),
+                        version_id,
+                        metadata,
+                    );
+
+                    current.insert_edge_direct(edge)?;
+                    historical.add_edge_version(
+                        edge_id,
+                        version_id,
+                        temporal,
+                        interned_label,
+                        source,
+                        target,
+                        properties,
+                    )?;
+
+                    max_version_id = max_version_id.max(next_version_id - 1);
+                }
+                WalOperation::UpdateNode {
+                    node_id,
+                    version_id,
+                    label,
+                    properties,
+                    temporal,
+                } => {
+                    max_version_id = max_version_id.max(version_id.as_u64());
+                    next_version_id = next_version_id.max(version_id.as_u64() + 1);
+
+                    let interned_label =
+                        GLOBAL_INTERNER
+                            .intern(&label)
+                            .map_err(|e| StorageError::WalError {
+                                reason: format!("Failed to intern label: {}", e),
+                            })?;
+
+                    let commit_timestamp = temporal.transaction_time().start();
+                    let metadata =
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+
+                    let node = Node::with_metadata(
+                        node_id,
+                        interned_label,
+                        properties.clone(),
+                        version_id,
+                        metadata,
+                    );
+
+                    current.update_node_direct(node, commit_timestamp)?;
+
+                    if let Some(prev_version_id) = historical.get_current_node_version(node_id) {
+                        historical.close_node_version_transaction_time(
+                            prev_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
+
+                    historical.add_node_version(
+                        node_id,
+                        version_id,
+                        temporal,
+                        interned_label,
+                        properties,
+                    )?;
+                }
+                WalOperation::UpdateEdge {
+                    edge_id,
+                    version_id,
+                    label,
+                    properties,
+                    temporal,
+                } => {
+                    max_version_id = max_version_id.max(version_id.as_u64());
+                    next_version_id = next_version_id.max(version_id.as_u64() + 1);
+
+                    let current_edge = current.get_edge(edge_id)?;
+
+                    let interned_label =
+                        GLOBAL_INTERNER
+                            .intern(&label)
+                            .map_err(|e| StorageError::WalError {
+                                reason: format!("Failed to intern label: {}", e),
+                            })?;
+
+                    let commit_timestamp = temporal.transaction_time().start();
+                    let metadata =
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+
+                    let edge = Edge::with_metadata(
+                        edge_id,
+                        interned_label,
+                        current_edge.source,
+                        current_edge.target,
+                        properties.clone(),
+                        version_id,
+                        metadata,
+                    );
+
+                    current.update_edge_direct(edge)?;
+
+                    if let Some(prev_version_id) = historical.get_current_edge_version(edge_id) {
+                        historical.close_edge_version_transaction_time(
+                            prev_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
+
+                    historical.add_edge_version(
+                        edge_id,
+                        version_id,
+                        temporal,
+                        interned_label,
+                        current_edge.source,
+                        current_edge.target,
+                        properties,
+                    )?;
+                }
+                WalOperation::DeleteNode { node_id, temporal } => {
+                    let node = current.get_node(node_id)?;
+                    let commit_timestamp = temporal.transaction_time().start();
+
+                    if let Some(current_version_id) = historical.get_current_node_version(node_id) {
+                        historical.close_node_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
+
+                    let tombstone_version_id = VersionId::new(next_version_id)?;
+                    next_version_id += 1;
+
+                    let tombstone_temporal = temporal.close_valid_time(commit_timestamp);
+
+                    historical.add_node_version(
+                        node_id,
+                        tombstone_version_id,
+                        tombstone_temporal,
+                        node.label,
+                        node.properties.clone(),
+                    )?;
+
+                    current.delete_node_direct(node_id, commit_timestamp)?;
+                    max_version_id = max_version_id.max(next_version_id - 1);
+                }
+                WalOperation::DeleteEdge { edge_id, temporal } => {
+                    let edge = current.get_edge(edge_id)?;
+                    let commit_timestamp = temporal.transaction_time().start();
+
+                    if let Some(current_version_id) = historical.get_current_edge_version(edge_id) {
+                        historical.close_edge_version_transaction_time(
+                            current_version_id,
+                            commit_timestamp,
+                        )?;
+                    }
+
+                    let tombstone_version_id = VersionId::new(next_version_id)?;
+                    next_version_id += 1;
+
+                    let tombstone_temporal = temporal.close_valid_time(commit_timestamp);
+
+                    historical.add_edge_version(
+                        edge_id,
+                        tombstone_version_id,
+                        tombstone_temporal,
+                        edge.label,
+                        edge.source,
+                        edge.target,
+                        edge.properties.clone(),
+                    )?;
+
+                    current.delete_edge_direct(edge_id)?;
+                    max_version_id = max_version_id.max(next_version_id - 1);
+                }
+                WalOperation::Checkpoint { .. } => {
+                    // Checkpoint markers are informational only during replay
+                }
+            }
+        }
+
+        let final_lsn = wal.current_lsn();
+
+        // Initialize ID generators
+        current.init_node_id_generator(max_node_id + 1);
+        current.init_edge_id_generator(max_edge_id + 1);
+        current.init_version_id_generator(max_version_id + 1);
+
+        Ok((current, historical, final_lsn))
+    }
+}
+
+/// Statistics from a checkpoint operation.
+#[derive(Debug, Clone)]
+pub struct CheckpointStats {
+    /// Time taken for checkpoint creation
+    pub duration: Duration,
+    /// Total bytes written to disk
+    pub bytes_written: u64,
+    /// LSN at checkpoint time
+    pub lsn: LSN,
+    /// Number of nodes persisted
+    pub node_count: usize,
+    /// Number of edges persisted
+    pub edge_count: usize,
+    /// Number of versions persisted
+    pub version_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::id::NodeId;
+    use crate::core::property::PropertyMap;
+    use crate::core::temporal::{BiTemporalInterval, time};
+    use crate::storage::wal::WalOperation;
+    use crate::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
+    use crate::{PropertyMapBuilder, api::transaction::types::TxId};
+    use tempfile::TempDir;
+
+    // ========================================================================
+    // TDD Tests: Checkpoint-Index Persistence Integration
+    // ========================================================================
+
+    /// Test basic checkpoint creation and stats.
+    #[test]
+    fn test_checkpoint_creation_basic() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig::with_data_dir(temp_dir.path());
+        let mut manager = CheckpointManager::new(config)?;
+
+        let current = CurrentStorage::new();
+        let historical = HistoricalStorage::new();
+
+        let stats = manager.create_checkpoint(LSN(100), &current, &historical)?;
+
+        assert_eq!(stats.lsn, LSN(100));
+        assert_eq!(stats.node_count, 0);
+        assert_eq!(stats.edge_count, 0);
+        assert!(stats.bytes_written > 0); // At least manifest should be written
+
+        Ok(())
+    }
+
+    /// Test checkpoint persists nodes and edges.
+    #[test]
+    fn test_checkpoint_persists_graph_data() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig::with_data_dir(temp_dir.path());
+        let mut manager = CheckpointManager::new(config)?;
+
+        let current = CurrentStorage::new();
+
+        // Create some nodes
+        for i in 1..=10 {
+            let props = PropertyMapBuilder::new()
+                .insert("name", format!("Node{}", i))
+                .build();
+            let node_id = NodeId::new(i)?;
+            let label = GLOBAL_INTERNER
+                .intern("Person")
+                .map_err(|e| StorageError::WalError {
+                    reason: e.to_string(),
+                })?;
+            let version_id = VersionId::new(i)?;
+            let node = Node::new(node_id, label, props, version_id);
+            current.insert_node_direct(node, time::now())?;
+        }
+
+        let historical = HistoricalStorage::new();
+        let stats = manager.create_checkpoint(LSN(50), &current, &historical)?;
+
+        assert_eq!(stats.node_count, 10);
+
+        // Verify files were created
+        assert!(manager.persistence_manager.manifest_path().exists());
+        assert!(manager.persistence_manager.interner_path().exists());
+        assert!(
+            manager
+                .persistence_manager
+                .graph_path()
+                .join("adjacency.idx")
+                .exists()
+        );
+
+        Ok(())
+    }
+
+    /// Test checkpoint recovery loads persisted state.
+    #[test]
+    fn test_checkpoint_recovery_loads_state() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let data_dir = temp_dir.path().join("data");
+
+        // Phase 1: Create checkpoint with data
+        {
+            let config = CheckpointConfig::with_data_dir(&data_dir);
+            let mut manager = CheckpointManager::new(config)?;
+
+            let current = CurrentStorage::new();
+
+            // Create 5 nodes
+            for i in 1..=5 {
+                let props = PropertyMapBuilder::new()
+                    .insert("name", format!("Node{}", i))
+                    .build();
+                let node_id = NodeId::new(i)?;
+                let label =
+                    GLOBAL_INTERNER
+                        .intern("Document")
+                        .map_err(|e| StorageError::WalError {
+                            reason: e.to_string(),
+                        })?;
+                let version_id = VersionId::new(i)?;
+                let node = Node::new(node_id, label, props, version_id);
+                current.insert_node_direct(node, time::now())?;
+            }
+
+            let historical = HistoricalStorage::new();
+            manager.create_checkpoint(LSN(25), &current, &historical)?;
+        }
+
+        // Phase 2: Recover from checkpoint
+        {
+            let config = CheckpointConfig::with_data_dir(&data_dir);
+            let mut manager = CheckpointManager::new(config)?;
+
+            // Create empty WAL (no entries after checkpoint)
+            let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+            let wal = ConcurrentWalSystem::new(wal_config)?;
+
+            let (recovered_current, _recovered_historical, lsn) = manager.recover(&wal)?;
+
+            // Verify state was restored
+            assert_eq!(recovered_current.node_count(), 5);
+            assert_eq!(lsn, LSN::initial()); // Empty WAL
+
+            // Verify node data
+            for i in 1..=5 {
+                let node = recovered_current.get_node(NodeId::new(i)?)?;
+                let name = node.get_property("name").unwrap().as_str().unwrap();
+                assert_eq!(name, format!("Node{}", i));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Test recovery with WAL replay after checkpoint.
+    ///
+    /// This test verifies that:
+    /// 1. Nodes from the checkpoint are restored
+    /// 2. WAL entries after the checkpoint LSN are replayed
+    #[test]
+    fn test_checkpoint_recovery_with_wal_replay() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let data_dir = temp_dir.path().join("data");
+
+        // Create WAL first to have a proper LSN sequence
+        let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+        let wal = ConcurrentWalSystem::new(wal_config)?;
+
+        // Phase 1: Add initial nodes to WAL (to establish LSN sequence)
+        for i in 1..=3 {
+            let props = PropertyMapBuilder::new()
+                .insert("name", format!("Initial{}", i))
+                .build();
+            wal.append(WalOperation::CreateNode {
+                node_id: NodeId::new(i)?,
+                label: "Person".to_string(),
+                properties: props,
+                temporal: BiTemporalInterval::current(time::now()),
+            })?;
+        }
+        wal.flush()?;
+
+        // Create checkpoint at last written WAL LSN
+        // current_lsn() returns the *next* LSN to be allocated, so subtract 1
+        let checkpoint_lsn = LSN(wal.current_lsn().0.saturating_sub(1));
+        {
+            let config = CheckpointConfig::with_data_dir(&data_dir);
+            let mut manager = CheckpointManager::new(config)?;
+
+            let current = CurrentStorage::new();
+
+            // Create 3 nodes directly (matching what was logged to WAL)
+            for i in 1..=3 {
+                let props = PropertyMapBuilder::new()
+                    .insert("name", format!("Initial{}", i))
+                    .build();
+                let node_id = NodeId::new(i)?;
+                let label =
+                    GLOBAL_INTERNER
+                        .intern("Person")
+                        .map_err(|e| StorageError::WalError {
+                            reason: e.to_string(),
+                        })?;
+                let version_id = VersionId::new(i)?;
+                let node = Node::new(node_id, label, props, version_id);
+                current.insert_node_direct(node, time::now())?;
+            }
+
+            let historical = HistoricalStorage::new();
+            manager.create_checkpoint(checkpoint_lsn, &current, &historical)?;
+        }
+
+        // Phase 2: Add more WAL entries after checkpoint
+        for i in 4..=5 {
+            let props = PropertyMapBuilder::new()
+                .insert("name", format!("WalNode{}", i))
+                .build();
+            wal.append(WalOperation::CreateNode {
+                node_id: NodeId::new(i)?,
+                label: "Person".to_string(),
+                properties: props,
+                temporal: BiTemporalInterval::current(time::now()),
+            })?;
+        }
+        wal.flush()?;
+
+        // Phase 3: Recover (should load checkpoint + replay WAL)
+        let config = CheckpointConfig::with_data_dir(&data_dir);
+        let mut manager = CheckpointManager::new(config)?;
+
+        let (recovered_current, _recovered_historical, _lsn) = manager.recover(&wal)?;
+
+        // Should have 3 from checkpoint + 2 from WAL = 5 total
+        assert_eq!(recovered_current.node_count(), 5);
+
+        // Verify checkpoint nodes
+        for i in 1..=3 {
+            let node = recovered_current.get_node(NodeId::new(i)?)?;
+            let name = node.get_property("name").unwrap().as_str().unwrap();
+            assert_eq!(name, format!("Initial{}", i));
+        }
+
+        // Verify WAL-replayed nodes
+        for i in 4..=5 {
+            let node = recovered_current.get_node(NodeId::new(i)?)?;
+            let name = node.get_property("name").unwrap().as_str().unwrap();
+            assert_eq!(name, format!("WalNode{}", i));
+        }
+
+        Ok(())
+    }
+
+    /// Test LSN consistency between checkpoint and manifest.
+    #[test]
+    fn test_lsn_consistency() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig::with_data_dir(temp_dir.path());
+        let mut manager = CheckpointManager::new(config)?;
+
+        let current = CurrentStorage::new();
+        let historical = HistoricalStorage::new();
+
+        // Create checkpoint at LSN 42
+        manager.create_checkpoint(LSN(42), &current, &historical)?;
+
+        // Verify persisted LSN
+        let persisted_lsn = manager.get_persisted_lsn();
+        assert_eq!(persisted_lsn, Some(LSN(42)));
+
+        Ok(())
+    }
+
+    /// Test should_checkpoint logic.
+    #[test]
+    fn test_should_checkpoint_logic() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig {
+            data_dir: temp_dir.path().to_path_buf(),
+            checkpoint_interval: Duration::from_secs(3600), // 1 hour
+            min_wal_entries: 100,
+            ..Default::default()
+        };
+        let mut manager = CheckpointManager::new(config)?;
+
+        // Should checkpoint initially (never checkpointed)
+        assert!(manager.should_checkpoint(LSN(1)));
+
+        // Simulate a checkpoint
+        manager.last_checkpoint_time = SystemTime::now();
+        manager.last_checkpoint_lsn = LSN(50);
+
+        // Should NOT checkpoint (not enough time or entries)
+        assert!(!manager.should_checkpoint(LSN(60)));
+
+        // Should checkpoint when LSN threshold exceeded
+        assert!(manager.should_checkpoint(LSN(200)));
+
+        Ok(())
+    }
+
+    /// Test recovery without persisted state (fresh start).
+    #[test]
+    fn test_recovery_without_persisted_state() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let data_dir = temp_dir.path().join("data");
+
+        let config = CheckpointConfig::with_data_dir(&data_dir);
+        let mut manager = CheckpointManager::new(config)?;
+
+        // Create WAL with some entries (no checkpoint)
+        let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+        let wal = ConcurrentWalSystem::new(wal_config)?;
+
+        for i in 1..=3 {
+            let props = PropertyMapBuilder::new().insert("value", i as i64).build();
+            wal.append(WalOperation::CreateNode {
+                node_id: NodeId::new(i)?,
+                label: "Test".to_string(),
+                properties: props,
+                temporal: BiTemporalInterval::current(time::now()),
+            })?;
+        }
+        wal.flush()?;
+
+        // Recover (should replay full WAL)
+        let (recovered_current, _recovered_historical, _lsn) = manager.recover(&wal)?;
+
+        assert_eq!(recovered_current.node_count(), 3);
+
+        Ok(())
+    }
+
+    /// Test checkpoint with compression enabled.
+    #[test]
+    fn test_checkpoint_with_compression() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig {
+            data_dir: temp_dir.path().to_path_buf(),
+            enable_compression: true,
+            compression_level: 3,
+            ..Default::default()
+        };
+        let mut manager = CheckpointManager::new(config)?;
+
+        let current = CurrentStorage::new();
+
+        // Create nodes with larger properties to benefit from compression
+        for i in 1..=100 {
+            let props = PropertyMapBuilder::new()
+                .insert("name", format!("Node{} with some longer text for compression", i))
+                .insert("description", "This is a longer description that should compress well when repeated across many nodes")
+                .build();
+            let node_id = NodeId::new(i)?;
+            let label = GLOBAL_INTERNER
+                .intern("Document")
+                .map_err(|e| StorageError::WalError {
+                    reason: e.to_string(),
+                })?;
+            let version_id = VersionId::new(i)?;
+            let node = Node::new(node_id, label, props, version_id);
+            current.insert_node_direct(node, time::now())?;
+        }
+
+        let historical = HistoricalStorage::new();
+        let stats = manager.create_checkpoint(LSN(100), &current, &historical)?;
+
+        assert_eq!(stats.node_count, 100);
+        assert!(stats.bytes_written > 0);
+
+        Ok(())
+    }
+
+    /// Test has_persisted_state check.
+    #[test]
+    fn test_has_persisted_state() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig::with_data_dir(temp_dir.path());
+        let mut manager = CheckpointManager::new(config)?;
+
+        // Initially no persisted state
+        assert!(!manager.has_persisted_state());
+
+        // Create checkpoint
+        let current = CurrentStorage::new();
+        let historical = HistoricalStorage::new();
+        manager.create_checkpoint(LSN(1), &current, &historical)?;
+
+        // Now has persisted state
+        assert!(manager.has_persisted_state());
+
+        Ok(())
+    }
+
+    /// Test checkpoint preserves node properties correctly.
+    #[test]
+    fn test_checkpoint_preserves_properties() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let wal_dir = temp_dir.path().join("wal");
+        let data_dir = temp_dir.path().join("data");
+
+        // Phase 1: Create checkpoint with various property types
+        {
+            let config = CheckpointConfig::with_data_dir(&data_dir);
+            let mut manager = CheckpointManager::new(config)?;
+
+            let current = CurrentStorage::new();
+
+            let props = PropertyMapBuilder::new()
+                .insert("string_prop", "hello")
+                .insert("int_prop", 42i64)
+                .insert("float_prop", 3.14f64)
+                .insert("bool_prop", true)
+                .build();
+
+            let node_id = NodeId::new(1)?;
+            let label = GLOBAL_INTERNER
+                .intern("TestNode")
+                .map_err(|e| StorageError::WalError {
+                    reason: e.to_string(),
+                })?;
+            let version_id = VersionId::new(1)?;
+            let node = Node::new(node_id, label, props, version_id);
+            current.insert_node_direct(node, time::now())?;
+
+            let historical = HistoricalStorage::new();
+            manager.create_checkpoint(LSN(1), &current, &historical)?;
+        }
+
+        // Phase 2: Recover and verify properties
+        {
+            let config = CheckpointConfig::with_data_dir(&data_dir);
+            let mut manager = CheckpointManager::new(config)?;
+
+            let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+            let wal = ConcurrentWalSystem::new(wal_config)?;
+
+            let (recovered_current, _recovered_historical, _lsn) = manager.recover(&wal)?;
+
+            let node = recovered_current.get_node(NodeId::new(1)?)?;
+
+            assert_eq!(
+                node.get_property("string_prop").unwrap().as_str().unwrap(),
+                "hello"
+            );
+            assert_eq!(node.get_property("int_prop").unwrap().as_int().unwrap(), 42);
+            assert!(
+                (node.get_property("float_prop").unwrap().as_float().unwrap() - 3.14).abs() < 0.001
+            );
+            assert!(node.get_property("bool_prop").unwrap().as_bool().unwrap());
+        }
+
+        Ok(())
+    }
+}

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -319,6 +319,7 @@ impl CurrentStorage {
     /// # Arguments
     ///
     /// * `start` - The next ID to generate (typically max_id + 1)
+    #[inline]
     pub(crate) fn init_version_id_generator(&self, start: u64) {
         self.version_id_gen.reset_to(start);
     }
@@ -332,6 +333,7 @@ impl CurrentStorage {
     /// # Arguments
     ///
     /// * `min_value` - The minimum next version ID to generate
+    #[inline]
     pub(crate) fn ensure_version_id_generator_at_least(&self, min_value: u64) {
         self.version_id_gen.ensure_at_least(min_value);
     }

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -323,6 +323,19 @@ impl CurrentStorage {
         self.version_id_gen.reset_to(start);
     }
 
+    /// Ensure the version ID generator's next value is at least the specified minimum.
+    ///
+    /// This is used during recovery when we need to account for version IDs from multiple
+    /// sources (e.g., current storage and historical storage) without overwriting
+    /// a higher value that was already set.
+    ///
+    /// # Arguments
+    ///
+    /// * `min_value` - The minimum next version ID to generate
+    pub(crate) fn ensure_version_id_generator_at_least(&self, min_value: u64) {
+        self.version_id_gen.ensure_at_least(min_value);
+    }
+
     /// Enable vector indexing for a specific property.
     ///
     /// Multiple properties can be indexed simultaneously with different configurations.

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -245,6 +245,8 @@ pub struct NodeVersionEntry {
     pub version_id: u64,
     /// Node ID
     pub node_id: u64,
+    /// Label index in string interner
+    pub label_idx: u32,
     /// Valid time start (unix timestamp)
     pub valid_from: i64,
     /// Valid time end (None = still valid)
@@ -297,6 +299,8 @@ pub struct EdgeVersionEntry {
     pub source_id: u64,
     /// Target node ID
     pub target_id: u64,
+    /// Label index in string interner
+    pub label_idx: u32,
     /// Valid time start
     pub valid_from: i64,
     /// Valid time end

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -62,6 +62,7 @@ pub fn convert_node_version(version: &NodeVersion) -> Result<NodeVersionEntry> {
     Ok(NodeVersionEntry {
         version_id: version.id.as_u64(),
         node_id: version.node_id.as_u64(),
+        label_idx: version.label.as_u32(),
         valid_from: valid_time.start().wallclock(),
         valid_to: if valid_time.is_current() {
             None
@@ -119,6 +120,7 @@ pub fn convert_edge_version(version: &EdgeVersion) -> Result<EdgeVersionEntry> {
         edge_id: version.edge_id.as_u64(),
         source_id: version.source.as_u64(),
         target_id: version.target.as_u64(),
+        label_idx: version.label.as_u32(),
         valid_from: valid_time.start().wallclock(),
         valid_to: if valid_time.is_current() {
             None
@@ -136,15 +138,12 @@ pub fn convert_edge_version(version: &EdgeVersion) -> Result<EdgeVersionEntry> {
 /// # Arguments
 ///
 /// * `entry` - The persisted node version entry
-/// * `label` - The node label (must be provided as it's not stored in the entry)
 ///
 /// # Errors
 ///
 /// Returns an error if property restoration fails (e.g., corrupted interned strings).
-pub fn restore_node_version(
-    entry: &NodeVersionEntry,
-    label: InternedString,
-) -> Result<NodeVersion> {
+pub fn restore_node_version(entry: &NodeVersionEntry) -> Result<NodeVersion> {
+    let label = InternedString::from_raw(entry.label_idx);
     let node_id = NodeId::new(entry.node_id).map_err(|e| {
         IndexPersistenceError::Serialization(format!("Invalid node ID {}: {}", entry.node_id, e))
     })?;
@@ -223,15 +222,12 @@ pub fn restore_node_version(
 /// # Arguments
 ///
 /// * `entry` - The persisted edge version entry
-/// * `label` - The edge label (must be provided as it's not stored in the entry)
 ///
 /// # Errors
 ///
 /// Returns an error if property restoration fails (e.g., corrupted interned strings).
-pub fn restore_edge_version(
-    entry: &EdgeVersionEntry,
-    label: InternedString,
-) -> Result<EdgeVersion> {
+pub fn restore_edge_version(entry: &EdgeVersionEntry) -> Result<EdgeVersion> {
+    let label = InternedString::from_raw(entry.label_idx);
     let edge_id = EdgeId::new(entry.edge_id).map_err(|e| {
         IndexPersistenceError::Serialization(format!("Invalid edge ID {}: {}", entry.edge_id, e))
     })?;
@@ -323,8 +319,6 @@ pub fn restore_edge_version(
 ///
 /// * `data` - The temporal index data loaded from disk
 /// * `historical` - The HistoricalStorage to populate
-/// * `node_labels` - Map of node_id -> label for restoring node versions
-/// * `edge_labels` - Map of edge_id -> label for restoring edge versions
 ///
 /// # Errors
 ///
@@ -332,22 +326,13 @@ pub fn restore_edge_version(
 pub fn restore_into_historical_storage(
     data: &TemporalIndexData,
     historical: &mut crate::storage::historical::HistoricalStorage,
-    node_labels: &std::collections::HashMap<u64, InternedString>,
-    edge_labels: &std::collections::HashMap<u64, InternedString>,
 ) -> Result<()> {
     // Pre-allocate capacity for better performance during bulk restoration
     historical.reserve_restoration_capacity(data.node_versions.len(), data.edge_versions.len());
 
     // Restore node versions
     for entry in &data.node_versions {
-        let label = node_labels.get(&entry.node_id).ok_or_else(|| {
-            IndexPersistenceError::Serialization(format!(
-                "Missing label for node ID {}",
-                entry.node_id
-            ))
-        })?;
-
-        let version = restore_node_version(entry, *label)?;
+        let version = restore_node_version(entry)?;
         historical
             .insert_restored_node_version(version)
             .map_err(|e| {
@@ -360,14 +345,7 @@ pub fn restore_into_historical_storage(
 
     // Restore edge versions
     for entry in &data.edge_versions {
-        let label = edge_labels.get(&entry.edge_id).ok_or_else(|| {
-            IndexPersistenceError::Serialization(format!(
-                "Missing label for edge ID {}",
-                entry.edge_id
-            ))
-        })?;
-
-        let version = restore_edge_version(entry, *label)?;
+        let version = restore_edge_version(entry)?;
         historical
             .insert_restored_edge_version(version)
             .map_err(|e| {
@@ -490,13 +468,16 @@ mod tests {
 
     #[test]
     fn test_temporal_index_round_trip() {
+        use crate::core::GLOBAL_INTERNER;
         let dir = tempdir().unwrap();
         let path = dir.path().join("temporal.idx");
 
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
         let mut data = new_temporal_index_data();
         data.node_versions.push(NodeVersionEntry {
             version_id: 100,
             node_id: 1,
+            label_idx: label.as_u32(),
             valid_from: 1000,
             valid_to: Some(2000),
             tx_time: 1000,
@@ -664,9 +645,11 @@ mod tests {
             .entries
             .push((age_key.as_u32(), PersistedPropertyValue::Int(30)));
 
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
         let entry = NodeVersionEntry {
             version_id: 100,
             node_id: 1,
+            label_idx: label.as_u32(),
             valid_from: 1000,
             valid_to: Some(2000),
             tx_time: 1000,
@@ -675,8 +658,7 @@ mod tests {
             vector_snapshot_id: Some(42),
         };
 
-        let label = GLOBAL_INTERNER.intern("Person").unwrap();
-        let version = restore_node_version(&entry, label).unwrap();
+        let version = restore_node_version(&entry).unwrap();
 
         assert_eq!(version.id.as_u64(), 100);
         assert_eq!(version.node_id.as_u64(), 1);
@@ -712,9 +694,11 @@ mod tests {
             .entries
             .push((age_key.as_u32(), PersistedPropertyValue::Int(31)));
 
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
         let entry = NodeVersionEntry {
             version_id: 101,
             node_id: 1,
+            label_idx: label.as_u32(),
             valid_from: 2000,
             valid_to: Some(3000),
             tx_time: 2000,
@@ -726,8 +710,7 @@ mod tests {
             vector_snapshot_id: None,
         };
 
-        let label = GLOBAL_INTERNER.intern("Person").unwrap();
-        let version = restore_node_version(&entry, label).unwrap();
+        let version = restore_node_version(&entry).unwrap();
 
         assert_eq!(version.node_id.as_u64(), 1);
         assert!(version.data.is_delta());
@@ -753,11 +736,13 @@ mod tests {
             .entries
             .push((weight_key.as_u32(), PersistedPropertyValue::Float(1.5)));
 
+        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
         let entry = EdgeVersionEntry {
             version_id: 200,
             edge_id: 10,
             source_id: 1,
             target_id: 2,
+            label_idx: label.as_u32(),
             valid_from: 1000,
             valid_to: Some(2000),
             tx_time: 1000,
@@ -765,8 +750,7 @@ mod tests {
             properties,
         };
 
-        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
-        let version = restore_edge_version(&entry, label).unwrap();
+        let version = restore_edge_version(&entry).unwrap();
 
         assert_eq!(version.id.as_u64(), 200);
         assert_eq!(version.edge_id.as_u64(), 10);
@@ -810,6 +794,7 @@ mod tests {
         let entry = NodeVersionEntry {
             version_id: 100,
             node_id: 1,
+            label_idx: person_label.as_u32(),
             valid_from: 1000,
             valid_to: Some(2000),
             tx_time: 1000,
@@ -818,25 +803,13 @@ mod tests {
             vector_snapshot_id: Some(42),
         };
 
-        // Create temporal data with node labels
+        // Create temporal data (labels are now stored in entries)
         let mut temporal_data = new_temporal_index_data();
         temporal_data.node_versions.push(entry);
 
-        // Create a map of node_id -> label
-        let mut node_labels = std::collections::HashMap::new();
-        node_labels.insert(1, person_label);
-
-        let edge_labels = std::collections::HashMap::new();
-
         // Restore into HistoricalStorage
         let mut historical = HistoricalStorage::new();
-        restore_into_historical_storage(
-            &temporal_data,
-            &mut historical,
-            &node_labels,
-            &edge_labels,
-        )
-        .unwrap();
+        restore_into_historical_storage(&temporal_data, &mut historical).unwrap();
 
         // Verify the version was restored
         let versions = historical.get_node_versions();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,7 +6,9 @@
 //! - Version management: Version chain structures and compression
 //! - WAL: Write-ahead log for durability and crash recovery
 //! - Persistence: Memory-mapped file storage and checkpointing
+//! - Checkpoint: Full state snapshots via index persistence
 
+pub mod checkpoint;
 pub mod current;
 pub mod historical;
 pub mod index_persistence;
@@ -17,6 +19,9 @@ pub mod wal;
 pub mod wal_reader;
 
 // Re-export commonly used types
+pub use checkpoint::{
+    CheckpointConfig as UnifiedCheckpointConfig, CheckpointManager, CheckpointStats,
+};
 pub use current::{CurrentStats, CurrentStorage, DEFAULT_MAX_VECTOR_PROPERTIES, VectorIndexInfo};
 pub use historical::{CacheMetrics, HistoricalStats, HistoricalStorage};
 pub use observer::{Observer, StorageEvent, StorageObserver};

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2016,8 +2016,8 @@ fn test_temporal_version_round_trip() {
     );
 
     // Restore versions
-    let restored_node = restore_node_version(&loaded_data.node_versions[0], person_label).unwrap();
-    let restored_edge = restore_edge_version(&loaded_data.edge_versions[0], knows_label).unwrap();
+    let restored_node = restore_node_version(&loaded_data.node_versions[0]).unwrap();
+    let restored_edge = restore_edge_version(&loaded_data.edge_versions[0]).unwrap();
 
     // ========================================================================
     // Phase 4: Verify
@@ -2338,7 +2338,7 @@ fn test_delta_removed_properties_persistence() {
 
     // Restore
     let loaded_data = load_temporal_index(&temporal_path).unwrap();
-    let restored_delta = restore_node_version(&loaded_data.node_versions[0], person_label).unwrap();
+    let restored_delta = restore_node_version(&loaded_data.node_versions[0]).unwrap();
 
     println!("✓ Restored delta version");
 
@@ -2397,7 +2397,6 @@ fn test_version_chain_reconstruction() {
     use gallifreydb::storage::index_persistence::temporal::{
         new_temporal_index_data, restore_into_historical_storage,
     };
-    use std::collections::HashMap;
 
     // Create multiple versions for the same node with different tx_times
     // Version 1: tx_time = 1000 (oldest)
@@ -2413,6 +2412,7 @@ fn test_version_chain_reconstruction() {
         NodeVersionEntry {
             version_id: 200,
             node_id,
+            label_idx: label.as_u32(),
             valid_from: 0,
             valid_to: None,
             tx_time: 2000,
@@ -2427,6 +2427,7 @@ fn test_version_chain_reconstruction() {
         NodeVersionEntry {
             version_id: 300,
             node_id,
+            label_idx: label.as_u32(),
             valid_from: 0,
             valid_to: None,
             tx_time: 3000,
@@ -2441,6 +2442,7 @@ fn test_version_chain_reconstruction() {
         NodeVersionEntry {
             version_id: 100,
             node_id,
+            label_idx: label.as_u32(),
             valid_from: 0,
             valid_to: None,
             tx_time: 1000,
@@ -2454,14 +2456,9 @@ fn test_version_chain_reconstruction() {
     let mut temporal_data = new_temporal_index_data();
     temporal_data.node_versions = node_versions;
 
-    // Create label maps
-    let mut node_labels = HashMap::new();
-    node_labels.insert(node_id, label);
-    let edge_labels: HashMap<u64, _> = HashMap::new();
-
-    // Restore into HistoricalStorage
+    // Restore into HistoricalStorage (labels are now stored in the entries)
     let mut historical = HistoricalStorage::new();
-    restore_into_historical_storage(&temporal_data, &mut historical, &node_labels, &edge_labels)
+    restore_into_historical_storage(&temporal_data, &mut historical)
         .expect("Restoration should succeed");
 
     // Now verify the version chains are correctly reconstructed using public APIs

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -52,6 +52,12 @@
 //!   - Recovery time benchmarks (target: <10 seconds)
 //!   - Throughput measurements
 //!
+//! - **`checkpoint_recovery_tests`** - CheckpointManager with index persistence
+//!   - Full state persistence (graph + temporal indexes)
+//!   - Recovery from persisted state + WAL replay
+//!   - LSN consistency across checkpoint and recovery
+//!   - ID generator initialization from persisted state
+//!
 //! ## Running Tests
 //!
 //! ```bash
@@ -106,3 +112,6 @@ mod crash_scenarios;
 
 #[path = "recovery/large_dataset_recovery.rs"]
 mod large_dataset_recovery;
+
+#[path = "recovery/checkpoint_recovery_tests.rs"]
+mod checkpoint_recovery_tests;

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -1,0 +1,476 @@
+//! Tests for CheckpointManager with index persistence recovery (Issue #294 extension)
+//!
+//! These tests verify that the checkpoint system correctly:
+//! - Persists full graph and temporal state to disk
+//! - Recovers database state from persisted indexes
+//! - Correctly replays WAL entries after checkpoint LSN
+//! - Maintains LSN consistency across checkpoint and recovery
+
+use gallifreydb::{
+    PropertyMapBuilder,
+    core::{
+        GLOBAL_INTERNER,
+        graph::Node,
+        id::{EdgeId, NodeId, VersionId},
+        property::PropertyMap,
+        temporal::{BiTemporalInterval, time},
+    },
+    storage::{
+        CheckpointManager, UnifiedCheckpointConfig,
+        current::CurrentStorage,
+        historical::HistoricalStorage,
+        wal::{
+            LSN, WalOperation,
+            concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig},
+        },
+    },
+    utils::error::Result,
+};
+use tempfile::TempDir;
+
+// ============================================================================
+// CheckpointManager Recovery Tests
+// ============================================================================
+
+#[test]
+fn test_checkpoint_recovery_basic() -> Result<()> {
+    // Given: WAL with some entries and a checkpoint
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    // Create WAL and add entries
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    for i in 1..=5 {
+        let props = PropertyMapBuilder::new()
+            .insert("name", format!("Node{}", i))
+            .build();
+        wal.append(WalOperation::CreateNode {
+            node_id: NodeId::new(i)?,
+            label: "Person".to_string(),
+            properties: props,
+            temporal: BiTemporalInterval::current(time::now()),
+        })?;
+    }
+    wal.flush()?;
+
+    // Create checkpoint with matching state
+    let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+    let mut manager = CheckpointManager::new(config)?;
+
+    // When: Recover from empty checkpoint + WAL
+    let (recovered_current, _recovered_historical, _final_lsn) = manager.recover(&wal)?;
+
+    // Then: All nodes should be recovered
+    assert_eq!(recovered_current.node_count(), 5);
+
+    for i in 1..=5 {
+        let node = recovered_current.get_node(NodeId::new(i)?)?;
+        let name = node.get_property("name").unwrap().as_str().unwrap();
+        assert_eq!(name, format!("Node{}", i));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_with_persisted_state_and_wal_replay() -> Result<()> {
+    // Given: Checkpoint with 3 nodes, WAL has 2 more nodes after checkpoint
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    // Create WAL entries
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    // First 3 entries will be checkpointed
+    for i in 1..=3 {
+        let props = PropertyMapBuilder::new().insert("value", i as i64).build();
+        wal.append(WalOperation::CreateNode {
+            node_id: NodeId::new(i)?,
+            label: "Test".to_string(),
+            properties: props,
+            temporal: BiTemporalInterval::current(time::now()),
+        })?;
+    }
+    wal.flush()?;
+
+    // Create checkpoint at LSN 3
+    let checkpoint_lsn = LSN(wal.current_lsn().0.saturating_sub(1));
+    {
+        let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+        let mut manager = CheckpointManager::new(config)?;
+
+        // Build current storage state matching WAL
+        let current = CurrentStorage::new();
+        let label = GLOBAL_INTERNER.intern("Test")?;
+        for i in 1..=3 {
+            let props = PropertyMapBuilder::new().insert("value", i as i64).build();
+            let node = Node::new(NodeId::new(i)?, label, props, VersionId::new(i)?);
+            current.insert_node_direct(node, time::now())?;
+        }
+
+        let historical = HistoricalStorage::new();
+        manager.create_checkpoint(checkpoint_lsn, &current, &historical)?;
+    }
+
+    // Add 2 more WAL entries after checkpoint
+    for i in 4..=5 {
+        let props = PropertyMapBuilder::new().insert("value", i as i64).build();
+        wal.append(WalOperation::CreateNode {
+            node_id: NodeId::new(i)?,
+            label: "Test".to_string(),
+            properties: props,
+            temporal: BiTemporalInterval::current(time::now()),
+        })?;
+    }
+    wal.flush()?;
+
+    // When: Recover with new manager (simulates restart)
+    let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+    let mut manager = CheckpointManager::new(config)?;
+    let (recovered_current, _recovered_historical, _final_lsn) = manager.recover(&wal)?;
+
+    // Then: Should have all 5 nodes (3 from checkpoint + 2 from WAL)
+    assert_eq!(recovered_current.node_count(), 5);
+
+    for i in 1..=5 {
+        let node = recovered_current.get_node(NodeId::new(i)?)?;
+        let value = node.get_property("value").unwrap().as_int().unwrap();
+        assert_eq!(value, i as i64);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_recovery_preserves_edges() -> Result<()> {
+    // Given: Checkpoint with nodes and edges
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    // Track the edge ID we create
+    let edge_id: EdgeId;
+
+    // Create checkpoint with nodes and edges
+    {
+        let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+        let mut manager = CheckpointManager::new(config)?;
+
+        let current = CurrentStorage::new();
+
+        // Create nodes
+        let node1 = current.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )?;
+        let node2 = current.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )?;
+
+        // Create edge and store its ID
+        edge_id = current.create_edge(
+            node1,
+            node2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020i64).build(),
+        )?;
+
+        let historical = HistoricalStorage::new();
+        manager.create_checkpoint(LSN(10), &current, &historical)?;
+    }
+
+    // When: Recover
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+    let mut manager = CheckpointManager::new(config)?;
+    let (recovered_current, _recovered_historical, _final_lsn) = manager.recover(&wal)?;
+
+    // Then: Nodes and edges should be recovered
+    assert_eq!(recovered_current.node_count(), 2);
+    assert_eq!(recovered_current.edge_count(), 1);
+
+    let edge = recovered_current.get_edge(edge_id)?;
+    let since = edge.get_property("since").unwrap().as_int().unwrap();
+    assert_eq!(since, 2020);
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_recovery_id_generators_initialized() -> Result<()> {
+    // Given: Checkpoint with nodes having specific (high) IDs
+    // This tests that after recovery, ID generators continue from max existing IDs
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    // Create nodes and checkpoint
+    {
+        let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+        let mut manager = CheckpointManager::new(config)?;
+
+        let current = CurrentStorage::new();
+
+        // Create 5 nodes using the normal API, which generates sequential IDs
+        for i in 1..=5 {
+            current.create_node(
+                "Test",
+                PropertyMapBuilder::new().insert("idx", i as i64).build(),
+            )?;
+        }
+
+        // Verify we have 5 nodes
+        assert_eq!(current.node_count(), 5);
+
+        let historical = HistoricalStorage::new();
+        let stats = manager.create_checkpoint(LSN(5), &current, &historical)?;
+
+        // Verify checkpoint captured the nodes
+        assert_eq!(stats.node_count, 5);
+    }
+
+    // When: Recover and create new node
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+    let mut manager = CheckpointManager::new(config)?;
+
+    // First verify persisted state exists
+    assert!(
+        manager.has_persisted_state(),
+        "Should have persisted state after checkpoint"
+    );
+
+    let (recovered_current, _recovered_historical, _final_lsn) = manager.recover(&wal)?;
+
+    // Verify recovery loaded the nodes
+    assert_eq!(
+        recovered_current.node_count(),
+        5,
+        "Should have 5 nodes after recovery"
+    );
+
+    // Create a new node - ID should be >= 5 (since IDs start at 0, nodes have IDs 0-4)
+    let new_node_id = recovered_current.create_node("NewNode", PropertyMap::new())?;
+
+    // Then: New node ID should be >= 5 (since IDs 0-4 were used by the 5 recovered nodes)
+    assert!(
+        new_node_id.as_u64() >= 5,
+        "New node ID {} should be >= 5 (after max recovered ID 4)",
+        new_node_id.as_u64()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_manager_should_checkpoint() -> Result<()> {
+    // Given: CheckpointManager with specific thresholds
+    let temp_dir = TempDir::new().unwrap();
+    let config = UnifiedCheckpointConfig {
+        data_dir: temp_dir.path().to_path_buf(),
+        checkpoint_interval: std::time::Duration::from_secs(3600), // 1 hour
+        min_wal_entries: 100,
+        ..Default::default()
+    };
+    let mut manager = CheckpointManager::new(config)?;
+
+    // When: Check with various LSNs
+
+    // Then: Should checkpoint initially (never checkpointed)
+    assert!(manager.should_checkpoint(LSN(1)));
+
+    // Simulate a checkpoint
+    manager.create_checkpoint(LSN(50), &CurrentStorage::new(), &HistoricalStorage::new())?;
+
+    // Should NOT checkpoint (not enough entries)
+    assert!(!manager.should_checkpoint(LSN(60)));
+
+    // Should checkpoint when threshold exceeded
+    assert!(manager.should_checkpoint(LSN(200)));
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_recovery_with_updates() -> Result<()> {
+    // Given: WAL with create and update operations
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    // Create WAL with create and update
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    let node_id = NodeId::new(1)?;
+
+    // Create node
+    wal.append(WalOperation::CreateNode {
+        node_id,
+        label: "Person".to_string(),
+        properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
+        temporal: BiTemporalInterval::current(time::now()),
+    })?;
+
+    // Update node
+    wal.append(WalOperation::UpdateNode {
+        node_id,
+        version_id: VersionId::new(2)?,
+        label: "Person".to_string(),
+        properties: PropertyMapBuilder::new()
+            .insert("name", "Alice Updated")
+            .build(),
+        temporal: BiTemporalInterval::current(time::now()),
+    })?;
+
+    wal.flush()?;
+
+    // When: Recover
+    let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+    let mut manager = CheckpointManager::new(config)?;
+    let (recovered_current, recovered_historical, _final_lsn) = manager.recover(&wal)?;
+
+    // Then: Current state should reflect the update
+    let node = recovered_current.get_node(node_id)?;
+    let name = node.get_property("name").unwrap().as_str().unwrap();
+    assert_eq!(name, "Alice Updated");
+
+    // Historical should have version entries
+    let hist_stats = recovered_historical.stats();
+    assert!(
+        hist_stats.total_node_versions >= 1,
+        "Should have historical versions"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_recovery_with_deletes() -> Result<()> {
+    // Given: WAL with create and delete operations
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    // Create WAL
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
+    // Create 3 nodes
+    for i in 1..=3 {
+        wal.append(WalOperation::CreateNode {
+            node_id: NodeId::new(i)?,
+            label: "Test".to_string(),
+            properties: PropertyMap::new(),
+            temporal: BiTemporalInterval::current(time::now()),
+        })?;
+    }
+
+    // Delete node 2
+    wal.append(WalOperation::DeleteNode {
+        node_id: NodeId::new(2)?,
+        temporal: BiTemporalInterval::current(time::now()),
+    })?;
+
+    wal.flush()?;
+
+    // When: Recover
+    let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
+    let mut manager = CheckpointManager::new(config)?;
+    let (recovered_current, _recovered_historical, _final_lsn) = manager.recover(&wal)?;
+
+    // Then: Should have 2 nodes (node 2 was deleted)
+    assert_eq!(recovered_current.node_count(), 2);
+    assert!(recovered_current.get_node(NodeId::new(1)?).is_ok());
+    assert!(recovered_current.get_node(NodeId::new(2)?).is_err()); // Deleted
+    assert!(recovered_current.get_node(NodeId::new(3)?).is_ok());
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_stats() -> Result<()> {
+    // Given: Storage with specific data
+    let temp_dir = TempDir::new().unwrap();
+    let config = UnifiedCheckpointConfig::with_data_dir(temp_dir.path());
+    let mut manager = CheckpointManager::new(config)?;
+
+    let current = CurrentStorage::new();
+
+    // Create 10 nodes and collect their IDs
+    let mut node_ids = Vec::new();
+    for i in 1..=10 {
+        let node_id = current.create_node(
+            "Test",
+            PropertyMapBuilder::new().insert("idx", i as i64).build(),
+        )?;
+        node_ids.push(node_id);
+    }
+
+    // Create 5 edges between nodes
+    for i in 0..5 {
+        current.create_edge(node_ids[i], node_ids[i + 5], "LINKS", PropertyMap::new())?;
+    }
+
+    let historical = HistoricalStorage::new();
+
+    // When: Create checkpoint
+    let stats = manager.create_checkpoint(LSN(50), &current, &historical)?;
+
+    // Then: Stats should reflect the data
+    assert_eq!(stats.node_count, 10);
+    assert_eq!(stats.edge_count, 5);
+    assert_eq!(stats.lsn, LSN(50));
+    assert!(stats.bytes_written > 0);
+    assert!(stats.duration.as_nanos() > 0);
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_has_persisted_state() -> Result<()> {
+    // Given: Fresh CheckpointManager
+    let temp_dir = TempDir::new().unwrap();
+    let config = UnifiedCheckpointConfig::with_data_dir(temp_dir.path());
+    let mut manager = CheckpointManager::new(config)?;
+
+    // Then: Initially no persisted state
+    assert!(!manager.has_persisted_state());
+
+    // When: Create checkpoint
+    manager.create_checkpoint(LSN(1), &CurrentStorage::new(), &HistoricalStorage::new())?;
+
+    // Then: Now has persisted state
+    assert!(manager.has_persisted_state());
+
+    Ok(())
+}
+
+#[test]
+fn test_checkpoint_get_persisted_lsn() -> Result<()> {
+    // Given: CheckpointManager with no checkpoint
+    let temp_dir = TempDir::new().unwrap();
+    let config = UnifiedCheckpointConfig::with_data_dir(temp_dir.path());
+    let mut manager = CheckpointManager::new(config)?;
+
+    // Then: No persisted LSN
+    assert_eq!(manager.get_persisted_lsn(), None);
+
+    // When: Create checkpoint at LSN 42
+    manager.create_checkpoint(LSN(42), &CurrentStorage::new(), &HistoricalStorage::new())?;
+
+    // Then: Persisted LSN is 42
+    assert_eq!(manager.get_persisted_lsn(), Some(LSN(42)));
+
+    Ok(())
+}

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -156,6 +156,10 @@ fn test_checkpoint_recovery_preserves_edges() -> Result<()> {
     // Track the edge ID we create
     let edge_id: EdgeId;
 
+    // Create WAL first so we have a valid LSN for the checkpoint
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
     // Create checkpoint with nodes and edges
     {
         let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
@@ -182,13 +186,11 @@ fn test_checkpoint_recovery_preserves_edges() -> Result<()> {
         )?;
 
         let historical = HistoricalStorage::new();
-        manager.create_checkpoint(LSN(10), &current, &historical)?;
+        // Use LSN(0) which is valid for an empty WAL
+        manager.create_checkpoint(LSN(0), &current, &historical)?;
     }
 
-    // When: Recover
-    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
-    let wal = ConcurrentWalSystem::new(wal_config)?;
-
+    // When: Recover using the same WAL
     let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
     let mut manager = CheckpointManager::new(config)?;
     let (recovered_current, _recovered_historical, _final_lsn) = manager.recover(&wal)?;
@@ -212,6 +214,10 @@ fn test_checkpoint_recovery_id_generators_initialized() -> Result<()> {
     let wal_dir = temp_dir.path().join("wal");
     let data_dir = temp_dir.path().join("data");
 
+    // Create WAL first so we have a valid LSN for the checkpoint
+    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config)?;
+
     // Create nodes and checkpoint
     {
         let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
@@ -231,16 +237,14 @@ fn test_checkpoint_recovery_id_generators_initialized() -> Result<()> {
         assert_eq!(current.node_count(), 5);
 
         let historical = HistoricalStorage::new();
-        let stats = manager.create_checkpoint(LSN(5), &current, &historical)?;
+        // Use LSN(0) which is valid for an empty WAL
+        let stats = manager.create_checkpoint(LSN(0), &current, &historical)?;
 
         // Verify checkpoint captured the nodes
         assert_eq!(stats.node_count, 5);
     }
 
-    // When: Recover and create new node
-    let wal_config = ConcurrentWalSystemConfig::new(&wal_dir);
-    let wal = ConcurrentWalSystem::new(wal_config)?;
-
+    // When: Recover and create new node using the same WAL
     let config = UnifiedCheckpointConfig::with_data_dir(&data_dir);
     let mut manager = CheckpointManager::new(config)?;
 


### PR DESCRIPTION
feat(checkpoint): integrate index persistence with checkpoint system
This commit adds a new CheckpointManager that coordinates checkpoints
with the index persistence system for full state snapshots. Key features:

- Full state persistence: Graph index, temporal index, and string
  interner are persisted to disk during checkpoint creation
- Fast recovery: Load indexes from disk instead of replaying entire WAL
- LSN consistency: Manifest tracks checkpoint LSN for incremental WAL replay
- Compression support: Optional zstd compression for graph indexes
- TDD approach: Comprehensive tests for checkpoint creation, recovery,
  and WAL replay scenarios

The integration enables:
- 6-30x faster startup (load from disk vs WAL replay)
- Consistent recovery by combining persisted state + WAL delta
- Configurable checkpoint intervals and thresholds