### PR TITLE
perf(wal): use InternedString directly to eliminate allocations (issu…

### DIFF
--- a/benches/checkpoints.rs
+++ b/benches/checkpoints.rs
@@ -31,7 +31,7 @@ fn bench_checkpoint_creation(c: &mut Criterion) {
             for i in 0..*node_count {
                 current
                     .create_node(
-                        GLOBAL_INTERNER.intern("Person").unwrap(),
+                        "Person",
                         PropertyMapBuilder::new().insert("id", i as i64).build(),
                     )
                     .unwrap();

--- a/benches/checkpoints.rs
+++ b/benches/checkpoints.rs
@@ -4,6 +4,7 @@ mod common;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::core::{
+    interning::GLOBAL_INTERNER,
     property::PropertyMapBuilder,
     temporal::{BiTemporalInterval, time},
 };
@@ -30,7 +31,7 @@ fn bench_checkpoint_creation(c: &mut Criterion) {
             for i in 0..*node_count {
                 current
                     .create_node(
-                        "Person",
+                        GLOBAL_INTERNER.intern("Person").unwrap(),
                         PropertyMapBuilder::new().insert("id", i as i64).build(),
                     )
                     .unwrap();
@@ -122,7 +123,7 @@ fn bench_recovery(c: &mut Criterion) {
             for i in 0..*wal_entries {
                 let operation = WalOperation::CreateNode {
                     node_id: gallifreydb::core::id::NodeId::new(i).unwrap(),
-                    label: "Person".to_string(),
+                    label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };
@@ -152,7 +153,7 @@ fn bench_recovery(c: &mut Criterion) {
             for i in *wal_entries..(*wal_entries + 100) {
                 let operation = WalOperation::CreateNode {
                     node_id: gallifreydb::core::id::NodeId::new(i).unwrap(),
-                    label: "Person".to_string(),
+                    label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };

--- a/benches/durability_modes.rs
+++ b/benches/durability_modes.rs
@@ -20,6 +20,7 @@ use gallifreydb::{
     GallifreyDB, WalConfigBuilder, WriteOps, WriteOptions,
     core::{
         PropertyMapBuilder,
+        interning::GLOBAL_INTERNER,
         temporal::{BiTemporalInterval, time},
     },
     storage::wal::{
@@ -650,7 +651,7 @@ fn bench_wal_append(c: &mut Criterion) {
                 let operation = match *op_type {
                     "create_node" => WalOperation::CreateNode {
                         node_id: black_box(gallifreydb::core::id::NodeId::new(1).unwrap()),
-                        label: "Person".to_string(),
+                        label: GLOBAL_INTERNER.intern("Person").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
                     },
@@ -658,14 +659,14 @@ fn bench_wal_append(c: &mut Criterion) {
                         edge_id: black_box(gallifreydb::core::id::EdgeId::new(1).unwrap()),
                         source: gallifreydb::core::id::NodeId::new(1).unwrap(),
                         target: gallifreydb::core::id::NodeId::new(2).unwrap(),
-                        label: "KNOWS".to_string(),
+                        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
                     },
                     _ => WalOperation::UpdateNode {
                         node_id: gallifreydb::core::id::NodeId::new(1).unwrap(),
                         version_id: gallifreydb::core::id::VersionId::new(2).unwrap(),
-                        label: "Person".to_string(),
+                        label: GLOBAL_INTERNER.intern("Person").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
                     },
@@ -699,7 +700,7 @@ fn bench_wal_throughput(c: &mut Criterion) {
                 for i in 0..1000 {
                     let operation = WalOperation::CreateNode {
                         node_id: gallifreydb::core::id::NodeId::new(i).unwrap(),
-                        label: "Person".to_string(),
+                        label: GLOBAL_INTERNER.intern("Person").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         temporal: BiTemporalInterval::current(time::now()),
                     };
@@ -745,7 +746,7 @@ fn bench_wal_with_sync(c: &mut Criterion) {
             b.iter(|| {
                 let operation = WalOperation::CreateNode {
                     node_id: gallifreydb::core::id::NodeId::new(1).unwrap(),
-                    label: "Person".to_string(),
+                    label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -77,9 +77,7 @@ fn create_checkpointed_database(
             .insert("name", format!("Node{}", name_id))
             .build();
 
-        current
-            .create_node(GLOBAL_INTERNER.intern("TestNode").unwrap(), props)
-            .unwrap();
+        current.create_node("TestNode", props).unwrap();
     }
 
     // Create edges (exactly edge_count edges)
@@ -95,7 +93,7 @@ fn create_checkpointed_database(
             .create_edge(
                 source_id,
                 target_id,
-                GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
+                "CONNECTS",
                 PropertyMapBuilder::new().insert("weight", i as i64).build(),
             )
             .unwrap();
@@ -152,9 +150,7 @@ fn create_vector_checkpointed_database(
             .insert_vector("embedding", &embedding)
             .build();
 
-        current
-            .create_node(GLOBAL_INTERNER.intern("VectorNode").unwrap(), props)
-            .unwrap();
+        current.create_node("VectorNode", props).unwrap();
     }
 
     let historical = HistoricalStorage::new();

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -22,6 +22,7 @@ mod common;
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use gallifreydb::core::id::NodeId;
+use gallifreydb::core::interning::GLOBAL_INTERNER;
 use gallifreydb::core::property::PropertyMapBuilder;
 use gallifreydb::core::temporal::{BiTemporalInterval, time};
 use gallifreydb::index::vector::DistanceMetric;
@@ -76,7 +77,9 @@ fn create_checkpointed_database(
             .insert("name", format!("Node{}", name_id))
             .build();
 
-        current.create_node("TestNode", props).unwrap();
+        current
+            .create_node(GLOBAL_INTERNER.intern("TestNode").unwrap(), props)
+            .unwrap();
     }
 
     // Create edges (exactly edge_count edges)
@@ -92,7 +95,7 @@ fn create_checkpointed_database(
             .create_edge(
                 source_id,
                 target_id,
-                "CONNECTS",
+                GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
                 PropertyMapBuilder::new().insert("weight", i as i64).build(),
             )
             .unwrap();
@@ -149,7 +152,9 @@ fn create_vector_checkpointed_database(
             .insert_vector("embedding", &embedding)
             .build();
 
-        current.create_node("VectorNode", props).unwrap();
+        current
+            .create_node(GLOBAL_INTERNER.intern("VectorNode").unwrap(), props)
+            .unwrap();
     }
 
     let historical = HistoricalStorage::new();
@@ -181,7 +186,7 @@ fn create_wal_only_database(operation_count: usize) -> (TempDir, ConcurrentWalSy
             // Create node operation
             WalOperation::CreateNode {
                 node_id: NodeId::new(i as u64).unwrap(),
-                label: "WalNode".to_string(),
+                label: GLOBAL_INTERNER.intern("WalNode").unwrap(),
                 properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
                 temporal: BiTemporalInterval::current(time::now()),
             }
@@ -194,7 +199,7 @@ fn create_wal_only_database(operation_count: usize) -> (TempDir, ConcurrentWalSy
                 node_id: NodeId::new(node_id).unwrap(),
                 version_id: gallifreydb::core::id::VersionId::new((update_count + 1) as u64)
                     .unwrap(),
-                label: "WalNode".to_string(),
+                label: GLOBAL_INTERNER.intern("WalNode").unwrap(),
                 properties: PropertyMapBuilder::new()
                     .insert("id", node_id as i64)
                     .insert("updated", true)

--- a/benches/wal_batch_append.rs
+++ b/benches/wal_batch_append.rs
@@ -16,6 +16,7 @@ use gallifreydb::{
     core::{
         PropertyMapBuilder,
         id::NodeId,
+        interning::GLOBAL_INTERNER,
         temporal::{BiTemporalInterval, time},
     },
     storage::wal::{
@@ -44,7 +45,7 @@ fn create_test_operations(count: usize) -> Vec<WalOperation> {
     (0..count)
         .map(|i| WalOperation::CreateNode {
             node_id: NodeId::new(i as u64 + 1).unwrap(),
-            label: format!("Node{}", i),
+            label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("id", i as i64)
                 .insert("name", format!("Node {}", i))
@@ -59,7 +60,7 @@ fn create_minimal_operations(count: usize) -> Vec<WalOperation> {
     (0..count)
         .map(|i| WalOperation::CreateNode {
             node_id: NodeId::new(i as u64 + 1).unwrap(),
-            label: "N".to_string(),
+            label: GLOBAL_INTERNER.intern("N").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: BiTemporalInterval::current(time::now()),
         })

--- a/benches/wal_batch_append.rs
+++ b/benches/wal_batch_append.rs
@@ -45,7 +45,7 @@ fn create_test_operations(count: usize) -> Vec<WalOperation> {
     (0..count)
         .map(|i| WalOperation::CreateNode {
             node_id: NodeId::new(i as u64 + 1).unwrap(),
-            label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+            label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("id", i as i64)
                 .insert("name", format!("Node {}", i))

--- a/benches/wal_serialization.rs
+++ b/benches/wal_serialization.rs
@@ -10,6 +10,7 @@ use gallifreydb::{
     core::{
         PropertyMapBuilder,
         id::{EdgeId, NodeId, VersionId},
+        interning::GLOBAL_INTERNER,
         temporal::{BiTemporalInterval, time},
     },
     storage::wal::{
@@ -46,7 +47,7 @@ fn bench_serialize_create_node(c: &mut Criterion) {
 
                 let operation = WalOperation::CreateNode {
                     node_id: black_box(NodeId::new(1).unwrap()),
-                    label: "Person".to_string(),
+                    label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: props.build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };
@@ -79,7 +80,7 @@ fn bench_serialize_create_edge(c: &mut Criterion) {
                     edge_id: black_box(EdgeId::new(1).unwrap()),
                     source: NodeId::new(1).unwrap(),
                     target: NodeId::new(2).unwrap(),
-                    label: "KNOWS".to_string(),
+                    label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
                     properties: props.build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };
@@ -110,7 +111,7 @@ fn bench_serialize_update_node(c: &mut Criterion) {
                 let operation = WalOperation::UpdateNode {
                     node_id: black_box(NodeId::new(1).unwrap()),
                     version_id: VersionId::new(2).unwrap(),
-                    label: "Person".to_string(),
+                    label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: props.build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };
@@ -135,7 +136,7 @@ fn bench_serialize_batch(c: &mut Criterion) {
             for i in 0..1000 {
                 let operation = WalOperation::CreateNode {
                     node_id: NodeId::new(i).unwrap(),
-                    label: "Person".to_string(),
+                    label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };
@@ -159,7 +160,7 @@ fn bench_serialize_high_frequency(c: &mut Criterion) {
             for i in 0..10000 {
                 let operation = WalOperation::CreateNode {
                     node_id: NodeId::new(i).unwrap(),
-                    label: "Test".to_string(),
+                    label: GLOBAL_INTERNER.intern("Test").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };

--- a/examples/recovery/basic_recovery.rs
+++ b/examples/recovery/basic_recovery.rs
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
         let node_id = NodeId::new(i)?;
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: GLOBAL_INTERNER.intern(&format!("Person{}", i)).unwrap(),
+            label: GLOBAL_INTERNER.intern(format!("Person{}", i)).unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", format!("Alice{}", i))
                 .insert("age", (20 + i) as i64)

--- a/examples/recovery/basic_recovery.rs
+++ b/examples/recovery/basic_recovery.rs
@@ -60,6 +60,7 @@
 
 use gallifreydb::core::{
     id::{EdgeId, NodeId},
+    interning::GLOBAL_INTERNER,
     property::{PropertyMapBuilder, PropertyValue},
     temporal::{BiTemporalInterval, time},
 };
@@ -98,7 +99,7 @@ fn main() -> Result<()> {
         let node_id = NodeId::new(i)?;
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: format!("Person{}", i),
+            label: GLOBAL_INTERNER.intern(&format!("Person{}", i)).unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", format!("Alice{}", i))
                 .insert("age", (20 + i) as i64)
@@ -117,7 +118,7 @@ fn main() -> Result<()> {
             edge_id,
             source,
             target,
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("since", 2020 + (i as i64))
                 .build(),
@@ -132,7 +133,7 @@ fn main() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: node_id_1,
         version_id: version_id_51,
-        label: "Person1Updated".to_string(),
+        label: GLOBAL_INTERNER.intern("Person1Updated").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("name", "Alice1 (updated)")
             .insert("age", 21)

--- a/examples/recovery/manual_recovery.rs
+++ b/examples/recovery/manual_recovery.rs
@@ -75,6 +75,7 @@
 
 use gallifreydb::core::{
     id::{EdgeId, NodeId},
+    interning::GLOBAL_INTERNER,
     property::{PropertyMapBuilder, PropertyValue},
     temporal::{BiTemporalInterval, time},
 };
@@ -136,7 +137,7 @@ fn main() -> Result<()> {
         let node_id = NodeId::new(i)?;
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: format!("Node{}", i),
+            label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("id", i as i64)
                 .insert("name", format!("Node {}", i))
@@ -154,7 +155,7 @@ fn main() -> Result<()> {
             edge_id,
             source,
             target,
-            label: "LINKS_TO".to_string(),
+            label: GLOBAL_INTERNER.intern("LINKS_TO").unwrap(),
             properties: PropertyMapBuilder::new().insert("weight", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -166,7 +167,7 @@ fn main() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: node_id_1,
         version_id: version_id_500,
-        label: "Node1Updated".to_string(),
+        label: GLOBAL_INTERNER.intern("Node1Updated").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("id", 1)
             .insert("name", "Node 1 (Updated)")

--- a/examples/recovery/manual_recovery.rs
+++ b/examples/recovery/manual_recovery.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
         let node_id = NodeId::new(i)?;
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+            label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("id", i as i64)
                 .insert("name", format!("Node {}", i))

--- a/examples/recovery/progress_callback.rs
+++ b/examples/recovery/progress_callback.rs
@@ -191,7 +191,7 @@ fn main() -> Result<()> {
         let node_id = NodeId::new(i)?;
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+            label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;

--- a/examples/recovery/progress_callback.rs
+++ b/examples/recovery/progress_callback.rs
@@ -61,6 +61,7 @@
 
 use gallifreydb::core::{
     id::{EdgeId, NodeId},
+    interning::GLOBAL_INTERNER,
     property::PropertyMapBuilder,
     temporal::{BiTemporalInterval, time},
 };
@@ -190,7 +191,7 @@ fn main() -> Result<()> {
         let node_id = NodeId::new(i)?;
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: format!("Node{}", i),
+            label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -206,7 +207,7 @@ fn main() -> Result<()> {
             edge_id,
             source,
             target,
-            label: "EDGE".to_string(),
+            label: GLOBAL_INTERNER.intern("EDGE").unwrap(),
             properties: PropertyMapBuilder::new().insert("weight", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -640,13 +640,10 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    let label_str = GLOBAL_INTERNER
-                        .resolve(*label)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| String::from(""));
+                    // No allocation! Just copy the 4-byte InternedString ID
                     WalOperation::CreateNode {
                         node_id: *node_id,
-                        label: label_str,
+                        label: *label,
                         properties: properties.clone(),
                         temporal,
                     }
@@ -659,15 +656,12 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    let label_str = GLOBAL_INTERNER
-                        .resolve(*label)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| String::from(""));
+                    // No allocation! Just copy the 4-byte InternedString ID
                     WalOperation::CreateEdge {
                         edge_id: *edge_id,
                         source: *source,
                         target: *target,
-                        label: label_str,
+                        label: *label,
                         properties: properties.clone(),
                         temporal,
                     }
@@ -679,14 +673,11 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    let label_str = GLOBAL_INTERNER
-                        .resolve(*label)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| String::from(""));
+                    // No allocation! Just copy the 4-byte InternedString ID
                     WalOperation::UpdateNode {
                         node_id: *node_id,
                         version_id: *version_id,
-                        label: label_str,
+                        label: *label,
                         properties: properties.clone(),
                         temporal,
                     }
@@ -698,14 +689,11 @@ impl WriteTransaction {
                     properties,
                     ..
                 } => {
-                    let label_str = GLOBAL_INTERNER
-                        .resolve(*label)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| String::from(""));
+                    // No allocation! Just copy the 4-byte InternedString ID
                     WalOperation::UpdateEdge {
                         edge_id: *edge_id,
                         version_id: *version_id,
-                        label: label_str,
+                        label: *label,
                         properties: properties.clone(),
                         temporal,
                     }

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -2942,7 +2942,7 @@ mod tests {
         for i in 1..=100 {
             let op = WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+                label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             };
@@ -3052,7 +3052,7 @@ mod tests {
         for i in 1..=100 {
             let op = WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+                label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             };
@@ -3164,7 +3164,7 @@ mod tests {
         for i in 1..=50 {
             let op = WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+                label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             };

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1103,12 +1103,8 @@ impl CheckpointManager {
                 } => {
                     max_node_id = max_node_id.max(node_id.as_u64());
 
-                    let interned_label =
-                        GLOBAL_INTERNER
-                            .intern(&label)
-                            .map_err(|e| StorageError::WalError {
-                                reason: format!("Failed to intern label: {}", e),
-                            })?;
+                    // Label is already an InternedString (no allocation needed!)
+                    let interned_label = label;
 
                     let commit_timestamp = temporal.transaction_time().start();
                     let metadata =
@@ -1145,12 +1141,8 @@ impl CheckpointManager {
                 } => {
                     max_edge_id = max_edge_id.max(edge_id.as_u64());
 
-                    let interned_label =
-                        GLOBAL_INTERNER
-                            .intern(&label)
-                            .map_err(|e| StorageError::WalError {
-                                reason: format!("Failed to intern label: {}", e),
-                            })?;
+                    // Label is already an InternedString (no allocation needed!)
+                    let interned_label = label;
 
                     let commit_timestamp = temporal.transaction_time().start();
                     let metadata =
@@ -1191,12 +1183,8 @@ impl CheckpointManager {
                     max_version_id = max_version_id.max(version_id.as_u64());
                     next_version_id = next_version_id.max(version_id.as_u64() + 1);
 
-                    let interned_label =
-                        GLOBAL_INTERNER
-                            .intern(&label)
-                            .map_err(|e| StorageError::WalError {
-                                reason: format!("Failed to intern label: {}", e),
-                            })?;
+                    // Label is already an InternedString (no allocation needed!)
+                    let interned_label = label;
 
                     let commit_timestamp = temporal.transaction_time().start();
                     let metadata =
@@ -1239,12 +1227,8 @@ impl CheckpointManager {
 
                     let current_edge = current.get_edge(edge_id)?;
 
-                    let interned_label =
-                        GLOBAL_INTERNER
-                            .intern(&label)
-                            .map_err(|e| StorageError::WalError {
-                                reason: format!("Failed to intern label: {}", e),
-                            })?;
+                    // Label is already an InternedString (no allocation needed!)
+                    let interned_label = label;
 
                     let commit_timestamp = temporal.transaction_time().start();
                     let metadata =
@@ -1379,6 +1363,7 @@ pub struct CheckpointStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GLOBAL_INTERNER;
     use crate::PropertyMapBuilder;
     use crate::core::id::NodeId;
     use crate::core::temporal::{BiTemporalInterval, time};
@@ -1538,7 +1523,7 @@ mod tests {
                 .build();
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: "Person".to_string(),
+                label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: props,
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -1582,7 +1567,7 @@ mod tests {
                 .build();
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: "Person".to_string(),
+                label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: props,
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -1681,7 +1666,7 @@ mod tests {
             let props = PropertyMapBuilder::new().insert("value", i as i64).build();
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: "Test".to_string(),
+                label: GLOBAL_INTERNER.intern("Test").unwrap(),
                 properties: props,
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -2075,7 +2060,7 @@ mod tests {
         for i in 1..=2 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: "Person".to_string(),
+                label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: PropertyMapBuilder::new()
                     .insert("name", format!("Person{}", i))
                     .build(),
@@ -2088,7 +2073,7 @@ mod tests {
             edge_id: EdgeId::new(1)?,
             source: NodeId::new(1)?,
             target: NodeId::new(2)?,
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("since", 2023i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2128,7 +2113,7 @@ mod tests {
         // Create node
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", "Alice")
                 .insert("age", 30i64)
@@ -2140,7 +2125,7 @@ mod tests {
         wal.append(WalOperation::UpdateNode {
             node_id,
             version_id: VersionId::new(2)?,
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", "Alice")
                 .insert("age", 31i64)
@@ -2182,7 +2167,7 @@ mod tests {
         for i in 1..=2 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: "Person".to_string(),
+                label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -2195,7 +2180,7 @@ mod tests {
             edge_id,
             source: NodeId::new(1)?,
             target: NodeId::new(2)?,
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("strength", 5i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2204,7 +2189,7 @@ mod tests {
         wal.append(WalOperation::UpdateEdge {
             edge_id,
             version_id: VersionId::new(4)?,
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("strength", 10i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2242,7 +2227,7 @@ mod tests {
         // Create node
         wal.append(WalOperation::CreateNode {
             node_id,
-            label: "ToDelete".to_string(),
+            label: GLOBAL_INTERNER.intern("ToDelete").unwrap(),
             properties: PropertyMapBuilder::new().insert("temp", true).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2285,7 +2270,7 @@ mod tests {
         for i in 1..=2 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: "Person".to_string(),
+                label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -2298,7 +2283,7 @@ mod tests {
             edge_id,
             source: NodeId::new(1)?,
             target: NodeId::new(2)?,
-            label: "TEMP_EDGE".to_string(),
+            label: GLOBAL_INTERNER.intern("TEMP_EDGE").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2340,7 +2325,7 @@ mod tests {
         // Create a node
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(1)?,
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2354,7 +2339,7 @@ mod tests {
         // Create another node
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(2)?,
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2765,7 +2750,7 @@ mod tests {
         // Add entry with high node ID
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(500)?,
-            label: "HighId".to_string(),
+            label: GLOBAL_INTERNER.intern("HighId").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2775,7 +2760,7 @@ mod tests {
             edge_id: EdgeId::new(600)?,
             source: NodeId::new(1)?,
             target: NodeId::new(500)?,
-            label: "HighEdge".to_string(),
+            label: GLOBAL_INTERNER.intern("HighEdge").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -2957,7 +2942,7 @@ mod tests {
         for i in 1..=100 {
             let op = WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: format!("Node{}", i),
+                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             };
@@ -3067,7 +3052,7 @@ mod tests {
         for i in 1..=100 {
             let op = WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: format!("Node{}", i),
+                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             };
@@ -3179,7 +3164,7 @@ mod tests {
         for i in 1..=50 {
             let op = WalOperation::CreateNode {
                 node_id: NodeId::new(i)?,
-                label: format!("Node{}", i),
+                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 temporal: BiTemporalInterval::current(time::now()),
             };

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -14,6 +14,7 @@
 
 use crate::api::transaction::types::TxId;
 use crate::core::{
+    GLOBAL_INTERNER,
     graph::{Edge, Node},
     id::{EdgeId, NodeId, VersionId},
     interning::InternedString,
@@ -710,7 +711,18 @@ impl PersistenceManager {
         temporal: BiTemporalInterval,
         next_version_id: &mut u64,
     ) -> Result<()> {
-        // WAL now stores InternedString directly (no allocation needed!)
+        // Validate that the InternedString ID exists in the interner
+        // This protects against corrupted WAL files or missing checkpoint data
+        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+            StorageError::CorruptedData(format!(
+                "InternedString ID {} for node_id={} not found in interner. \
+                 This indicates corrupted WAL or missing checkpoint data.",
+                label.as_u32(),
+                node_id
+            ))
+        })?;
+
+        // ID is valid, use it directly (no allocation!)
         let interned_label = label;
 
         // Extract commit timestamp from temporal interval
@@ -755,7 +767,17 @@ impl PersistenceManager {
         temporal: BiTemporalInterval,
         next_version_id: &mut u64,
     ) -> Result<()> {
-        // WAL now stores InternedString directly (no allocation needed!)
+        // Validate that the InternedString ID exists in the interner
+        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+            StorageError::CorruptedData(format!(
+                "InternedString ID {} for edge_id={} not found in interner. \
+                 This indicates corrupted WAL or missing checkpoint data.",
+                label.as_u32(),
+                edge_id
+            ))
+        })?;
+
+        // ID is valid, use it directly (no allocation!)
         let interned_label = label;
 
         // Extract commit timestamp from temporal interval
@@ -808,7 +830,18 @@ impl PersistenceManager {
         properties: PropertyMap,
         temporal: BiTemporalInterval,
     ) -> Result<()> {
-        // WAL now stores InternedString directly (no allocation needed!)
+        // Validate that the InternedString ID exists in the interner
+        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+            StorageError::CorruptedData(format!(
+                "InternedString ID {} for node_id={} version_id={} not found in interner. \
+                 This indicates corrupted WAL or missing checkpoint data.",
+                label.as_u32(),
+                node_id,
+                version_id
+            ))
+        })?;
+
+        // ID is valid, use it directly (no allocation!)
         let interned_label = label;
 
         // Extract commit timestamp from temporal interval
@@ -855,7 +888,18 @@ impl PersistenceManager {
         properties: PropertyMap,
         temporal: BiTemporalInterval,
     ) -> Result<()> {
-        // WAL now stores InternedString directly (no allocation needed!)
+        // Validate that the InternedString ID exists in the interner
+        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+            StorageError::CorruptedData(format!(
+                "InternedString ID {} for edge_id={} version_id={} not found in interner. \
+                 This indicates corrupted WAL or missing checkpoint data.",
+                label.as_u32(),
+                edge_id,
+                version_id
+            ))
+        })?;
+
+        // ID is valid, use it directly (no allocation!)
         let interned_label = label;
 
         // Extract commit timestamp from temporal interval

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -14,9 +14,9 @@
 
 use crate::api::transaction::types::TxId;
 use crate::core::{
-    GLOBAL_INTERNER,
     graph::{Edge, Node},
     id::{EdgeId, NodeId, VersionId},
+    interning::InternedString,
     property::PropertyMap,
     temporal::{BiTemporalInterval, Timestamp, time},
 };
@@ -705,21 +705,13 @@ impl PersistenceManager {
         current: &CurrentStorage,
         historical: &mut HistoricalStorage,
         node_id: NodeId,
-        label: String,
+        label: InternedString,
         properties: PropertyMap,
         temporal: BiTemporalInterval,
         next_version_id: &mut u64,
     ) -> Result<()> {
-        // Intern the label string (WAL stores strings, but Node needs InternedString)
-        let interned_label =
-            GLOBAL_INTERNER
-                .intern(&label)
-                .map_err(|e| StorageError::WalError {
-                    reason: format!(
-                        "Failed to intern node label '{}' for node_id={} during recovery: {}",
-                        label, node_id, e
-                    ),
-                })?;
+        // WAL now stores InternedString directly (no allocation needed!)
+        let interned_label = label;
 
         // Extract commit timestamp from temporal interval
         let commit_timestamp = temporal.transaction_time().start();
@@ -758,21 +750,13 @@ impl PersistenceManager {
         edge_id: EdgeId,
         source: NodeId,
         target: NodeId,
-        label: String,
+        label: InternedString,
         properties: PropertyMap,
         temporal: BiTemporalInterval,
         next_version_id: &mut u64,
     ) -> Result<()> {
-        // Intern the label string (WAL stores strings, but Edge needs InternedString)
-        let interned_label =
-            GLOBAL_INTERNER
-                .intern(&label)
-                .map_err(|e| StorageError::WalError {
-                    reason: format!(
-                        "Failed to intern edge label '{}' for edge_id={} during recovery: {}",
-                        label, edge_id, e
-                    ),
-                })?;
+        // WAL now stores InternedString directly (no allocation needed!)
+        let interned_label = label;
 
         // Extract commit timestamp from temporal interval
         let commit_timestamp = temporal.transaction_time().start();
@@ -820,19 +804,12 @@ impl PersistenceManager {
         historical: &mut HistoricalStorage,
         node_id: NodeId,
         version_id: VersionId,
-        label: String,
+        label: InternedString,
         properties: PropertyMap,
         temporal: BiTemporalInterval,
     ) -> Result<()> {
-        // Intern the label string (WAL stores strings, but Node needs InternedString)
-        let interned_label = GLOBAL_INTERNER.intern(&label).map_err(|e| {
-            StorageError::WalError {
-                reason: format!(
-                    "Failed to intern node label '{}' for node_id={} version_id={} during recovery: {}",
-                    label, node_id, version_id, e
-                ),
-            }
-        })?;
+        // WAL now stores InternedString directly (no allocation needed!)
+        let interned_label = label;
 
         // Extract commit timestamp from temporal interval
         let commit_timestamp = temporal.transaction_time().start();
@@ -874,19 +851,12 @@ impl PersistenceManager {
         version_id: VersionId,
         source: NodeId,
         target: NodeId,
-        label: String,
+        label: InternedString,
         properties: PropertyMap,
         temporal: BiTemporalInterval,
     ) -> Result<()> {
-        // Intern the label string (WAL stores strings, but Edge needs InternedString)
-        let interned_label = GLOBAL_INTERNER.intern(&label).map_err(|e| {
-            StorageError::WalError {
-                reason: format!(
-                    "Failed to intern edge label '{}' for edge_id={} version_id={} during recovery: {}",
-                    label, edge_id, version_id, e
-                ),
-            }
-        })?;
+        // WAL now stores InternedString directly (no allocation needed!)
+        let interned_label = label;
 
         // Extract commit timestamp from temporal interval
         let commit_timestamp = temporal.transaction_time().start();
@@ -1026,6 +996,7 @@ impl PersistenceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GLOBAL_INTERNER;
     use crate::core::graph::Node;
     use crate::storage::version::VersionMetadata;
     use crate::{PropertyMapBuilder, api::transaction::types::TxId};
@@ -1493,7 +1464,7 @@ mod tests {
         for i in 1..=5 {
             wal.append(crate::storage::wal::WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: "Test".to_string(),
+                label: GLOBAL_INTERNER.intern("Test").unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -1654,7 +1625,7 @@ mod tests {
             // Write to WAL
             wal.append(WalOperation::CreateNode {
                 node_id,
-                label: "Document".to_string(),
+                label: GLOBAL_INTERNER.intern("Document").unwrap(),
                 properties: props.clone(),
                 temporal,
             })?;
@@ -1776,7 +1747,7 @@ mod tests {
 
             wal.append(WalOperation::CreateNode {
                 node_id,
-                label: "Document".to_string(),
+                label: GLOBAL_INTERNER.intern("Document").unwrap(),
                 properties: props.clone(),
                 temporal,
             })?;
@@ -1860,7 +1831,7 @@ mod tests {
 
             wal.append(WalOperation::CreateNode {
                 node_id,
-                label: "Doc".to_string(),
+                label: GLOBAL_INTERNER.intern("Doc").unwrap(),
                 properties: props.clone(),
                 temporal,
             })?;

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -120,6 +120,7 @@ pub use group_commit::GroupCommitCoordinator;
 
 use crate::core::{
     id::{EdgeId, NodeId, VersionId},
+    interning::InternedString,
     property::PropertyMap,
     temporal::{BiTemporalInterval, Timestamp, time},
 };
@@ -147,8 +148,8 @@ pub enum WalOperation {
     CreateNode {
         /// The node ID
         node_id: NodeId,
-        /// The node label
-        label: String,
+        /// The node label (interned for efficiency)
+        label: InternedString,
         /// The node properties
         properties: PropertyMap,
         /// The bi-temporal interval
@@ -162,8 +163,8 @@ pub enum WalOperation {
         source: NodeId,
         /// The target node ID
         target: NodeId,
-        /// The edge label
-        label: String,
+        /// The edge label (interned for efficiency)
+        label: InternedString,
         /// The edge properties
         properties: PropertyMap,
         /// The bi-temporal interval
@@ -175,8 +176,8 @@ pub enum WalOperation {
         node_id: NodeId,
         /// The version ID
         version_id: VersionId,
-        /// The new label
-        label: String,
+        /// The new label (interned for efficiency)
+        label: InternedString,
         /// The new properties
         properties: PropertyMap,
         /// The bi-temporal interval
@@ -188,8 +189,8 @@ pub enum WalOperation {
         edge_id: EdgeId,
         /// The version ID
         version_id: VersionId,
-        /// The new label
-        label: String,
+        /// The new label (interned for efficiency)
+        label: InternedString,
         /// The new properties
         properties: PropertyMap,
         /// The bi-temporal interval
@@ -273,11 +274,10 @@ impl WalEntry {
 
 use crate::utils::error::Result;
 
-/// Helper to serialize a string into the buffer (length prefix + bytes)
+/// Helper to serialize an InternedString into the buffer (4-byte ID)
 #[inline(always)]
-fn serialize_str(s: &str, buffer: &mut Vec<u8>) {
-    buffer.extend_from_slice(&(s.len() as u32).to_le_bytes());
-    buffer.extend_from_slice(s.as_bytes());
+fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
+    buffer.extend_from_slice(&s.as_u32().to_le_bytes());
 }
 
 /// Estimate the required buffer capacity for serializing a WAL entry.
@@ -324,32 +324,24 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
     const TEMPORAL_SIZE: usize = 48;
 
     let variable_size = match operation {
-        WalOperation::CreateNode {
-            label, properties, ..
-        } => {
-            // op type (1) + node_id (8) + label length prefix (4) + label + properties + temporal (48)
-            let base = 1 + 8 + 4 + label.len() + TEMPORAL_SIZE;
+        WalOperation::CreateNode { properties, .. } => {
+            // op type (1) + node_id (8) + label (4-byte InternedString ID) + properties + temporal (48)
+            let base = 1 + 8 + 4 + TEMPORAL_SIZE;
             base + estimate_property_map_size(properties)
         }
-        WalOperation::CreateEdge {
-            label, properties, ..
-        } => {
-            // op type (1) + edge_id (8) + source (8) + target (8) + label length (4) + label + properties + temporal (48)
-            let base = 1 + 8 + 8 + 8 + 4 + label.len() + TEMPORAL_SIZE;
+        WalOperation::CreateEdge { properties, .. } => {
+            // op type (1) + edge_id (8) + source (8) + target (8) + label (4-byte InternedString ID) + properties + temporal (48)
+            let base = 1 + 8 + 8 + 8 + 4 + TEMPORAL_SIZE;
             base + estimate_property_map_size(properties)
         }
-        WalOperation::UpdateNode {
-            label, properties, ..
-        } => {
-            // op type (1) + node_id (8) + version_id (8) + label length (4) + label + properties + temporal (48)
-            let base = 1 + 8 + 8 + 4 + label.len() + TEMPORAL_SIZE;
+        WalOperation::UpdateNode { properties, .. } => {
+            // op type (1) + node_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + temporal (48)
+            let base = 1 + 8 + 8 + 4 + TEMPORAL_SIZE;
             base + estimate_property_map_size(properties)
         }
-        WalOperation::UpdateEdge {
-            label, properties, ..
-        } => {
-            // op type (1) + edge_id (8) + version_id (8) + label length (4) + label + properties + temporal (48)
-            let base = 1 + 8 + 8 + 4 + label.len() + TEMPORAL_SIZE;
+        WalOperation::UpdateEdge { properties, .. } => {
+            // op type (1) + edge_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + temporal (48)
+            let base = 1 + 8 + 8 + 4 + TEMPORAL_SIZE;
             base + estimate_property_map_size(properties)
         }
         WalOperation::DeleteNode { .. } => {
@@ -468,7 +460,7 @@ pub(crate) fn serialize_entry_into(entry: &WalEntry, buffer: &mut Vec<u8>) -> Re
         } => {
             buffer.push(1); // operation type
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
-            serialize_str(label, buffer);
+            serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             temporal.serialize_into(buffer);
         }
@@ -484,7 +476,7 @@ pub(crate) fn serialize_entry_into(entry: &WalEntry, buffer: &mut Vec<u8>) -> Re
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&source.as_u64().to_le_bytes());
             buffer.extend_from_slice(&target.as_u64().to_le_bytes());
-            serialize_str(label, buffer);
+            serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             temporal.serialize_into(buffer);
         }
@@ -498,7 +490,7 @@ pub(crate) fn serialize_entry_into(entry: &WalEntry, buffer: &mut Vec<u8>) -> Re
             buffer.push(3); // operation type
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
-            serialize_str(label, buffer);
+            serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             temporal.serialize_into(buffer);
         }
@@ -512,7 +504,7 @@ pub(crate) fn serialize_entry_into(entry: &WalEntry, buffer: &mut Vec<u8>) -> Re
             buffer.push(4); // operation type
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
-            serialize_str(label, buffer);
+            serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             temporal.serialize_into(buffer);
         }
@@ -551,6 +543,7 @@ mod tests {
     use super::*;
     use crate::core::EdgeId;
     use crate::core::NodeId;
+    use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::BiTemporalInterval;
 
@@ -645,20 +638,20 @@ mod tests {
     #[test]
     fn test_estimate_capacity_create_node_empty_properties() {
         // CreateNode with empty properties:
-        // Fixed: 24 bytes
-        // op type (1) + node_id (8) + label_len (4) + label (4 for "test") + properties (4 for count) + temporal (48)
-        // = 24 + 1 + 8 + 4 + 4 + 4 + 48 = 93 bytes
+        // Fixed: 24 bytes (LSN + Timestamp + Checksum)
+        // op type (1) + node_id (8) + label (4-byte InternedString) + properties (4 for empty count) + temporal (48)
+        // = 24 + 1 + 8 + 4 + 4 + 48 = 89 bytes
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
-            label: "test".to_string(),
+            label: GLOBAL_INTERNER.intern("test").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             temporal: test_temporal(),
         };
 
         let estimated = estimate_entry_capacity(&op);
         assert_eq!(
-            estimated, 93,
-            "CreateNode with empty properties should be 93 bytes"
+            estimated, 89,
+            "CreateNode with empty properties should be 89 bytes"
         );
 
         // Verify by actually serializing
@@ -684,7 +677,7 @@ mod tests {
 
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties,
             temporal: test_temporal(),
         };
@@ -725,7 +718,7 @@ mod tests {
             edge_id: EdgeId::new(1).unwrap(),
             source: NodeId::new(1).unwrap(),
             target: NodeId::new(2).unwrap(),
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties,
             temporal: test_temporal(),
         };
@@ -763,7 +756,7 @@ mod tests {
 
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
-            label: "Document".to_string(),
+            label: GLOBAL_INTERNER.intern("Document").unwrap(),
             properties,
             temporal: test_temporal(),
         };
@@ -803,7 +796,7 @@ mod tests {
         let op = WalOperation::UpdateNode {
             node_id: NodeId::new(1).unwrap(),
             version_id: crate::core::VersionId::new(1).unwrap(),
-            label: "LargeNode".to_string(),
+            label: GLOBAL_INTERNER.intern("LargeNode").unwrap(),
             properties,
             temporal: test_temporal(),
         };

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -818,7 +818,7 @@ mod tests {
         let ops: Vec<WalOperation> = (0..100)
             .map(|i| WalOperation::CreateNode {
                 node_id: NodeId::new(i + 1).unwrap(),
-                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
+                label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             })

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -523,6 +523,7 @@ impl ConcurrentWal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GLOBAL_INTERNER;
     use crate::core::id::NodeId;
     use crate::core::property::PropertyMap;
     use crate::core::temporal::{BiTemporalInterval, time};
@@ -533,7 +534,7 @@ mod tests {
     fn test_operation() -> WalOperation {
         WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         }
@@ -817,7 +818,7 @@ mod tests {
         let ops: Vec<WalOperation> = (0..100)
             .map(|i| WalOperation::CreateNode {
                 node_id: NodeId::new(i + 1).unwrap(),
-                label: format!("Node{}", i),
+                label: GLOBAL_INTERNER.intern(&format!("Node{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             })

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -700,6 +700,7 @@ impl Drop for ConcurrentWalSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GLOBAL_INTERNER;
     use crate::core::id::NodeId;
     use crate::core::property::PropertyMap;
     use crate::core::temporal::{BiTemporalInterval, time};
@@ -708,7 +709,7 @@ mod tests {
     fn create_test_operation(id: u64) -> WalOperation {
         WalOperation::CreateNode {
             node_id: NodeId::new(id).unwrap(),
-            label: format!("Node{}", id),
+            label: GLOBAL_INTERNER.intern(&format!("Node{}", id)).unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         }

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -709,7 +709,7 @@ mod tests {
     fn create_test_operation(id: u64) -> WalOperation {
         WalOperation::CreateNode {
             node_id: NodeId::new(id).unwrap(),
-            label: GLOBAL_INTERNER.intern(&format!("Node{}", id)).unwrap(),
+            label: GLOBAL_INTERNER.intern(format!("Node{}", id)).unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1150,7 +1150,7 @@ mod tests {
 
             let operation = WalOperation::CreateNode {
                 node_id: NodeId::new(i + 1).unwrap(),
-                label: format!("Node_{}", i),
+                label: GLOBAL_INTERNER.intern(format!("Node_{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             };
@@ -1202,7 +1202,9 @@ mod tests {
 
                 let operation = WalOperation::CreateNode {
                     node_id: NodeId::new(lsn.0).unwrap(),
-                    label: format!("Node_seg{}_entry{}", seg_id, i),
+                    label: GLOBAL_INTERNER
+                        .intern(format!("Node_seg{}_entry{}", seg_id, i))
+                        .unwrap(),
                     properties: PropertyMap::new(),
                     temporal: BiTemporalInterval::current(time::now()),
                 };
@@ -1250,7 +1252,7 @@ mod tests {
             let lsn = LSN(i);
             let operation = WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: format!("Node_{}", i),
+                label: GLOBAL_INTERNER.intern(format!("Node_{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             };
@@ -1316,7 +1318,7 @@ mod tests {
         // Write one complete entry
         let operation = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
-            label: "Node_1".to_string(),
+            label: GLOBAL_INTERNER.intern("Node_1").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -247,24 +247,24 @@ pub(crate) fn parse_entry_at(
             let node_id = deserialize_node_id(buffer, current_offset, "CreateNode")?;
             current_offset += 8;
 
-            let label_len = u32::from_le_bytes(
-                buffer[current_offset..current_offset + 4]
-                    .try_into()
-                    .unwrap(), // Safe due to buffer length check above
-            ) as usize;
-            current_offset += 4;
-
-            // Use saturating_add to prevent overflow
-            if current_offset.saturating_add(label_len) > buffer.len() {
+            // Read 4-byte InternedString ID
+            if current_offset + 4 > buffer.len() {
                 return Err(StorageError::CorruptedData(
                     "Insufficient buffer size for CreateNode label".to_string(),
                 )
                 .into());
             }
-            let label =
-                String::from_utf8_lossy(&buffer[current_offset..current_offset + label_len])
-                    .to_string();
-            current_offset += label_len;
+            let label_id = u32::from_le_bytes(
+                buffer[current_offset..current_offset + 4]
+                    .try_into()
+                    .unwrap(), // Safe due to buffer length check above
+            );
+            current_offset += 4;
+
+            // Reconstruct InternedString from ID
+            // During recovery, the string should already be in the interner
+            // (either from checkpoint or previous WAL entries)
+            let label = crate::core::interning::InternedString::from_raw(label_id);
 
             // V1+: deserialize properties and temporal
             let (properties, temporal) = if version >= WAL_VERSION {
@@ -301,24 +301,22 @@ pub(crate) fn parse_entry_at(
             let target = deserialize_node_id(buffer, current_offset, "CreateEdge target")?;
             current_offset += 8;
 
-            let label_len = u32::from_le_bytes(
-                buffer[current_offset..current_offset + 4]
-                    .try_into()
-                    .unwrap(), // Safe due to buffer length check above
-            ) as usize;
-            current_offset += 4;
-
-            // Use saturating_add to prevent overflow
-            if current_offset.saturating_add(label_len) > buffer.len() {
+            // Read 4-byte InternedString ID
+            if current_offset + 4 > buffer.len() {
                 return Err(StorageError::CorruptedData(
                     "Insufficient buffer size for CreateEdge label".to_string(),
                 )
                 .into());
             }
-            let label =
-                String::from_utf8_lossy(&buffer[current_offset..current_offset + label_len])
-                    .to_string();
-            current_offset += label_len;
+            let label_id = u32::from_le_bytes(
+                buffer[current_offset..current_offset + 4]
+                    .try_into()
+                    .unwrap(), // Safe due to buffer length check above
+            );
+            current_offset += 4;
+
+            // Reconstruct InternedString from ID
+            let label = crate::core::interning::InternedString::from_raw(label_id);
 
             let (properties, temporal) = if version >= WAL_VERSION {
                 let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
@@ -341,7 +339,7 @@ pub(crate) fn parse_entry_at(
         }
         3 => {
             // UpdateNode
-            if current_offset + 16 > buffer.len() {
+            if current_offset + 20 > buffer.len() {
                 return Err(StorageError::CorruptedData(
                     "Insufficient buffer size for UpdateNode".to_string(),
                 )
@@ -354,24 +352,17 @@ pub(crate) fn parse_entry_at(
             current_offset += 8;
 
             let (label, properties, temporal) = if version >= WAL_VERSION {
-                let label_len = u32::from_le_bytes([
+                // Read 4-byte InternedString ID
+                let label_id = u32::from_le_bytes([
                     buffer[current_offset],
                     buffer[current_offset + 1],
                     buffer[current_offset + 2],
                     buffer[current_offset + 3],
-                ]) as usize;
+                ]);
                 current_offset += 4;
 
-                if current_offset + label_len > buffer.len() {
-                    return Err(StorageError::CorruptedData(
-                        "Insufficient buffer size for UpdateNode label".to_string(),
-                    )
-                    .into());
-                }
-                let lbl =
-                    String::from_utf8_lossy(&buffer[current_offset..current_offset + label_len])
-                        .to_string();
-                current_offset += label_len;
+                // Reconstruct InternedString from ID
+                let lbl = crate::core::interning::InternedString::from_raw(label_id);
 
                 let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
                 current_offset += props_len;
@@ -380,7 +371,8 @@ pub(crate) fn parse_entry_at(
                 (lbl, props, temp)
             } else {
                 (
-                    String::new(),
+                    // For old WAL format, create a dummy InternedString (this shouldn't happen in practice)
+                    crate::core::interning::InternedString::from_raw(0),
                     PropertyMap::new(),
                     BiTemporalInterval::current(timestamp),
                 )
@@ -409,24 +401,17 @@ pub(crate) fn parse_entry_at(
             current_offset += 8;
 
             let (label, properties, temporal) = if version >= WAL_VERSION {
-                let label_len = u32::from_le_bytes([
+                // Read 4-byte InternedString ID
+                let label_id = u32::from_le_bytes([
                     buffer[current_offset],
                     buffer[current_offset + 1],
                     buffer[current_offset + 2],
                     buffer[current_offset + 3],
-                ]) as usize;
+                ]);
                 current_offset += 4;
 
-                if current_offset + label_len > buffer.len() {
-                    return Err(StorageError::CorruptedData(
-                        "Insufficient buffer size for UpdateEdge label".to_string(),
-                    )
-                    .into());
-                }
-                let lbl =
-                    String::from_utf8_lossy(&buffer[current_offset..current_offset + label_len])
-                        .to_string();
-                current_offset += label_len;
+                // Reconstruct InternedString from ID
+                let lbl = crate::core::interning::InternedString::from_raw(label_id);
 
                 let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
                 current_offset += props_len;
@@ -435,7 +420,8 @@ pub(crate) fn parse_entry_at(
                 (lbl, props, temp)
             } else {
                 (
-                    String::new(),
+                    // For old WAL format, create a dummy InternedString (this shouldn't happen in practice)
+                    crate::core::interning::InternedString::from_raw(0),
                     PropertyMap::new(),
                     BiTemporalInterval::current(timestamp),
                 )
@@ -618,6 +604,7 @@ fn deserialize_version_id(buffer: &[u8], offset: usize, context: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::temporal::time;
     use crate::storage::wal::serialize_entry_into;
     use tempfile::TempDir;
@@ -647,7 +634,7 @@ mod tests {
         let node_id = NodeId::new(42).unwrap();
         let operation = WalOperation::CreateNode {
             node_id,
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };
@@ -670,7 +657,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(parsed_id, node_id);
-                assert_eq!(label, "Person");
+                assert_eq!(label, GLOBAL_INTERNER.intern("Person").unwrap());
             }
             _ => panic!("Expected CreateNode operation"),
         }
@@ -686,7 +673,7 @@ mod tests {
             edge_id,
             source,
             target,
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };
@@ -713,7 +700,7 @@ mod tests {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(parsed_source, source);
                 assert_eq!(parsed_target, target);
-                assert_eq!(label, "KNOWS");
+                assert_eq!(label, GLOBAL_INTERNER.intern("KNOWS").unwrap());
             }
             _ => panic!("Expected CreateEdge operation"),
         }
@@ -727,7 +714,7 @@ mod tests {
         let operation = WalOperation::UpdateNode {
             node_id,
             version_id,
-            label: "UpdatedPerson".to_string(),
+            label: GLOBAL_INTERNER.intern("UpdatedPerson").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };
@@ -752,7 +739,7 @@ mod tests {
             } => {
                 assert_eq!(parsed_id, node_id);
                 assert_eq!(parsed_version, version_id);
-                assert_eq!(label, "UpdatedPerson");
+                assert_eq!(label, GLOBAL_INTERNER.intern("UpdatedPerson").unwrap());
             }
             _ => panic!("Expected UpdateNode operation"),
         }
@@ -766,7 +753,7 @@ mod tests {
         let operation = WalOperation::UpdateEdge {
             edge_id,
             version_id,
-            label: "UPDATED_KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("UPDATED_KNOWS").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };
@@ -791,7 +778,7 @@ mod tests {
             } => {
                 assert_eq!(parsed_id, edge_id);
                 assert_eq!(parsed_version, version_id);
-                assert_eq!(label, "UPDATED_KNOWS");
+                assert_eq!(label, GLOBAL_INTERNER.intern("UPDATED_KNOWS").unwrap());
             }
             _ => panic!("Expected UpdateEdge operation"),
         }
@@ -890,7 +877,7 @@ mod tests {
         // Create two entries
         let operation1 = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
-            label: "First".to_string(),
+            label: GLOBAL_INTERNER.intern("First").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };
@@ -898,7 +885,7 @@ mod tests {
 
         let operation2 = WalOperation::CreateNode {
             node_id: NodeId::new(2).unwrap(),
-            label: "Second".to_string(),
+            label: GLOBAL_INTERNER.intern("Second").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };
@@ -923,7 +910,7 @@ mod tests {
         assert_eq!(parsed_entry.lsn, LSN(2));
         match parsed_entry.operation {
             WalOperation::CreateNode { label, .. } => {
-                assert_eq!(label, "Second");
+                assert_eq!(label, GLOBAL_INTERNER.intern("Second").unwrap());
             }
             _ => panic!("Expected CreateNode operation"),
         }
@@ -1012,10 +999,9 @@ mod tests {
         // Node ID (8 bytes)
         buffer.extend_from_slice(&123u64.to_le_bytes());
 
-        // Label
-        let label = "TestNode";
-        buffer.extend_from_slice(&(label.len() as u32).to_le_bytes());
-        buffer.extend_from_slice(label.as_bytes());
+        // Label (4-byte InternedString ID)
+        let label_id = GLOBAL_INTERNER.intern("TestNode").unwrap().as_u32();
+        buffer.extend_from_slice(&label_id.to_le_bytes());
 
         // Note: Version 0 format does NOT include properties or temporal data
 
@@ -1040,7 +1026,7 @@ mod tests {
                 temporal,
             } => {
                 assert_eq!(node_id.as_u64(), 123);
-                assert_eq!(parsed_label, "TestNode");
+                assert_eq!(parsed_label, GLOBAL_INTERNER.intern("TestNode").unwrap());
                 // Version 0 should have empty properties
                 assert!(properties.is_empty());
                 // Temporal should be set to current(timestamp)
@@ -1056,7 +1042,7 @@ mod tests {
         let node_id = NodeId::new(42).unwrap();
         let operation = WalOperation::CreateNode {
             node_id,
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         };

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1310,7 +1310,7 @@ fn test_recovery_after_concurrent_writes() {
                             NodeId::new((thread_id * appends_per_thread + i) as u64).unwrap();
                         let operation = WalOperation::CreateNode {
                             node_id,
-                            label: "CrashTest".into(),
+                            label: GLOBAL_INTERNER.intern("CrashTest").unwrap(),
                             properties: PropertyMap::new(),
                             temporal: BiTemporalInterval::current(time::now()),
                         };
@@ -1444,7 +1444,7 @@ fn test_recovery_partial_flush_ordering() {
                             NodeId::new((thread_id * appends_per_thread + i) as u64).unwrap();
                         let operation = WalOperation::CreateNode {
                             node_id,
-                            label: "PartialCrashTest".into(),
+                            label: GLOBAL_INTERNER.intern("PartialCrashTest").unwrap(),
                             properties: PropertyMap::new(),
                             temporal: BiTemporalInterval::current(time::now()),
                         };

--- a/tests/issue_225_wal_interned_strings.rs
+++ b/tests/issue_225_wal_interned_strings.rs
@@ -1,0 +1,239 @@
+//! Tests for issue #225: WAL should accept InternedString directly
+//!
+//! This test verifies that WalOperation uses InternedString instead of String,
+//! eliminating unnecessary allocations in the hot path.
+
+use gallifreydb::core::id::{EdgeId, NodeId, VersionId};
+use gallifreydb::core::interning::GLOBAL_INTERNER;
+use gallifreydb::core::property::PropertyMapBuilder;
+use gallifreydb::core::temporal::{BiTemporalInterval, time};
+use gallifreydb::storage::wal::{LSN, WalEntry, WalOperation};
+
+/// Helper to create a test temporal interval
+fn test_temporal() -> BiTemporalInterval {
+    BiTemporalInterval::current(time::now())
+}
+
+/// Test that WalOperation::CreateNode uses InternedString for label
+#[test]
+fn test_wal_create_node_uses_interned_string() {
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+    let node_id = NodeId::new(1).unwrap();
+    let properties = PropertyMapBuilder::new().insert("name", "Alice").build();
+    let temporal = test_temporal();
+
+    // This should compile without needing to resolve the InternedString
+    let op = WalOperation::CreateNode {
+        node_id,
+        label, // Should accept InternedString directly
+        properties,
+        temporal,
+    };
+
+    // Verify the operation was created successfully
+    match op {
+        WalOperation::CreateNode { label: l, .. } => {
+            // The label should be an InternedString, not a String
+            assert_eq!(l, label);
+        }
+        _ => panic!("Expected CreateNode operation"),
+    }
+}
+
+/// Test that WalOperation::CreateEdge uses InternedString for label
+#[test]
+fn test_wal_create_edge_uses_interned_string() {
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let edge_id = EdgeId::new(1).unwrap();
+    let source = NodeId::new(1).unwrap();
+    let target = NodeId::new(2).unwrap();
+    let properties = PropertyMapBuilder::new().build();
+    let temporal = test_temporal();
+
+    let op = WalOperation::CreateEdge {
+        edge_id,
+        source,
+        target,
+        label, // Should accept InternedString directly
+        properties,
+        temporal,
+    };
+
+    match op {
+        WalOperation::CreateEdge { label: l, .. } => {
+            assert_eq!(l, label);
+        }
+        _ => panic!("Expected CreateEdge operation"),
+    }
+}
+
+/// Test that WalOperation::UpdateNode uses InternedString for label
+#[test]
+fn test_wal_update_node_uses_interned_string() {
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+    let node_id = NodeId::new(1).unwrap();
+    let version_id = VersionId::new(2).unwrap();
+    let properties = PropertyMapBuilder::new().insert("name", "Bob").build();
+    let temporal = test_temporal();
+
+    let op = WalOperation::UpdateNode {
+        node_id,
+        version_id,
+        label, // Should accept InternedString directly
+        properties,
+        temporal,
+    };
+
+    match op {
+        WalOperation::UpdateNode { label: l, .. } => {
+            assert_eq!(l, label);
+        }
+        _ => panic!("Expected UpdateNode operation"),
+    }
+}
+
+/// Test that WalOperation::UpdateEdge uses InternedString for label
+#[test]
+fn test_wal_update_edge_uses_interned_string() {
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let edge_id = EdgeId::new(1).unwrap();
+    let version_id = VersionId::new(2).unwrap();
+    let properties = PropertyMapBuilder::new().build();
+    let temporal = test_temporal();
+
+    let op = WalOperation::UpdateEdge {
+        edge_id,
+        version_id,
+        label, // Should accept InternedString directly
+        properties,
+        temporal,
+    };
+
+    match op {
+        WalOperation::UpdateEdge { label: l, .. } => {
+            assert_eq!(l, label);
+        }
+        _ => panic!("Expected UpdateEdge operation"),
+    }
+}
+
+/// Test that WalEntry can be created with InternedString
+#[test]
+fn test_wal_entry_creation_with_interned_string() {
+    let label = GLOBAL_INTERNER.intern("TestLabel").unwrap();
+    let node_id = NodeId::new(42).unwrap();
+    let properties = PropertyMapBuilder::new().insert("key", "value").build();
+    let temporal = test_temporal();
+
+    let op = WalOperation::CreateNode {
+        node_id,
+        label,
+        properties,
+        temporal,
+    };
+
+    // Creating a WAL entry should work without any allocations
+    let entry = WalEntry::new(LSN(100), op);
+
+    // Verify the entry was created successfully
+    match &entry.operation {
+        WalOperation::CreateNode { label: l, .. } => {
+            assert_eq!(*l, label);
+        }
+        _ => panic!("Expected CreateNode operation"),
+    }
+}
+
+/// Test that no allocations occur when converting BufferedWrite to WalOperation
+#[test]
+fn test_no_allocations_in_buffered_write_to_wal_operation() {
+    use gallifreydb::api::transaction::write_buffer::BufferedWrite;
+
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+    let node_id = NodeId::new(1).unwrap();
+    let version_id = VersionId::new(1).unwrap();
+    let properties = PropertyMapBuilder::new().build();
+    let temporal = test_temporal();
+
+    let buffered = BufferedWrite::CreateNode {
+        node_id,
+        version_id,
+        label,
+        properties: properties.clone(),
+        temporal,
+    };
+
+    // When converting to WalOperation, the label should be copied directly
+    // without resolving to String (no allocation)
+    let wal_op = match buffered {
+        BufferedWrite::CreateNode {
+            node_id,
+            label,
+            properties,
+            temporal,
+            ..
+        } => {
+            WalOperation::CreateNode {
+                node_id,
+                label, // Should copy InternedString directly (just a u32)
+                properties,
+                temporal,
+            }
+        }
+        _ => panic!("Expected CreateNode"),
+    };
+
+    // Verify the operation was created without string allocation
+    match wal_op {
+        WalOperation::CreateNode { label: l, .. } => {
+            // The label should still be the same InternedString
+            assert_eq!(l, label);
+        }
+        _ => panic!("Expected CreateNode operation"),
+    }
+}
+
+/// Test that operations with different label lengths have same InternedString size
+#[test]
+fn test_interned_string_size_independence() {
+    let short_label = GLOBAL_INTERNER.intern("A").unwrap();
+    let long_label = GLOBAL_INTERNER
+        .intern("VeryLongLabelNameWithManyCharacters")
+        .unwrap();
+
+    // Both labels should be 4 bytes (u32) regardless of string length
+    assert_eq!(std::mem::size_of_val(&short_label), 4);
+    assert_eq!(std::mem::size_of_val(&long_label), 4);
+
+    // Create operations with both labels
+    let node_id = NodeId::new(1).unwrap();
+    let properties = PropertyMapBuilder::new().build();
+    let temporal = test_temporal();
+
+    let op1 = WalOperation::CreateNode {
+        node_id,
+        label: short_label,
+        properties: properties.clone(),
+        temporal,
+    };
+
+    let op2 = WalOperation::CreateNode {
+        node_id,
+        label: long_label,
+        properties,
+        temporal,
+    };
+
+    // Both operations should use the same amount of memory for the label field
+    // (4 bytes for the InternedString ID, not the original string length)
+    match (&op1, &op2) {
+        (
+            WalOperation::CreateNode { label: l1, .. },
+            WalOperation::CreateNode { label: l2, .. },
+        ) => {
+            assert_eq!(std::mem::size_of_val(l1), std::mem::size_of_val(l2));
+            assert_eq!(std::mem::size_of_val(l1), 4);
+        }
+        _ => panic!("Expected CreateNode operations"),
+    }
+}

--- a/tests/issue_225_wal_validation.rs
+++ b/tests/issue_225_wal_validation.rs
@@ -5,7 +5,7 @@
 //! WAL files or missing checkpoint data.
 
 use gallifreydb::core::id::NodeId;
-use gallifreydb::core::interning::{InternedString, GLOBAL_INTERNER};
+use gallifreydb::core::interning::{GLOBAL_INTERNER, InternedString};
 use gallifreydb::core::property::PropertyMapBuilder;
 use gallifreydb::core::temporal::{BiTemporalInterval, time};
 use gallifreydb::storage::persistence::{CheckpointConfig, PersistenceManager};
@@ -63,7 +63,9 @@ fn test_wal_replay_rejects_invalid_interned_string() {
             );
         }
         Err(other) => panic!("Expected StorageError::CorruptedData, got: {:?}", other),
-        Ok(_) => panic!("Expected recovery to fail with corrupted InternedString ID, but it succeeded"),
+        Ok(_) => {
+            panic!("Expected recovery to fail with corrupted InternedString ID, but it succeeded")
+        }
     }
 }
 

--- a/tests/issue_225_wal_validation.rs
+++ b/tests/issue_225_wal_validation.rs
@@ -1,0 +1,167 @@
+//! Test for issue #225: Validation of InternedString IDs during WAL replay
+//!
+//! This test verifies that invalid InternedString IDs in WAL entries are
+//! detected and rejected during recovery, preventing crashes from corrupted
+//! WAL files or missing checkpoint data.
+
+use gallifreydb::core::id::NodeId;
+use gallifreydb::core::interning::{InternedString, GLOBAL_INTERNER};
+use gallifreydb::core::property::PropertyMapBuilder;
+use gallifreydb::core::temporal::{BiTemporalInterval, time};
+use gallifreydb::storage::persistence::{CheckpointConfig, PersistenceManager};
+use gallifreydb::storage::wal::WalOperation;
+use gallifreydb::storage::wal::concurrent_system::{
+    ConcurrentWalSystem, ConcurrentWalSystemConfig,
+};
+use gallifreydb::utils::error::Error;
+use tempfile::TempDir;
+
+/// Test that WAL replay rejects invalid InternedString IDs
+#[test]
+fn test_wal_replay_rejects_invalid_interned_string() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let wal_config = ConcurrentWalSystemConfig::new(wal_dir.clone());
+    let wal = ConcurrentWalSystem::new(wal_config).unwrap();
+
+    // Create a WalOperation with an INVALID InternedString ID
+    // Use a very high ID that is unlikely to exist in the interner
+    let invalid_label = InternedString::from_raw(999999);
+    let node_id = NodeId::new(1).unwrap();
+    let properties = PropertyMapBuilder::new().build();
+    let temporal = BiTemporalInterval::current(time::now());
+
+    let op = WalOperation::CreateNode {
+        node_id,
+        label: invalid_label,
+        properties,
+        temporal,
+    };
+
+    // Write the operation to WAL
+    wal.append(op).unwrap();
+    wal.flush().unwrap();
+
+    // Now try to recover from this WAL
+    // This should fail with a CorruptedData error because the InternedString ID
+    // doesn't exist in the interner
+    let config = CheckpointConfig {
+        checkpoint_dir: temp_dir.path().join("checkpoints"),
+        ..Default::default()
+    };
+    let mut manager = PersistenceManager::new(config).unwrap();
+    let recovery_result = manager.recover(&wal);
+
+    match recovery_result {
+        Err(Error::Storage(storage_err)) => {
+            let err_msg = format!("{}", storage_err);
+            assert!(
+                err_msg.contains("InternedString ID") && err_msg.contains("not found in interner"),
+                "Expected error message about InternedString not found, got: {}",
+                err_msg
+            );
+        }
+        Err(other) => panic!("Expected StorageError::CorruptedData, got: {:?}", other),
+        Ok(_) => panic!("Expected recovery to fail with corrupted InternedString ID, but it succeeded"),
+    }
+}
+
+/// Test that valid InternedString IDs are accepted during WAL replay
+#[test]
+fn test_wal_replay_accepts_valid_interned_string() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let wal_config = ConcurrentWalSystemConfig::new(wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config).unwrap();
+
+    // Create a WalOperation with a VALID InternedString (intern it first)
+    let valid_label = GLOBAL_INTERNER.intern("TestNode").unwrap();
+    let node_id = NodeId::new(1).unwrap();
+    let properties = PropertyMapBuilder::new().build();
+    let temporal = BiTemporalInterval::current(time::now());
+
+    let op = WalOperation::CreateNode {
+        node_id,
+        label: valid_label,
+        properties,
+        temporal,
+    };
+
+    // Write the operation to WAL
+    wal.append(op).unwrap();
+    wal.flush().unwrap();
+
+    // Now try to recover from this WAL
+    // This should succeed because the InternedString ID exists in the interner
+    let config = CheckpointConfig {
+        checkpoint_dir: temp_dir.path().join("checkpoints"),
+        ..Default::default()
+    };
+    let mut manager = PersistenceManager::new(config).unwrap();
+    let recovery_result = manager.recover(&wal);
+
+    match recovery_result {
+        Ok((current, _historical, lsn)) => {
+            // Recovery succeeded, verify the node was created
+            assert!(lsn.0 > 0, "LSN should be > 0 after recovery");
+            let node = current.get_node(node_id).unwrap();
+            assert_eq!(node.id, node_id);
+            assert!(node.has_label_str("TestNode"));
+        }
+        Err(e) => panic!("Expected recovery to succeed, but got error: {:?}", e),
+    }
+}
+
+/// Test that corrupted WAL with random bytes for InternedString ID is rejected
+#[test]
+fn test_wal_replay_rejects_corrupted_interned_string() {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let wal_config = ConcurrentWalSystemConfig::new(wal_dir);
+    let wal = ConcurrentWalSystem::new(wal_config).unwrap();
+
+    // Create multiple operations with invalid InternedString IDs
+    // simulating a corrupted WAL file
+    for i in 1..=10 {
+        let invalid_label = InternedString::from_raw(1000000 + i);
+        let node_id = NodeId::new(i as u64).unwrap();
+        let properties = PropertyMapBuilder::new().build();
+        let temporal = BiTemporalInterval::current(time::now());
+
+        let op = WalOperation::CreateNode {
+            node_id,
+            label: invalid_label,
+            properties,
+            temporal,
+        };
+
+        wal.append(op).unwrap();
+    }
+
+    wal.flush().unwrap();
+
+    // Recovery should fail on the first corrupted entry
+    let config = CheckpointConfig {
+        checkpoint_dir: temp_dir.path().join("checkpoints"),
+        ..Default::default()
+    };
+    let mut manager = PersistenceManager::new(config).unwrap();
+    let recovery_result = manager.recover(&wal);
+
+    assert!(
+        recovery_result.is_err(),
+        "Expected recovery to fail with corrupted WAL, but it succeeded"
+    );
+
+    if let Err(e) = recovery_result {
+        let err_msg = format!("{}", e);
+        assert!(
+            err_msg.contains("InternedString ID") && err_msg.contains("not found"),
+            "Expected error about InternedString not found, got: {}",
+            err_msg
+        );
+    }
+}

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -7,9 +7,8 @@
 //! - Maintains LSN consistency across checkpoint and recovery
 
 use gallifreydb::{
-    PropertyMapBuilder,
+    GLOBAL_INTERNER, PropertyMapBuilder,
     core::{
-        GLOBAL_INTERNER,
         graph::Node,
         id::{EdgeId, NodeId, VersionId},
         property::PropertyMap,

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -49,7 +49,7 @@ fn test_checkpoint_recovery_basic() -> Result<()> {
             .build();
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i)?,
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: props,
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -91,7 +91,7 @@ fn test_checkpoint_with_persisted_state_and_wal_replay() -> Result<()> {
         let props = PropertyMapBuilder::new().insert("value", i as i64).build();
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i)?,
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: props,
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -122,7 +122,7 @@ fn test_checkpoint_with_persisted_state_and_wal_replay() -> Result<()> {
         let props = PropertyMapBuilder::new().insert("value", i as i64).build();
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i)?,
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: props,
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -321,7 +321,7 @@ fn test_checkpoint_recovery_with_updates() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -330,7 +330,7 @@ fn test_checkpoint_recovery_with_updates() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(2)?,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("name", "Alice Updated")
             .build(),
@@ -374,7 +374,7 @@ fn test_checkpoint_recovery_with_deletes() -> Result<()> {
     for i in 1..=3 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i)?,
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;

--- a/tests/recovery/crash_scenarios.rs
+++ b/tests/recovery/crash_scenarios.rs
@@ -19,6 +19,7 @@
 //! See: <https://github.com/madmax983/GallifreyDB/issues/XXX> (TODO: create issue)
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId, VersionId},
         property::{PropertyMap, PropertyMapBuilder, PropertyValue},
@@ -81,7 +82,7 @@ fn test_crash_before_checkpoint_nodes_only() -> Result<()> {
     for i in 1..=100 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: format!("Node{}", i),
+            label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new().insert("index", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -808,7 +809,7 @@ fn test_complex_workflow_create_update_delete() -> Result<()> {
             edge_id: EdgeId::new(i - 10).unwrap(),
             source: NodeId::new(i).unwrap(),
             target: NodeId::new(i + 1).unwrap(),
-            label: "WORKS_WITH".to_string(),
+            label: GLOBAL_INTERNER.intern("WORKS_WITH").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -883,21 +884,21 @@ fn test_complex_workflow_with_edges_and_updates() -> Result<()> {
     // Create nodes
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(1).unwrap(),
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(2).unwrap(),
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Bob").build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(3).unwrap(),
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Charlie").build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -925,7 +926,7 @@ fn test_complex_workflow_with_edges_and_updates() -> Result<()> {
     wal.append(WalOperation::UpdateEdge {
         edge_id: EdgeId::new(1).unwrap(),
         version_id: VersionId::new(6).unwrap(),
-        label: "FRIENDS_WITH".to_string(),
+        label: GLOBAL_INTERNER.intern("FRIENDS_WITH").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("since", 2020_i64)
             .insert("strength", "strong")
@@ -993,7 +994,7 @@ fn test_complex_workflow_with_vector_properties() -> Result<()> {
             .collect();
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Document".to_string(),
+            label: GLOBAL_INTERNER.intern("Document").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("title", format!("Doc{}", i))
                 .insert_vector("embedding", &embedding)
@@ -1007,7 +1008,7 @@ fn test_complex_workflow_with_vector_properties() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: NodeId::new(1).unwrap(),
         version_id: VersionId::new(6).unwrap(),
-        label: "Document".to_string(),
+        label: GLOBAL_INTERNER.intern("Document").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("title", "Doc1 - Updated")
             .insert_vector("embedding", &new_embedding)

--- a/tests/recovery/crash_scenarios.rs
+++ b/tests/recovery/crash_scenarios.rs
@@ -138,7 +138,7 @@ fn test_crash_before_checkpoint_nodes_and_edges() -> Result<()> {
     for i in 1..=50 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", format!("Person{}", i))
                 .build(),
@@ -152,7 +152,7 @@ fn test_crash_before_checkpoint_nodes_and_edges() -> Result<()> {
             edge_id: EdgeId::new(i).unwrap(),
             source: NodeId::new(i).unwrap(),
             target: NodeId::new(i + 1).unwrap(),
-            label: "KNOWS".to_string(),
+            label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("order", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -162,7 +162,7 @@ fn test_crash_before_checkpoint_nodes_and_edges() -> Result<()> {
         edge_id: EdgeId::new(50).unwrap(),
         source: NodeId::new(50).unwrap(),
         target: NodeId::new(1).unwrap(),
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new().insert("order", 50_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -213,7 +213,7 @@ fn test_crash_after_checkpoint_recovery() -> Result<()> {
     for i in 1..=50 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Phase1".to_string(),
+            label: GLOBAL_INTERNER.intern("Phase1").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("phase", 1_i64)
                 .insert("index", i as i64)
@@ -236,7 +236,7 @@ fn test_crash_after_checkpoint_recovery() -> Result<()> {
     for i in 51..=100 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Phase2".to_string(),
+            label: GLOBAL_INTERNER.intern("Phase2").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("phase", 2_i64)
                 .insert("index", i as i64)
@@ -296,7 +296,7 @@ fn test_checkpoint_with_mixed_operations() -> Result<()> {
     for i in 1..=20 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("value", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -307,7 +307,7 @@ fn test_checkpoint_with_mixed_operations() -> Result<()> {
         wal.append(WalOperation::UpdateNode {
             node_id: NodeId::new(i).unwrap(),
             version_id: VersionId::new(20 + i).unwrap(),
-            label: "UpdatedNode".to_string(),
+            label: GLOBAL_INTERNER.intern("UpdatedNode").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("value", (i * 100) as i64)
                 .build(),
@@ -327,7 +327,7 @@ fn test_checkpoint_with_mixed_operations() -> Result<()> {
     for i in 21..=30 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "NewNode".to_string(),
+            label: GLOBAL_INTERNER.intern("NewNode").unwrap(),
             properties: PropertyMapBuilder::new().insert("value", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -388,7 +388,7 @@ fn test_crash_with_truncated_wal() -> Result<()> {
     for i in 1..=10 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "SafeNode".to_string(),
+            label: GLOBAL_INTERNER.intern("SafeNode").unwrap(),
             properties: PropertyMapBuilder::new().insert("index", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -406,7 +406,7 @@ fn test_crash_with_truncated_wal() -> Result<()> {
     // Add one more operation that we'll truncate
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(11).unwrap(),
-        label: "TruncatedNode".to_string(),
+        label: GLOBAL_INTERNER.intern("TruncatedNode").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("index", 11_i64)
             .insert("will_be", "truncated")
@@ -473,7 +473,7 @@ fn test_crash_with_corrupted_wal_header() -> Result<()> {
     for i in 1..=5 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -541,7 +541,7 @@ fn test_multiple_crash_recovery_cycles() -> Result<()> {
         for i in 1..=20 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: "Cycle1".to_string(),
+                label: GLOBAL_INTERNER.intern("Cycle1").unwrap(),
                 properties: PropertyMapBuilder::new().insert("cycle", 1_i64).build(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -566,7 +566,7 @@ fn test_multiple_crash_recovery_cycles() -> Result<()> {
         for i in 21..=40 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: "Cycle2".to_string(),
+                label: GLOBAL_INTERNER.intern("Cycle2").unwrap(),
                 properties: PropertyMapBuilder::new().insert("cycle", 2_i64).build(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -591,7 +591,7 @@ fn test_multiple_crash_recovery_cycles() -> Result<()> {
         for i in 41..=60 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: "Cycle3".to_string(),
+                label: GLOBAL_INTERNER.intern("Cycle3").unwrap(),
                 properties: PropertyMapBuilder::new().insert("cycle", 3_i64).build(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -602,7 +602,7 @@ fn test_multiple_crash_recovery_cycles() -> Result<()> {
             wal.append(WalOperation::UpdateNode {
                 node_id: NodeId::new(i).unwrap(),
                 version_id: VersionId::new(60 + i).unwrap(),
-                label: "UpdatedCycle1".to_string(),
+                label: GLOBAL_INTERNER.intern("UpdatedCycle1").unwrap(),
                 properties: PropertyMapBuilder::new()
                     .insert("cycle", 1_i64)
                     .insert("updated", true)
@@ -664,7 +664,7 @@ fn test_crash_recovery_with_deletions_across_cycles() -> Result<()> {
         for i in 1..=10 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: "Node".to_string(),
+                label: GLOBAL_INTERNER.intern("Node").unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -699,7 +699,7 @@ fn test_crash_recovery_with_deletions_across_cycles() -> Result<()> {
         for i in 11..=15 {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i).unwrap(),
-                label: "NewNode".to_string(),
+                label: GLOBAL_INTERNER.intern("NewNode").unwrap(),
                 properties: PropertyMap::new(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;
@@ -755,7 +755,7 @@ fn test_complex_workflow_create_update_delete() -> Result<()> {
     for i in 1..=10 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", format!("Person{}", i))
                 .insert("age", (20 + i) as i64)
@@ -770,7 +770,7 @@ fn test_complex_workflow_create_update_delete() -> Result<()> {
         wal.append(WalOperation::UpdateNode {
             node_id: NodeId::new(i).unwrap(),
             version_id: VersionId::new(next_version_id).unwrap(),
-            label: "Person".to_string(),
+            label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", format!("Person{}", i))
                 .insert("age", (30 + i) as i64)
@@ -793,7 +793,7 @@ fn test_complex_workflow_create_update_delete() -> Result<()> {
     for i in 11..=15 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Employee".to_string(),
+            label: GLOBAL_INTERNER.intern("Employee").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("name", format!("Employee{}", i))
                 .insert("department", "Engineering")
@@ -907,7 +907,7 @@ fn test_complex_workflow_with_edges_and_updates() -> Result<()> {
         edge_id: EdgeId::new(1).unwrap(),
         source: NodeId::new(1).unwrap(),
         target: NodeId::new(2).unwrap(),
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new().insert("since", 2020_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -916,7 +916,7 @@ fn test_complex_workflow_with_edges_and_updates() -> Result<()> {
         edge_id: EdgeId::new(2).unwrap(),
         source: NodeId::new(2).unwrap(),
         target: NodeId::new(3).unwrap(),
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new().insert("since", 2021_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/large_dataset_recovery.rs
+++ b/tests/recovery/large_dataset_recovery.rs
@@ -51,7 +51,7 @@ fn test_large_dataset_recovery_10k_nodes() -> Result<()> {
     for i in 1..=LARGE_DATASET_NODE_COUNT {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "LargeNode".to_string(),
+            label: GLOBAL_INTERNER.intern("LargeNode").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("index", i as i64)
                 .insert("batch", (i / 1000) as i64)
@@ -143,7 +143,7 @@ fn test_large_dataset_recovery_50k_edges() -> Result<()> {
     for i in 1..=node_count {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -161,7 +161,7 @@ fn test_large_dataset_recovery_50k_edges() -> Result<()> {
             edge_id: EdgeId::new(i).unwrap(),
             source: NodeId::new(source).unwrap(),
             target: NodeId::new(target).unwrap(),
-            label: "CONNECTS".to_string(),
+            label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMapBuilder::new().insert("index", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -257,7 +257,7 @@ fn test_large_dataset_full_recovery() -> Result<()> {
     for i in 1..=LARGE_DATASET_NODE_COUNT {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Entity".to_string(),
+            label: GLOBAL_INTERNER.intern("Entity").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("id", i as i64)
                 .insert("type", "node")
@@ -285,7 +285,7 @@ fn test_large_dataset_full_recovery() -> Result<()> {
             edge_id: EdgeId::new(i).unwrap(),
             source: NodeId::new(source).unwrap(),
             target: NodeId::new(target).unwrap(),
-            label: "RELATES_TO".to_string(),
+            label: GLOBAL_INTERNER.intern("RELATES_TO").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("weight", (i % 100) as i64)
                 .build(),
@@ -402,7 +402,7 @@ fn test_large_dataset_with_updates() -> Result<()> {
     for i in 1..=node_count {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "VersionedNode".to_string(),
+            label: GLOBAL_INTERNER.intern("VersionedNode").unwrap(),
             properties: PropertyMapBuilder::new()
                 .insert("version", 0_i64)
                 .insert("value", (i * 10) as i64)
@@ -418,7 +418,7 @@ fn test_large_dataset_with_updates() -> Result<()> {
             wal.append(WalOperation::UpdateNode {
                 node_id: NodeId::new(i).unwrap(),
                 version_id: gallifreydb::core::id::VersionId::new(version_id).unwrap(),
-                label: "VersionedNode".to_string(),
+                label: GLOBAL_INTERNER.intern("VersionedNode").unwrap(),
                 properties: PropertyMapBuilder::new()
                     .insert("version", update_round as i64)
                     .insert("value", (i * 10 + update_round) as i64)
@@ -505,7 +505,7 @@ fn test_large_dataset_with_deletions() -> Result<()> {
     for i in 1..=node_count {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("index", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -607,7 +607,7 @@ fn bench_recovery_throughput() -> Result<()> {
         for i in 1..=size {
             wal.append(WalOperation::CreateNode {
                 node_id: NodeId::new(i as u64).unwrap(),
-                label: "BenchNode".to_string(),
+                label: GLOBAL_INTERNER.intern("BenchNode").unwrap(),
                 properties: PropertyMapBuilder::new().insert("i", i as i64).build(),
                 temporal: BiTemporalInterval::current(time::now()),
             })?;

--- a/tests/recovery/large_dataset_recovery.rs
+++ b/tests/recovery/large_dataset_recovery.rs
@@ -9,6 +9,7 @@
 //! Run with: `cargo test --test recovery large_dataset -- --ignored`
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId},
         property::{PropertyMap, PropertyMapBuilder},

--- a/tests/recovery/property_based_tests.rs
+++ b/tests/recovery/property_based_tests.rs
@@ -28,6 +28,7 @@
 //! **50,000-200,000 operations** to thoroughly validate invariants.
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId, VersionId},
         property::PropertyMapBuilder,
@@ -217,7 +218,7 @@ impl RecoveryTestHarness {
                     if !created_nodes.contains(id) {
                         wal.append(WalOperation::CreateNode {
                             node_id: NodeId::new(*id)?,
-                            label: label.clone(),
+                            label: GLOBAL_INTERNER.intern(label).unwrap(),
                             properties: PropertyMapBuilder::new().insert("value", *value).build(),
                             temporal: BiTemporalInterval::current(timestamp_counter),
                         })?;
@@ -262,7 +263,7 @@ impl RecoveryTestHarness {
                             edge_id: EdgeId::new(*id)?,
                             source: NodeId::new(*from)?,
                             target: NodeId::new(*to)?,
-                            label: label.clone(),
+                            label: GLOBAL_INTERNER.intern(label).unwrap(),
                             properties: PropertyMapBuilder::new().build(),
                             temporal: BiTemporalInterval::current(timestamp_counter),
                         })?;

--- a/tests/recovery/property_based_tests.rs
+++ b/tests/recovery/property_based_tests.rs
@@ -231,7 +231,7 @@ impl RecoveryTestHarness {
                         wal.append(WalOperation::UpdateNode {
                             node_id: NodeId::new(*id)?,
                             version_id,
-                            label: "Updated".to_string(),
+                            label: GLOBAL_INTERNER.intern("Updated").unwrap(),
                             properties: PropertyMapBuilder::new()
                                 .insert("value", *new_value)
                                 .build(),
@@ -276,7 +276,7 @@ impl RecoveryTestHarness {
                         wal.append(WalOperation::UpdateEdge {
                             edge_id: EdgeId::new(*id)?,
                             version_id,
-                            label: "Updated".to_string(),
+                            label: GLOBAL_INTERNER.intern("Updated").unwrap(),
                             properties: PropertyMapBuilder::new()
                                 .insert("value", *new_value)
                                 .build(),

--- a/tests/recovery/replay_create_tests.rs
+++ b/tests/recovery/replay_create_tests.rs
@@ -39,7 +39,7 @@ fn test_replay_create_node_basic() -> Result<()> {
 
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(timestamp),
     })?;
@@ -84,7 +84,7 @@ fn test_replay_create_node_with_properties() -> Result<()> {
 
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "User".to_string(),
+        label: GLOBAL_INTERNER.intern("User").unwrap(),
         properties: properties.clone(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -134,7 +134,7 @@ fn test_replay_create_node_with_vector() -> Result<()> {
 
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Document".to_string(),
+        label: GLOBAL_INTERNER.intern("Document").unwrap(),
         properties: properties.clone(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -177,14 +177,14 @@ fn test_replay_create_edge_basic() -> Result<()> {
     // Create source and target nodes
     wal.append(WalOperation::CreateNode {
         node_id: source_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: target_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -238,14 +238,14 @@ fn test_replay_create_edge_with_properties() -> Result<()> {
     // Create nodes first
     wal.append(WalOperation::CreateNode {
         node_id: source_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: target_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/replay_create_tests.rs
+++ b/tests/recovery/replay_create_tests.rs
@@ -9,6 +9,7 @@
 //! - Temporal index updates
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId},
         property::{PropertyMap, PropertyMapBuilder},
@@ -194,7 +195,7 @@ fn test_replay_create_edge_basic() -> Result<()> {
         edge_id,
         source: source_id,
         target: target_id,
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -260,7 +261,7 @@ fn test_replay_create_edge_with_properties() -> Result<()> {
         edge_id,
         source: source_id,
         target: target_id,
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: edge_properties.clone(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -301,7 +302,7 @@ fn test_replay_multiple_creates() -> Result<()> {
     for i in 1..=10 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: format!("Node{}", i),
+            label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -313,7 +314,7 @@ fn test_replay_multiple_creates() -> Result<()> {
             edge_id: EdgeId::new(i).unwrap(),
             source: NodeId::new(i).unwrap(),
             target: NodeId::new(i + 1).unwrap(),
-            label: "LINKS_TO".to_string(),
+            label: GLOBAL_INTERNER.intern("LINKS_TO").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -352,7 +353,7 @@ fn test_replay_create_node_tracks_max_id() -> Result<()> {
     for id in [5, 100, 42] {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(id).unwrap(),
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -396,7 +397,7 @@ fn test_replay_preserves_temporal_interval() -> Result<()> {
 
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Test".to_string(),
+        label: GLOBAL_INTERNER.intern("Test").unwrap(),
         properties: PropertyMap::new(),
         temporal,
     })?;

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -8,6 +8,7 @@
 //! - Tombstone versions in historical storage
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId, VersionId},
         property::{PropertyMap, PropertyMapBuilder},
@@ -160,7 +161,7 @@ fn test_replay_delete_edge_basic() -> Result<()> {
         edge_id,
         source: source_id,
         target: target_id,
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -210,7 +211,7 @@ fn test_replay_multiple_deletes() -> Result<()> {
     for i in 1..=5 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -264,7 +265,7 @@ fn test_replay_delete_with_vector() -> Result<()> {
     // Create node with vector
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Document".to_string(),
+        label: GLOBAL_INTERNER.intern("Document").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert_vector("embedding", &embedding)
             .build(),
@@ -308,7 +309,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
     // Create node 1
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(1).unwrap(),
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 1_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -316,7 +317,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
     // Create node 2
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(2).unwrap(),
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 2_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -325,7 +326,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: NodeId::new(1).unwrap(),
         version_id: VersionId::new(3).unwrap(),
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 10_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -339,7 +340,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
     // Create node 3
     wal.append(WalOperation::CreateNode {
         node_id: NodeId::new(3).unwrap(),
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 3_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -40,7 +40,7 @@ fn test_replay_delete_node_basic() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         temporal: BiTemporalInterval::current(timestamp1),
     })?;
@@ -85,7 +85,7 @@ fn test_replay_delete_node_after_update() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -94,7 +94,7 @@ fn test_replay_delete_node_after_update() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(2).unwrap(),
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("name", "Alice")
             .insert("age", 30_i64)
@@ -143,14 +143,14 @@ fn test_replay_delete_edge_basic() -> Result<()> {
     // Create nodes
     wal.append(WalOperation::CreateNode {
         node_id: source_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: target_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/replay_id_tracking_tests.rs
+++ b/tests/recovery/replay_id_tracking_tests.rs
@@ -36,7 +36,7 @@ fn test_recover_initializes_node_id_generator() -> Result<()> {
     for i in 1..=5 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -77,7 +77,7 @@ fn test_recover_initializes_edge_id_generator() -> Result<()> {
     for i in 1..=2 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -89,7 +89,7 @@ fn test_recover_initializes_edge_id_generator() -> Result<()> {
             edge_id: EdgeId::new(i).unwrap(),
             source: NodeId::new(1).unwrap(),
             target: NodeId::new(2).unwrap(),
-            label: "CONNECTS".to_string(),
+            label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -135,7 +135,7 @@ fn test_recover_initializes_version_id_generator() -> Result<()> {
     // Create node (version 1)
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("count", 0_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -145,7 +145,7 @@ fn test_recover_initializes_version_id_generator() -> Result<()> {
         wal.append(WalOperation::UpdateNode {
             node_id,
             version_id: VersionId::new((i + 1) as u64).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("count", i).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -189,7 +189,7 @@ fn test_recover_handles_gaps_in_ids() -> Result<()> {
     for id in [1, 5, 10] {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(id).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -229,7 +229,7 @@ fn test_recover_with_deletes_tracks_max_ids() -> Result<()> {
     for i in 1..=3 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -305,7 +305,7 @@ fn test_recover_all_generators_independent() -> Result<()> {
     for i in 1..=3 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -317,7 +317,7 @@ fn test_recover_all_generators_independent() -> Result<()> {
             edge_id: EdgeId::new(i).unwrap(),
             source: NodeId::new(1).unwrap(),
             target: NodeId::new(2).unwrap(),
-            label: "CONNECTS".to_string(),
+            label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;

--- a/tests/recovery/replay_id_tracking_tests.rs
+++ b/tests/recovery/replay_id_tracking_tests.rs
@@ -7,6 +7,7 @@
 //! - Ensure new operations generate non-conflicting IDs
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId, VersionId},
         property::{PropertyMap, PropertyMapBuilder},
@@ -327,7 +328,7 @@ fn test_recover_all_generators_independent() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: NodeId::new(1).unwrap(),
         version_id: VersionId::new(6).unwrap(),
-        label: "UpdatedNode".to_string(),
+        label: GLOBAL_INTERNER.intern("UpdatedNode").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/replay_loop_tests.rs
+++ b/tests/recovery/replay_loop_tests.rs
@@ -78,7 +78,7 @@ fn test_recover_tracks_max_node_id() -> Result<()> {
     for id in [10, 20, 100] {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(id).unwrap(),
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -119,7 +119,7 @@ fn test_recover_tracks_max_edge_id() -> Result<()> {
     for id in [1, 2] {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(id).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -131,7 +131,7 @@ fn test_recover_tracks_max_edge_id() -> Result<()> {
             edge_id: EdgeId::new(id).unwrap(),
             source: NodeId::new(1).unwrap(),
             target: NodeId::new(2).unwrap(),
-            label: "CONNECTS".to_string(),
+            label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -178,7 +178,7 @@ fn test_recover_tracks_max_version_id() -> Result<()> {
     // Create node first
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -188,7 +188,7 @@ fn test_recover_tracks_max_version_id() -> Result<()> {
         wal.append(WalOperation::UpdateNode {
             node_id,
             version_id: VersionId::new(version_id).unwrap(),
-            label: "Updated".to_string(),
+            label: GLOBAL_INTERNER.intern("Updated").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -233,7 +233,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -360,7 +360,7 @@ fn test_recover_from_checkpoint_lsn() -> Result<()> {
     for i in 1..=100 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -423,7 +423,7 @@ fn test_recover_handles_checkpoint_marker() -> Result<()> {
     for i in 1..=10 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -439,7 +439,7 @@ fn test_recover_handles_checkpoint_marker() -> Result<()> {
     for i in 11..=20 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Test".to_string(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;

--- a/tests/recovery/replay_loop_tests.rs
+++ b/tests/recovery/replay_loop_tests.rs
@@ -7,6 +7,7 @@
 //! - Handles errors gracefully (corrupt entries, invalid IDs)
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId, VersionId},
         property::PropertyMap,
@@ -242,7 +243,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(100).unwrap(),
-        label: "Updated".to_string(),
+        label: GLOBAL_INTERNER.intern("Updated").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -251,7 +252,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(50).unwrap(),
-        label: "Another".to_string(),
+        label: GLOBAL_INTERNER.intern("Another").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -298,7 +299,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -308,7 +309,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
         edge_id,
         source: node_id,
         target: NodeId::new(2).unwrap(),
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -317,7 +318,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(2).unwrap(),
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/replay_update_tests.rs
+++ b/tests/recovery/replay_update_tests.rs
@@ -40,7 +40,7 @@ fn test_replay_update_node_basic() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         temporal: BiTemporalInterval::current(timestamp1),
     })?;
@@ -49,7 +49,7 @@ fn test_replay_update_node_basic() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(2).unwrap(),
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("name", "Alice")
             .insert("age", 30_i64)
@@ -100,7 +100,7 @@ fn test_replay_update_node_label_change() -> Result<()> {
     // Create node with "Person" label
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -109,7 +109,7 @@ fn test_replay_update_node_label_change() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(2).unwrap(),
-        label: "User".to_string(),
+        label: GLOBAL_INTERNER.intern("User").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -146,7 +146,7 @@ fn test_replay_update_node_with_vector() -> Result<()> {
     // Create node with initial embedding
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Document".to_string(),
+        label: GLOBAL_INTERNER.intern("Document").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert_vector("embedding", &embedding_v1)
             .build(),
@@ -157,7 +157,7 @@ fn test_replay_update_node_with_vector() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id,
         version_id: VersionId::new(2).unwrap(),
-        label: "Document".to_string(),
+        label: GLOBAL_INTERNER.intern("Document").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert_vector("embedding", &embedding_v2)
             .build(),
@@ -256,14 +256,14 @@ fn test_replay_update_edge_basic() -> Result<()> {
     // Create nodes
     wal.append(WalOperation::CreateNode {
         node_id: source_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: target_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -333,14 +333,14 @@ fn test_replay_update_edge_label_change() -> Result<()> {
     // Create nodes
     wal.append(WalOperation::CreateNode {
         node_id: source_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
 
     wal.append(WalOperation::CreateNode {
         node_id: target_id,
-        label: "Person".to_string(),
+        label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;

--- a/tests/recovery/replay_update_tests.rs
+++ b/tests/recovery/replay_update_tests.rs
@@ -8,6 +8,7 @@
 //! - Version metadata creation for updates
 
 use gallifreydb::{
+    GLOBAL_INTERNER,
     core::{
         id::{EdgeId, NodeId, VersionId},
         property::{PropertyMap, PropertyMapBuilder},
@@ -200,7 +201,7 @@ fn test_replay_multiple_updates_same_node() -> Result<()> {
     // Create node
     wal.append(WalOperation::CreateNode {
         node_id,
-        label: "Counter".to_string(),
+        label: GLOBAL_INTERNER.intern("Counter").unwrap(),
         properties: PropertyMapBuilder::new().insert("count", 0_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -210,7 +211,7 @@ fn test_replay_multiple_updates_same_node() -> Result<()> {
         wal.append(WalOperation::UpdateNode {
             node_id,
             version_id: VersionId::new((i + 1) as u64).unwrap(),
-            label: "Counter".to_string(),
+            label: GLOBAL_INTERNER.intern("Counter").unwrap(),
             properties: PropertyMapBuilder::new().insert("count", i).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -273,7 +274,7 @@ fn test_replay_update_edge_basic() -> Result<()> {
         edge_id,
         source: source_id,
         target: target_id,
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new().insert("since", 2020_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -282,7 +283,7 @@ fn test_replay_update_edge_basic() -> Result<()> {
     wal.append(WalOperation::UpdateEdge {
         edge_id,
         version_id: VersionId::new(4).unwrap(),
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new()
             .insert("since", 2020_i64)
             .insert("strength", 0.8)
@@ -350,7 +351,7 @@ fn test_replay_update_edge_label_change() -> Result<()> {
         edge_id,
         source: source_id,
         target: target_id,
-        label: "KNOWS".to_string(),
+        label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -359,7 +360,7 @@ fn test_replay_update_edge_label_change() -> Result<()> {
     wal.append(WalOperation::UpdateEdge {
         edge_id,
         version_id: VersionId::new(4).unwrap(),
-        label: "FRIENDS_WITH".to_string(),
+        label: GLOBAL_INTERNER.intern("FRIENDS_WITH").unwrap(),
         properties: PropertyMap::new(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -393,7 +394,7 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
     for i in 1..=3 {
         wal.append(WalOperation::CreateNode {
             node_id: NodeId::new(i).unwrap(),
-            label: "Node".to_string(),
+            label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("value", i as i64).build(),
             temporal: BiTemporalInterval::current(time::now()),
         })?;
@@ -403,7 +404,7 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: NodeId::new(1).unwrap(),
         version_id: VersionId::new(4).unwrap(),
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 10_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;
@@ -411,7 +412,7 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
     wal.append(WalOperation::UpdateNode {
         node_id: NodeId::new(2).unwrap(),
         version_id: VersionId::new(5).unwrap(),
-        label: "Node".to_string(),
+        label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 20_i64).build(),
         temporal: BiTemporalInterval::current(time::now()),
     })?;


### PR DESCRIPTION
…e #225)

## Problem
The WAL write path was resolving interned strings and allocating new Strings for every buffered operation during transaction commits. For a transaction with 1000 operations, this generated 1000 unnecessary String allocations, causing memory fragmentation and reducing performance.

## Solution
Changed WalOperation to store InternedString (4-byte ID) directly instead of String. This eliminates all string allocations in the hot commit path.

### Changes
- **WalOperation enum**: Changed label fields from `String` to `InternedString`
- **Serialization**: Write 4-byte InternedString ID instead of length-prefixed string
- **Deserialization**: Read 4-byte ID and reconstruct InternedString
- **BufferedWrite → WalOperation conversion**: Direct copy of InternedString (no resolve/allocate)
- **Recovery**: Labels already interned, no allocation during WAL replay
- **Tests**: Updated all tests and benchmarks to use InternedString

### Performance Impact
- **Zero allocations** for labels during transaction commit
- **Smaller WAL files**: 4 bytes per label vs (4 + string_length) bytes
- **Faster serialization**: Direct u32 write vs length-prefix + memcpy
- **Faster deserialization**: Single u32 read vs length read + allocation + memcpy

### Breaking Change
WAL format changed from storing strings to storing InternedString IDs. Existing WAL files created with the old format are not compatible.

Fixes #225