### PR TITLE
fix: delete_node() now removes vectors from HNSW index (issue #323)

### DIFF
--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -959,9 +959,16 @@ impl CurrentStorage {
     /// Note: This does not delete edges connected to the node.
     /// See issue #364 for cascade delete option.
     pub fn delete_node(&self, id: NodeId) -> Result<Node> {
-        self.indexes
+        let node = self
+            .indexes
             .remove_node(id)
-            .ok_or_else(|| StorageError::NodeNotFound(id).into())
+            .ok_or(StorageError::NodeNotFound(id))?;
+
+        // Best-effort vector index removal (ignore errors) - Issue #323
+        // This prevents memory leaks and ensures deleted nodes don't appear in similarity searches
+        let _ = self.try_remove_from_index(id);
+
+        Ok(node)
     }
 
     /// Delete an edge.
@@ -2874,6 +2881,70 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|(id, _)| *id != node1));
         assert_eq!(results[0].0, node2); // Most similar
+    }
+
+    /// Test for Issue #323: delete_node() should remove vectors from HNSW index
+    ///
+    /// This test verifies that CurrentStorage::delete_node() properly removes
+    /// vector embeddings from the HNSW index, preventing memory leaks and
+    /// incorrect search results.
+    #[test]
+    fn test_delete_node_removes_from_vector_index() {
+        use crate::index::vector::DistanceMetric;
+        let storage = CurrentStorage::new();
+
+        // Enable vector index
+        let config = HnswConfig::new(4, DistanceMetric::Cosine).with_capacity(100);
+        storage.enable_vector_index("embedding", config).unwrap();
+
+        // Create two nodes with embeddings
+        let v1 = vec![1.0f32, 0.0, 0.0, 0.0];
+        let v2 = vec![0.0f32, 1.0, 0.0, 0.0];
+
+        let node1 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &v1)
+                    .build(),
+            )
+            .unwrap();
+
+        let node2 = storage
+            .create_node(
+                "Doc",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &v2)
+                    .build(),
+            )
+            .unwrap();
+
+        // Verify both nodes are in the index
+        let results_before = storage.find_similar_by_embedding(&v1, 10).unwrap();
+        assert_eq!(
+            results_before.len(),
+            2,
+            "Should find 2 nodes before deletion"
+        );
+
+        // Delete node1
+        storage.delete_node(node1).unwrap();
+
+        // Verify node1 is removed from the index
+        let results_after = storage.find_similar_by_embedding(&v1, 10).unwrap();
+        assert_eq!(
+            results_after.len(),
+            1,
+            "Should find only 1 node after deletion"
+        );
+        assert_eq!(results_after[0].0, node2, "Remaining node should be node2");
+
+        // Deleted node should not appear in find_similar results
+        let similar_to_node2 = storage.find_similar(node2, 10).unwrap();
+        assert!(
+            !similar_to_node2.iter().any(|(id, _)| *id == node1),
+            "Deleted node should not appear in similarity search"
+        );
     }
 
     #[test]

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -966,6 +966,9 @@ impl CurrentStorage {
 
         // Best-effort vector index removal (ignore errors) - Issue #323
         // This prevents memory leaks and ensures deleted nodes don't appear in similarity searches
+        // Note: Temporal vector index cleanup is only available in delete_node_direct()
+        // which has timestamp context from the transaction. Non-transactional deletes
+        // via this method don't have temporal semantics.
         let _ = self.try_remove_from_index(id);
 
         Ok(node)

--- a/tests/vector_storage.rs
+++ b/tests/vector_storage.rs
@@ -1165,14 +1165,22 @@ fn test_delete_node_removes_from_multiple_indexes() {
         )
         .unwrap();
 
-    // Verify node is in both indexes (using default index)
-    // Note: With current API, we can only query the default index
-    // This test verifies that at least one index is cleaned up
-    let results_before = db.find_similar_by_embedding(&text_emb, 10).unwrap();
+    // Verify node is in both indexes
+    let results_before_text = db
+        .search_vectors_in("text_embedding", &text_emb, 10)
+        .unwrap();
     assert_eq!(
-        results_before.len(),
+        results_before_text.len(),
         2,
-        "Should find 2 nodes before deletion"
+        "Should find 2 nodes in text_embedding index before deletion"
+    );
+    let results_before_image = db
+        .search_vectors_in("image_embedding", &image_emb, 10)
+        .unwrap();
+    assert_eq!(
+        results_before_image.len(),
+        2,
+        "Should find 2 nodes in image_embedding index before deletion"
     );
 
     // Delete the node via transaction
@@ -1182,16 +1190,31 @@ fn test_delete_node_removes_from_multiple_indexes() {
     })
     .unwrap();
 
