### PR TITLE
Implement vector loading in parallel index persistence

### DIFF
--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -372,6 +372,17 @@ pub struct PersistedHnswConfig {
     pub ef_search: u16,
 }
 
+/// Fully loaded vector index data.
+#[derive(Debug, Clone)]
+pub struct VectorIndexData {
+    /// Metadata
+    pub meta: VectorIndexMeta,
+    /// ID Mappings
+    pub mappings: VectorMappingsData,
+    /// Path to the usearch index file
+    pub index_path: std::path::PathBuf,
+}
+
 /// Vector ID mappings (NodeId <-> usearch key).
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct VectorMappingsData {

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -179,13 +179,18 @@ pub(crate) fn atomic_write(path: &std::path::Path, data: &[u8]) -> Result<()> {
 pub fn load_indexes_parallel(
     graph_path: &std::path::Path,
     temporal_path: Option<&std::path::Path>,
-    _vector_paths: Vec<&std::path::Path>, // TODO: implement vector loading
-) -> Result<(formats::GraphIndexData, Option<formats::TemporalIndexData>)> {
+    vector_paths: Vec<&std::path::Path>,
+) -> Result<(
+    formats::GraphIndexData,
+    Option<formats::TemporalIndexData>,
+    Vec<formats::VectorIndexData>,
+)> {
     use std::thread;
 
     // Convert paths to owned PathBufs for thread safety
     let graph_path = graph_path.to_path_buf();
     let temporal_path_opt = temporal_path.map(|p| p.to_path_buf());
+    let vector_paths: Vec<_> = vector_paths.into_iter().map(|p| p.to_path_buf()).collect();
 
     // Spawn thread for graph loading
     let graph_handle = thread::spawn(move || graph::load_graph_index(&graph_path));
@@ -194,7 +199,11 @@ pub fn load_indexes_parallel(
     let temporal_handle =
         temporal_path_opt.map(|path| thread::spawn(move || temporal::load_temporal_index(&path)));
 
-    // TODO: Spawn threads for vector index loading
+    // Spawn threads for vector index loading
+    let vector_handles: Vec<_> = vector_paths
+        .into_iter()
+        .map(|path| thread::spawn(move || vector::load_vector_index(&path)))
+        .collect();
 
     // Join threads and collect results
     let graph_data = graph_handle
@@ -207,5 +216,10 @@ pub fn load_indexes_parallel(
         None
     };
 
-    Ok((graph_data, temporal_data))
+    let mut vector_data = Vec::with_capacity(vector_handles.len());
+    for handle in vector_handles {
+        vector_data.push(handle.join().expect("Vector loading thread panicked")?);
+    }
+
+    Ok((graph_data, temporal_data, vector_data))
 }

--- a/src/storage/index_persistence/vector.rs
+++ b/src/storage/index_persistence/vector.rs
@@ -12,7 +12,7 @@ use crc32fast::Hasher;
 
 use super::error::{IndexPersistenceError, Result};
 use super::formats::{
-    PersistedHnswConfig, VectorIndexMeta, VectorMappingsData, VectorSnapshotMeta,
+    PersistedHnswConfig, VectorIndexData, VectorIndexMeta, VectorMappingsData, VectorSnapshotMeta,
 };
 use super::{MANIFEST_VERSION, VECTOR_META_MAGIC};
 
@@ -121,6 +121,31 @@ pub fn load_snapshot_meta(path: &Path) -> Result<VectorSnapshotMeta> {
     let data = load_with_crc(path)?;
     let meta: VectorSnapshotMeta = bitcode::decode(&data)?;
     Ok(meta)
+}
+
+/// Load a complete vector index (meta + mappings + index path) from a directory.
+///
+/// # Arguments
+///
+/// * `path` - Directory containing the vector index files
+///
+/// # Errors
+///
+/// Returns an error if any required file (meta.idx, mappings.idx) is missing or corrupted.
+pub fn load_vector_index(path: &Path) -> Result<VectorIndexData> {
+    let meta_path = path.join("meta.idx");
+    let mappings_path = path.join("mappings.idx");
+    // usearch index is just a file path, we don't load it into memory here generally
+    let index_path = path.join("current.usearch");
+
+    let meta = load_vector_meta(&meta_path)?;
+    let mappings = load_vector_mappings(&mappings_path)?;
+
+    Ok(VectorIndexData {
+        meta,
+        mappings,
+        index_path,
+    })
 }
 
 /// Create new vector index metadata.

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2637,3 +2637,85 @@ fn test_persist_indexes_uses_actual_wal_lsn() {
     );
     println!("✓ Issue #410 fix verified: No hardcoded LSN, exact match confirmed");
 }
+
+/// Test parallel loading with vector indexes.
+///
+/// This test ensures that `load_indexes_parallel` correctly handles the `vector_paths` argument
+/// and loads vector indexes concurrently. This covers the vector loading logic in `load_indexes_parallel`
+/// and `load_vector_index`.
+#[test]
+fn test_parallel_loading_with_vectors() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use gallifreydb::storage::index_persistence::formats::PersistedHnswConfig;
+    use gallifreydb::storage::index_persistence::graph::{
+        new_graph_index_data, save_graph_index,
+    };
+    use gallifreydb::storage::index_persistence::vector::{
+        new_vector_mappings, new_vector_meta, save_vector_mappings, save_vector_meta,
+    };
+    use gallifreydb::storage::index_persistence::load_indexes_parallel;
+
+    let dir = tempdir().unwrap();
+    let graph_path = dir.path().join("graph.idx");
+
+    // Create minimal graph index
+    let graph_data = new_graph_index_data();
+    save_graph_index(&graph_data, &graph_path).unwrap();
+
+    // Create vector index 1
+    let vector_dir1 = dir.path().join("vector_embedding1");
+    std::fs::create_dir_all(&vector_dir1).unwrap();
+
+    let hnsw_config1 = PersistedHnswConfig {
+        m: 16,
+        ef_construction: 128,
+        ef_search: 64,
+    };
+    let vector_meta1 = new_vector_meta("embedding1", 384, 0, hnsw_config1);
+    let vector_mappings1 = new_vector_mappings();
+
+    save_vector_meta(&vector_meta1, &vector_dir1.join("meta.idx")).unwrap();
+    save_vector_mappings(&vector_mappings1, &vector_dir1.join("mappings.idx")).unwrap();
+
+    // Create vector index 2
+    let vector_dir2 = dir.path().join("vector_embedding2");
+    std::fs::create_dir_all(&vector_dir2).unwrap();
+
+    let hnsw_config2 = PersistedHnswConfig {
+        m: 24,
+        ef_construction: 200,
+        ef_search: 100,
+    };
+    let vector_meta2 = new_vector_meta("embedding2", 768, 1, hnsw_config2);
+    let vector_mappings2 = new_vector_mappings();
+
+    save_vector_meta(&vector_meta2, &vector_dir2.join("meta.idx")).unwrap();
+    save_vector_mappings(&vector_mappings2, &vector_dir2.join("mappings.idx")).unwrap();
+
+    // Call load_indexes_parallel with vector paths
+    let (_, _, mut vector_data) = load_indexes_parallel(
+        &graph_path,
+        None,
+        vec![&vector_dir1, &vector_dir2],
+    ).unwrap();
+
+    // Sort vector data by property name to ensure deterministic assertions (threads might finish in any order)
+    vector_data.sort_by(|a, b| a.meta.property_name.cmp(&b.meta.property_name));
+
+    assert_eq!(vector_data.len(), 2);
+
+    // Check first vector index
+    assert_eq!(vector_data[0].meta.property_name, "embedding1");
+    assert_eq!(vector_data[0].meta.dimensions, 384);
+    assert_eq!(vector_data[0].mappings.count, 0);
+    assert!(vector_data[0].index_path.ends_with("current.usearch"));
+
+    // Check second vector index
+    assert_eq!(vector_data[1].meta.property_name, "embedding2");
+    assert_eq!(vector_data[1].meta.dimensions, 768);
+    assert_eq!(vector_data[1].meta.metric, 1); // Euclidean
+    assert_eq!(vector_data[1].mappings.count, 0);
+
+    println!("✓ Parallel loading with vectors test passed");
+}

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -899,9 +899,9 @@ fn test_parallel_loading_is_faster() {
     let handle2 = thread::spawn(move || load_indexes_parallel(&graph_path_clone2, None, vec![]));
     let handle3 = thread::spawn(move || load_indexes_parallel(&graph_path_clone3, None, vec![]));
 
-    let (data1_par, _) = handle1.join().expect("Thread 1 panicked").unwrap();
-    let (data2_par, _) = handle2.join().expect("Thread 2 panicked").unwrap();
-    let (data3_par, _) = handle3.join().expect("Thread 3 panicked").unwrap();
+    let (data1_par, _, _) = handle1.join().expect("Thread 1 panicked").unwrap();
+    let (data2_par, _, _) = handle2.join().expect("Thread 2 panicked").unwrap();
+    let (data3_par, _, _) = handle3.join().expect("Thread 3 panicked").unwrap();
 
     let parallel_duration = start.elapsed();
 

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2648,13 +2648,11 @@ fn test_parallel_loading_with_vectors() {
     let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
 
     use gallifreydb::storage::index_persistence::formats::PersistedHnswConfig;
-    use gallifreydb::storage::index_persistence::graph::{
-        new_graph_index_data, save_graph_index,
-    };
+    use gallifreydb::storage::index_persistence::graph::{new_graph_index_data, save_graph_index};
+    use gallifreydb::storage::index_persistence::load_indexes_parallel;
     use gallifreydb::storage::index_persistence::vector::{
         new_vector_mappings, new_vector_meta, save_vector_mappings, save_vector_meta,
     };
-    use gallifreydb::storage::index_persistence::load_indexes_parallel;
 
     let dir = tempdir().unwrap();
     let graph_path = dir.path().join("graph.idx");
@@ -2694,11 +2692,8 @@ fn test_parallel_loading_with_vectors() {
     save_vector_mappings(&vector_mappings2, &vector_dir2.join("mappings.idx")).unwrap();
 
     // Call load_indexes_parallel with vector paths
-    let (_, _, mut vector_data) = load_indexes_parallel(
-        &graph_path,
-        None,
-        vec![&vector_dir1, &vector_dir2],
-    ).unwrap();
+    let (_, _, mut vector_data) =
+        load_indexes_parallel(&graph_path, None, vec![&vector_dir1, &vector_dir2]).unwrap();
 
     // Sort vector data by property name to ensure deterministic assertions (threads might finish in any order)
     vector_data.sort_by(|a, b| a.meta.property_name.cmp(&b.meta.property_name));


### PR DESCRIPTION
Implemented vector index loading in the parallel loading path. `load_indexes_parallel` now accepts a list of vector index paths and loads them concurrently with graph and temporal indexes. It returns a vector of loaded `VectorIndexData` structs.


---
*PR created automatically by Jules for task [12014869524230411276](https://jules.google.com/task/12014869524230411276) started by @madmax983*