### PR TITLE
perf(traversal): add zero-allocation iterator methods for edge traversal

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -449,75 +449,111 @@ impl TraversalIterator {
 
         match self.direction {
             Direction::Outgoing => {
-                let edges = if let Some(ref label) = self.label {
-                    self.current.get_outgoing_edges_with_label(node_id, label)
+                // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
+                if let Some(ref label) = self.label {
+                    self.current
+                        .get_outgoing_edges_with_label_iter(node_id, label)
+                        .filter_map(|edge_id| {
+                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                                return None;
+                            }
+                            self.current
+                                .get_edge(edge_id)
+                                .ok()
+                                .map(|e| (e.target, edge_id))
+                        })
+                        .collect()
                 } else {
-                    self.current.get_outgoing_edges(node_id)
-                };
-
-                edges
-                    .into_iter()
-                    .filter_map(|edge_id| {
-                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                            return None;
-                        }
-                        self.current
-                            .get_edge(edge_id)
-                            .ok()
-                            .map(|e| (e.target, edge_id))
-                    })
-                    .collect()
+                    self.current
+                        .get_outgoing_edges_iter(node_id)
+                        .filter_map(|edge_id| {
+                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                                return None;
+                            }
+                            self.current
+                                .get_edge(edge_id)
+                                .ok()
+                                .map(|e| (e.target, edge_id))
+                        })
+                        .collect()
+                }
             }
             Direction::Incoming => {
-                let edges = if let Some(ref label) = self.label {
-                    self.current.get_incoming_edges_with_label(node_id, label)
+                // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
+                if let Some(ref label) = self.label {
+                    self.current
+                        .get_incoming_edges_with_label_iter(node_id, label)
+                        .filter_map(|edge_id| {
+                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                                return None;
+                            }
+                            self.current
+                                .get_edge(edge_id)
+                                .ok()
+                                .map(|e| (e.source, edge_id))
+                        })
+                        .collect()
                 } else {
-                    self.current.get_incoming_edges(node_id)
-                };
-
-                edges
-                    .into_iter()
-                    .filter_map(|edge_id| {
-                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                            return None;
-                        }
-                        self.current
-                            .get_edge(edge_id)
-                            .ok()
-                            .map(|e| (e.source, edge_id))
-                    })
-                    .collect()
+                    self.current
+                        .get_incoming_edges_iter(node_id)
+                        .filter_map(|edge_id| {
+                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                                return None;
+                            }
+                            self.current
+                                .get_edge(edge_id)
+                                .ok()
+                                .map(|e| (e.source, edge_id))
+                        })
+                        .collect()
+                }
             }
             Direction::Both => {
                 let mut neighbors = Vec::new();
 
-                let out_edges = if let Some(ref label) = self.label {
-                    self.current.get_outgoing_edges_with_label(node_id, label)
-                } else {
-                    self.current.get_outgoing_edges(node_id)
-                };
-
-                for edge_id in out_edges {
+                // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
+                // Helper closure to process edges and add to neighbors
+                let mut process_outgoing = |edge_id| {
                     if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                        continue;
+                        return;
                     }
                     if let Ok(e) = self.current.get_edge(edge_id) {
                         neighbors.push((e.target, edge_id));
                     }
-                }
-
-                let in_edges = if let Some(ref label) = self.label {
-                    self.current.get_incoming_edges_with_label(node_id, label)
-                } else {
-                    self.current.get_incoming_edges(node_id)
                 };
 
-                for edge_id in in_edges {
+                if let Some(ref label) = self.label {
+                    for edge_id in self
+                        .current
+                        .get_outgoing_edges_with_label_iter(node_id, label)
+                    {
+                        process_outgoing(edge_id);
+                    }
+                } else {
+                    for edge_id in self.current.get_outgoing_edges_iter(node_id) {
+                        process_outgoing(edge_id);
+                    }
+                }
+
+                let mut process_incoming = |edge_id| {
                     if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                        continue;
+                        return;
                     }
                     if let Ok(e) = self.current.get_edge(edge_id) {
                         neighbors.push((e.source, edge_id));
+                    }
+                };
+
+                if let Some(ref label) = self.label {
+                    for edge_id in self
+                        .current
+                        .get_incoming_edges_with_label_iter(node_id, label)
+                    {
+                        process_incoming(edge_id);
+                    }
+                } else {
+                    for edge_id in self.current.get_incoming_edges_iter(node_id) {
+                        process_incoming(edge_id);
                     }
                 }
 

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -288,7 +288,13 @@ macro_rules! impl_edge_iter {
             }
         }
 