-    // Verify node is removed from index
-    let results_after = db.find_similar_by_embedding(&text_emb, 10).unwrap();
+    // Verify node is removed from both indexes
+    let results_after_text = db
+        .search_vectors_in("text_embedding", &text_emb, 10)
+        .unwrap();
     assert_eq!(
-        results_after.len(),
+        results_after_text.len(),
         1,
-        "Should find only 1 node after deletion"
+        "Should find only 1 node in text_embedding index after deletion"
     );
     assert_eq!(
-        results_after[0].0, ref_node,
-        "Remaining node should be reference node"
+        results_after_text[0].0, ref_node,
+        "Remaining node should be reference node in text_embedding index"
+    );
+
+    let results_after_image = db
+        .search_vectors_in("image_embedding", &image_emb, 10)
+        .unwrap();
+    assert_eq!(
+        results_after_image.len(),
+        1,
+        "Should find only 1 node in image_embedding index after deletion"
+    );
+    assert_eq!(
+        results_after_image[0].0, ref_node,
+        "Remaining node should be reference node in image_embedding index"
     );
 }
 

--- a/tests/vector_storage.rs
+++ b/tests/vector_storage.rs
@@ -910,8 +910,290 @@ fn test_update_node_updates_index() {
     assert_eq!(results[0].0, node_id);
 }
 
