### PR TITLE
Parallel vector index loading with Rayon

### DIFF
--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -202,11 +202,16 @@ pub fn load_indexes_parallel(
     // Load vector indexes in parallel using Rayon (blocks current thread)
     // We do this while graph and temporal indexes are loading in background threads
     use rayon::prelude::*;
-    let vector_data: Result<Vec<_>> = vector_paths
-        .par_iter()
-        .map(|path| vector::load_vector_index(path))
-        .collect();
-    let vector_data = vector_data?;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(8) // A reasonable number for I/O-bound tasks, can be configured.
+        .build()
+        .unwrap();
+    let vector_data = pool.install(|| {
+        vector_paths
+            .par_iter()
+            .map(|path| vector::load_vector_index(path))
+            .collect::<Result<Vec<_>>>()
+    })?;
 
     // Join threads and collect results
     let graph_data = graph_handle

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -199,11 +199,14 @@ pub fn load_indexes_parallel(
     let temporal_handle =
         temporal_path_opt.map(|path| thread::spawn(move || temporal::load_temporal_index(&path)));
 
-    // Spawn threads for vector index loading
-    let vector_handles: Vec<_> = vector_paths
-        .into_iter()
-        .map(|path| thread::spawn(move || vector::load_vector_index(&path)))
+    // Load vector indexes in parallel using Rayon (blocks current thread)
+    // We do this while graph and temporal indexes are loading in background threads
+    use rayon::prelude::*;
+    let vector_data: Result<Vec<_>> = vector_paths
+        .par_iter()
+        .map(|path| vector::load_vector_index(path))
         .collect();
+    let vector_data = vector_data?;
 
     // Join threads and collect results
     let graph_data = graph_handle
@@ -215,11 +218,6 @@ pub fn load_indexes_parallel(
     } else {
         None
     };
-
-    let mut vector_data = Vec::with_capacity(vector_handles.len());
-    for handle in vector_handles {
-        vector_data.push(handle.join().expect("Vector loading thread panicked")?);
-    }
 
     Ok((graph_data, temporal_data, vector_data))
 }

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -81,6 +81,7 @@ pub use api::{
 pub use error::{IndexPersistenceError, Result};
 pub use formats::*;
 pub use loader::IndexPersistenceManager;
+use rayon::prelude::*;
 
 /// Current manifest format version.
 pub const MANIFEST_VERSION: u16 = 1;
@@ -201,17 +202,11 @@ pub fn load_indexes_parallel(
 
     // Load vector indexes in parallel using Rayon (blocks current thread)
     // We do this while graph and temporal indexes are loading in background threads
-    use rayon::prelude::*;
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(8) // A reasonable number for I/O-bound tasks, can be configured.
-        .build()
-        .unwrap();
-    let vector_data = pool.install(|| {
-        vector_paths
-            .par_iter()
-            .map(|path| vector::load_vector_index(path))
-            .collect::<Result<Vec<_>>>()
-    })?;
+    let vector_data: Result<Vec<_>> = vector_paths
+        .par_iter()
+        .map(|path| vector::load_vector_index(path))
+        .collect();
+    let vector_data = vector_data?;
 
     // Join threads and collect results
     let graph_data = graph_handle

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2793,11 +2793,7 @@ fn test_parallel_loading_graph_error() {
 
     // Call load_indexes_parallel with a non-existent graph path
     // This should cause the graph loading thread to return an error, which should be propagated
-    let result = load_indexes_parallel(
-        &graph_path,
-        None,
-        vec![]
-    );
+    let result = load_indexes_parallel(&graph_path, None, vec![]);
 
     // Should return an error
     assert!(result.is_err());
@@ -2806,8 +2802,13 @@ fn test_parallel_loading_graph_error() {
     let err = result.unwrap_err();
     let err_str = format!("{}", err);
     // The exact error message depends on the OS, but it should be an IO error about missing file
-    assert!(err_str.contains("No such file") || err_str.contains("entity not found") || err_str.contains("os error"),
-            "Error should indicate missing graph file, got: {}", err_str);
+    assert!(
+        err_str.contains("No such file")
+            || err_str.contains("entity not found")
+            || err_str.contains("os error"),
+        "Error should indicate missing graph file, got: {}",
+        err_str
+    );
 
     println!("✓ Parallel loading graph error test passed");
 }

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2765,8 +2765,14 @@ fn test_parallel_loading_error_propagation() {
     // Verify the error is related to the missing file
     let err = result.unwrap_err();
     let err_str = format!("{}", err);
+    // On different OSs, the IO error message varies.
+    // Windows: "The system cannot find the file specified"
+    // Unix: "No such file or directory"
+    // The wrapped error might not contain the filename depending on how fs::read returned it.
     assert!(
-        err_str.contains("mappings.idx") || err_str.contains("No such file"),
+        err_str.contains("mappings.idx")
+            || err_str.contains("No such file")
+            || err_str.contains("cannot find the file"),
         "Error should indicate missing mappings file, got: {}",
         err_str
     );

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2720,12 +2720,12 @@ fn test_parallel_loading_with_vectors() {
 fn test_parallel_loading_error_propagation() {
     let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
 
+    use gallifreydb::storage::index_persistence::formats::PersistedHnswConfig;
     use gallifreydb::storage::index_persistence::graph::{new_graph_index_data, save_graph_index};
     use gallifreydb::storage::index_persistence::load_indexes_parallel;
     use gallifreydb::storage::index_persistence::vector::{
         new_vector_mappings, new_vector_meta, save_vector_mappings, save_vector_meta,
     };
-    use gallifreydb::storage::index_persistence::formats::PersistedHnswConfig;
 
     let dir = tempdir().unwrap();
     let graph_path = dir.path().join("graph.idx");
@@ -2757,11 +2757,7 @@ fn test_parallel_loading_error_propagation() {
     save_vector_meta(&vector_meta, &vector_dir2.join("meta.idx")).unwrap();
 
     // Call load_indexes_parallel with both valid and corrupted vector paths
-    let result = load_indexes_parallel(
-        &graph_path,
-        None,
-        vec![&vector_dir1, &vector_dir2]
-    );
+    let result = load_indexes_parallel(&graph_path, None, vec![&vector_dir1, &vector_dir2]);
 
     // Should return an error
     assert!(result.is_err());
@@ -2769,8 +2765,43 @@ fn test_parallel_loading_error_propagation() {
     // Verify the error is related to the missing file
     let err = result.unwrap_err();
     let err_str = format!("{}", err);
-    assert!(err_str.contains("mappings.idx") || err_str.contains("No such file"),
-            "Error should indicate missing mappings file, got: {}", err_str);
+    assert!(
+        err_str.contains("mappings.idx") || err_str.contains("No such file"),
+        "Error should indicate missing mappings file, got: {}",
+        err_str
+    );
 
     println!("✓ Parallel loading error propagation test passed");
+}
+
+/// Test that graph loading errors are correctly propagated in parallel loading.
+#[test]
+fn test_parallel_loading_graph_error() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use gallifreydb::storage::index_persistence::load_indexes_parallel;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let graph_path = dir.path().join("non_existent_graph.idx");
+
+    // Call load_indexes_parallel with a non-existent graph path
+    // This should cause the graph loading thread to return an error, which should be propagated
+    let result = load_indexes_parallel(
+        &graph_path,
+        None,
+        vec![]
+    );
+
+    // Should return an error
+    assert!(result.is_err());
+
+    // Verify the error
+    let err = result.unwrap_err();
+    let err_str = format!("{}", err);
+    // The exact error message depends on the OS, but it should be an IO error about missing file
+    assert!(err_str.contains("No such file") || err_str.contains("entity not found") || err_str.contains("os error"),
+            "Error should indicate missing graph file, got: {}", err_str);
+
+    println!("✓ Parallel loading graph error test passed");
 }

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2714,3 +2714,63 @@ fn test_parallel_loading_with_vectors() {
 
     println!("✓ Parallel loading with vectors test passed");
 }
+
+/// Test that errors in parallel loading are correctly propagated.
+#[test]
+fn test_parallel_loading_error_propagation() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use gallifreydb::storage::index_persistence::graph::{new_graph_index_data, save_graph_index};
+    use gallifreydb::storage::index_persistence::load_indexes_parallel;
+    use gallifreydb::storage::index_persistence::vector::{
+        new_vector_mappings, new_vector_meta, save_vector_mappings, save_vector_meta,
+    };
+    use gallifreydb::storage::index_persistence::formats::PersistedHnswConfig;
+
+    let dir = tempdir().unwrap();
+    let graph_path = dir.path().join("graph.idx");
+
+    // Create minimal graph index
+    let graph_data = new_graph_index_data();
+    save_graph_index(&graph_data, &graph_path).unwrap();
+
+    // Create a valid vector index
+    let vector_dir1 = dir.path().join("vector_valid");
+    std::fs::create_dir_all(&vector_dir1).unwrap();
+
+    let hnsw_config = PersistedHnswConfig {
+        m: 16,
+        ef_construction: 128,
+        ef_search: 64,
+    };
+    let vector_meta = new_vector_meta("valid", 384, 0, hnsw_config);
+    let vector_mappings = new_vector_mappings();
+
+    save_vector_meta(&vector_meta, &vector_dir1.join("meta.idx")).unwrap();
+    save_vector_mappings(&vector_mappings, &vector_dir1.join("mappings.idx")).unwrap();
+
+    // Create a CORRUPTED vector index (missing mappings.idx)
+    let vector_dir2 = dir.path().join("vector_corrupted");
+    std::fs::create_dir_all(&vector_dir2).unwrap();
+
+    // Only save meta, missing mappings will cause load failure
+    save_vector_meta(&vector_meta, &vector_dir2.join("meta.idx")).unwrap();
+
+    // Call load_indexes_parallel with both valid and corrupted vector paths
+    let result = load_indexes_parallel(
+        &graph_path,
+        None,
+        vec![&vector_dir1, &vector_dir2]
+    );
+
+    // Should return an error
+    assert!(result.is_err());
+
+    // Verify the error is related to the missing file
+    let err = result.unwrap_err();
+    let err_str = format!("{}", err);
+    assert!(err_str.contains("mappings.idx") || err_str.contains("No such file"),
+            "Error should indicate missing mappings file, got: {}", err_str);
+
+    println!("✓ Parallel loading error propagation test passed");
+}


### PR DESCRIPTION
Implemented parallel vector index loading using Rayon. Replaced manual thread spawning with `rayon::par_iter` for better resource management. Verified with existing tests.

---
*PR created automatically by Jules for task [10153721569627008443](https://jules.google.com/task/10153721569627008443) started by @madmax983*