### PR TITLE
🛡️ Sentry: Implement parallel vector index loading

### DIFF
--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -423,6 +423,22 @@ pub enum PersistedSnapshotType {
     },
 }
 
+/// Loaded vector index data (runtime structure).
+///
+/// This struct aggregates the various components of a loaded vector index:
+/// - Metadata (dimensions, metric, etc.)
+/// - ID mappings (NodeId <-> usearch key)
+/// - Path to the memory-mapped usearch index file
+#[derive(Debug, Clone)]
+pub struct VectorIndexData {
+    /// Vector index metadata
+    pub meta: VectorIndexMeta,
+    /// Vector ID mappings
+    pub mappings: VectorMappingsData,
+    /// Path to the usearch index file
+    pub index_path: std::path::PathBuf,
+}
+
 // ============================================================================
 // Persistence Policies
 // ============================================================================

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -179,8 +179,12 @@ pub(crate) fn atomic_write(path: &std::path::Path, data: &[u8]) -> Result<()> {
 pub fn load_indexes_parallel(
     graph_path: &std::path::Path,
     temporal_path: Option<&std::path::Path>,
-    _vector_paths: Vec<&std::path::Path>, // TODO: implement vector loading
-) -> Result<(formats::GraphIndexData, Option<formats::TemporalIndexData>)> {
+    vector_paths: Vec<&std::path::Path>,
+) -> Result<(
+    formats::GraphIndexData,
+    Option<formats::TemporalIndexData>,
+    Vec<formats::VectorIndexData>,
+)> {
     use std::thread;
 
     // Convert paths to owned PathBufs for thread safety
@@ -194,7 +198,26 @@ pub fn load_indexes_parallel(
     let temporal_handle =
         temporal_path_opt.map(|path| thread::spawn(move || temporal::load_temporal_index(&path)));
 
-    // TODO: Spawn threads for vector index loading
+    // Spawn threads for vector index loading
+    let mut vector_handles = Vec::new();
+    for path in vector_paths {
+        let path = path.to_path_buf();
+        let handle = thread::spawn(move || -> Result<formats::VectorIndexData> {
+            let meta_path = path.join("meta.idx");
+            let mappings_path = path.join("mappings.idx");
+            let index_path = path.join("current.usearch");
+
+            let meta = vector::load_vector_meta(&meta_path)?;
+            let mappings = vector::load_vector_mappings(&mappings_path)?;
+
+            Ok(formats::VectorIndexData {
+                meta,
+                mappings,
+                index_path,
+            })
+        });
+        vector_handles.push(handle);
+    }
 
     // Join threads and collect results
     let graph_data = graph_handle
@@ -207,5 +230,11 @@ pub fn load_indexes_parallel(
         None
     };
 
-    Ok((graph_data, temporal_data))
+    let mut vector_data = Vec::with_capacity(vector_handles.len());
+    for handle in vector_handles {
+        let data = handle.join().expect("Vector loading thread panicked")?;
+        vector_data.push(data);
+    }
+
+    Ok((graph_data, temporal_data, vector_data))
 }

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -899,9 +899,9 @@ fn test_parallel_loading_is_faster() {
     let handle2 = thread::spawn(move || load_indexes_parallel(&graph_path_clone2, None, vec![]));
     let handle3 = thread::spawn(move || load_indexes_parallel(&graph_path_clone3, None, vec![]));
 
-    let (data1_par, _) = handle1.join().expect("Thread 1 panicked").unwrap();
-    let (data2_par, _) = handle2.join().expect("Thread 2 panicked").unwrap();
-    let (data3_par, _) = handle3.join().expect("Thread 3 panicked").unwrap();
+    let (data1_par, _, _) = handle1.join().expect("Thread 1 panicked").unwrap();
+    let (data2_par, _, _) = handle2.join().expect("Thread 2 panicked").unwrap();
+    let (data3_par, _, _) = handle3.join().expect("Thread 3 panicked").unwrap();
 
     let parallel_duration = start.elapsed();
 
@@ -2636,4 +2636,69 @@ fn test_persist_indexes_uses_actual_wal_lsn() {
         manifest.lsn, expected_lsn
     );
     println!("✓ Issue #410 fix verified: No hardcoded LSN, exact match confirmed");
+}
+
+#[test]
+fn test_load_indexes_parallel_includes_vectors() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use gallifreydb::storage::index_persistence::IndexPersistenceManager;
+    use gallifreydb::storage::index_persistence::load_indexes_parallel;
+    use gallifreydb::storage::index_persistence::vector::{
+        new_vector_mappings, new_vector_meta, save_vector_mappings, save_vector_meta,
+    };
+    use gallifreydb::storage::index_persistence::formats::PersistedHnswConfig;
+    use gallifreydb::storage::index_persistence::graph::{
+        new_graph_index_data, save_graph_index,
+    };
+
+    let dir = tempdir().unwrap();
+    let manager = IndexPersistenceManager::new(dir.path());
+    manager.ensure_directories().unwrap();
+
+    // Create a minimal graph index so the function doesn't fail on graph loading
+    let graph_path = manager.graph_path().join("adjacency.idx");
+    let graph_data = new_graph_index_data();
+    save_graph_index(&graph_data, &graph_path).unwrap();
+
+    // Setup vector index for "test_embedding"
+    let prop_name = "test_embedding";
+    let vec_path = manager.vector_path(prop_name);
+    std::fs::create_dir_all(&vec_path).unwrap();
+
+    // Save metadata
+    let hnsw_config = PersistedHnswConfig {
+        m: 16,
+        ef_construction: 100,
+        ef_search: 50,
+    };
+    let meta = new_vector_meta(prop_name, 128, 0, hnsw_config);
+    save_vector_meta(&meta, &vec_path.join("meta.idx")).unwrap();
+
+    // Save mappings
+    let mappings = new_vector_mappings();
+    save_vector_mappings(&mappings, &vec_path.join("mappings.idx")).unwrap();
+
+    // Prepare paths
+    let vector_paths = vec![vec_path.as_path()];
+
+    // Execute parallel loading
+    let (graph_loaded, temporal_loaded, vectors_loaded) = load_indexes_parallel(
+        &graph_path,
+        None,
+        vector_paths,
+    ).unwrap();
+
+    // Verify graph loaded
+    assert_eq!(graph_loaded.node_count, 0);
+    assert!(temporal_loaded.is_none());
+
+    // Verify vectors loaded
+    assert_eq!(vectors_loaded.len(), 1, "Should have loaded 1 vector index");
+
+    let vec_data = &vectors_loaded[0];
+    assert_eq!(vec_data.meta.property_name, prop_name);
+    assert_eq!(vec_data.meta.dimensions, 128);
+    assert_eq!(vec_data.index_path, vec_path.join("current.usearch"));
+    assert_eq!(vec_data.mappings.count, 0);
 }


### PR DESCRIPTION
🛡️ Sentry: Implemented parallel vector index loading

🎯 Target: `src/storage/index_persistence/mod.rs` - `load_indexes_parallel`

💣 Risk: Previously, vector indexes were ignored during parallel loading (marked as TODO), which would cause data loss if this function were used for startup. This change ensures vector indexes are loaded concurrently along with graph and temporal indexes.

🧪 Strategy:
- Added `VectorIndexData` struct to `formats.rs` to encapsulate loaded vector state.
- Spawned threads for each vector path in `load_indexes_parallel`.
- Updated existing tests to handle the new return signature.
- Added `test_load_indexes_parallel_includes_vectors` to specifically verify vector loading.

🔬 Verification: `cargo test --test index_persistence` passed, including the new regression test.

---
*PR created automatically by Jules for task [7371590930644751879](https://jules.google.com/task/7371590930644751879) started by @madmax983*