### PR TITLE
feat(query): add query language parser with Cypher-like syntax

### DIFF
--- a/docs/guides/query-pipeline-guide.md
+++ b/docs/guides/query-pipeline-guide.md
@@ -1,0 +1,378 @@
+# Query Pipeline Guide
+
+This guide covers the complete GQL (Gallifrey Query Language) pipeline from parsing to execution.
+
+## Overview
+
+GallifreyDB provides a full query pipeline for executing Cypher-like queries with extensions for vector search and bi-temporal queries:
+
+```
+┌─────────────┐     ┌───────────┐     ┌───────────┐     ┌─────────┐     ┌──────────┐
+│ GQL String  │ ──► │  Parser   │ ──► │ Converter │ ──► │ Planner │ ──► │ Executor │
+│             │     │           │     │           │     │         │     │          │
+│ "MATCH..."  │     │ QueryAst  │     │  Query    │     │ Plan    │     │ Results  │
+└─────────────┘     └───────────┘     └───────────┘     └─────────┘     └──────────┘
+```
+
+## Quick Start
+
+### Basic Query Execution
+
+```rust
+use gallifreydb::query::{parse_query, QueryPlanner, QueryExecutor, Statistics};
+use gallifreydb::storage::{CurrentStorage, HistoricalStorage};
+use std::sync::{Arc, RwLock};
+
+// 1. Parse and convert the query
+let query = parse_query("MATCH (n:Person) WHERE n.age > 21 RETURN n LIMIT 10")?;
+
+// 2. Create storage and planner
+let current = Arc::new(CurrentStorage::new());
+let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+let stats = Arc::new(Statistics::default());
+let planner = QueryPlanner::new(stats, Arc::clone(&current));
+
+// 3. Plan the query
+let plan = planner.plan(query)?;
+
+// 4. Execute the plan
+let executor = QueryExecutor::new(Arc::clone(&current), Arc::clone(&historical));
+let results = executor.execute(&plan)?;
+
+// 5. Process results
+for row in results {
+    let row = row?;
+    println!("Found: {:?}", row.entity);
+}
+```
+
+## Query Types
+
+### 1. Graph Pattern Matching
+
+Match nodes by label:
+```cypher
+MATCH (n:Person) RETURN n
+```
+
+Match with relationships:
+```cypher
+-- Outgoing relationship
+MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b
+
+-- Incoming relationship
+MATCH (a:Person)<-[:FOLLOWS]-(b:Person) RETURN b
+
+-- Any direction
+MATCH (a:Person)-[:FRIENDS]-(b:Person) RETURN b
+```
+
+Variable-length paths:
+```cypher
+-- Exactly 2 hops
+MATCH (a:Person)-[:KNOWS*2]->(b:Person) RETURN b
+
+-- 1 to 3 hops
+MATCH (a:Person)-[:KNOWS*1..3]->(b:Person) RETURN b
+
+-- Any number of hops (use with caution)
+MATCH (a:Person)-[:KNOWS*]->(b:Person) RETURN b
+```
+
+### 2. Vector Search
+
+k-NN search with literal embedding:
+```cypher
+SIMILAR TO [0.1, 0.2, 0.3, ...] LIMIT 10
+```
+
+k-NN search with parameter:
+```rust
+let mut params = HashMap::new();
+params.insert("emb".to_string(),
+    ParameterValue::Embedding(Arc::from(embedding.as_slice())));
+
+let query = parse_query_with_params(
+    "SIMILAR TO $emb LIMIT 10",
+    params
+)?;
+```
+
+Find similar to existing node:
+```cypher
+FIND SIMILAR TO (123) LIMIT 5
+```
+
+Hybrid graph + vector:
+```cypher
+MATCH (n:Document) RANK BY SIMILARITY TO [0.1, 0.2, ...] TOP 10 RETURN n
+```
+
+### 3. Temporal Queries
+
+Point-in-time query (valid time only):
+```cypher
+AS OF 1704067200000000 MATCH (n:Person) RETURN n
+```
+
+Point-in-time query (valid time + transaction time):
+```cypher
+AS OF 1704067200000000, 1704153600000000 MATCH (n:Person) RETURN n
+```
+
+Time range query:
+```cypher
+BETWEEN 1704067200000000 AND 1704153600000000 MATCH (n:Person) RETURN n
+```
+
+**Note:** Timestamps are in microseconds since Unix epoch.
+
+### 4. Filtering (WHERE clause)
+
+Comparison operators:
+```cypher
+WHERE n.age > 21
+WHERE n.age >= 21
+WHERE n.age < 65
+WHERE n.age <= 65
+WHERE n.name = 'Alice'
+WHERE n.name <> 'Bob'
+```
+
+String predicates:
+```cypher
+WHERE n.bio CONTAINS 'engineer'
+WHERE n.name STARTS WITH 'A'
+WHERE n.email ENDS WITH '.com'
+```
+
+IN list:
+```cypher
+WHERE n.status IN ['active', 'pending', 'review']
+```
+
+Existence checks:
+```cypher
+WHERE EXISTS(n.email)
+WHERE n.deleted IS NULL
+WHERE n.verified IS NOT NULL
+```
+
+Logical operators:
+```cypher
+WHERE n.age > 21 AND n.active = true
+WHERE n.role = 'admin' OR n.role = 'moderator'
+WHERE NOT n.banned = true
+WHERE (n.age > 21 AND n.verified = true) OR n.role = 'admin'
+```
+
+### 5. Result Modifiers
+
+Projection:
+```cypher
+RETURN n                    -- Entire node
+RETURN n.name, n.age       -- Specific properties
+RETURN DISTINCT n          -- Deduplicate
+```
+
+Pagination:
+```cypher
+RETURN n LIMIT 10          -- First 10 results
+RETURN n SKIP 20 LIMIT 10  -- Results 21-30
+```
+
+## Pipeline Components
+
+### Parser (`gallifreydb::query::Parser`)
+
+Converts GQL strings to AST:
+
+```rust
+use gallifreydb::query::Parser;
+
+let ast = Parser::parse("MATCH (n:Person) RETURN n")?;
+println!("Source: {:?}", ast.source);
+println!("Return: {:?}", ast.return_clause);
+```
+
+### Converter (`gallifreydb::query::AstConverter`)
+
+Converts AST to Query (sequence of operations):
+
+```rust
+use gallifreydb::query::{Parser, AstConverter, ParameterValue};
+
+let ast = Parser::parse("SIMILAR TO $emb LIMIT 10")?;
+
+let mut converter = AstConverter::new();
+converter.bind("emb", ParameterValue::Embedding(embedding));
+
+let query = converter.convert(&ast)?;
+```
+
+### Planner (`gallifreydb::query::QueryPlanner`)
+
+Optimizes and creates physical execution plan:
+
+```rust
+use gallifreydb::query::{QueryPlanner, Statistics};
+use gallifreydb::storage::CurrentStorage;
+
+let storage = Arc::new(CurrentStorage::new());
+let stats = Arc::new(Statistics::default());
+let planner = QueryPlanner::new(stats, storage);
+
+let plan = planner.plan(query)?;
+
+// View the execution plan
+println!("{}", plan.explain());
+```
+
+### Executor (`gallifreydb::query::QueryExecutor`)
+
+Executes physical plans:
+
+```rust
+use gallifreydb::query::QueryExecutor;
+
+let executor = QueryExecutor::new(current_storage, historical_storage);
+let results = executor.execute(&plan)?;
+```
+
+## Parameters
+
+### Types of Parameters
+
+| Type | Usage | Example Binding |
+|------|-------|-----------------|
+| `Embedding` | `SIMILAR TO $emb` | `ParameterValue::Embedding(Arc::from(...))` |
+| `NodeId` | `FIND SIMILAR TO ($node)` | `ParameterValue::NodeId(NodeId::new(42)?)` |
+| `Value` | `WHERE n.x = $val` | `ParameterValue::Value(PredicateValue::Int(21))` |
+
+### Binding Parameters
+
+Method 1: Using `parse_query_with_params`:
+```rust
+let mut params = HashMap::new();
+params.insert("emb".to_string(), ParameterValue::Embedding(embedding));
+
+let query = parse_query_with_params("SIMILAR TO $emb LIMIT 10", params)?;
+```
+
+Method 2: Using `AstConverter::bind`:
+```rust
+let ast = Parser::parse("FIND SIMILAR TO ($node) LIMIT 5")?;
+
+let mut converter = AstConverter::new();
+converter
+    .bind("node", ParameterValue::NodeId(node_id))
+    .bind("other", ParameterValue::Value(PredicateValue::Int(42)));
+
+let query = converter.convert(&ast)?;
+```
+
+## Error Handling
+
+### Parse Errors
+
+```rust
+use gallifreydb::query::parse_query;
+
+match parse_query("MATCH (n:Person RETURN n") {
+    Ok(_) => unreachable!(),
+    Err(e) => {
+        // Error contains position and expected token
+        println!("Parse error: {}", e);
+    }
+}
+```
+
+### Conversion Errors
+
+```rust
+// Missing parameter
+let result = parse_query("SIMILAR TO $missing LIMIT 10");
+assert!(result.is_err());
+
+// Wrong parameter type
+let mut params = HashMap::new();
+params.insert("node".to_string(), ParameterValue::Value(PredicateValue::Int(42)));
+// Expected NodeId but got Value
+let result = parse_query_with_params("FIND SIMILAR TO ($node) LIMIT 5", params);
+assert!(result.is_err());
+```
+
+### Planning Errors
+
+```rust
+// Vector search without index
+let query = parse_query("SIMILAR TO [0.1, 0.2] LIMIT 10")?;
+let result = planner.plan(query);
+// May fail if no vector index exists
+```
+
+## Performance Tips
+
+1. **Use parameters** for repeated queries with different values
+2. **Add LIMIT** to avoid scanning entire dataset
+3. **Use labels** in MATCH patterns to filter early
+4. **Avoid variable-length paths** (`*`) without bounds
+5. **Place selective predicates first** in WHERE clauses
+
+## Complete Example
+
+```rust
+use gallifreydb::GallifreyDB;
+use gallifreydb::query::{
+    parse_query_with_params, ParameterValue,
+    QueryPlanner, QueryExecutor, Statistics
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn search_similar_documents(
+    db: &GallifreyDB,
+    query_embedding: Vec<f32>,
+    min_score: f64,
+    limit: usize,
+) -> Result<Vec<NodeId>, Error> {
+    // Build query with parameters
+    let mut params = HashMap::new();
+    params.insert(
+        "embedding".to_string(),
+        ParameterValue::Embedding(Arc::from(query_embedding.as_slice())),
+    );
+
+    let query = parse_query_with_params(
+        "SIMILAR TO $embedding LIMIT 100",
+        params,
+    )?;
+
+    // Plan and execute
+    let stats = Arc::new(Statistics::default());
+    let planner = QueryPlanner::new(stats, db.current_storage());
+    let plan = planner.plan(query)?;
+
+    let executor = QueryExecutor::new(
+        db.current_storage(),
+        db.historical_storage(),
+    );
+
+    // Collect results
+    let results = executor.execute(&plan)?;
+    let nodes: Vec<NodeId> = results
+        .filter_map(|r| r.ok())
+        .filter(|r| r.score.unwrap_or(0.0) >= min_score as f32)
+        .take(limit)
+        .filter_map(|r| r.entity.as_node_id())
+        .collect();
+
+    Ok(nodes)
+}
+```
+
+## See Also
+
+- [Query Language Design](../query-language-design.md) - Full grammar specification
+- [Vector Search Guide](vector-search-integration.md) - Detailed vector search documentation
+- [Hybrid Query Guide](hybrid-query-guide.md) - Graph + Vector hybrid queries

