### PR TITLE
🔒 Warden: Harden HNSW FFI and audit unsafe usage

### DIFF
--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -366,7 +366,7 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap(); // Lock before manipulating env
         let original_var = std::env::var("OPENAI_API_KEY").ok();
 
-// SAFETY: This test modifies a global environment variable. Access is protected by the `ENV_MUTEX` to prevent race conditions when tests are run in parallel.
+        // SAFETY: Only used in single-threaded test context protected by mutex
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
         }
@@ -382,7 +382,7 @@ mod tests {
 
         // Restore original value
         if let Some(val) = original_var {
-// SAFETY: This test modifies a global environment variable. Access is protected by the `ENV_MUTEX` to prevent race conditions when tests are run in parallel.
+            // SAFETY: Only used in single-threaded test context protected by mutex
             unsafe {
                 std::env::set_var("OPENAI_API_KEY", val);
             }

--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -366,7 +366,7 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap(); // Lock before manipulating env
         let original_var = std::env::var("OPENAI_API_KEY").ok();
 
-        // SAFETY: Only used in single-threaded test context protected by mutex
+// SAFETY: This test modifies a global environment variable. Access is protected by the `ENV_MUTEX` to prevent race conditions when tests are run in parallel.
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
         }

--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -382,7 +382,7 @@ mod tests {
 
         // Restore original value
         if let Some(val) = original_var {
-            // SAFETY: Only used in single-threaded test context protected by mutex
+// SAFETY: This test modifies a global environment variable. Access is protected by the `ENV_MUTEX` to prevent race conditions when tests are run in parallel.
             unsafe {
                 std::env::set_var("OPENAI_API_KEY", val);
             }

--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -366,6 +366,7 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap(); // Lock before manipulating env
         let original_var = std::env::var("OPENAI_API_KEY").ok();
 
+        // SAFETY: Only used in single-threaded test context protected by mutex
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
         }
@@ -381,6 +382,7 @@ mod tests {
 
         // Restore original value
         if let Some(val) = original_var {
+            // SAFETY: Only used in single-threaded test context protected by mutex
             unsafe {
                 std::env::set_var("OPENAI_API_KEY", val);
             }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -479,7 +479,16 @@ impl HnswIndexBuilder {
             // 3. The data is properly aligned for f32
             let metric_wrapper: Box<dyn Fn(*const f32, *const f32) -> f32 + Send + Sync> =
                 Box::new(move |a: *const f32, b: *const f32| {
-                    // SAFETY: usearch guarantees pointers are valid for `dims` elements
+                    // Check for null pointers to prevent UB
+                    if a.is_null() || b.is_null() {
+                        // This should never happen with a correct usearch implementation.
+                        // If it does, we panic to prevent UB from dereferencing null.
+                        // We cannot return an error here because the signature is fixed by usearch trait.
+                        panic!("usearch passed null pointer to metric function");
+                    }
+
+                    // SAFETY: usearch guarantees pointers are valid for `dims` elements.
+                    // We verified they are not null above.
                     let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
                     let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
                     distance_fn(slice_a, slice_b)

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1730,7 +1730,7 @@ mod tests {
         let wrapper = create_metric_wrapper(4, distance_fn);
 
         // Create a valid pointer for one argument
-        let vec = vec![0.0f32; 4];
+        let vec = [0.0f32; 4];
         let valid_ptr = vec.as_ptr();
         let null_ptr = std::ptr::null();
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -358,6 +358,31 @@ fn is_retryable_usearch_error(error_msg: &str) -> bool {
     error_msg.contains("No available threads to lock")
 }
 
+// Helper to create the metric wrapper - extracted for testing
+fn create_metric_wrapper<F>(
+    dims: usize,
+    distance_fn: Arc<F>,
+) -> Box<dyn Fn(*const f32, *const f32) -> f32 + Send + Sync>
+where
+    F: Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static + ?Sized,
+{
+    Box::new(move |a: *const f32, b: *const f32| {
+        // Check for null pointers to prevent UB
+        if a.is_null() || b.is_null() {
+            // This should never happen with a correct usearch implementation.
+            // If it does, we panic to prevent UB from dereferencing null.
+            // We cannot return an error here because the signature is fixed by usearch trait.
+            panic!("usearch passed null pointer to metric function");
+        }
+
+        // SAFETY: usearch guarantees pointers are valid for `dims` elements.
+        // We verified they are not null above.
+        let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
+        let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
+        distance_fn(slice_a, slice_b)
+    })
+}
+
 /// Builder for configuring and creating an `HnswIndex`.
 pub struct HnswIndexBuilder {
     config: HnswConfig,
@@ -477,22 +502,7 @@ impl HnswIndexBuilder {
             // 1. Both pointers are valid and point to `dims` contiguous f32 values
             // 2. The pointers remain valid for the duration of the function call
             // 3. The data is properly aligned for f32
-            let metric_wrapper: Box<dyn Fn(*const f32, *const f32) -> f32 + Send + Sync> =
-                Box::new(move |a: *const f32, b: *const f32| {
-                    // Check for null pointers to prevent UB
-                    if a.is_null() || b.is_null() {
-                        // This should never happen with a correct usearch implementation.
-                        // If it does, we panic to prevent UB from dereferencing null.
-                        // We cannot return an error here because the signature is fixed by usearch trait.
-                        panic!("usearch passed null pointer to metric function");
-                    }
-
-                    // SAFETY: usearch guarantees pointers are valid for `dims` elements.
-                    // We verified they are not null above.
-                    let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
-                    let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
-                    distance_fn(slice_a, slice_b)
-                });
+            let metric_wrapper = create_metric_wrapper(dims, distance_fn);
 
             index.change_metric(metric_wrapper);
         }
@@ -1709,5 +1719,22 @@ mod tests {
         assert_eq!(after_update - initial_adds, 3);
 
         Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "usearch passed null pointer")]
+    fn test_metric_wrapper_panic_on_null() {
+        // This test ensures that the metric wrapper correctly detects null pointers
+        // and panics to prevent UB. This covers the safety check added for FFI.
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        // Create a valid pointer for one argument
+        let vec = vec![0.0f32; 4];
+        let valid_ptr = vec.as_ptr();
+        let null_ptr = std::ptr::null();
+
+        // Pass null pointer - should panic
+        wrapper(valid_ptr, null_ptr);
     }
 }

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1061,5 +1061,4 @@ mod tests {
         let result = buf.try_append(PendingEntry::new_async(LSN(3), vec![]));
         assert!(result.is_err());
     }
-
 }

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1061,4 +1061,5 @@ mod tests {
         let result = buf.try_append(PendingEntry::new_async(LSN(3), vec![]));
         assert!(result.is_err());
     }
+
 }


### PR DESCRIPTION
This PR hardens the codebase against potential vulnerabilities identified during a security audit.

### 🛡️ Defense: HNSW FFI Safety
The `HnswIndex` uses a closure to bridge Rust's safe slice API with `usearch`'s raw pointer API. Previously, it assumed `usearch` would never pass null pointers.
*   **Fix:** Added explicit `is_null()` checks. If a null pointer is detected, the code now panics with a descriptive message instead of triggering Undefined Behavior.

### 🛡️ Defense: Test Hygiene
In `src/embeddings/providers/openai.rs`, `unsafe` blocks are used around `std::env::set_var`. While generally safe in single-threaded contexts, this is flagged by the compiler in this environment.
*   **Fix:** Added `// SAFETY` comments explaining that these operations are protected by a Mutex for test isolation.

### 🔍 Audit: WalRingBuffer
Investigated a potential memory leak in `WalRingBuffer::drop` where undrained entries might be leaked.
*   **Result:** Verified that Rust's ownership model correctly drops `UnsafeCell<Option<PendingEntry>>` contents recursively, so no manual cleanup is required.

### 🧪 Verification
*   Ran `cargo test hnsw` to verify `HnswIndex` changes (all passed).
*   Ran `cargo test --features embedding-openai` to verify OpenAI provider tests.


---
*PR created automatically by Jules for task [2637643494463116989](https://jules.google.com/task/2637643494463116989) started by @madmax983*