### PR TITLE
🎻 Bard: Storage Index Persistence Documentation Update

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -709,7 +709,7 @@ impl PropertyValue {
 /// * `v` - The vector data to serialize
 ///
 /// # Returns
-/// A Vec<u8> containing the serialized vector
+/// A `Vec<u8>` containing the serialized vector
 ///
 /// # Example
 /// ```ignore
@@ -926,7 +926,7 @@ pub fn deserialize_vector(bytes: &[u8]) -> Result<(Arc<[f32]>, usize)> {
 /// * `sv` - The sparse vector to serialize
 ///
 /// # Returns
-/// A Vec<u8> containing the serialized sparse vector
+/// A `Vec<u8>` containing the serialized sparse vector
 pub fn serialize_sparse_vector(sv: &SparseVec) -> Vec<u8> {
     let mut buffer = Vec::with_capacity(1 + 4 + 4 + sv.nnz() * 8);
     serialize_sparse_vector_into(sv, &mut buffer);

--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -1094,7 +1094,7 @@ impl TemporalIndexes {
     ///
     /// # Current Limitations
     ///
-    /// This implementation still allocates a Vec<VersionId> internally due to
+    /// This implementation still allocates a `Vec<VersionId>` internally due to
     /// DashMap's guard-based access patterns. Future optimizations might use
     /// different concurrent data structures to enable true lazy iteration.
     fn find_version_at_point_iter_impl(

--- a/src/index/vector/temporal.rs
+++ b/src/index/vector/temporal.rs
@@ -959,7 +959,7 @@ pub struct TemporalVectorIndex {
     current: Arc<HnswIndex>,
 
     /// Combined current vector storage and metadata protected by a single lock
-    /// **Issue #233**: This replaces separate DashMap<vectors> and RwLock<metadata>
+    /// **Issue #233**: This replaces separate `DashMap<vectors>` and `RwLock<metadata>`
     /// to reduce lock contention from 3 acquisitions to 1 per add() call
     current_state: RwLock<VectorState>,
 

--- a/src/storage/cold_storage.rs
+++ b/src/storage/cold_storage.rs
@@ -1005,7 +1005,7 @@ enum SerializableVersionData {
 
 /// Serializable property value.
 ///
-/// Note: Array is stored as a serialized Vec<u8> to avoid recursive type issues with bitcode.
+/// Note: Array is stored as a serialized `Vec<u8>` to avoid recursive type issues with bitcode.
 #[derive(bitcode::Encode, bitcode::Decode)]
 enum SerializablePropertyValue {
     Null,

--- a/src/storage/current.rs
+++ b/src/storage/current.rs
@@ -1334,7 +1334,7 @@ impl CurrentStorage {
     }
 
     /// Helper method to prepare for vector search.
-    /// Returns the Arc<HnswIndex> and the query vector.
+    /// Returns the `Arc<HnswIndex>` and the query vector.
     ///
     /// This uses the "default" property (first enabled) for backward compatibility.
     /// For multi-property searches, use `find_similar_in` instead.
@@ -1845,7 +1845,7 @@ impl CurrentStorage {
     }
 
     /// Helper method to prepare for raw embedding vector search.
-    /// Returns the Arc<HnswIndex> and validates the embedding.
+    /// Returns the `Arc<HnswIndex>` and validates the embedding.
     ///
     /// This uses the "default" property (first enabled) for backward compatibility.
     /// For multi-property searches, use `search_vectors_in` instead.

--- a/src/storage/historical.rs
+++ b/src/storage/historical.rs
@@ -1242,7 +1242,7 @@ impl HistoricalStorage {
 
     /// Get all node versions for all nodes.
     ///
-    /// Returns a map of NodeId -> Vec<NodeVersion> for recovery property tests.
+    /// Returns a map of NodeId -> `Vec<NodeVersion>` for recovery property tests.
     /// This walks through all node versions and groups them by entity ID.
     pub fn get_all_node_versions(&self) -> std::collections::HashMap<NodeId, Vec<&NodeVersion>> {
         let mut result: std::collections::HashMap<NodeId, Vec<&NodeVersion>> =
@@ -1257,7 +1257,7 @@ impl HistoricalStorage {
 
     /// Get all edge versions for all edges.
     ///
-    /// Returns a map of EdgeId -> Vec<EdgeVersion> for recovery property tests.
+    /// Returns a map of EdgeId -> `Vec<EdgeVersion>` for recovery property tests.
     /// This walks through all edge versions and groups them by entity ID.
     pub fn get_all_edge_versions(&self) -> std::collections::HashMap<EdgeId, Vec<&EdgeVersion>> {
         let mut result: std::collections::HashMap<EdgeId, Vec<&EdgeVersion>> =

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -1,4 +1,20 @@
 //! Bitcode-serializable format structs for index persistence.
+//!
+//! This module defines the schema for all persisted index files. These structs are
+//! serialized using [bitcode](https://github.com/llogiq/bitcode), a fast and compact
+//! binary serialization format.
+//!
+//! # Schema Overview
+//!
+//! | Struct | Corresponding File | Description |
+//! |--------|-------------------|-------------|
+//! | [`IndexManifest`] | `manifest.idx` | Root registry of all indexes |
+//! | [`StringInternerData`] | `strings/interner.idx` | Interned strings table |
+//! | [`GraphIndexData`] | `graph/adjacency.idx` | Graph structure and properties |
+//! | [`GraphIndexDelta`] | `graph/delta.idx` | Incremental graph changes |
+//! | [`TemporalIndexData`] | `temporal/versions.idx` | Historical version chains |
+//! | [`VectorIndexMeta`] | `vector/{prop}/meta.idx` | Vector index metadata |
+//! | [`VectorMappingsData`] | `vector/{prop}/mappings.idx` | Vector ID mappings |
 
 use bitcode::{Decode, Encode};
 

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -136,7 +136,7 @@ pub fn restore_property_map(persisted: &PersistedPropertyMap) -> Result<Property
 
 /// Save graph index data to disk with CRC32 checksum using atomic write.
 ///
-/// Format: [bitcode_data][crc32_checksum_4_bytes]
+/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
 ///
 /// Uses write-temp-then-rename to prevent corruption on crash.
 pub fn save_graph_index(data: &GraphIndexData, path: &Path) -> Result<()> {

--- a/src/storage/index_persistence/manifest.rs
+++ b/src/storage/index_persistence/manifest.rs
@@ -48,7 +48,7 @@ impl IndexManifest {
 
 /// Save manifest to disk with CRC32 checksum using atomic write.
 ///
-/// Format: [bitcode_data][crc32_checksum_4_bytes]
+/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
 ///
 /// Uses write-temp-then-rename to prevent corruption on crash.
 pub fn save_manifest(manifest: &IndexManifest, path: &Path) -> Result<()> {

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -13,7 +13,7 @@
 //! ├── manifest.idx          # Index registry
 //! ├── strings/interner.idx  # String interning table
 //! ├── graph/adjacency.idx   # CSR adjacency data
-//! ├── temporal/*.idx        # Version chains
+//! ├── temporal/versions.idx # Version chains
 //! └── vector/{prop}/        # Per-property vector indexes
 //! ```
 //!
@@ -27,7 +27,7 @@
 //!
 //! ```ignore
 //! use gallifreydb::storage::index_persistence::{
-//!     IndexPersistenceManager, PersistenceConfig
+//!     IndexPersistenceManager, PersistenceConfig, IndexManifest
 //! };
 //!
 //! let manager = IndexPersistenceManager::new("data");
@@ -48,22 +48,31 @@
 //!
 //! # Format Details
 //!
-//! All index files use bitcode serialization with magic bytes and version validation:
+//! All index files (except the native HNSW index) use [bitcode](https://github.com/llogiq/bitcode)
+//! serialization with a consistent header format: `[MAGIC:4][VERSION:1][DATA...]`.
 //!
-//! - **Manifest** (`GIDX`): Index registry, LSN tracking, timestamps
-//! - **String Interner** (`GSTR`): Ordered string list for ID restoration
-//! - **Graph** (`GGRP`): Nodes, edges, CSR adjacency, properties
-//! - **Temporal** (`GTMP`): Version chains, anchors, deltas
-//! - **Vector** (`GVEC`): Metadata, ID mappings, HNSW snapshots
+//! | File Type | Magic Bytes | Rust Struct | Description |
+//! |-----------|-------------|-------------|-------------|
+//! | **Manifest** | `GIDX` | [`formats::IndexManifest`] | Registry of all indexes, LSN tracking, and timestamps. |
+//! | **String Interner** | `GSTR` | [`formats::StringInternerData`] | Ordered list of interned strings for ID restoration. |
+//! | **Graph Index** | `GGRP` | [`formats::GraphIndexData`] | Nodes, edges, CSR adjacency, and current properties. |
+//! | **Graph Delta** | `GDLT` | [`formats::GraphIndexDelta`] | Incremental changes (added/modified/deleted) since base snapshot. |
+//! | **Temporal Index** | `GTMP` | [`formats::TemporalIndexData`] | Version chains, anchors, and deltas for time-travel. |
+//! | **Vector Meta** | `GVEC` | [`formats::VectorIndexMeta`] | Metadata for a vector index (dimensions, metric, etc.). |
 //!
-//! # Versioning
+//! ## Vector Index Hybrid Format
 //!
-//! Current format version: 1
+//! Vector indexes use a hybrid format for performance:
+//! 1. **Metadata** (`meta.idx`): Bitcode-serialized [`formats::VectorIndexMeta`].
+//! 2. **Mappings** (`mappings.idx`): Bitcode-serialized [`formats::VectorMappingsData`] mapping NodeIDs to usearch keys.
+//! 3. **Index** (`current.usearch`): Native binary format produced by the `usearch` C++ library (HNSW graph).
 //!
-//! Backward compatibility:
-//! - Same major version: guaranteed compatible
-//! - Newer minor version: older code can read newer files
-//! - Unsupported version: returns `UnsupportedVersion` error
+//! # Safety and Integrity
+//!
+//! - **Atomic Writes**: All files are written using a write-temp-then-rename strategy (`atomic_write`) to prevent corruption during crashes.
+//! - **Checksums**: Many formats (Graph, Vector Meta/Mappings) include CRC32 checksums for integrity verification.
+//! - **Magic Bytes**: All files start with 4 magic bytes to prevent parsing invalid file types.
+//! - **Versioning**: All files include a version byte to support future schema evolution.
 
 pub mod api;
 mod error;

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -12,7 +12,7 @@ use super::{INTERNER_MAGIC, MANIFEST_VERSION};
 
 /// Save the global string interner to disk with CRC32 checksum using atomic write.
 ///
-/// Format: [bitcode_data][crc32_checksum_4_bytes]
+/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
 ///
 /// Uses write-temp-then-rename to prevent corruption on crash.
 pub fn save_string_interner(path: &Path) -> Result<()> {

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -409,7 +409,7 @@ pub fn restore_into_historical_storage(
 
 /// Save temporal index data to disk with CRC32 checksum using atomic write.
 ///
-/// Format: [bitcode_data][crc32_checksum_4_bytes]
+/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
 ///
 /// Uses write-temp-then-rename to prevent corruption on crash.
 pub fn save_temporal_index(data: &TemporalIndexData, path: &Path) -> Result<()> {

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -50,7 +50,7 @@ use std::sync::Arc;
 ///
 /// Snapshots use Arc-based COW:
 /// - Snapshot creation does ONE iteration over DashMap/structures
-/// - Collects Arc<T> references (cheap, just pointer + refcount)
+/// - Collects `Arc<T>` references (cheap, just pointer + refcount)
 /// - Total memory: 8 bytes × num_entities (not full clones)
 /// - Iteration over snapshot is isolated from concurrent writes
 pub trait StorageSnapshot: Send + Sync {
@@ -155,7 +155,7 @@ impl StorageSnapshot for CurrentStorageSnapshot {
 /// Iterator over nodes in CurrentStorageSnapshot.
 ///
 /// Clones nodes from Arc references during iteration (streaming).
-/// No Vec<Node> allocation - memory efficient for large graphs.
+/// No `Vec<Node>` allocation - memory efficient for large graphs.
 pub struct CurrentNodeIterator {
     nodes: Vec<Arc<Node>>,
     index: usize,
@@ -189,7 +189,7 @@ impl ExactSizeIterator for CurrentNodeIterator {
 /// Iterator over edges in CurrentStorageSnapshot.
 ///
 /// Clones edges from Arc references during iteration (streaming).
-/// No Vec<Edge> allocation - memory efficient for large graphs.
+/// No `Vec<Edge>` allocation - memory efficient for large graphs.
 pub struct CurrentEdgeIterator {
     edges: Vec<Arc<Edge>>,
     index: usize,


### PR DESCRIPTION
🎻 Bard: Storage Index Persistence Documentation Update

📖 Chapter: The `storage::index_persistence` module.

🔦 Insight:
- Clarified the relationship between on-disk file formats (GIDX, GSTR, etc.) and their Rust struct representations.
- Added a detailed "Format Details" table linking magic bytes to structs.
- Documented the safety mechanisms (atomic writes, checksums) used in persistence.
- Added module-level documentation to `src/storage/index_persistence/formats.rs` explaining it as the schema definition.

🧪 Verification:
- Ran `cargo test storage` to ensure no regressions.
- Ran `cargo doc` and fixed several pre-existing documentation warnings (unclosed HTML tags, broken links).

Example of improved documentation:
```rust
//! # Schema Overview
//!
//! | Struct | Corresponding File | Description |
//! |--------|-------------------|-------------|
//! | [`IndexManifest`] | `manifest.idx` | Root registry of all indexes |
//! | ...
```


---
*PR created automatically by Jules for task [984163317773834164](https://jules.google.com/task/984163317773834164) started by @madmax983*