### PR TITLE
Fix flaky test_append_async_mode test

### DIFF
--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -742,12 +742,6 @@ mod tests {
         let dir = tempdir().unwrap();
         let config = ConcurrentWalSystemConfig::new(dir.path()).with_durability_mode(
             DurabilityMode::Async {
-                // Use a long flush interval (10 seconds) to prevent background
-                // flush thread from racing with the explicit flush() call.
-                // In CI under heavy load, the test setup + appends could take
-                // >100ms, causing the background thread to drain entries before
-                // the explicit flush, making entries_flushed == 0 and failing
-                // the test. A 10s interval makes this race extremely unlikely.
                 flush_interval_ms: 10_000,
             },
         );
@@ -761,10 +755,12 @@ mod tests {
 
         assert_eq!(wal.total_appends(), 10);
 
-        // Explicit flush - should flush all 10 entries since background thread
-        // won't have woken up yet (10s interval)
-        let stats = wal.flush().unwrap();
-        assert!(stats.entries_flushed >= 1);
+        // Explicit flush - ensure all entries are durable.
+        // Note: The background flush thread may have already flushed some/all
+        // entries, so we check total_flushed() rather than the return stats.
+        // This makes the test deterministic regardless of timing.
+        wal.flush().unwrap();
+        assert_eq!(wal.total_flushed(), 10, "All 10 entries should be flushed");
 
         wal.shutdown();
     }


### PR DESCRIPTION
The test was failing intermittently because it was checking the return value of flush() to see if entries were flushed. However, in async mode, the background flush thread could drain and flush entries before the explicit flush() call, causing flush() to return FlushStats::default() with entries_flushed = 0.

Fixed by checking total_flushed() instead of the flush stats. This makes the test deterministic - it verifies all entries were persisted to disk regardless of whether the background thread or explicit flush did it.

https://claude.ai/code/session_0118yHv8M8d8rgcNFdC2NHWw