-        impl ExactSizeIterator for $name {}
+        impl ExactSizeIterator for $name {
+            #[inline]
+            fn len(&self) -> usize {
+                self.guard.len().saturating_sub(self.index)
+            }
+        }
+
         impl std::iter::FusedIterator for $name {}
     };
 }
@@ -309,6 +315,7 @@ macro_rules! impl_edge_iter_with_label {
             "\n\n# Performance",
             "\n\n- **Zero allocation**: Holds an `AdjacencyGuard` and pre-resolved label ID",
             "\n- **Lazy evaluation**: Filters as you iterate",
+            "\n- **O(n) complexity**: Single linear scan regardless of match distribution",
             "\n- **Early termination**: If label doesn't exist, returns empty iterator"
         )]
         pub struct $name {
@@ -334,20 +341,25 @@ macro_rules! impl_edge_iter_with_label {
 
             #[inline]
             fn next(&mut self) -> Option<Self::Item> {
+                // Early return if label doesn't exist in interner
                 let label_id = self.label_id?;
-                let remaining = &self.guard[self.index..];
 
-                if let Some(pos) = remaining.iter().position(|e| e.label == label_id) {
-                    self.index += pos + 1;
-                    Some(remaining[pos].edge_id)
-                } else {
-                    self.index = self.guard.len();
-                    None
+                // Linear scan with manual indexing - O(n) total complexity
+                // Avoids the O(n²) worst-case of using .position() repeatedly
+                while self.index < self.guard.len() {
+                    let entry = &self.guard[self.index];
+                    self.index += 1;
+                    if entry.label == label_id {
+                        return Some(entry.edge_id);
+                    }
                 }
+                None
             }
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
+                // Lower bound is 0 (all remaining could be filtered out)
+                // Upper bound is remaining entries
                 let remaining = self.guard.len().saturating_sub(self.index);
                 (0, Some(remaining))
             }

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -6,10 +6,10 @@
 
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
-use crate::core::interning::GLOBAL_INTERNER;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
 use crate::core::property::PropertyMap;
 use crate::core::temporal::Timestamp;
-use crate::index::current::CurrentIndexes;
+use crate::index::current::{AdjacencyGuard, CurrentIndexes};
 use crate::index::vector::hnsw::{HnswConfig, HnswIndex};
 use crate::index::vector::temporal::{TemporalVectorConfig, TemporalVectorIndex};
 use crate::index::vector::{DistanceMetric, TemporalSearchResults, VectorIndex};
@@ -231,6 +231,208 @@ impl TemporalVectorIndexState {
     #[allow(dead_code)] // Kept for backward compatibility with legacy single-property API
     fn is_enabled(&self) -> bool {
         self.index.is_some()
+    }
+}
+
+/// Iterator over outgoing edge IDs from a node.
+///
+/// This iterator provides zero-allocation traversal of outgoing edges,
+/// avoiding the `Vec` allocation overhead of [`CurrentStorage::get_outgoing_edges`].
+///
+/// # Performance
+///
+/// - **Zero allocation**: Holds an `AdjacencyGuard` (just an `Arc` clone, ~5-10ns)
+/// - **Lazy evaluation**: Only computes results as you iterate
+/// - **Cache-friendly**: Sequential access to CSR adjacency data
+///
+/// # Issue #187
+///
+/// This iterator addresses the performance issue where `get_outgoing_edges()`
+/// unnecessarily allocated a new `Vec<EdgeId>` on every call, adding 100-500ns
+/// overhead per traversal.
+pub struct OutgoingEdgesIter {
+    guard: AdjacencyGuard,
+    index: usize,
+}
+
+impl OutgoingEdgesIter {
+    /// Create a new iterator over outgoing edges.
+    #[inline]
+    fn new(guard: AdjacencyGuard) -> Self {
+        OutgoingEdgesIter { guard, index: 0 }
+    }
+}
+
+impl Iterator for OutgoingEdgesIter {
+    type Item = EdgeId;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let entries = &*self.guard;
+        if self.index < entries.len() {
+            let edge_id = entries[self.index].edge_id;
+            self.index += 1;
+            Some(edge_id)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.guard.len() - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for OutgoingEdgesIter {}
+
+/// Iterator over incoming edge IDs to a node.
+///
+/// This iterator provides zero-allocation traversal of incoming edges,
+/// avoiding the `Vec` allocation overhead of [`CurrentStorage::get_incoming_edges`].
+///
+/// See [`OutgoingEdgesIter`] for performance details.
+pub struct IncomingEdgesIter {
+    guard: AdjacencyGuard,
+    index: usize,
+}
+
+impl IncomingEdgesIter {
+    /// Create a new iterator over incoming edges.
+    #[inline]
+    fn new(guard: AdjacencyGuard) -> Self {
+        IncomingEdgesIter { guard, index: 0 }
+    }
+}
+
+impl Iterator for IncomingEdgesIter {
+    type Item = EdgeId;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let entries = &*self.guard;
+        if self.index < entries.len() {
+            let edge_id = entries[self.index].edge_id;
+            self.index += 1;
+            Some(edge_id)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.guard.len() - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for IncomingEdgesIter {}
+
+/// Iterator over outgoing edge IDs from a node, filtered by label.
+///
+/// This iterator provides zero-allocation traversal of outgoing edges
+/// that match a specific label.
+///
+/// # Performance
+///
+/// - **Zero allocation**: Holds an `AdjacencyGuard` and pre-resolved label ID
+/// - **Lazy evaluation**: Filters as you iterate
+/// - **Early termination**: If label doesn't exist, returns empty iterator
+pub struct OutgoingEdgesWithLabelIter {
+    guard: AdjacencyGuard,
+    index: usize,
+    label_id: Option<InternedString>,
+}
+
+impl OutgoingEdgesWithLabelIter {
+    /// Create a new iterator over outgoing edges with a specific label.
+    #[inline]
+    fn new(guard: AdjacencyGuard, label_id: Option<InternedString>) -> Self {
+        OutgoingEdgesWithLabelIter {
+            guard,
+            index: 0,
+            label_id,
+        }
+    }
+}
+
+impl Iterator for OutgoingEdgesWithLabelIter {
+    type Item = EdgeId;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        // If label doesn't exist, return None immediately
+        let label_id = self.label_id?;
+
+        let entries = &*self.guard;
+        while self.index < entries.len() {
+            let entry = &entries[self.index];
+            self.index += 1;
+            if entry.label == label_id {
+                return Some(entry.edge_id);
+            }
+        }
+        None
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Upper bound is remaining entries; lower bound is 0 (all could be filtered)
+        let remaining = self.guard.len().saturating_sub(self.index);
+        (0, Some(remaining))
+    }
+}
+
+/// Iterator over incoming edge IDs to a node, filtered by label.
+///
+/// This iterator provides zero-allocation traversal of incoming edges
+/// that match a specific label.
+///
+/// See [`OutgoingEdgesWithLabelIter`] for performance details.
+pub struct IncomingEdgesWithLabelIter {
+    guard: AdjacencyGuard,
+    index: usize,
+    label_id: Option<InternedString>,
+}
+
+impl IncomingEdgesWithLabelIter {
+    /// Create a new iterator over incoming edges with a specific label.
+    #[inline]
+    fn new(guard: AdjacencyGuard, label_id: Option<InternedString>) -> Self {
+        IncomingEdgesWithLabelIter {
+            guard,
+            index: 0,
+            label_id,
+        }
+    }
+}
+
+impl Iterator for IncomingEdgesWithLabelIter {
+    type Item = EdgeId;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        // If label doesn't exist, return None immediately
+        let label_id = self.label_id?;
+
+        let entries = &*self.guard;
+        while self.index < entries.len() {
+            let entry = &entries[self.index];
+            self.index += 1;
+            if entry.label == label_id {
+                return Some(entry.edge_id);
+            }
+        }
+        None
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Upper bound is remaining entries; lower bound is 0 (all could be filtered)
+        let remaining = self.guard.len().saturating_sub(self.index);
+        (0, Some(remaining))
     }
 }
 
@@ -898,6 +1100,73 @@ impl CurrentStorage {
             .into_iter()
             .map(|entry| entry.edge_id)
             .collect()
+    }
+
+    /// Get all outgoing edges from a node as an iterator.
+    ///
+    /// This is a zero-allocation alternative to [`get_outgoing_edges`] that returns
+    /// an iterator instead of collecting into a `Vec`. Use this for performance-critical
+    /// traversals where you don't need to store all edges.
+    ///
+    /// # Performance
+    ///
+    /// - No `Vec` allocation (saves 100-500ns per call)
+    /// - Lazy evaluation - only computes what you consume
+    /// - Can be short-circuited with `.take()`, `.find()`, etc.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Get first outgoing edge without allocating a Vec
+    /// let first_edge = storage.get_outgoing_edges_iter(node).next();
+    ///
+    /// // Count edges without allocation
+    /// let count = storage.get_outgoing_edges_iter(node).count();
+    /// ```
+    #[inline]
+    pub fn get_outgoing_edges_iter(&self, source: NodeId) -> OutgoingEdgesIter {
+        OutgoingEdgesIter::new(self.indexes.get_outgoing(source))
+    }
+
+    /// Get all incoming edges to a node as an iterator.
+    ///
+    /// This is a zero-allocation alternative to [`get_incoming_edges`] that returns
+    /// an iterator instead of collecting into a `Vec`.
+    ///
+    /// See [`get_outgoing_edges_iter`] for performance details and usage examples.
+    #[inline]
+    pub fn get_incoming_edges_iter(&self, target: NodeId) -> IncomingEdgesIter {
+        IncomingEdgesIter::new(self.indexes.get_incoming(target))
+    }
+
+    /// Get outgoing edges with a specific label as an iterator.
+    ///
+    /// This is a zero-allocation alternative to [`get_outgoing_edges_with_label`].
+    ///
+    /// Returns an empty iterator if the label doesn't exist.
+    #[inline]
+    pub fn get_outgoing_edges_with_label_iter(
+        &self,
+        source: NodeId,
+        label: &str,
+    ) -> OutgoingEdgesWithLabelIter {
+        let label_id = GLOBAL_INTERNER.get_id(label);
+        OutgoingEdgesWithLabelIter::new(self.indexes.get_outgoing(source), label_id)
+    }
+
+    /// Get incoming edges with a specific label as an iterator.
+    ///
+    /// This is a zero-allocation alternative to [`get_incoming_edges_with_label`].
+    ///
+    /// Returns an empty iterator if the label doesn't exist.
+    #[inline]
+    pub fn get_incoming_edges_with_label_iter(
+        &self,
+        target: NodeId,
+        label: &str,
+    ) -> IncomingEdgesWithLabelIter {
+        let label_id = GLOBAL_INTERNER.get_id(label);
+        IncomingEdgesWithLabelIter::new(self.indexes.get_incoming(target), label_id)
     }
 
     /// Export outgoing CSR adjacency data for persistence.
@@ -3262,5 +3531,277 @@ mod tests {
         );
 
         assert!(result.is_err(), "Should fail on dimension mismatch");
+    }
+
+    // TDD tests for Issue #187 - Performance optimization for graph traversal methods
+    // These tests verify the new iterator-based API that avoids unnecessary Vec allocations
+
+    #[test]
+    fn test_get_outgoing_edges_iter_basic() {
+        let storage = CurrentStorage::new();
+
+        // Create nodes
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create edges
+        let e1 = storage
+            .create_edge(n0, n1, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        let e2 = storage
+            .create_edge(n0, n2, "FOLLOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Test iterator returns same results as Vec version
+        let vec_result: Vec<EdgeId> = storage.get_outgoing_edges(n0);
+        let iter_result: Vec<EdgeId> = storage.get_outgoing_edges_iter(n0).collect();
+
+        assert_eq!(vec_result.len(), iter_result.len());
+        assert!(iter_result.contains(&e1));
+        assert!(iter_result.contains(&e2));
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_iter_empty() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Node with no outgoing edges
+        let count = storage.get_outgoing_edges_iter(n0).count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_get_incoming_edges_iter_basic() {
+        let storage = CurrentStorage::new();
+
+        // Create nodes
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create edges pointing to n2
+        let e1 = storage
+            .create_edge(n0, n2, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        let e2 = storage
+            .create_edge(n1, n2, "FOLLOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Test iterator returns same results as Vec version
+        let vec_result: Vec<EdgeId> = storage.get_incoming_edges(n2);
+        let iter_result: Vec<EdgeId> = storage.get_incoming_edges_iter(n2).collect();
+
+        assert_eq!(vec_result.len(), iter_result.len());
+        assert!(iter_result.contains(&e1));
+        assert!(iter_result.contains(&e2));
+    }
+
+    #[test]
+    fn test_get_incoming_edges_iter_empty() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Node with no incoming edges
+        let count = storage.get_incoming_edges_iter(n0).count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_with_label_iter_basic() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create edges with different labels
+        let e1 = storage
+            .create_edge(n0, n1, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        let _e2 = storage
+            .create_edge(n0, n2, "FOLLOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Test iterator with label filter
+        let iter_result: Vec<EdgeId> = storage
+            .get_outgoing_edges_with_label_iter(n0, "KNOWS")
+            .collect();
+        assert_eq!(iter_result.len(), 1);
+        assert!(iter_result.contains(&e1));
+
+        // Compare with Vec version
+        let vec_result = storage.get_outgoing_edges_with_label(n0, "KNOWS");
+        assert_eq!(vec_result.len(), iter_result.len());
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_with_label_iter_nonexistent_label() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        storage
+            .create_edge(n0, n1, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Non-existent label should return empty iterator
+        let count = storage
+            .get_outgoing_edges_with_label_iter(n0, "LOVES")
+            .count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_get_incoming_edges_with_label_iter_basic() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create edges with different labels pointing to n2
+        let e1 = storage
+            .create_edge(n0, n2, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        let _e2 = storage
+            .create_edge(n1, n2, "FOLLOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Test iterator with label filter
+        let iter_result: Vec<EdgeId> = storage
+            .get_incoming_edges_with_label_iter(n2, "KNOWS")
+            .collect();
+        assert_eq!(iter_result.len(), 1);
+        assert!(iter_result.contains(&e1));
+
+        // Compare with Vec version
+        let vec_result = storage.get_incoming_edges_with_label(n2, "KNOWS");
+        assert_eq!(vec_result.len(), iter_result.len());
+    }
+
+    #[test]
+    fn test_get_incoming_edges_with_label_iter_nonexistent_label() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        storage
+            .create_edge(n0, n1, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Non-existent label should return empty iterator
+        let count = storage
+            .get_incoming_edges_with_label_iter(n1, "LOVES")
+            .count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_iterator_can_be_partially_consumed() {
+        let storage = CurrentStorage::new();
+
+        let n0 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n1 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n3 = storage
+            .create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Create multiple edges
+        storage
+            .create_edge(n0, n1, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        storage
+            .create_edge(n0, n2, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+        storage
+            .create_edge(n0, n3, "KNOWS", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Take only first 2 elements - demonstrating lazy evaluation benefit
+        let first_two: Vec<EdgeId> = storage.get_outgoing_edges_iter(n0).take(2).collect();
+        assert_eq!(first_two.len(), 2);
+    }
+
+    #[test]
+    fn test_iterator_consistency_with_vec() {
+        let storage = CurrentStorage::new();
+
+        // Create a more complex graph
+        let nodes: Vec<NodeId> = (0..5)
+            .map(|_| {
+                storage
+                    .create_node("Person", PropertyMapBuilder::new().build())
+                    .unwrap()
+            })
+            .collect();
+
+        // Create a star pattern: n0 -> n1, n2, n3, n4
+        for i in 1..5 {
+            storage
+                .create_edge(
+                    nodes[0],
+                    nodes[i],
+                    "KNOWS",
+                    PropertyMapBuilder::new().build(),
+                )
+                .unwrap();
+        }
+
+        // Verify iterator and Vec return same edges (order may differ)
+        let vec_edges: std::collections::HashSet<EdgeId> =
+            storage.get_outgoing_edges(nodes[0]).into_iter().collect();
+        let iter_edges: std::collections::HashSet<EdgeId> =
+            storage.get_outgoing_edges_iter(nodes[0]).collect();
+
+        assert_eq!(vec_edges, iter_edges);
     }
 }

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -234,207 +234,156 @@ impl TemporalVectorIndexState {
     }
 }
 
-/// Iterator over outgoing edge IDs from a node.
+/// Macro to generate edge iterator types.
 ///
-/// This iterator provides zero-allocation traversal of outgoing edges,
-/// avoiding the `Vec` allocation overhead of [`CurrentStorage::get_outgoing_edges`].
-///
-/// # Performance
-///
-/// - **Zero allocation**: Holds an `AdjacencyGuard` (just an `Arc` clone, ~5-10ns)
-/// - **Lazy evaluation**: Only computes results as you iterate
-/// - **Cache-friendly**: Sequential access to CSR adjacency data
-///
-/// # Issue #187
-///
-/// This iterator addresses the performance issue where `get_outgoing_edges()`
-/// unnecessarily allocated a new `Vec<EdgeId>` on every call, adding 100-500ns
-/// overhead per traversal.
-pub struct OutgoingEdgesIter {
-    guard: AdjacencyGuard,
-    index: usize,
-}
-
-impl OutgoingEdgesIter {
-    /// Create a new iterator over outgoing edges.
-    #[inline]
-    fn new(guard: AdjacencyGuard) -> Self {
-        OutgoingEdgesIter { guard, index: 0 }
-    }
-}
-
-impl Iterator for OutgoingEdgesIter {
-    type Item = EdgeId;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let entries = &*self.guard;
-        if self.index < entries.len() {
-            let edge_id = entries[self.index].edge_id;
-            self.index += 1;
-            Some(edge_id)
-        } else {
-            None
+/// This eliminates code duplication between outgoing/incoming iterator variants
+/// while preserving distinct types for API clarity.
+macro_rules! impl_edge_iter {
+    (
+        $(#[$meta:meta])*
+        $name:ident,
+        $method_link:literal,
+        $direction:literal
+    ) => {
+        $(#[$meta])*
+        #[doc = concat!(
+            "\n\nThis iterator provides zero-allocation traversal of ", $direction, " edges,",
+            "\navoiding the `Vec` allocation overhead of [`", $method_link, "`](Self::", $method_link, ").",
+            "\n\n# Performance",
+            "\n\n- **Zero allocation**: Holds an `AdjacencyGuard` (just an `Arc` clone, ~5-10ns)",
+            "\n- **Lazy evaluation**: Only computes results as you iterate",
+            "\n- **Cache-friendly**: Sequential access to CSR adjacency data",
+            "\n\n# Issue #187",
+            "\n\nThis iterator addresses the performance issue where edge traversal methods",
+            "\nunnecessarily allocated a new `Vec<EdgeId>` on every call, adding 100-500ns",
+            "\noverhead per traversal."
+        )]
+        pub struct $name {
+            guard: AdjacencyGuard,
+            index: usize,
         }
-    }
 
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.guard.len() - self.index;
-        (remaining, Some(remaining))
-    }
-}
-
-impl ExactSizeIterator for OutgoingEdgesIter {}
-
-/// Iterator over incoming edge IDs to a node.
-///
-/// This iterator provides zero-allocation traversal of incoming edges,
-/// avoiding the `Vec` allocation overhead of [`CurrentStorage::get_incoming_edges`].
-///
-/// See [`OutgoingEdgesIter`] for performance details.
-pub struct IncomingEdgesIter {
-    guard: AdjacencyGuard,
-    index: usize,
-}
-
-impl IncomingEdgesIter {
-    /// Create a new iterator over incoming edges.
-    #[inline]
-    fn new(guard: AdjacencyGuard) -> Self {
-        IncomingEdgesIter { guard, index: 0 }
-    }
-}
-
-impl Iterator for IncomingEdgesIter {
-    type Item = EdgeId;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let entries = &*self.guard;
-        if self.index < entries.len() {
-            let edge_id = entries[self.index].edge_id;
-            self.index += 1;
-            Some(edge_id)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.guard.len() - self.index;
-        (remaining, Some(remaining))
-    }
-}
-
-impl ExactSizeIterator for IncomingEdgesIter {}
-
-/// Iterator over outgoing edge IDs from a node, filtered by label.
-///
-/// This iterator provides zero-allocation traversal of outgoing edges
-/// that match a specific label.
-///
-/// # Performance
-///
-/// - **Zero allocation**: Holds an `AdjacencyGuard` and pre-resolved label ID
-/// - **Lazy evaluation**: Filters as you iterate
-/// - **Early termination**: If label doesn't exist, returns empty iterator
-pub struct OutgoingEdgesWithLabelIter {
-    guard: AdjacencyGuard,
-    index: usize,
-    label_id: Option<InternedString>,
-}
-
-impl OutgoingEdgesWithLabelIter {
-    /// Create a new iterator over outgoing edges with a specific label.
-    #[inline]
-    fn new(guard: AdjacencyGuard, label_id: Option<InternedString>) -> Self {
-        OutgoingEdgesWithLabelIter {
-            guard,
-            index: 0,
-            label_id,
-        }
-    }
-}
-
-impl Iterator for OutgoingEdgesWithLabelIter {
-    type Item = EdgeId;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        // If label doesn't exist, return None immediately
-        let label_id = self.label_id?;
-
-        let entries = &*self.guard;
-        while self.index < entries.len() {
-            let entry = &entries[self.index];
-            self.index += 1;
-            if entry.label == label_id {
-                return Some(entry.edge_id);
+        impl $name {
+            #[doc = concat!("Create a new iterator over ", $direction, " edges.")]
+            #[inline]
+            fn new(guard: AdjacencyGuard) -> Self {
+                Self { guard, index: 0 }
             }
         }
-        None
-    }
 
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // Upper bound is remaining entries; lower bound is 0 (all could be filtered)
-        let remaining = self.guard.len().saturating_sub(self.index);
-        (0, Some(remaining))
-    }
-}
+        impl Iterator for $name {
+            type Item = EdgeId;
 
-/// Iterator over incoming edge IDs to a node, filtered by label.
-///
-/// This iterator provides zero-allocation traversal of incoming edges
-/// that match a specific label.
-///
-/// See [`OutgoingEdgesWithLabelIter`] for performance details.
-pub struct IncomingEdgesWithLabelIter {
-    guard: AdjacencyGuard,
-    index: usize,
-    label_id: Option<InternedString>,
-}
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {
+                let entry = self.guard.get(self.index)?;
+                self.index += 1;
+                Some(entry.edge_id)
+            }
 
-impl IncomingEdgesWithLabelIter {
-    /// Create a new iterator over incoming edges with a specific label.
-    #[inline]
-    fn new(guard: AdjacencyGuard, label_id: Option<InternedString>) -> Self {
-        IncomingEdgesWithLabelIter {
-            guard,
-            index: 0,
-            label_id,
-        }
-    }
-}
-
-impl Iterator for IncomingEdgesWithLabelIter {
-    type Item = EdgeId;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        // If label doesn't exist, return None immediately
-        let label_id = self.label_id?;
-
-        let entries = &*self.guard;
-        while self.index < entries.len() {
-            let entry = &entries[self.index];
-            self.index += 1;
-            if entry.label == label_id {
-                return Some(entry.edge_id);
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                let remaining = self.guard.len().saturating_sub(self.index);
+                (remaining, Some(remaining))
             }
         }
-        None
-    }
 
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // Upper bound is remaining entries; lower bound is 0 (all could be filtered)
-        let remaining = self.guard.len().saturating_sub(self.index);
-        (0, Some(remaining))
-    }
+        impl ExactSizeIterator for $name {}
+        impl std::iter::FusedIterator for $name {}
+    };
 }
+
+/// Macro to generate label-filtered edge iterator types.
+macro_rules! impl_edge_iter_with_label {
+    (
+        $(#[$meta:meta])*
+        $name:ident,
+        $method_link:literal,
+        $direction:literal
+    ) => {
+        $(#[$meta])*
+        #[doc = concat!(
+            "\n\nThis iterator provides zero-allocation traversal of ", $direction, " edges",
+            "\nthat match a specific label, avoiding the `Vec` allocation overhead of",
+            "\n[`", $method_link, "`](Self::", $method_link, ").",
+            "\n\n# Performance",
+            "\n\n- **Zero allocation**: Holds an `AdjacencyGuard` and pre-resolved label ID",
+            "\n- **Lazy evaluation**: Filters as you iterate",
+            "\n- **Early termination**: If label doesn't exist, returns empty iterator"
+        )]
+        pub struct $name {
+            guard: AdjacencyGuard,
+            index: usize,
+            label_id: Option<InternedString>,
+        }
+
+        impl $name {
+            #[doc = concat!("Create a new iterator over ", $direction, " edges with a specific label.")]
+            #[inline]
+            fn new(guard: AdjacencyGuard, label_id: Option<InternedString>) -> Self {
+                Self {
+                    guard,
+                    index: 0,
+                    label_id,
+                }
+            }
+        }
+
+        impl Iterator for $name {
+            type Item = EdgeId;
+
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {
+                let label_id = self.label_id?;
+                let remaining = &self.guard[self.index..];
+
+                if let Some(pos) = remaining.iter().position(|e| e.label == label_id) {
+                    self.index += pos + 1;
+                    Some(remaining[pos].edge_id)
+                } else {
+                    self.index = self.guard.len();
+                    None
+                }
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                let remaining = self.guard.len().saturating_sub(self.index);
+                (0, Some(remaining))
+            }
+        }
+
+        impl std::iter::FusedIterator for $name {}
+    };
+}
+
+impl_edge_iter!(
+    /// Iterator over outgoing edge IDs from a node.
+    OutgoingEdgesIter,
+    "get_outgoing_edges",
+    "outgoing"
+);
+
+impl_edge_iter!(
+    /// Iterator over incoming edge IDs to a node.
+    IncomingEdgesIter,
+    "get_incoming_edges",
+    "incoming"
+);
+
+impl_edge_iter_with_label!(
+    /// Iterator over outgoing edge IDs from a node, filtered by label.
+    OutgoingEdgesWithLabelIter,
+    "get_outgoing_edges_with_label",
+    "outgoing"
+);
+
+impl_edge_iter_with_label!(
+    /// Iterator over incoming edge IDs to a node, filtered by label.
+    IncomingEdgesWithLabelIter,
+    "get_incoming_edges_with_label",
+    "incoming"
+);
 
 /// Current-state storage engine.
 ///
@@ -1104,7 +1053,7 @@ impl CurrentStorage {
 
     /// Get all outgoing edges from a node as an iterator.
     ///
-    /// This is a zero-allocation alternative to [`get_outgoing_edges`] that returns
+    /// This is a zero-allocation alternative to [`Self::get_outgoing_edges`] that returns
     /// an iterator instead of collecting into a `Vec`. Use this for performance-critical
     /// traversals where you don't need to store all edges.
     ///
@@ -1130,10 +1079,10 @@ impl CurrentStorage {
 
     /// Get all incoming edges to a node as an iterator.
     ///
-    /// This is a zero-allocation alternative to [`get_incoming_edges`] that returns
+    /// This is a zero-allocation alternative to [`Self::get_incoming_edges`] that returns
     /// an iterator instead of collecting into a `Vec`.
     ///
-    /// See [`get_outgoing_edges_iter`] for performance details and usage examples.
+    /// See [`Self::get_outgoing_edges_iter`] for performance details and usage examples.
     #[inline]
     pub fn get_incoming_edges_iter(&self, target: NodeId) -> IncomingEdgesIter {
         IncomingEdgesIter::new(self.indexes.get_incoming(target))
@@ -1141,7 +1090,7 @@ impl CurrentStorage {
 
     /// Get outgoing edges with a specific label as an iterator.
     ///
-    /// This is a zero-allocation alternative to [`get_outgoing_edges_with_label`].
+    /// This is a zero-allocation alternative to [`Self::get_outgoing_edges_with_label`].
     ///
     /// Returns an empty iterator if the label doesn't exist.
     #[inline]
@@ -1156,7 +1105,7 @@ impl CurrentStorage {
 
     /// Get incoming edges with a specific label as an iterator.
     ///
-    /// This is a zero-allocation alternative to [`get_incoming_edges_with_label`].
+    /// This is a zero-allocation alternative to [`Self::get_incoming_edges_with_label`].
     ///
     /// Returns an empty iterator if the label doesn't exist.
     #[inline]
@@ -3559,11 +3508,13 @@ mod tests {
             .create_edge(n0, n2, "FOLLOWS", PropertyMapBuilder::new().build())
             .unwrap();
 
-        // Test iterator returns same results as Vec version
-        let vec_result: Vec<EdgeId> = storage.get_outgoing_edges(n0);
-        let iter_result: Vec<EdgeId> = storage.get_outgoing_edges_iter(n0).collect();
+        // Test iterator returns same results as Vec version using HashSet for robust comparison
+        let vec_result: std::collections::HashSet<EdgeId> =
+            storage.get_outgoing_edges(n0).into_iter().collect();
+        let iter_result: std::collections::HashSet<EdgeId> =
+            storage.get_outgoing_edges_iter(n0).collect();
 
-        assert_eq!(vec_result.len(), iter_result.len());
+        assert_eq!(vec_result, iter_result);
         assert!(iter_result.contains(&e1));
         assert!(iter_result.contains(&e2));
     }
@@ -3604,11 +3555,13 @@ mod tests {
             .create_edge(n1, n2, "FOLLOWS", PropertyMapBuilder::new().build())
             .unwrap();
 
-        // Test iterator returns same results as Vec version
-        let vec_result: Vec<EdgeId> = storage.get_incoming_edges(n2);
-        let iter_result: Vec<EdgeId> = storage.get_incoming_edges_iter(n2).collect();
+        // Test iterator returns same results as Vec version using HashSet for robust comparison
+        let vec_result: std::collections::HashSet<EdgeId> =
+            storage.get_incoming_edges(n2).into_iter().collect();
+        let iter_result: std::collections::HashSet<EdgeId> =
+            storage.get_incoming_edges_iter(n2).collect();
 
-        assert_eq!(vec_result.len(), iter_result.len());
+        assert_eq!(vec_result, iter_result);
         assert!(iter_result.contains(&e1));
         assert!(iter_result.contains(&e2));
     }


### PR DESCRIPTION
Issue #187: The existing get_outgoing_edges() and related methods were allocating a new Vec<EdgeId> on every call, adding 100-500ns overhead per traversal operation.

Added four new iterator-based methods that avoid allocation:
- get_outgoing_edges_iter() -> OutgoingEdgesIter
- get_incoming_edges_iter() -> IncomingEdgesIter
- get_outgoing_edges_with_label_iter() -> OutgoingEdgesWithLabelIter
- get_incoming_edges_with_label_iter() -> IncomingEdgesWithLabelIter

These iterators hold an AdjacencyGuard internally and yield EdgeIds lazily, enabling:
- Zero allocation for traversals where Vec is not needed
- Early termination with .take(), .find(), .any(), etc.
- ExactSizeIterator support for basic iterators

The original Vec-returning methods are preserved for API compatibility.