### PR TITLE
docs: fix broken and ignored code examples

### DIFF
--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -11,27 +11,52 @@
 //! # API Styles
 //!
 //! **Closure-based (recommended)**:
-//! ```ignore
+//! ```rust,no_run
+//! # use gallifreydb::{GallifreyDB, PropertyMapBuilder, properties};
+//! # use gallifreydb::core::NodeId;
+//! # use gallifreydb::api::transaction::{ReadOps, WriteOps};
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let db = GallifreyDB::new()?;
+//! # let id = NodeId::new(1)?;
+//! # let other = NodeId::new(2)?;
+//! # let props = PropertyMapBuilder::new().build();
+//! # let edge_props = PropertyMapBuilder::new().build();
 //! // Read-only
-//! db.read(|tx| {
-//!     let node = tx.get_node(id)?;
-//!     Ok(node.get_property("name"))
+//! let result = db.read(|tx| {
+//!     // get_node might fail if node doesn't exist
+//!     if let Ok(node) = tx.get_node(id) {
+//!         Ok(node.get_property("name").cloned())
+//!     } else {
+//!         Ok(None)
+//!     }
 //! })?;
 //!
 //! // Read-write (auto-commit on Ok, auto-rollback on Err)
-//! db.write(|tx| {
+//! let node_id = db.write(|tx| {
 //!     let node_id = tx.create_node("Person", props)?;
 //!     tx.create_edge(node_id, other, "KNOWS", edge_props)?;
 //!     Ok(node_id)
 //! })?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! **Explicit handles**:
-//! ```ignore
-//! let mut tx = db.write_transaction();
-//! tx.create_node("Person", props)?;
+//! ```rust,no_run
+//! # use gallifreydb::{GallifreyDB, PropertyMapBuilder};
+//! # use gallifreydb::core::NodeId;
+//! # use gallifreydb::api::transaction::WriteOps;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let db = GallifreyDB::new()?;
+//! # let n1 = NodeId::new(1)?;
+//! # let n2 = NodeId::new(2)?;
+//! # let props = PropertyMapBuilder::new().build();
+//! let mut tx = db.write_transaction()?;
+//! tx.create_node("Person", props.clone())?;
 //! tx.create_edge(n1, n2, "KNOWS", props)?;
 //! tx.commit()?;  // or tx.rollback()
+//! # Ok(())
+//! # }
 //! ```
 
 pub mod read_tx;
