### PR TITLE
feat(http): set up HTTP server with Actix-web (issue #465)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ rmcp = { version = "0.13", features = ["server", "transport-io"], optional = tru
 base64 = { version = "0.22", optional = true }
 chrono = { version = "0.4", optional = true }
 
+# HTTP server support (optional)
+actix-web = { version = "4.9", optional = true }
+actix-cors = { version = "0.7", optional = true }
+actix-rt = { version = "2.10", optional = true }
+
 # Embedding generation dependencies (all optional via feature flags)
 # Async runtime for API-based embedding providers
 tokio = { version = "1.35", features = ["rt-multi-thread", "macros"], optional = true }
@@ -119,6 +124,9 @@ sharding-rpc = ["dep:reqwest", "dep:serde", "dep:serde_json"]
 
 # SQL:2011 temporal syntax support
 sql = ["dep:sqlparser"]
+
+# HTTP server support (Issue #465)
+http-server = ["dep:actix-web", "dep:actix-cors", "dep:actix-rt", "dep:tokio", "dep:serde", "dep:serde_json"]
 
 # MVCC snapshot TDD tests (not yet implemented)
 mvcc-snapshots-tdd = []
@@ -312,4 +320,10 @@ path = "benches/vector_serialization.rs"
 name = "gallifrey-mcp"
 path = "src/bin/mcp_server.rs"
 required-features = ["mcp-server"]
+
+# HTTP server binary (Issue #465)
+[[bin]]
+name = "gallifrey-server"
+path = "src/bin/server.rs"
+required-features = ["http-server"]
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -6,41 +6,105 @@
 //! # Usage
 //!
 //! ```bash
-//! # Run with default settings (port 8080)
+//! # Run with default settings (port 8080, restrictive CORS)
 //! cargo run --bin gallifrey-server --features http-server
 //!
-//! # The server will start and listen for requests
-//! # Health check: curl http://localhost:8080/status
+//! # Run with custom port
+//! GALLIFREYDB_PORT=3000 cargo run --bin gallifrey-server --features http-server
+//!
+//! # Run with permissive CORS (development only!)
+//! GALLIFREYDB_CORS_PERMISSIVE=true cargo run --bin gallifrey-server --features http-server
+//!
+//! # Health check
+//! curl http://localhost:8080/status
 //! ```
 //!
 //! # Environment Variables
 //!
 //! - `GALLIFREYDB_PORT`: Port to listen on (default: 8080)
 //! - `GALLIFREYDB_HOST`: Host to bind to (default: 0.0.0.0)
+//! - `GALLIFREYDB_CORS_PERMISSIVE`: Set to "true" to allow any origin (default: false)
+//! - `GALLIFREYDB_CORS_ORIGINS`: Comma-separated list of allowed origins
 //!
 //! # Endpoints
 //!
 //! - `GET /status` - Health check endpoint, returns `{"status": "healthy"}`
+//!
+//! # Security Notes
+//!
+//! - By default, CORS is restrictive (only localhost:3000 allowed)
+//! - Set `GALLIFREYDB_CORS_ORIGINS` to configure allowed origins for production
+//! - Only use `GALLIFREYDB_CORS_PERMISSIVE=true` in development environments
 //!
 //! # Graceful Shutdown
 //!
 //! The server handles SIGTERM and SIGINT signals for graceful shutdown,
 //! allowing in-flight requests to complete before terminating.
 
-use gallifreydb::http::{ServerConfig, run_server};
+use gallifreydb::http::{CorsConfig, ServerConfig, run_server};
 use std::env;
+
+/// Parse port from environment variable with warning on invalid values.
+fn parse_port() -> u16 {
+    match env::var("GALLIFREYDB_PORT") {
+        Ok(port_str) => match port_str.parse::<u16>() {
+            Ok(port) => port,
+            Err(e) => {
+                eprintln!(
+                    "WARNING: Invalid GALLIFREYDB_PORT '{}': {}. Using default port 8080.",
+                    port_str, e
+                );
+                8080
+            }
+        },
+        Err(_) => 8080,
+    }
+}
+
+/// Parse host from environment variable.
+fn parse_host() -> String {
+    env::var("GALLIFREYDB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string())
+}
+
+/// Parse CORS configuration from environment variables.
+fn parse_cors_config() -> CorsConfig {
+    // Check if permissive mode is enabled
+    let is_permissive = env::var("GALLIFREYDB_CORS_PERMISSIVE")
+        .map(|v| v.to_lowercase() == "true" || v == "1")
+        .unwrap_or(false);
+
+    if is_permissive {
+        return CorsConfig::permissive();
+    }
+
+    // Parse allowed origins from comma-separated list
+    match env::var("GALLIFREYDB_CORS_ORIGINS") {
+        Ok(origins_str) => {
+            let mut config = CorsConfig::restrictive();
+            for origin in origins_str
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                config = config.allow_origin(origin);
+            }
+            config
+        }
+        Err(_) => CorsConfig::restrictive(),
+    }
+}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Read configuration from environment variables
-    let port: u16 = env::var("GALLIFREYDB_PORT")
-        .ok()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(8080);
+    let port = parse_port();
+    let host = parse_host();
+    let cors = parse_cors_config();
 
-    let host = env::var("GALLIFREYDB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-
-    let config = ServerConfig::builder().port(port).host(host).build();
+    let config = ServerConfig::builder()
+        .port(port)
+        .host(host)
+        .cors(cors)
+        .build();
 
     run_server(config).await
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,46 @@
+//! GallifreyDB HTTP Server Binary
+//!
+//! This binary launches the GallifreyDB HTTP server, providing a REST API
+//! for interacting with the database.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Run with default settings (port 8080)
+//! cargo run --bin gallifrey-server --features http-server
+//!
+//! # The server will start and listen for requests
+//! # Health check: curl http://localhost:8080/status
+//! ```
+//!
+//! # Environment Variables
+//!
+//! - `GALLIFREYDB_PORT`: Port to listen on (default: 8080)
+//! - `GALLIFREYDB_HOST`: Host to bind to (default: 0.0.0.0)
+//!
+//! # Endpoints
+//!
+//! - `GET /status` - Health check endpoint, returns `{"status": "healthy"}`
+//!
+//! # Graceful Shutdown
+//!
+//! The server handles SIGTERM and SIGINT signals for graceful shutdown,
+//! allowing in-flight requests to complete before terminating.
+
+use gallifreydb::http::{ServerConfig, run_server};
+use std::env;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // Read configuration from environment variables
+    let port: u16 = env::var("GALLIFREYDB_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080);
+
+    let host = env::var("GALLIFREYDB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+
+    let config = ServerConfig::builder().port(port).host(host).build();
+
+    run_server(config).await
+}

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -1,20 +1,125 @@
 //! HTTP server configuration.
 
+/// CORS (Cross-Origin Resource Sharing) configuration.
+#[derive(Debug, Clone)]
+pub struct CorsConfig {
+    /// Allowed origins. Empty means allow any origin (development mode only).
+    allowed_origins: Vec<String>,
+    /// Allowed HTTP methods.
+    allowed_methods: Vec<String>,
+    /// Allowed HTTP headers.
+    allowed_headers: Vec<String>,
+    /// Max age for preflight cache in seconds.
+    max_age: u32,
+}
+
+impl CorsConfig {
+    /// Create a permissive CORS config for development.
+    ///
+    /// # Security Warning
+    ///
+    /// This allows any origin and should NOT be used in production.
+    /// Use [`CorsConfig::restrictive`] or configure specific origins instead.
+    pub fn permissive() -> Self {
+        Self {
+            allowed_origins: vec![],
+            allowed_methods: vec![
+                "GET".to_string(),
+                "POST".to_string(),
+                "PUT".to_string(),
+                "DELETE".to_string(),
+                "OPTIONS".to_string(),
+            ],
+            allowed_headers: vec!["Content-Type".to_string(), "Authorization".to_string()],
+            max_age: 3600,
+        }
+    }
+
+    /// Create a restrictive CORS config with no allowed origins.
+    ///
+    /// You must explicitly add allowed origins using [`CorsConfig::allow_origin`].
+    pub fn restrictive() -> Self {
+        Self {
+            allowed_origins: vec!["http://localhost:3000".to_string()],
+            allowed_methods: vec!["GET".to_string(), "POST".to_string(), "OPTIONS".to_string()],
+            allowed_headers: vec!["Content-Type".to_string()],
+            max_age: 3600,
+        }
+    }
+
+    /// Add an allowed origin.
+    pub fn allow_origin(mut self, origin: impl Into<String>) -> Self {
+        self.allowed_origins.push(origin.into());
+        self
+    }
+
+    /// Set allowed HTTP methods.
+    pub fn allowed_methods(mut self, methods: Vec<String>) -> Self {
+        self.allowed_methods = methods;
+        self
+    }
+
+    /// Set allowed HTTP headers.
+    pub fn allowed_headers(mut self, headers: Vec<String>) -> Self {
+        self.allowed_headers = headers;
+        self
+    }
+
+    /// Set max age for preflight cache.
+    pub fn max_age(mut self, seconds: u32) -> Self {
+        self.max_age = seconds;
+        self
+    }
+
+    /// Check if any origin is allowed (permissive mode).
+    pub fn is_permissive(&self) -> bool {
+        self.allowed_origins.is_empty()
+    }
+
+    /// Get allowed origins.
+    pub fn allowed_origins(&self) -> &[String] {
+        &self.allowed_origins
+    }
+
+    /// Get allowed methods.
+    pub fn get_allowed_methods(&self) -> &[String] {
+        &self.allowed_methods
+    }
+
+    /// Get allowed headers.
+    pub fn get_allowed_headers(&self) -> &[String] {
+        &self.allowed_headers
+    }
+
+    /// Get max age in seconds.
+    pub fn get_max_age(&self) -> u32 {
+        self.max_age
+    }
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self::restrictive()
+    }
+}
+
 /// Configuration for the HTTP server.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     port: u16,
     host: String,
+    cors: CorsConfig,
 }
 
 impl ServerConfig {
     /// Create a new server config with the specified port.
     ///
-    /// Uses default host of "0.0.0.0" (all interfaces).
+    /// Uses default host of "0.0.0.0" (all interfaces) and restrictive CORS.
     pub fn new(port: u16) -> Self {
         Self {
             port,
             host: "0.0.0.0".to_string(),
+            cors: CorsConfig::default(),
         }
     }
 
@@ -26,6 +131,11 @@ impl ServerConfig {
     /// Get the configured host.
     pub fn host(&self) -> &str {
         &self.host
+    }
+
+    /// Get the CORS configuration.
+    pub fn cors(&self) -> &CorsConfig {
+        &self.cors
     }
 
     /// Get the bind address as "host:port".
@@ -44,6 +154,7 @@ impl Default for ServerConfig {
         Self {
             port: 8080,
             host: "0.0.0.0".to_string(),
+            cors: CorsConfig::default(),
         }
     }
 }
@@ -53,6 +164,7 @@ impl Default for ServerConfig {
 pub struct ServerConfigBuilder {
     port: Option<u16>,
     host: Option<String>,
+    cors: Option<CorsConfig>,
 }
 
 impl ServerConfigBuilder {
@@ -63,8 +175,33 @@ impl ServerConfigBuilder {
     }
 
     /// Set the host to bind to.
+    ///
+    /// # Valid Values
+    ///
+    /// - IPv4 addresses: "0.0.0.0", "127.0.0.1", etc.
+    /// - IPv6 addresses: "::", "::1", etc.
+    /// - Hostnames: "localhost", etc.
+    ///
+    /// The host is validated at bind time by the underlying server.
     pub fn host(mut self, host: impl Into<String>) -> Self {
         self.host = Some(host.into());
+        self
+    }
+
+    /// Set the CORS configuration.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use gallifreydb::http::{ServerConfig, CorsConfig};
+    ///
+    /// let config = ServerConfig::builder()
+    ///     .port(8080)
+    ///     .cors(CorsConfig::restrictive().allow_origin("https://myapp.com"))
+    ///     .build();
+    /// ```
+    pub fn cors(mut self, cors: CorsConfig) -> Self {
+        self.cors = Some(cors);
         self
     }
 
@@ -73,6 +210,7 @@ impl ServerConfigBuilder {
         ServerConfig {
             port: self.port.unwrap_or(8080),
             host: self.host.unwrap_or_else(|| "0.0.0.0".to_string()),
+            cors: self.cors.unwrap_or_default(),
         }
     }
 }
@@ -86,6 +224,7 @@ mod tests {
         let config = ServerConfig::default();
         assert_eq!(config.port(), 8080);
         assert_eq!(config.host(), "0.0.0.0");
+        assert!(!config.cors().is_permissive());
     }
 
     #[test]
@@ -106,5 +245,37 @@ mod tests {
     fn test_bind_address() {
         let config = ServerConfig::builder().port(8080).host("localhost").build();
         assert_eq!(config.bind_address(), "localhost:8080");
+    }
+
+    #[test]
+    fn test_cors_permissive() {
+        let cors = CorsConfig::permissive();
+        assert!(cors.is_permissive());
+        assert!(cors.allowed_origins().is_empty());
+    }
+
+    #[test]
+    fn test_cors_restrictive() {
+        let cors = CorsConfig::restrictive();
+        assert!(!cors.is_permissive());
+        assert!(!cors.allowed_origins().is_empty());
+    }
+
+    #[test]
+    fn test_cors_allow_origin() {
+        let cors = CorsConfig::restrictive().allow_origin("https://example.com");
+        assert!(
+            cors.allowed_origins()
+                .contains(&"https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_builder_with_cors() {
+        let config = ServerConfig::builder()
+            .port(8080)
+            .cors(CorsConfig::permissive())
+            .build();
+        assert!(config.cors().is_permissive());
     }
 }

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -1,0 +1,110 @@
+//! HTTP server configuration.
+
+/// Configuration for the HTTP server.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    port: u16,
+    host: String,
+}
+
+impl ServerConfig {
+    /// Create a new server config with the specified port.
+    ///
+    /// Uses default host of "0.0.0.0" (all interfaces).
+    pub fn new(port: u16) -> Self {
+        Self {
+            port,
+            host: "0.0.0.0".to_string(),
+        }
+    }
+
+    /// Get the configured port.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the configured host.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Get the bind address as "host:port".
+    pub fn bind_address(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+
+    /// Create a builder for more complex configuration.
+    pub fn builder() -> ServerConfigBuilder {
+        ServerConfigBuilder::default()
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            port: 8080,
+            host: "0.0.0.0".to_string(),
+        }
+    }
+}
+
+/// Builder for [`ServerConfig`].
+#[derive(Debug, Clone, Default)]
+pub struct ServerConfigBuilder {
+    port: Option<u16>,
+    host: Option<String>,
+}
+
+impl ServerConfigBuilder {
+    /// Set the port to bind to.
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    /// Set the host to bind to.
+    pub fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+
+    /// Build the server configuration.
+    pub fn build(self) -> ServerConfig {
+        ServerConfig {
+            port: self.port.unwrap_or(8080),
+            host: self.host.unwrap_or_else(|| "0.0.0.0".to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = ServerConfig::default();
+        assert_eq!(config.port(), 8080);
+        assert_eq!(config.host(), "0.0.0.0");
+    }
+
+    #[test]
+    fn test_new_with_port() {
+        let config = ServerConfig::new(3000);
+        assert_eq!(config.port(), 3000);
+        assert_eq!(config.host(), "0.0.0.0");
+    }
+
+    #[test]
+    fn test_builder() {
+        let config = ServerConfig::builder().port(9000).host("127.0.0.1").build();
+        assert_eq!(config.port(), 9000);
+        assert_eq!(config.host(), "127.0.0.1");
+    }
+
+    #[test]
+    fn test_bind_address() {
+        let config = ServerConfig::builder().port(8080).host("localhost").build();
+        assert_eq!(config.bind_address(), "localhost:8080");
+    }
+}

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1,0 +1,63 @@
+//! HTTP request handlers.
+
+use actix_web::{HttpResponse, web};
+use serde::Serialize;
+
+/// Health check response structure.
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    status: String,
+}
+
+/// Health check endpoint handler.
+///
+/// Returns a JSON response with `{"status": "healthy"}` and HTTP 200 OK.
+///
+/// # Example
+///
+/// ```ignore
+/// // Route: GET /status
+/// // Response: {"status": "healthy"}
+/// ```
+pub async fn health_check() -> HttpResponse {
+    let response = HealthResponse {
+        status: "healthy".to_string(),
+    };
+    HttpResponse::Ok().json(response)
+}
+
+/// Configure the health routes.
+pub fn configure_health_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/status", web::get().to(health_check));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{App, test};
+
+    #[actix_rt::test]
+    async fn test_health_check_returns_ok() {
+        let app =
+            test::init_service(App::new().route("/status", web::get().to(health_check))).await;
+
+        let req = test::TestRequest::get().uri("/status").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+    }
+
+    #[actix_rt::test]
+    async fn test_health_check_returns_json() {
+        let app =
+            test::init_service(App::new().route("/status", web::get().to(health_check))).await;
+
+        let req = test::TestRequest::get().uri("/status").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["status"], "healthy");
+    }
+}

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -56,7 +56,8 @@ mod tests {
         let resp = test::call_service(&app, req).await;
 
         let body = test::read_body(resp).await;
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let json: serde_json::Value =
+            serde_json::from_slice(&body).expect("Response body should be valid JSON");
 
         assert_eq!(json["status"], "healthy");
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -31,6 +31,6 @@ mod config;
 mod handlers;
 mod server;
 
-pub use config::{ServerConfig, ServerConfigBuilder};
+pub use config::{CorsConfig, ServerConfig, ServerConfigBuilder};
 pub use handlers::health_check;
 pub use server::{ShutdownHandle, configure_app, create_app, create_server, run_server};

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,36 @@
+//! HTTP server module for GallifreyDB (Issue #465)
+//!
+//! This module provides an HTTP server using Actix-web for REST API access
+//! to GallifreyDB functionality.
+//!
+//! # Features
+//!
+//! - Health endpoint at `GET /status`
+//! - CORS support for cross-origin requests
+//! - Request logging middleware
+//! - Graceful shutdown handling
+//! - Configurable port and host binding
+//!
+//! # Example
+//!
+//! ```ignore
+//! use gallifreydb::http::{ServerConfig, run_server};
+//!
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     let config = ServerConfig::builder()
+//!         .port(8080)
+//!         .host("127.0.0.1")
+//!         .build();
+//!
+//!     run_server(config).await
+//! }
+//! ```
+
+mod config;
+mod handlers;
+mod server;
+
+pub use config::{ServerConfig, ServerConfigBuilder};
+pub use handlers::health_check;
+pub use server::{ShutdownHandle, configure_app, create_app, create_server, run_server};

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -4,7 +4,7 @@ use actix_cors::Cors;
 use actix_web::{App, HttpServer, dev::Server, middleware::Logger, web};
 use tokio::sync::oneshot;
 
-use super::config::ServerConfig;
+use super::config::{CorsConfig, ServerConfig};
 use super::handlers::configure_health_routes;
 
 /// Handle for gracefully shutting down the server.
@@ -33,12 +33,13 @@ impl ShutdownHandle {
     }
 }
 
-/// Configure the Actix-web application with all routes and middleware.
+/// Configure the Actix-web application routes.
 ///
-/// This function sets up:
+/// This function sets up the HTTP routes:
 /// - Health check endpoint at `/status`
-/// - CORS middleware for cross-origin requests
-/// - Request logging middleware
+///
+/// Note: This function only configures routes, not middleware.
+/// Middleware (CORS, logging) is configured in [`create_app`] or [`create_app_with_config`].
 ///
 /// # Example
 ///
@@ -52,12 +53,53 @@ pub fn configure_app(cfg: &mut web::ServiceConfig) {
     configure_health_routes(cfg);
 }
 
+/// Build CORS middleware from configuration.
+fn build_cors(cors_config: &CorsConfig) -> Cors {
+    let mut cors = Cors::default();
+
+    if cors_config.is_permissive() {
+        // Development mode: allow any origin
+        cors = cors.allow_any_origin();
+    } else {
+        // Production mode: allow only configured origins
+        for origin in cors_config.allowed_origins() {
+            cors = cors.allowed_origin(origin);
+        }
+    }
+
+    // Configure allowed methods
+    let methods: Vec<actix_web::http::Method> = cors_config
+        .get_allowed_methods()
+        .iter()
+        .filter_map(|m| m.parse().ok())
+        .collect();
+    cors = cors.allowed_methods(methods);
+
+    // Configure allowed headers
+    let headers: Vec<actix_web::http::header::HeaderName> = cors_config
+        .get_allowed_headers()
+        .iter()
+        .filter_map(|h| h.parse().ok())
+        .collect();
+    cors = cors.allowed_headers(headers);
+
+    cors.max_age(cors_config.get_max_age() as usize)
+}
+
 /// Create a configured Actix-web application factory with all middleware.
 ///
+/// This creates an app with **permissive CORS** suitable for development/testing.
+/// For production use, prefer [`create_app_with_config`] with proper CORS settings.
+///
 /// This includes:
-/// - Request logging
-/// - CORS support
+/// - Request logging middleware
+/// - Permissive CORS support (allows any origin)
 /// - All configured routes
+///
+/// # Security Warning
+///
+/// This function uses permissive CORS settings. For production deployments,
+/// use [`create_app_with_config`] with a properly configured [`ServerConfig`].
 pub fn create_app() -> App<
     impl actix_web::dev::ServiceFactory<
         actix_web::dev::ServiceRequest,
@@ -67,17 +109,10 @@ pub fn create_app() -> App<
         InitError = (),
     >,
 > {
+    let cors_config = CorsConfig::permissive();
     App::new()
-        // Enable request logging
         .wrap(Logger::default())
-        // Enable CORS
-        .wrap(
-            Cors::default()
-                .allow_any_origin()
-                .allow_any_method()
-                .allow_any_header()
-                .max_age(3600),
-        )
+        .wrap(build_cors(&cors_config))
         .configure(configure_app)
 }
 
@@ -88,7 +123,7 @@ pub fn create_app() -> App<
 ///
 /// # Arguments
 ///
-/// * `config` - Server configuration including port and host
+/// * `config` - Server configuration including port, host, and CORS settings
 ///
 /// # Returns
 ///
@@ -99,9 +134,12 @@ pub fn create_app() -> App<
 /// # Example
 ///
 /// ```ignore
-/// use gallifreydb::http::{ServerConfig, create_server};
+/// use gallifreydb::http::{ServerConfig, CorsConfig, create_server};
 ///
-/// let config = ServerConfig::new(8080);
+/// let config = ServerConfig::builder()
+///     .port(8080)
+///     .cors(CorsConfig::restrictive().allow_origin("https://myapp.com"))
+///     .build();
 /// let (server, shutdown) = create_server(config).await?;
 ///
 /// // Later, to shut down:
@@ -112,15 +150,21 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
     let shutdown_handle = ShutdownHandle::new(shutdown_tx);
 
     let bind_address = config.bind_address();
+    let cors_config = config.cors().clone();
 
-    let server = HttpServer::new(create_app)
-        .bind(&bind_address)?
-        .disable_signals() // We handle signals ourselves
-        .run();
+    let server = HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .wrap(build_cors(&cors_config))
+            .configure(configure_app)
+    })
+    .bind(&bind_address)?
+    .disable_signals() // We handle signals ourselves
+    .run();
 
-    // Spawn a task that waits for shutdown signal
+    // Spawn a task that waits for shutdown signal using actix runtime
     let server_handle = server.handle();
-    tokio::spawn(async move {
+    actix_rt::spawn(async move {
         let _ = shutdown_rx.await;
         server_handle.stop(true).await;
     });
@@ -134,25 +178,43 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
 ///
 /// # Arguments
 ///
-/// * `config` - Server configuration including port and host
+/// * `config` - Server configuration including port, host, and CORS settings
 ///
 /// # Example
 ///
 /// ```ignore
-/// use gallifreydb::http::{ServerConfig, run_server};
+/// use gallifreydb::http::{ServerConfig, CorsConfig, run_server};
 ///
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
-///     let config = ServerConfig::new(8080);
+///     let config = ServerConfig::builder()
+///         .port(8080)
+///         .cors(CorsConfig::restrictive().allow_origin("https://myapp.com"))
+///         .build();
 ///     run_server(config).await
 /// }
 /// ```
 pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
     let bind_address = config.bind_address();
+    let cors_config = config.cors().clone();
 
     eprintln!("Starting GallifreyDB HTTP server on {}", bind_address);
+    if cors_config.is_permissive() {
+        eprintln!(
+            "WARNING: CORS is configured in permissive mode (any origin allowed). \
+             This is not recommended for production."
+        );
+    }
 
-    HttpServer::new(create_app).bind(&bind_address)?.run().await
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .wrap(build_cors(&cors_config))
+            .configure(configure_app)
+    })
+    .bind(&bind_address)?
+    .run()
+    .await
 }
 
 #[cfg(test)]
