### PR TITLE
fix(ci): limit parallel jobs to prevent linker memory exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,10 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
-        run: cargo test --verbose --all-features
+        run: cargo test --verbose --all-features --jobs 2
 
       - name: Run doc tests
-        run: cargo test --doc --verbose --all-features
+        run: cargo test --doc --verbose --all-features --jobs 2
 
   coverage:
     name: Code Coverage
@@ -91,7 +91,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate coverage report
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info --jobs 2
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -104,7 +104,7 @@ jobs:
           verbose: true
 
       - name: Check coverage thresholds
-        run: cargo llvm-cov --all-features --fail-under-lines 85 --fail-under-functions 88 --fail-under-regions 88
+        run: cargo llvm-cov --all-features --fail-under-lines 85 --fail-under-functions 88 --fail-under-regions 88 --jobs 2
 
   lint:
     name: Linting


### PR DESCRIPTION
## Summary

Fixes CI linker crashes (Signal 7 Bus error) on ubuntu-latest runners by limiting cargo parallelism to `--jobs 2`.

## Problem

PR #443 and potentially other PRs with large code additions are experiencing non-deterministic CI failures:

```
error: linking with `cc` failed: exit status: 1
collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
```

**Root Cause:** Memory exhaustion during parallel test binary linking when compiling with `--all-features`. The combination of:
- Tiered storage implementation (substantial new code)
- All optional features enabled (ONNX, Tracy profiling, embeddings, observability)
- Multiple test binaries being linked in parallel
- Limited RAM on GitHub Actions ubuntu-latest runners (7GB, 2 cores)

Results in the linker process exceeding available memory and crashing.

## Solution

Limit parallel compilation jobs to 2 across all test and coverage commands:

- `cargo test --verbose --all-features --jobs 2`
- `cargo test --doc --verbose --all-features --jobs 2`
- `cargo llvm-cov --all-features --lcov --output-path lcov.info --jobs 2`
- `cargo llvm-cov --all-features --fail-under-lines 85 ... --jobs 2`

**Benefits:**
- Halves peak memory usage during linking
- Still maintains 2x parallelism (better than serial `--jobs 1`)
- Standard solution used by many Rust projects on CI
- Addresses infrastructure limitation without code changes

## References

- [actions/runner-images#13367](https://github.com/actions/runner-images/issues/13367) - Known issue: ubuntu-latest runner linker crashes
- [rust-lang/cargo#9735](https://github.com/rust-lang/cargo/issues/9735) - Memory exhaustion during workspace linking
- [rust-lang/cargo#9157](https://github.com/rust-lang/cargo/issues/9157) - Request for parallel linker invocation control

## Testing

- ✅ YAML syntax validated with Python yaml parser
- ⏳ CI will test the fix automatically on this PR

Fixes CI failures in #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)