### PR TITLE
fix: sort WAL entries by LSN during recovery to handle striped archit…

### DIFF
--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -64,6 +64,11 @@ pub fn read_entries_from_dir(wal_dir: &Path, start_lsn: LSN) -> Result<Vec<WalEn
         entries.extend(segment_entries);
     }
 
+    // Sort entries by LSN to ensure correct ordering across segments.
+    // In a striped WAL architecture, entries can be flushed to different segments
+    // in an order that differs from their LSN assignment order.
+    entries.sort_by_key(|entry| entry.lsn);
+
     Ok(entries)
 }
 


### PR DESCRIPTION
…ecture

The concurrent WAL system uses multiple stripes, and entries can be flushed to segments in a different order than their LSNs were assigned. This caused the test_recovery_after_concurrent_writes test to fail intermittently with LSN ordering violations.

The fix adds a sort by LSN after reading all segments, ensuring that recovered entries are always in the correct LSN order regardless of how they were flushed across stripes.

Fixes flaky test: test_recovery_after_concurrent_writes
Related: LSN ordering in striped WAL architecture

https://claude.ai/code/session_01FXeAR5Bq6AKiZwNvnh93kE