### PR TITLE
fix(storage): resolve Redb cold tier wiring issues

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -124,6 +124,8 @@ pub struct GallifreyDB {
     persistence_tracker: Option<Arc<PersistenceTracker>>,
     /// Background persistence thread health flag - set to true if thread panics or stops
     persistence_thread_stopped: Arc<std::sync::atomic::AtomicBool>,
+    /// Background persistence thread handle (if enabled) - used to join thread on shutdown
+    persistence_thread_handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl GallifreyDB {
@@ -237,7 +239,7 @@ impl GallifreyDB {
             None
         };
 
-        let db = GallifreyDB {
+        let mut db = GallifreyDB {
             current: Arc::new(CurrentStorage::new()),
             historical: Arc::new(RwLock::new(HistoricalStorage::from_unified_config(
                 config.historical,
@@ -256,6 +258,7 @@ impl GallifreyDB {
             persistence_manager: persistence_manager.clone(),
             persistence_tracker: persistence_tracker.clone(),
             persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            persistence_thread_handle: None,
         };
 
         // Load indexes on startup if enabled
@@ -276,7 +279,7 @@ impl GallifreyDB {
         if let Some(ref tracker) = persistence_tracker
             && let Some(ref manager) = persistence_manager
         {
-            spawn_background_persistence_thread(
+            let handle = spawn_background_persistence_thread(
                 Arc::clone(&db.current),
                 Arc::clone(&db.historical),
                 Arc::clone(&db.temporal_indexes),
@@ -286,6 +289,7 @@ impl GallifreyDB {
                 config.persistence.policies.clone(),
                 Arc::clone(&db.persistence_thread_stopped),
             );
+            db.persistence_thread_handle = Some(handle);
         }
 
         // Wire temporal indexes to historical storage for O(log n) version lookups (Issue #209)
@@ -347,6 +351,7 @@ impl GallifreyDB {
             persistence_manager: None,
             persistence_tracker: None,
             persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            persistence_thread_handle: None,
         };
 
         // Wire temporal indexes to historical storage for O(log n) version lookups (Issue #209)
@@ -2555,9 +2560,12 @@ impl Drop for GallifreyDB {
         if let Some(ref tracker) = self.persistence_tracker {
             tracker.signal_shutdown();
 
-            // Give the thread a moment to finish and persist on shutdown
-            // The background thread will call persist_all_indexes() before exiting
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            // Wait for the background thread to fully exit and release all resources
+            // This ensures the thread drops its Arc references to TieredStorage/RedbColdStorage
+            // before Drop returns, preventing file locking issues when reopening Redb.
+            if let Some(handle) = self.persistence_thread_handle.take() {
+                let _ = handle.join();
+            }
         }
     }
 }

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -878,6 +878,42 @@ impl HistoricalStorage {
         self.reconstruct_node_properties_with_depth(version_id, 0)
     }
 
+    /// Get a node version from hot or cold storage.
+    ///
+    /// This is a helper for reconstruction that checks hot storage first (fast path),
+    /// then falls back to tiered storage for cold data access.
+    ///
+    /// Returns `Err(VersionNotFound)` if the version doesn't exist in any tier.
+    #[inline]
+    fn get_node_version_any_tier(&self, version_id: VersionId) -> Result<Arc<NodeVersion>> {
+        if let Some(v) = self.node_versions.get(&version_id) {
+            // Fast path: version in hot storage
+            Ok(Arc::new(v.clone()))
+        } else {
+            // Slow path: check cold storage via tiered layer
+            self.get_node_version_tiered(version_id)?
+                .ok_or(StorageError::VersionNotFound(version_id).into())
+        }
+    }
+
+    /// Get an edge version from hot or cold storage.
+    ///
+    /// This is a helper for reconstruction that checks hot storage first (fast path),
+    /// then falls back to tiered storage for cold data access.
+    ///
+    /// Returns `Err(VersionNotFound)` if the version doesn't exist in any tier.
+    #[inline]
+    fn get_edge_version_any_tier(&self, version_id: VersionId) -> Result<Arc<EdgeVersion>> {
+        if let Some(v) = self.edge_versions.get(&version_id) {
+            // Fast path: version in hot storage
+            Ok(Arc::new(v.clone()))
+        } else {
+            // Slow path: check cold storage via tiered layer
+            self.get_edge_version_tiered(version_id)?
+                .ok_or(StorageError::VersionNotFound(version_id).into())
+        }
+    }
+
     /// Iterative property reconstruction helper for nodes (Issue #211).
     ///
     /// This function implements the core iterative reconstruction algorithm.
@@ -920,10 +956,7 @@ impl HistoricalStorage {
                 .into());
             }
 
-            let version = self
-                .node_versions
-                .get(&current_id)
-                .ok_or(StorageError::VersionNotFound(current_id))?;
+            let version = self.get_node_version_any_tier(current_id)?;
 
             let is_anchor = version.is_anchor();
             let prev_id = version.prev_version;
@@ -956,10 +989,7 @@ impl HistoricalStorage {
                     reason: "Empty version chain during reconstruction".to_string(),
                 })?;
 
-        let anchor_version = self
-            .node_versions
-            .get(&anchor_id)
-            .ok_or(StorageError::VersionNotFound(anchor_id))?;
+        let anchor_version = self.get_node_version_any_tier(anchor_id)?;
 
         let mut properties = match &anchor_version.data {
             VersionData::Anchor { properties, .. } => properties.clone(),
@@ -976,10 +1006,7 @@ impl HistoricalStorage {
         // Apply deltas in forward order (reverse of collection order)
         // Skip the last element (anchor) since we already have its properties
         for &vid in version_ids.iter().rev().skip(1) {
-            let version = self
-                .node_versions
-                .get(&vid)
-                .ok_or(StorageError::VersionNotFound(vid))?;
+            let version = self.get_node_version_any_tier(vid)?;
 
             match &version.data {
                 VersionData::Delta { delta } => {
@@ -1027,10 +1054,7 @@ impl HistoricalStorage {
                 .into());
             }
 
-            let version = self
-                .edge_versions
-                .get(&current_id)
-                .ok_or(StorageError::VersionNotFound(current_id))?;
+            let version = self.get_edge_version_any_tier(current_id)?;
 
             let is_anchor = version.is_anchor();
             let prev_id = version.prev_version;
@@ -1063,10 +1087,7 @@ impl HistoricalStorage {
                     reason: "Empty version chain during reconstruction".to_string(),
                 })?;
 
-        let anchor_version = self
-            .edge_versions
-            .get(&anchor_id)
-            .ok_or(StorageError::VersionNotFound(anchor_id))?;
+        let anchor_version = self.get_edge_version_any_tier(anchor_id)?;
 
         let mut properties = match &anchor_version.data {
             VersionData::Anchor { properties, .. } => properties.clone(),
@@ -1083,10 +1104,7 @@ impl HistoricalStorage {
         // Apply deltas in forward order (reverse of collection order)
         // Skip the last element (anchor) since we already have its properties
         for &vid in version_ids.iter().rev().skip(1) {
-            let version = self
-                .edge_versions
-                .get(&vid)
-                .ok_or(StorageError::VersionNotFound(vid))?;
+            let version = self.get_edge_version_any_tier(vid)?;
 
             match &version.data {
                 VersionData::Delta { delta } => {
@@ -2324,6 +2342,35 @@ impl HistoricalStorage {
             .collect();
 
         HistoricalStorageSnapshot::new(lsn, node_versions, edge_versions)
+    }
+
+    /// **Test-only helper**: Remove a node version from hot storage.
+    ///
+    /// This is used in tests to simulate version migration to cold storage.
+    /// In production, versions are migrated by the `MigrationService` which
+    /// atomically moves versions from hot to cold storage.
+    ///
+    /// # Safety
+    /// This method directly modifies internal state and should only be used
+    /// in tests. It does not update caches or notify observers.
+    #[doc(hidden)]
+    pub fn __test_remove_node_version(&mut self, version_id: VersionId) {
+        self.node_versions.remove(&version_id);
+    }
+
+    /// **Test-only helper**: Clear the property reconstruction cache.
+    ///
+    /// This is used in tests to force actual property reconstruction instead
+    /// of returning cached values. This is essential for testing that reconstruction
+    /// works correctly when versions are in cold storage.
+    ///
+    /// # Safety
+    /// This method clears caches and should only be used in tests where you
+    /// want to verify reconstruction behavior without cache interference.
+    #[doc(hidden)]
+    pub fn __test_clear_property_cache(&self) {
+        self.node_property_cache.clear();
+        self.node_anchor_cache.clear();
     }
 }
 

--- a/src/storage/index_persistence/worker.rs
+++ b/src/storage/index_persistence/worker.rs
@@ -41,7 +41,7 @@ pub(crate) fn spawn_background_persistence_thread(
     tracker: Arc<PersistenceTracker>,
     policies: PersistencePolicies,
     stopped_flag: Arc<AtomicBool>,
-) {
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         // Wrap entire thread in panic handler to prevent silent failures
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -138,5 +138,5 @@ pub(crate) fn spawn_background_persistence_thread(
                 eprintln!("You MUST restart the database to restore automatic persistence.");
             }
         }
-    });
+    })
 }

--- a/tests/redb_file_locking.rs
+++ b/tests/redb_file_locking.rs
@@ -1,0 +1,139 @@
+#![cfg(test)]
+
+//! Tests for Redb file locking issue with background persistence thread.
+//!
+//! These tests verify that RedbColdStorage can be safely reopened after
+//! the database is dropped, even when a background persistence thread is running.
+
+use gallifreydb::GallifreyDB;
+use gallifreydb::PropertyMapBuilder;
+use gallifreydb::config::GallifreyDBConfig;
+use gallifreydb::storage::index_persistence::PersistenceConfig;
+use gallifreydb::storage::redb_cold_storage::{RedbColdStorage, RedbConfig};
+use gallifreydb::storage::tiered_storage::{TieredStorage, TieredStorageConfig};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+/// Test that Redb file can be reopened after database shutdown with background thread.
+///
+/// This is the core issue: When GallifreyDB has a background persistence thread,
+/// dropping the database signals shutdown but doesn't wait for the thread to finish.
+/// The background thread holds Arc references to TieredStorage → RedbColdStorage,
+/// which keeps the Redb database file locked. When we try to reopen the same file,
+/// it fails because Redb requires exclusive file access.
+///
+/// Setup:
+/// 1. Create database with Redb cold storage and persistence enabled
+/// 2. Add some data to trigger background thread activity
+/// 3. Drop the database (signals shutdown but returns immediately)
+/// 4. Try to reopen the same Redb file
+///
+/// Expected (before fix): Fails with "Failed to open Redb database" (file still locked)
+/// Expected (after fix): Successfully reopens the database file
+#[test]
+fn test_reopen_redb_after_shutdown_with_background_thread() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let cold_path = data_dir.join("cold.redb");
+
+    // Phase 1: Create database with persistence enabled (spawns background thread)
+    {
+        let config = GallifreyDBConfig::builder()
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: data_dir.clone(),
+                load_on_startup: false,
+                ..Default::default()
+            })
+            .build();
+
+        let db = GallifreyDB::with_unified_config(config).unwrap();
+
+        // Create Redb cold storage
+        let cold = RedbColdStorage::new(&cold_path, RedbConfig::new()).unwrap();
+        let tiered = Arc::new(TieredStorage::new(
+            TieredStorageConfig::default(),
+            Box::new(cold),
+        ));
+
+        // Wire up tiered storage to historical storage
+        {
+            let mut historical = db.__test_historical_storage().write();
+            historical.set_tiered_storage(tiered.clone());
+        }
+
+        // Add some data to trigger background thread activity
+        let _node1 = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", "Alice")
+                    .insert("age", 30i64)
+                    .build(),
+            )
+            .unwrap();
+
+        let _node2 = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("name", "Bob")
+                    .insert("age", 25i64)
+                    .build(),
+            )
+            .unwrap();
+
+        // Persist to ensure background thread has references
+        db.persist_indexes().unwrap();
+
+        // Drop database - this signals shutdown but returns immediately
+        // The background thread may still be running and holding the Redb file
+        println!("Dropping database...");
+        drop(db);
+        println!("Database dropped, but background thread may still be running");
+    }
+
+    // Phase 2: Try to reopen the same Redb file
+    // THIS IS THE KEY TEST: Should the file still be locked?
+    println!("Attempting to reopen Redb file...");
+
+    // Before fix: This fails with "Failed to open Redb database: DatabaseAlreadyOpen"
+    // After fix: This succeeds because background thread has fully exited
+    let result = RedbColdStorage::new(&cold_path, RedbConfig::new());
+
+    match result {
+        Ok(_) => println!("✓ Successfully reopened Redb file"),
+        Err(e) => {
+            println!("✗ Failed to reopen Redb file: {}", e);
+            panic!(
+                "EXPECTED FAILURE (RED phase): Background thread still holds Redb file lock. \
+                    This test should fail before the fix is implemented. \
+                    Error: {}",
+                e
+            );
+        }
+    }
+}
+
+/// Test that Redb file can be reopened immediately without background thread.
+///
+/// This is a control test to verify that the issue is specifically related to the
+/// background persistence thread, not Redb itself.
+#[test]
+fn test_reopen_redb_without_background_thread() {
+    let temp_dir = TempDir::new().unwrap();
+    let cold_path = temp_dir.path().join("cold.redb");
+
+    // Create Redb storage without any background threads
+    {
+        let _cold = RedbColdStorage::new(&cold_path, RedbConfig::new()).unwrap();
+        // Drop immediately
+    }
+
+    // Should be able to reopen immediately since no background thread involved
+    let result = RedbColdStorage::new(&cold_path, RedbConfig::new());
+    assert!(
+        result.is_ok(),
+        "Should be able to reopen Redb file without background thread"
+    );
+}

--- a/tests/tiered_storage_reconstruction.rs
+++ b/tests/tiered_storage_reconstruction.rs
@@ -1,0 +1,254 @@
+#![cfg(test)]
+
+//! Tests for version chain reconstruction with tiered storage.
+//!
+//! These tests verify that HistoricalStorage can reconstruct properties
+//! from version chains even when some versions have been migrated to cold storage.
+
+use gallifreydb::PropertyMapBuilder;
+use gallifreydb::core::GLOBAL_INTERNER;
+use gallifreydb::core::id::{NodeId, VersionId};
+use gallifreydb::core::temporal::{BiTemporalInterval, time};
+use gallifreydb::storage::historical::HistoricalStorage;
+use gallifreydb::storage::redb_cold_storage::{RedbColdStorage, RedbConfig};
+use gallifreydb::storage::tiered_storage::{TieredStorage, TieredStorageConfig};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+/// Test that version chain reconstruction works when middle versions are in cold storage.
+///
+/// This is the core issue: when versions in the middle of a chain are migrated to cold,
+/// reconstruct_node_properties should still be able to walk the chain and reconstruct properties.
+///
+/// Setup:
+/// 1. Create a node with 5 versions (v1 -> v2 -> v3 -> v4 -> v5)
+/// 2. Migrate v2, v3, v4 to cold storage (keep v1 and v5 in hot)
+/// 3. Attempt to reconstruct properties for v5
+///
+/// Expected: Should successfully reconstruct by walking chain through cold storage
+/// Actual (before fix): Fails with "Delta version has no previous version"
+#[test]
+fn test_reconstruct_properties_with_cold_versions_in_chain() {
+    let temp_dir = TempDir::new().unwrap();
+    let cold_path = temp_dir.path().join("cold.redb");
+
+    // Create cold storage and tiered storage
+    let cold = RedbColdStorage::new(&cold_path, RedbConfig::new()).unwrap();
+    let tiered_config = TieredStorageConfig::default();
+    let tiered = Arc::new(TieredStorage::new(tiered_config, Box::new(cold)));
+
+    // Create historical storage with tiered storage enabled
+    let mut historical = HistoricalStorage::new();
+    historical.set_tiered_storage(tiered.clone());
+
+    let node_id = NodeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+
+    // Create version 1 (anchor) - name: "Alice"
+    let v1_id = VersionId::new(1).unwrap();
+    let props_v1 = PropertyMapBuilder::new()
+        .insert("name", "Alice")
+        .insert("age", 30i64)
+        .build();
+    historical
+        .add_node_version(
+            node_id,
+            v1_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v1.clone(),
+        )
+        .unwrap();
+
+    // Create version 2 (delta) - name: "Alice", age: 31
+    let v2_id = VersionId::new(2).unwrap();
+    let props_v2 = PropertyMapBuilder::new()
+        .insert("name", "Alice")
+        .insert("age", 31i64)
+        .build();
+    historical
+        .add_node_version(
+            node_id,
+            v2_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v2.clone(),
+        )
+        .unwrap();
+
+    // Create version 3 (delta) - name: "Alice Smith", age: 31
+    let v3_id = VersionId::new(3).unwrap();
+    let props_v3 = PropertyMapBuilder::new()
+        .insert("name", "Alice Smith")
+        .insert("age", 31i64)
+        .build();
+    historical
+        .add_node_version(
+            node_id,
+            v3_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v3.clone(),
+        )
+        .unwrap();
+
+    // Create version 4 (delta) - name: "Alice Smith", age: 32
+    let v4_id = VersionId::new(4).unwrap();
+    let props_v4 = PropertyMapBuilder::new()
+        .insert("name", "Alice Smith")
+        .insert("age", 32i64)
+        .build();
+    historical
+        .add_node_version(
+            node_id,
+            v4_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v4.clone(),
+        )
+        .unwrap();
+
+    // Create version 5 (delta) - name: "Alice Smith-Jones", age: 32
+    let v5_id = VersionId::new(5).unwrap();
+    let props_v5 = PropertyMapBuilder::new()
+        .insert("name", "Alice Smith-Jones")
+        .insert("age", 32i64)
+        .build();
+    historical
+        .add_node_version(
+            node_id,
+            v5_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v5.clone(),
+        )
+        .unwrap();
+
+    // Skip the before-migration reconstruction to avoid populating the cache
+    // (The cache would make the test pass incorrectly)
+
+    // Now migrate v2, v3, v4 to cold storage
+    // In a real scenario, this would be done by MigrationService,
+    // but we'll manually move them to cold storage and remove from hot
+    let v2 = historical.get_node_version(v2_id).unwrap().clone();
+    let v3 = historical.get_node_version(v3_id).unwrap().clone();
+    let v4 = historical.get_node_version(v4_id).unwrap().clone();
+
+    // Store in cold storage
+    tiered.cold_storage().store_node_version(&v2).unwrap();
+    tiered.cold_storage().store_node_version(&v3).unwrap();
+    tiered.cold_storage().store_node_version(&v4).unwrap();
+
+    // Remove from hot storage to simulate migration
+    println!(
+        "Before removal: v4 in hot = {}",
+        historical.get_node_version(v4_id).is_some()
+    );
+    historical.__test_remove_node_version(v2_id);
+    historical.__test_remove_node_version(v3_id);
+    historical.__test_remove_node_version(v4_id);
+    println!(
+        "After removal: v4 in hot = {}",
+        historical.get_node_version(v4_id).is_some()
+    );
+
+    // Verify they're not in hot storage
+    assert!(
+        historical.get_node_version(v2_id).is_none(),
+        "v2 should not be in hot storage"
+    );
+    assert!(
+        historical.get_node_version(v3_id).is_none(),
+        "v3 should not be in hot storage"
+    );
+    assert!(
+        historical.get_node_version(v4_id).is_none(),
+        "v4 should not be in hot storage"
+    );
+
+    // Verify they're in cold storage via tiered access
+    assert!(historical.get_node_version_tiered(v2_id).unwrap().is_some());
+    assert!(historical.get_node_version_tiered(v3_id).unwrap().is_some());
+    assert!(historical.get_node_version_tiered(v4_id).unwrap().is_some());
+
+    // Clear the property cache to force actual reconstruction (not using cached values)
+    println!("Clearing property cache to force chain traversal");
+    historical.__test_clear_property_cache();
+
+    // THIS IS THE KEY TEST: Reconstruct v5 properties with cold versions in chain
+    // Should walk: v5 (hot) -> v4 (cold) -> v3 (cold) -> v2 (cold) -> v1 (hot, anchor)
+    // The bug: reconstruct_node_properties only looks in hot storage when walking the chain
+    println!("About to reconstruct v5 - this SHOULD fail because v4 is not in hot storage");
+
+    let reconstructed = historical.reconstruct_node_properties(v5_id);
+
+    // GREEN PHASE: After the fix, reconstruction should succeed!
+    let reconstructed = reconstructed.unwrap();
+    assert_eq!(
+        reconstructed.get("name").unwrap().as_str().unwrap(),
+        "Alice Smith-Jones",
+        "Name should be reconstructed correctly from version chain spanning cold storage"
+    );
+    assert_eq!(
+        reconstructed.get("age").unwrap().as_int().unwrap(),
+        32,
+        "Age should be reconstructed correctly from version chain spanning cold storage"
+    );
+}
+
+/// Test edge case: reconstruct when the requested version itself is in cold storage.
+#[test]
+fn test_reconstruct_properties_for_version_in_cold_storage() {
+    let temp_dir = TempDir::new().unwrap();
+    let cold_path = temp_dir.path().join("cold.redb");
+
+    let cold = RedbColdStorage::new(&cold_path, RedbConfig::new()).unwrap();
+    let tiered = Arc::new(TieredStorage::new(
+        TieredStorageConfig::default(),
+        Box::new(cold),
+    ));
+
+    let mut historical = HistoricalStorage::new();
+    historical.set_tiered_storage(tiered.clone());
+
+    let node_id = NodeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+
+    // Create anchor
+    let v1_id = VersionId::new(1).unwrap();
+    let props_v1 = PropertyMapBuilder::new().insert("name", "Bob").build();
+    historical
+        .add_node_version(
+            node_id,
+            v1_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v1.clone(),
+        )
+        .unwrap();
+
+    // Create delta
+    let v2_id = VersionId::new(2).unwrap();
+    let props_v2 = PropertyMapBuilder::new().insert("name", "Robert").build();
+    historical
+        .add_node_version(
+            node_id,
+            v2_id,
+            BiTemporalInterval::current(time::now()),
+            label,
+            props_v2.clone(),
+        )
+        .unwrap();
+
+    // Migrate v2 itself to cold storage
+    let v2 = historical.get_node_version(v2_id).unwrap().clone();
+    tiered.cold_storage().store_node_version(&v2).unwrap();
+    historical.__test_remove_node_version(v2_id);
+
+    // Reconstruct v2 (which is now in cold storage)
+    let reconstructed = historical.reconstruct_node_properties(v2_id).unwrap();
+    assert_eq!(
+        reconstructed.get("name").unwrap().as_str().unwrap(),
+        "Robert"
+    );
+}


### PR DESCRIPTION
## Summary
Fixed two critical bugs preventing Redb cold storage integration:

### Issue 1: Version Chain Reconstruction Failure
**Problem**: `reconstruct_node_properties()` fails with "Delta version has no previous version" when versions are migrated to cold storage.

**Root Cause**: Reconstruction only checked hot storage (in-memory HashMap), failed when versions moved to cold tier.

**Solution**: 
- Added `get_node_version_any_tier()` and `get_edge_version_any_tier()` helper methods
- Updated reconstruction to check hot → warm cache → cold storage
- Applied fix to both node and edge reconstruction

**Tests**:
- `test_reconstruct_properties_with_cold_versions_in_chain` - Core test with 5-version chain
- `test_reconstruct_properties_for_version_in_cold_storage` - Edge case test

### Issue 2: Redb File Locking on Reopen
**Problem**: Cannot reopen Redb database file after `drop(db)` - fails with "Database already open. Cannot acquire lock."

**Root Cause**: Background persistence thread holds `Arc<TieredStorage>` → `Arc<RedbColdStorage>`, keeping file locked. `Drop` only signals shutdown and sleeps 100ms, doesn't wait for thread to exit.

**Solution**:
- Store `JoinHandle<()>` for background thread in `GallifreyDB`
- Modified `Drop` impl to `join()` thread instead of `sleep(100ms)`
- Ensures thread fully exits and releases all Arc references before Drop returns

**Tests**:
- `test_reopen_redb_after_shutdown_with_background_thread` - Core test with background thread
- `test_reopen_redb_without_background_thread` - Control test confirming Redb works without thread

## Test Coverage
- ✅ All 4 new tests pass
- ✅ All 83 existing historical storage tests still pass (no regression)
- ✅ Clippy passes with no warnings

## TDD Approach
Both fixes followed strict RED-GREEN-REFACTOR cycle:
1. **RED**: Wrote failing tests demonstrating the bugs
2. **GREEN**: Implemented minimal fixes to make tests pass
3. **REFACTOR**: Cleaned up code (extracted helpers, removed duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)