### PR TITLE
⚡ Optimize HNSW persistence for async contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ observability-prometheus = ["observability", "dep:metrics", "dep:metrics-exporte
 # Default features
 default = ["config-toml"]
 
+# Async runtime support
+tokio = ["dep:tokio"]
+
 # Configuration file support (TOML)
 config-toml = ["dep:serde", "dep:toml"]
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -895,10 +895,12 @@ impl VectorIndex for HnswIndex {
 
     fn save(&self, path: &Path) -> Result<()> {
         #[cfg(feature = "tokio")]
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread {
-                return tokio::task::block_in_place(|| self.save_internal(path));
-            }
+        if let Some(result) = tokio::runtime::Handle::try_current()
+            .ok()
+            .filter(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+            .map(|_| tokio::task::block_in_place(|| self.save_internal(path)))
+        {
+            return result;
         }
 
         self.save_internal(path)

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -894,6 +894,38 @@ impl VectorIndex for HnswIndex {
     }
 
     fn save(&self, path: &Path) -> Result<()> {
+        #[cfg(feature = "tokio")]
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread {
+                return tokio::task::block_in_place(|| self.save_internal(path));
+            }
+        }
+
+        self.save_internal(path)
+    }
+
+    fn memory_usage(&self) -> usize {
+        self.inner.read().memory_usage()
+    }
+
+    fn quantization(&self) -> Quantization {
+        self.config.quantization
+    }
+
+    fn compact(&self) -> Result<()> {
+        // usearch native deletes don't require compaction
+        Ok(())
+    }
+}
+
+// Private helper methods for HnswIndex
+impl HnswIndex {
+    /// Internal implementation of index saving.
+    ///
+    /// This method performs the actual blocking I/O operations for saving the index
+    /// and its mappings. It is separated from `save()` to allow the latter to use
+    /// `tokio::task::block_in_place` when running within a Tokio runtime.
+    fn save_internal(&self, path: &Path) -> Result<()> {
         let index = self.inner.read();
         index
             .save(path.to_str().ok_or_else(|| {
@@ -950,22 +982,6 @@ impl VectorIndex for HnswIndex {
         Ok(())
     }
 
-    fn memory_usage(&self) -> usize {
-        self.inner.read().memory_usage()
-    }
-
-    fn quantization(&self) -> Quantization {
-        self.config.quantization
-    }
-
-    fn compact(&self) -> Result<()> {
-        // usearch native deletes don't require compaction
-        Ok(())
-    }
-}
-
-// Private helper methods for HnswIndex
-impl HnswIndex {
     /// Convert usearch matches to sorted vector of (NodeId, similarity) tuples.
     ///
     /// This helper function encapsulates the common logic of:

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -893,14 +893,29 @@ impl VectorIndex for HnswIndex {
         Ok(())
     }
 
+    /// Save the index to disk.
+    ///
+    /// # Async Runtime Behavior
+    ///
+    /// This method performs blocking I/O operations (`std::fs::write` and `usearch::Index::save`).
+    /// When running within a multi-threaded Tokio runtime (enabled via `tokio` or `embeddings` features),
+    /// it automatically uses `tokio::task::block_in_place` to offload this work from the async worker thread.
+    ///
+    /// This prevents the blocking operation from stalling the async reactor, maintaining responsiveness
+    /// for other tasks running on the same thread.
+    ///
+    /// # Fallback
+    ///
+    /// If executed outside a Tokio runtime, or in a single-threaded runtime (where `block_in_place`
+    /// would panic), it falls back to standard synchronous execution.
     fn save(&self, path: &Path) -> Result<()> {
-        #[cfg(feature = "tokio")]
-        if let Some(result) = tokio::runtime::Handle::try_current()
-            .ok()
-            .filter(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
-            .map(|_| tokio::task::block_in_place(|| self.save_internal(path)))
-        {
-            return result;
+        #[cfg(any(feature = "tokio", feature = "embeddings"))]
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            // Note: Clippy suggests collapsing this if, but 'let chains' are unstable in this context
+            #[allow(clippy::collapsible_if)]
+            if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread {
+                return tokio::task::block_in_place(|| self.save_internal(path));
+            }
         }
 
         self.save_internal(path)

--- a/tests/hnsw_persistence_perf.rs
+++ b/tests/hnsw_persistence_perf.rs
@@ -2,7 +2,6 @@ use gallifreydb::core::id::NodeId;
 use gallifreydb::index::vector::hnsw::HnswConfig;
 use gallifreydb::index::vector::hnsw::HnswIndex;
 use gallifreydb::index::vector::{DistanceMetric, VectorIndex};
-use std::sync::Arc;
 use std::time::Instant;
 use tempfile::tempdir;
 
@@ -54,6 +53,8 @@ fn test_save_performance_and_correctness() {
 #[cfg(any(feature = "tokio", feature = "embeddings"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_save_in_tokio_context() {
+    use std::sync::Arc;
+
     let dimensions = 128;
     let count = 500;
 

--- a/tests/hnsw_persistence_perf.rs
+++ b/tests/hnsw_persistence_perf.rs
@@ -115,7 +115,9 @@ fn test_save_fallback_no_runtime() {
     // 2. Populate with data
     for i in 0..count {
         let node_id = NodeId::new(i as u64 + 1).unwrap();
-        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        let vector: Vec<f32> = (0..dimensions)
+            .map(|x| (x as f32) / (dimensions as f32))
+            .collect();
         index.add(node_id, &vector).expect("Failed to add vector");
     }
 

--- a/tests/hnsw_persistence_perf.rs
+++ b/tests/hnsw_persistence_perf.rs
@@ -2,6 +2,7 @@ use gallifreydb::core::id::NodeId;
 use gallifreydb::index::vector::hnsw::HnswConfig;
 use gallifreydb::index::vector::hnsw::HnswIndex;
 use gallifreydb::index::vector::{DistanceMetric, VectorIndex};
+use std::sync::Arc;
 use std::time::Instant;
 use tempfile::tempdir;
 
@@ -17,7 +18,9 @@ fn test_save_performance_and_correctness() {
     // 2. Populate with data
     for i in 0..count {
         let node_id = NodeId::new(i as u64 + 1).unwrap();
-        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        let vector: Vec<f32> = (0..dimensions)
+            .map(|x| (x as f32) / (dimensions as f32))
+            .collect();
         index.add(node_id, &vector).expect("Failed to add vector");
     }
 
@@ -34,14 +37,21 @@ fn test_save_performance_and_correctness() {
 
     // 5. Verify files exist
     assert!(file_path.exists(), "Index file should exist");
-    assert!(file_path.with_extension("usearch.mappings").exists(), "Mappings file should exist");
+    assert!(
+        file_path.with_extension("usearch.mappings").exists(),
+        "Mappings file should exist"
+    );
 
     // 6. Verify loading works (validity check)
     let loaded_index = HnswIndex::load(&file_path, index.config()).expect("Failed to load index");
-    assert_eq!(loaded_index.len(), count, "Loaded index should have same count");
+    assert_eq!(
+        loaded_index.len(),
+        count,
+        "Loaded index should have same count"
+    );
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(any(feature = "tokio", feature = "embeddings"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_save_in_tokio_context() {
     let dimensions = 128;
@@ -49,12 +59,14 @@ async fn test_save_in_tokio_context() {
 
     // 1. Setup index
     let config = HnswConfig::new(dimensions, DistanceMetric::Cosine).with_capacity(count);
-    let index = HnswIndex::new(config).expect("Failed to create index");
+    let index = Arc::new(HnswIndex::new(config).expect("Failed to create index"));
 
     // 2. Populate with data
     for i in 0..count {
         let node_id = NodeId::new(i as u64 + 1).unwrap();
-        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        let vector: Vec<f32> = (0..dimensions)
+            .map(|x| (x as f32) / (dimensions as f32))
+            .collect();
         index.add(node_id, &vector).expect("Failed to add vector");
     }
 
@@ -62,11 +74,24 @@ async fn test_save_in_tokio_context() {
     let dir = tempdir().expect("Failed to create temp dir");
     let file_path = dir.path().join("test_index_async.usearch");
 
-    // 4. Measure save time in async context
+    // 4. Verify concurrent execution
+    // Spawn a background task that sleeps briefly to simulate other work
+    // If save() blocks the thread, this task might be delayed if both run on same thread
+    // but in multi-thread runtime, they should run in parallel if block_in_place works
     let start = Instant::now();
-    // This call is synchronous, but we want to make sure it doesn't panic or fail inside tokio runtime
-    // and ideally (after optimization) uses block_in_place
-    index.save(&file_path).expect("Failed to save index");
+
+    let index_clone = Arc::clone(&index);
+    let path_clone = file_path.clone();
+
+    let save_handle = tokio::spawn(async move {
+        // This will block the thread if block_in_place is not working
+        index_clone.save(&path_clone).expect("Failed to save index");
+    });
+
+    // Do some "concurrent" work
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    save_handle.await.expect("Save task failed");
     let duration = start.elapsed();
 
     println!("Async context save operation took: {:?}", duration);
@@ -76,7 +101,7 @@ async fn test_save_in_tokio_context() {
     assert!(file_path.with_extension("usearch.mappings").exists());
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(any(feature = "tokio", feature = "embeddings"))]
 #[tokio::test(flavor = "current_thread")]
 async fn test_save_in_single_thread_context() {
     let dimensions = 128;
@@ -89,7 +114,9 @@ async fn test_save_in_single_thread_context() {
     // 2. Populate with data
     for i in 0..count {
         let node_id = NodeId::new(i as u64 + 1).unwrap();
-        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        let vector: Vec<f32> = (0..dimensions)
+            .map(|x| (x as f32) / (dimensions as f32))
+            .collect();
         index.add(node_id, &vector).expect("Failed to add vector");
     }
 

--- a/tests/hnsw_persistence_perf.rs
+++ b/tests/hnsw_persistence_perf.rs
@@ -1,0 +1,106 @@
+use gallifreydb::core::id::NodeId;
+use gallifreydb::index::vector::hnsw::HnswConfig;
+use gallifreydb::index::vector::hnsw::HnswIndex;
+use gallifreydb::index::vector::{DistanceMetric, VectorIndex};
+use std::time::Instant;
+use tempfile::tempdir;
+
+#[test]
+fn test_save_performance_and_correctness() {
+    let dimensions = 128; // Smaller dimensions for faster test
+    let count = 1000;
+
+    // 1. Setup index
+    let config = HnswConfig::new(dimensions, DistanceMetric::Cosine).with_capacity(count);
+    let index = HnswIndex::new(config).expect("Failed to create index");
+
+    // 2. Populate with data
+    for i in 0..count {
+        let node_id = NodeId::new(i as u64 + 1).unwrap();
+        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        index.add(node_id, &vector).expect("Failed to add vector");
+    }
+
+    // 3. Prepare temp directory
+    let dir = tempdir().expect("Failed to create temp dir");
+    let file_path = dir.path().join("test_index.usearch");
+
+    // 4. Measure save time
+    let start = Instant::now();
+    index.save(&file_path).expect("Failed to save index");
+    let duration = start.elapsed();
+
+    println!("Save operation took: {:?}", duration);
+
+    // 5. Verify files exist
+    assert!(file_path.exists(), "Index file should exist");
+    assert!(file_path.with_extension("usearch.mappings").exists(), "Mappings file should exist");
+
+    // 6. Verify loading works (validity check)
+    let loaded_index = HnswIndex::load(&file_path, index.config()).expect("Failed to load index");
+    assert_eq!(loaded_index.len(), count, "Loaded index should have same count");
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_save_in_tokio_context() {
+    let dimensions = 128;
+    let count = 500;
+
+    // 1. Setup index
+    let config = HnswConfig::new(dimensions, DistanceMetric::Cosine).with_capacity(count);
+    let index = HnswIndex::new(config).expect("Failed to create index");
+
+    // 2. Populate with data
+    for i in 0..count {
+        let node_id = NodeId::new(i as u64 + 1).unwrap();
+        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        index.add(node_id, &vector).expect("Failed to add vector");
+    }
+
+    // 3. Prepare temp directory
+    let dir = tempdir().expect("Failed to create temp dir");
+    let file_path = dir.path().join("test_index_async.usearch");
+
+    // 4. Measure save time in async context
+    let start = Instant::now();
+    // This call is synchronous, but we want to make sure it doesn't panic or fail inside tokio runtime
+    // and ideally (after optimization) uses block_in_place
+    index.save(&file_path).expect("Failed to save index");
+    let duration = start.elapsed();
+
+    println!("Async context save operation took: {:?}", duration);
+
+    // 5. Verify files
+    assert!(file_path.exists());
+    assert!(file_path.with_extension("usearch.mappings").exists());
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test(flavor = "current_thread")]
+async fn test_save_in_single_thread_context() {
+    let dimensions = 128;
+    let count = 100;
+
+    // 1. Setup index
+    let config = HnswConfig::new(dimensions, DistanceMetric::Cosine).with_capacity(count);
+    let index = HnswIndex::new(config).expect("Failed to create index");
+
+    // 2. Populate with data
+    for i in 0..count {
+        let node_id = NodeId::new(i as u64 + 1).unwrap();
+        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        index.add(node_id, &vector).expect("Failed to add vector");
+    }
+
+    // 3. Prepare temp directory
+    let dir = tempdir().expect("Failed to create temp dir");
+    let file_path = dir.path().join("test_index_single_thread.usearch");
+
+    // 4. Measure save time in async context (should fallback to blocking)
+    index.save(&file_path).expect("Failed to save index");
+
+    // 5. Verify files
+    assert!(file_path.exists());
+    assert!(file_path.with_extension("usearch.mappings").exists());
+}

--- a/tests/hnsw_persistence_perf.rs
+++ b/tests/hnsw_persistence_perf.rs
@@ -101,6 +101,36 @@ async fn test_save_in_tokio_context() {
     assert!(file_path.with_extension("usearch.mappings").exists());
 }
 
+#[test]
+fn test_save_fallback_no_runtime() {
+    // Explicitly test the synchronous fallback path when no runtime is present
+    // This runs in a standard thread, ensuring coverage for the !tokio path logic
+    let dimensions = 128;
+    let count = 100;
+
+    // 1. Setup index
+    let config = HnswConfig::new(dimensions, DistanceMetric::Cosine).with_capacity(count);
+    let index = HnswIndex::new(config).expect("Failed to create index");
+
+    // 2. Populate with data
+    for i in 0..count {
+        let node_id = NodeId::new(i as u64 + 1).unwrap();
+        let vector: Vec<f32> = (0..dimensions).map(|x| (x as f32) / (dimensions as f32)).collect();
+        index.add(node_id, &vector).expect("Failed to add vector");
+    }
+
+    // 3. Prepare temp directory
+    let dir = tempdir().expect("Failed to create temp dir");
+    let file_path = dir.path().join("test_index_no_runtime.usearch");
+
+    // 4. Save - should work synchronously
+    index.save(&file_path).expect("Failed to save index");
+
+    // 5. Verify files
+    assert!(file_path.exists());
+    assert!(file_path.with_extension("usearch.mappings").exists());
+}
+
 #[cfg(any(feature = "tokio", feature = "embeddings"))]
 #[tokio::test(flavor = "current_thread")]
 async fn test_save_in_single_thread_context() {


### PR DESCRIPTION
💡 **What:** 
Refactored `HnswIndex::save` to use `tokio::task::block_in_place` when executing within a multi-threaded Tokio runtime. This required exposing the `tokio` feature in `Cargo.toml` and checking the runtime flavor to avoid panics on single-threaded runtimes.

🎯 **Why:** 
The `save` operation involves synchronous file I/O (`std::fs::write` and `usearch::Index::save`). Calling this directly from an async task (e.g., in a background persistence job) blocks the worker thread, potentially stalling other tasks on the same thread. By using `block_in_place`, we signal the runtime to offload the blocking work, improving overall system responsiveness.

📊 **Measured Improvement:** 
Added a new test suite `tests/hnsw_persistence_perf.rs` which verifies:
1.  **Correctness:** The index is saved and loaded correctly.
2.  **Safety:** The code correctly detects single-threaded runtimes and falls back to blocking execution instead of panicking.
3.  **Performance:** While wall-clock time for `save` itself remains similar (it's the same I/O), this change prevents it from blocking the async reactor, which is critical for concurrent performance in a real application. Tests passed with and without the `tokio` feature enabled.

---
*PR created automatically by Jules for task [14804090386396837342](https://jules.google.com/task/14804090386396837342) started by @madmax983*