### PR TITLE
perf(vector): eliminate unnecessary clone in prepare_vector_search

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -265,6 +265,56 @@ impl PropertyValue {
         }
     }
 
+    /// Get the underlying Arc for a vector (dense embedding) without copying.
+    ///
+    /// Returns `Some(Arc<[f32]>)` if this is a `Vector` variant, `None` otherwise.
+    /// This is more efficient than `as_vector().map(|s| s.to_vec())` because it
+    /// clones the Arc (O(1) reference count increment) rather than copying the
+    /// entire vector data.
+    ///
+    /// # Use Case
+    ///
+    /// Use this method when you need an owned reference to the vector data that
+    /// can outlive the PropertyValue, without incurring the cost of copying.
+    /// This is particularly useful for:
+    /// - Passing vectors to functions that need ownership
+    /// - Storing vector references across async boundaries
+    /// - Avoiding allocations in performance-critical paths (Issue #188)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::core::PropertyValue;
+    /// use std::sync::Arc;
+    ///
+    /// let embedding = vec![0.1f32, 0.2, 0.3];
+    /// let prop = PropertyValue::vector(&embedding);
+    ///
+    /// // Get an Arc to the data without copying
+    /// if let Some(arc) = prop.as_arc_vector() {
+    ///     assert_eq!(arc.len(), 3);
+    ///     // The Arc can outlive `prop` and be passed around cheaply
+    /// }
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// - O(1) operation (just increments Arc reference count)
+    /// - No memory allocation or data copying
+    /// - Safe to call multiple times (returns same underlying data)
+    ///
+    /// # See Also
+    ///
+    /// - [`as_vector`](Self::as_vector) for borrowing the vector as a slice
+    /// - [`vector`](Self::vector) for creating vector properties
+    #[inline]
+    pub fn as_arc_vector(&self) -> Option<Arc<[f32]>> {
+        match self {
+            PropertyValue::Vector(v) => Some(Arc::clone(v)),
+            _ => None,
+        }
+    }
+
     /// Create a sparse vector property value from a SparseVec.
     ///
     /// Sparse vectors store only non-zero values along with their indices,
