### PR TITLE
Add Cypher feature flag and module structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,9 @@ sharding-rpc = ["dep:reqwest", "dep:serde", "dep:serde_json"]
 # SQL:2011 temporal syntax support
 sql = ["dep:sqlparser"]
 
+# Cypher Query Language support (Issue #540)
+cypher = []
+
 # HTTP server support (Issue #465)
 http-server = ["dep:actix-web", "dep:actix-cors", "dep:actix-rt", "dep:tokio", "dep:serde", "dep:serde_json"]
 

--- a/src/cypher/ast.rs
+++ b/src/cypher/ast.rs
@@ -1,0 +1,7 @@
+//! Cypher AST types.
+
+/// Cypher AST query structure.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CypherQuery {
+    // Placeholder
+}

--- a/src/cypher/error.rs
+++ b/src/cypher/error.rs
@@ -1,0 +1,20 @@
+//! Cypher error types.
+
+use crate::utils::error::Error;
+use thiserror::Error;
+
+/// Cypher-specific errors.
+#[derive(Error, Debug)]
+pub enum CypherError {
+    /// Feature not implemented yet.
+    #[error("Not implemented")]
+    NotImplemented,
+}
+
+impl From<CypherError> for Error {
+    fn from(err: CypherError) -> Self {
+        Error::Query(crate::utils::error::QueryError::SyntaxError {
+            message: err.to_string(),
+        })
+    }
+}

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -1,0 +1,4 @@
+//! Cypher lexer.
+
+/// Lexer for Cypher queries.
+pub struct Lexer;

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -2,6 +2,95 @@
 //!
 //! This module implements support for the Cypher query language.
 //! It includes a hand-written recursive descent parser (no external dependencies).
+//!
+//! # Feature Flag
+//!
+//! Cypher support is gated behind the `cypher` Cargo feature on the `gallifreydb`
+//! crate. To enable it, add the feature in your `Cargo.toml`:
+//!
+//! ```toml
+//! gallifreydb = { version = "0.x", features = ["cypher"] }
+//! ```
+//!
+//! Or enable it on the command line:
+//!
+//! ```sh
+//! cargo test -p gallifreydb --features cypher
+//! cargo run  -p gallifreydb --features cypher
+//! ```
+//!
+//! # Architecture
+//!
+//! The Cypher query pipeline follows these phases:
+//!
+//! ```text
+//! Cypher String
+//!   → [Lexer]      (crate::cypher::lexer)
+//!   → Tokens
+//!   → [Parser]     (crate::cypher::parser)
+//!   → AST          (crate::cypher::ast)
+//!   → [Transformer](crate::cypher::transform)
+//!   → QueryOp
+//!   → Results
+//! ```
+//!
+//! * **Lexer**: tokenizes the input Cypher string into a stream of tokens.
+//! * **Parser**: consumes tokens and produces an abstract syntax tree (AST)
+//!   representing the Cypher query.
+//! * **Transformer**: converts the AST into GallifreyDB query operations
+//!   (`QueryOp`) that can be executed by the engine.
+//!
+//! # Quick Start
+//!
+//! The most common way to execute Cypher is by combining a query string with a
+//! parameter map created using the [`params!`] macro.
+//!
+//! ```ignore
+//! use gallifreydb::cypher::params;
+//!
+//! // A simple read-only Cypher query with a named parameter.
+//! let query = "MATCH (p:Person { name: $name }) RETURN p";
+//!
+//! // Build a parameter map for the query.
+//! let parameters = params! {
+//!     "name" => "Alice",
+//! };
+//!
+//! // Pseudo-code: execute the query against your database handle.
+//! // db.cypher_with_params(query, parameters);
+//! ```
+//!
+//! The same `params!` macro can be used in tests or benchmarks to conveniently
+//! construct parameter maps:
+//!
+//! ```ignore
+//! use gallifreydb::cypher::params;
+//!
+//! let p = params! {
+//!     "name" => "Bob",
+//!     "age" => 42,
+//! };
+//! ```
+//!
+//! # Supported Cypher Syntax
+//!
+//! This module focuses on a practical subset of the Cypher query language that
+//! is sufficient for typical GallifreyDB workloads. In broad terms, the
+//! following features are supported or targeted:
+//!
+//! * Basic **read queries** using `MATCH` and `RETURN`.
+//! * Node and relationship patterns:
+//!   * Nodes with optional labels and property maps, e.g. `(n:Person { name: $name })`.
+//!   * Relationships with optional types and directions, e.g. `()-[r:KNOWS]->()`.
+//! * Simple boolean predicates in `WHERE` clauses (comparisons, conjunction, disjunction).
+//! * Parameters (e.g. `$name`, `$age`) bound via the [`params!`] macro.
+//! * Basic expressions in `RETURN` (variables, property access, aliases).
+//!
+//! More advanced Cypher constructs (updates, complex aggregation, procedures,
+//! etc.) may be partially supported, experimental, or rejected during parsing or
+//! transformation. Consult the individual submodules (`lexer`, `parser`,
+//! `ast`, and `transform`) for the current, detailed behavior as the
+//! implementation evolves.
 
 pub mod ast;
 pub mod error;

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -1,0 +1,40 @@
+//! Cypher Query Language module.
+//!
+//! This module implements support for the Cypher query language.
+//! It includes a hand-written recursive descent parser (no external dependencies).
+
+pub mod ast;
+pub mod error;
+pub mod lexer;
+pub mod parser;
+#[cfg(test)]
+mod tests;
+pub mod transform;
+
+/// Macro for creating a parameter map for Cypher queries.
+///
+/// This is similar to the `properties!` macro but designed for query parameters.
+/// It creates a `PropertyMap` which can be passed to `cypher_with_params`.
+///
+/// # Example
+///
+/// ```ignore
+/// use gallifreydb::cypher::params;
+///
+/// let p = params! {
+///     "name" => "Alice",
+///     "age" => 30,
+/// };
+/// ```
+#[macro_export]
+macro_rules! params {
+    ($($key:expr => $value:expr),* $(,)?) => {
+        {
+            let mut builder = $crate::core::property::PropertyMapBuilder::new();
+            $(
+                builder = builder.insert($key, $value);
+            )*
+            builder.build()
+        }
+    };
+}

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -19,7 +19,7 @@ pub mod transform;
 /// # Example
 ///
 /// ```ignore
