### PR TITLE
⚡ Bolt: Optimize node/edge ID collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,13 @@ harness = false
 path = "benches/gallifreydb.rs"
 required-features = []
 
+# Storage layer benchmarks
+[[bench]]
+name = "storage_current"
+harness = false
+path = "benches/storage/current.rs"
+required-features = []
+
 # Persistence layer - durability modes and checkpoint operations
 [[bench]]
 name = "durability_modes"

--- a/benches/storage/current.rs
+++ b/benches/storage/current.rs
@@ -1,0 +1,34 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use gallifreydb::core::property::PropertyMapBuilder;
+use gallifreydb::storage::current::CurrentStorage;
+
+fn create_large_graph(storage: &CurrentStorage, count: usize) {
+    for i in 0..count {
+        storage
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", format!("Person_{}", i))
+                    .insert("age", i as i64)
+                    .build(),
+            )
+            .unwrap();
+    }
+}
+
+fn bench_get_all_node_ids(c: &mut Criterion) {
+    let mut group = c.benchmark_group("storage_current");
+
+    // Setup storage with 10k nodes
+    let storage = CurrentStorage::new();
+    create_large_graph(&storage, 10_000);
+
+    group.bench_function("get_all_node_ids_10k", |b| {
+        b.iter(|| black_box(storage.get_all_node_ids()))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_get_all_node_ids);
+criterion_main!(benches);

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -1937,4 +1937,38 @@ mod zero_copy_access_tests {
             handle.join().expect("Thread should complete successfully");
         }
     }
+
+    #[test]
+    fn test_iter_node_ids_optimization() {
+        let indexes = CurrentIndexes::new();
+
+        // Create nodes with properties to verify we're not cloning them
+        let n1 = create_test_node(1, "Person");
+        let n2 = create_test_node(2, "Person");
+        indexes.insert_node(n1);
+        indexes.insert_node(n2);
+
+        // Collect IDs using new optimized method
+        let ids: Vec<NodeId> = indexes.iter_node_ids().collect();
+
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&NodeId::new(1).unwrap()));
+        assert!(ids.contains(&NodeId::new(2).unwrap()));
+    }
+
+    #[test]
+    fn test_iter_edge_ids_optimization() {
+        let indexes = CurrentIndexes::new();
+
+        let e1 = create_test_edge(1, 0, 1, "KNOWS");
+        let e2 = create_test_edge(2, 1, 2, "FOLLOWS");
+        indexes.insert_edge(e1);
+        indexes.insert_edge(e2);
+
+        let ids: Vec<EdgeId> = indexes.iter_edge_ids().collect();
+
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&EdgeId::new(1).unwrap()));
+        assert!(ids.contains(&EdgeId::new(2).unwrap()));
+    }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -698,9 +698,19 @@ impl CurrentIndexes {
         self.nodes.iter().map(|entry| entry.value().clone())
     }
 
+    /// Iterate over all node IDs.
+    pub fn iter_node_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.nodes.iter().map(|entry| *entry.key())
+    }
+
     /// Iterate over all edges.
     pub fn iter_edges(&self) -> impl Iterator<Item = Edge> + '_ {
         self.edges.iter().map(|entry| entry.value().clone())
+    }
+
+    /// Iterate over all edge IDs.
+    pub fn iter_edge_ids(&self) -> impl Iterator<Item = EdgeId> + '_ {
+        self.edges.iter().map(|entry| *entry.key())
     }
 
     /// Export outgoing CSR data for persistence.

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -699,6 +699,9 @@ impl CurrentIndexes {
     }
 
     /// Iterate over all node IDs.
+    ///
+    /// This is more efficient than `iter_nodes().map(|n| n.id)` when only
+    /// IDs are needed, as it avoids cloning the full Node objects.
     pub fn iter_node_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
         self.nodes.iter().map(|entry| *entry.key())
     }
@@ -709,6 +712,9 @@ impl CurrentIndexes {
     }
 
     /// Iterate over all edge IDs.
+    ///
+    /// This is more efficient than `iter_edges().map(|e| e.id)` when only
+    /// IDs are needed, as it avoids cloning the full Edge objects.
     pub fn iter_edge_ids(&self) -> impl Iterator<Item = EdgeId> + '_ {
         self.edges.iter().map(|entry| *entry.key())
     }

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -2301,7 +2301,7 @@ impl CurrentStorage {
     /// This is used by the query executor for full node scans.
     /// For large graphs, prefer using label-filtered scans instead.
     pub fn get_all_node_ids(&self) -> Vec<NodeId> {
-        self.indexes.iter_nodes().map(|n| n.id).collect()
+        self.indexes.iter_node_ids().collect()
     }
 
     /// Get all edge IDs in the current storage.
@@ -2309,7 +2309,7 @@ impl CurrentStorage {
     /// This is used by recovery tests and query executor for full edge scans.
     /// For large graphs, prefer using filtered scans instead.
     pub fn get_all_edge_ids(&self) -> Vec<EdgeId> {
-        self.indexes.iter_edges().map(|e| e.id).collect()
+        self.indexes.iter_edge_ids().collect()
     }
 
     /// Get all nodes in the current storage.


### PR DESCRIPTION
Optimized `get_all_node_ids` and `get_all_edge_ids` to avoid cloning `Node` and `Edge` objects. This significantly reduces memory allocation overhead for operations that only require IDs, such as `NodeScanIterator` initialization.

---
*PR created automatically by Jules for task [16791191369523334549](https://jules.google.com/task/16791191369523334549) started by @madmax983*