@@ -122,12 +147,19 @@ pub trait WriteOps: ReadOps {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::WriteOps;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let properties = properties! { "name" => "DeleteMe" };
     /// let mut tx = db.write_transaction()?;
     /// let node_id = tx.create_node("Person", properties)?;
     /// // ... create edges ...
     /// tx.delete_node_cascade(node_id)?; // Deletes node and all connected edges
     /// tx.commit()?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn delete_node_cascade(&mut self, node_id: NodeId) -> Result<()>;
 

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -43,7 +43,7 @@
 //!
 //! # Examples
 //!
-//! ```ignore
+//! ```rust
 //! use gallifreydb::index::VectorIndex;
 //! use gallifreydb::core::id::NodeId;
 //!
@@ -315,10 +315,12 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
     /// # use gallifreydb::core::id::NodeId;
-    /// # fn example(index: &impl VectorIndex) -> gallifreydb::utils::Result<()> {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// let node_id = NodeId::new(123).unwrap();
     /// let embedding = vec![0.1, 0.2, 0.3, 0.4];
     /// index.add(node_id, &embedding)?;
@@ -342,10 +344,12 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
     /// # use gallifreydb::core::id::NodeId;
-    /// # fn example(index: &impl VectorIndex) -> gallifreydb::utils::Result<()> {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// let node_id = NodeId::new(123).unwrap();
     /// index.remove(node_id)?;
     /// # Ok(())
@@ -378,9 +382,11 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
-    /// # fn example(index: &impl VectorIndex) -> gallifreydb::utils::Result<()> {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// let query = vec![0.5, 0.3, 0.1, 0.9];
     /// let results = index.search(&query, 10)?;
     ///
@@ -426,11 +432,13 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
     /// # use gallifreydb::core::id::NodeId;
     /// # use std::collections::HashSet;
-    /// # fn example(index: &impl VectorIndex) -> gallifreydb::utils::Result<()> {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// let query = vec![0.5, 0.3, 0.1, 0.9];
     /// let allowed = HashSet::from([NodeId::new(1).unwrap(), NodeId::new(5).unwrap(), NodeId::new(10).unwrap()]);
     ///
@@ -452,10 +460,13 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
-    /// # fn example(index: &impl VectorIndex) {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// println!("Index contains {} vectors", index.len());
+    /// # Ok(())
     /// # }
     /// ```
     #[must_use]
@@ -467,11 +478,14 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
-    /// # fn example(index: &impl VectorIndex) {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// let dims = index.dimensions();
     /// println!("This index accepts {}-dimensional vectors", dims);
+    /// # Ok(())
     /// # }
     /// ```
     #[must_use]
@@ -494,9 +508,11 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::{VectorIndex, DistanceMetric};
-    /// # fn example(index: &impl VectorIndex) {
+    /// # use gallifreydb::index::vector::HnswIndexBuilder;
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// match index.distance_metric() {
     ///     DistanceMetric::Cosine => println!("Using cosine similarity"),
     ///     DistanceMetric::Euclidean => println!("Using Euclidean distance"),
@@ -505,6 +521,7 @@ pub trait VectorIndex: Send + Sync {
     ///     DistanceMetric::Hamming => println!("Using Hamming distance"),
     ///     DistanceMetric::Tanimoto => println!("Using Tanimoto similarity"),
     /// }
+    /// # Ok(())
     /// # }
     /// ```
     #[must_use]
@@ -516,12 +533,15 @@ pub trait VectorIndex: Send + Sync {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```rust
     /// # use gallifreydb::index::VectorIndex;
-    /// # fn example(index: &impl VectorIndex) {
+    /// # use gallifreydb::index::vector::{HnswIndexBuilder, DistanceMetric};
+    /// # fn main() -> gallifreydb::utils::Result<()> {
+    /// # let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
     /// if index.is_empty() {
     ///     println!("No vectors indexed yet");
     /// }
+    /// # Ok(())
     /// # }
     /// ```
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,12 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use gallifreydb::{GallifreyDB, properties};
+//! ```rust,no_run
+//! use gallifreydb::{GallifreyDB, properties, WriteOps};
+//! use gallifreydb::core::temporal::time;
 //!
-//! let db = GallifreyDB::new();
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = GallifreyDB::new()?;
 //!
 //! // Create a node
 //! let alice = db.create_node("Person", properties! {
@@ -35,15 +37,19 @@
 //! })?;
 //!
 //! // Later, update a property
-//! db.update_node(alice, properties! {
+//! db.write(|tx| tx.update_node(alice, properties! {
 //!     "age" => 31,
-//! })?;
+//! }))?;
 //!
 //! // Query current state
 //! let current = db.get_node(alice)?;
 //!
 //! // Time-travel to see historical state
-//! let historical = db.as_of(timestamp).get_node(alice)?;
+//! // Use current time as a placeholder for the point in time we want to query
+//! let now = time::now();
+//! let historical = db.get_node_at_time(alice, now, now)?;
+//! # Ok(())
+//! # }
 //! ```
 
 #![warn(missing_docs)]

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -6,7 +6,19 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust
+//! use gallifreydb::query::QueryBuilder;
+//! use gallifreydb::core::NodeId;
+//! use gallifreydb::core::temporal::Timestamp;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let alice_id = NodeId::new(1)?;
+//! let bob_id = NodeId::new(2)?;
+//! let node_id = NodeId::new(3)?;
+//! let embedding = vec![0.1, 0.2, 0.3];
+//! let valid_time = Timestamp::new(1000, 0)?;
+//! let tx_time = Timestamp::new(2000, 0)?;
+//!
 //! // Build a graph + vector query
 //! let query = QueryBuilder::new()
 //!     .start(alice_id)
@@ -34,6 +46,8 @@
 //!         .label_filter("Person")
 //!         .finish()
 //!     .build();
+//! # Ok(())
+//! # }
 //! ```
 
 use std::marker::PhantomData;
@@ -184,7 +198,11 @@ impl QueryBuilder<state::Initial> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust
+    /// use gallifreydb::query::QueryBuilder;
+    /// use gallifreydb::index::vector::DistanceMetric;
+    ///
+    /// let embedding = vec![0.1, 0.2, 0.3];
     /// let query = QueryBuilder::new()
     ///     .find_similar_builder(&embedding, 10)
     ///         .property("title_embedding")
@@ -289,7 +307,14 @@ impl QueryBuilder<state::HasNodes> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust
+    /// use gallifreydb::query::QueryBuilder;
+    /// use gallifreydb::core::NodeId;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let alice_id = NodeId::new(1)?;
+    /// let embedding = vec![0.1, 0.2, 0.3];
+    ///
     /// let query = QueryBuilder::new()
     ///     .start(alice_id)
     ///     .traverse("KNOWS")
@@ -297,6 +322,8 @@ impl QueryBuilder<state::HasNodes> {
     ///         .property("custom_embedding")
     ///         .finish()
     ///     .build();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn rank_by_similarity_builder(
         self,
@@ -334,11 +361,19 @@ impl QueryBuilder<state::HasNodes> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::GallifreyDB;
+    /// # use gallifreydb::core::NodeId;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let node_id = NodeId::new(1)?;
+    /// # let bob_id = NodeId::new(2)?;
     /// let results = db.query()
     ///     .start(node_id)
     ///     .similar_to(bob_id, 10)
-    ///     .execute()?;
+    ///     .execute(&db)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # See Also
@@ -375,7 +410,13 @@ impl QueryBuilder<state::HasNodes> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::GallifreyDB;
+    /// # use gallifreydb::core::NodeId;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let alice_id = NodeId::new(1)?;
+    /// # let bob_id = NodeId::new(2)?;
     /// // Find similar documents using custom embedding
     /// let results = db.query()
     ///     .start(alice_id)
@@ -383,7 +424,9 @@ impl QueryBuilder<state::HasNodes> {
     ///         .property("custom_embedding")
     ///         .label_filter("Document")
     ///         .finish()
-    ///     .execute()?;
+    ///     .execute(&db)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -556,13 +599,22 @@ impl<S: QueryState> QueryBuilder<S> {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// let results = db.query()
+    /// ```rust
+    /// # use gallifreydb::query::QueryBuilder;
+    /// # use gallifreydb::core::NodeId;
+    /// # use gallifreydb::core::temporal::Timestamp;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let timestamp = Timestamp::new(1000, 0)?;
+    /// # let tx_time = Timestamp::new(2000, 0)?;
+    /// # let node_id = NodeId::new(1)?;
+    /// let query = QueryBuilder::new()
     ///     .as_of(timestamp, tx_time)
     ///     .start(node_id)
     ///     .traverse("KNOWS")
     ///     .with_provenance()
     ///     .build();
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn with_provenance(mut self) -> Self {
@@ -593,10 +645,14 @@ impl<S: QueryState> QueryBuilder<S> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
     /// use gallifreydb::GallifreyDB;
+    /// use gallifreydb::core::NodeId;
     ///
-    /// let db = GallifreyDB::new();
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = GallifreyDB::new()?;
+    /// let alice_id = NodeId::new(1)?;
+    ///
     /// let results = db.query()
     ///     .start(alice_id)
     ///     .traverse("KNOWS")
@@ -606,6 +662,8 @@ impl<S: QueryState> QueryBuilder<S> {
     ///     let row = row?;
     ///     println!("Found: {:?}", row.entity);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn execute(
         self,
@@ -648,7 +706,12 @@ impl<S: QueryState> QueryBuilder<S> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```rust
+/// # use gallifreydb::query::QueryBuilder;
+/// # use gallifreydb::core::NodeId;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let alice_id = NodeId::new(1)?;
+/// # let bob_id = NodeId::new(2)?;
 /// let query = QueryBuilder::new()
 ///     .start(alice_id)
 ///     .similar_to_builder(bob_id, 10)
@@ -656,6 +719,8 @@ impl<S: QueryState> QueryBuilder<S> {
 ///         .label_filter("Person")
 ///         .finish()
 ///     .build();
+/// # Ok(())
+/// # }
 /// ```
 #[must_use = "builders do nothing unless you call finish()"]
 pub struct SimilarToBuilder<S: QueryState> {
@@ -686,10 +751,18 @@ impl<S: QueryState> SimilarToBuilder<S> {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// .similar_to_builder(node_id, 10)
+    /// ```rust
+    /// # use gallifreydb::query::QueryBuilder;
+    /// # use gallifreydb::core::NodeId;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let node_id = NodeId::new(1)?;
+    /// QueryBuilder::new()
+    ///     .start(node_id)
+    ///     .similar_to_builder(node_id, 10)
     ///     .property("custom_embedding")
-    ///     .finish()
+    ///     .finish();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn property(mut self, key: impl Into<String>) -> Self {
         self.property_key = Some(key.into());
@@ -700,10 +773,18 @@ impl<S: QueryState> SimilarToBuilder<S> {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// .similar_to_builder(node_id, 10)
+    /// ```rust
+    /// # use gallifreydb::query::QueryBuilder;
+    /// # use gallifreydb::core::NodeId;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let node_id = NodeId::new(1)?;
+    /// QueryBuilder::new()
+    ///     .start(node_id)
+    ///     .similar_to_builder(node_id, 10)
     ///     .label_filter("Document")
-    ///     .finish()
+    ///     .finish();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn label_filter(mut self, label: impl Into<String>) -> Self {
         self.label_filter = Some(label.into());
@@ -727,7 +808,12 @@ impl<S: QueryState> SimilarToBuilder<S> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```rust
+/// # use gallifreydb::query::QueryBuilder;
+/// # use gallifreydb::core::NodeId;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let alice_id = NodeId::new(1)?;
+/// # let embedding = vec![0.1, 0.2, 0.3];
 /// let query = QueryBuilder::new()
 ///     .start(alice_id)
 ///     .traverse("KNOWS")
@@ -735,6 +821,8 @@ impl<S: QueryState> SimilarToBuilder<S> {
 ///         .property("custom_embedding")
 ///         .finish()
 ///     .build();
+/// # Ok(())
+/// # }
 /// ```
 #[must_use = "builders do nothing unless you call finish()"]
 pub struct RankBySimilarityBuilder<S: QueryState> {
@@ -760,10 +848,20 @@ impl<S: QueryState> RankBySimilarityBuilder<S> {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// .rank_by_similarity_builder(&embedding, 10)
+    /// ```rust
+    /// # use gallifreydb::query::QueryBuilder;
+    /// # use gallifreydb::core::NodeId;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let alice_id = NodeId::new(1)?;
+    /// # let embedding = vec![0.1, 0.2, 0.3];
+    /// QueryBuilder::new()
+    ///     .start(alice_id)
+    ///     .traverse("KNOWS")
+    ///     .rank_by_similarity_builder(&embedding, 10)
     ///     .property("custom_embedding")
-    ///     .finish()
+    ///     .finish();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn property(mut self, key: impl Into<String>) -> Self {
         self.property_key = Some(key.into());
@@ -786,13 +884,18 @@ impl<S: QueryState> RankBySimilarityBuilder<S> {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```rust
+/// # use gallifreydb::query::QueryBuilder;
+/// # use gallifreydb::index::vector::DistanceMetric;
+/// # fn main() {
+/// # let embedding = vec![0.1, 0.2, 0.3];
 /// let query = QueryBuilder::new()
 ///     .find_similar_builder(&embedding, 10)
 ///         .property("title_embedding")
 ///         .metric(DistanceMetric::Euclidean)
 ///         .finish()
 ///     .build();
+/// # }
 /// ```
 #[must_use = "builders do nothing unless you call finish()"]
 pub struct FindSimilarBuilder {
@@ -820,10 +923,15 @@ impl FindSimilarBuilder {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// .find_similar_builder(&embedding, 10)
+    /// ```rust
+    /// # use gallifreydb::query::QueryBuilder;
+    /// # fn main() {
+    /// # let embedding = vec![0.1, 0.2, 0.3];
+    /// QueryBuilder::new()
+    ///     .find_similar_builder(&embedding, 10)
     ///     .property("body_embedding")
-    ///     .finish()
+    ///     .finish();
+    /// # }
     /// ```
     pub fn property(mut self, key: impl Into<String>) -> Self {
         self.property_key = Some(key.into());
@@ -836,10 +944,16 @@ impl FindSimilarBuilder {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// .find_similar_builder(&embedding, 10)
+    /// ```rust
+    /// # use gallifreydb::query::QueryBuilder;
+    /// # use gallifreydb::index::vector::DistanceMetric;
+    /// # fn main() {
+    /// # let embedding = vec![0.1, 0.2, 0.3];
+    /// QueryBuilder::new()
+    ///     .find_similar_builder(&embedding, 10)
     ///     .metric(DistanceMetric::Euclidean)
-    ///     .finish()
+    ///     .finish();
+    /// # }
     /// ```
     pub fn metric(mut self, metric: DistanceMetric) -> Self {
         self.metric = metric;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -12,19 +12,31 @@
 //!
 //! # Example Usage
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! # use gallifreydb::GallifreyDB;
+//! # use gallifreydb::core::NodeId;
+//! # use gallifreydb::core::temporal::Timestamp;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let db = GallifreyDB::new()?;
+//! # let alice_id = NodeId::new(1)?;
+//! # let bob_embedding = vec![0.1, 0.2, 0.3];
+//! # let embedding = vec![0.1, 0.2, 0.3];
+//! # let timestamp_2023 = Timestamp::new(1672531200000000, 0)?;
+//! # let tx_time = gallifreydb::core::temporal::time::now();
 //! // Graph + Vector: "Who does Alice know that's similar to Bob?"
 //! let results = db.query()
 //!     .start(alice_id)
 //!     .traverse("KNOWS")
 //!     .rank_by_similarity(&bob_embedding, 10)
-//!     .execute()?;
+//!     .execute(&db)?;
 //!
 //! // Temporal + Vector: "What was similar to this in 2023?"
 //! let results = db.query()
 //!     .as_of(timestamp_2023, tx_time)
 //!     .find_similar(&embedding, 10)
-//!     .execute()?;
+//!     .execute(&db)?;
+//! # Ok(())
+//! # }
 //! ```
 
 pub mod ast;


### PR DESCRIPTION
This PR fixes several documentation examples that were marked as `ignore` or were broken. It ensures that the documentation reflects the current API and that examples are compilable (using `no_run` where appropriate).

Changes:
- `src/lib.rs`: Updated the top-level example to use `db.get_node_at_time` instead of the non-existent `db.as_of`, and used `write` transaction correctly.
- `src/query/builder.rs`: Un-ignored examples, adding necessary imports and mock variables.
- `src/api/transaction/mod.rs`: Un-ignored examples, adding setup code.
- `src/index/vector/mod.rs`: Un-ignored examples, using `HnswIndexBuilder` for context where needed, or keeping them as generic trait examples but compile-checked.
- `src/query/mod.rs`: Un-ignored usage example.

Verified with `cargo test --doc`.

---
*PR created automatically by Jules for task [8670092024416133978](https://jules.google.com/task/8670092024416133978) started by @madmax983*