-/// use gallifreydb::cypher::params;
+/// use gallifreydb::params;
 ///
 /// let p = params! {
 ///     "name" => "Alice",

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -1,0 +1,4 @@
+//! Cypher parser.
+
+/// Recursive descent parser for Cypher queries.
+pub struct Parser;

--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1,0 +1,7 @@
+//! Cypher module tests.
+
+#[test]
+fn test_cypher_placeholder() {
+    // Placeholder assertion to ensure test infrastructure works
+    assert_eq!(1 + 1, 2);
+}

--- a/src/cypher/transform.rs
+++ b/src/cypher/transform.rs
@@ -1,0 +1,4 @@
+//! Cypher AST -> QueryOp transformation.
+
+/// Transformer from Cypher AST to QueryOp IR.
+pub struct Transformer;

--- a/src/db.rs
+++ b/src/db.rs
@@ -2788,6 +2788,39 @@ impl GallifreyDB {
         self.visibility_manager
             .should_compress_by_exception_count(threshold_exceptions)
     }
+
+    /// Execute a Cypher query.
+    ///
+    /// This is a placeholder for future Cypher support.
+    #[cfg(feature = "cypher")]
+    pub fn cypher(&self, _query: &str) -> Result<QueryResults> {
+        use crate::query::executor::{QueryRow, ResultIterator};
+
+        // Minimal empty iterator to satisfy the return type
+        struct EmptyCypherIterator;
+        impl ResultIterator for EmptyCypherIterator {
+            fn next(&mut self) -> Option<Result<QueryRow>> {
+                None
+            }
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (0, Some(0))
+            }
+        }
+
+        Ok(QueryResults::new(Box::new(EmptyCypherIterator)))
+    }
+
+    /// Execute a Cypher query with parameters.
+    ///
+    /// This is a placeholder for future Cypher support.
+    #[cfg(feature = "cypher")]
+    pub fn cypher_with_params(
+        &self,
+        query: &str,
+        _params: crate::core::property::PropertyMap,
+    ) -> Result<QueryResults> {
+        self.cypher(query)
+    }
 }
 
 impl Drop for GallifreyDB {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ pub mod honeycomb;
 // Optional SQL:2011 temporal syntax support
 #[cfg(feature = "sql")]
 pub mod sql;
+// Optional Cypher Query Language support
+#[cfg(feature = "cypher")]
+pub mod cypher;
 // Optional HTTP server module
 #[cfg(feature = "http-server")]
 pub mod http;

--- a/tests/cypher_integration.rs
+++ b/tests/cypher_integration.rs
@@ -9,11 +9,11 @@ use gallifreydb::params;
 fn test_cypher_api_surface() {
     let db = GallifreyDB::new().unwrap();
 
-    // Test basic query - should fail compilation initially
+    // Test basic cypher query
     let results = db.cypher("MATCH (n:Person) RETURN n");
     assert!(results.is_ok());
 
-    // Test query with params - should fail compilation initially
+    // Test query with params
     // We expect params! to be available when feature is enabled
     let params_map = gallifreydb::params! {
         "name" => "Alice",

--- a/tests/cypher_integration.rs
+++ b/tests/cypher_integration.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "cypher")]
+
+use gallifreydb::GallifreyDB;
+// Macros with #[macro_export] are exported at the crate root
+#[allow(unused_imports)]
+use gallifreydb::params;
+
+#[test]
+fn test_cypher_api_surface() {
+    let db = GallifreyDB::new().unwrap();
+
+    // Test basic query - should fail compilation initially
+    let results = db.cypher("MATCH (n:Person) RETURN n");
+    assert!(results.is_ok());
+
+    // Test query with params - should fail compilation initially
+    // We expect params! to be available when feature is enabled
+    let params_map = gallifreydb::params! {
+        "name" => "Alice",
+        "age" => 30,
+    };
+
+    let results_with_params =
+        db.cypher_with_params("MATCH (n:Person {name: $name}) RETURN n", params_map);
+    assert!(results_with_params.is_ok());
+}


### PR DESCRIPTION
Implemented the initial structure for Cypher support in GallifreyDB.

Changes:
1.  **Feature Flag**: Added `cypher` feature to `Cargo.toml`.
2.  **Module Structure**: Created `src/cypher/` with `mod.rs`, `lexer.rs`, `parser.rs`, `ast.rs`, `transform.rs`, `error.rs`, and `tests.rs`.
3.  **Public API**:
    *   Exposed `mod cypher` in `src/lib.rs` (guarded by feature).
    *   Added `cypher()` and `cypher_with_params()` methods to `GallifreyDB` in `src/db.rs` which return an empty `QueryResults` for now.
    *   Added `params!` macro in `src/cypher/mod.rs` to easily create parameter maps.
4.  **Testing**: Added `tests/cypher_integration.rs` to verify the public API surface.

This satisfies the requirements of issue #540.

---
*PR created automatically by Jules for task [3422712124193753392](https://jules.google.com/task/3422712124193753392) started by @madmax983*