@@ -195,5 +257,19 @@ mod tests {
         let resp = test::call_service(&app, req).await;
 
         assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    #[actix_rt::test]
+    async fn test_build_cors_permissive() {
+        let cors_config = CorsConfig::permissive();
+        let _cors = build_cors(&cors_config);
+        // If we get here without panic, CORS middleware was created successfully
+    }
+
+    #[actix_rt::test]
+    async fn test_build_cors_restrictive() {
+        let cors_config = CorsConfig::restrictive();
+        let _cors = build_cors(&cors_config);
+        // If we get here without panic, CORS middleware was created successfully
     }
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,0 +1,199 @@
+//! HTTP server creation and management.
+
+use actix_cors::Cors;
+use actix_web::{App, HttpServer, dev::Server, middleware::Logger, web};
+use tokio::sync::oneshot;
+
+use super::config::ServerConfig;
+use super::handlers::configure_health_routes;
+
+/// Handle for gracefully shutting down the server.
+#[derive(Debug)]
+pub struct ShutdownHandle {
+    sender: Option<oneshot::Sender<()>>,
+}
+
+impl ShutdownHandle {
+    /// Create a new shutdown handle with the given sender.
+    fn new(sender: oneshot::Sender<()>) -> Self {
+        Self {
+            sender: Some(sender),
+        }
+    }
+
+    /// Trigger graceful shutdown of the server.
+    ///
+    /// This will signal the server to stop accepting new connections
+    /// and wait for existing connections to complete.
+    pub async fn shutdown(mut self) {
+        if let Some(sender) = self.sender.take() {
+            // Ignore error if receiver is already dropped
+            let _ = sender.send(());
+        }
+    }
+}
+
+/// Configure the Actix-web application with all routes and middleware.
+///
+/// This function sets up:
+/// - Health check endpoint at `/status`
+/// - CORS middleware for cross-origin requests
+/// - Request logging middleware
+///
+/// # Example
+///
+/// ```ignore
+/// use actix_web::App;
+/// use gallifreydb::http::configure_app;
+///
+/// let app = App::new().configure(configure_app);
+/// ```
+pub fn configure_app(cfg: &mut web::ServiceConfig) {
+    configure_health_routes(cfg);
+}
+
+/// Create a configured Actix-web application factory with all middleware.
+///
+/// This includes:
+/// - Request logging
+/// - CORS support
+/// - All configured routes
+pub fn create_app() -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+> {
+    App::new()
+        // Enable request logging
+        .wrap(Logger::default())
+        // Enable CORS
+        .wrap(
+            Cors::default()
+                .allow_any_origin()
+                .allow_any_method()
+                .allow_any_header()
+                .max_age(3600),
+        )
+        .configure(configure_app)
+}
+
+/// Create an HTTP server with the given configuration.
+///
+/// Returns the server instance and a shutdown handle that can be used
+/// to gracefully terminate the server.
+///
+/// # Arguments
+///
+/// * `config` - Server configuration including port and host
+///
+/// # Returns
+///
+/// A tuple of `(Server, ShutdownHandle)` where:
+/// - `Server` is the Actix-web server that can be awaited
+/// - `ShutdownHandle` can be used to trigger graceful shutdown
+///
+/// # Example
+///
+/// ```ignore
+/// use gallifreydb::http::{ServerConfig, create_server};
+///
+/// let config = ServerConfig::new(8080);
+/// let (server, shutdown) = create_server(config).await?;
+///
+/// // Later, to shut down:
+/// shutdown.shutdown().await;
+/// ```
+pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, ShutdownHandle)> {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let shutdown_handle = ShutdownHandle::new(shutdown_tx);
+
+    let bind_address = config.bind_address();
+
+    let server = HttpServer::new(create_app)
+        .bind(&bind_address)?
+        .disable_signals() // We handle signals ourselves
+        .run();
+
+    // Spawn a task that waits for shutdown signal
+    let server_handle = server.handle();
+    tokio::spawn(async move {
+        let _ = shutdown_rx.await;
+        server_handle.stop(true).await;
+    });
+
+    Ok((server, shutdown_handle))
+}
+
+/// Run the HTTP server with the given configuration.
+///
+/// This function blocks until the server is shut down via SIGTERM or SIGINT.
+///
+/// # Arguments
+///
+/// * `config` - Server configuration including port and host
+///
+/// # Example
+///
+/// ```ignore
+/// use gallifreydb::http::{ServerConfig, run_server};
+///
+/// #[actix_web::main]
+/// async fn main() -> std::io::Result<()> {
+///     let config = ServerConfig::new(8080);
+///     run_server(config).await
+/// }
+/// ```
+pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
+    let bind_address = config.bind_address();
+
+    eprintln!("Starting GallifreyDB HTTP server on {}", bind_address);
+
+    HttpServer::new(create_app).bind(&bind_address)?.run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::test;
+
+    #[actix_rt::test]
+    async fn test_configure_app_has_health_endpoint() {
+        let app = test::init_service(App::new().configure(configure_app)).await;
+
+        let req = test::TestRequest::get().uri("/status").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+    }
+
+    #[actix_rt::test]
+    async fn test_create_app_with_cors() {
+        let app = test::init_service(create_app()).await;
+
+        let req = test::TestRequest::default()
+            .method(actix_web::http::Method::OPTIONS)
+            .uri("/status")
+            .insert_header(("Origin", "http://example.com"))
+            .insert_header(("Access-Control-Request-Method", "GET"))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+
+        // CORS preflight should succeed
+        assert!(resp.status().is_success() || resp.status().as_u16() == 204);
+    }
+
+    #[actix_rt::test]
+    async fn test_unknown_route_returns_404() {
+        let app = test::init_service(create_app()).await;
+
+        let req = test::TestRequest::get().uri("/nonexistent").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ pub mod honeycomb;
 // Optional SQL:2011 temporal syntax support
 #[cfg(feature = "sql")]
 pub mod sql;
+// Optional HTTP server module
+#[cfg(feature = "http-server")]
+pub mod http;
 
 // Re-export commonly used types at the crate root
 pub use config::{

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -1,0 +1,223 @@
+//! Integration tests for HTTP server (Issue #465)
+//!
+//! This test module verifies the HTTP server functionality:
+//! - Health endpoint returns correct response
+//! - Server starts on configurable port
+//! - CORS headers are properly set
+//! - Graceful shutdown handling
+//!
+//! Run with: cargo test --test http_server --features http-server
+
+#![cfg(feature = "http-server")]
+
+use actix_web::{App, test};
+use gallifreydb::http::{ServerConfig, configure_app, create_app, health_check};
+use serde_json::Value;
+
+/// Test that health endpoint returns 200 OK with {"status": "healthy"}
+#[actix_rt::test]
+async fn test_health_endpoint_returns_healthy_status() {
+    // Create test app with our configuration
+    let app = test::init_service(App::new().configure(configure_app)).await;
+
+    // Make request to health endpoint
+    let req = test::TestRequest::get().uri("/status").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    // Assert response status is 200 OK
+    assert!(
+        resp.status().is_success(),
+        "Health endpoint should return 200 OK"
+    );
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // Parse response body
+    let body = test::read_body(resp).await;
+    let json: Value = serde_json::from_slice(&body).expect("Response should be valid JSON");
+
+    // Assert response body contains status: healthy
+    assert_eq!(
+        json.get("status").and_then(|v| v.as_str()),
+        Some("healthy"),
+        "Health endpoint should return {{\"status\": \"healthy\"}}"
+    );
+}
+
+/// Test that health endpoint returns correct Content-Type header
+#[actix_rt::test]
+async fn test_health_endpoint_returns_json_content_type() {
+    let app = test::init_service(App::new().configure(configure_app)).await;
+
+    let req = test::TestRequest::get().uri("/status").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .expect("Should have Content-Type header")
+        .to_str()
+        .expect("Content-Type should be valid string");
+
+    assert!(
+        content_type.contains("application/json"),
+        "Content-Type should be application/json, got: {}",
+        content_type
+    );
+}
+
+/// Test that CORS is enabled and allows requests
+#[actix_rt::test]
+async fn test_cors_headers_present() {
+    // Use create_app() which includes CORS middleware
+    let app = test::init_service(create_app()).await;
+
+    // Send OPTIONS preflight request
+    let req = test::TestRequest::default()
+        .method(actix_web::http::Method::OPTIONS)
+        .uri("/status")
+        .insert_header(("Origin", "http://example.com"))
+        .insert_header(("Access-Control-Request-Method", "GET"))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+
+    // CORS should return appropriate headers
+    let has_cors = resp.headers().contains_key("access-control-allow-origin")
+        || resp.headers().contains_key("access-control-allow-methods");
+
+    assert!(has_cors, "CORS headers should be present in response");
+}
+
+/// Test that server config has default port
+#[actix_rt::test]
+async fn test_server_config_default_port() {
+    let config = ServerConfig::default();
+
+    assert_eq!(config.port(), 8080, "Default port should be 8080");
+}
+
+/// Test that server config accepts custom port
+#[actix_rt::test]
+async fn test_server_config_custom_port() {
+    let config = ServerConfig::new(3000);
+
+    assert_eq!(config.port(), 3000, "Custom port should be respected");
+}
+
+/// Test that server config validates port range
+#[actix_rt::test]
+async fn test_server_config_port_validation() {
+    // Port 0 should be allowed (OS assigns random available port)
+    let config = ServerConfig::new(0);
+    assert_eq!(config.port(), 0);
+
+    // Standard ports should work
+    let config = ServerConfig::new(80);
+    assert_eq!(config.port(), 80);
+
+    let config = ServerConfig::new(443);
+    assert_eq!(config.port(), 443);
+
+    // High ports should work
+    let config = ServerConfig::new(65535);
+    assert_eq!(config.port(), 65535);
+}
+
+/// Test that server config can be built with builder pattern
+#[actix_rt::test]
+async fn test_server_config_builder() {
+    let config = ServerConfig::builder().port(9000).host("127.0.0.1").build();
+
+    assert_eq!(config.port(), 9000);
+    assert_eq!(config.host(), "127.0.0.1");
+}
+
+/// Test default host is 0.0.0.0 (all interfaces)
+#[actix_rt::test]
+async fn test_server_config_default_host() {
+    let config = ServerConfig::default();
+
+    assert_eq!(config.host(), "0.0.0.0", "Default host should be 0.0.0.0");
+}
+
+/// Test that the health check handler returns proper response
+#[actix_rt::test]
+async fn test_health_check_handler_directly() {
+    let resp = health_check().await;
+
+    // The handler should return an HttpResponse
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// Test request logging is configured (verifies middleware doesn't break requests)
+#[actix_rt::test]
+async fn test_request_logging_middleware_configured() {
+    let app = test::init_service(App::new().configure(configure_app)).await;
+
+    // Make multiple requests to ensure logging middleware doesn't break anything
+    for _ in 0..3 {
+        let req = test::TestRequest::get().uri("/status").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+    }
+}
+
+/// Test unknown routes return 404
+#[actix_rt::test]
+async fn test_unknown_route_returns_404() {
+    let app = test::init_service(App::new().configure(configure_app)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/nonexistent-route")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "Unknown routes should return 404"
+    );
+}
+
+#[cfg(test)]
+mod shutdown_tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// Test that server can be gracefully shut down
+    #[actix_rt::test]
+    async fn test_graceful_shutdown_signal() {
+        use gallifreydb::http::create_server;
+
+        let config = ServerConfig::new(0); // Use port 0 for random available port
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let shutdown_flag_clone = shutdown_flag.clone();
+
+        // Create server with shutdown handle
+        let (server, shutdown_handle) = create_server(config).await.expect("Should create server");
+
+        // Spawn server in background
+        let server_handle = tokio::spawn(async move {
+            server.await.ok();
+            shutdown_flag_clone.store(true, Ordering::SeqCst);
+        });
+
+        // Give server time to start
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Trigger graceful shutdown
+        shutdown_handle.shutdown().await;
+
+        // Wait for server to shut down with timeout
+        let result = timeout(Duration::from_secs(5), server_handle).await;
+        assert!(result.is_ok(), "Server should shut down within timeout");
+
+        assert!(
+            shutdown_flag.load(Ordering::SeqCst),
+            "Shutdown flag should be set after graceful shutdown"
+        );
+    }
+}


### PR DESCRIPTION
Implemented using TDD approach (red/green/refactor):

RED Phase:
- Wrote failing tests for health endpoint, configurable port, CORS headers, graceful shutdown, and request logging

GREEN Phase:
- Added actix-web, actix-cors, actix-rt dependencies
- Created src/http/ module with:
  - config.rs: ServerConfig and ServerConfigBuilder
  - handlers.rs: health_check endpoint handler
  - server.rs: create_server, run_server, ShutdownHandle
- Added http-server feature flag
- Created bin/server.rs entry point with env var configuration

REFACTOR Phase:
- Applied cargo fmt
- Verified clippy passes
- All 21 tests pass (12 integration + 9 unit)

Features:
- Health endpoint: GET /status returns {"status": "healthy"}
- CORS support: Allows any origin, method, header
- Request logging: Actix Logger middleware
- Graceful shutdown: ShutdownHandle for programmatic control
- Configurable: Port/host via ServerConfig or env vars

https://claude.ai/code/session_01LgDWipYS2dfogNY9sFdYtk