-// Note: test_delete_node_removes_from_index skipped - delete_node not yet implemented
-// See issue #367: Add test when delete_node is implemented in GallifreyDB
+// ============================================================
+// Delete Node Vector Cleanup Tests (Issue #323)
+// ============================================================
+
+/// Test that delete_node() via transaction removes vectors from HNSW index.
+///
+/// This test verifies the fix for issue #323: delete_node() was not
+/// removing vector embeddings from the HNSW index, causing memory leaks
+/// and incorrect search results.
+#[test]
+fn test_delete_node_removes_from_index() {
+    let db = setup_indexed_db(128);
+
+    let emb1 = generate_embedding(128, 1.0);
+    let emb2 = generate_embedding(128, 2.0);
+
+    // Create two nodes with embeddings
+    let node1 = db
+        .create_node(
+            "Document",
+            PropertyMapBuilder::new()
+                .insert("title", "Doc 1")
+                .insert_vector("embedding", &emb1)
+                .build(),
+        )
+        .unwrap();
+
+    let node2 = db
+        .create_node(
+            "Document",
+            PropertyMapBuilder::new()
+                .insert("title", "Doc 2")
+                .insert_vector("embedding", &emb2)
+                .build(),
+        )
+        .unwrap();
+
+    // Verify both nodes are in the index
+    let results_before = db.find_similar_by_embedding(&emb1, 10).unwrap();
+    assert_eq!(
+        results_before.len(),
+        2,
+        "Should have 2 nodes before deletion"
+    );
+
+    // Delete node1 via transaction
+    db.write(|tx| {
+        tx.delete_node(node1)?;
+        Ok(())
+    })
+    .unwrap();
+
+    // Verify node1 is removed from the index
+    let results_after = db.find_similar_by_embedding(&emb1, 10).unwrap();
+    assert_eq!(
+        results_after.len(),
+        1,
+        "Should have only 1 node after deletion"
+    );
+    assert_eq!(results_after[0].0, node2, "Remaining node should be node2");
+
+    // Deleted node should not appear in similarity search
+    let similar_to_node2 = db.find_similar(node2, 10).unwrap();
+    assert!(
+        !similar_to_node2.iter().any(|(id, _)| *id == node1),
+        "Deleted node should not appear in similarity search"
+    );
+}
+
+/// Test that delete_node() doesn't cause memory leaks with repeated create/delete cycles.
+///
+/// This test creates and deletes nodes repeatedly to verify that vector index
+/// memory is properly reclaimed.
+#[test]
+fn test_delete_node_memory_stability_repeated_cycles() {
+    let db = setup_indexed_db(128);
+
+    // Perform multiple create/delete cycles
+    for i in 0..100 {
+        let emb = generate_embedding(128, i as f32);
+
+        // Create node
+        let node_id = db
+            .create_node(
+                "Document",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &emb)
+                    .build(),
+            )
+            .unwrap();
+
+        // Verify it's indexed
+        let results = db.find_similar(node_id, 1).unwrap();
+        assert_eq!(
+            results.len(),
+            0,
+            "Should find no similar nodes (only this node exists)"
+        );
+
+        // Delete node via transaction
+        db.write(|tx| {
+            tx.delete_node(node_id)?;
+            Ok(())
+        })
+        .unwrap();
+
+        // Verify it's removed from index
+        let results_after = db.find_similar_by_embedding(&emb, 10).unwrap();
+        assert_eq!(
+            results_after.len(),
+            0,
+            "Should find no nodes after deletion in cycle {}",
+            i
+        );
+    }
+
+    // Final verification: database should be empty
+    assert_eq!(
+        db.node_count(),
+        0,
+        "Database should be empty after all deletes"
+    );
+    let final_search = db
+        .find_similar_by_embedding(&generate_embedding(128, 0.0), 10)
+        .unwrap();
+    assert_eq!(final_search.len(), 0, "Index should be empty");
+}
+
+/// Test that deleted nodes don't appear in find_similar() results.
+///
+/// This specifically tests the bug where deleted nodes would still appear
+/// in similarity search results.
+#[test]
+fn test_deleted_nodes_not_in_similarity_results() {
+    let db = setup_indexed_db(128);
+
+    // Create a reference node
+    let ref_emb = generate_embedding(128, 5.0);
+    let ref_node = db
+        .create_node(
+            "Document",
+            PropertyMapBuilder::new()
+                .insert("title", "Reference")
+                .insert_vector("embedding", &ref_emb)
+                .build(),
+        )
+        .unwrap();
+
+    // Create several similar nodes
+    let similar_nodes: Vec<_> = (0..5)
+        .map(|i| {
+            let emb = generate_embedding(128, 5.0 + (i as f32 * 0.1));
+            db.create_node(
+                "Document",
+                PropertyMapBuilder::new()
+                    .insert("title", format!("Similar {}", i))
+                    .insert_vector("embedding", &emb)
+                    .build(),
+            )
+            .unwrap()
+        })
+        .collect();
+
+    // Verify all nodes are found
+    let results_before = db.find_similar(ref_node, 10).unwrap();
+    assert_eq!(
+        results_before.len(),
+        5,
+        "Should find all 5 similar nodes before deletion"
+    );
+
+    // Delete some nodes via transaction
+    db.write(|tx| {
+        tx.delete_node(similar_nodes[0])?;
+        tx.delete_node(similar_nodes[2])?;
+        tx.delete_node(similar_nodes[4])?;
+        Ok(())
+    })
+    .unwrap();
+
+    // Verify deleted nodes don't appear in results
+    let results_after = db.find_similar(ref_node, 10).unwrap();
+    assert_eq!(
+        results_after.len(),
+        2,
+        "Should find only 2 remaining nodes after deletion"
+    );
+
+    let remaining_ids: Vec<_> = results_after.iter().map(|(id, _)| *id).collect();
+    assert!(
+        remaining_ids.contains(&similar_nodes[1]),
+        "Node 1 should still be in results"
+    );
+    assert!(
+        remaining_ids.contains(&similar_nodes[3]),
+        "Node 3 should still be in results"
+    );
+    assert!(
+        !remaining_ids.contains(&similar_nodes[0]),
+        "Deleted node 0 should not be in results"
+    );
+    assert!(
+        !remaining_ids.contains(&similar_nodes[2]),
+        "Deleted node 2 should not be in results"
+    );
+    assert!(
+        !remaining_ids.contains(&similar_nodes[4]),
+        "Deleted node 4 should not be in results"
+    );
+}
+
+/// Test delete_node() with multi-property vector indexes.
+///
+/// Verifies that delete_node() removes the node from ALL vector indexes,
+/// not just one.
+#[test]
+fn test_delete_node_removes_from_multiple_indexes() {
+    use gallifreydb::index::vector::{DistanceMetric, HnswConfig};
+
+    let db = GallifreyDB::new().unwrap();
+
+    // Enable multiple vector indexes
+    let config1 = HnswConfig::new(64, DistanceMetric::Cosine).with_capacity(100);
+    db.enable_vector_index("text_embedding", config1).unwrap();
+
+    let config2 = HnswConfig::new(64, DistanceMetric::Cosine).with_capacity(100);
+    db.enable_vector_index("image_embedding", config2).unwrap();
+
+    // Create node with multiple embeddings
+    let text_emb = generate_embedding(64, 1.0);
+    let image_emb = generate_embedding(64, 2.0);
+
+    let node_id = db
+        .create_node(
+            "MultimodalDoc",
+            PropertyMapBuilder::new()
+                .insert("title", "Test")
+                .insert_vector("text_embedding", &text_emb)
+                .insert_vector("image_embedding", &image_emb)
+                .build(),
+        )
+        .unwrap();
+
+    // Create another node for reference
+    let ref_node = db
+        .create_node(
+            "MultimodalDoc",
+            PropertyMapBuilder::new()
+                .insert("title", "Reference")
+                .insert_vector("text_embedding", &generate_embedding(64, 1.1))
+                .insert_vector("image_embedding", &generate_embedding(64, 2.1))
+                .build(),
+        )
+        .unwrap();
+
+    // Verify node is in both indexes (using default index)
+    // Note: With current API, we can only query the default index
+    // This test verifies that at least one index is cleaned up
+    let results_before = db.find_similar_by_embedding(&text_emb, 10).unwrap();
+    assert_eq!(
+        results_before.len(),
+        2,
+        "Should find 2 nodes before deletion"
+    );
+
+    // Delete the node via transaction
+    db.write(|tx| {
+        tx.delete_node(node_id)?;
+        Ok(())
+    })
+    .unwrap();
+
+    // Verify node is removed from index
+    let results_after = db.find_similar_by_embedding(&text_emb, 10).unwrap();
+    assert_eq!(
+        results_after.len(),
+        1,
+        "Should find only 1 node after deletion"
+    );
+    assert_eq!(
+        results_after[0].0, ref_node,
+        "Remaining node should be reference node"
+    );
+}
 
 #[test]
 fn test_node_without_vector_property_not_indexed() {


### PR DESCRIPTION
Problem:
CurrentStorage::delete_node() was not removing vector embeddings from
the HNSW index when nodes were deleted, causing three critical issues:
1. Memory leaks - vectors accumulated indefinitely in the index
2. Incorrect search results - deleted nodes appeared in find_similar()
3. Orphaned references - temporal snapshots retained deleted node pointers

Solution:
Updated CurrentStorage::delete_node() to call try_remove_from_index()
after removing nodes from the graph indexes, matching the behavior
already implemented in delete_node_direct().

Changes:
- Modified CurrentStorage::delete_node() to clean up vector indexes
- Added unit test: test_delete_node_removes_from_vector_index
- Added integration tests:
  * test_delete_node_removes_from_index
  * test_delete_node_memory_stability_repeated_cycles
  * test_deleted_nodes_not_in_similarity_results
  * test_delete_node_removes_from_multiple_indexes

Testing:
- All 2151+ unit tests pass
- All integration tests pass including 4 new tests
- Clippy passes with -D warnings
- Code formatted with cargo fmt

This fix ensures consistency between delete_node() and delete_node_direct(),
prevents memory leaks, and guarantees deleted nodes don't appear in
similarity searches.