### PR TITLE
Optimize add_batch to avoid cloning vectors

### DIFF
--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -551,6 +551,17 @@ pub trait VectorIndex: Send + Sync {
         Ok(())
     }
 
+    /// Adds multiple vectors in a batch operation using references.
+    ///
+    /// This allows adding vectors without transferring ownership, avoiding clones.
+    /// Default implementation calls `add()` sequentially.
+    fn add_batch_ref(&self, items: &[(NodeId, &[f32])]) -> Result<()> {
+        for (id, vec) in items {
+            self.add(*id, vec)?;
+        }
+        Ok(())
+    }
+
     /// Removes multiple vectors in a batch operation.
     ///
     /// Default implementation calls `remove()` sequentially.

--- a/src/index/vector/sharded.rs
+++ b/src/index/vector/sharded.rs
@@ -1554,9 +1554,7 @@ mod tests {
     fn test_add_batch_ref() -> Result<()> {
         let index = ShardedVectorIndex::with_defaults(4, DistanceMetric::Cosine, 4)?;
 
-        let vectors: Vec<Vec<f32>> = (1..=10)
-            .map(|i| vec![i as f32, 0.0, 0.0, 0.0])
-            .collect();
+        let vectors: Vec<Vec<f32>> = (1..=10).map(|i| vec![i as f32, 0.0, 0.0, 0.0]).collect();
 
         let items: Vec<(NodeId, &[f32])> = vectors
             .iter()

--- a/src/index/vector/sharded.rs
+++ b/src/index/vector/sharded.rs
@@ -639,6 +639,17 @@ impl VectorIndex for ShardedVectorIndex {
     }
 
     fn add_batch(&self, items: &[(NodeId, Vec<f32>)]) -> Result<()> {
+        // Optimization: Use add_batch_ref to avoid cloning vectors
+        // We create references to the vectors in the input items
+        let refs: Vec<(NodeId, &[f32])> = items
+            .iter()
+            .map(|(id, vec)| (*id, vec.as_slice()))
+            .collect();
+
+        self.add_batch_ref(&refs)
+    }
+
+    fn add_batch_ref(&self, items: &[(NodeId, &[f32])]) -> Result<()> {
         // Group item indices by shard first
         let mut shard_indices: Vec<Vec<usize>> = vec![Vec::new(); self.shards.len()];
 
@@ -650,13 +661,11 @@ impl VectorIndex for ShardedVectorIndex {
         // Add to each shard
         for (shard_idx, indices) in shard_indices.into_iter().enumerate() {
             if !indices.is_empty() {
-                // TODO: HnswIndex::add_batch requires owned Vec<f32>, so we must clone here.
-                // A future optimization could add a add_batch_ref method that accepts &[f32].
-                let shard_items: Vec<(NodeId, Vec<f32>)> = indices
+                let shard_items: Vec<(NodeId, &[f32])> = indices
                     .iter()
-                    .map(|&idx| (items[idx].0, items[idx].1.clone()))
+                    .map(|&idx| (items[idx].0, items[idx].1))
                     .collect();
-                self.shards[shard_idx].add_batch(&shard_items)?;
+                self.shards[shard_idx].add_batch_ref(&shard_items)?;
             }
         }
 
@@ -1535,5 +1544,30 @@ mod tests {
         // NaN should be less than normal values
         assert!(nan < normal);
         assert!(normal > nan);
+    }
+
+    // ============================================================
+    // Add Batch Ref Tests
+    // ============================================================
+
+    #[test]
+    fn test_add_batch_ref() -> Result<()> {
+        let index = ShardedVectorIndex::with_defaults(4, DistanceMetric::Cosine, 4)?;
+
+        let vectors: Vec<Vec<f32>> = (1..=10)
+            .map(|i| vec![i as f32, 0.0, 0.0, 0.0])
+            .collect();
+
+        let items: Vec<(NodeId, &[f32])> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (NodeId::new((i + 1) as u64).unwrap(), v.as_slice()))
+            .collect();
+
+        index.add_batch_ref(&items)?;
+
+        assert_eq!(index.len(), 10);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR optimizes the `add_batch` operation in `ShardedVectorIndex` by introducing a new `add_batch_ref` method to the `VectorIndex` trait. This allows vector batch insertion using references (`&[f32]`) instead of owned `Vec<f32>`, eliminating unnecessary cloning when distributing vectors to shards.

Key changes:
- Added `add_batch_ref` to `VectorIndex` trait in `src/index/vector/mod.rs` with a default implementation.
- Implemented `add_batch_ref` in `ShardedVectorIndex` (`src/index/vector/sharded.rs`) to handle sharding with references.
- Updated `ShardedVectorIndex::add_batch` to use `add_batch_ref`, converting owned vectors to references instead of cloning them.
- Added a test case `test_add_batch_ref` in `src/index/vector/sharded.rs` to verify the new functionality.

---
*PR created automatically by Jules for task [14164546917067550362](https://jules.google.com/task/14164546917067550362) started by @madmax983*