### PR TITLE
Verify temporal interval in replay tests

### DIFF
--- a/tests/recovery/replay_create_tests.rs
+++ b/tests/recovery/replay_create_tests.rs
@@ -417,14 +417,20 @@ fn test_replay_preserves_temporal_interval() -> Result<()> {
     let node_versions = all_versions
         .get(&node_id)
         .expect("Node should exist in historical storage");
-    assert_eq!(node_versions.len(), 1, "Should have exactly one version");
 
-    let version = node_versions[0];
-    assert_eq!(
-        version.temporal(),
-        &temporal,
-        "Temporal interval should match"
-    );
+    if let [version] = node_versions.as_slice() {
+        assert_eq!(
+            version.temporal(),
+            &temporal,
+            "Temporal interval should match"
+        );
+    } else {
+        panic!(
+            "Expected exactly one version for node {}, but found {}",
+            node_id,
+            node_versions.len()
+        );
+    }
 
     Ok(())
 }

--- a/tests/recovery/replay_create_tests.rs
+++ b/tests/recovery/replay_create_tests.rs
@@ -17,6 +17,7 @@ use gallifreydb::{
     },
     storage::{
         persistence::{CheckpointConfig, PersistenceManager},
+        version::TemporalVersion,
         wal::{
             WalOperation,
             concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig},
@@ -412,10 +413,18 @@ fn test_replay_preserves_temporal_interval() -> Result<()> {
     let (_current, historical, _lsn) = manager.recover(&wal)?;
 
     // Then: Historical version has correct temporal interval
-    // TODO: Once we can query historical versions, verify the temporal interval
-    // For now, verify that historical storage has the version
-    let hist_stats = historical.stats();
-    assert_eq!(hist_stats.total_node_versions, 1);
+    let all_versions = historical.get_all_node_versions();
+    let node_versions = all_versions
+        .get(&node_id)
+        .expect("Node should exist in historical storage");
+    assert_eq!(node_versions.len(), 1, "Should have exactly one version");
+
+    let version = node_versions[0];
+    assert_eq!(
+        version.temporal(),
+        &temporal,
+        "Temporal interval should match"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Implemented verification of temporal intervals in replay tests.
- Replaced a TODO comment in `tests/recovery/replay_create_tests.rs` with actual verification logic.
- Ensures that the bi-temporal interval (valid time and transaction time) is correctly preserved during WAL replay and recovery.
- Uses `historical.get_all_node_versions()` to inspect the historical storage state.

---
*PR created automatically by Jules for task [14156380795042829151](https://jules.google.com/task/14156380795042829151) started by @madmax983*