--- a/docs/query-language-design.md
+++ b/docs/query-language-design.md
@@ -1,0 +1,409 @@
+# Query Language Design for GallifreyDB
+
+This document describes the query language extensions for GallifreyDB, providing a Cypher-like syntax with support for vector search operations, bi-temporal queries, and hybrid graph-vector queries.
+
+## Overview
+
+GallifreyDB's query language (GQL - Gallifrey Query Language) extends the Cypher graph query language with:
+
+1. **Vector Search Operations**: Native k-NN search and similarity-based ranking
+2. **Bi-Temporal Queries**: Point-in-time and time-range queries
+3. **Hybrid Queries**: Unified syntax combining graph, vector, and temporal operations
+
+## Design Principles
+
+1. **Cypher Compatibility**: Familiar syntax for graph database users
+2. **Composability**: Operations can be freely combined
+3. **Explicit Semantics**: Clear behavior for all operations
+4. **Performance Hints**: Optional syntax for query optimization
+
+## Grammar Specification
+
+### EBNF Grammar
+
+```ebnf
+(* Top-level query *)
+query           = [ temporal_clause ]
+                  ( match_clause | vector_clause )
+                  { where_clause }
+                  [ return_clause ]
+                  [ order_clause ]
+                  [ skip_clause ]
+                  [ limit_clause ] ;
+
+(* Temporal Clauses *)
+temporal_clause = as_of_clause | between_clause ;
+as_of_clause    = "AS" "OF" timestamp [ "," timestamp ] ;
+between_clause  = "BETWEEN" timestamp "AND" timestamp ;
+timestamp       = string_literal | integer_literal ;
+
+(* Match Clause - Graph Pattern Matching *)
+match_clause    = "MATCH" pattern { "," pattern } ;
+pattern         = node_pattern { relationship_pattern node_pattern } ;
+node_pattern    = "(" [ identifier ] [ ":" label ] [ properties ] ")" ;
+relationship_pattern = "-[" [ identifier ] [ ":" label ] [ depth_spec ] "]->"
+                     | "<-[" [ identifier ] [ ":" label ] [ depth_spec ] "]-"
+                     | "-[" [ identifier ] [ ":" label ] [ depth_spec ] "]-" ;
+depth_spec      = "*" [ integer_literal [ ".." integer_literal ] ] ;
+properties      = "{" property_list "}" ;
+property_list   = property { "," property } ;
+property        = identifier ":" value ;
+
+(* Vector Clause - Similarity Search *)
+vector_clause   = "SIMILAR" "TO" embedding [ "USING" metric ] [ "LIMIT" integer_literal ]
+                | "FIND" "SIMILAR" "TO" "(" identifier ")" [ "LIMIT" integer_literal ] ;
+embedding       = parameter | "[" float_list "]" ;
+float_list      = float_literal { "," float_literal } ;
+metric          = "COSINE" | "EUCLIDEAN" | "DOT_PRODUCT" ;
+
+(* Where Clause - Filtering *)
+where_clause    = "WHERE" predicate ;
+predicate       = comparison
+                | existence_check
+                | string_predicate
+                | predicate "AND" predicate
+                | predicate "OR" predicate
+                | "NOT" predicate
+                | "(" predicate ")" ;
+comparison      = expression comp_op expression ;
+comp_op         = "=" | "<>" | "!=" | "<" | "<=" | ">" | ">=" | "IN" ;
+existence_check = "EXISTS" "(" identifier "." identifier ")"
+                | identifier "." identifier "IS" [ "NOT" ] "NULL" ;
+string_predicate = identifier "." identifier "CONTAINS" string_literal
+                 | identifier "." identifier "STARTS" "WITH" string_literal
+                 | identifier "." identifier "ENDS" "WITH" string_literal ;
+
+(* Expression *)
+expression      = property_access | literal | parameter | function_call ;
+property_access = identifier "." identifier ;
+literal         = string_literal | integer_literal | float_literal | boolean_literal | "NULL" ;
+parameter       = "$" identifier ;
+function_call   = identifier "(" [ expression { "," expression } ] ")" ;
+
+(* Return Clause - Projection *)
+return_clause   = "RETURN" return_item { "," return_item }
+                | "RETURN" "DISTINCT" return_item { "," return_item }
+                | "RETURN" "COUNT" "(" ( "*" | identifier ) ")" ;
+return_item     = expression [ "AS" identifier ] ;
+
+(* Order Clause - Sorting *)
+order_clause    = "ORDER" "BY" order_item { "," order_item } ;
+order_item      = expression [ "ASC" | "DESC" ] ;
+
+(* Skip and Limit Clauses *)
+skip_clause     = "SKIP" integer_literal ;
+limit_clause    = "LIMIT" integer_literal ;
+
+(* Hybrid Operations *)
+rank_clause     = "RANK" "BY" "SIMILARITY" "TO" embedding [ "TOP" integer_literal ] ;
+
+(* Identifiers and Literals *)
+identifier      = letter { letter | digit | "_" } ;
+label           = identifier ;
+string_literal  = "'" { character } "'" | '"' { character } '"' ;
+integer_literal = [ "-" ] digit { digit } ;
+float_literal   = [ "-" ] digit { digit } "." digit { digit } [ exponent ] ;
+exponent        = ( "e" | "E" ) [ "+" | "-" ] digit { digit } ;
+boolean_literal = "true" | "false" | "TRUE" | "FALSE" ;
+letter          = "A" | ... | "Z" | "a" | ... | "z" ;
+digit           = "0" | ... | "9" ;
+```
+
+## Query Examples
+
+### Basic Graph Queries
+
+```cypher
+-- Find a person by name
+MATCH (n:Person {name: "Alice"})
+RETURN n
+
+-- Find friends of Alice
+MATCH (a:Person {name: "Alice"})-[:KNOWS]->(friend:Person)
+RETURN friend
+
+-- Multi-hop traversal (friends of friends)
+MATCH (a:Person {name: "Alice"})-[:KNOWS*2]->(friend)
+RETURN friend
+
+-- Variable depth traversal (1 to 3 hops)
+MATCH (a:Person {name: "Alice"})-[:KNOWS*1..3]->(connection)
+RETURN DISTINCT connection
+```
+
+### Vector Search Queries
+
+```cypher
+-- Find 10 most similar nodes to an embedding
+SIMILAR TO $embedding LIMIT 10
+
+-- Find similar with specific metric
+SIMILAR TO [0.1, 0.2, 0.3, ...] USING COSINE LIMIT 10
+
+-- Find nodes similar to another node
+FIND SIMILAR TO (node_id) LIMIT 10
+```
+
+### Hybrid Graph + Vector Queries
+
+```cypher
+-- Find Alice's friends ranked by similarity to Bob
+MATCH (a:Person {name: "Alice"})-[:KNOWS]->(friend)
+RANK BY SIMILARITY TO $bob_embedding TOP 10
+RETURN friend
+
+-- Find documents similar to a query, then get their authors
+SIMILAR TO $query_embedding LIMIT 20
+MATCH (doc)<-[:WROTE]-(author:Person)
+RETURN author, doc
+
+-- Find similar content within a specific category
+MATCH (doc:Document)-[:IN_CATEGORY]->(cat:Category {name: "Science"})
+RANK BY SIMILARITY TO $embedding TOP 10
+RETURN doc
+```
+
+### Bi-Temporal Queries
+
+```cypher
+-- Point-in-time query (valid time only)
+AS OF '2024-01-15T10:00:00Z'
+MATCH (n:Person {name: "Alice"})
+RETURN n
+
+-- Bi-temporal query (valid time, transaction time)
+AS OF '2024-01-15T10:00:00Z', '2024-01-20T00:00:00Z'
+MATCH (n:Person {name: "Alice"})
+RETURN n
+
+-- Time range query
+BETWEEN '2024-01-01T00:00:00Z' AND '2024-12-31T23:59:59Z'
+MATCH (n:Person {name: "Alice"})
+RETURN n
+```
+
+### Temporal + Vector Queries
+
+```cypher
+-- What was similar to this embedding in 2023?
+AS OF '2023-06-15T00:00:00Z'
+SIMILAR TO $embedding LIMIT 10
+
+-- Track how similar documents changed over time
+BETWEEN '2024-01-01' AND '2024-06-30'
+MATCH (doc:Document {id: 123})
+RETURN doc
+```
+
+### Complex Hybrid Queries
+
+```cypher
+-- Full hybrid: temporal + graph + vector
+AS OF '2024-06-01T00:00:00Z'
+MATCH (user:User {id: $user_id})-[:VIEWED]->(item:Product)
+RANK BY SIMILARITY TO $recommendation_embedding TOP 20
+WHERE item.price < 100
+RETURN item, item.name, item.price
+ORDER BY score DESC
+LIMIT 10
+```
+
+## Semantic Mapping
+
+### Query to Internal IR Mapping
+
+| Query Clause | IR Operation |
+|--------------|--------------|
+| `MATCH (n:Label)` | `QueryOp::ScanNodes { label: Some("Label") }` |
+| `MATCH (n {id: X})` | `QueryOp::StartNode(NodeId)` |
+| `-[:REL]->` | `QueryOp::TraverseOut { label: Some("REL"), depth: Exact(1) }` |
+| `<-[:REL]-` | `QueryOp::TraverseIn { ... }` |
+| `-[:REL]-` | `QueryOp::TraverseBoth { ... }` |
+| `-[:REL*N]-` | `QueryOp::TraverseOut { ..., depth: Exact(N) }` |
+| `-[:REL*M..N]-` | `QueryOp::TraverseOut { ..., depth: Range { min: M, max: N } }` |
+| `SIMILAR TO $emb LIMIT K` | `QueryOp::VectorSearch { ..., k: K }` |
+| `RANK BY SIMILARITY` | `QueryOp::RankBySimilarity { ... }` |
+| `AS OF T1, T2` | `QueryOp::AsOf { valid_time: T1, transaction_time: T2 }` |
+| `BETWEEN T1 AND T2` | `QueryOp::Between { time_range: ... }` |
+| `WHERE pred` | `QueryOp::Filter(Predicate)` |
+| `LIMIT N` | `QueryOp::Limit(N)` |
+| `SKIP N` | `QueryOp::Skip(N)` |
+| `RETURN DISTINCT` | `QueryOp::Distinct` |
+| `RETURN COUNT(*)` | `QueryOp::Count` |
+| `RETURN a, b` | `QueryOp::Project(vec!["a", "b"])` |
+
+### Predicate Mapping
+
+| Query Predicate | IR Predicate |
+|-----------------|--------------|
+| `n.prop = value` | `Predicate::Eq { key, value }` |
+| `n.prop <> value` | `Predicate::Ne { key, value }` |
+| `n.prop > value` | `Predicate::Gt { key, value }` |
+| `n.prop >= value` | `Predicate::Gte { key, value }` |
+| `n.prop < value` | `Predicate::Lt { key, value }` |
+| `n.prop <= value` | `Predicate::Lte { key, value }` |
+| `n.prop IN [...]` | `Predicate::In { key, values }` |
+| `n.prop CONTAINS str` | `Predicate::Contains { key, substring }` |
+| `n.prop STARTS WITH str` | `Predicate::StartsWith { key, prefix }` |
+| `n.prop ENDS WITH str` | `Predicate::EndsWith { key, suffix }` |
+| `EXISTS(n.prop)` | `Predicate::Exists(key)` |
+| `n.prop IS NULL` | `Predicate::NotExists(key)` |
+| `p1 AND p2` | `Predicate::And(vec![p1, p2])` |
+| `p1 OR p2` | `Predicate::Or(vec![p1, p2])` |
+| `NOT p` | `Predicate::Not(Box::new(p))` |
+
+## Parser Architecture
+
+The parser consists of three main components:
+
+### 1. Lexer (`src/query/lexer.rs`)
+
+Tokenizes input into a stream of tokens:
+
+```rust
+pub enum Token {
+    // Keywords
+    Match, Where, Return, Order, By, Limit, Skip,
+    As, Of, Between, And, Or, Not, In, Is, Null,
+    Similar, To, Using, Find, Rank, Similarity, Top,
+    Distinct, Count, Asc, Desc, True, False,
+    Exists, Contains, Starts, Ends, With,
+    Cosine, Euclidean, DotProduct,
+
+    // Punctuation
+    LeftParen, RightParen,
+    LeftBracket, RightBracket,
+    LeftBrace, RightBrace,
+    Colon, Comma, Dot, Star, Arrow, LeftArrow, Dash,
+
+    // Operators
+    Eq, Ne, Lt, Le, Gt, Ge,
+
+    // Literals
+    Identifier(String),
+    StringLiteral(String),
+    IntegerLiteral(i64),
+    FloatLiteral(f64),
+    Parameter(String),
+
+    // End
+    Eof,
+}
+```
+
+### 2. AST (`src/query/ast.rs`)
+
+Abstract Syntax Tree representing parsed queries:
+
+```rust
+pub struct QueryAst {
+    pub temporal: Option<TemporalClause>,
+    pub source: SourceClause,
+    pub where_clauses: Vec<WhereClause>,
+    pub return_clause: Option<ReturnClause>,
+    pub order: Option<OrderClause>,
+    pub skip: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+pub enum SourceClause {
+    Match(Vec<Pattern>),
+    VectorSearch { embedding: Embedding, metric: Option<DistanceMetric>, limit: usize },
+    FindSimilar { node_ref: NodeRef, limit: usize },
+}
+```
+
+### 3. Parser (`src/query/parser.rs`)
+
+Recursive descent parser that produces AST from tokens:
+
+```rust
+pub struct Parser {
+    tokens: Vec<Token>,
+    position: usize,
+}
+
+impl Parser {
+    pub fn parse(input: &str) -> Result<QueryAst, ParseError>;
+}
+```
+
+## Error Handling
+
+The parser provides descriptive error messages:
+
+```rust
+pub enum ParseError {
+    UnexpectedToken { expected: String, found: Token, position: usize },
+    UnexpectedEof { expected: String },
+    InvalidNumber { value: String, position: usize },
+    InvalidEmbedding { reason: String, position: usize },
+    InvalidPattern { reason: String, position: usize },
+    UnknownKeyword { keyword: String, position: usize },
+}
+```
+
+Example error messages:
+
+```
+Error: Unexpected token at position 15
+  Expected: RETURN or LIMIT clause
+  Found: 'UNKNOWN'
+
+  MATCH (n:Person) UNKNOWN ...
+                   ^^^^^^^
+```
+
+## Future Extensions
+
+### SQL:2011 Temporal Syntax
+
+Support for standard temporal SQL syntax:
+
+```sql
+-- System time (transaction time)
+SELECT * FROM Person FOR SYSTEM_TIME AS OF '2024-01-01'
+
+-- Application time (valid time)
+SELECT * FROM Person FOR APPLICATION_TIME AS OF '2024-01-01'
+```
+
+### Path Patterns
+
+Support for complex path expressions:
+
+```cypher
+-- Named paths
+MATCH path = (a)-[:KNOWS*]-(b)
+RETURN path
+
+-- Path predicates
+MATCH (a)-[path:KNOWS*]-(b)
+WHERE length(path) > 3
+RETURN a, b
+```
+
+### Graph Algorithms
+
+Built-in support for common graph algorithms:
+
+```cypher
+-- Shortest path
+MATCH shortestPath((a:Person)-[:KNOWS*]-(b:Person))
+WHERE a.name = 'Alice' AND b.name = 'Bob'
+RETURN path
+
+-- PageRank
+CALL pageRank('Person', 'KNOWS')
+YIELD node, score
+RETURN node.name, score
+ORDER BY score DESC
+LIMIT 10
+```
+
+## References
+
+- [openCypher Specification](https://opencypher.org/)
+- [GQL Standard (ISO/IEC 39075)](https://www.gqlstandards.org/)
+- [SQL:2011 Temporal Features](https://en.wikipedia.org/wiki/SQL:2011)
+- [XTDB Bi-temporality](https://v1-docs.xtdb.com/concepts/bitemporality/)

--- a/docs/query-language-design.md
+++ b/docs/query-language-design.md
@@ -299,7 +299,8 @@ Abstract Syntax Tree representing parsed queries:
 pub struct QueryAst {
     pub temporal: Option<TemporalClause>,
     pub source: SourceClause,
-    pub where_clauses: Vec<WhereClause>,
+    pub rank: Option<RankClause>,
+    pub where_clause: Option<WhereClause>,  // Single optional WHERE clause
     pub return_clause: Option<ReturnClause>,
     pub order: Option<OrderClause>,
     pub skip: Option<usize>,
@@ -308,7 +309,7 @@ pub struct QueryAst {
 
 pub enum SourceClause {
     Match(Vec<Pattern>),
-    VectorSearch { embedding: Embedding, metric: Option<DistanceMetric>, limit: usize },
+    VectorSearch { embedding: EmbeddingRef, metric: Option<DistanceMetric>, limit: usize },
     FindSimilar { node_ref: NodeRef, limit: usize },
 }
 ```

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -129,9 +129,12 @@ pub enum TemporalClause {
 /// A timestamp literal (string or integer).
 #[derive(Debug, Clone, PartialEq)]
 pub enum TimestampLiteral {
-    /// ISO 8601 string: '2024-01-15T10:00:00Z'
+    /// String timestamp - currently parsed as integer microseconds.
+    /// Example: '1704067200000000'
+    /// Note: ISO 8601 string parsing (e.g., '2024-01-15T10:00:00Z')
+    /// is not yet implemented.
     String(String),
-    /// Unix timestamp in milliseconds
+    /// Unix timestamp in microseconds (not milliseconds)
     Integer(i64),
 }
 
@@ -362,16 +365,13 @@ impl DepthSpec {
 
     /// Create a range depth.
     ///
-    /// # Panics
-    /// Panics if `min > max`.
-    pub fn range(min: usize, max: usize) -> Self {
-        assert!(
-            min <= max,
-            "DepthSpec range min ({}) must be <= max ({})",
-            min,
-            max
-        );
-        DepthSpec::Range { min, max }
+    /// # Errors
+    /// Returns an error if `min > max`.
+    pub fn range(min: usize, max: usize) -> Result<Self, &'static str> {
+        if min > max {
+            return Err("DepthSpec range min must be <= max");
+        }
+        Ok(DepthSpec::Range { min, max })
     }
 }
 
@@ -664,15 +664,6 @@ impl ReturnItem {
     }
 }
 
-/// COUNT(*) or COUNT(expr) return.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CountExpr {
-    /// COUNT(*)
-    All,
-    /// COUNT(expr)
-    Expression(Expression),
-}
-
 /// ORDER BY clause.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OrderClause {
@@ -841,7 +832,7 @@ mod tests {
     fn test_relationship_pattern_with_depth() {
         let rel = RelationshipPattern::outgoing()
             .with_type("KNOWS")
-            .with_depth(DepthSpec::range(1, 3));
+            .with_depth(DepthSpec::range(1, 3).unwrap());
         assert_eq!(rel.depth, Some(DepthSpec::Range { min: 1, max: 3 }));
     }
 
@@ -1013,6 +1004,10 @@ mod tests {
     fn test_depth_spec() {
         assert_eq!(DepthSpec::one(), DepthSpec::Exact(1));
         assert_eq!(DepthSpec::exact(3), DepthSpec::Exact(3));
-        assert_eq!(DepthSpec::range(1, 5), DepthSpec::Range { min: 1, max: 5 });
+        assert_eq!(
+            DepthSpec::range(1, 5).unwrap(),
+            DepthSpec::Range { min: 1, max: 5 }
+        );
+        assert!(DepthSpec::range(5, 1).is_err()); // min > max should fail
     }
 }

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -1,0 +1,1007 @@
+//! Abstract Syntax Tree for GQL (Gallifrey Query Language)
+//!
+//! This module defines the AST types that represent parsed GQL queries.
+//! The AST is produced by the parser and consumed by the query planner
+//! to generate a logical query plan.
+
+use std::sync::Arc;
+
+use crate::index::vector::DistanceMetric;
+
+/// A complete GQL query.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryAst {
+    /// Optional temporal clause (AS OF or BETWEEN)
+    pub temporal: Option<TemporalClause>,
+    /// Main query source (MATCH or vector search)
+    pub source: SourceClause,
+    /// Optional ranking clause (RANK BY SIMILARITY)
+    pub rank: Option<RankClause>,
+    /// WHERE predicates
+    pub where_clause: Option<WhereClause>,
+    /// RETURN clause
+    pub return_clause: Option<ReturnClause>,
+    /// ORDER BY clause
+    pub order: Option<OrderClause>,
+    /// SKIP clause
+    pub skip: Option<usize>,
+    /// LIMIT clause
+    pub limit: Option<usize>,
+}
+
+impl QueryAst {
+    /// Create a new query AST with the given source clause.
+    pub fn new(source: SourceClause) -> Self {
+        QueryAst {
+            temporal: None,
+            source,
+            rank: None,
+            where_clause: None,
+            return_clause: None,
+            order: None,
+            skip: None,
+            limit: None,
+        }
+    }
+
+    /// Add a temporal clause to the query.
+    #[must_use]
+    pub fn with_temporal(mut self, temporal: TemporalClause) -> Self {
+        self.temporal = Some(temporal);
+        self
+    }
+
+    /// Add a rank clause to the query.
+    #[must_use]
+    pub fn with_rank(mut self, rank: RankClause) -> Self {
+        self.rank = Some(rank);
+        self
+    }
+
+    /// Add a WHERE clause to the query.
+    #[must_use]
+    pub fn with_where(mut self, where_clause: WhereClause) -> Self {
+        self.where_clause = Some(where_clause);
+        self
+    }
+
+    /// Add a RETURN clause to the query.
+    #[must_use]
+    pub fn with_return(mut self, return_clause: ReturnClause) -> Self {
+        self.return_clause = Some(return_clause);
+        self
+    }
+
+    /// Add an ORDER BY clause to the query.
+    #[must_use]
+    pub fn with_order(mut self, order: OrderClause) -> Self {
+        self.order = Some(order);
+        self
+    }
+
+    /// Add a SKIP clause to the query.
+    #[must_use]
+    pub fn with_skip(mut self, skip: usize) -> Self {
+        self.skip = Some(skip);
+        self
+    }
+
+    /// Add a LIMIT clause to the query.
+    #[must_use]
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Check if this query has temporal context.
+    pub fn is_temporal(&self) -> bool {
+        self.temporal.is_some()
+    }
+
+    /// Check if this query involves vector operations.
+    pub fn has_vector_ops(&self) -> bool {
+        matches!(
+            self.source,
+            SourceClause::VectorSearch { .. } | SourceClause::FindSimilar { .. }
+        ) || self.rank.is_some()
+    }
+}
+
+/// Temporal clause for time-travel queries.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TemporalClause {
+    /// AS OF timestamp [, transaction_time]
+    AsOf {
+        /// Valid time
+        valid_time: TimestampLiteral,
+        /// Optional transaction time
+        transaction_time: Option<TimestampLiteral>,
+    },
+    /// BETWEEN start AND end
+    Between {
+        /// Start time
+        start: TimestampLiteral,
+        /// End time
+        end: TimestampLiteral,
+    },
+}
+
+/// A timestamp literal (string or integer).
+#[derive(Debug, Clone, PartialEq)]
+pub enum TimestampLiteral {
+    /// ISO 8601 string: '2024-01-15T10:00:00Z'
+    String(String),
+    /// Unix timestamp in milliseconds
+    Integer(i64),
+}
+
+/// Main source clause of a query.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SourceClause {
+    /// MATCH pattern
+    Match(Vec<Pattern>),
+    /// SIMILAR TO embedding
+    VectorSearch {
+        /// The embedding to search for (parameter or literal)
+        embedding: EmbeddingRef,
+        /// Distance metric (optional, defaults to Cosine)
+        metric: Option<DistanceMetric>,
+        /// Result limit
+        limit: usize,
+    },
+    /// FIND SIMILAR TO (node_ref)
+    FindSimilar {
+        /// Reference to the source node
+        node_ref: NodeRef,
+        /// Result limit
+        limit: usize,
+    },
+}
+
+/// An embedding reference (parameter or literal array).
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmbeddingRef {
+    /// Parameter reference: $embedding
+    Parameter(String),
+    /// Literal array: [0.1, 0.2, 0.3, ...]
+    Literal(Arc<[f32]>),
+}
+
+/// A reference to a node.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NodeRef {
+    /// Reference by identifier: (n)
+    Identifier(String),
+    /// Reference by ID: (123)
+    Id(u64),
+    /// Reference by parameter: ($node_id)
+    Parameter(String),
+}
+
+/// A graph pattern in a MATCH clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pattern {
+    /// Sequence of pattern elements (nodes and relationships)
+    pub elements: Vec<PatternElement>,
+}
+
+impl Pattern {
+    /// Create a new pattern with a single node.
+    pub fn node(node: NodePattern) -> Self {
+        Pattern {
+            elements: vec![PatternElement::Node(node)],
+        }
+    }
+
+    /// Add a relationship and node to the pattern.
+    #[must_use]
+    pub fn then(mut self, rel: RelationshipPattern, node: NodePattern) -> Self {
+        self.elements.push(PatternElement::Relationship(rel));
+        self.elements.push(PatternElement::Node(node));
+        self
+    }
+}
+
+/// An element in a pattern (either a node or relationship).
+#[derive(Debug, Clone, PartialEq)]
+pub enum PatternElement {
+    /// A node pattern: (n:Label {props})
+    Node(NodePattern),
+    /// A relationship pattern: -[:REL]->
+    Relationship(RelationshipPattern),
+}
+
+/// A node pattern.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodePattern {
+    /// Optional variable binding
+    pub variable: Option<String>,
+    /// Optional label
+    pub label: Option<String>,
+    /// Optional inline properties
+    pub properties: Option<PropertyMap>,
+}
+
+impl NodePattern {
+    /// Create an empty node pattern: ()
+    pub fn empty() -> Self {
+        NodePattern {
+            variable: None,
+            label: None,
+            properties: None,
+        }
+    }
+
+    /// Create a node pattern with just a variable: (n)
+    pub fn var(name: impl Into<String>) -> Self {
+        NodePattern {
+            variable: Some(name.into()),
+            label: None,
+            properties: None,
+        }
+    }
+
+    /// Create a node pattern with variable and label: (n:Person)
+    pub fn with_label(name: impl Into<String>, label: impl Into<String>) -> Self {
+        NodePattern {
+            variable: Some(name.into()),
+            label: Some(label.into()),
+            properties: None,
+        }
+    }
+
+    /// Add properties to the pattern.
+    #[must_use]
+    pub fn with_properties(mut self, properties: PropertyMap) -> Self {
+        self.properties = Some(properties);
+        self
+    }
+}
+
+/// A relationship pattern.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelationshipPattern {
+    /// Optional variable binding
+    pub variable: Option<String>,
+    /// Optional relationship type (label)
+    pub rel_type: Option<String>,
+    /// Direction of the relationship
+    pub direction: RelationshipDirection,
+    /// Depth specification for variable-length paths
+    pub depth: Option<DepthSpec>,
+}
+
+impl RelationshipPattern {
+    /// Create an outgoing relationship: -[]->(
+    pub fn outgoing() -> Self {
+        RelationshipPattern {
+            variable: None,
+            rel_type: None,
+            direction: RelationshipDirection::Outgoing,
+            depth: None,
+        }
+    }
+
+    /// Create an incoming relationship: <-[]-
+    pub fn incoming() -> Self {
+        RelationshipPattern {
+            variable: None,
+            rel_type: None,
+            direction: RelationshipDirection::Incoming,
+            depth: None,
+        }
+    }
+
+    /// Create a bidirectional relationship: -[]-
+    pub fn both() -> Self {
+        RelationshipPattern {
+            variable: None,
+            rel_type: None,
+            direction: RelationshipDirection::Both,
+            depth: None,
+        }
+    }
+
+    /// Add a relationship type: -[:KNOWS]->
+    #[must_use]
+    pub fn with_type(mut self, rel_type: impl Into<String>) -> Self {
+        self.rel_type = Some(rel_type.into());
+        self
+    }
+
+    /// Add a variable binding: -[r:KNOWS]->
+    #[must_use]
+    pub fn with_variable(mut self, var: impl Into<String>) -> Self {
+        self.variable = Some(var.into());
+        self
+    }
+
+    /// Add a depth specification: -[:KNOWS*1..3]->
+    #[must_use]
+    pub fn with_depth(mut self, depth: DepthSpec) -> Self {
+        self.depth = Some(depth);
+        self
+    }
+}
+
+/// Direction of a relationship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationshipDirection {
+    /// Outgoing: ->
+    Outgoing,
+    /// Incoming: <-
+    Incoming,
+    /// Both: - (undirected)
+    Both,
+}
+
+/// Depth specification for variable-length paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum DepthSpec {
+    /// Exactly N hops: *N
+    Exact(usize),
+    /// Up to N hops: *..N
+    Max(usize),
+    /// Range of hops: *M..N
+    Range { min: usize, max: usize },
+    /// Unbounded: *
+    Variable,
+}
+
+impl DepthSpec {
+    /// Create a single-hop depth.
+    pub fn one() -> Self {
+        DepthSpec::Exact(1)
+    }
+
+    /// Create an exact depth.
+    pub fn exact(n: usize) -> Self {
+        DepthSpec::Exact(n)
+    }
+
+    /// Create a range depth.
+    pub fn range(min: usize, max: usize) -> Self {
+        DepthSpec::Range { min, max }
+    }
+}
+
+/// A map of properties for inline property matching.
+pub type PropertyMap = Vec<(String, PropertyValue)>;
+
+/// A property value in a pattern or predicate.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PropertyValue {
+    /// Null value
+    Null,
+    /// Boolean value
+    Bool(bool),
+    /// Integer value
+    Int(i64),
+    /// Float value
+    Float(f64),
+    /// String value
+    String(String),
+    /// Parameter reference
+    Parameter(String),
+}
+
+impl From<bool> for PropertyValue {
+    fn from(v: bool) -> Self {
+        PropertyValue::Bool(v)
+    }
+}
+
+impl From<i64> for PropertyValue {
+    fn from(v: i64) -> Self {
+        PropertyValue::Int(v)
+    }
+}
+
+impl From<f64> for PropertyValue {
+    fn from(v: f64) -> Self {
+        PropertyValue::Float(v)
+    }
+}
+
+impl From<String> for PropertyValue {
+    fn from(v: String) -> Self {
+        PropertyValue::String(v)
+    }
+}
+
+impl From<&str> for PropertyValue {
+    fn from(v: &str) -> Self {
+        PropertyValue::String(v.to_string())
+    }
+}
+
+/// RANK BY SIMILARITY clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankClause {
+    /// The embedding to rank by
+    pub embedding: EmbeddingRef,
+    /// Optional TOP k limit
+    pub top_k: Option<usize>,
+}
+
+/// WHERE clause containing a predicate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WhereClause {
+    /// The predicate expression
+    pub predicate: PredicateExpr,
+}
+
+/// A predicate expression.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(missing_docs)]
+pub enum PredicateExpr {
+    /// Comparison: n.prop = value
+    Comparison {
+        left: Expression,
+        op: ComparisonOp,
+        right: Expression,
+    },
+    /// Existence check: EXISTS(n.prop)
+    Exists(PropertyAccess),
+    /// NULL check: n.prop IS NULL
+    IsNull(PropertyAccess),
+    /// NOT NULL check: n.prop IS NOT NULL
+    IsNotNull(PropertyAccess),
+    /// String contains: n.prop CONTAINS 'str'
+    Contains {
+        property: PropertyAccess,
+        substring: String,
+    },
+    /// String starts with: n.prop STARTS WITH 'str'
+    StartsWith {
+        property: PropertyAccess,
+        prefix: String,
+    },
+    /// String ends with: n.prop ENDS WITH 'str'
+    EndsWith {
+        property: PropertyAccess,
+        suffix: String,
+    },
+    /// IN list: n.prop IN [1, 2, 3]
+    In {
+        property: PropertyAccess,
+        values: Vec<PropertyValue>,
+    },
+    /// Logical AND
+    And(Box<PredicateExpr>, Box<PredicateExpr>),
+    /// Logical OR
+    Or(Box<PredicateExpr>, Box<PredicateExpr>),
+    /// Logical NOT
+    Not(Box<PredicateExpr>),
+    /// Parenthesized expression
+    Grouped(Box<PredicateExpr>),
+}
+
+impl PredicateExpr {
+    /// Create an equality comparison.
+    pub fn eq(left: Expression, right: Expression) -> Self {
+        PredicateExpr::Comparison {
+            left,
+            op: ComparisonOp::Eq,
+            right,
+        }
+    }
+
+    /// Create a greater-than comparison.
+    pub fn gt(left: Expression, right: Expression) -> Self {
+        PredicateExpr::Comparison {
+            left,
+            op: ComparisonOp::Gt,
+            right,
+        }
+    }
+
+    /// Combine with AND.
+    pub fn and(self, other: PredicateExpr) -> Self {
+        PredicateExpr::And(Box::new(self), Box::new(other))
+    }
+
+    /// Combine with OR.
+    pub fn or(self, other: PredicateExpr) -> Self {
+        PredicateExpr::Or(Box::new(self), Box::new(other))
+    }
+
+    /// Negate this predicate.
+    pub fn negate(self) -> Self {
+        PredicateExpr::Not(Box::new(self))
+    }
+}
+
+impl std::ops::Not for PredicateExpr {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        PredicateExpr::Not(Box::new(self))
+    }
+}
+
+/// Comparison operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparisonOp {
+    /// =
+    Eq,
+    /// <> or !=
+    Ne,
+    /// <
+    Lt,
+    /// <=
+    Le,
+    /// >
+    Gt,
+    /// >=
+    Ge,
+}
+
+/// An expression (used in comparisons and projections).
+#[derive(Debug, Clone, PartialEq)]
+#[allow(missing_docs)]
+pub enum Expression {
+    /// Property access: n.prop
+    Property(PropertyAccess),
+    /// Literal value
+    Literal(PropertyValue),
+    /// Parameter: $param
+    Parameter(String),
+    /// Function call: func(args)
+    FunctionCall { name: String, args: Vec<Expression> },
+}
+
+impl Expression {
+    /// Create a property access expression.
+    pub fn property(var: impl Into<String>, prop: impl Into<String>) -> Self {
+        Expression::Property(PropertyAccess {
+            variable: var.into(),
+            property: prop.into(),
+        })
+    }
+
+    /// Create a literal expression.
+    pub fn literal(value: PropertyValue) -> Self {
+        Expression::Literal(value)
+    }
+
+    /// Create an integer literal expression.
+    pub fn int(value: i64) -> Self {
+        Expression::Literal(PropertyValue::Int(value))
+    }
+
+    /// Create a string literal expression.
+    pub fn string(value: impl Into<String>) -> Self {
+        Expression::Literal(PropertyValue::String(value.into()))
+    }
+
+    /// Create a parameter expression.
+    pub fn param(name: impl Into<String>) -> Self {
+        Expression::Parameter(name.into())
+    }
+}
+
+/// Property access: variable.property
+#[derive(Debug, Clone, PartialEq)]
+pub struct PropertyAccess {
+    /// Variable name
+    pub variable: String,
+    /// Property name
+    pub property: String,
+}
+
+impl PropertyAccess {
+    /// Create a new property access.
+    pub fn new(variable: impl Into<String>, property: impl Into<String>) -> Self {
+        PropertyAccess {
+            variable: variable.into(),
+            property: property.into(),
+        }
+    }
+}
+
+/// RETURN clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReturnClause {
+    /// Return items
+    pub items: Vec<ReturnItem>,
+    /// DISTINCT modifier
+    pub distinct: bool,
+}
+
+impl ReturnClause {
+    /// Create a new RETURN clause.
+    pub fn new(items: Vec<ReturnItem>) -> Self {
+        ReturnClause {
+            items,
+            distinct: false,
+        }
+    }
+
+    /// Add DISTINCT modifier.
+    #[must_use]
+    pub fn distinct(mut self) -> Self {
+        self.distinct = true;
+        self
+    }
+}
+
+/// An item in a RETURN clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReturnItem {
+    /// The expression to return
+    pub expression: Expression,
+    /// Optional alias: AS alias
+    pub alias: Option<String>,
+}
+
+impl ReturnItem {
+    /// Create a new return item.
+    pub fn new(expression: Expression) -> Self {
+        ReturnItem {
+            expression,
+            alias: None,
+        }
+    }
+
+    /// Add an alias.
+    #[must_use]
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+}
+
+/// COUNT(*) or COUNT(expr) return.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CountExpr {
+    /// COUNT(*)
+    All,
+    /// COUNT(expr)
+    Expression(Expression),
+}
+
+/// ORDER BY clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderClause {
+    /// Order items
+    pub items: Vec<OrderItem>,
+}
+
+impl OrderClause {
+    /// Create a new ORDER BY clause.
+    pub fn new(items: Vec<OrderItem>) -> Self {
+        OrderClause { items }
+    }
+}
+
+/// An item in an ORDER BY clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderItem {
+    /// Expression to order by
+    pub expression: Expression,
+    /// Sort direction (true = descending)
+    pub descending: bool,
+}
+
+impl OrderItem {
+    /// Create an ascending order item.
+    pub fn asc(expression: Expression) -> Self {
+        OrderItem {
+            expression,
+            descending: false,
+        }
+    }
+
+    /// Create a descending order item.
+    pub fn desc(expression: Expression) -> Self {
+        OrderItem {
+            expression,
+            descending: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =====================================================
+    // QueryAst Tests
+    // =====================================================
+
+    #[test]
+    fn test_query_ast_new() {
+        let source = SourceClause::Match(vec![Pattern::node(NodePattern::var("n"))]);
+        let query = QueryAst::new(source);
+
+        assert!(query.temporal.is_none());
+        assert!(query.rank.is_none());
+        assert!(query.where_clause.is_none());
+        assert!(query.return_clause.is_none());
+        assert!(query.order.is_none());
+        assert!(query.skip.is_none());
+        assert!(query.limit.is_none());
+    }
+
+    #[test]
+    fn test_query_ast_with_temporal() {
+        let source = SourceClause::Match(vec![Pattern::node(NodePattern::var("n"))]);
+        let query = QueryAst::new(source).with_temporal(TemporalClause::AsOf {
+            valid_time: TimestampLiteral::String("2024-01-15".to_string()),
+            transaction_time: None,
+        });
+
+        assert!(query.is_temporal());
+    }
+
+    #[test]
+    fn test_query_ast_has_vector_ops() {
+        // Vector search
+        let query = QueryAst::new(SourceClause::VectorSearch {
+            embedding: EmbeddingRef::Parameter("emb".to_string()),
+            metric: None,
+            limit: 10,
+        });
+        assert!(query.has_vector_ops());
+
+        // Find similar
+        let query = QueryAst::new(SourceClause::FindSimilar {
+            node_ref: NodeRef::Identifier("n".to_string()),
+            limit: 10,
+        });
+        assert!(query.has_vector_ops());
+
+        // Match with rank
+        let query = QueryAst::new(SourceClause::Match(vec![Pattern::node(NodePattern::var(
+            "n",
+        ))]))
+        .with_rank(RankClause {
+            embedding: EmbeddingRef::Parameter("emb".to_string()),
+            top_k: Some(10),
+        });
+        assert!(query.has_vector_ops());
+
+        // Plain match
+        let query = QueryAst::new(SourceClause::Match(vec![Pattern::node(NodePattern::var(
+            "n",
+        ))]));
+        assert!(!query.has_vector_ops());
+    }
+
+    // =====================================================
+    // Pattern Tests
+    // =====================================================
+
+    #[test]
+    fn test_node_pattern_empty() {
+        let node = NodePattern::empty();
+        assert!(node.variable.is_none());
+        assert!(node.label.is_none());
+        assert!(node.properties.is_none());
+    }
+
+    #[test]
+    fn test_node_pattern_var() {
+        let node = NodePattern::var("n");
+        assert_eq!(node.variable, Some("n".to_string()));
+        assert!(node.label.is_none());
+    }
+
+    #[test]
+    fn test_node_pattern_with_label() {
+        let node = NodePattern::with_label("n", "Person");
+        assert_eq!(node.variable, Some("n".to_string()));
+        assert_eq!(node.label, Some("Person".to_string()));
+    }
+
+    #[test]
+    fn test_node_pattern_with_properties() {
+        let props = vec![(
+            "name".to_string(),
+            PropertyValue::String("Alice".to_string()),
+        )];
+        let node = NodePattern::with_label("n", "Person").with_properties(props.clone());
+        assert_eq!(node.properties, Some(props));
+    }
+
+    #[test]
+    fn test_relationship_pattern_outgoing() {
+        let rel = RelationshipPattern::outgoing().with_type("KNOWS");
+        assert_eq!(rel.direction, RelationshipDirection::Outgoing);
+        assert_eq!(rel.rel_type, Some("KNOWS".to_string()));
+    }
+
+    #[test]
+    fn test_relationship_pattern_incoming() {
+        let rel = RelationshipPattern::incoming().with_type("FOLLOWS");
+        assert_eq!(rel.direction, RelationshipDirection::Incoming);
+        assert_eq!(rel.rel_type, Some("FOLLOWS".to_string()));
+    }
+
+    #[test]
+    fn test_relationship_pattern_both() {
+        let rel = RelationshipPattern::both();
+        assert_eq!(rel.direction, RelationshipDirection::Both);
+    }
+
+    #[test]
+    fn test_relationship_pattern_with_depth() {
+        let rel = RelationshipPattern::outgoing()
+            .with_type("KNOWS")
+            .with_depth(DepthSpec::range(1, 3));
+        assert_eq!(rel.depth, Some(DepthSpec::Range { min: 1, max: 3 }));
+    }
+
+    #[test]
+    fn test_pattern_chain() {
+        let pattern = Pattern::node(NodePattern::var("a"))
+            .then(
+                RelationshipPattern::outgoing().with_type("KNOWS"),
+                NodePattern::var("b"),
+            )
+            .then(
+                RelationshipPattern::outgoing().with_type("LIKES"),
+                NodePattern::var("c"),
+            );
+
+        assert_eq!(pattern.elements.len(), 5); // a, -[:KNOWS]->, b, -[:LIKES]->, c
+    }
+
+    // =====================================================
+    // Predicate Tests
+    // =====================================================
+
+    #[test]
+    fn test_predicate_comparison() {
+        let pred = PredicateExpr::eq(Expression::property("n", "age"), Expression::int(30));
+
+        assert!(matches!(pred, PredicateExpr::Comparison { .. }));
+    }
+
+    #[test]
+    fn test_predicate_and() {
+        let p1 = PredicateExpr::eq(Expression::property("n", "age"), Expression::int(30));
+        let p2 = PredicateExpr::eq(
+            Expression::property("n", "name"),
+            Expression::string("Alice"),
+        );
+
+        let combined = p1.and(p2);
+        assert!(matches!(combined, PredicateExpr::And(_, _)));
+    }
+
+    #[test]
+    fn test_predicate_or() {
+        let p1 = PredicateExpr::eq(Expression::property("n", "age"), Expression::int(30));
+        let p2 = PredicateExpr::eq(Expression::property("n", "age"), Expression::int(40));
+
+        let combined = p1.or(p2);
+        assert!(matches!(combined, PredicateExpr::Or(_, _)));
+    }
+
+    #[test]
+    fn test_predicate_not() {
+        let pred = PredicateExpr::eq(
+            Expression::property("n", "active"),
+            Expression::literal(PropertyValue::Bool(true)),
+        );
+        let negated = !pred;
+        assert!(matches!(negated, PredicateExpr::Not(_)));
+    }
+
+    // =====================================================
+    // Return Clause Tests
+    // =====================================================
+
+    #[test]
+    fn test_return_clause() {
+        let items = vec![
+            ReturnItem::new(Expression::property("n", "name")),
+            ReturnItem::new(Expression::property("n", "age")).with_alias("years"),
+        ];
+        let ret = ReturnClause::new(items);
+
+        assert!(!ret.distinct);
+        assert_eq!(ret.items.len(), 2);
+        assert_eq!(ret.items[1].alias, Some("years".to_string()));
+    }
+
+    #[test]
+    fn test_return_clause_distinct() {
+        let items = vec![ReturnItem::new(Expression::property("n", "name"))];
+        let ret = ReturnClause::new(items).distinct();
+        assert!(ret.distinct);
+    }
+
+    // =====================================================
+    // Order Clause Tests
+    // =====================================================
+
+    #[test]
+    fn test_order_clause() {
+        let items = vec![
+            OrderItem::desc(Expression::property("n", "age")),
+            OrderItem::asc(Expression::property("n", "name")),
+        ];
+        let order = OrderClause::new(items);
+
+        assert_eq!(order.items.len(), 2);
+        assert!(order.items[0].descending);
+        assert!(!order.items[1].descending);
+    }
+
+    // =====================================================
+    // Property Value Tests
+    // =====================================================
+
+    #[test]
+    fn test_property_value_from() {
+        let _v: PropertyValue = true.into();
+        let _v: PropertyValue = 42i64.into();
+        let _v: PropertyValue = 3.14f64.into();
+        let _v: PropertyValue = "hello".into();
+        let _v: PropertyValue = String::from("world").into();
+    }
+
+    // =====================================================
+    // Temporal Clause Tests
+    // =====================================================
+
+    #[test]
+    fn test_temporal_as_of() {
+        let temporal = TemporalClause::AsOf {
+            valid_time: TimestampLiteral::String("2024-01-15T10:00:00Z".to_string()),
+            transaction_time: Some(TimestampLiteral::Integer(1705315200000)),
+        };
+
+        if let TemporalClause::AsOf {
+            valid_time,
+            transaction_time,
+        } = temporal
+        {
+            assert!(matches!(valid_time, TimestampLiteral::String(_)));
+            assert!(transaction_time.is_some());
+        }
+    }
+
+    #[test]
+    fn test_temporal_between() {
+        let temporal = TemporalClause::Between {
+            start: TimestampLiteral::String("2024-01-01".to_string()),
+            end: TimestampLiteral::String("2024-12-31".to_string()),
+        };
+
+        assert!(matches!(temporal, TemporalClause::Between { .. }));
+    }
+
+    // =====================================================
+    // Embedding Ref Tests
+    // =====================================================
+
+    #[test]
+    fn test_embedding_ref_parameter() {
+        let emb = EmbeddingRef::Parameter("embedding".to_string());
+        assert!(matches!(emb, EmbeddingRef::Parameter(_)));
+    }
+
+    #[test]
+    fn test_embedding_ref_literal() {
+        let emb = EmbeddingRef::Literal(Arc::from([0.1f32, 0.2, 0.3].as_slice()));
+        if let EmbeddingRef::Literal(arr) = emb {
+            assert_eq!(arr.len(), 3);
+        }
+    }
+
+    // =====================================================
+    // Depth Spec Tests
+    // =====================================================
+
+    #[test]
+    fn test_depth_spec() {
+        assert_eq!(DepthSpec::one(), DepthSpec::Exact(1));
+        assert_eq!(DepthSpec::exact(3), DepthSpec::Exact(3));
+        assert_eq!(DepthSpec::range(1, 5), DepthSpec::Range { min: 1, max: 5 });
+    }
+}

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -361,7 +361,16 @@ impl DepthSpec {
     }
 
     /// Create a range depth.
+    ///
+    /// # Panics
+    /// Panics if `min > max`.
     pub fn range(min: usize, max: usize) -> Self {
+        assert!(
+            min <= max,
+            "DepthSpec range min ({}) must be <= max ({})",
+            min,
+            max
+        );
         DepthSpec::Range { min, max }
     }
 }
@@ -544,6 +553,8 @@ pub enum ComparisonOp {
 pub enum Expression {
     /// Property access: n.prop
     Property(PropertyAccess),
+    /// Bare identifier (variable reference): n
+    Identifier(String),
     /// Literal value
     Literal(PropertyValue),
     /// Parameter: $param
@@ -940,7 +951,7 @@ mod tests {
     fn test_property_value_from() {
         let _v: PropertyValue = true.into();
         let _v: PropertyValue = 42i64.into();
-        let _v: PropertyValue = 3.14f64.into();
+        let _v: PropertyValue = 2.71f64.into();
         let _v: PropertyValue = "hello".into();
         let _v: PropertyValue = String::from("world").into();
     }

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -176,12 +176,12 @@ use crate::index::vector::DistanceMetric;
 use crate::utils::error::{Error, QueryError, Result};
 
 use super::ast::{
-    ComparisonOp, DepthSpec, EmbeddingRef, Expression, NodePattern, NodeRef, Pattern,
+    ComparisonOp, DepthSpec, EmbeddingRef, Expression, NodePattern, NodeRef, OrderClause, Pattern,
     PatternElement, PredicateExpr, PropertyValue, QueryAst, RelationshipDirection,
     RelationshipPattern, ReturnClause, SourceClause, TemporalClause, TimestampLiteral,
 };
 use super::builder::Query;
-use super::ir::{Predicate, PredicateValue, QueryOp, TraversalDepth};
+use super::ir::{Predicate, PredicateValue, QueryOp, SortKey, TraversalDepth};
 use super::plan::{QueryHints, TemporalContext};
 
 /// Converts a parsed [`QueryAst`] into a [`Query`] that can be executed.
@@ -418,7 +418,12 @@ impl AstConverter {
             }
         }
 
-        // 6. Convert SKIP and LIMIT
+        // 6. Convert ORDER BY clause
+        if let Some(ref order_clause) = ast.order {
+            self.convert_order(order_clause, &mut ops)?;
+        }
+
+        // 7. Convert SKIP and LIMIT
         if let Some(skip) = ast.skip {
             ops.push(QueryOp::Skip(skip));
         }
@@ -771,6 +776,35 @@ impl AstConverter {
             }
         }
         Ok(projections)
+    }
+
+    /// Convert ORDER BY clause to Sort operations.
+    fn convert_order(&self, order_clause: &OrderClause, ops: &mut Vec<QueryOp>) -> Result<()> {
+        for item in &order_clause.items {
+            let sort_key = match &item.expression {
+                Expression::Property(prop) => SortKey::Property(prop.property.clone()),
+                Expression::Identifier(name) => {
+                    // Special identifiers for built-in sort keys
+                    match name.as_str() {
+                        "score" => SortKey::Score,
+                        "timestamp" => SortKey::Timestamp,
+                        _ => SortKey::Property(name.clone()),
+                    }
+                }
+                _ => {
+                    return Err(Error::Query(QueryError::SyntaxError {
+                        message: "ORDER BY expression must be a property access or identifier"
+                            .to_string(),
+                    }));
+                }
+            };
+
+            ops.push(QueryOp::Sort {
+                key: sort_key,
+                descending: item.descending,
+            });
+        }
+        Ok(())
     }
 
     /// Resolve an embedding reference to an actual embedding vector.
@@ -1449,6 +1483,130 @@ mod tests {
 
         let plan = planner.plan(query).unwrap();
         // Verify the plan has a valid root operation (not empty)
+        assert!(!matches!(
+            plan.root,
+            crate::query::planner::PhysicalOp::Empty
+        ));
+    }
+
+    // ========================================================================
+    // ORDER BY conversion tests
+    // ========================================================================
+
+    #[test]
+    fn test_convert_order_by_property() {
+        // MATCH (n:Person) RETURN n ORDER BY n.age DESC
+        let ast = Parser::parse("MATCH (n:Person) RETURN n ORDER BY n.age DESC").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let sort_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::Sort { .. }));
+        assert!(sort_op.is_some(), "Expected Sort operation");
+        if let Some(QueryOp::Sort { key, descending }) = sort_op {
+            assert!(
+                matches!(key, SortKey::Property(p) if p == "age"),
+                "Expected property key 'age'"
+            );
+            assert!(*descending, "Expected descending order");
+        }
+    }
+
+    #[test]
+    fn test_convert_order_by_ascending() {
+        // MATCH (n:Person) RETURN n ORDER BY n.name ASC
+        let ast = Parser::parse("MATCH (n:Person) RETURN n ORDER BY n.name ASC").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let sort_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::Sort { .. }));
+        assert!(sort_op.is_some(), "Expected Sort operation");
+        if let Some(QueryOp::Sort { key, descending }) = sort_op {
+            assert!(
+                matches!(key, SortKey::Property(p) if p == "name"),
+                "Expected property key 'name'"
+            );
+            assert!(!*descending, "Expected ascending order");
+        }
+    }
+
+    #[test]
+    fn test_convert_order_by_score() {
+        // SIMILAR TO [0.1, 0.2, 0.3] LIMIT 10 ORDER BY score DESC
+        let ast = Parser::parse("SIMILAR TO [0.1, 0.2, 0.3] LIMIT 10 ORDER BY score DESC").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let sort_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::Sort { .. }));
+        assert!(sort_op.is_some(), "Expected Sort operation");
+        if let Some(QueryOp::Sort { key, descending }) = sort_op {
+            assert!(matches!(key, SortKey::Score), "Expected Score key");
+            assert!(*descending, "Expected descending order");
+        }
+    }
+
+    #[test]
+    fn test_convert_order_by_multiple() {
+        // MATCH (n) RETURN n ORDER BY n.age DESC, n.name ASC
+        let ast = Parser::parse("MATCH (n) RETURN n ORDER BY n.age DESC, n.name ASC").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let sort_ops: Vec<_> = query
+            .ops
+            .iter()
+            .filter(|op| matches!(op, QueryOp::Sort { .. }))
+            .collect();
+
+        assert_eq!(sort_ops.len(), 2, "Expected 2 Sort operations");
+
+        // First sort by age DESC
+        if let QueryOp::Sort { key, descending } = sort_ops[0] {
+            assert!(
+                matches!(key, SortKey::Property(p) if p == "age"),
+                "First sort should be by age"
+            );
+            assert!(*descending, "First sort should be descending");
+        }
+
+        // Second sort by name ASC
+        if let QueryOp::Sort { key, descending } = sort_ops[1] {
+            assert!(
+                matches!(key, SortKey::Property(p) if p == "name"),
+                "Second sort should be by name"
+            );
+            assert!(!*descending, "Second sort should be ascending");
+        }
+    }
+
+    #[test]
+    fn test_planner_integration_with_order_by() {
+        use crate::query::planner::{QueryPlanner, Statistics};
+        use crate::storage::CurrentStorage;
+        use std::sync::Arc;
+
+        // Parse and convert
+        let query =
+            super::parse_query("MATCH (n:Person) RETURN n ORDER BY n.age DESC LIMIT 10").unwrap();
+
+        // Create storage and planner
+        let storage = Arc::new(CurrentStorage::new());
+        let stats = Arc::new(Statistics::default());
+        let planner = QueryPlanner::new(stats, storage);
+
+        // Plan the query - should succeed
+        let result = planner.plan(query);
+        assert!(result.is_ok(), "Planning should succeed");
+
+        let plan = result.unwrap();
         assert!(!matches!(
             plan.root,
             crate::query::planner::PhysicalOp::Empty

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -171,7 +171,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::core::NodeId;
-use crate::core::temporal::{time, TimeRange, Timestamp};
+use crate::core::temporal::{TimeRange, Timestamp, time};
 use crate::index::vector::DistanceMetric;
 use crate::utils::error::{Error, QueryError, Result};
 
@@ -560,7 +560,9 @@ impl AstConverter {
         // Check for inline property filters that might specify a node ID
         if let Some(ref props) = node.properties {
             for (key, value) in props {
-                if key == "id" && let PropertyValue::Int(id) = value {
+                if key == "id"
+                    && let PropertyValue::Int(id) = value
+                {
                     ops.push(QueryOp::StartNode(NodeId::new(*id as u64)?));
                     return Ok(());
                 }
@@ -685,13 +687,13 @@ impl AstConverter {
         op: ComparisonOp,
         right: &Expression,
     ) -> Result<Predicate> {
-        // Extract property key from left side
+        // Extract property key from left side - must be a property access (e.g., n.age)
         let key = match left {
             Expression::Property(prop) => prop.property.clone(),
-            Expression::Identifier(name) => name.clone(),
             _ => {
                 return Err(Error::Query(QueryError::SyntaxError {
-                    message: "Left side of comparison must be a property or identifier".to_string(),
+                    message: "Left side of comparison must be a property access (e.g., n.age)"
+                        .to_string(),
                 }));
             }
         };
@@ -759,8 +761,8 @@ impl AstConverter {
                     projections.push(prop.property.clone());
                 }
                 Expression::Identifier(name) => {
-                    // Variable reference - include all properties
-                    // For now, we just note the variable
+                    // Bare variable (e.g., RETURN n) - store the variable name.
+                    // The executor handles returning the full node for bare variables.
                     projections.push(name.clone());
                 }
                 _ => {

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -1,0 +1,1056 @@
+//! AST to IR Converter
+//!
+//! Converts parsed GQL queries (AST) into the internal Query representation
+//! that can be executed by the query planner and executor.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::core::NodeId;
+use crate::core::temporal::{TimeRange, Timestamp, time};
+use crate::index::vector::DistanceMetric;
+use crate::utils::error::{Error, QueryError, Result};
+
+use super::ast::{
+    ComparisonOp, DepthSpec, EmbeddingRef, Expression, NodePattern, NodeRef, Pattern,
+    PatternElement, PredicateExpr, PropertyValue, QueryAst, RelationshipDirection,
+    RelationshipPattern, ReturnClause, SourceClause, TemporalClause, TimestampLiteral,
+};
+use super::builder::Query;
+use super::ir::{Predicate, PredicateValue, QueryOp, TraversalDepth};
+use super::plan::{QueryHints, TemporalContext};
+
+/// Converts a parsed QueryAst into a Query that can be executed.
+///
+/// The converter handles:
+/// - Temporal clauses (AS OF, BETWEEN)
+/// - Source clauses (MATCH patterns, vector search)
+/// - WHERE predicates
+/// - RETURN projections
+/// - ORDER BY, SKIP, LIMIT
+pub struct AstConverter {
+    /// Parameter bindings for the query
+    parameters: HashMap<String, ParameterValue>,
+}
+
+/// Parameter values that can be bound to a query.
+#[derive(Debug, Clone)]
+pub enum ParameterValue {
+    /// Node ID parameter
+    NodeId(NodeId),
+    /// Embedding vector parameter
+    Embedding(Arc<[f32]>),
+    /// Scalar value parameter
+    Value(PredicateValue),
+}
+
+impl AstConverter {
+    /// Create a new converter with no parameters.
+    pub fn new() -> Self {
+        AstConverter {
+            parameters: HashMap::new(),
+        }
+    }
+
+    /// Create a converter with parameter bindings.
+    pub fn with_parameters(parameters: HashMap<String, ParameterValue>) -> Self {
+        AstConverter { parameters }
+    }
+
+    /// Bind a parameter value.
+    pub fn bind(&mut self, name: impl Into<String>, value: ParameterValue) -> &mut Self {
+        self.parameters.insert(name.into(), value);
+        self
+    }
+
+    /// Convert an AST to a Query.
+    pub fn convert(&self, ast: &QueryAst) -> Result<Query> {
+        let mut ops = Vec::new();
+        let hints = QueryHints::default();
+
+        // 1. Convert temporal clause to context
+        let temporal_context = self.convert_temporal(&ast.temporal)?;
+
+        // 2. Convert source clause (MATCH or vector search)
+        self.convert_source(&ast.source, &mut ops)?;
+
+        // 3. Convert WHERE clause to filter operations
+        if let Some(ref where_clause) = ast.where_clause {
+            let predicate = self.convert_predicate(&where_clause.predicate)?;
+            ops.push(QueryOp::Filter(predicate));
+        }
+
+        // 4. Convert RANK BY SIMILARITY clause
+        if let Some(ref rank) = ast.rank {
+            let embedding = self.resolve_embedding(&rank.embedding)?;
+            ops.push(QueryOp::RankBySimilarity {
+                embedding,
+                top_k: rank.top_k,
+                property_key: None,
+            });
+        }
+
+        // 5. Convert RETURN clause to projection
+        if let Some(ref return_clause) = ast.return_clause {
+            let projection = self.convert_return(return_clause)?;
+            if !projection.is_empty() {
+                ops.push(QueryOp::Project(projection));
+            }
+            if return_clause.distinct {
+                ops.push(QueryOp::Distinct);
+            }
+        }
+
+        // 6. Convert SKIP and LIMIT
+        if let Some(skip) = ast.skip {
+            ops.push(QueryOp::Skip(skip));
+        }
+        if let Some(limit) = ast.limit {
+            ops.push(QueryOp::Limit(limit));
+        }
+
+        Ok(Query {
+            ops,
+            temporal_context,
+            hints,
+        })
+    }
+
+    /// Convert temporal clause to TemporalContext.
+    fn convert_temporal(
+        &self,
+        temporal: &Option<TemporalClause>,
+    ) -> Result<Option<TemporalContext>> {
+        match temporal {
+            None => Ok(None),
+            Some(TemporalClause::AsOf {
+                valid_time,
+                transaction_time,
+            }) => {
+                let vt = self.convert_timestamp(valid_time)?;
+                let tt = match transaction_time {
+                    Some(t) => self.convert_timestamp(t)?,
+                    None => time::now(),
+                };
+                Ok(Some(TemporalContext::as_of(vt, tt)))
+            }
+            Some(TemporalClause::Between { start, end }) => {
+                let start_ts = self.convert_timestamp(start)?;
+                let end_ts = self.convert_timestamp(end)?;
+                let range = TimeRange::new(start_ts, end_ts).map_err(|e| {
+                    Error::Query(QueryError::InvalidParameter {
+                        parameter: "time_range".to_string(),
+                        reason: format!("Invalid time range: {}", e),
+                    })
+                })?;
+                Ok(Some(TemporalContext::between(range)))
+            }
+        }
+    }
+
+    /// Convert a timestamp literal to a Timestamp.
+    ///
+    /// Accepts:
+    /// - Integer: treated as microseconds since Unix epoch
+    /// - String containing an integer: parsed as microseconds
+    ///
+    /// Note: ISO 8601 string parsing requires the `mcp-server` feature.
+    fn convert_timestamp(&self, ts: &TimestampLiteral) -> Result<Timestamp> {
+        match ts {
+            // Treat integer as microseconds (consistent with the database's internal format)
+            TimestampLiteral::Integer(micros) => Ok(Timestamp::from(*micros)),
+            TimestampLiteral::String(s) => {
+                // Try parsing as microseconds since epoch
+                if let Ok(micros) = s.parse::<i64>() {
+                    return Ok(Timestamp::from(micros));
+                }
+
+                Err(Error::Query(QueryError::InvalidParameter {
+                    parameter: "timestamp".to_string(),
+                    reason: format!(
+                        "Invalid timestamp '{}'. Expected microseconds since epoch.",
+                        s
+                    ),
+                }))
+            }
+        }
+    }
+
+    /// Convert source clause to query operations.
+    fn convert_source(&self, source: &SourceClause, ops: &mut Vec<QueryOp>) -> Result<()> {
+        match source {
+            SourceClause::Match(patterns) => {
+                self.convert_patterns(patterns, ops)?;
+            }
+            SourceClause::VectorSearch {
+                embedding,
+                metric,
+                limit,
+            } => {
+                let emb = self.resolve_embedding(embedding)?;
+                ops.push(QueryOp::VectorSearch {
+                    embedding: emb,
+                    k: *limit,
+                    metric: metric.unwrap_or(DistanceMetric::Cosine),
+                    property_key: None,
+                });
+            }
+            SourceClause::FindSimilar { node_ref, limit } => {
+                let node_id = self.resolve_node_ref(node_ref)?;
+                ops.push(QueryOp::SimilarTo {
+                    source_node: node_id,
+                    k: *limit,
+                    property_key: None,
+                    label_filter: None,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert MATCH patterns to query operations.
+    fn convert_patterns(&self, patterns: &[Pattern], ops: &mut Vec<QueryOp>) -> Result<()> {
+        for pattern in patterns {
+            self.convert_pattern(pattern, ops)?;
+        }
+        Ok(())
+    }
+
+    /// Convert a single pattern to query operations.
+    fn convert_pattern(&self, pattern: &Pattern, ops: &mut Vec<QueryOp>) -> Result<()> {
+        let mut is_first = true;
+
+        for element in &pattern.elements {
+            match element {
+                PatternElement::Node(node) => {
+                    if is_first {
+                        // First node - this is the starting point
+                        self.convert_node_pattern(node, ops)?;
+                        is_first = false;
+                    }
+                    // Subsequent nodes are targets of traversals, handled in relationship conversion
+                }
+                PatternElement::Relationship(rel) => {
+                    self.convert_relationship_pattern(rel, ops)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert a node pattern to query operations.
+    fn convert_node_pattern(&self, node: &NodePattern, ops: &mut Vec<QueryOp>) -> Result<()> {
+        // Check for inline property filters that might specify a node ID
+        if let Some(ref props) = node.properties {
+            for (key, value) in props {
+                if key == "id" && let PropertyValue::Int(id) = value {
+                    ops.push(QueryOp::StartNode(NodeId::new(*id as u64)?));
+                    return Ok(());
+                }
+            }
+        }
+
+        // Otherwise, scan by label or all nodes
+        ops.push(QueryOp::ScanNodes {
+            label: node.label.clone(),
+        });
+
+        // Add filters for inline properties
+        if let Some(ref props) = node.properties {
+            for (key, value) in props {
+                if key != "id" {
+                    let pred_value = self.convert_property_value(value)?;
+                    ops.push(QueryOp::Filter(Predicate::Eq {
+                        key: key.clone(),
+                        value: pred_value,
+                    }));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Convert a relationship pattern to traversal operations.
+    fn convert_relationship_pattern(
+        &self,
+        rel: &RelationshipPattern,
+        ops: &mut Vec<QueryOp>,
+    ) -> Result<()> {
+        let depth = self.convert_depth_spec(&rel.depth);
+        let label = rel.rel_type.clone();
+
+        match rel.direction {
+            RelationshipDirection::Outgoing => {
+                ops.push(QueryOp::TraverseOut { label, depth });
+            }
+            RelationshipDirection::Incoming => {
+                ops.push(QueryOp::TraverseIn { label, depth });
+            }
+            RelationshipDirection::Both => {
+                ops.push(QueryOp::TraverseBoth { label, depth });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Convert depth specification from AST to IR.
+    fn convert_depth_spec(&self, depth: &Option<DepthSpec>) -> TraversalDepth {
+        match depth {
+            None => TraversalDepth::Exact(1),
+            Some(DepthSpec::Exact(n)) => TraversalDepth::Exact(*n),
+            Some(DepthSpec::Max(n)) => TraversalDepth::Max(*n),
+            Some(DepthSpec::Range { min, max }) => TraversalDepth::Range {
+                min: *min,
+                max: *max,
+            },
+            Some(DepthSpec::Variable) => TraversalDepth::Variable,
+        }
+    }
+
+    /// Convert a predicate expression to IR Predicate.
+    fn convert_predicate(&self, expr: &PredicateExpr) -> Result<Predicate> {
+        match expr {
+            PredicateExpr::Comparison { left, op, right } => {
+                self.convert_comparison(left, *op, right)
+            }
+            PredicateExpr::Exists(prop) => Ok(Predicate::Exists(prop.property.clone())),
+            PredicateExpr::IsNull(prop) => Ok(Predicate::NotExists(prop.property.clone())),
+            PredicateExpr::IsNotNull(prop) => Ok(Predicate::Exists(prop.property.clone())),
+            PredicateExpr::Contains {
+                property,
+                substring,
+            } => Ok(Predicate::Contains {
+                key: property.property.clone(),
+                substring: substring.clone(),
+            }),
+            PredicateExpr::StartsWith { property, prefix } => Ok(Predicate::StartsWith {
+                key: property.property.clone(),
+                prefix: prefix.clone(),
+            }),
+            PredicateExpr::EndsWith { property, suffix } => Ok(Predicate::EndsWith {
+                key: property.property.clone(),
+                suffix: suffix.clone(),
+            }),
+            PredicateExpr::In { property, values } => {
+                let pred_values: Result<Vec<PredicateValue>> = values
+                    .iter()
+                    .map(|v| self.convert_property_value(v))
+                    .collect();
+                Ok(Predicate::In {
+                    key: property.property.clone(),
+                    values: pred_values?,
+                })
+            }
+            PredicateExpr::And(left, right) => {
+                let l = self.convert_predicate(left)?;
+                let r = self.convert_predicate(right)?;
+                Ok(l.and(r))
+            }
+            PredicateExpr::Or(left, right) => {
+                let l = self.convert_predicate(left)?;
+                let r = self.convert_predicate(right)?;
+                Ok(l.or(r))
+            }
+            PredicateExpr::Not(inner) => {
+                let p = self.convert_predicate(inner)?;
+                Ok(!p)
+            }
+            PredicateExpr::Grouped(inner) => self.convert_predicate(inner),
+        }
+    }
+
+    /// Convert a comparison expression.
+    fn convert_comparison(
+        &self,
+        left: &Expression,
+        op: ComparisonOp,
+        right: &Expression,
+    ) -> Result<Predicate> {
+        // Extract property key from left side
+        let key = match left {
+            Expression::Property(prop) => prop.property.clone(),
+            Expression::Identifier(name) => name.clone(),
+            _ => {
+                return Err(Error::Query(QueryError::SyntaxError {
+                    message: "Left side of comparison must be a property or identifier".to_string(),
+                }));
+            }
+        };
+
+        // Extract value from right side
+        let value = self.expression_to_predicate_value(right)?;
+
+        Ok(match op {
+            ComparisonOp::Eq => Predicate::Eq { key, value },
+            ComparisonOp::Ne => Predicate::Ne { key, value },
+            ComparisonOp::Lt => Predicate::Lt { key, value },
+            ComparisonOp::Le => Predicate::Lte { key, value },
+            ComparisonOp::Gt => Predicate::Gt { key, value },
+            ComparisonOp::Ge => Predicate::Gte { key, value },
+        })
+    }
+
+    /// Convert an expression to a predicate value.
+    fn expression_to_predicate_value(&self, expr: &Expression) -> Result<PredicateValue> {
+        match expr {
+            Expression::Literal(pv) => self.convert_property_value(pv),
+            Expression::Parameter(name) => {
+                if let Some(ParameterValue::Value(v)) = self.parameters.get(name) {
+                    Ok(v.clone())
+                } else {
+                    Err(Error::Query(QueryError::InvalidParameter {
+                        parameter: name.clone(),
+                        reason: "not found or has wrong type".to_string(),
+                    }))
+                }
+            }
+            _ => Err(Error::Query(QueryError::SyntaxError {
+                message: "Expected literal or parameter on right side of comparison".to_string(),
+            })),
+        }
+    }
+
+    /// Convert a property value to a predicate value.
+    fn convert_property_value(&self, value: &PropertyValue) -> Result<PredicateValue> {
+        match value {
+            PropertyValue::Null => Ok(PredicateValue::Null),
+            PropertyValue::Bool(b) => Ok(PredicateValue::Bool(*b)),
+            PropertyValue::Int(i) => Ok(PredicateValue::Int(*i)),
+            PropertyValue::Float(f) => Ok(PredicateValue::Float(*f)),
+            PropertyValue::String(s) => Ok(PredicateValue::String(s.clone())),
+            PropertyValue::Parameter(name) => {
+                if let Some(ParameterValue::Value(v)) = self.parameters.get(name) {
+                    Ok(v.clone())
+                } else {
+                    Err(Error::Query(QueryError::InvalidParameter {
+                        parameter: name.clone(),
+                        reason: "not found or has wrong type".to_string(),
+                    }))
+                }
+            }
+        }
+    }
+
+    /// Convert RETURN clause to projection list.
+    fn convert_return(&self, return_clause: &ReturnClause) -> Result<Vec<String>> {
+        let mut projections = Vec::new();
+        for item in &return_clause.items {
+            match &item.expression {
+                Expression::Property(prop) => {
+                    projections.push(prop.property.clone());
+                }
+                Expression::Identifier(name) => {
+                    // Variable reference - include all properties
+                    // For now, we just note the variable
+                    projections.push(name.clone());
+                }
+                _ => {
+                    // Other expressions are computed at execution time
+                }
+            }
+        }
+        Ok(projections)
+    }
+
+    /// Resolve an embedding reference to an actual embedding vector.
+    fn resolve_embedding(&self, emb_ref: &EmbeddingRef) -> Result<Arc<[f32]>> {
+        match emb_ref {
+            EmbeddingRef::Literal(arr) => Ok(arr.clone()),
+            EmbeddingRef::Parameter(name) => {
+                if let Some(ParameterValue::Embedding(emb)) = self.parameters.get(name) {
+                    Ok(emb.clone())
+                } else {
+                    Err(Error::Query(QueryError::InvalidParameter {
+                        parameter: name.clone(),
+                        reason: "embedding parameter not found".to_string(),
+                    }))
+                }
+            }
+        }
+    }
+
+    /// Resolve a node reference to a NodeId.
+    fn resolve_node_ref(&self, node_ref: &NodeRef) -> Result<NodeId> {
+        match node_ref {
+            NodeRef::Id(id) => Ok(NodeId::new(*id)?),
+            NodeRef::Parameter(name) => {
+                if let Some(ParameterValue::NodeId(id)) = self.parameters.get(name) {
+                    Ok(*id)
+                } else {
+                    Err(Error::Query(QueryError::InvalidParameter {
+                        parameter: name.clone(),
+                        reason: "node ID parameter not found".to_string(),
+                    }))
+                }
+            }
+            NodeRef::Identifier(name) => Err(Error::Query(QueryError::InvalidParameter {
+                parameter: name.clone(),
+                reason: "variable node references require execution context".to_string(),
+            })),
+        }
+    }
+}
+
+impl Default for AstConverter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse a GQL query string and convert it to a Query.
+///
+/// This is a convenience function that combines parsing and conversion.
+///
+/// # Example
+///
+/// ```ignore
+/// use gallifreydb::query::converter::parse_query;
+///
+/// let query = parse_query("MATCH (n:Person) RETURN n")?;
+/// ```
+pub fn parse_query(gql: &str) -> Result<Query> {
+    let ast = super::parser::Parser::parse(gql).map_err(|e| {
+        Error::Query(QueryError::SyntaxError {
+            message: e.to_string(),
+        })
+    })?;
+    let converter = AstConverter::new();
+    converter.convert(&ast)
+}
+
+/// Parse a GQL query string with parameters and convert it to a Query.
+///
+/// # Example
+///
+/// ```ignore
+/// use gallifreydb::query::converter::{parse_query_with_params, ParameterValue};
+/// use std::collections::HashMap;
+///
+/// let mut params = HashMap::new();
+/// params.insert("name".to_string(), ParameterValue::Value(PredicateValue::String("Alice".to_string())));
+///
+/// let query = parse_query_with_params("MATCH (n:Person {name: $name}) RETURN n", params)?;
+/// ```
+pub fn parse_query_with_params(
+    gql: &str,
+    params: HashMap<String, ParameterValue>,
+) -> Result<Query> {
+    let ast = super::parser::Parser::parse(gql).map_err(|e| {
+        Error::Query(QueryError::SyntaxError {
+            message: e.to_string(),
+        })
+    })?;
+    let converter = AstConverter::with_parameters(params);
+    converter.convert(&ast)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::parser::Parser;
+
+    // ========================================================================
+    // RED PHASE: Failing tests for basic conversion
+    // ========================================================================
+
+    #[test]
+    fn test_convert_simple_match() {
+        // MATCH (n:Person) RETURN n
+        let ast = Parser::parse("MATCH (n:Person) RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have ScanNodes with label "Person"
+        assert!(!query.ops.is_empty());
+        assert!(matches!(
+            &query.ops[0],
+            QueryOp::ScanNodes {
+                label: Some(l)
+            } if l == "Person"
+        ));
+    }
+
+    #[test]
+    fn test_convert_match_with_traversal() {
+        // MATCH (n:Person)-[:KNOWS]->(m) RETURN m
+        let ast = Parser::parse("MATCH (n:Person)-[:KNOWS]->(m) RETURN m").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have ScanNodes + TraverseOut
+        assert!(query.ops.len() >= 2);
+        assert!(matches!(
+            &query.ops[0],
+            QueryOp::ScanNodes { label: Some(l) } if l == "Person"
+        ));
+        assert!(matches!(
+            &query.ops[1],
+            QueryOp::TraverseOut {
+                label: Some(l),
+                depth: TraversalDepth::Exact(1)
+            } if l == "KNOWS"
+        ));
+    }
+
+    #[test]
+    fn test_convert_match_with_where() {
+        // MATCH (n:Person) WHERE n.age > 25 RETURN n
+        let ast = Parser::parse("MATCH (n:Person) WHERE n.age > 25 RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have ScanNodes + Filter
+        assert!(query.ops.len() >= 2);
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(matches!(pred, Predicate::Gt { key, .. } if key == "age"));
+        }
+    }
+
+    #[test]
+    fn test_convert_match_with_limit() {
+        // MATCH (n:Person) RETURN n LIMIT 10
+        let ast = Parser::parse("MATCH (n:Person) RETURN n LIMIT 10").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have Limit operation
+        let limit_op = query.ops.iter().find(|op| matches!(op, QueryOp::Limit(_)));
+        assert!(limit_op.is_some());
+        if let Some(QueryOp::Limit(n)) = limit_op {
+            assert_eq!(*n, 10);
+        }
+    }
+
+    #[test]
+    fn test_convert_match_with_skip() {
+        // MATCH (n:Person) RETURN n SKIP 5 LIMIT 10
+        let ast = Parser::parse("MATCH (n:Person) RETURN n SKIP 5 LIMIT 10").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have Skip operation
+        let skip_op = query.ops.iter().find(|op| matches!(op, QueryOp::Skip(_)));
+        assert!(skip_op.is_some());
+        if let Some(QueryOp::Skip(n)) = skip_op {
+            assert_eq!(*n, 5);
+        }
+    }
+
+    #[test]
+    fn test_convert_vector_search() {
+        // SIMILAR TO [0.1, 0.2, 0.3] LIMIT 10
+        let ast = Parser::parse("SIMILAR TO [0.1, 0.2, 0.3] LIMIT 10").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have VectorSearch operation
+        assert!(matches!(&query.ops[0], QueryOp::VectorSearch { k: 10, .. }));
+    }
+
+    #[test]
+    fn test_convert_find_similar_with_parameter() {
+        // FIND SIMILAR TO ($node_id) LIMIT 5
+        let ast = Parser::parse("FIND SIMILAR TO ($node_id) LIMIT 5").unwrap();
+        let mut converter = AstConverter::new();
+        converter.bind("node_id", ParameterValue::NodeId(NodeId::new(42).unwrap()));
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have SimilarTo operation
+        assert!(matches!(
+            &query.ops[0],
+            QueryOp::SimilarTo {
+                source_node,
+                k: 5,
+                ..
+            } if source_node.as_u64() == 42
+        ));
+    }
+
+    #[test]
+    fn test_convert_temporal_as_of() {
+        // AS OF 1000 MATCH (n:Person) RETURN n
+        let ast = Parser::parse("AS OF 1000 MATCH (n:Person) RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have temporal context
+        assert!(query.temporal_context.is_some());
+        let ctx = query.temporal_context.unwrap();
+        assert!(ctx.as_of.is_some());
+        let (vt, _tt) = ctx.as_of.unwrap();
+        // Timestamp is stored as microseconds, so 1000 is 1000 microseconds
+        assert_eq!(vt.wallclock(), 1000);
+    }
+
+    #[test]
+    fn test_convert_temporal_between() {
+        // BETWEEN 1000 AND 2000 MATCH (n:Person) RETURN n
+        let ast = Parser::parse("BETWEEN 1000 AND 2000 MATCH (n:Person) RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Should have temporal context with between
+        assert!(query.temporal_context.is_some());
+        let ctx = query.temporal_context.unwrap();
+        assert!(ctx.between.is_some());
+    }
+
+    #[test]
+    fn test_convert_predicate_and() {
+        // MATCH (n) WHERE n.a = 1 AND n.b = 2 RETURN n
+        let ast = Parser::parse("MATCH (n) WHERE n.a = 1 AND n.b = 2 RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(matches!(pred, Predicate::And(_)));
+        }
+    }
+
+    #[test]
+    fn test_convert_predicate_or() {
+        // MATCH (n) WHERE n.a = 1 OR n.b = 2 RETURN n
+        let ast = Parser::parse("MATCH (n) WHERE n.a = 1 OR n.b = 2 RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(matches!(pred, Predicate::Or(_)));
+        }
+    }
+
+    #[test]
+    fn test_convert_predicate_not() {
+        // MATCH (n) WHERE NOT n.active = true RETURN n
+        let ast = Parser::parse("MATCH (n) WHERE NOT n.active = true RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(matches!(pred, Predicate::Not(_)));
+        }
+    }
+
+    #[test]
+    fn test_convert_predicate_contains() {
+        // MATCH (n) WHERE n.name CONTAINS 'test' RETURN n
+        let ast = Parser::parse("MATCH (n) WHERE n.name CONTAINS 'test' RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(matches!(
+                pred,
+                Predicate::Contains { key, substring } if key == "name" && substring == "test"
+            ));
+        }
+    }
+
+    #[test]
+    fn test_convert_predicate_starts_with() {
+        // MATCH (n) WHERE n.name STARTS WITH 'Al' RETURN n
+        let ast = Parser::parse("MATCH (n) WHERE n.name STARTS WITH 'Al' RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(matches!(
+                pred,
+                Predicate::StartsWith { key, prefix } if key == "name" && prefix == "Al"
+            ));
+        }
+    }
+
+    #[test]
+    fn test_convert_predicate_in() {
+        // MATCH (n) WHERE n.status IN ['active', 'pending'] RETURN n
+        let ast =
+            Parser::parse("MATCH (n) WHERE n.status IN ['active', 'pending'] RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_op = query.ops.iter().find(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(filter_op.is_some());
+        if let Some(QueryOp::Filter(pred)) = filter_op {
+            assert!(
+                matches!(pred, Predicate::In { key, values } if key == "status" && values.len() == 2)
+            );
+        }
+    }
+
+    #[test]
+    fn test_convert_variable_length_traversal() {
+        // MATCH (n)-[:KNOWS*1..3]->(m) RETURN m
+        let ast = Parser::parse("MATCH (n)-[:KNOWS*1..3]->(m) RETURN m").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let traverse_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::TraverseOut { .. }));
+        assert!(traverse_op.is_some());
+        if let Some(QueryOp::TraverseOut { depth, .. }) = traverse_op {
+            assert!(matches!(depth, TraversalDepth::Range { min: 1, max: 3 }));
+        }
+    }
+
+    #[test]
+    fn test_convert_incoming_traversal() {
+        // MATCH (n)<-[:KNOWS]-(m) RETURN m
+        let ast = Parser::parse("MATCH (n)<-[:KNOWS]-(m) RETURN m").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let traverse_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::TraverseIn { .. }));
+        assert!(traverse_op.is_some());
+    }
+
+    #[test]
+    fn test_convert_bidirectional_traversal() {
+        // MATCH (n)-[:KNOWS]-(m) RETURN m
+        let ast = Parser::parse("MATCH (n)-[:KNOWS]-(m) RETURN m").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let traverse_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::TraverseBoth { .. }));
+        assert!(traverse_op.is_some());
+    }
+
+    #[test]
+    fn test_convert_rank_by_similarity() {
+        // MATCH (n:Document) RANK BY SIMILARITY TO [0.1, 0.2] TOP 5 RETURN n
+        let ast =
+            Parser::parse("MATCH (n:Document) RANK BY SIMILARITY TO [0.1, 0.2] TOP 5 RETURN n")
+                .unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let rank_op = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::RankBySimilarity { .. }));
+        assert!(rank_op.is_some());
+        if let Some(QueryOp::RankBySimilarity { top_k, .. }) = rank_op {
+            assert_eq!(*top_k, Some(5));
+        }
+    }
+
+    #[test]
+    fn test_convert_distinct() {
+        // MATCH (n) RETURN DISTINCT n
+        let ast = Parser::parse("MATCH (n) RETURN DISTINCT n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let distinct_op = query.ops.iter().find(|op| matches!(op, QueryOp::Distinct));
+        assert!(distinct_op.is_some());
+    }
+
+    #[test]
+    fn test_convert_with_embedding_parameter() {
+        // SIMILAR TO $embedding LIMIT 10
+        let ast = Parser::parse("SIMILAR TO $embedding LIMIT 10").unwrap();
+        let mut converter = AstConverter::new();
+        converter.bind(
+            "embedding",
+            ParameterValue::Embedding(Arc::from([0.1f32, 0.2, 0.3].as_slice())),
+        );
+        let query = converter.convert(&ast).unwrap();
+
+        assert!(matches!(&query.ops[0], QueryOp::VectorSearch { k: 10, .. }));
+    }
+
+    #[test]
+    fn test_convert_error_missing_parameter() {
+        // SIMILAR TO $embedding LIMIT 10 (without binding)
+        let ast = Parser::parse("SIMILAR TO $embedding LIMIT 10").unwrap();
+        let converter = AstConverter::new();
+        let result = converter.convert(&ast);
+
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Convenience function tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_query() {
+        let query = super::parse_query("MATCH (n:Person) RETURN n").unwrap();
+        assert!(!query.ops.is_empty());
+    }
+
+    #[test]
+    fn test_parse_query_with_params() {
+        use std::collections::HashMap;
+
+        let mut params = HashMap::new();
+        params.insert(
+            "embedding".to_string(),
+            ParameterValue::Embedding(Arc::from([0.1f32, 0.2, 0.3].as_slice())),
+        );
+
+        let query =
+            super::parse_query_with_params("SIMILAR TO $embedding LIMIT 10", params).unwrap();
+        assert!(matches!(&query.ops[0], QueryOp::VectorSearch { k: 10, .. }));
+    }
+
+    // ========================================================================
+    // Planner integration tests
+    // ========================================================================
+
+    #[test]
+    fn test_planner_integration_simple_match() {
+        use crate::query::planner::{QueryPlanner, Statistics};
+        use crate::storage::CurrentStorage;
+        use std::sync::Arc;
+
+        // Parse and convert
+        let query = super::parse_query("MATCH (n:Person) RETURN n LIMIT 10").unwrap();
+
+        // Create storage and planner
+        let storage = Arc::new(CurrentStorage::new());
+        let stats = Arc::new(Statistics::default());
+        let planner = QueryPlanner::new(stats, storage);
+
+        // Plan the query - should succeed
+        let result = planner.plan(query);
+        assert!(result.is_ok());
+
+        let plan = result.unwrap();
+        // Verify the plan has a valid root operation (not empty)
+        assert!(!matches!(
+            plan.root,
+            crate::query::planner::PhysicalOp::Empty
+        ));
+    }
+
+    #[test]
+    fn test_planner_integration_with_traversal() {
+        use crate::query::planner::{QueryPlanner, Statistics};
+        use crate::storage::CurrentStorage;
+        use std::sync::Arc;
+
+        // Parse and convert
+        let query = super::parse_query("MATCH (n:Person)-[:KNOWS]->(m:Person) RETURN m").unwrap();
+
+        // Create storage and planner
+        let storage = Arc::new(CurrentStorage::new());
+        let stats = Arc::new(Statistics::default());
+        let planner = QueryPlanner::new(stats, storage);
+
+        // Plan the query
+        let result = planner.plan(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_planner_integration_with_filter() {
+        use crate::query::planner::{QueryPlanner, Statistics};
+        use crate::storage::CurrentStorage;
+        use std::sync::Arc;
+
+        // Parse and convert
+        let query =
+            super::parse_query("MATCH (n:Person) WHERE n.age > 25 RETURN n LIMIT 10").unwrap();
+
+        // Create storage and planner
+        let storage = Arc::new(CurrentStorage::new());
+        let stats = Arc::new(Statistics::default());
+        let planner = QueryPlanner::new(stats, storage);
+
+        // Plan the query
+        let result = planner.plan(query);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_planner_integration_temporal() {
+        use crate::query::planner::{QueryPlanner, Statistics};
+        use crate::storage::CurrentStorage;
+        use std::sync::Arc;
+
+        // Parse and convert - temporal query
+        let query = super::parse_query("AS OF 1000000 MATCH (n:Person) RETURN n").unwrap();
+        assert!(query.temporal_context.is_some());
+
+        // Create storage and planner
+        let storage = Arc::new(CurrentStorage::new());
+        let stats = Arc::new(Statistics::default());
+        let planner = QueryPlanner::new(stats, storage);
+
+        // Plan the query
+        let result = planner.plan(query);
+        assert!(result.is_ok());
+
+        let plan = result.unwrap();
+        // Temporal queries should include temporal context in the plan
+        assert!(plan.is_temporal());
+    }
+
+    #[test]
+    fn test_full_pipeline_parse_convert_plan() {
+        use crate::query::planner::{QueryPlanner, Statistics};
+        use crate::storage::CurrentStorage;
+        use std::sync::Arc;
+
+        // Complex query with multiple operations
+        let gql = "MATCH (n:Person)-[:KNOWS*1..3]->(m:Person) WHERE n.age > 21 AND m.active = true RETURN m LIMIT 100";
+
+        // Parse
+        let ast = Parser::parse(gql).unwrap();
+
+        // Convert
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        // Verify conversion produced expected operations
+        assert!(
+            query
+                .ops
+                .iter()
+                .any(|op| matches!(op, QueryOp::ScanNodes { .. }))
+        );
+        assert!(
+            query
+                .ops
+                .iter()
+                .any(|op| matches!(op, QueryOp::TraverseOut { .. }))
+        );
+        assert!(query.ops.iter().any(|op| matches!(op, QueryOp::Filter(_))));
+        assert!(query.ops.iter().any(|op| matches!(op, QueryOp::Limit(100))));
+
+        // Plan
+        let storage = Arc::new(CurrentStorage::new());
+        let stats = Arc::new(Statistics::default());
+        let planner = QueryPlanner::new(stats, storage);
+
+        let plan = planner.plan(query).unwrap();
+        // Verify the plan has a valid root operation (not empty)
+        assert!(!matches!(
+            plan.root,
+            crate::query::planner::PhysicalOp::Empty
+        ));
+    }
+}

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -1,13 +1,177 @@
 //! AST to IR Converter
 //!
-//! Converts parsed GQL queries (AST) into the internal Query representation
-//! that can be executed by the query planner and executor.
+//! This module converts parsed GQL (Gallifrey Query Language) queries from their
+//! Abstract Syntax Tree (AST) representation into the internal `Query` type that
+//! can be executed by the query planner and executor.
+//!
+//! # Architecture
+//!
+//! The query processing pipeline in GallifreyDB follows this flow:
+//!
+//! ```text
+//! GQL String → [Parser] → AST → [Converter] → Query → [Planner] → PhysicalPlan → [Executor] → Results
+//! ```
+//!
+//! This module handles the **Converter** step, bridging the gap between the
+//! human-readable AST and the internal query representation.
+//!
+//! # Quick Start
+//!
+//! The simplest way to execute a GQL query is using the [`parse_query`] function:
+//!
+//! ```rust
+//! use gallifreydb::query::{parse_query, QueryPlanner};
+//! use gallifreydb::query::planner::Statistics;
+//! use gallifreydb::storage::CurrentStorage;
+//! use std::sync::Arc;
+//!
+//! // Parse and convert a GQL query
+//! let query = parse_query("MATCH (n:Person) WHERE n.age > 21 RETURN n LIMIT 10")
+//!     .expect("Failed to parse query");
+//!
+//! // Create planner and execute
+//! let storage = Arc::new(CurrentStorage::new());
+//! let stats = Arc::new(Statistics::default());
+//! let planner = QueryPlanner::new(stats, storage);
+//! let plan = planner.plan(query).expect("Failed to plan query");
+//! ```
+//!
+//! # Using Parameters
+//!
+//! For queries with dynamic values, use parameterized queries to prevent injection
+//! and improve performance through query caching:
+//!
+//! ```rust
+//! use gallifreydb::query::{parse_query_with_params, ParameterValue};
+//! use gallifreydb::query::ir::PredicateValue;
+//! use std::collections::HashMap;
+//! use std::sync::Arc;
+//!
+//! // Create parameter bindings
+//! let mut params = HashMap::new();
+//! params.insert(
+//!     "min_age".to_string(),
+//!     ParameterValue::Value(PredicateValue::Int(21)),
+//! );
+//!
+//! // Parse with parameters (not yet fully supported in WHERE clause)
+//! // For vector search with embedding parameters:
+//! let mut vector_params = HashMap::new();
+//! vector_params.insert(
+//!     "embedding".to_string(),
+//!     ParameterValue::Embedding(Arc::from([0.1f32, 0.2, 0.3].as_slice())),
+//! );
+//!
+//! let query = parse_query_with_params(
+//!     "SIMILAR TO $embedding LIMIT 10",
+//!     vector_params,
+//! ).expect("Failed to parse query");
+//! ```
+//!
+//! # Supported Query Features
+//!
+//! ## Graph Pattern Matching (MATCH)
+//!
+//! ```text
+//! MATCH (n:Person)                           -- Node with label
+//! MATCH (n:Person)-[:KNOWS]->(m)             -- Outgoing relationship
+//! MATCH (n)<-[:FOLLOWS]-(m)                  -- Incoming relationship
+//! MATCH (n)-[:FRIENDS]-(m)                   -- Bidirectional
+//! MATCH (n)-[:KNOWS*1..3]->(m)               -- Variable-length path
+//! ```
+//!
+//! ## Vector Search
+//!
+//! ```text
+//! SIMILAR TO [0.1, 0.2, 0.3] LIMIT 10        -- k-NN search with literal
+//! SIMILAR TO $embedding LIMIT 10             -- k-NN with parameter
+//! FIND SIMILAR TO ($node_id) LIMIT 5         -- Find similar to existing node
+//! MATCH (n) RANK BY SIMILARITY TO [...] TOP 5 -- Rank existing results
+//! ```
+//!
+//! ## Temporal Queries
+//!
+//! ```text
+//! AS OF 1704067200000000 MATCH (n) ...       -- Point-in-time (microseconds)
+//! AS OF 1704067200000000, 1704153600000000 MATCH ... -- Valid time, tx time
+//! BETWEEN 1704067200000000 AND 1704153600000000 MATCH ... -- Time range
+//! ```
+//!
+//! ## Predicates (WHERE clause)
+//!
+//! ```text
+//! WHERE n.age > 21                           -- Comparison
+//! WHERE n.name = 'Alice'                     -- Equality
+//! WHERE n.status IN ['active', 'pending']   -- IN list
+//! WHERE n.bio CONTAINS 'engineer'            -- String contains
+//! WHERE n.name STARTS WITH 'A'               -- String prefix
+//! WHERE n.email ENDS WITH '.com'             -- String suffix
+//! WHERE EXISTS(n.email)                      -- Property exists
+//! WHERE n.deleted IS NULL                    -- NULL check
+//! WHERE n.age > 21 AND n.active = true       -- Logical AND
+//! WHERE n.role = 'admin' OR n.role = 'mod'   -- Logical OR
+//! WHERE NOT n.banned = true                  -- Logical NOT
+//! ```
+//!
+//! ## Result Modifiers
+//!
+//! ```text
+//! RETURN n                                   -- Return nodes
+//! RETURN DISTINCT n                          -- Deduplicate
+//! RETURN n.name, n.age                       -- Project properties
+//! SKIP 10 LIMIT 20                           -- Pagination
+//! ```
+//!
+//! # Manual Conversion
+//!
+//! For more control, use [`AstConverter`] directly:
+//!
+//! ```rust
+//! use gallifreydb::query::{Parser, AstConverter, ParameterValue};
+//! use gallifreydb::core::NodeId;
+//!
+//! // Parse the query
+//! let ast = Parser::parse("FIND SIMILAR TO ($node) LIMIT 5")
+//!     .expect("Parse failed");
+//!
+//! // Create converter with parameters
+//! let mut converter = AstConverter::new();
+//! converter.bind("node", ParameterValue::NodeId(NodeId::new(42).unwrap()));
+//!
+//! // Convert to Query
+//! let query = converter.convert(&ast).expect("Conversion failed");
+//! ```
+//!
+//! # Error Handling
+//!
+//! The converter returns detailed errors for:
+//!
+//! - **Missing parameters**: When a `$param` reference has no binding
+//! - **Type mismatches**: When a parameter has the wrong type (e.g., NodeId vs Embedding)
+//! - **Invalid timestamps**: When timestamp strings can't be parsed
+//! - **Syntax errors**: Propagated from the parser
+//!
+//! ```rust
+//! use gallifreydb::query::parse_query;
+//!
+//! // Missing parameter error
+//! let result = parse_query("SIMILAR TO $missing LIMIT 10");
+//! assert!(result.is_err());
+//! ```
+//!
+//! # Performance Considerations
+//!
+//! - **Reuse converters**: Create one [`AstConverter`] and reuse it for multiple
+//!   queries with the same parameters
+//! - **Parameterize queries**: Parameterized queries can be cached and reused
+//! - **Avoid large IN lists**: Large `IN [...]` clauses are converted to sequential
+//!   value checks; consider using joins for very large lists
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::core::NodeId;
-use crate::core::temporal::{TimeRange, Timestamp, time};
+use crate::core::temporal::{time, TimeRange, Timestamp};
 use crate::index::vector::DistanceMetric;
 use crate::utils::error::{Error, QueryError, Result};
 
@@ -20,50 +184,203 @@ use super::builder::Query;
 use super::ir::{Predicate, PredicateValue, QueryOp, TraversalDepth};
 use super::plan::{QueryHints, TemporalContext};
 
-/// Converts a parsed QueryAst into a Query that can be executed.
+/// Converts a parsed [`QueryAst`] into a [`Query`] that can be executed.
 ///
-/// The converter handles:
-/// - Temporal clauses (AS OF, BETWEEN)
-/// - Source clauses (MATCH patterns, vector search)
-/// - WHERE predicates
-/// - RETURN projections
-/// - ORDER BY, SKIP, LIMIT
+/// The `AstConverter` is the bridge between the parser output (AST) and the
+/// query execution engine. It transforms the tree-structured AST into a
+/// sequence of [`QueryOp`] operations that the planner can optimize.
+///
+/// # Conversion Process
+///
+/// The converter processes the AST in this order:
+///
+/// 1. **Temporal context**: `AS OF` or `BETWEEN` clauses → [`TemporalContext`]
+/// 2. **Source clause**: `MATCH` patterns or vector search → source [`QueryOp`]s
+/// 3. **WHERE clause**: Predicates → [`QueryOp::Filter`]
+/// 4. **RANK clause**: Similarity ranking → [`QueryOp::RankBySimilarity`]
+/// 5. **RETURN clause**: Projections → [`QueryOp::Project`], [`QueryOp::Distinct`]
+/// 6. **Modifiers**: `SKIP`, `LIMIT` → [`QueryOp::Skip`], [`QueryOp::Limit`]
+///
+/// # Example
+///
+/// ```rust
+/// use gallifreydb::query::{Parser, AstConverter};
+///
+/// let ast = Parser::parse("MATCH (n:Person) WHERE n.age > 21 RETURN n").unwrap();
+/// let converter = AstConverter::new();
+/// let query = converter.convert(&ast).unwrap();
+///
+/// // The query now contains: ScanNodes, Filter, Project operations
+/// ```
+///
+/// # Parameter Binding
+///
+/// Use [`bind`](Self::bind) to set parameter values before conversion:
+///
+/// ```rust
+/// use gallifreydb::query::{Parser, AstConverter, ParameterValue};
+/// use std::sync::Arc;
+///
+/// let ast = Parser::parse("SIMILAR TO $embedding LIMIT 10").unwrap();
+///
+/// let mut converter = AstConverter::new();
+/// converter.bind(
+///     "embedding",
+///     ParameterValue::Embedding(Arc::from([0.1f32, 0.2, 0.3].as_slice())),
+/// );
+///
+/// let query = converter.convert(&ast).unwrap();
+/// ```
 pub struct AstConverter {
-    /// Parameter bindings for the query
+    /// Parameter bindings for the query.
+    ///
+    /// Parameters are referenced in GQL using `$name` syntax and must be
+    /// bound before conversion.
     parameters: HashMap<String, ParameterValue>,
 }
 
 /// Parameter values that can be bound to a query.
+///
+/// GQL queries can reference parameters using the `$name` syntax. These
+/// parameters must be bound to actual values before the query can be
+/// converted and executed.
+///
+/// # Parameter Types
+///
+/// | Type | GQL Usage | Example |
+/// |------|-----------|---------|
+/// | `NodeId` | `FIND SIMILAR TO ($node)` | Reference to a specific node |
+/// | `Embedding` | `SIMILAR TO $embedding` | Vector for k-NN search |
+/// | `Value` | `WHERE n.age > $min_age` | Scalar comparison value |
+///
+/// # Example
+///
+/// ```rust
+/// use gallifreydb::query::ParameterValue;
+/// use gallifreydb::query::ir::PredicateValue;
+/// use gallifreydb::core::NodeId;
+/// use std::sync::Arc;
+///
+/// // Node ID parameter
+/// let node_param = ParameterValue::NodeId(NodeId::new(42).unwrap());
+///
+/// // Embedding parameter (384-dimensional vector)
+/// let embedding_param = ParameterValue::Embedding(
+///     Arc::from(vec![0.0f32; 384].as_slice())
+/// );
+///
+/// // Scalar value parameter
+/// let age_param = ParameterValue::Value(PredicateValue::Int(21));
+/// let name_param = ParameterValue::Value(PredicateValue::String("Alice".to_string()));
+/// ```
 #[derive(Debug, Clone)]
 pub enum ParameterValue {
-    /// Node ID parameter
+    /// A node ID parameter for `FIND SIMILAR TO ($node)` queries.
+    ///
+    /// Used when searching for nodes similar to an existing node.
     NodeId(NodeId),
-    /// Embedding vector parameter
+
+    /// An embedding vector parameter for `SIMILAR TO $embedding` queries.
+    ///
+    /// The vector dimensions must match the configured index dimensions.
     Embedding(Arc<[f32]>),
-    /// Scalar value parameter
+
+    /// A scalar value parameter for use in predicates.
+    ///
+    /// Supports all predicate value types: null, bool, int, float, string.
     Value(PredicateValue),
 }
 
 impl AstConverter {
-    /// Create a new converter with no parameters.
+    /// Create a new converter with no parameter bindings.
+    ///
+    /// Use this when the query has no parameters, or when you'll bind
+    /// parameters later using [`bind`](Self::bind).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::query::AstConverter;
+    ///
+    /// let converter = AstConverter::new();
+    /// ```
     pub fn new() -> Self {
         AstConverter {
             parameters: HashMap::new(),
         }
     }
 
-    /// Create a converter with parameter bindings.
+    /// Create a converter with pre-populated parameter bindings.
+    ///
+    /// This is useful when parameters are collected from an external source
+    /// (e.g., HTTP request, configuration file).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::query::{AstConverter, ParameterValue};
+    /// use gallifreydb::query::ir::PredicateValue;
+    /// use std::collections::HashMap;
+    ///
+    /// let mut params = HashMap::new();
+    /// params.insert("limit".to_string(), ParameterValue::Value(PredicateValue::Int(100)));
+    ///
+    /// let converter = AstConverter::with_parameters(params);
+    /// ```
     pub fn with_parameters(parameters: HashMap<String, ParameterValue>) -> Self {
         AstConverter { parameters }
     }
 
-    /// Bind a parameter value.
+    /// Bind a parameter value by name.
+    ///
+    /// Parameters in GQL are referenced with the `$name` syntax. This method
+    /// associates a name with a concrete value.
+    ///
+    /// Returns `&mut Self` for method chaining.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::query::{AstConverter, ParameterValue};
+    /// use gallifreydb::core::NodeId;
+    /// use std::sync::Arc;
+    ///
+    /// let mut converter = AstConverter::new();
+    /// converter
+    ///     .bind("node_id", ParameterValue::NodeId(NodeId::new(1).unwrap()))
+    ///     .bind("embedding", ParameterValue::Embedding(Arc::from([0.1f32; 384].as_slice())));
+    /// ```
     pub fn bind(&mut self, name: impl Into<String>, value: ParameterValue) -> &mut Self {
         self.parameters.insert(name.into(), value);
         self
     }
 
     /// Convert an AST to a Query.
+    ///
+    /// This is the main conversion method. It processes all parts of the AST
+    /// and produces a [`Query`] containing a sequence of [`QueryOp`] operations.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - A referenced parameter (`$name`) is not bound
+    /// - A parameter has the wrong type for its usage
+    /// - A timestamp string cannot be parsed
+    /// - The time range in `BETWEEN` is invalid (start > end)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gallifreydb::query::{Parser, AstConverter};
+    ///
+    /// let ast = Parser::parse("MATCH (n:Person) RETURN n LIMIT 10").unwrap();
+    /// let converter = AstConverter::new();
+    ///
+    /// match converter.convert(&ast) {
+    ///     Ok(query) => println!("Query converted successfully"),
+    ///     Err(e) => eprintln!("Conversion failed: {}", e),
+    /// }
+    /// ```
     pub fn convert(&self, ast: &QueryAst) -> Result<Query> {
         let mut ops = Vec::new();
         let hints = QueryHints::default();
@@ -501,14 +818,54 @@ impl Default for AstConverter {
 
 /// Parse a GQL query string and convert it to a Query.
 ///
-/// This is a convenience function that combines parsing and conversion.
+/// This is the simplest way to convert a GQL string into an executable query.
+/// It combines parsing and conversion in a single step.
+///
+/// # Arguments
+///
+/// * `gql` - A GQL query string (e.g., `"MATCH (n:Person) RETURN n"`)
+///
+/// # Returns
+///
+/// * `Ok(Query)` - The converted query ready for planning/execution
+/// * `Err(Error)` - Parse error or conversion error
 ///
 /// # Example
 ///
-/// ```ignore
-/// use gallifreydb::query::converter::parse_query;
+/// ```rust
+/// use gallifreydb::query::parse_query;
 ///
-/// let query = parse_query("MATCH (n:Person) RETURN n")?;
+/// // Simple node scan
+/// let query = parse_query("MATCH (n:Person) RETURN n").unwrap();
+///
+/// // Graph traversal with filter
+/// let query = parse_query(
+///     "MATCH (n:Person)-[:KNOWS]->(m:Person) WHERE m.age > 21 RETURN m"
+/// ).unwrap();
+///
+/// // Vector search
+/// let query = parse_query("SIMILAR TO [0.1, 0.2, 0.3] LIMIT 10").unwrap();
+///
+/// // Temporal query
+/// let query = parse_query("AS OF 1704067200000000 MATCH (n:Person) RETURN n").unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Returns an error for:
+/// - Syntax errors in the GQL string
+/// - Unbound parameters (use [`parse_query_with_params`] for parameterized queries)
+///
+/// ```rust
+/// use gallifreydb::query::parse_query;
+///
+/// // Syntax error
+/// let result = parse_query("MATCH (n:Person RETURN n"); // Missing closing paren
+/// assert!(result.is_err());
+///
+/// // Unbound parameter
+/// let result = parse_query("SIMILAR TO $embedding LIMIT 10");
+/// assert!(result.is_err());
 /// ```
 pub fn parse_query(gql: &str) -> Result<Query> {
     let ast = super::parser::Parser::parse(gql).map_err(|e| {
@@ -522,17 +879,59 @@ pub fn parse_query(gql: &str) -> Result<Query> {
 
 /// Parse a GQL query string with parameters and convert it to a Query.
 ///
+/// Use this function when your query contains parameter references (`$name`).
+/// Parameters allow dynamic values without string concatenation, which:
+///
+/// - Prevents injection vulnerabilities
+/// - Enables query plan caching
+/// - Provides type safety
+///
+/// # Arguments
+///
+/// * `gql` - A GQL query string with parameter references
+/// * `params` - A map of parameter names to values
+///
+/// # Returns
+///
+/// * `Ok(Query)` - The converted query with parameters resolved
+/// * `Err(Error)` - Parse error, conversion error, or missing parameter
+///
 /// # Example
 ///
-/// ```ignore
-/// use gallifreydb::query::converter::{parse_query_with_params, ParameterValue};
+/// ```rust
+/// use gallifreydb::query::{parse_query_with_params, ParameterValue};
 /// use std::collections::HashMap;
+/// use std::sync::Arc;
 ///
+/// // Vector search with embedding parameter
 /// let mut params = HashMap::new();
-/// params.insert("name".to_string(), ParameterValue::Value(PredicateValue::String("Alice".to_string())));
+/// params.insert(
+///     "embedding".to_string(),
+///     ParameterValue::Embedding(Arc::from([0.1f32, 0.2, 0.3].as_slice())),
+/// );
 ///
-/// let query = parse_query_with_params("MATCH (n:Person {name: $name}) RETURN n", params)?;
+/// let query = parse_query_with_params(
+///     "SIMILAR TO $embedding LIMIT 10",
+///     params,
+/// ).unwrap();
 /// ```
+///
+/// # Parameter Types
+///
+/// Different query contexts require different parameter types:
+///
+/// | Context | Required Type | Example |
+/// |---------|--------------|---------|
+/// | `SIMILAR TO $param` | `Embedding` | `ParameterValue::Embedding(Arc::from(...))` |
+/// | `FIND SIMILAR TO ($param)` | `NodeId` | `ParameterValue::NodeId(NodeId::new(42)?)` |
+/// | `WHERE n.prop = $param` | `Value` | `ParameterValue::Value(PredicateValue::Int(21))` |
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The GQL string has syntax errors
+/// - A referenced parameter is not in the `params` map
+/// - A parameter has the wrong type for its context
 pub fn parse_query_with_params(
     gql: &str,
     params: HashMap<String, ParameterValue>,

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -134,6 +134,14 @@ pub enum QueryOp {
     /// Skip a number of results
     Skip(usize),
 
+    /// Sort results by a key
+    Sort {
+        /// Sort key (property name or special key like "score")
+        key: SortKey,
+        /// Sort order (true = descending)
+        descending: bool,
+    },
+
     // === Aggregation Operations ===
     /// Count results
     Count,
@@ -218,6 +226,17 @@ pub enum Direction {
     Incoming,
     /// Both directions
     Both,
+}
+
+/// Key for sorting results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortKey {
+    /// Sort by a property value
+    Property(String),
+    /// Sort by similarity score (for vector search results)
+    Score,
+    /// Sort by timestamp (for temporal queries)
+    Timestamp,
 }
 
 /// Property predicates for filtering nodes and edges.

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -229,7 +229,7 @@ impl<'a> Lexer<'a> {
 
     /// Get the next token from the input.
     pub fn next_token(&mut self) -> Result<Token, LexerError> {
-        self.skip_whitespace_and_comments();
+        self.skip_whitespace_and_comments()?;
 
         let Some(&(pos, ch)) = self.chars.peek() else {
             return Ok(Token::Eof);
@@ -321,7 +321,7 @@ impl<'a> Lexer<'a> {
         result
     }
 
-    fn skip_whitespace_and_comments(&mut self) {
+    fn skip_whitespace_and_comments(&mut self) -> Result<(), LexerError> {
         loop {
             // Skip whitespace
             while let Some(&(_, ch)) = self.chars.peek() {
@@ -372,17 +372,22 @@ impl<'a> Lexer<'a> {
                             // Skip to */
                             self.advance(); // /
                             self.advance(); // *
+                            let mut found_end = false;
                             loop {
                                 match self.advance() {
                                     Some((_, '*')) => {
                                         if let Some(&(_, '/')) = self.chars.peek() {
                                             self.advance();
+                                            found_end = true;
                                             break;
                                         }
                                     }
                                     None => break,
                                     _ => {}
                                 }
+                            }
+                            if !found_end {
+                                return Err(self.error("Unterminated block comment".to_string()));
                             }
                             continue;
                         }
@@ -391,6 +396,7 @@ impl<'a> Lexer<'a> {
             }
             break;
         }
+        Ok(())
     }
 
     fn read_dash_or_arrow(&mut self) -> Result<Token, LexerError> {
@@ -985,11 +991,11 @@ mod tests {
 
     #[test]
     fn test_float_literals() {
-        let tokens = Lexer::tokenize("3.14 0.5 10.0").unwrap();
+        let tokens = Lexer::tokenize("2.71 0.5 10.0").unwrap();
         assert_eq!(
             tokens,
             vec![
-                Token::FloatLiteral(3.14),
+                Token::FloatLiteral(2.71),
                 Token::FloatLiteral(0.5),
                 Token::FloatLiteral(10.0),
                 Token::Eof
@@ -999,8 +1005,8 @@ mod tests {
 
     #[test]
     fn test_negative_float() {
-        let tokens = Lexer::tokenize("-3.14").unwrap();
-        assert_eq!(tokens, vec![Token::FloatLiteral(-3.14), Token::Eof]);
+        let tokens = Lexer::tokenize("-2.71").unwrap();
+        assert_eq!(tokens, vec![Token::FloatLiteral(-2.71), Token::Eof]);
     }
 
     #[test]
@@ -1323,7 +1329,7 @@ mod tests {
             "'bar'"
         );
         assert_eq!(format!("{}", Token::IntegerLiteral(42)), "42");
-        assert_eq!(format!("{}", Token::FloatLiteral(3.14)), "3.14");
+        assert_eq!(format!("{}", Token::FloatLiteral(2.71)), "2.71");
         assert_eq!(format!("{}", Token::Parameter("p".to_string())), "$p");
     }
 }

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -1,0 +1,1329 @@
+//! Query Language Lexer
+//!
+//! Tokenizes GQL (Gallifrey Query Language) input strings into a stream of tokens.
+//! This is the first stage of parsing - converting raw text into structured tokens
+//! that the parser can work with.
+
+use std::fmt;
+
+/// A token in the GQL language.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(missing_docs)]
+pub enum Token {
+    // Keywords - Graph
+    Match,
+    Where,
+    Return,
+    Order,
+    By,
+    Limit,
+    Skip,
+    Distinct,
+    Count,
+    Asc,
+    Desc,
+
+    // Keywords - Logical
+    And,
+    Or,
+    Not,
+    In,
+    Is,
+    Null,
+    True,
+    False,
+
+    // Keywords - Vector
+    Similar,
+    To,
+    Using,
+    Find,
+    Rank,
+    Similarity,
+    Top,
+
+    // Keywords - Temporal
+    As,
+    Of,
+    Between,
+
+    // Keywords - String predicates
+    Exists,
+    Contains,
+    Starts,
+    Ends,
+    With,
+
+    // Keywords - Distance metrics
+    Cosine,
+    Euclidean,
+    DotProduct,
+
+    // Punctuation
+    LeftParen,
+    RightParen,
+    LeftBracket,
+    RightBracket,
+    LeftBrace,
+    RightBrace,
+    Colon,
+    Comma,
+    Dot,
+    Star,
+    Dash,
+
+    // Arrow patterns for relationships
+    Arrow,
+    LeftArrow,
+
+    // Comparison operators
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+
+    // Literals
+    Identifier(String),
+    StringLiteral(String),
+    IntegerLiteral(i64),
+    FloatLiteral(f64),
+    Parameter(String),
+
+    // End of file
+    Eof,
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Token::Match => write!(f, "MATCH"),
+            Token::Where => write!(f, "WHERE"),
+            Token::Return => write!(f, "RETURN"),
+            Token::Order => write!(f, "ORDER"),
+            Token::By => write!(f, "BY"),
+            Token::Limit => write!(f, "LIMIT"),
+            Token::Skip => write!(f, "SKIP"),
+            Token::Distinct => write!(f, "DISTINCT"),
+            Token::Count => write!(f, "COUNT"),
+            Token::Asc => write!(f, "ASC"),
+            Token::Desc => write!(f, "DESC"),
+            Token::And => write!(f, "AND"),
+            Token::Or => write!(f, "OR"),
+            Token::Not => write!(f, "NOT"),
+            Token::In => write!(f, "IN"),
+            Token::Is => write!(f, "IS"),
+            Token::Null => write!(f, "NULL"),
+            Token::True => write!(f, "TRUE"),
+            Token::False => write!(f, "FALSE"),
+            Token::Similar => write!(f, "SIMILAR"),
+            Token::To => write!(f, "TO"),
+            Token::Using => write!(f, "USING"),
+            Token::Find => write!(f, "FIND"),
+            Token::Rank => write!(f, "RANK"),
+            Token::Similarity => write!(f, "SIMILARITY"),
+            Token::Top => write!(f, "TOP"),
+            Token::As => write!(f, "AS"),
+            Token::Of => write!(f, "OF"),
+            Token::Between => write!(f, "BETWEEN"),
+            Token::Exists => write!(f, "EXISTS"),
+            Token::Contains => write!(f, "CONTAINS"),
+            Token::Starts => write!(f, "STARTS"),
+            Token::Ends => write!(f, "ENDS"),
+            Token::With => write!(f, "WITH"),
+            Token::Cosine => write!(f, "COSINE"),
+            Token::Euclidean => write!(f, "EUCLIDEAN"),
+            Token::DotProduct => write!(f, "DOT_PRODUCT"),
+            Token::LeftParen => write!(f, "("),
+            Token::RightParen => write!(f, ")"),
+            Token::LeftBracket => write!(f, "["),
+            Token::RightBracket => write!(f, "]"),
+            Token::LeftBrace => write!(f, "{{"),
+            Token::RightBrace => write!(f, "}}"),
+            Token::Colon => write!(f, ":"),
+            Token::Comma => write!(f, ","),
+            Token::Dot => write!(f, "."),
+            Token::Star => write!(f, "*"),
+            Token::Dash => write!(f, "-"),
+            Token::Arrow => write!(f, "->"),
+            Token::LeftArrow => write!(f, "<-"),
+            Token::Eq => write!(f, "="),
+            Token::Ne => write!(f, "<>"),
+            Token::Lt => write!(f, "<"),
+            Token::Le => write!(f, "<="),
+            Token::Gt => write!(f, ">"),
+            Token::Ge => write!(f, ">="),
+            Token::Identifier(s) => write!(f, "{}", s),
+            Token::StringLiteral(s) => write!(f, "'{}'", s),
+            Token::IntegerLiteral(n) => write!(f, "{}", n),
+            Token::FloatLiteral(n) => write!(f, "{}", n),
+            Token::Parameter(s) => write!(f, "${}", s),
+            Token::Eof => write!(f, "EOF"),
+        }
+    }
+}
+
+/// Error type for lexer errors.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexerError {
+    /// Error message describing what went wrong
+    pub message: String,
+    /// Byte position in the input where the error occurred
+    pub position: usize,
+    /// Line number (1-indexed) where the error occurred
+    pub line: usize,
+    /// Column number (1-indexed) where the error occurred
+    pub column: usize,
+}
+
+impl fmt::Display for LexerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Lexer error at line {}, column {}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for LexerError {}
+
+/// A lexer for the GQL query language.
+pub struct Lexer<'a> {
+    input: &'a str,
+    chars: std::iter::Peekable<std::str::CharIndices<'a>>,
+    position: usize,
+    line: usize,
+    column: usize,
+}
+
+impl<'a> Lexer<'a> {
+    /// Create a new lexer for the given input.
+    pub fn new(input: &'a str) -> Self {
+        Lexer {
+            input,
+            chars: input.char_indices().peekable(),
+            position: 0,
+            line: 1,
+            column: 1,
+        }
+    }
+
+    /// Tokenize the entire input and return a vector of tokens.
+    pub fn tokenize(input: &str) -> Result<Vec<Token>, LexerError> {
+        let mut lexer = Lexer::new(input);
+        let mut tokens = Vec::new();
+
+        loop {
+            let token = lexer.next_token()?;
+            let is_eof = token == Token::Eof;
+            tokens.push(token);
+            if is_eof {
+                break;
+            }
+        }
+
+        Ok(tokens)
+    }
+
+    /// Get the next token from the input.
+    pub fn next_token(&mut self) -> Result<Token, LexerError> {
+        self.skip_whitespace_and_comments();
+
+        let Some(&(pos, ch)) = self.chars.peek() else {
+            return Ok(Token::Eof);
+        };
+
+        self.position = pos;
+
+        match ch {
+            // Single character tokens
+            '(' => {
+                self.advance();
+                Ok(Token::LeftParen)
+            }
+            ')' => {
+                self.advance();
+                Ok(Token::RightParen)
+            }
+            '[' => {
+                self.advance();
+                Ok(Token::LeftBracket)
+            }
+            ']' => {
+                self.advance();
+                Ok(Token::RightBracket)
+            }
+            '{' => {
+                self.advance();
+                Ok(Token::LeftBrace)
+            }
+            '}' => {
+                self.advance();
+                Ok(Token::RightBrace)
+            }
+            ':' => {
+                self.advance();
+                Ok(Token::Colon)
+            }
+            ',' => {
+                self.advance();
+                Ok(Token::Comma)
+            }
+            '.' => {
+                self.advance();
+                // Note: We don't support floats starting with . (like .5)
+                // Use 0.5 instead. This allows us to parse 1..3 as range syntax.
+                Ok(Token::Dot)
+            }
+            '*' => {
+                self.advance();
+                Ok(Token::Star)
+            }
+            '=' => {
+                self.advance();
+                Ok(Token::Eq)
+            }
+
+            // Multi-character operators
+            '-' => self.read_dash_or_arrow(),
+            '<' => self.read_less_than(),
+            '>' => self.read_greater_than(),
+            '!' => self.read_not_equal(),
+
+            // String literals
+            '\'' | '"' => self.read_string(),
+
+            // Parameter
+            '$' => self.read_parameter(),
+
+            // Number or negative number
+            '0'..='9' => self.read_number(),
+
+            // Identifier or keyword
+            'a'..='z' | 'A'..='Z' | '_' => self.read_identifier_or_keyword(),
+
+            _ => Err(self.error(format!("Unexpected character: '{}'", ch))),
+        }
+    }
+
+    fn advance(&mut self) -> Option<(usize, char)> {
+        let result = self.chars.next();
+        if let Some((_, ch)) = result {
+            if ch == '\n' {
+                self.line += 1;
+                self.column = 1;
+            } else {
+                self.column += 1;
+            }
+        }
+        result
+    }
+
+    fn skip_whitespace_and_comments(&mut self) {
+        loop {
+            // Skip whitespace
+            while let Some(&(_, ch)) = self.chars.peek() {
+                if ch.is_whitespace() {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+
+            // Check for comments
+            if let Some(&(_, ch)) = self.chars.peek() {
+                if ch == '-' {
+                    // Check for -- comment
+                    let mut chars_clone = self.chars.clone();
+                    chars_clone.next();
+                    if let Some(&(_, '-')) = chars_clone.peek() {
+                        // Skip to end of line
+                        self.advance(); // first -
+                        self.advance(); // second -
+                        while let Some(&(_, ch)) = self.chars.peek() {
+                            if ch == '\n' {
+                                self.advance();
+                                break;
+                            }
+                            self.advance();
+                        }
+                        continue;
+                    }
+                } else if ch == '/' {
+                    // Check for // or /* comment
+                    let mut chars_clone = self.chars.clone();
+                    chars_clone.next();
+                    if let Some(&(_, next_ch)) = chars_clone.peek() {
+                        if next_ch == '/' {
+                            // Skip to end of line
+                            self.advance(); // first /
+                            self.advance(); // second /
+                            while let Some(&(_, ch)) = self.chars.peek() {
+                                if ch == '\n' {
+                                    self.advance();
+                                    break;
+                                }
+                                self.advance();
+                            }
+                            continue;
+                        } else if next_ch == '*' {
+                            // Skip to */
+                            self.advance(); // /
+                            self.advance(); // *
+                            loop {
+                                match self.advance() {
+                                    Some((_, '*')) => {
+                                        if let Some(&(_, '/')) = self.chars.peek() {
+                                            self.advance();
+                                            break;
+                                        }
+                                    }
+                                    None => break,
+                                    _ => {}
+                                }
+                            }
+                            continue;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    fn read_dash_or_arrow(&mut self) -> Result<Token, LexerError> {
+        self.advance(); // consume '-'
+
+        if let Some(&(_, ch)) = self.chars.peek() {
+            match ch {
+                '>' => {
+                    self.advance();
+                    return Ok(Token::Arrow);
+                }
+                '[' | '(' => {
+                    // This is a relationship start, just return dash
+                    return Ok(Token::Dash);
+                }
+                '0'..='9' => {
+                    // Negative number
+                    return self.read_negative_number();
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Token::Dash)
+    }
+
+    fn read_less_than(&mut self) -> Result<Token, LexerError> {
+        self.advance(); // consume '<'
+
+        if let Some(&(_, ch)) = self.chars.peek() {
+            match ch {
+                '=' => {
+                    self.advance();
+                    return Ok(Token::Le);
+                }
+                '>' => {
+                    self.advance();
+                    return Ok(Token::Ne);
+                }
+                '-' => {
+                    self.advance();
+                    return Ok(Token::LeftArrow);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Token::Lt)
+    }
+
+    fn read_greater_than(&mut self) -> Result<Token, LexerError> {
+        self.advance(); // consume '>'
+
+        if let Some(&(_, '=')) = self.chars.peek() {
+            self.advance();
+            return Ok(Token::Ge);
+        }
+
+        Ok(Token::Gt)
+    }
+
+    fn read_not_equal(&mut self) -> Result<Token, LexerError> {
+        self.advance(); // consume '!'
+
+        if let Some(&(_, '=')) = self.chars.peek() {
+            self.advance();
+            return Ok(Token::Ne);
+        }
+
+        Err(self.error("Expected '=' after '!'".to_string()))
+    }
+
+    fn read_string(&mut self) -> Result<Token, LexerError> {
+        let quote = self.advance().map(|(_, c)| c).unwrap();
+        let mut value = String::new();
+
+        loop {
+            match self.advance() {
+                Some((_, ch)) if ch == quote => {
+                    // Check for escaped quote
+                    if let Some(&(_, next_ch)) = self.chars.peek()
+                        && next_ch == quote
+                    {
+                        value.push(quote);
+                        self.advance();
+                        continue;
+                    }
+                    break;
+                }
+                Some((_, '\\')) => {
+                    // Handle escape sequences
+                    match self.advance() {
+                        Some((_, 'n')) => value.push('\n'),
+                        Some((_, 't')) => value.push('\t'),
+                        Some((_, 'r')) => value.push('\r'),
+                        Some((_, '\\')) => value.push('\\'),
+                        Some((_, ch)) if ch == quote => value.push(quote),
+                        Some((_, ch)) => {
+                            value.push('\\');
+                            value.push(ch);
+                        }
+                        None => return Err(self.error("Unterminated string".to_string())),
+                    }
+                }
+                Some((_, ch)) => value.push(ch),
+                None => return Err(self.error("Unterminated string".to_string())),
+            }
+        }
+
+        Ok(Token::StringLiteral(value))
+    }
+
+    fn read_parameter(&mut self) -> Result<Token, LexerError> {
+        self.advance(); // consume '$'
+        let mut name = String::new();
+
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch.is_alphanumeric() || ch == '_' {
+                name.push(ch);
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        if name.is_empty() {
+            return Err(self.error("Expected parameter name after '$'".to_string()));
+        }
+
+        Ok(Token::Parameter(name))
+    }
+
+    fn read_number(&mut self) -> Result<Token, LexerError> {
+        let start_pos = self.position;
+        let mut has_dot = false;
+        let mut has_exp = false;
+
+        while let Some(&(pos, ch)) = self.chars.peek() {
+            match ch {
+                '0'..='9' => {
+                    self.advance();
+                }
+                '.' if !has_dot && !has_exp => {
+                    // Check if next char is a digit
+                    let mut chars_clone = self.chars.clone();
+                    chars_clone.next();
+                    if let Some(&(_, next_ch)) = chars_clone.peek() {
+                        if next_ch.is_ascii_digit() {
+                            has_dot = true;
+                            self.advance();
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                'e' | 'E' if !has_exp => {
+                    has_exp = true;
+                    has_dot = true; // Exponent implies float
+                    self.advance();
+                    // Optional sign after exponent
+                    if let Some(&(_, sign)) = self.chars.peek()
+                        && (sign == '+' || sign == '-')
+                    {
+                        self.advance();
+                    }
+                }
+                _ => break,
+            }
+            let _ = pos; // silence unused warning
+        }
+
+        let text = &self.input[start_pos..self.position + self.current_offset()];
+        self.parse_number(text, has_dot)
+    }
+
+    fn read_negative_number(&mut self) -> Result<Token, LexerError> {
+        // We already consumed the '-'
+        // Update position to current location (the first digit) so read_number starts there
+        if let Some(&(pos, _)) = self.chars.peek() {
+            self.position = pos;
+        }
+        // Read the number and negate it
+        let token = self.read_number()?;
+        match token {
+            Token::IntegerLiteral(n) => Ok(Token::IntegerLiteral(-n)),
+            Token::FloatLiteral(f) => Ok(Token::FloatLiteral(-f)),
+            _ => Err(self.error("Expected number after '-'".to_string())),
+        }
+    }
+
+    fn current_offset(&self) -> usize {
+        self.chars
+            .clone()
+            .next()
+            .map(|(pos, _)| pos - self.position)
+            .unwrap_or(self.input.len() - self.position)
+    }
+
+    fn parse_number(&self, text: &str, is_float: bool) -> Result<Token, LexerError> {
+        if is_float {
+            text.parse::<f64>()
+                .map(Token::FloatLiteral)
+                .map_err(|_| self.error(format!("Invalid float: {}", text)))
+        } else {
+            text.parse::<i64>()
+                .map(Token::IntegerLiteral)
+                .map_err(|_| self.error(format!("Invalid integer: {}", text)))
+        }
+    }
+
+    fn read_identifier_or_keyword(&mut self) -> Result<Token, LexerError> {
+        let start_pos = self.position;
+
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch.is_alphanumeric() || ch == '_' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        let end_pos = self
+            .chars
+            .peek()
+            .map(|(pos, _)| *pos)
+            .unwrap_or(self.input.len());
+        let text = &self.input[start_pos..end_pos];
+
+        // Check for keywords (case-insensitive)
+        let token = match text.to_uppercase().as_str() {
+            "MATCH" => Token::Match,
+            "WHERE" => Token::Where,
+            "RETURN" => Token::Return,
+            "ORDER" => Token::Order,
+            "BY" => Token::By,
+            "LIMIT" => Token::Limit,
+            "SKIP" => Token::Skip,
+            "DISTINCT" => Token::Distinct,
+            "COUNT" => Token::Count,
+            "ASC" => Token::Asc,
+            "DESC" => Token::Desc,
+            "AND" => Token::And,
+            "OR" => Token::Or,
+            "NOT" => Token::Not,
+            "IN" => Token::In,
+            "IS" => Token::Is,
+            "NULL" => Token::Null,
+            "TRUE" => Token::True,
+            "FALSE" => Token::False,
+            "SIMILAR" => Token::Similar,
+            "TO" => Token::To,
+            "USING" => Token::Using,
+            "FIND" => Token::Find,
+            "RANK" => Token::Rank,
+            "SIMILARITY" => Token::Similarity,
+            "TOP" => Token::Top,
+            "AS" => Token::As,
+            "OF" => Token::Of,
+            "BETWEEN" => Token::Between,
+            "EXISTS" => Token::Exists,
+            "CONTAINS" => Token::Contains,
+            "STARTS" => Token::Starts,
+            "ENDS" => Token::Ends,
+            "WITH" => Token::With,
+            "COSINE" => Token::Cosine,
+            "EUCLIDEAN" => Token::Euclidean,
+            "DOT_PRODUCT" => Token::DotProduct,
+            _ => Token::Identifier(text.to_string()),
+        };
+
+        Ok(token)
+    }
+
+    fn error(&self, message: String) -> LexerError {
+        LexerError {
+            message,
+            position: self.position,
+            line: self.line,
+            column: self.column,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =====================================================
+    // Basic Token Tests
+    // =====================================================
+
+    #[test]
+    fn test_empty_input() {
+        let tokens = Lexer::tokenize("").unwrap();
+        assert_eq!(tokens, vec![Token::Eof]);
+    }
+
+    #[test]
+    fn test_whitespace_only() {
+        let tokens = Lexer::tokenize("   \n\t  ").unwrap();
+        assert_eq!(tokens, vec![Token::Eof]);
+    }
+
+    // =====================================================
+    // Keyword Tests
+    // =====================================================
+
+    #[test]
+    fn test_graph_keywords() {
+        let tokens = Lexer::tokenize("MATCH WHERE RETURN ORDER BY LIMIT SKIP").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Match,
+                Token::Where,
+                Token::Return,
+                Token::Order,
+                Token::By,
+                Token::Limit,
+                Token::Skip,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_keywords_case_insensitive() {
+        let tokens = Lexer::tokenize("match Match MATCH").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::Match, Token::Match, Token::Match, Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_vector_keywords() {
+        let tokens = Lexer::tokenize("SIMILAR TO USING FIND RANK SIMILARITY TOP").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Similar,
+                Token::To,
+                Token::Using,
+                Token::Find,
+                Token::Rank,
+                Token::Similarity,
+                Token::Top,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_temporal_keywords() {
+        let tokens = Lexer::tokenize("AS OF BETWEEN").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::As, Token::Of, Token::Between, Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_logical_keywords() {
+        let tokens = Lexer::tokenize("AND OR NOT IN IS NULL TRUE FALSE").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::And,
+                Token::Or,
+                Token::Not,
+                Token::In,
+                Token::Is,
+                Token::Null,
+                Token::True,
+                Token::False,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_string_predicate_keywords() {
+        let tokens = Lexer::tokenize("EXISTS CONTAINS STARTS ENDS WITH").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Exists,
+                Token::Contains,
+                Token::Starts,
+                Token::Ends,
+                Token::With,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_metric_keywords() {
+        let tokens = Lexer::tokenize("COSINE EUCLIDEAN DOT_PRODUCT").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Cosine,
+                Token::Euclidean,
+                Token::DotProduct,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_result_keywords() {
+        let tokens = Lexer::tokenize("DISTINCT COUNT ASC DESC").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Distinct,
+                Token::Count,
+                Token::Asc,
+                Token::Desc,
+                Token::Eof
+            ]
+        );
+    }
+
+    // =====================================================
+    // Punctuation Tests
+    // =====================================================
+
+    #[test]
+    fn test_punctuation() {
+        let tokens = Lexer::tokenize("()[]{}:,.*").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::LeftParen,
+                Token::RightParen,
+                Token::LeftBracket,
+                Token::RightBracket,
+                Token::LeftBrace,
+                Token::RightBrace,
+                Token::Colon,
+                Token::Comma,
+                Token::Dot,
+                Token::Star,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_arrows() {
+        let tokens = Lexer::tokenize("-> <- -").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::Arrow, Token::LeftArrow, Token::Dash, Token::Eof]
+        );
+    }
+
+    // =====================================================
+    // Operator Tests
+    // =====================================================
+
+    #[test]
+    fn test_comparison_operators() {
+        let tokens = Lexer::tokenize("= <> != < <= > >=").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Eq,
+                Token::Ne,
+                Token::Ne,
+                Token::Lt,
+                Token::Le,
+                Token::Gt,
+                Token::Ge,
+                Token::Eof
+            ]
+        );
+    }
+
+    // =====================================================
+    // Identifier Tests
+    // =====================================================
+
+    #[test]
+    fn test_identifiers() {
+        let tokens = Lexer::tokenize("foo bar_baz _underscore camelCase").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Identifier("foo".to_string()),
+                Token::Identifier("bar_baz".to_string()),
+                Token::Identifier("_underscore".to_string()),
+                Token::Identifier("camelCase".to_string()),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_identifier_with_numbers() {
+        let tokens = Lexer::tokenize("node1 var2name item_3").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Identifier("node1".to_string()),
+                Token::Identifier("var2name".to_string()),
+                Token::Identifier("item_3".to_string()),
+                Token::Eof
+            ]
+        );
+    }
+
+    // =====================================================
+    // String Literal Tests
+    // =====================================================
+
+    #[test]
+    fn test_single_quoted_string() {
+        let tokens = Lexer::tokenize("'hello world'").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::StringLiteral("hello world".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_double_quoted_string() {
+        let tokens = Lexer::tokenize("\"hello world\"").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::StringLiteral("hello world".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_string_with_escape_sequences() {
+        let tokens = Lexer::tokenize("'hello\\nworld\\ttab'").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::StringLiteral("hello\nworld\ttab".to_string()),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_string_with_escaped_quote() {
+        let tokens = Lexer::tokenize("'it''s escaped'").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::StringLiteral("it's escaped".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let tokens = Lexer::tokenize("''").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::StringLiteral("".to_string()), Token::Eof]
+        );
+    }
+
+    // =====================================================
+    // Number Literal Tests
+    // =====================================================
+
+    #[test]
+    fn test_integer_literals() {
+        let tokens = Lexer::tokenize("0 42 12345").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::IntegerLiteral(0),
+                Token::IntegerLiteral(42),
+                Token::IntegerLiteral(12345),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_negative_integer() {
+        let tokens = Lexer::tokenize("-42").unwrap();
+        assert_eq!(tokens, vec![Token::IntegerLiteral(-42), Token::Eof]);
+    }
+
+    #[test]
+    fn test_float_literals() {
+        let tokens = Lexer::tokenize("3.14 0.5 10.0").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::FloatLiteral(3.14),
+                Token::FloatLiteral(0.5),
+                Token::FloatLiteral(10.0),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_negative_float() {
+        let tokens = Lexer::tokenize("-3.14").unwrap();
+        assert_eq!(tokens, vec![Token::FloatLiteral(-3.14), Token::Eof]);
+    }
+
+    #[test]
+    fn test_scientific_notation() {
+        let tokens = Lexer::tokenize("1e10 2.5E-3 1e+5").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::FloatLiteral(1e10),
+                Token::FloatLiteral(2.5e-3),
+                Token::FloatLiteral(1e5),
+                Token::Eof
+            ]
+        );
+    }
+
+    // =====================================================
+    // Parameter Tests
+    // =====================================================
+
+    #[test]
+    fn test_parameters() {
+        let tokens = Lexer::tokenize("$embedding $user_id $1").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Parameter("embedding".to_string()),
+                Token::Parameter("user_id".to_string()),
+                Token::Parameter("1".to_string()),
+                Token::Eof
+            ]
+        );
+    }
+
+    // =====================================================
+    // Comment Tests
+    // =====================================================
+
+    #[test]
+    fn test_line_comment_double_dash() {
+        let tokens = Lexer::tokenize("MATCH -- this is a comment\nWHERE").unwrap();
+        assert_eq!(tokens, vec![Token::Match, Token::Where, Token::Eof]);
+    }
+
+    #[test]
+    fn test_line_comment_double_slash() {
+        let tokens = Lexer::tokenize("MATCH // this is a comment\nWHERE").unwrap();
+        assert_eq!(tokens, vec![Token::Match, Token::Where, Token::Eof]);
+    }
+
+    #[test]
+    fn test_block_comment() {
+        let tokens = Lexer::tokenize("MATCH /* multi\nline\ncomment */ WHERE").unwrap();
+        assert_eq!(tokens, vec![Token::Match, Token::Where, Token::Eof]);
+    }
+
+    // =====================================================
+    // Complex Query Tests
+    // =====================================================
+
+    #[test]
+    fn test_simple_match_query() {
+        let tokens = Lexer::tokenize("MATCH (n:Person) RETURN n").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Match,
+                Token::LeftParen,
+                Token::Identifier("n".to_string()),
+                Token::Colon,
+                Token::Identifier("Person".to_string()),
+                Token::RightParen,
+                Token::Return,
+                Token::Identifier("n".to_string()),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_match_with_properties() {
+        let tokens = Lexer::tokenize("MATCH (n:Person {name: 'Alice'})").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Match,
+                Token::LeftParen,
+                Token::Identifier("n".to_string()),
+                Token::Colon,
+                Token::Identifier("Person".to_string()),
+                Token::LeftBrace,
+                Token::Identifier("name".to_string()),
+                Token::Colon,
+                Token::StringLiteral("Alice".to_string()),
+                Token::RightBrace,
+                Token::RightParen,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_match_with_relationship() {
+        let tokens = Lexer::tokenize("MATCH (a)-[:KNOWS]->(b)").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Match,
+                Token::LeftParen,
+                Token::Identifier("a".to_string()),
+                Token::RightParen,
+                Token::Dash,
+                Token::LeftBracket,
+                Token::Colon,
+                Token::Identifier("KNOWS".to_string()),
+                Token::RightBracket,
+                Token::Arrow,
+                Token::LeftParen,
+                Token::Identifier("b".to_string()),
+                Token::RightParen,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_vector_search_query() {
+        let tokens = Lexer::tokenize("SIMILAR TO $embedding USING COSINE LIMIT 10").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Similar,
+                Token::To,
+                Token::Parameter("embedding".to_string()),
+                Token::Using,
+                Token::Cosine,
+                Token::Limit,
+                Token::IntegerLiteral(10),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_temporal_query() {
+        let tokens = Lexer::tokenize("AS OF '2024-01-15' MATCH (n)").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::As,
+                Token::Of,
+                Token::StringLiteral("2024-01-15".to_string()),
+                Token::Match,
+                Token::LeftParen,
+                Token::Identifier("n".to_string()),
+                Token::RightParen,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_where_clause() {
+        let tokens = Lexer::tokenize("WHERE n.age > 18 AND n.name = 'Alice'").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Where,
+                Token::Identifier("n".to_string()),
+                Token::Dot,
+                Token::Identifier("age".to_string()),
+                Token::Gt,
+                Token::IntegerLiteral(18),
+                Token::And,
+                Token::Identifier("n".to_string()),
+                Token::Dot,
+                Token::Identifier("name".to_string()),
+                Token::Eq,
+                Token::StringLiteral("Alice".to_string()),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_hybrid_query() {
+        let tokens = Lexer::tokenize(
+            "AS OF '2024-01-01' MATCH (a:Person)-[:KNOWS]->(b) RANK BY SIMILARITY TO $embedding TOP 10",
+        )
+        .unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::As,
+                Token::Of,
+                Token::StringLiteral("2024-01-01".to_string()),
+                Token::Match,
+                Token::LeftParen,
+                Token::Identifier("a".to_string()),
+                Token::Colon,
+                Token::Identifier("Person".to_string()),
+                Token::RightParen,
+                Token::Dash,
+                Token::LeftBracket,
+                Token::Colon,
+                Token::Identifier("KNOWS".to_string()),
+                Token::RightBracket,
+                Token::Arrow,
+                Token::LeftParen,
+                Token::Identifier("b".to_string()),
+                Token::RightParen,
+                Token::Rank,
+                Token::By,
+                Token::Similarity,
+                Token::To,
+                Token::Parameter("embedding".to_string()),
+                Token::Top,
+                Token::IntegerLiteral(10),
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_order_by_clause() {
+        let tokens = Lexer::tokenize("ORDER BY n.age DESC, n.name ASC").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Order,
+                Token::By,
+                Token::Identifier("n".to_string()),
+                Token::Dot,
+                Token::Identifier("age".to_string()),
+                Token::Desc,
+                Token::Comma,
+                Token::Identifier("n".to_string()),
+                Token::Dot,
+                Token::Identifier("name".to_string()),
+                Token::Asc,
+                Token::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_variable_length_path() {
+        let tokens = Lexer::tokenize("MATCH (a)-[:KNOWS*1..3]->(b)").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Match,
+                Token::LeftParen,
+                Token::Identifier("a".to_string()),
+                Token::RightParen,
+                Token::Dash,
+                Token::LeftBracket,
+                Token::Colon,
+                Token::Identifier("KNOWS".to_string()),
+                Token::Star,
+                Token::IntegerLiteral(1),
+                Token::Dot,
+                Token::Dot,
+                Token::IntegerLiteral(3),
+                Token::RightBracket,
+                Token::Arrow,
+                Token::LeftParen,
+                Token::Identifier("b".to_string()),
+                Token::RightParen,
+                Token::Eof
+            ]
+        );
+    }
+
+    // =====================================================
+    // Error Tests
+    // =====================================================
+
+    #[test]
+    fn test_unterminated_string() {
+        let result = Lexer::tokenize("'unterminated");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unterminated string"));
+    }
+
+    #[test]
+    fn test_unexpected_character() {
+        let result = Lexer::tokenize("MATCH @invalid");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unexpected character"));
+    }
+
+    #[test]
+    fn test_invalid_not_equal() {
+        let result = Lexer::tokenize("!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_parameter() {
+        let result = Lexer::tokenize("$");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("parameter name"));
+    }
+
+    // =====================================================
+    // Token Display Tests
+    // =====================================================
+
+    #[test]
+    fn test_token_display() {
+        assert_eq!(format!("{}", Token::Match), "MATCH");
+        assert_eq!(format!("{}", Token::Arrow), "->");
+        assert_eq!(format!("{}", Token::Identifier("foo".to_string())), "foo");
+        assert_eq!(
+            format!("{}", Token::StringLiteral("bar".to_string())),
+            "'bar'"
+        );
+        assert_eq!(format!("{}", Token::IntegerLiteral(42)), "42");
+        assert_eq!(format!("{}", Token::FloatLiteral(3.14)), "3.14");
+        assert_eq!(format!("{}", Token::Parameter("p".to_string())), "$p");
+    }
+}

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -470,7 +470,10 @@ impl<'a> Lexer<'a> {
     }
 
     fn read_string(&mut self) -> Result<Token, LexerError> {
-        let quote = self.advance().map(|(_, c)| c).unwrap();
+        let quote = self
+            .advance()
+            .map(|(_, c)| c)
+            .ok_or_else(|| self.error("Unexpected EOF while reading string".to_string()))?;
         let mut value = String::new();
 
         loop {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -27,17 +27,23 @@
 //!     .execute()?;
 //! ```
 
+pub mod ast;
 pub mod builder;
 pub mod executor;
 pub mod hybrid;
 pub mod ir;
+pub mod lexer;
+pub mod parser;
 pub mod plan;
 pub mod planner;
 
 // Re-export commonly used types
+pub use ast::QueryAst;
 pub use builder::{Query, QueryBuilder};
 pub use executor::{QueryExecutor, QueryResults, QueryRow};
 pub use hybrid::traverse_and_rank;
 pub use ir::{Direction, Predicate, QueryOp, TraversalDepth};
+pub use lexer::{Lexer, LexerError, Token};
+pub use parser::{ParseError, Parser};
 pub use plan::{LogicalOp, LogicalPlan};
 pub use planner::{PhysicalPlan, QueryPlanner};

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -44,7 +44,7 @@ pub use builder::{Query, QueryBuilder};
 pub use converter::{AstConverter, ParameterValue, parse_query, parse_query_with_params};
 pub use executor::{QueryExecutor, QueryResults, QueryRow};
 pub use hybrid::traverse_and_rank;
-pub use ir::{Direction, Predicate, QueryOp, TraversalDepth};
+pub use ir::{Direction, Predicate, QueryOp, SortKey, TraversalDepth};
 pub use lexer::{Lexer, LexerError, Token};
 pub use parser::{ParseError, Parser};
 pub use plan::{LogicalOp, LogicalPlan};

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -29,6 +29,7 @@
 
 pub mod ast;
 pub mod builder;
+pub mod converter;
 pub mod executor;
 pub mod hybrid;
 pub mod ir;
@@ -40,6 +41,7 @@ pub mod planner;
 // Re-export commonly used types
 pub use ast::QueryAst;
 pub use builder::{Query, QueryBuilder};
+pub use converter::{AstConverter, ParameterValue, parse_query, parse_query_with_params};
 pub use executor::{QueryExecutor, QueryResults, QueryRow};
 pub use hybrid::traverse_and_rank;
 pub use ir::{Direction, Predicate, QueryOp, TraversalDepth};

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1173,7 +1173,10 @@ impl Parser {
                     ));
                 }
                 self.advance();
-                Ok(n as usize)
+                // Safe conversion: on 32-bit systems, values > usize::MAX are clamped.
+                // This is acceptable for SKIP/LIMIT as such large values are impractical.
+                let result = usize::try_from(n).unwrap_or(usize::MAX);
+                Ok(result)
             }
             _ => Err(self.error(
                 "Expected non-negative integer".to_string(),

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1,0 +1,1623 @@
+//! GQL Parser
+//!
+//! A recursive descent parser that converts tokenized GQL input into an AST.
+//! The parser supports the full GQL grammar including MATCH patterns, vector
+//! search operations, temporal clauses, and hybrid queries.
+
+use std::sync::Arc;
+
+use crate::index::vector::DistanceMetric;
+
+use super::ast::*;
+use super::lexer::{Lexer, LexerError, Token};
+
+/// Error type for parser errors.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseError {
+    /// Error message
+    pub message: String,
+    /// Position in the token stream
+    pub position: usize,
+    /// Expected token description
+    pub expected: Option<String>,
+    /// Found token
+    pub found: Option<Token>,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Parse error at position {}: {}",
+            self.position, self.message
+        )?;
+        if let Some(expected) = &self.expected {
+            write!(f, " (expected {})", expected)?;
+        }
+        if let Some(found) = &self.found {
+            write!(f, " (found {})", found)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl From<LexerError> for ParseError {
+    fn from(err: LexerError) -> Self {
+        ParseError {
+            message: err.message,
+            position: err.position,
+            expected: None,
+            found: None,
+        }
+    }
+}
+
+/// A parser for the GQL query language.
+pub struct Parser {
+    tokens: Vec<Token>,
+    position: usize,
+}
+
+impl Parser {
+    /// Parse a GQL query string into an AST.
+    pub fn parse(input: &str) -> Result<QueryAst, ParseError> {
+        let tokens = Lexer::tokenize(input)?;
+        let mut parser = Parser {
+            tokens,
+            position: 0,
+        };
+        parser.parse_query()
+    }
+
+    /// Parse a complete query.
+    fn parse_query(&mut self) -> Result<QueryAst, ParseError> {
+        // Parse optional temporal clause
+        let temporal = self.parse_temporal_clause()?;
+
+        // Parse main source clause (MATCH or vector search)
+        let source = self.parse_source_clause()?;
+
+        // Build initial query
+        let mut query = QueryAst::new(source);
+        if let Some(t) = temporal {
+            query = query.with_temporal(t);
+        }
+
+        // Parse optional RANK BY SIMILARITY clause
+        if let Some(rank) = self.parse_rank_clause()? {
+            query = query.with_rank(rank);
+        }
+
+        // Parse optional WHERE clause
+        if let Some(where_clause) = self.parse_where_clause()? {
+            query = query.with_where(where_clause);
+        }
+
+        // Parse optional RETURN clause
+        if let Some(return_clause) = self.parse_return_clause()? {
+            query = query.with_return(return_clause);
+        }
+
+        // Parse optional ORDER BY clause
+        if let Some(order) = self.parse_order_clause()? {
+            query = query.with_order(order);
+        }
+
+        // Parse optional SKIP clause
+        if let Some(skip) = self.parse_skip_clause()? {
+            query = query.with_skip(skip);
+        }
+
+        // Parse optional LIMIT clause
+        if let Some(limit) = self.parse_limit_clause()? {
+            query = query.with_limit(limit);
+        }
+
+        // Ensure we've consumed all tokens
+        if !self.is_at_end() {
+            return Err(self.error(
+                "Unexpected tokens at end of query".to_string(),
+                Some("end of query".to_string()),
+            ));
+        }
+
+        Ok(query)
+    }
+
+    // =========================================================
+    // Temporal Clause Parsing
+    // =========================================================
+
+    fn parse_temporal_clause(&mut self) -> Result<Option<TemporalClause>, ParseError> {
+        if self.check(&Token::As) {
+            self.advance(); // consume AS
+            self.expect(&Token::Of)?; // expect OF
+            return self.parse_as_of_clause().map(Some);
+        }
+
+        if self.check(&Token::Between) {
+            self.advance(); // consume BETWEEN
+            return self.parse_between_clause().map(Some);
+        }
+
+        Ok(None)
+    }
+
+    fn parse_as_of_clause(&mut self) -> Result<TemporalClause, ParseError> {
+        let valid_time = self.parse_timestamp()?;
+
+        let transaction_time = if self.check(&Token::Comma) {
+            self.advance(); // consume comma
+            Some(self.parse_timestamp()?)
+        } else {
+            None
+        };
+
+        Ok(TemporalClause::AsOf {
+            valid_time,
+            transaction_time,
+        })
+    }
+
+    fn parse_between_clause(&mut self) -> Result<TemporalClause, ParseError> {
+        let start = self.parse_timestamp()?;
+        self.expect(&Token::And)?;
+        let end = self.parse_timestamp()?;
+
+        Ok(TemporalClause::Between { start, end })
+    }
+
+    fn parse_timestamp(&mut self) -> Result<TimestampLiteral, ParseError> {
+        match self.current() {
+            Some(Token::StringLiteral(s)) => {
+                let ts = TimestampLiteral::String(s.clone());
+                self.advance();
+                Ok(ts)
+            }
+            Some(Token::IntegerLiteral(n)) => {
+                let ts = TimestampLiteral::Integer(*n);
+                self.advance();
+                Ok(ts)
+            }
+            _ => Err(self.error(
+                "Expected timestamp (string or integer)".to_string(),
+                Some("timestamp".to_string()),
+            )),
+        }
+    }
+
+    // =========================================================
+    // Source Clause Parsing
+    // =========================================================
+
+    fn parse_source_clause(&mut self) -> Result<SourceClause, ParseError> {
+        if self.check(&Token::Match) {
+            return self.parse_match_clause();
+        }
+
+        if self.check(&Token::Similar) {
+            return self.parse_similar_clause();
+        }
+
+        if self.check(&Token::Find) {
+            return self.parse_find_similar_clause();
+        }
+
+        Err(self.error(
+            "Expected MATCH, SIMILAR, or FIND clause".to_string(),
+            Some("MATCH, SIMILAR, or FIND".to_string()),
+        ))
+    }
+
+    fn parse_match_clause(&mut self) -> Result<SourceClause, ParseError> {
+        self.expect(&Token::Match)?;
+
+        let mut patterns = vec![self.parse_pattern()?];
+
+        // Parse additional patterns separated by commas
+        while self.check(&Token::Comma) {
+            self.advance();
+            patterns.push(self.parse_pattern()?);
+        }
+
+        Ok(SourceClause::Match(patterns))
+    }
+
+    fn parse_similar_clause(&mut self) -> Result<SourceClause, ParseError> {
+        self.expect(&Token::Similar)?;
+        self.expect(&Token::To)?;
+
+        let embedding = self.parse_embedding_ref()?;
+
+        let metric = if self.check(&Token::Using) {
+            self.advance();
+            Some(self.parse_distance_metric()?)
+        } else {
+            None
+        };
+
+        let limit = if self.check(&Token::Limit) {
+            self.advance();
+            self.parse_integer()? as usize
+        } else {
+            10 // default limit
+        };
+
+        Ok(SourceClause::VectorSearch {
+            embedding,
+            metric,
+            limit,
+        })
+    }
+
+    fn parse_find_similar_clause(&mut self) -> Result<SourceClause, ParseError> {
+        self.expect(&Token::Find)?;
+        self.expect(&Token::Similar)?;
+        self.expect(&Token::To)?;
+        self.expect(&Token::LeftParen)?;
+
+        let node_ref = self.parse_node_ref()?;
+
+        self.expect(&Token::RightParen)?;
+
+        let limit = if self.check(&Token::Limit) {
+            self.advance();
+            self.parse_integer()? as usize
+        } else {
+            10 // default limit
+        };
+
+        Ok(SourceClause::FindSimilar { node_ref, limit })
+    }
+
+    fn parse_embedding_ref(&mut self) -> Result<EmbeddingRef, ParseError> {
+        match self.current() {
+            Some(Token::Parameter(name)) => {
+                let emb = EmbeddingRef::Parameter(name.clone());
+                self.advance();
+                Ok(emb)
+            }
+            Some(Token::LeftBracket) => {
+                self.advance();
+                let values = self.parse_float_list()?;
+                self.expect(&Token::RightBracket)?;
+                Ok(EmbeddingRef::Literal(Arc::from(values)))
+            }
+            _ => Err(self.error(
+                "Expected parameter or embedding array".to_string(),
+                Some("$parameter or [float, ...]".to_string()),
+            )),
+        }
+    }
+
+    fn parse_float_list(&mut self) -> Result<Vec<f32>, ParseError> {
+        let mut values = Vec::new();
+
+        loop {
+            let value = match self.current() {
+                Some(Token::FloatLiteral(f)) => *f as f32,
+                Some(Token::IntegerLiteral(i)) => *i as f32,
+                Some(Token::Dash) => {
+                    self.advance();
+                    match self.current() {
+                        Some(Token::FloatLiteral(f)) => -(*f as f32),
+                        Some(Token::IntegerLiteral(i)) => -(*i as f32),
+                        _ => {
+                            return Err(self.error(
+                                "Expected number after '-'".to_string(),
+                                Some("number".to_string()),
+                            ));
+                        }
+                    }
+                }
+                _ => break,
+            };
+            self.advance();
+            values.push(value);
+
+            if !self.check(&Token::Comma) {
+                break;
+            }
+            self.advance(); // consume comma
+        }
+
+        Ok(values)
+    }
+
+    fn parse_distance_metric(&mut self) -> Result<DistanceMetric, ParseError> {
+        match self.current() {
+            Some(Token::Cosine) => {
+                self.advance();
+                Ok(DistanceMetric::Cosine)
+            }
+            Some(Token::Euclidean) => {
+                self.advance();
+                Ok(DistanceMetric::Euclidean)
+            }
+            Some(Token::DotProduct) => {
+                self.advance();
+                Ok(DistanceMetric::DotProduct)
+            }
+            _ => Err(self.error(
+                "Expected distance metric".to_string(),
+                Some("COSINE, EUCLIDEAN, or DOT_PRODUCT".to_string()),
+            )),
+        }
+    }
+
+    fn parse_node_ref(&mut self) -> Result<NodeRef, ParseError> {
+        match self.current() {
+            Some(Token::Identifier(name)) => {
+                let node_ref = NodeRef::Identifier(name.clone());
+                self.advance();
+                Ok(node_ref)
+            }
+            Some(Token::IntegerLiteral(id)) => {
+                let node_ref = NodeRef::Id(*id as u64);
+                self.advance();
+                Ok(node_ref)
+            }
+            Some(Token::Parameter(name)) => {
+                let node_ref = NodeRef::Parameter(name.clone());
+                self.advance();
+                Ok(node_ref)
+            }
+            _ => Err(self.error(
+                "Expected node reference".to_string(),
+                Some("identifier, integer, or parameter".to_string()),
+            )),
+        }
+    }
+
+    // =========================================================
+    // Pattern Parsing
+    // =========================================================
+
+    fn parse_pattern(&mut self) -> Result<Pattern, ParseError> {
+        let first_node = self.parse_node_pattern()?;
+        let mut pattern = Pattern::node(first_node);
+
+        // Parse relationship and node pairs
+        while self.is_relationship_start() {
+            let rel = self.parse_relationship_pattern()?;
+            let node = self.parse_node_pattern()?;
+            pattern = pattern.then(rel, node);
+        }
+
+        Ok(pattern)
+    }
+
+    fn is_relationship_start(&self) -> bool {
+        matches!(self.current(), Some(Token::Dash) | Some(Token::LeftArrow))
+    }
+
+    fn parse_node_pattern(&mut self) -> Result<NodePattern, ParseError> {
+        self.expect(&Token::LeftParen)?;
+
+        let mut node = NodePattern::empty();
+
+        // Parse optional variable
+        if let Some(Token::Identifier(name)) = self.current() {
+            node.variable = Some(name.clone());
+            self.advance();
+        }
+
+        // Parse optional label
+        if self.check(&Token::Colon) {
+            self.advance();
+            if let Some(Token::Identifier(label)) = self.current() {
+                node.label = Some(label.clone());
+                self.advance();
+            } else {
+                return Err(self.error(
+                    "Expected label after ':'".to_string(),
+                    Some("label".to_string()),
+                ));
+            }
+        }
+
+        // Parse optional properties
+        if self.check(&Token::LeftBrace) {
+            node.properties = Some(self.parse_property_map()?);
+        }
+
+        self.expect(&Token::RightParen)?;
+
+        Ok(node)
+    }
+
+    fn parse_relationship_pattern(&mut self) -> Result<RelationshipPattern, ParseError> {
+        let direction_start = if self.check(&Token::LeftArrow) {
+            self.advance();
+            RelationshipDirection::Incoming
+        } else if self.check(&Token::Dash) {
+            self.advance();
+            RelationshipDirection::Both // Default, may change to Outgoing
+        } else {
+            return Err(self.error(
+                "Expected relationship pattern".to_string(),
+                Some("'-' or '<-'".to_string()),
+            ));
+        };
+
+        // Parse relationship details inside brackets
+        self.expect(&Token::LeftBracket)?;
+
+        let mut rel = RelationshipPattern {
+            variable: None,
+            rel_type: None,
+            direction: direction_start,
+            depth: None,
+        };
+
+        // Parse optional variable
+        if let Some(Token::Identifier(name)) = self.current() {
+            // Check if followed by colon (label) or other
+            let mut peek_clone = self.tokens[self.position..].iter();
+            peek_clone.next(); // skip current
+            if matches!(
+                peek_clone.next(),
+                Some(Token::Colon) | Some(Token::Star) | Some(Token::RightBracket)
+            ) {
+                rel.variable = Some(name.clone());
+                self.advance();
+            }
+        }
+
+        // Parse optional type
+        if self.check(&Token::Colon) {
+            self.advance();
+            if let Some(Token::Identifier(label)) = self.current() {
+                rel.rel_type = Some(label.clone());
+                self.advance();
+            }
+        }
+
+        // Parse optional depth specification
+        if self.check(&Token::Star) {
+            rel.depth = Some(self.parse_depth_spec()?);
+        }
+
+        self.expect(&Token::RightBracket)?;
+
+        // Parse end arrow to determine final direction
+        // Pattern combinations:
+        //   -[]->  = Outgoing
+        //   <-[]-  = Incoming
+        //   -[]-   = Both
+        //   <-[]-> = Both (bidirectional)
+        if self.check(&Token::Arrow) {
+            self.advance();
+            if direction_start == RelationshipDirection::Incoming {
+                // <-[]-> is bidirectional
+                rel.direction = RelationshipDirection::Both;
+            } else {
+                // -[]-> is outgoing
+                rel.direction = RelationshipDirection::Outgoing;
+            }
+        } else if self.check(&Token::Dash) {
+            self.advance();
+            if direction_start == RelationshipDirection::Incoming {
+                // <-[]- stays as Incoming
+                rel.direction = RelationshipDirection::Incoming;
+            } else {
+                // -[]- is both
+                rel.direction = RelationshipDirection::Both;
+            }
+        }
+        // If no ending marker, keep the start direction
+
+        Ok(rel)
+    }
+
+    fn parse_depth_spec(&mut self) -> Result<DepthSpec, ParseError> {
+        self.expect(&Token::Star)?;
+
+        // Check for range or exact
+        match self.current() {
+            Some(Token::IntegerLiteral(n)) => {
+                let min = *n as usize;
+                self.advance();
+
+                if self.check(&Token::Dot) {
+                    self.advance();
+                    self.expect(&Token::Dot)?;
+
+                    if let Some(Token::IntegerLiteral(m)) = self.current() {
+                        let max = *m as usize;
+                        self.advance();
+                        Ok(DepthSpec::Range { min, max })
+                    } else {
+                        // *n.. is max(unbounded), treat as Range { min, max: usize::MAX }
+                        Ok(DepthSpec::Range {
+                            min,
+                            max: usize::MAX,
+                        })
+                    }
+                } else {
+                    Ok(DepthSpec::Exact(min))
+                }
+            }
+            Some(Token::Dot) => {
+                self.advance();
+                self.expect(&Token::Dot)?;
+
+                if let Some(Token::IntegerLiteral(n)) = self.current() {
+                    let max = *n as usize;
+                    self.advance();
+                    Ok(DepthSpec::Max(max))
+                } else {
+                    Ok(DepthSpec::Variable)
+                }
+            }
+            _ => Ok(DepthSpec::Variable),
+        }
+    }
+
+    fn parse_property_map(&mut self) -> Result<PropertyMap, ParseError> {
+        self.expect(&Token::LeftBrace)?;
+
+        let mut props = Vec::new();
+
+        if !self.check(&Token::RightBrace) {
+            loop {
+                let key = self.parse_identifier()?;
+                self.expect(&Token::Colon)?;
+                let value = self.parse_property_value()?;
+                props.push((key, value));
+
+                if !self.check(&Token::Comma) {
+                    break;
+                }
+                self.advance();
+            }
+        }
+
+        self.expect(&Token::RightBrace)?;
+        Ok(props)
+    }
+
+    fn parse_property_value(&mut self) -> Result<PropertyValue, ParseError> {
+        match self.current() {
+            Some(Token::Null) => {
+                self.advance();
+                Ok(PropertyValue::Null)
+            }
+            Some(Token::True) => {
+                self.advance();
+                Ok(PropertyValue::Bool(true))
+            }
+            Some(Token::False) => {
+                self.advance();
+                Ok(PropertyValue::Bool(false))
+            }
+            Some(Token::IntegerLiteral(n)) => {
+                let v = PropertyValue::Int(*n);
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::FloatLiteral(f)) => {
+                let v = PropertyValue::Float(*f);
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::StringLiteral(s)) => {
+                let v = PropertyValue::String(s.clone());
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::Parameter(p)) => {
+                let v = PropertyValue::Parameter(p.clone());
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::Dash) => {
+                self.advance();
+                match self.current() {
+                    Some(Token::IntegerLiteral(n)) => {
+                        let v = PropertyValue::Int(-*n);
+                        self.advance();
+                        Ok(v)
+                    }
+                    Some(Token::FloatLiteral(f)) => {
+                        let v = PropertyValue::Float(-*f);
+                        self.advance();
+                        Ok(v)
+                    }
+                    _ => Err(self.error(
+                        "Expected number after '-'".to_string(),
+                        Some("number".to_string()),
+                    )),
+                }
+            }
+            _ => Err(self.error(
+                "Expected property value".to_string(),
+                Some("value".to_string()),
+            )),
+        }
+    }
+
+    // =========================================================
+    // RANK BY SIMILARITY Clause
+    // =========================================================
+
+    fn parse_rank_clause(&mut self) -> Result<Option<RankClause>, ParseError> {
+        if !self.check(&Token::Rank) {
+            return Ok(None);
+        }
+
+        self.advance(); // RANK
+        self.expect(&Token::By)?;
+        self.expect(&Token::Similarity)?;
+        self.expect(&Token::To)?;
+
+        let embedding = self.parse_embedding_ref()?;
+
+        let top_k = if self.check(&Token::Top) {
+            self.advance();
+            Some(self.parse_integer()? as usize)
+        } else {
+            None
+        };
+
+        Ok(Some(RankClause { embedding, top_k }))
+    }
+
+    // =========================================================
+    // WHERE Clause
+    // =========================================================
+
+    fn parse_where_clause(&mut self) -> Result<Option<WhereClause>, ParseError> {
+        if !self.check(&Token::Where) {
+            return Ok(None);
+        }
+
+        self.advance(); // WHERE
+        let predicate = self.parse_predicate()?;
+
+        Ok(Some(WhereClause { predicate }))
+    }
+
+    fn parse_predicate(&mut self) -> Result<PredicateExpr, ParseError> {
+        self.parse_or_predicate()
+    }
+
+    fn parse_or_predicate(&mut self) -> Result<PredicateExpr, ParseError> {
+        let mut left = self.parse_and_predicate()?;
+
+        while self.check(&Token::Or) {
+            self.advance();
+            let right = self.parse_and_predicate()?;
+            left = PredicateExpr::Or(Box::new(left), Box::new(right));
+        }
+
+        Ok(left)
+    }
+
+    fn parse_and_predicate(&mut self) -> Result<PredicateExpr, ParseError> {
+        let mut left = self.parse_not_predicate()?;
+
+        while self.check(&Token::And) {
+            self.advance();
+            let right = self.parse_not_predicate()?;
+            left = PredicateExpr::And(Box::new(left), Box::new(right));
+        }
+
+        Ok(left)
+    }
+
+    fn parse_not_predicate(&mut self) -> Result<PredicateExpr, ParseError> {
+        if self.check(&Token::Not) {
+            self.advance();
+            let pred = self.parse_not_predicate()?;
+            return Ok(PredicateExpr::Not(Box::new(pred)));
+        }
+
+        self.parse_primary_predicate()
+    }
+
+    fn parse_primary_predicate(&mut self) -> Result<PredicateExpr, ParseError> {
+        // Parenthesized predicate
+        if self.check(&Token::LeftParen) {
+            self.advance();
+            let pred = self.parse_predicate()?;
+            self.expect(&Token::RightParen)?;
+            return Ok(PredicateExpr::Grouped(Box::new(pred)));
+        }
+
+        // EXISTS(n.prop)
+        if self.check(&Token::Exists) {
+            self.advance();
+            self.expect(&Token::LeftParen)?;
+            let prop = self.parse_property_access()?;
+            self.expect(&Token::RightParen)?;
+            return Ok(PredicateExpr::Exists(prop));
+        }
+
+        // Property-based predicates
+        let expr = self.parse_expression()?;
+
+        // IS [NOT] NULL
+        if self.check(&Token::Is) {
+            self.advance();
+            let is_not = if self.check(&Token::Not) {
+                self.advance();
+                true
+            } else {
+                false
+            };
+            self.expect(&Token::Null)?;
+
+            if let Expression::Property(prop) = expr {
+                return Ok(if is_not {
+                    PredicateExpr::IsNotNull(prop)
+                } else {
+                    PredicateExpr::IsNull(prop)
+                });
+            } else {
+                return Err(self.error(
+                    "IS NULL requires property access".to_string(),
+                    Some("property".to_string()),
+                ));
+            }
+        }
+
+        // CONTAINS, STARTS WITH, ENDS WITH
+        if self.check(&Token::Contains) {
+            self.advance();
+            let substring = self.parse_string()?;
+            if let Expression::Property(prop) = expr {
+                return Ok(PredicateExpr::Contains {
+                    property: prop,
+                    substring,
+                });
+            }
+        }
+
+        if self.check(&Token::Starts) {
+            self.advance();
+            self.expect(&Token::With)?;
+            let prefix = self.parse_string()?;
+            if let Expression::Property(prop) = expr {
+                return Ok(PredicateExpr::StartsWith {
+                    property: prop,
+                    prefix,
+                });
+            }
+        }
+
+        if self.check(&Token::Ends) {
+            self.advance();
+            self.expect(&Token::With)?;
+            let suffix = self.parse_string()?;
+            if let Expression::Property(prop) = expr {
+                return Ok(PredicateExpr::EndsWith {
+                    property: prop,
+                    suffix,
+                });
+            }
+        }
+
+        // IN [list]
+        if self.check(&Token::In) {
+            self.advance();
+            self.expect(&Token::LeftBracket)?;
+            let mut values = Vec::new();
+            if !self.check(&Token::RightBracket) {
+                loop {
+                    values.push(self.parse_property_value()?);
+                    if !self.check(&Token::Comma) {
+                        break;
+                    }
+                    self.advance();
+                }
+            }
+            self.expect(&Token::RightBracket)?;
+            if let Expression::Property(prop) = expr {
+                return Ok(PredicateExpr::In {
+                    property: prop,
+                    values,
+                });
+            }
+        }
+
+        // Comparison operators
+        let op = match self.current() {
+            Some(Token::Eq) => ComparisonOp::Eq,
+            Some(Token::Ne) => ComparisonOp::Ne,
+            Some(Token::Lt) => ComparisonOp::Lt,
+            Some(Token::Le) => ComparisonOp::Le,
+            Some(Token::Gt) => ComparisonOp::Gt,
+            Some(Token::Ge) => ComparisonOp::Ge,
+            _ => {
+                return Err(self.error(
+                    "Expected comparison operator".to_string(),
+                    Some("=, <>, <, <=, >, >=".to_string()),
+                ));
+            }
+        };
+        self.advance();
+
+        let right = self.parse_expression()?;
+
+        Ok(PredicateExpr::Comparison {
+            left: expr,
+            op,
+            right,
+        })
+    }
+
+    fn parse_expression(&mut self) -> Result<Expression, ParseError> {
+        match self.current() {
+            Some(Token::Identifier(_)) => {
+                // Could be property access (n.prop) or just identifier
+                let ident = self.parse_identifier()?;
+                if self.check(&Token::Dot) {
+                    self.advance();
+                    let prop = self.parse_identifier()?;
+                    Ok(Expression::Property(PropertyAccess {
+                        variable: ident,
+                        property: prop,
+                    }))
+                } else {
+                    // Just an identifier - treat as property on implicit node?
+                    // For now, return as identifier wrapped in property with empty variable
+                    Ok(Expression::Property(PropertyAccess {
+                        variable: String::new(),
+                        property: ident,
+                    }))
+                }
+            }
+            Some(Token::Parameter(p)) => {
+                let param = p.clone();
+                self.advance();
+                Ok(Expression::Parameter(param))
+            }
+            Some(Token::StringLiteral(s)) => {
+                let val = PropertyValue::String(s.clone());
+                self.advance();
+                Ok(Expression::Literal(val))
+            }
+            Some(Token::IntegerLiteral(n)) => {
+                let val = PropertyValue::Int(*n);
+                self.advance();
+                Ok(Expression::Literal(val))
+            }
+            Some(Token::FloatLiteral(f)) => {
+                let val = PropertyValue::Float(*f);
+                self.advance();
+                Ok(Expression::Literal(val))
+            }
+            Some(Token::True) => {
+                self.advance();
+                Ok(Expression::Literal(PropertyValue::Bool(true)))
+            }
+            Some(Token::False) => {
+                self.advance();
+                Ok(Expression::Literal(PropertyValue::Bool(false)))
+            }
+            Some(Token::Null) => {
+                self.advance();
+                Ok(Expression::Literal(PropertyValue::Null))
+            }
+            Some(Token::Dash) => {
+                self.advance();
+                match self.current() {
+                    Some(Token::IntegerLiteral(n)) => {
+                        let val = PropertyValue::Int(-*n);
+                        self.advance();
+                        Ok(Expression::Literal(val))
+                    }
+                    Some(Token::FloatLiteral(f)) => {
+                        let val = PropertyValue::Float(-*f);
+                        self.advance();
+                        Ok(Expression::Literal(val))
+                    }
+                    _ => Err(self.error(
+                        "Expected number after '-'".to_string(),
+                        Some("number".to_string()),
+                    )),
+                }
+            }
+            _ => Err(self.error(
+                "Expected expression".to_string(),
+                Some("identifier, literal, or parameter".to_string()),
+            )),
+        }
+    }
+
+    fn parse_property_access(&mut self) -> Result<PropertyAccess, ParseError> {
+        let variable = self.parse_identifier()?;
+        self.expect(&Token::Dot)?;
+        let property = self.parse_identifier()?;
+        Ok(PropertyAccess { variable, property })
+    }
+
+    // =========================================================
+    // RETURN Clause
+    // =========================================================
+
+    fn parse_return_clause(&mut self) -> Result<Option<ReturnClause>, ParseError> {
+        if !self.check(&Token::Return) {
+            return Ok(None);
+        }
+
+        self.advance(); // RETURN
+
+        let distinct = if self.check(&Token::Distinct) {
+            self.advance();
+            true
+        } else {
+            false
+        };
+
+        // Check for COUNT
+        if self.check(&Token::Count) {
+            self.advance();
+            self.expect(&Token::LeftParen)?;
+            if self.check(&Token::Star) {
+                self.advance();
+            } else {
+                self.parse_expression()?;
+            }
+            self.expect(&Token::RightParen)?;
+
+            // For simplicity, we'll just return COUNT as a special item
+            let items = vec![ReturnItem::new(Expression::FunctionCall {
+                name: "COUNT".to_string(),
+                args: vec![],
+            })];
+            return Ok(Some(ReturnClause { items, distinct }));
+        }
+
+        let mut items = vec![self.parse_return_item()?];
+
+        while self.check(&Token::Comma) {
+            self.advance();
+            items.push(self.parse_return_item()?);
+        }
+
+        Ok(Some(ReturnClause { items, distinct }))
+    }
+
+    fn parse_return_item(&mut self) -> Result<ReturnItem, ParseError> {
+        let expr = self.parse_expression()?;
+
+        let alias = if self.check(&Token::As) {
+            self.advance();
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+
+        Ok(ReturnItem {
+            expression: expr,
+            alias,
+        })
+    }
+
+    // =========================================================
+    // ORDER BY Clause
+    // =========================================================
+
+    fn parse_order_clause(&mut self) -> Result<Option<OrderClause>, ParseError> {
+        if !self.check(&Token::Order) {
+            return Ok(None);
+        }
+
+        self.advance(); // ORDER
+        self.expect(&Token::By)?;
+
+        let mut items = vec![self.parse_order_item()?];
+
+        while self.check(&Token::Comma) {
+            self.advance();
+            items.push(self.parse_order_item()?);
+        }
+
+        Ok(Some(OrderClause { items }))
+    }
+
+    fn parse_order_item(&mut self) -> Result<OrderItem, ParseError> {
+        let expr = self.parse_expression()?;
+
+        let descending = if self.check(&Token::Desc) {
+            self.advance();
+            true
+        } else if self.check(&Token::Asc) {
+            self.advance();
+            false
+        } else {
+            false // default ASC
+        };
+
+        Ok(OrderItem {
+            expression: expr,
+            descending,
+        })
+    }
+
+    // =========================================================
+    // SKIP/LIMIT Clauses
+    // =========================================================
+
+    fn parse_skip_clause(&mut self) -> Result<Option<usize>, ParseError> {
+        if !self.check(&Token::Skip) {
+            return Ok(None);
+        }
+
+        self.advance();
+        Ok(Some(self.parse_integer()? as usize))
+    }
+
+    fn parse_limit_clause(&mut self) -> Result<Option<usize>, ParseError> {
+        if !self.check(&Token::Limit) {
+            return Ok(None);
+        }
+
+        self.advance();
+        Ok(Some(self.parse_integer()? as usize))
+    }
+
+    // =========================================================
+    // Utility Methods
+    // =========================================================
+
+    fn current(&self) -> Option<&Token> {
+        self.tokens.get(self.position)
+    }
+
+    fn check(&self, expected: &Token) -> bool {
+        match (self.current(), expected) {
+            (Some(current), expected) => {
+                std::mem::discriminant(current) == std::mem::discriminant(expected)
+            }
+            _ => false,
+        }
+    }
+
+    fn advance(&mut self) {
+        if !self.is_at_end() {
+            self.position += 1;
+        }
+    }
+
+    fn is_at_end(&self) -> bool {
+        matches!(self.current(), Some(Token::Eof) | None)
+    }
+
+    fn expect(&mut self, expected: &Token) -> Result<(), ParseError> {
+        if self.check(expected) {
+            self.advance();
+            Ok(())
+        } else {
+            Err(self.error(format!("Expected {}", expected), Some(expected.to_string())))
+        }
+    }
+
+    fn parse_identifier(&mut self) -> Result<String, ParseError> {
+        match self.current() {
+            Some(Token::Identifier(name)) => {
+                let name = name.clone();
+                self.advance();
+                Ok(name)
+            }
+            _ => Err(self.error(
+                "Expected identifier".to_string(),
+                Some("identifier".to_string()),
+            )),
+        }
+    }
+
+    fn parse_integer(&mut self) -> Result<i64, ParseError> {
+        match self.current() {
+            Some(Token::IntegerLiteral(n)) => {
+                let n = *n;
+                self.advance();
+                Ok(n)
+            }
+            _ => Err(self.error("Expected integer".to_string(), Some("integer".to_string()))),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, ParseError> {
+        match self.current() {
+            Some(Token::StringLiteral(s)) => {
+                let s = s.clone();
+                self.advance();
+                Ok(s)
+            }
+            _ => Err(self.error("Expected string".to_string(), Some("string".to_string()))),
+        }
+    }
+
+    fn error(&self, message: String, expected: Option<String>) -> ParseError {
+        ParseError {
+            message,
+            position: self.position,
+            expected,
+            found: self.current().cloned(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =====================================================
+    // Basic Query Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_simple_match() {
+        let query = Parser::parse("MATCH (n) RETURN n").unwrap();
+
+        assert!(matches!(query.source, SourceClause::Match(_)));
+        assert!(query.return_clause.is_some());
+    }
+
+    #[test]
+    fn test_parse_match_with_label() {
+        let query = Parser::parse("MATCH (n:Person) RETURN n").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            assert_eq!(patterns.len(), 1);
+            if let PatternElement::Node(node) = &patterns[0].elements[0] {
+                assert_eq!(node.variable, Some("n".to_string()));
+                assert_eq!(node.label, Some("Person".to_string()));
+            } else {
+                panic!("Expected node pattern");
+            }
+        } else {
+            panic!("Expected MATCH clause");
+        }
+    }
+
+    #[test]
+    fn test_parse_match_with_properties() {
+        let query = Parser::parse("MATCH (n:Person {name: 'Alice'}) RETURN n").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            if let PatternElement::Node(node) = &patterns[0].elements[0] {
+                assert!(node.properties.is_some());
+                let props = node.properties.as_ref().unwrap();
+                assert_eq!(props.len(), 1);
+                assert_eq!(props[0].0, "name");
+                assert_eq!(props[0].1, PropertyValue::String("Alice".to_string()));
+            }
+        }
+    }
+
+    // =====================================================
+    // Relationship Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_outgoing_relationship() {
+        let query = Parser::parse("MATCH (a)-[:KNOWS]->(b) RETURN a, b").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            assert_eq!(patterns[0].elements.len(), 3); // a, rel, b
+            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
+                assert_eq!(rel.direction, RelationshipDirection::Outgoing);
+                assert_eq!(rel.rel_type, Some("KNOWS".to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_incoming_relationship() {
+        let query = Parser::parse("MATCH (a)<-[:FOLLOWS]-(b) RETURN a, b").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
+                assert_eq!(rel.direction, RelationshipDirection::Incoming);
+                assert_eq!(rel.rel_type, Some("FOLLOWS".to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_bidirectional_relationship() {
+        let query = Parser::parse("MATCH (a)-[:RELATED]-(b) RETURN a, b").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
+                assert_eq!(rel.direction, RelationshipDirection::Both);
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_variable_length_path() {
+        let query = Parser::parse("MATCH (a)-[:KNOWS*1..3]->(b) RETURN b").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
+                assert_eq!(rel.depth, Some(DepthSpec::Range { min: 1, max: 3 }));
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_exact_depth_path() {
+        let query = Parser::parse("MATCH (a)-[:KNOWS*2]->(b) RETURN b").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
+                assert_eq!(rel.depth, Some(DepthSpec::Exact(2)));
+            }
+        }
+    }
+
+    // =====================================================
+    // Vector Search Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_similar_to_parameter() {
+        let query = Parser::parse("SIMILAR TO $embedding LIMIT 10").unwrap();
+
+        if let SourceClause::VectorSearch {
+            embedding, limit, ..
+        } = &query.source
+        {
+            assert!(matches!(embedding, EmbeddingRef::Parameter(_)));
+            assert_eq!(*limit, 10);
+        } else {
+            panic!("Expected VectorSearch clause");
+        }
+    }
+
+    #[test]
+    fn test_parse_similar_to_literal() {
+        let query = Parser::parse("SIMILAR TO [0.1, 0.2, 0.3] LIMIT 5").unwrap();
+
+        if let SourceClause::VectorSearch {
+            embedding, limit, ..
+        } = &query.source
+        {
+            if let EmbeddingRef::Literal(arr) = embedding {
+                assert_eq!(arr.len(), 3);
+                assert!((arr[0] - 0.1).abs() < 0.001);
+            }
+            assert_eq!(*limit, 5);
+        }
+    }
+
+    #[test]
+    fn test_parse_similar_with_metric() {
+        let query = Parser::parse("SIMILAR TO $emb USING COSINE LIMIT 10").unwrap();
+
+        if let SourceClause::VectorSearch { metric, .. } = &query.source {
+            assert_eq!(*metric, Some(DistanceMetric::Cosine));
+        }
+    }
+
+    #[test]
+    fn test_parse_find_similar() {
+        let query = Parser::parse("FIND SIMILAR TO (node_id) LIMIT 10").unwrap();
+
+        assert!(matches!(query.source, SourceClause::FindSimilar { .. }));
+    }
+
+    // =====================================================
+    // Temporal Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_as_of_string() {
+        let query = Parser::parse("AS OF '2024-01-15T10:00:00Z' MATCH (n) RETURN n").unwrap();
+
+        assert!(query.temporal.is_some());
+        if let Some(TemporalClause::AsOf {
+            valid_time,
+            transaction_time,
+        }) = &query.temporal
+        {
+            assert!(matches!(valid_time, TimestampLiteral::String(_)));
+            assert!(transaction_time.is_none());
+        }
+    }
+
+    #[test]
+    fn test_parse_as_of_bitemporal() {
+        let query = Parser::parse("AS OF '2024-01-15', 1705315200000 MATCH (n) RETURN n").unwrap();
+
+        if let Some(TemporalClause::AsOf {
+            valid_time,
+            transaction_time,
+        }) = &query.temporal
+        {
+            assert!(matches!(valid_time, TimestampLiteral::String(_)));
+            assert!(transaction_time.is_some());
+            assert!(matches!(
+                transaction_time.as_ref().unwrap(),
+                TimestampLiteral::Integer(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_parse_between() {
+        let query =
+            Parser::parse("BETWEEN '2024-01-01' AND '2024-12-31' MATCH (n) RETURN n").unwrap();
+
+        assert!(matches!(
+            query.temporal,
+            Some(TemporalClause::Between { .. })
+        ));
+    }
+
+    // =====================================================
+    // WHERE Clause Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_where_equality() {
+        let query = Parser::parse("MATCH (n) WHERE n.name = 'Alice' RETURN n").unwrap();
+
+        assert!(query.where_clause.is_some());
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::Comparison { .. }));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_comparison() {
+        let query = Parser::parse("MATCH (n) WHERE n.age > 18 RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            if let PredicateExpr::Comparison { op, .. } = predicate {
+                assert_eq!(*op, ComparisonOp::Gt);
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_where_and() {
+        let query =
+            Parser::parse("MATCH (n) WHERE n.age > 18 AND n.name = 'Alice' RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::And(_, _)));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_or() {
+        let query = Parser::parse("MATCH (n) WHERE n.age = 20 OR n.age = 30 RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::Or(_, _)));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_not() {
+        let query = Parser::parse("MATCH (n) WHERE NOT n.active = true RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::Not(_)));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_is_null() {
+        let query = Parser::parse("MATCH (n) WHERE n.email IS NULL RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::IsNull(_)));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_is_not_null() {
+        let query = Parser::parse("MATCH (n) WHERE n.email IS NOT NULL RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::IsNotNull(_)));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_contains() {
+        let query = Parser::parse("MATCH (n) WHERE n.name CONTAINS 'Ali' RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::Contains { .. }));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_starts_with() {
+        let query = Parser::parse("MATCH (n) WHERE n.name STARTS WITH 'A' RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::StartsWith { .. }));
+        }
+    }
+
+    #[test]
+    fn test_parse_where_in() {
+        let query = Parser::parse("MATCH (n) WHERE n.age IN [20, 30, 40] RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            if let PredicateExpr::In { values, .. } = predicate {
+                assert_eq!(values.len(), 3);
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_where_grouped() {
+        let query =
+            Parser::parse("MATCH (n) WHERE (n.a = 1 OR n.b = 2) AND n.c = 3 RETURN n").unwrap();
+
+        if let Some(WhereClause { predicate }) = &query.where_clause {
+            assert!(matches!(predicate, PredicateExpr::And(_, _)));
+        }
+    }
+
+    // =====================================================
+    // RANK BY SIMILARITY Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_rank_by_similarity() {
+        let query = Parser::parse(
+            "MATCH (a:Person)-[:KNOWS]->(b) RANK BY SIMILARITY TO $embedding TOP 10 RETURN b",
+        )
+        .unwrap();
+
+        assert!(query.rank.is_some());
+        if let Some(rank) = &query.rank {
+            assert!(matches!(rank.embedding, EmbeddingRef::Parameter(_)));
+            assert_eq!(rank.top_k, Some(10));
+        }
+    }
+
+    // =====================================================
+    // RETURN Clause Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_return_multiple() {
+        let query = Parser::parse("MATCH (n) RETURN n.name, n.age").unwrap();
+
+        if let Some(ret) = &query.return_clause {
+            assert_eq!(ret.items.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_parse_return_with_alias() {
+        let query = Parser::parse("MATCH (n) RETURN n.name AS name, n.age AS years").unwrap();
+
+        if let Some(ret) = &query.return_clause {
+            assert_eq!(ret.items[0].alias, Some("name".to_string()));
+            assert_eq!(ret.items[1].alias, Some("years".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_parse_return_distinct() {
+        let query = Parser::parse("MATCH (n) RETURN DISTINCT n.name").unwrap();
+
+        if let Some(ret) = &query.return_clause {
+            assert!(ret.distinct);
+        }
+    }
+
+    #[test]
+    fn test_parse_return_count() {
+        let query = Parser::parse("MATCH (n) RETURN COUNT(*)").unwrap();
+
+        if let Some(ret) = &query.return_clause {
+            assert_eq!(ret.items.len(), 1);
+            if let Expression::FunctionCall { name, .. } = &ret.items[0].expression {
+                assert_eq!(name, "COUNT");
+            }
+        }
+    }
+
+    // =====================================================
+    // ORDER BY Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_order_by() {
+        let query = Parser::parse("MATCH (n) RETURN n ORDER BY n.age DESC").unwrap();
+
+        assert!(query.order.is_some());
+        if let Some(order) = &query.order {
+            assert_eq!(order.items.len(), 1);
+            assert!(order.items[0].descending);
+        }
+    }
+
+    #[test]
+    fn test_parse_order_by_multiple() {
+        let query = Parser::parse("MATCH (n) RETURN n ORDER BY n.age DESC, n.name ASC").unwrap();
+
+        if let Some(order) = &query.order {
+            assert_eq!(order.items.len(), 2);
+            assert!(order.items[0].descending);
+            assert!(!order.items[1].descending);
+        }
+    }
+
+    // =====================================================
+    // SKIP/LIMIT Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_limit() {
+        let query = Parser::parse("MATCH (n) RETURN n LIMIT 10").unwrap();
+        assert_eq!(query.limit, Some(10));
+    }
+
+    #[test]
+    fn test_parse_skip() {
+        let query = Parser::parse("MATCH (n) RETURN n SKIP 5 LIMIT 10").unwrap();
+        assert_eq!(query.skip, Some(5));
+        assert_eq!(query.limit, Some(10));
+    }
+
+    // =====================================================
+    // Hybrid Query Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_full_hybrid_query() {
+        let query = Parser::parse(
+            "AS OF '2024-01-01' MATCH (a:Person)-[:KNOWS]->(b) \
+             RANK BY SIMILARITY TO $emb TOP 10 \
+             WHERE b.age > 18 \
+             RETURN b.name, b.age \
+             ORDER BY b.age DESC \
+             SKIP 5 LIMIT 10",
+        )
+        .unwrap();
+
+        assert!(query.temporal.is_some());
+        assert!(matches!(query.source, SourceClause::Match(_)));
+        assert!(query.rank.is_some());
+        assert!(query.where_clause.is_some());
+        assert!(query.return_clause.is_some());
+        assert!(query.order.is_some());
+        assert_eq!(query.skip, Some(5));
+        assert_eq!(query.limit, Some(10));
+    }
+
+    // =====================================================
+    // Error Tests
+    // =====================================================
+
+    #[test]
+    fn test_parse_error_missing_source() {
+        let result = Parser::parse("WHERE n.age > 18");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_error_invalid_pattern() {
+        let result = Parser::parse("MATCH n RETURN n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_error_unclosed_paren() {
+        let result = Parser::parse("MATCH (n:Person RETURN n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_error_missing_label() {
+        let result = Parser::parse("MATCH (n:) RETURN n");
+        assert!(result.is_err());
+    }
+}

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -240,7 +240,7 @@ impl Parser {
 
         let limit = if self.check(&Token::Limit) {
             self.advance();
-            self.parse_integer()? as usize
+            self.parse_usize()?
         } else {
             10 // default limit
         };
@@ -264,7 +264,7 @@ impl Parser {
 
         let limit = if self.check(&Token::Limit) {
             self.advance();
-            self.parse_integer()? as usize
+            self.parse_usize()?
         } else {
             10 // default limit
         };
@@ -282,6 +282,12 @@ impl Parser {
             Some(Token::LeftBracket) => {
                 self.advance();
                 let values = self.parse_float_list()?;
+                if values.is_empty() {
+                    return Err(self.error(
+                        "Embedding array cannot be empty".to_string(),
+                        Some("non-empty array".to_string()),
+                    ));
+                }
                 self.expect(&Token::RightBracket)?;
                 Ok(EmbeddingRef::Literal(Arc::from(values)))
             }
@@ -518,7 +524,14 @@ impl Parser {
         // Check for range or exact
         match self.current() {
             Some(Token::IntegerLiteral(n)) => {
-                let min = *n as usize;
+                let n_val = *n;
+                if n_val < 0 {
+                    return Err(self.error(
+                        format!("Depth must be non-negative, got {}", n_val),
+                        Some("non-negative integer".to_string()),
+                    ));
+                }
+                let min = n_val as usize;
                 self.advance();
 
                 if self.check(&Token::Dot) {
@@ -526,14 +539,28 @@ impl Parser {
                     self.expect(&Token::Dot)?;
 
                     if let Some(Token::IntegerLiteral(m)) = self.current() {
-                        let max = *m as usize;
+                        let m_val = *m;
+                        if m_val < 0 {
+                            return Err(self.error(
+                                format!("Depth must be non-negative, got {}", m_val),
+                                Some("non-negative integer".to_string()),
+                            ));
+                        }
+                        let max = m_val as usize;
+                        if min > max {
+                            return Err(self.error(
+                                format!("Invalid depth range: min ({}) > max ({})", min, max),
+                                Some("valid range".to_string()),
+                            ));
+                        }
                         self.advance();
                         Ok(DepthSpec::Range { min, max })
                     } else {
-                        // *n.. is max(unbounded), treat as Range { min, max: usize::MAX }
+                        // *n.. is unbounded max, use Variable with min hops
+                        // Since we can't express min with Variable, use a large max
                         Ok(DepthSpec::Range {
                             min,
-                            max: usize::MAX,
+                            max: usize::MAX / 2, // Use half max to avoid overflow issues
                         })
                     }
                 } else {
@@ -545,7 +572,14 @@ impl Parser {
                 self.expect(&Token::Dot)?;
 
                 if let Some(Token::IntegerLiteral(n)) = self.current() {
-                    let max = *n as usize;
+                    let n_val = *n;
+                    if n_val < 0 {
+                        return Err(self.error(
+                            format!("Depth must be non-negative, got {}", n_val),
+                            Some("non-negative integer".to_string()),
+                        ));
+                    }
+                    let max = n_val as usize;
                     self.advance();
                     Ok(DepthSpec::Max(max))
                 } else {
@@ -657,7 +691,7 @@ impl Parser {
 
         let top_k = if self.check(&Token::Top) {
             self.advance();
-            Some(self.parse_integer()? as usize)
+            Some(self.parse_usize()?)
         } else {
             None
         };
@@ -773,6 +807,11 @@ impl Parser {
                     property: prop,
                     substring,
                 });
+            } else {
+                return Err(self.error(
+                    "CONTAINS requires a property expression".to_string(),
+                    Some("property.name CONTAINS 'value'".to_string()),
+                ));
             }
         }
 
@@ -785,6 +824,11 @@ impl Parser {
                     property: prop,
                     prefix,
                 });
+            } else {
+                return Err(self.error(
+                    "STARTS WITH requires a property expression".to_string(),
+                    Some("property.name STARTS WITH 'value'".to_string()),
+                ));
             }
         }
 
@@ -797,6 +841,11 @@ impl Parser {
                     property: prop,
                     suffix,
                 });
+            } else {
+                return Err(self.error(
+                    "ENDS WITH requires a property expression".to_string(),
+                    Some("property.name ENDS WITH 'value'".to_string()),
+                ));
             }
         }
 
@@ -820,6 +869,11 @@ impl Parser {
                     property: prop,
                     values,
                 });
+            } else {
+                return Err(self.error(
+                    "IN requires a property expression".to_string(),
+                    Some("property.name IN [...]".to_string()),
+                ));
             }
         }
 
@@ -852,7 +906,7 @@ impl Parser {
     fn parse_expression(&mut self) -> Result<Expression, ParseError> {
         match self.current() {
             Some(Token::Identifier(_)) => {
-                // Could be property access (n.prop) or just identifier
+                // Could be property access (n.prop) or just identifier (n)
                 let ident = self.parse_identifier()?;
                 if self.check(&Token::Dot) {
                     self.advance();
@@ -862,12 +916,8 @@ impl Parser {
                         property: prop,
                     }))
                 } else {
-                    // Just an identifier - treat as property on implicit node?
-                    // For now, return as identifier wrapped in property with empty variable
-                    Ok(Expression::Property(PropertyAccess {
-                        variable: String::new(),
-                        property: ident,
-                    }))
+                    // Just an identifier - a variable reference
+                    Ok(Expression::Identifier(ident))
                 }
             }
             Some(Token::Parameter(p)) => {
@@ -1049,7 +1099,7 @@ impl Parser {
         }
 
         self.advance();
-        Ok(Some(self.parse_integer()? as usize))
+        Ok(Some(self.parse_usize()?))
     }
 
     fn parse_limit_clause(&mut self) -> Result<Option<usize>, ParseError> {
@@ -1058,7 +1108,7 @@ impl Parser {
         }
 
         self.advance();
-        Ok(Some(self.parse_integer()? as usize))
+        Ok(Some(self.parse_usize()?))
     }
 
     // =========================================================
@@ -1111,14 +1161,23 @@ impl Parser {
         }
     }
 
-    fn parse_integer(&mut self) -> Result<i64, ParseError> {
+    fn parse_usize(&mut self) -> Result<usize, ParseError> {
         match self.current() {
             Some(Token::IntegerLiteral(n)) => {
                 let n = *n;
+                if n < 0 {
+                    return Err(self.error(
+                        format!("Expected non-negative integer, got {}", n),
+                        Some("non-negative integer".to_string()),
+                    ));
+                }
                 self.advance();
-                Ok(n)
+                Ok(n as usize)
             }
-            _ => Err(self.error("Expected integer".to_string(), Some("integer".to_string()))),
+            _ => Err(self.error(
+                "Expected non-negative integer".to_string(),
+                Some("non-negative integer".to_string()),
+            )),
         }
     }
 
@@ -1180,14 +1239,14 @@ mod tests {
     fn test_parse_match_with_properties() {
         let query = Parser::parse("MATCH (n:Person {name: 'Alice'}) RETURN n").unwrap();
 
-        if let SourceClause::Match(patterns) = &query.source {
-            if let PatternElement::Node(node) = &patterns[0].elements[0] {
-                assert!(node.properties.is_some());
-                let props = node.properties.as_ref().unwrap();
-                assert_eq!(props.len(), 1);
-                assert_eq!(props[0].0, "name");
-                assert_eq!(props[0].1, PropertyValue::String("Alice".to_string()));
-            }
+        if let SourceClause::Match(patterns) = &query.source
+            && let PatternElement::Node(node) = &patterns[0].elements[0]
+        {
+            assert!(node.properties.is_some());
+            let props = node.properties.as_ref().unwrap();
+            assert_eq!(props.len(), 1);
+            assert_eq!(props[0].0, "name");
+            assert_eq!(props[0].1, PropertyValue::String("Alice".to_string()));
         }
     }
 
@@ -1212,11 +1271,11 @@ mod tests {
     fn test_parse_incoming_relationship() {
         let query = Parser::parse("MATCH (a)<-[:FOLLOWS]-(b) RETURN a, b").unwrap();
 
-        if let SourceClause::Match(patterns) = &query.source {
-            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
-                assert_eq!(rel.direction, RelationshipDirection::Incoming);
-                assert_eq!(rel.rel_type, Some("FOLLOWS".to_string()));
-            }
+        if let SourceClause::Match(patterns) = &query.source
+            && let PatternElement::Relationship(rel) = &patterns[0].elements[1]
+        {
+            assert_eq!(rel.direction, RelationshipDirection::Incoming);
+            assert_eq!(rel.rel_type, Some("FOLLOWS".to_string()));
         }
     }
 
@@ -1224,10 +1283,10 @@ mod tests {
     fn test_parse_bidirectional_relationship() {
         let query = Parser::parse("MATCH (a)-[:RELATED]-(b) RETURN a, b").unwrap();
 
-        if let SourceClause::Match(patterns) = &query.source {
-            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
-                assert_eq!(rel.direction, RelationshipDirection::Both);
-            }
+        if let SourceClause::Match(patterns) = &query.source
+            && let PatternElement::Relationship(rel) = &patterns[0].elements[1]
+        {
+            assert_eq!(rel.direction, RelationshipDirection::Both);
         }
     }
 
@@ -1235,10 +1294,10 @@ mod tests {
     fn test_parse_variable_length_path() {
         let query = Parser::parse("MATCH (a)-[:KNOWS*1..3]->(b) RETURN b").unwrap();
 
-        if let SourceClause::Match(patterns) = &query.source {
-            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
-                assert_eq!(rel.depth, Some(DepthSpec::Range { min: 1, max: 3 }));
-            }
+        if let SourceClause::Match(patterns) = &query.source
+            && let PatternElement::Relationship(rel) = &patterns[0].elements[1]
+        {
+            assert_eq!(rel.depth, Some(DepthSpec::Range { min: 1, max: 3 }));
         }
     }
 
@@ -1246,10 +1305,10 @@ mod tests {
     fn test_parse_exact_depth_path() {
         let query = Parser::parse("MATCH (a)-[:KNOWS*2]->(b) RETURN b").unwrap();
 
-        if let SourceClause::Match(patterns) = &query.source {
-            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
-                assert_eq!(rel.depth, Some(DepthSpec::Exact(2)));
-            }
+        if let SourceClause::Match(patterns) = &query.source
+            && let PatternElement::Relationship(rel) = &patterns[0].elements[1]
+        {
+            assert_eq!(rel.depth, Some(DepthSpec::Exact(2)));
         }
     }
 
@@ -1370,10 +1429,10 @@ mod tests {
     fn test_parse_where_comparison() {
         let query = Parser::parse("MATCH (n) WHERE n.age > 18 RETURN n").unwrap();
 
-        if let Some(WhereClause { predicate }) = &query.where_clause {
-            if let PredicateExpr::Comparison { op, .. } = predicate {
-                assert_eq!(*op, ComparisonOp::Gt);
-            }
+        if let Some(WhereClause { predicate }) = &query.where_clause
+            && let PredicateExpr::Comparison { op, .. } = predicate
+        {
+            assert_eq!(*op, ComparisonOp::Gt);
         }
     }
 
@@ -1445,10 +1504,10 @@ mod tests {
     fn test_parse_where_in() {
         let query = Parser::parse("MATCH (n) WHERE n.age IN [20, 30, 40] RETURN n").unwrap();
 
-        if let Some(WhereClause { predicate }) = &query.where_clause {
-            if let PredicateExpr::In { values, .. } = predicate {
-                assert_eq!(values.len(), 3);
-            }
+        if let Some(WhereClause { predicate }) = &query.where_clause
+            && let PredicateExpr::In { values, .. } = predicate
+        {
+            assert_eq!(values.len(), 3);
         }
     }
 
@@ -1619,5 +1678,59 @@ mod tests {
     fn test_parse_error_missing_label() {
         let result = Parser::parse("MATCH (n:) RETURN n");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_error_negative_limit() {
+        let result = Parser::parse("MATCH (n) RETURN n LIMIT -10");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("non-negative"));
+    }
+
+    #[test]
+    fn test_parse_error_negative_skip() {
+        let result = Parser::parse("MATCH (n) RETURN n SKIP -5");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_error_empty_embedding() {
+        let result = Parser::parse("SIMILAR TO [] LIMIT 10");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_error_negative_depth() {
+        let result = Parser::parse("MATCH (a)-[:KNOWS*-5]->(b) RETURN b");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("non-negative"));
+    }
+
+    #[test]
+    fn test_parse_error_invalid_depth_range() {
+        let result = Parser::parse("MATCH (a)-[:KNOWS*10..5]->(b) RETURN b");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Invalid depth range"));
+    }
+
+    #[test]
+    fn test_parse_error_contains_on_non_property() {
+        let result = Parser::parse("MATCH (n) WHERE 'hello' CONTAINS 'ell' RETURN n");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("property expression"));
+    }
+
+    #[test]
+    fn test_parse_error_in_on_non_property() {
+        let result = Parser::parse("MATCH (n) WHERE 5 IN [1, 2, 3] RETURN n");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("property expression"));
     }
 }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1007,17 +1007,18 @@ impl Parser {
         if self.check(&Token::Count) {
             self.advance();
             self.expect(&Token::LeftParen)?;
-            if self.check(&Token::Star) {
+            let arg = if self.check(&Token::Star) {
                 self.advance();
+                // Represent COUNT(*) with a special identifier
+                Expression::Identifier("*".to_string())
             } else {
-                self.parse_expression()?;
-            }
+                self.parse_expression()?
+            };
             self.expect(&Token::RightParen)?;
 
-            // For simplicity, we'll just return COUNT as a special item
             let items = vec![ReturnItem::new(Expression::FunctionCall {
                 name: "COUNT".to_string(),
-                args: vec![],
+                args: vec![arg],
             })];
             return Ok(Some(ReturnClause { items, distinct }));
         }
@@ -1577,9 +1578,35 @@ mod tests {
 
         if let Some(ret) = &query.return_clause {
             assert_eq!(ret.items.len(), 1);
-            if let Expression::FunctionCall { name, .. } = &ret.items[0].expression {
+            if let Expression::FunctionCall { name, args } = &ret.items[0].expression {
                 assert_eq!(name, "COUNT");
+                assert_eq!(args.len(), 1);
+                // COUNT(*) should have "*" as the argument
+                assert!(matches!(&args[0], Expression::Identifier(s) if s == "*"));
+            } else {
+                panic!("Expected FunctionCall");
             }
+        } else {
+            panic!("Expected return clause");
+        }
+    }
+
+    #[test]
+    fn test_parse_return_count_expression() {
+        let query = Parser::parse("MATCH (n) RETURN COUNT(n)").unwrap();
+
+        if let Some(ret) = &query.return_clause {
+            assert_eq!(ret.items.len(), 1);
+            if let Expression::FunctionCall { name, args } = &ret.items[0].expression {
+                assert_eq!(name, "COUNT");
+                assert_eq!(args.len(), 1);
+                // COUNT(n) should have "n" as the argument
+                assert!(matches!(&args[0], Expression::Identifier(s) if s == "n"));
+            } else {
+                panic!("Expected FunctionCall");
+            }
+        } else {
+            panic!("Expected return clause");
         }
     }
 

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -19,7 +19,7 @@ use crate::utils::error::{Error, QueryError, Result};
 
 use super::builder::Query;
 use super::ir::QueryOp;
-use super::plan::{LogicalOp, LogicalPlan, ScanOp, TemporalContext, UnaryOp};
+use super::plan::{LogicalOp, LogicalPlan, ScanOp, SortKey, TemporalContext, UnaryOp};
 
 pub use cost::{Cost, CostModel};
 pub use physical::{PhysicalOp, PhysicalPlan};
@@ -304,6 +304,27 @@ impl QueryPlanner {
                     })
                 })?;
                 Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input))
+            }
+
+            QueryOp::Sort { key, descending } => {
+                let input = current.ok_or_else(|| {
+                    Error::Query(QueryError::SyntaxError {
+                        message: "Sort requires a source".to_string(),
+                    })
+                })?;
+                // Convert IR SortKey to Plan SortKey
+                let plan_key = match key {
+                    crate::query::ir::SortKey::Property(prop) => SortKey::Property(prop.clone()),
+                    crate::query::ir::SortKey::Score => SortKey::Score,
+                    crate::query::ir::SortKey::Timestamp => SortKey::Timestamp,
+                };
+                Ok(LogicalOp::unary(
+                    UnaryOp::Sort {
+                        key: plan_key,
+                        descending: *descending,
+                    },
+                    input,
+                ))
             }
 
             QueryOp::GetEdges { direction: _ } => {


### PR DESCRIPTION
Implements issues https://github.com/madmax983/GallifreyDB/issues/105 and https://github.com/madmax983/GallifreyDB/issues/106:

Issue https://github.com/madmax983/GallifreyDB/issues/105: Design query language extensions
- Create docs/query-language-design.md with full grammar specification
- Design Cypher-like syntax for graph patterns, vector search, and temporal queries
- Document semantic mapping from query syntax to internal IR operations

Issue https://github.com/madmax983/GallifreyDB/issues/106: Implement query language parser
- Add lexer (src/query/lexer.rs) with tokenization for all keywords, operators, and literals
- Add AST types (src/query/ast.rs) representing parsed queries
- Add recursive descent parser (src/query/parser.rs) producing AST from tokens
- Support MATCH patterns with variable-length paths
- Support SIMILAR TO and FIND SIMILAR vector search operations
- Support AS OF and BETWEEN temporal queries
- Support WHERE clauses with comparisons, logical operators, and string predicates
- Support RETURN, ORDER BY, SKIP, and LIMIT clauses
- Support RANK BY SIMILARITY for hybrid graph+vector queries
- Comprehensive test coverage using TDD approach

All 460 query module tests pass.