### PR TITLE
perf(historical): optimize anchor interval counting from O(N) to O(1) (issue #208)

### DIFF
--- a/benches/historical_storage.rs
+++ b/benches/historical_storage.rs
@@ -1,0 +1,196 @@
+//! Benchmarks for HistoricalStorage anchor creation and version counting
+//!
+//! Issue #208: Measures the performance impact of count_versions_since_anchor
+//! walking the chain on every add operation.
+
+mod common;
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use gallifreydb::core::id::{NodeId, VersionId};
+use gallifreydb::core::interning::GLOBAL_INTERNER;
+use gallifreydb::core::property::PropertyMapBuilder;
+use gallifreydb::core::temporal::BiTemporalInterval;
+use gallifreydb::storage::historical::HistoricalStorage;
+use gallifreydb::storage::version::AnchorConfig;
+
+/// Benchmark: Add node versions with varying anchor intervals
+///
+/// This benchmark measures the performance impact of count_versions_since_anchor
+/// walking the chain on every add. With the default anchor_interval=10, each add
+/// performs up to 9 HashMap lookups just for counting.
+///
+/// Expected before fix: O(anchor_interval) - linear with anchor interval
+/// Expected after fix: O(1) - constant time regardless of anchor interval
+fn bench_add_node_version_with_varying_anchor_intervals(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_node_version_anchor_counting");
+
+    // Test with anchor intervals: 5, 10, 20, 50
+    // Before fix: Higher intervals = more lookups per add
+    // After fix: Should be constant regardless of interval
+    for anchor_interval in [5u32, 10, 20, 50] {
+        group.bench_with_input(
+            BenchmarkId::new("anchor_interval", anchor_interval),
+            &anchor_interval,
+            |b, &interval| {
+                b.iter_batched(
+                    || {
+                        // Setup: Create storage with specific anchor interval
+                        let config = AnchorConfig {
+                            anchor_interval: interval,
+                            max_delta_chain: 100,
+                        };
+                        let mut storage = HistoricalStorage::with_config(config);
+                        let node_id = NodeId::new(1).unwrap();
+                        (storage, node_id)
+                    },
+                    |(mut storage, node_id)| {
+                        // Benchmark: Add 100 versions
+                        // This simulates a bulk insert scenario
+                        let label = GLOBAL_INTERNER.intern("TestLabel").unwrap();
+                        for i in 0..100u64 {
+                            let version_id = VersionId::new(i).unwrap();
+                            let temporal =
+                                BiTemporalInterval::current((1000 + (i as i64) * 100).into());
+                            let properties = PropertyMapBuilder::new()
+                                .insert("version", i as i64)
+                                .build();
+
+                            black_box(storage.add_node_version(
+                                node_id, version_id, temporal, label, properties,
+                            ))
+                            .unwrap();
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark: Single add operation performance with different chain positions
+///
+/// Measures the cost of a single add_node_version at different positions in the
+/// version chain (early vs late in chain before anchor).
+///
+/// Expected before fix: Performance degrades as chain length increases
+/// Expected after fix: Constant performance regardless of position
+fn bench_single_add_at_chain_positions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("single_add_chain_position");
+
+    let config = AnchorConfig {
+        anchor_interval: 10,
+        max_delta_chain: 100,
+    };
+
+    // Test adding at different positions: 1, 3, 5, 7, 9 (deltas before anchor)
+    for position in [1, 3, 5, 7, 9] {
+        group.bench_with_input(
+            BenchmarkId::new("deltas_before_anchor", position),
+            &position,
+            |b, &pos| {
+                b.iter_batched(
+                    || {
+                        // Setup: Create storage and add 'pos' versions
+                        let mut storage = HistoricalStorage::with_config(config.clone());
+                        let node_id = NodeId::new(1).unwrap();
+                        let label = GLOBAL_INTERNER.intern("TestLabel").unwrap();
+
+                        // Pre-populate with 'pos' versions
+                        for i in 0..pos {
+                            let version_id = VersionId::new(i as u64).unwrap();
+                            let temporal =
+                                BiTemporalInterval::current((1000 + (i as i64) * 100).into());
+                            let properties = PropertyMapBuilder::new()
+                                .insert("version", i as i64)
+                                .build();
+
+                            storage
+                                .add_node_version(node_id, version_id, temporal, label, properties)
+                                .unwrap();
+                        }
+
+                        (storage, node_id, pos)
+                    },
+                    |(mut storage, node_id, pos)| {
+                        // Benchmark: Add one more version at this position
+                        let label = GLOBAL_INTERNER.intern("TestLabel").unwrap();
+                        let version_id = VersionId::new(pos as u64).unwrap();
+                        let temporal =
+                            BiTemporalInterval::current((1000 + (pos as i64) * 100).into());
+                        let properties = PropertyMapBuilder::new()
+                            .insert("version", pos as i64)
+                            .build();
+
+                        black_box(
+                            storage
+                                .add_node_version(node_id, version_id, temporal, label, properties),
+                        )
+                        .unwrap();
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark: Bulk insert performance across multiple entities
+///
+/// Simulates a realistic workload with multiple entities being updated concurrently.
+/// This stresses the version counting logic across different entity chains.
+fn bench_bulk_insert_multiple_entities(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bulk_insert_multiple_entities");
+
+    for entity_count in [10, 50, 100] {
+        group.bench_with_input(
+            BenchmarkId::new("entities", entity_count),
+            &entity_count,
+            |b, &count| {
+                b.iter_batched(
+                    || {
+                        // Setup: Create storage with default anchor interval (10)
+                        let storage = HistoricalStorage::new();
+                        (storage, count)
+                    },
+                    |(mut storage, entity_count)| {
+                        // Benchmark: Add 20 versions to each entity
+                        let label = GLOBAL_INTERNER.intern("TestLabel").unwrap();
+                        for entity_id in 0..entity_count {
+                            let node_id = NodeId::new(entity_id).unwrap();
+
+                            for version in 0..20u64 {
+                                let version_id =
+                                    VersionId::new(entity_id * 1000 + version).unwrap();
+                                let temporal = BiTemporalInterval::current(
+                                    (1000 + (version as i64) * 100).into(),
+                                );
+                                let properties = PropertyMapBuilder::new()
+                                    .insert("entity_id", entity_id as i64)
+                                    .insert("version", version as i64)
+                                    .build();
+
+                                black_box(storage.add_node_version(
+                                    node_id, version_id, temporal, label, properties,
+                                ))
+                                .unwrap();
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_add_node_version_with_varying_anchor_intervals,
+    bench_single_add_at_chain_positions,
+    bench_bulk_insert_multiple_entities
+);
+criterion_main!(benches);

--- a/benches/historical_storage.rs
+++ b/benches/historical_storage.rs
@@ -39,7 +39,7 @@ fn bench_add_node_version_with_varying_anchor_intervals(c: &mut Criterion) {
                             anchor_interval: interval,
                             max_delta_chain: 100,
                         };
-                        let mut storage = HistoricalStorage::with_config(config);
+                        let storage = HistoricalStorage::with_config(config);
                         let node_id = NodeId::new(1).unwrap();
                         (storage, node_id)
                     },

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -1316,6 +1316,7 @@ impl HistoricalStorage {
     /// # Note (Issue #208)
     /// This method is no longer used in production code, retained for testing only.
     #[cfg(test)]
+    #[allow(dead_code)]
     fn count_versions_since_anchor_edge(&self, version_id: VersionId) -> usize {
         self.count_versions_since_anchor(version_id, |vid| self.edge_versions.get(&vid))
     }

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -1783,6 +1783,28 @@ impl HistoricalStorage {
             // Set head to the latest version (last in sorted order)
             if let Some(&latest_vid) = version_ids.last() {
                 self.node_version_heads.insert(node_id, latest_vid);
+
+                // Issue #208: Rebuild counter cache for anchor interval checks
+                // Count versions since last anchor by walking backwards from head
+                let mut count = 0;
+                let mut current_id = latest_vid;
+
+                while let Some(version) = self.node_versions.get(&current_id) {
+                    if version.is_anchor() {
+                        // Found anchor, counter is 0
+                        break;
+                    }
+                    // Delta version, increment counter and continue
+                    count += 1;
+                    if let Some(prev_id) = version.prev_version {
+                        current_id = prev_id;
+                    } else {
+                        // No more versions (shouldn't happen, first is always anchor)
+                        break;
+                    }
+                }
+
+                self.node_versions_since_anchor.insert(node_id, count);
             }
         }
 
@@ -1835,6 +1857,28 @@ impl HistoricalStorage {
             // Set head to the latest version (last in sorted order)
             if let Some(&latest_vid) = version_ids.last() {
                 self.edge_version_heads.insert(edge_id, latest_vid);
+
+                // Issue #208: Rebuild counter cache for anchor interval checks
+                // Count versions since last anchor by walking backwards from head
+                let mut count = 0;
+                let mut current_id = latest_vid;
+
+                while let Some(version) = self.edge_versions.get(&current_id) {
+                    if version.is_anchor() {
+                        // Found anchor, counter is 0
+                        break;
+                    }
+                    // Delta version, increment counter and continue
+                    count += 1;
+                    if let Some(prev_id) = version.prev_version {
+                        current_id = prev_id;
+                    } else {
+                        // No more versions (shouldn't happen, first is always anchor)
+                        break;
+                    }
+                }
+
+                self.edge_versions_since_anchor.insert(edge_id, count);
             }
         }
     }
@@ -5181,5 +5225,246 @@ mod tests {
 
         // Version 3 should be an anchor
         assert!(storage.get_edge_version(v3).unwrap().is_anchor());
+    }
+
+    #[test]
+    fn test_counter_cache_rebuilt_after_persistence_restore() {
+        // Test for issue #208 fix: Verify that counter cache is correctly
+        // rebuilt when loading from persistence
+        let config = AnchorConfig {
+            anchor_interval: 5,
+            max_delta_chain: 10,
+        };
+        let mut original = HistoricalStorage::with_config(config.clone());
+
+        let node_id = NodeId::new(1).unwrap();
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+
+        // Create 7 versions: anchor(0), delta(1), delta(2), delta(3), delta(4), anchor(5), delta(6)
+        for i in 0..7 {
+            let vid = VersionId::new(i).unwrap();
+            original
+                .add_node_version(
+                    node_id,
+                    vid,
+                    BiTemporalInterval::current((1000 + (i as i64) * 100).into()),
+                    label,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        // Verify anchor pattern before persistence
+        assert!(
+            original
+                .get_node_version(VersionId::new(0).unwrap())
+                .unwrap()
+                .is_anchor()
+        ); // anchor
+        assert!(
+            original
+                .get_node_version(VersionId::new(1).unwrap())
+                .unwrap()
+                .is_delta()
+        ); // delta
+        assert!(
+            original
+                .get_node_version(VersionId::new(4).unwrap())
+                .unwrap()
+                .is_delta()
+        ); // delta
+        assert!(
+            original
+                .get_node_version(VersionId::new(5).unwrap())
+                .unwrap()
+                .is_anchor()
+        ); // anchor
+        assert!(
+            original
+                .get_node_version(VersionId::new(6).unwrap())
+                .unwrap()
+                .is_delta()
+        ); // delta
+
+        // Extract all versions to simulate persistence save/load
+        let saved_versions: Vec<NodeVersion> = original.node_versions.values().cloned().collect();
+
+        // Create new storage and restore versions (simulating load from disk)
+        let mut restored = HistoricalStorage::with_config(config);
+
+        // Insert all restored versions
+        for version in saved_versions {
+            restored.insert_restored_node_version(version).unwrap();
+        }
+
+        // Rebuild version chains and counter cache
+        restored.rebuild_version_chains();
+
+        // Verify counter cache was rebuilt correctly
+        // After version 6 (delta), counter should be 1 (one delta since last anchor at v5)
+        let counter = restored
+            .node_versions_since_anchor
+            .get(&node_id)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            counter, 1,
+            "Counter should be 1 after version 6 (one delta since anchor at v5)"
+        );
+
+        // Now add more versions and verify anchor/delta pattern continues correctly
+        // Add versions 7-8 (should be deltas)
+        for i in 7..9 {
+            let vid = VersionId::new(i).unwrap();
+            restored
+                .add_node_version(
+                    node_id,
+                    vid,
+                    BiTemporalInterval::current((1000 + (i as i64) * 100).into()),
+                    label,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+
+            // Both should be deltas
+            assert!(
+                restored.get_node_version(vid).unwrap().is_delta(),
+                "Version {} should be delta",
+                i
+            );
+        }
+
+        // Add version 9 (should be delta, counter becomes 4)
+        let v9 = VersionId::new(9).unwrap();
+        restored
+            .add_node_version(
+                node_id,
+                v9,
+                BiTemporalInterval::current(1900.into()),
+                label,
+                PropertyMapBuilder::new().insert("version", 9i64).build(),
+            )
+            .unwrap();
+
+        assert!(
+            restored.get_node_version(v9).unwrap().is_delta(),
+            "Version 9 should be delta"
+        );
+
+        // Add version 10 - should trigger anchor (5 deltas since v5: v6,v7,v8,v9,v10)
+        let v10 = VersionId::new(10).unwrap();
+        restored
+            .add_node_version(
+                node_id,
+                v10,
+                BiTemporalInterval::current(2000.into()),
+                label,
+                PropertyMapBuilder::new().insert("version", 10i64).build(),
+            )
+            .unwrap();
+
+        // Version 10 should be an anchor
+        assert!(
+            restored.get_node_version(v10).unwrap().is_anchor(),
+            "Version 10 should be anchor after 5 deltas"
+        );
+
+        // Verify counter was reset to 0
+        let counter_after = restored
+            .node_versions_since_anchor
+            .get(&node_id)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            counter_after, 0,
+            "Counter should be reset to 0 after creating anchor"
+        );
+    }
+
+    #[test]
+    fn test_edge_counter_cache_rebuilt_after_restore() {
+        // Test edge counter cache rebuilding after persistence restore
+        let config = AnchorConfig {
+            anchor_interval: 3,
+            max_delta_chain: 10,
+        };
+        let mut original = HistoricalStorage::with_config(config.clone());
+
+        let edge_id = EdgeId::new(1).unwrap();
+        let from = NodeId::new(1).unwrap();
+        let to = NodeId::new(2).unwrap();
+        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+
+        // Create 5 versions: anchor(0), delta(1), delta(2), anchor(3), delta(4)
+        for i in 0..5 {
+            let vid = VersionId::new(i).unwrap();
+            original
+                .add_edge_version(
+                    edge_id,
+                    vid,
+                    BiTemporalInterval::current((1000 + (i as i64) * 100).into()),
+                    label,
+                    from,
+                    to,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        // Extract versions
+        let saved_versions: Vec<EdgeVersion> = original.edge_versions.values().cloned().collect();
+
+        // Restore to new storage
+        let mut restored = HistoricalStorage::with_config(config);
+        for version in saved_versions {
+            restored.insert_restored_edge_version(version).unwrap();
+        }
+        restored.rebuild_version_chains();
+
+        // Verify counter is 1 (version 4 is delta after anchor 3)
+        let counter = restored
+            .edge_versions_since_anchor
+            .get(&edge_id)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(counter, 1, "Edge counter should be 1 after restore");
+
+        // Add two more versions - should create anchor at v6
+        for i in 5..7 {
+            let vid = VersionId::new(i).unwrap();
+            restored
+                .add_edge_version(
+                    edge_id,
+                    vid,
+                    BiTemporalInterval::current((1000 + (i as i64) * 100).into()),
+                    label,
+                    from,
+                    to,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        // v5 should be delta, v6 should be anchor
+        assert!(
+            restored
+                .get_edge_version(VersionId::new(5).unwrap())
+                .unwrap()
+                .is_delta()
+        );
+        assert!(
+            restored
+                .get_edge_version(VersionId::new(6).unwrap())
+                .unwrap()
+                .is_anchor()
+        );
     }
 }

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -176,6 +176,18 @@ pub struct HistoricalStorage {
     node_version_counts: HashMap<NodeId, usize>,
     /// Cached version counts per edge (for O(1) capacity checks)
     edge_version_counts: HashMap<EdgeId, usize>,
+    /// Versions since last anchor per node (for O(1) anchor interval checks)
+    ///
+    /// Issue #208: Cache the count of versions since the last anchor to avoid
+    /// walking the version chain on every add operation. This improves write
+    /// performance from O(anchor_interval) to O(1).
+    node_versions_since_anchor: HashMap<NodeId, usize>,
+    /// Versions since last anchor per edge (for O(1) anchor interval checks)
+    ///
+    /// Issue #208: Cache the count of versions since the last anchor to avoid
+    /// walking the version chain on every add operation. This improves write
+    /// performance from O(anchor_interval) to O(1).
+    edge_versions_since_anchor: HashMap<EdgeId, usize>,
     /// TinyLFU cache for reconstructed node properties (reduces lock contention)
     node_property_cache: Arc<Cache<VersionId, Arc<PropertyMap>>>,
     /// TinyLFU cache for reconstructed edge properties
@@ -323,6 +335,8 @@ impl HistoricalStorage {
             edge_version_heads: HashMap::new(),
             node_version_counts: HashMap::new(),
             edge_version_counts: HashMap::new(),
+            node_versions_since_anchor: HashMap::new(),
+            edge_versions_since_anchor: HashMap::new(),
             node_property_cache: Arc::new(Cache::new(cache_size)),
             edge_property_cache: Arc::new(Cache::new(cache_size)),
             node_anchor_cache: Arc::new(Cache::new(anchor_cache_size)),
@@ -489,18 +503,29 @@ impl HistoricalStorage {
                 return Err(StorageError::VersionNotFound(prev_id).into());
             }
 
-            // Count versions since last anchor (including this new version)
-            let versions_since_anchor = self.count_versions_since_anchor_node(prev_id) + 1;
+            // Get cached counter and increment (O(1) instead of O(anchor_interval))
+            // Issue #208: Use cached counter to avoid walking version chain
+            let current_count = self
+                .node_versions_since_anchor
+                .get(&node_id)
+                .copied()
+                .unwrap_or(0);
+            let versions_since_anchor = current_count + 1;
 
             if versions_since_anchor >= self.config.anchor_interval as usize {
                 // Create anchor with link to previous version
                 let mut anchor =
                     NodeVersion::new_anchor(version_id, node_id, temporal, label, properties);
                 anchor.prev_version = Some(prev_id);
+                // Reset counter to 0 after creating anchor
+                self.node_versions_since_anchor.insert(node_id, 0);
                 anchor
             } else {
                 // Create delta from previous version
                 let old_properties = self.reconstruct_node_properties(prev_id)?;
+                // Update counter for next iteration
+                self.node_versions_since_anchor
+                    .insert(node_id, versions_since_anchor);
                 NodeVersion::new_delta(
                     version_id,
                     node_id,
@@ -513,6 +538,8 @@ impl HistoricalStorage {
             }
         } else {
             // First version is always an anchor
+            // Initialize counter to 0
+            self.node_versions_since_anchor.insert(node_id, 0);
             NodeVersion::new_anchor(version_id, node_id, temporal, label, properties)
         };
 
@@ -616,8 +643,14 @@ impl HistoricalStorage {
                 return Err(StorageError::VersionNotFound(prev_id).into());
             }
 
-            // Count versions since last anchor (including this new version)
-            let versions_since_anchor = self.count_versions_since_anchor_edge(prev_id) + 1;
+            // Get cached counter and increment (O(1) instead of O(anchor_interval))
+            // Issue #208: Use cached counter to avoid walking version chain
+            let current_count = self
+                .edge_versions_since_anchor
+                .get(&edge_id)
+                .copied()
+                .unwrap_or(0);
+            let versions_since_anchor = current_count + 1;
 
             if versions_since_anchor >= self.config.anchor_interval as usize {
                 // Create anchor with link to previous version
@@ -625,10 +658,15 @@ impl HistoricalStorage {
                     version_id, edge_id, temporal, label, source, target, properties,
                 );
                 anchor.prev_version = Some(prev_id);
+                // Reset counter to 0 after creating anchor
+                self.edge_versions_since_anchor.insert(edge_id, 0);
                 anchor
             } else {
                 // Create delta from previous version
                 let old_properties = self.reconstruct_edge_properties(prev_id)?;
+                // Update counter for next iteration
+                self.edge_versions_since_anchor
+                    .insert(edge_id, versions_since_anchor);
                 EdgeVersion::new_delta(
                     version_id,
                     edge_id,
@@ -643,6 +681,8 @@ impl HistoricalStorage {
             }
         } else {
             // First version is always an anchor
+            // Initialize counter to 0
+            self.edge_versions_since_anchor.insert(edge_id, 0);
             EdgeVersion::new_anchor(
                 version_id, edge_id, temporal, label, source, target, properties,
             )
@@ -1225,6 +1265,11 @@ impl HistoricalStorage {
     ///
     /// This is a generic helper that works for both nodes and edges, reducing code duplication.
     /// The `get_version` closure provides type-specific version lookup.
+    ///
+    /// # Note (Issue #208)
+    /// This method is no longer used in production code (replaced by cached counters for O(1) performance),
+    /// but is retained for testing purposes to verify cache correctness.
+    #[cfg(test)]
     fn count_versions_since_anchor<'a, V: EntityVersion + 'a>(
         &'a self,
         version_id: VersionId,
@@ -1255,6 +1300,10 @@ impl HistoricalStorage {
     ///
     /// Note: The closure overhead is negligible and typically optimized away by LLVM.
     /// If profiling shows this is a hotspot, consider monomorphizing.
+    ///
+    /// # Note (Issue #208)
+    /// This method is no longer used in production code, retained for testing only.
+    #[cfg(test)]
     fn count_versions_since_anchor_node(&self, version_id: VersionId) -> usize {
         self.count_versions_since_anchor(version_id, |vid| self.node_versions.get(&vid))
     }
@@ -1263,6 +1312,10 @@ impl HistoricalStorage {
     ///
     /// Note: The closure overhead is negligible and typically optimized away by LLVM.
     /// If profiling shows this is a hotspot, consider monomorphizing.
+    ///
+    /// # Note (Issue #208)
+    /// This method is no longer used in production code, retained for testing only.
+    #[cfg(test)]
     fn count_versions_since_anchor_edge(&self, version_id: VersionId) -> usize {
         self.count_versions_since_anchor(version_id, |vid| self.edge_versions.get(&vid))
     }
@@ -4944,5 +4997,189 @@ mod tests {
 
         // Test counting from version 3 (new anchor) - should find 0 deltas
         assert_eq!(storage.count_versions_since_anchor_node(version_ids[3]), 0);
+    }
+
+    #[test]
+    fn test_version_counter_cache() {
+        // Test that the version counter cache correctly tracks versions since last anchor
+        // This test verifies the fix for issue #208
+        let mut storage = HistoricalStorage::with_config(AnchorConfig {
+            anchor_interval: 5,
+            max_delta_chain: 10,
+        });
+
+        let node_id = NodeId::new(1).unwrap();
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+
+        // Add first version - should be anchor, counter should be 0
+        let v0 = VersionId::new(0).unwrap();
+        storage
+            .add_node_version(
+                node_id,
+                v0,
+                BiTemporalInterval::current(1000.into()),
+                label,
+                PropertyMapBuilder::new().insert("version", 0i64).build(),
+            )
+            .unwrap();
+
+        // Verify first version is an anchor
+        assert!(storage.get_node_version(v0).unwrap().is_anchor());
+
+        // Add 4 more versions (deltas)
+        for i in 1..5 {
+            let vid = VersionId::new(i).unwrap();
+            storage
+                .add_node_version(
+                    node_id,
+                    vid,
+                    BiTemporalInterval::current((1000 + (i as i64) * 100).into()),
+                    label,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+
+            // All should be deltas
+            assert!(storage.get_node_version(vid).unwrap().is_delta());
+        }
+
+        // Add 5th version - should trigger anchor creation (interval = 5)
+        let v5 = VersionId::new(5).unwrap();
+        storage
+            .add_node_version(
+                node_id,
+                v5,
+                BiTemporalInterval::current(1600.into()),
+                label,
+                PropertyMapBuilder::new().insert("version", 5i64).build(),
+            )
+            .unwrap();
+
+        // Version 5 should be an anchor
+        assert!(storage.get_node_version(v5).unwrap().is_anchor());
+
+        // Add one more version - should be delta, counter should reset
+        let v6 = VersionId::new(6).unwrap();
+        storage
+            .add_node_version(
+                node_id,
+                v6,
+                BiTemporalInterval::current(1700.into()),
+                label,
+                PropertyMapBuilder::new().insert("version", 6i64).build(),
+            )
+            .unwrap();
+
+        // Version 6 should be a delta
+        assert!(storage.get_node_version(v6).unwrap().is_delta());
+
+        // Test with multiple entities to ensure counters are independent
+        let node_id2 = NodeId::new(2).unwrap();
+
+        // Add versions to second entity
+        for i in 0..3 {
+            let vid = VersionId::new(100 + i).unwrap();
+            storage
+                .add_node_version(
+                    node_id2,
+                    vid,
+                    BiTemporalInterval::current((2000 + (i as i64) * 100).into()),
+                    label,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+        }
+
+        // First version of second entity should be anchor
+        assert!(
+            storage
+                .get_node_version(VersionId::new(100).unwrap())
+                .unwrap()
+                .is_anchor()
+        );
+        // Next two should be deltas
+        assert!(
+            storage
+                .get_node_version(VersionId::new(101).unwrap())
+                .unwrap()
+                .is_delta()
+        );
+        assert!(
+            storage
+                .get_node_version(VersionId::new(102).unwrap())
+                .unwrap()
+                .is_delta()
+        );
+    }
+
+    #[test]
+    fn test_edge_version_counter_cache() {
+        // Test that the version counter cache works for edges too
+        let mut storage = HistoricalStorage::with_config(AnchorConfig {
+            anchor_interval: 3,
+            max_delta_chain: 10,
+        });
+
+        let edge_id = EdgeId::new(1).unwrap();
+        let from = NodeId::new(1).unwrap();
+        let to = NodeId::new(2).unwrap();
+        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+
+        // Add first version - should be anchor
+        let v0 = VersionId::new(0).unwrap();
+        storage
+            .add_edge_version(
+                edge_id,
+                v0,
+                BiTemporalInterval::current(1000.into()),
+                label,
+                from,
+                to,
+                PropertyMapBuilder::new().insert("version", 0i64).build(),
+            )
+            .unwrap();
+
+        assert!(storage.get_edge_version(v0).unwrap().is_anchor());
+
+        // Add 2 deltas
+        for i in 1..3 {
+            let vid = VersionId::new(i).unwrap();
+            storage
+                .add_edge_version(
+                    edge_id,
+                    vid,
+                    BiTemporalInterval::current((1000 + (i as i64) * 100).into()),
+                    label,
+                    from,
+                    to,
+                    PropertyMapBuilder::new()
+                        .insert("version", i as i64)
+                        .build(),
+                )
+                .unwrap();
+
+            assert!(storage.get_edge_version(vid).unwrap().is_delta());
+        }
+
+        // Add 3rd delta - should trigger anchor creation (interval = 3)
+        let v3 = VersionId::new(3).unwrap();
+        storage
+            .add_edge_version(
+                edge_id,
+                v3,
+                BiTemporalInterval::current(1400.into()),
+                label,
+                from,
+                to,
+                PropertyMapBuilder::new().insert("version", 3i64).build(),
+            )
+            .unwrap();
+
+        // Version 3 should be an anchor
+        assert!(storage.get_edge_version(v3).unwrap().is_anchor());
     }
 }


### PR DESCRIPTION
Replace version chain walking with per-entity counter cache to eliminate
redundant HashMap lookups during version creation.

**Problem:**
`count_versions_since_anchor_node()` and `count_versions_since_anchor_edge()`
traversed backward through the version chain on every `add_node_version()` and
`add_edge_version()` call. With default anchor_interval=10, each add performed
up to 9 HashMap lookups, resulting in O(N × anchor_interval) complexity during
bulk inserts of N versions to the same entity.

**Solution (Option 1 from issue):**
- Add `node_versions_since_anchor: HashMap<NodeId, usize>` cache
- Add `edge_versions_since_anchor: HashMap<EdgeId, usize>` cache
- Increment counter on delta creation
- Reset counter to 0 on anchor creation
- Initialize counter to 0 for first version

**Results:**
- Write operations: O(anchor_interval) → O(1) for version counting
- No change to version chain structure or reconstruction logic
- Zero overhead for read operations
- Original count methods retained as `#[cfg(test)]` for verification

**Testing:**
- Added `test_version_counter_cache()` for node counter correctness
- Added `test_edge_version_counter_cache()` for edge counter correctness
- All 62 existing historical storage tests pass
- Added benchmarks in `benches/historical_storage.rs` to measure improvement

Issue: #208