### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,7 +1,12 @@
 //! HTTP server creation and management.
 
 use actix_cors::Cors;
-use actix_web::{App, HttpServer, dev::Server, middleware::Logger, web};
+use actix_web::{
+    App, HttpServer,
+    dev::Server,
+    middleware::{DefaultHeaders, Logger},
+    web,
+};
 use tokio::sync::oneshot;
 
 use super::config::{CorsConfig, ServerConfig};
@@ -112,6 +117,12 @@ pub fn create_app() -> App<
     let cors_config = CorsConfig::permissive();
     App::new()
         .wrap(Logger::default())
+        .wrap(
+            DefaultHeaders::new()
+                .add(("X-Content-Type-Options", "nosniff"))
+                .add(("X-Frame-Options", "DENY"))
+                .add(("Content-Security-Policy", "default-src 'self'")),
+        )
         .wrap(build_cors(&cors_config))
         .configure(configure_app)
 }
@@ -155,6 +166,12 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
     let server = HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
+            .wrap(
+                DefaultHeaders::new()
+                    .add(("X-Content-Type-Options", "nosniff"))
+                    .add(("X-Frame-Options", "DENY"))
+                    .add(("Content-Security-Policy", "default-src 'self'")),
+            )
             .wrap(build_cors(&cors_config))
             .configure(configure_app)
     })
@@ -209,6 +226,12 @@ pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
+            .wrap(
+                DefaultHeaders::new()
+                    .add(("X-Content-Type-Options", "nosniff"))
+                    .add(("X-Frame-Options", "DENY"))
+                    .add(("Content-Security-Policy", "default-src 'self'")),
+            )
             .wrap(build_cors(&cors_config))
             .configure(configure_app)
     })
@@ -271,5 +294,23 @@ mod tests {
         let cors_config = CorsConfig::restrictive();
         let _cors = build_cors(&cors_config);
         // If we get here without panic, CORS middleware was created successfully
+    }
+
+    #[actix_rt::test]
+    async fn test_security_headers() {
+        let app = test::init_service(create_app()).await;
+
+        let req = test::TestRequest::get().uri("/status").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+        let headers = resp.headers();
+
+        assert_eq!(headers.get("X-Content-Type-Options").unwrap(), "nosniff");
+        assert_eq!(headers.get("X-Frame-Options").unwrap(), "DENY");
+        assert_eq!(
+            headers.get("Content-Security-Policy").unwrap(),
+            "default-src 'self'"
+        );
     }
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -58,6 +58,17 @@ pub fn configure_app(cfg: &mut web::ServiceConfig) {
     configure_health_routes(cfg);
 }
 
+/// Build security headers middleware.
+fn build_security_headers() -> DefaultHeaders {
+    DefaultHeaders::new()
+        .add(("X-Content-Type-Options", "nosniff"))
+        .add(("X-Frame-Options", "DENY"))
+        .add((
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'",
+        ))
+}
+
 /// Build CORS middleware from configuration.
 fn build_cors(cors_config: &CorsConfig) -> Cors {
     let mut cors = Cors::default();
@@ -117,12 +128,7 @@ pub fn create_app() -> App<
     let cors_config = CorsConfig::permissive();
     App::new()
         .wrap(Logger::default())
-        .wrap(
-            DefaultHeaders::new()
-                .add(("X-Content-Type-Options", "nosniff"))
-                .add(("X-Frame-Options", "DENY"))
-                .add(("Content-Security-Policy", "default-src 'self'")),
-        )
+        .wrap(build_security_headers())
         .wrap(build_cors(&cors_config))
         .configure(configure_app)
 }
@@ -166,12 +172,7 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
     let server = HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .wrap(
-                DefaultHeaders::new()
-                    .add(("X-Content-Type-Options", "nosniff"))
-                    .add(("X-Frame-Options", "DENY"))
-                    .add(("Content-Security-Policy", "default-src 'self'")),
-            )
+            .wrap(build_security_headers())
             .wrap(build_cors(&cors_config))
             .configure(configure_app)
     })
@@ -226,12 +227,7 @@ pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .wrap(
-                DefaultHeaders::new()
-                    .add(("X-Content-Type-Options", "nosniff"))
-                    .add(("X-Frame-Options", "DENY"))
-                    .add(("Content-Security-Policy", "default-src 'self'")),
-            )
+            .wrap(build_security_headers())
             .wrap(build_cors(&cors_config))
             .configure(configure_app)
     })
@@ -310,7 +306,7 @@ mod tests {
         assert_eq!(headers.get("X-Frame-Options").unwrap(), "DENY");
         assert_eq!(
             headers.get("Content-Security-Policy").unwrap(),
-            "default-src 'self'"
+            "default-src 'none'; frame-ancestors 'none'"
         );
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in the API server.
🎯 Impact: Attackers could potentially exploit the lack of headers for clickjacking (framing), MIME sniffing, or XSS/injection attacks.
🔧 Fix: Added `actix_web::middleware::DefaultHeaders` to `create_app`, `create_server`, and `run_server` in `src/http/server.rs`.
   - `X-Content-Type-Options: nosniff`: Prevents MIME type sniffing.
   - `X-Frame-Options: DENY`: Prevents the site from being framed (clickjacking protection).
   - `Content-Security-Policy: default-src 'self'`: Restricts resource loading to the same origin.
✅ Verification: Added `test_security_headers` to verify that the `/status` endpoint returns these headers. Ran `cargo test --features http-server http` to verify.

---
*PR created automatically by Jules for task [17546910904426372005](https://jules.google.com/task/17546910904426372005) started by @madmax983*