@@ -2454,5 +2504,73 @@ mod tests {
         assert!(prop.as_str().is_none());
         assert!(prop.as_vector().is_none()); // Should not match dense vector
         assert!(prop.as_array().is_none());
+    }
+
+    // ========== Issue #188: Zero-copy vector access tests ==========
+
+    #[test]
+    fn test_as_arc_vector_returns_arc() {
+        // Test that as_arc_vector returns a cloned Arc without copying the data
+        let embedding: Vec<f32> = (0..384).map(|i| i as f32 * 0.001).collect();
+        let prop = PropertyValue::vector(&embedding);
+
+        // Get the Arc via as_arc_vector
+        let arc = prop.as_arc_vector().expect("Should return Some for Vector");
+
+        // The Arc should point to the same data
+        assert_eq!(&*arc, &embedding[..]);
+        assert_eq!(arc.len(), 384);
+    }
+
+    #[test]
+    fn test_as_arc_vector_shares_data_with_original() {
+        // Verify that as_arc_vector returns the same underlying Arc (not a copy)
+        let embedding: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+        let prop = PropertyValue::vector(&embedding);
+
+        // Get two Arcs - they should point to the same data
+        let arc1 = prop.as_arc_vector().unwrap();
+        let arc2 = prop.as_arc_vector().unwrap();
+
+        // Both Arcs should point to the same allocation (same pointer)
+        assert!(
+            Arc::ptr_eq(&arc1, &arc2),
+            "Multiple calls to as_arc_vector should return Arcs to the same data"
+        );
+    }
+
+    #[test]
+    fn test_as_arc_vector_returns_none_for_non_vector() {
+        // as_arc_vector should return None for non-vector types
+        assert!(PropertyValue::Null.as_arc_vector().is_none());
+        assert!(PropertyValue::Bool(true).as_arc_vector().is_none());
+        assert!(PropertyValue::Int(42).as_arc_vector().is_none());
+        assert!(PropertyValue::Float(2.5).as_arc_vector().is_none());
+        assert!(PropertyValue::string("test").as_arc_vector().is_none());
+        assert!(PropertyValue::bytes([1, 2, 3]).as_arc_vector().is_none());
+        assert!(PropertyValue::array(vec![]).as_arc_vector().is_none());
+    }
+
+    #[test]
+    fn test_as_arc_vector_does_not_copy_data() {
+        // Create a large vector to ensure we'd notice if data was copied
+        let large_embedding: Vec<f32> = (0..4096).map(|i| i as f32).collect();
+        let prop = PropertyValue::vector(&large_embedding);
+
+        // Get the internal Arc pointer before as_arc_vector
+        let internal_arc = if let PropertyValue::Vector(arc) = &prop {
+            arc.clone()
+        } else {
+            panic!("Expected Vector variant");
+        };
+
+        // Get Arc via as_arc_vector
+        let returned_arc = prop.as_arc_vector().unwrap();
+
+        // They should point to the exact same allocation
+        assert!(
+            Arc::ptr_eq(&internal_arc, &returned_arc),
+            "as_arc_vector should return the same Arc, not copy the data"
+        );
     }
 }

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -2541,6 +2541,8 @@ mod tests {
 
     #[test]
     fn test_as_arc_vector_returns_none_for_non_vector() {
+        use crate::core::vector::SparseVec;
+
         // as_arc_vector should return None for non-vector types
         assert!(PropertyValue::Null.as_arc_vector().is_none());
         assert!(PropertyValue::Bool(true).as_arc_vector().is_none());
@@ -2549,6 +2551,14 @@ mod tests {
         assert!(PropertyValue::string("test").as_arc_vector().is_none());
         assert!(PropertyValue::bytes([1, 2, 3]).as_arc_vector().is_none());
         assert!(PropertyValue::array(vec![]).as_arc_vector().is_none());
+
+        // SparseVector is a different type - should not match dense Vector
+        let sparse = SparseVec::new(vec![0, 1], vec![1.0, 2.0], 5).unwrap();
+        assert!(
+            PropertyValue::sparse_vector(sparse)
+                .as_arc_vector()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -957,7 +957,17 @@ impl CurrentStorage {
     ///
     /// This uses the "default" property (first enabled) for backward compatibility.
     /// For multi-property searches, use `find_similar_in` instead.
-    fn prepare_vector_search(&self, query_node_id: NodeId) -> Result<(Arc<HnswIndex>, Vec<f32>)> {
+    ///
+    /// # Performance (Issue #188)
+    ///
+    /// This method returns `Arc<[f32]>` instead of `Vec<f32>` to avoid unnecessary
+    /// memory allocation. The query vector is stored internally as `Arc<[f32]>`,
+    /// so returning an Arc clone (O(1) refcount increment) is much cheaper than
+    /// copying the entire vector (O(n) allocation + copy).
+    ///
+    /// For 384-dim embeddings, this saves ~1.5KB allocation per search.
+    /// For 1536-dim embeddings, this saves ~6KB allocation per search.
+    fn prepare_vector_search(&self, query_node_id: NodeId) -> Result<(Arc<HnswIndex>, Arc<[f32]>)> {
         // Get the default property name from legacy state
         let state = self.vector_index_state.read();
         let prop_name = state.property_name.as_ref().ok_or_else(|| {
@@ -979,11 +989,14 @@ impl CurrentStorage {
             .indexes
             .get_node(query_node_id)
             .ok_or(StorageError::NodeNotFound(query_node_id))?;
-        let query_vec_ref = query_node
+
+        // Use as_arc_vector() to get an Arc clone (O(1)) instead of to_vec() (O(n))
+        // This avoids unnecessary memory allocation - Issue #188
+        let query_vector = query_node
             .properties
             .get(&prop_name)
             .ok_or_else(|| StorageError::PropertyNotFound(prop_name.clone()))?
-            .as_vector()
+            .as_arc_vector()
             .ok_or_else(|| {
                 crate::utils::error::Error::Vector(
                     crate::utils::error::VectorError::InvalidVector {
@@ -992,9 +1005,7 @@ impl CurrentStorage {
                 )
             })?;
 
-        let query_vector: Vec<f32> = query_vec_ref.to_vec();
         let index = Arc::clone(&entry.value().index);
-        drop(query_node);
 
         Ok((index, query_vector))
     }

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -1005,6 +1005,11 @@ impl CurrentStorage {
                 )
             })?;
 
+        // Explicitly drop query_node before cloning the index Arc.
+        // While get_node() returns an owned Node (not a lock guard), this
+        // makes the lifetime scope explicit and matches the original code.
+        drop(query_node);
+
         let index = Arc::clone(&entry.value().index);
 
         Ok((index, query_vector))


### PR DESCRIPTION
Fixes #188: Removed unnecessary vector allocation in prepare_vector_search by using Arc clone instead of Vec clone.

Changes:
- Added PropertyValue::as_arc_vector() method that returns Arc<[f32]> instead of borrowing as &[f32]. This enables zero-copy access to the underlying vector data (O(1) refcount increment vs O(n) data copy).
- Updated prepare_vector_search to return Arc<[f32]> instead of Vec<f32>, using as_arc_vector() to avoid the to_vec() allocation.
- Added comprehensive tests for as_arc_vector() verifying:
  - Returns correct data
  - Shares underlying Arc (no copy)
  - Returns None for non-vector types

Performance improvement:
- 384-dim embeddings: saves ~1.5KB allocation per search
- 1536-dim embeddings: saves ~6KB allocation per search

The callers (find_similar, find_similar_with_label) continue to work unchanged because Arc<[f32]> implements Deref<Target=[f32]>.