### PR TITLE
⚒️ Forge: Deduplicate graph index persistence logic

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2144,10 +2144,6 @@ impl GallifreyDB {
     /// ```
     pub fn persist_indexes(&self) -> Result<()> {
         use crate::storage::index_persistence::formats::IndexManifest;
-        use crate::storage::index_persistence::formats::{PersistedEdge, PersistedNode};
-        use crate::storage::index_persistence::graph::{
-            new_graph_index_data, persist_property_map, save_graph_index,
-        };
 
         // Warn if background persistence thread has stopped
         if self
@@ -2173,47 +2169,10 @@ impl GallifreyDB {
         })?;
 
         // 2. Save graph index
-        let mut graph_data = new_graph_index_data();
-
-        // Export all nodes
-        let all_nodes = self.current.all_nodes();
-        for node in all_nodes {
-            let label_idx = node.label.as_u32();
-            let properties = persist_property_map(&node.properties).map_err(|e| {
-                StorageError::PersistenceError(format!("Failed to persist node properties: {}", e))
-            })?;
-
-            graph_data.nodes.push(PersistedNode {
-                id: node.id.as_u64(),
-                label_idx,
-                version_id: node.current_version.as_u64(),
-                properties,
-            });
-        }
-
-        // Export all edges
-        let all_edges = self.current.all_edges();
-        for edge in all_edges {
-            let label_idx = edge.label.as_u32();
-            let properties = persist_property_map(&edge.properties).map_err(|e| {
-                StorageError::PersistenceError(format!("Failed to persist edge properties: {}", e))
-            })?;
-
-            graph_data.edges.push(PersistedEdge {
-                id: edge.id.as_u64(),
-                source_id: edge.source.as_u64(),
-                target_id: edge.target.as_u64(),
-                label_idx,
-                version_id: edge.current_version.as_u64(),
-                properties,
-            });
-        }
-
-        graph_data.node_count = graph_data.nodes.len() as u64;
-        graph_data.edge_count = graph_data.edges.len() as u64;
-
-        save_graph_index(&graph_data, &manager.graph_path().join("adjacency.idx")).map_err(
-            |e| StorageError::PersistenceError(format!("Failed to save graph index: {}", e)),
+        crate::storage::index_persistence::operations::persist_graph_index(
+            &self.current,
+            manager,
+            self.persistence_tracker.as_ref(),
         )?;
 
         // 3. Save vector indexes

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -259,7 +259,7 @@ pub(crate) fn load_vector_indexes(
 pub(crate) fn persist_graph_index(
     current: &Arc<CurrentStorage>,
     manager: &Arc<IndexPersistenceManager>,
-    tracker: &Arc<PersistenceTracker>,
+    tracker: Option<&Arc<PersistenceTracker>>,
 ) -> Result<()> {
     use crate::storage::index_persistence::graph::{
         new_graph_index_data, persist_property_map, save_graph_index,
@@ -322,7 +322,9 @@ pub(crate) fn persist_graph_index(
         StorageError::PersistenceError(format!("Failed to save graph index: {}", e))
     })?;
 
-    tracker.reset_graph_mutations();
+    if let Some(tracker) = tracker {
+        tracker.reset_graph_mutations();
+    }
     Ok(())
 }
 
@@ -417,7 +419,7 @@ pub(crate) fn persist_all_indexes(
     if let Err(e) = persist_string_interner(manager, tracker) {
         eprintln!("Failed to persist string interner: {}", e);
     }
-    if let Err(e) = persist_graph_index(current, manager, tracker) {
+    if let Err(e) = persist_graph_index(current, manager, Some(tracker)) {
         eprintln!("Failed to persist graph index: {}", e);
     }
     if let Err(e) = persist_temporal_index(historical, temporal_indexes, manager, tracker) {

--- a/src/storage/index_persistence/worker.rs
+++ b/src/storage/index_persistence/worker.rs
@@ -74,7 +74,7 @@ pub(crate) fn spawn_background_persistence_thread(
                 let graph_seconds = tracker.seconds_since_graph_persist();
                 if (graph_mutations >= policies.graph.mutation_threshold as u64
                     || graph_seconds >= policies.graph.time_interval_secs as u64)
-                    && let Err(e) = persist_graph_index(&current, &manager, &tracker)
+                    && let Err(e) = persist_graph_index(&current, &manager, Some(&tracker))
                 {
                     eprintln!(
                         "Background persistence: Failed to persist graph index: {}",


### PR DESCRIPTION
🚮 Smell: `src/db.rs` contained a large block (~40 lines) of inline logic for persisting the graph index (nodes and edges) which duplicated logic found in `src/storage/index_persistence/operations.rs`. The duplicate implementation in `db.rs` also missed optimizations (CSR export) and correctness fixes (resetting mutation trackers) present in the shared function.

✨ Solution: 
1. Refactored `persist_graph_index` in `src/storage/index_persistence/operations.rs` to accept an optional `PersistenceTracker`.
2. Updated `GallifreyDB::persist_indexes` in `src/db.rs` to call this shared helper function instead of re-implementing it.

🧼 Benefit: 
- Reduces code duplication and potential for divergence.
- `persist_indexes` now benefits from CSR export optimization used in the background worker.
- Mutation tracker is correctly reset after manual persistence (if tracker is available).
- `src/db.rs` is slightly smaller (~40 lines less).

🛡️ Verification: 
- Ran `cargo test --test index_persistence` (26 tests passed).
- Ran `cargo clippy` (clean).
- Checked logic manually to ensure behavior parity.

---
*PR created automatically by Jules for task [234272783316570366](https://jules.google.com/task/234272783316570366) started by @madmax983*