### PR TITLE
🔒 Warden: Hardened graph persistence against DoS (File Size Limits)

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -43,6 +43,16 @@ Public HTTP and MCP endpoints could be vectors for DoS attacks via large inputs 
   - Vector dimensions validated against index configuration.
   - WAL segment reading limits file size to 1GB to prevent memory map exhaustion.
 
+## 2026-02-03 - Graph Persistence DoS Hardening
+
+**Threat:** Unbounded File Read / Memory Exhaustion
+The `load_graph_index` and `load_mappings_with_integrity` functions read entire files into memory without size checks. An attacker could supply a maliciously crafted large file (or sparse file), causing the application to panic or crash due to Out Of Memory (OOM) or address space exhaustion (DoS).
+
+**Defense:** File Size Limits
+- Enforced `MAX_GRAPH_FILE_SIZE` (4GB) in `src/storage/index_persistence/graph.rs` before reading or mapping graph index files.
+- Enforced `MAX_MAPPING_FILE_SIZE` (1GB) in `src/index/vector/hnsw.rs` before reading HNSW mapping files.
+- Added tests `test_load_oversized_graph_file` and `test_load_oversized_mapping_file` to verify rejection of oversized files (using lowered limits for testing).
+
 ## Open Risks
 - `usearch` FFI boundaries rely on the C++ library behaving correctly regarding pointer validity. We added panic guards for null pointers, but full memory safety depends on `usearch` correctness.
 - The `usearch` dependency points to a fork (`madmax983/USearch`). This fork contains Rust-specific fixes (move semantics) not yet in upstream. We have pinned the specific commit to ensure stability, but future upstream security patches will need manual cherry-picking.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1973,7 +1973,6 @@ mod tests {
 
     #[test]
     fn test_load_oversized_mapping_file() {
-        use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test_index.usearch");
         let mappings_path = path.with_extension("usearch.mappings");

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1107,37 +1107,30 @@ fn load_mappings_with_integrity(
     }
 
     // Open file first to avoid TOCTOU race condition
-    let mut file = std::fs::File::open(mappings_path).map_err(|e| {
-        Error::Vector(VectorError::IndexError(format!(
-            "Failed to open mappings file: {}",
-            e
-        )))
-    })?;
+    let mut file = std::fs::File::open(mappings_path)?;
 
     // Validate file size to prevent DoS
-    let metadata = file.metadata().map_err(|e| {
-        Error::Vector(VectorError::IndexError(format!(
-            "Failed to get mapping file metadata: {}",
-            e
-        )))
-    })?;
+    let metadata = file.metadata()?;
 
     if metadata.len() > MAX_MAPPING_FILE_SIZE {
-        return Err(Error::Vector(VectorError::IndexError(format!(
-            "Mapping file too large: {} bytes (limit: {} bytes)",
-            metadata.len(),
-            MAX_MAPPING_FILE_SIZE
-        ))));
+        return Err(Error::Vector(VectorError::SizeLimitExceeded {
+            message: format!(
+                "Mapping file too large: {} bytes (limit: {} bytes)",
+                metadata.len(),
+                MAX_MAPPING_FILE_SIZE
+            ),
+        }));
     }
 
     // Read data
-    let mut file_data = Vec::with_capacity(metadata.len() as usize);
-    file.read_to_end(&mut file_data).map_err(|e| {
-        Error::Vector(VectorError::IndexError(format!(
-            "Failed to read mappings: {}",
-            e
-        )))
+    let capacity: usize = metadata.len().try_into().map_err(|_| {
+        Error::Vector(VectorError::SizeLimitExceeded {
+            message: format!("File size {} exceeds platform capacity", metadata.len()),
+        })
     })?;
+
+    let mut file_data = Vec::with_capacity(capacity);
+    file.read_to_end(&mut file_data)?;
 
     // Minimum size: magic(4) + version(1) + count(8) + crc(4) = 17 bytes
     if file_data.len() < 17 {
@@ -1984,9 +1977,9 @@ mod tests {
         let result = load_mappings_with_integrity(&mappings_path);
         assert!(result.is_err());
         match result {
-            Err(Error::Vector(VectorError::IndexError(msg))) => {
-                assert!(msg.contains("too large"));
-                assert!(msg.contains("limit: 10485760 bytes")); // 10MB
+            Err(Error::Vector(VectorError::SizeLimitExceeded { message })) => {
+                assert!(message.contains("too large"));
+                assert!(message.contains("limit: 10485760 bytes")); // 10MB
             }
             Ok(_) => panic!("Expected oversized file error, got Ok"),
             Err(e) => panic!("Expected oversized file error, got {:?}", e),

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -103,6 +103,12 @@ const MAPPING_MAGIC: &[u8; 4] = b"GMAP";
 /// Current mapping file format version
 const MAPPING_VERSION: u8 = 1;
 
+#[cfg(not(test))]
+const MAX_MAPPING_FILE_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
+
+#[cfg(test)]
+const MAX_MAPPING_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB for testing
+
 /// Maximum number of results that can be requested in a search.
 ///
 /// This prevents DoS attacks via excessive memory allocation when an attacker
@@ -1100,7 +1106,33 @@ fn load_mappings_with_integrity(
         return Ok((id_mapping, reverse_mapping, max_key));
     }
 
-    let file_data = std::fs::read(mappings_path).map_err(|e| {
+    // Open file first to avoid TOCTOU race condition
+    let mut file = std::fs::File::open(mappings_path).map_err(|e| {
+        Error::Vector(VectorError::IndexError(format!(
+            "Failed to open mappings file: {}",
+            e
+        )))
+    })?;
+
+    // Validate file size to prevent DoS
+    let metadata = file.metadata().map_err(|e| {
+        Error::Vector(VectorError::IndexError(format!(
+            "Failed to get mapping file metadata: {}",
+            e
+        )))
+    })?;
+
+    if metadata.len() > MAX_MAPPING_FILE_SIZE {
+        return Err(Error::Vector(VectorError::IndexError(format!(
+            "Mapping file too large: {} bytes (limit: {} bytes)",
+            metadata.len(),
+            MAX_MAPPING_FILE_SIZE
+        ))));
+    }
+
+    // Read data
+    let mut file_data = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut file_data).map_err(|e| {
         Error::Vector(VectorError::IndexError(format!(
             "Failed to read mappings: {}",
             e
@@ -1937,5 +1969,29 @@ mod tests {
             ),
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_load_oversized_mapping_file() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test_index.usearch");
+        let mappings_path = path.with_extension("usearch.mappings");
+
+        // Create an oversized mappings file (> 10MB)
+        let mut file = std::fs::File::create(&mappings_path).unwrap();
+        file.set_len(MAX_MAPPING_FILE_SIZE + 10).unwrap();
+
+        // Test load_mappings_with_integrity directly to avoid needing a valid usearch index
+        let result = load_mappings_with_integrity(&mappings_path);
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(msg.contains("too large"));
+                assert!(msg.contains("limit: 10485760 bytes")); // 10MB
+            }
+            Ok(_) => panic!("Expected oversized file error, got Ok"),
+            Err(e) => panic!("Expected oversized file error, got {:?}", e),
+        }
     }
 }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1974,11 +1974,10 @@ mod tests {
     #[test]
     fn test_load_oversized_mapping_file() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test_index.usearch");
-        let mappings_path = path.with_extension("usearch.mappings");
+        let mappings_path = dir.path().join("test_index.usearch.mappings");
 
         // Create an oversized mappings file (> 10MB)
-        let mut file = std::fs::File::create(&mappings_path).unwrap();
+        let file = std::fs::File::create(&mappings_path).unwrap();
         file.set_len(MAX_MAPPING_FILE_SIZE + 10).unwrap();
 
         // Test load_mappings_with_integrity directly to avoid needing a valid usearch index

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -1,6 +1,7 @@
 //! Graph index persistence.
 
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -181,7 +182,6 @@ pub fn load_graph_index(path: &Path) -> Result<GraphIndexData> {
 
     // Pre-allocate buffer based on file size
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    use std::io::Read;
     file.read_to_end(&mut bytes)?;
 
     // Check minimum size (must have at least 4 bytes for CRC)
@@ -614,16 +614,7 @@ pub fn load_graph_index_with_delta(base_path: &Path, delta_path: &Path) -> Resul
     }
 
     // Load and decompress delta
-    let capacity: usize = metadata.len().try_into().map_err(|_| {
-        IndexPersistenceError::SizeLimitExceeded {
-            message: format!(
-                "Graph delta file size {} exceeds platform capacity",
-                metadata.len()
-            ),
-        }
-    })?;
-    let mut bytes = Vec::with_capacity(capacity);
-    use std::io::Read;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
     file.read_to_end(&mut bytes)?;
 
     // Check minimum size (must have at least 4 bytes for CRC)

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -15,6 +15,12 @@ use super::formats::{
 };
 use super::{DELTA_MAGIC, GRAPH_MAGIC, MANIFEST_VERSION};
 
+#[cfg(not(test))]
+const MAX_GRAPH_FILE_SIZE: u64 = 4 * 1024 * 1024 * 1024; // 4 GB
+
+#[cfg(test)]
+const MAX_GRAPH_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB for testing
+
 /// Convert PropertyValue to PersistedPropertyValue.
 ///
 /// # Errors
@@ -159,7 +165,24 @@ pub fn save_graph_index(data: &GraphIndexData, path: &Path) -> Result<()> {
 ///
 /// Automatically detects zstd compression by checking for magic bytes.
 pub fn load_graph_index(path: &Path) -> Result<GraphIndexData> {
-    let bytes = fs::read(path)?;
+    let mut file = fs::File::open(path)?;
+
+    // Validate file size before reading to prevent DoS via memory exhaustion
+    let metadata = file.metadata()?;
+    if metadata.len() > MAX_GRAPH_FILE_SIZE {
+        return Err(IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "Graph index file too large: {} bytes (limit: {} bytes)",
+                metadata.len(),
+                MAX_GRAPH_FILE_SIZE
+            ),
+        });
+    }
+
+    // Pre-allocate buffer based on file size
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    use std::io::Read;
+    file.read_to_end(&mut bytes)?;
 
     // Check minimum size (must have at least 4 bytes for CRC)
     if bytes.len() < 4 {
@@ -312,8 +335,22 @@ pub fn load_graph_index_mmap(path: &Path) -> Result<GraphIndexData> {
     use memmap2::Mmap;
     use std::fs::File;
 
-    // Open file and create memory map
+    // Open file first to avoid TOCTOU race condition
     let file = File::open(path)?;
+
+    // Validate file size before mapping to prevent DoS via address space exhaustion
+    let metadata = file.metadata()?;
+    if metadata.len() > MAX_GRAPH_FILE_SIZE {
+        return Err(IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "Graph index file too large: {} bytes (limit: {} bytes)",
+                metadata.len(),
+                MAX_GRAPH_FILE_SIZE
+            ),
+        });
+    }
+
+    // Create memory map
     let mmap = unsafe { Mmap::map(&file)? };
 
     // Check minimum size (must have at least 4 bytes for CRC)
@@ -562,8 +599,24 @@ pub fn load_graph_index_with_delta(base_path: &Path, delta_path: &Path) -> Resul
     // Load base index
     let mut base = load_graph_index(base_path)?;
 
+    let mut file = fs::File::open(delta_path)?;
+
+    // Validate delta file size before reading
+    let metadata = file.metadata()?;
+    if metadata.len() > MAX_GRAPH_FILE_SIZE {
+        return Err(IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "Graph delta file too large: {} bytes (limit: {} bytes)",
+                metadata.len(),
+                MAX_GRAPH_FILE_SIZE
+            ),
+        });
+    }
+
     // Load and decompress delta
-    let bytes = fs::read(delta_path)?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    use std::io::Read;
+    file.read_to_end(&mut bytes)?;
 
     // Check minimum size (must have at least 4 bytes for CRC)
     if bytes.len() < 4 {
@@ -776,6 +829,42 @@ mod tests {
         } else {
             panic!("Expected vector property");
         }
+    }
+
+    #[test]
+    fn test_load_oversized_graph_file() {
+        use std::io::Write;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("oversized.idx");
+
+        // Create a file slightly larger than the test limit (10MB)
+        let mut file = std::fs::File::create(&path).unwrap();
+        // Use seek to create a sparse file quickly without writing 10MB of zeros
+        file.set_len(MAX_GRAPH_FILE_SIZE + 10).unwrap();
+
+        // Test load_graph_index
+        let result = load_graph_index(&path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("too large"));
+        assert!(err_msg.contains("limit: 10485760 bytes")); // 10MB
+
+        // Test load_graph_index_mmap
+        let result = load_graph_index_mmap(&path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("too large"));
+
+        // Test load_graph_index_with_delta (using valid base but oversized delta)
+        let base_path = dir.path().join("base.idx");
+        let data = new_graph_index_data();
+        // Ensure base is small enough
+        save_graph_index(&data, &base_path).unwrap();
+
+        let result = load_graph_index_with_delta(&base_path, &path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("too large"));
     }
 }
 

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -614,7 +614,15 @@ pub fn load_graph_index_with_delta(base_path: &Path, delta_path: &Path) -> Resul
     }
 
     // Load and decompress delta
-    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    let capacity: usize = metadata.len().try_into().map_err(|_| {
+        IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "Graph delta file size {} exceeds platform capacity",
+                metadata.len()
+            ),
+        }
+    })?;
+    let mut bytes = Vec::with_capacity(capacity);
     use std::io::Read;
     file.read_to_end(&mut bytes)?;
 

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -833,12 +833,11 @@ mod tests {
 
     #[test]
     fn test_load_oversized_graph_file() {
-        use std::io::Write;
         let dir = tempdir().unwrap();
         let path = dir.path().join("oversized.idx");
 
         // Create a file slightly larger than the test limit (10MB)
-        let mut file = std::fs::File::create(&path).unwrap();
+        let file = std::fs::File::create(&path).unwrap();
         // Use seek to create a sparse file quickly without writing 10MB of zeros
         file.set_len(MAX_GRAPH_FILE_SIZE + 10).unwrap();
 

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -798,11 +798,19 @@ pub enum VectorError {
     },
     /// Error from underlying vector index implementation.
     IndexError(String),
+    /// Size limit exceeded (DoS protection).
+    SizeLimitExceeded {
+        /// Description of the size limit violation
+        message: String,
+    },
 }
 
 impl fmt::Display for VectorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            VectorError::SizeLimitExceeded { message } => {
+                write!(f, "Size limit exceeded: {}", message)
+            }
             VectorError::DimensionMismatch { expected, actual } => {
                 write!(
                     f,


### PR DESCRIPTION
This PR addresses a potential Denial of Service (DoS) vulnerability where loading excessively large graph index or vector mapping files could lead to memory exhaustion or address space exhaustion.

Key changes:
- Enforced strict file size limits (`MAX_GRAPH_FILE_SIZE` = 4GB, `MAX_MAPPING_FILE_SIZE` = 1GB) when loading graph persistence files and HNSW mappings.
- Implemented a safe file loading pattern (`File::open` -> `metadata()` -> `read`) to prevent Time-of-Check Time-of-Use (TOCTOU) race conditions.
- Added new error variant `IndexPersistenceError::SizeLimitExceeded` for clear error reporting.
- Added comprehensive tests `test_load_oversized_graph_file` and `test_load_oversized_mapping_file`, utilizing `#[cfg(test)]` to lower limits (10MB) for practical verification.
- Updated the security journal (`.jules/warden.md`) with the new findings and defenses.

This hardening prevents an attacker from supplying a malicious (e.g., sparse) file to crash the server via OOM.

---
*PR created automatically by Jules for task [960064121218230737](https://jules.google.com/task/960064121218230737) started by @madmax983*