### PR TITLE
🛡️ Sentry: Fix recursion stack overflow in PropertyValue deserialization

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Recursion Depth Limits in Deserialization
+**Learning:** Custom recursive deserialization logic (like `TAG_ARRAY`) is vulnerable to Stack Overflow DoS attacks if depth is not limited. Rust's stack overflow protection aborts the process, making it a severe availability risk.
+**Action:** Always enforce a `MAX_RECURSION_DEPTH` (e.g., 100) in recursive functions processing untrusted input. Use a helper function with a `depth` parameter.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -507,6 +507,7 @@ impl PropertyValue {
     /// Internal recursive deserialization helper with depth tracking.
     fn deserialize_recursive(bytes: &[u8], depth: usize) -> Result<(Self, usize)> {
         // Prevent recursion-based stack overflow DoS
+        // Depth 0 = top level, depth 100 = maximum nesting level
         if depth > MAX_RECURSION_DEPTH {
             return Err(StorageError::CorruptedData(format!(
                 "Property value recursion depth limit exceeded (max {})",

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -52,6 +52,10 @@ pub const MAX_ARRAY_ELEMENTS: usize = 1_000_000;
 /// Set to 100,000 - far exceeds typical embedding sizes (384-4096 dimensions).
 pub const MAX_VECTOR_DIMENSIONS: usize = 100_000;
 
+/// Maximum recursion depth for nested properties (e.g., arrays of arrays).
+/// Set to 100 to prevent stack overflow from malicious input.
+pub const MAX_RECURSION_DEPTH: usize = 100;
+
 /// Property key type.
 ///
 /// Uses interned strings for memory efficiency and O(1) equality comparisons.
@@ -490,7 +494,27 @@ impl PropertyValue {
     /// Deserialize a PropertyValue from bytes.
     ///
     /// Returns the deserialized value and the number of bytes consumed.
+    ///
+    /// # Recursion Depth
+    ///
+    /// This function implements recursion depth checking to prevent stack overflow
+    /// attacks via deeply nested structures (e.g., Array of Array of ...).
+    /// The maximum depth is defined by [`MAX_RECURSION_DEPTH`].
     pub fn deserialize(bytes: &[u8]) -> Result<(Self, usize)> {
+        Self::deserialize_recursive(bytes, 0)
+    }
+
+    /// Internal recursive deserialization helper with depth tracking.
+    fn deserialize_recursive(bytes: &[u8], depth: usize) -> Result<(Self, usize)> {
+        // Prevent recursion-based stack overflow DoS
+        if depth > MAX_RECURSION_DEPTH {
+            return Err(StorageError::CorruptedData(format!(
+                "Property value recursion depth limit exceeded (max {})",
+                MAX_RECURSION_DEPTH
+            ))
+            .into());
+        }
+
         if bytes.is_empty() {
             return Err(StorageError::CorruptedData(
                 "Empty buffer when deserializing PropertyValue".to_string(),
@@ -615,7 +639,9 @@ impl PropertyValue {
                         )
                         .into());
                     }
-                    let (item, consumed) = PropertyValue::deserialize(&bytes[offset..])?;
+                    // Recursive call with depth increment
+                    let (item, consumed) =
+                        PropertyValue::deserialize_recursive(&bytes[offset..], depth + 1)?;
                     items.push(item);
                     offset += consumed;
                 }
@@ -3535,5 +3561,85 @@ mod tests {
             }
             _ => panic!("Expected CorruptedData error"),
         }
+    }
+
+    #[test]
+    fn test_deserialize_recursion_limit() {
+        // Construct a deeply nested array exceeding the recursion limit
+        // Format: [TAG_ARRAY][count:1][TAG_ARRAY][count:1]...[TAG_NULL]
+        let depth = MAX_RECURSION_DEPTH + 1;
+        let mut bytes = Vec::new();
+
+        for _ in 0..depth {
+            bytes.push(TAG_ARRAY);
+            bytes.extend_from_slice(&(1u32).to_le_bytes()); // Count = 1
+        }
+
+        // Terminate with a Null value
+        bytes.push(TAG_NULL);
+
+        // Try to deserialize
+        let result = PropertyValue::deserialize(&bytes);
+
+        // Should fail with recursion limit error
+        assert!(result.is_err());
+        match result {
+            Err(crate::utils::error::Error::Storage(StorageError::CorruptedData(msg))) => {
+                assert!(msg.contains("recursion depth limit exceeded"));
+            }
+            _ => panic!("Expected CorruptedData error for recursion limit"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_recursion_limit_boundary() {
+        // Construct a deeply nested array exactly AT the limit (should succeed)
+        let depth = MAX_RECURSION_DEPTH;
+        let mut bytes = Vec::new();
+
+        for _ in 0..depth {
+            bytes.push(TAG_ARRAY);
+            bytes.extend_from_slice(&(1u32).to_le_bytes()); // Count = 1
+        }
+
+        // Terminate with a Null value
+        bytes.push(TAG_NULL);
+
+        // Try to deserialize
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_ok(), "Should succeed at recursion limit boundary");
+    }
+
+    #[test]
+    fn test_deserialize_truncated_after_tag() {
+        // Buffer containing only a tag but no data
+        let bytes = vec![TAG_STRING]; // String expects length prefix
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        match result {
+            Err(crate::utils::error::Error::Storage(StorageError::CorruptedData(msg))) => {
+                assert!(msg.contains("Buffer too short"));
+            }
+            _ => panic!("Expected CorruptedData error"),
+        }
+    }
+
+    #[test]
+    fn test_estimated_heap_size_nested_array() {
+        // Create a nested array: [[[[...]]]] (depth 10) containing a string at the bottom
+        let mut value = PropertyValue::string("data");
+        for _ in 0..10 {
+            value = PropertyValue::array(vec![value]);
+        }
+
+        let size = value.estimated_heap_size();
+
+        // Size should be:
+        // 10 * (Vec capacity overhead + sizeof(PropertyValue)) + string length
+        // Vec capacity is at least 1.
+        let min_vec_size = std::mem::size_of::<PropertyValue>();
+        let expected_min = 10 * min_vec_size + 4; // "data".len() = 4
+
+        assert!(size >= expected_min);
     }
 }

--- a/tests/property_dos.rs
+++ b/tests/property_dos.rs
@@ -1,10 +1,13 @@
-use gallifreydb::core::property::{PropertyValue, TAG_ARRAY, TAG_NULL, MAX_RECURSION_DEPTH};
+use gallifreydb::core::property::{PropertyValue, TAG_ARRAY, TAG_NULL};
 
 #[test]
 fn test_recursive_array_stack_overflow_protection() {
+    // Note: Only arrays support nesting. Vectors contain primitives (f32/f64)
+    // and cannot trigger recursion-based stack overflow.
+
     // Construct a deeply nested array: [[[[...]]]]
     // Format: [TAG_ARRAY][count:1][TAG_ARRAY][count:1]...[TAG_NULL]
-    let depth = (MAX_RECURSION_DEPTH + 1) as usize;
+    let depth = 150;
     let mut bytes = Vec::new();
 
     for _ in 0..depth {

--- a/tests/property_dos.rs
+++ b/tests/property_dos.rs
@@ -1,10 +1,10 @@
-use gallifreydb::core::property::{PropertyValue, TAG_ARRAY, TAG_NULL};
+use gallifreydb::core::property::{PropertyValue, TAG_ARRAY, TAG_NULL, MAX_RECURSION_DEPTH};
 
 #[test]
 fn test_recursive_array_stack_overflow_protection() {
     // Construct a deeply nested array: [[[[...]]]]
     // Format: [TAG_ARRAY][count:1][TAG_ARRAY][count:1]...[TAG_NULL]
-    let depth = 150;
+    let depth = (MAX_RECURSION_DEPTH + 1) as usize;
     let mut bytes = Vec::new();
 
     for _ in 0..depth {

--- a/tests/property_dos.rs
+++ b/tests/property_dos.rs
@@ -1,0 +1,31 @@
+use gallifreydb::core::property::{PropertyValue, TAG_ARRAY, TAG_NULL};
+
+#[test]
+fn test_recursive_array_stack_overflow_protection() {
+    // Construct a deeply nested array: [[[[...]]]]
+    // Format: [TAG_ARRAY][count:1][TAG_ARRAY][count:1]...[TAG_NULL]
+    let depth = 150;
+    let mut bytes = Vec::new();
+
+    for _ in 0..depth {
+        bytes.push(TAG_ARRAY);
+        bytes.extend_from_slice(&(1u32).to_le_bytes()); // Count = 1
+    }
+
+    // Terminate with a Null value
+    bytes.push(TAG_NULL);
+
+    // Try to deserialize
+    let result = PropertyValue::deserialize(&bytes);
+
+    // Should fail gracefully with a recursion limit error
+    match result {
+        Ok(_) => panic!("Deserialization should have failed due to recursion depth limit"),
+        Err(e) => {
+            let msg = e.to_string();
+            if !msg.contains("recursion depth limit exceeded") {
+                panic!("Expected recursion limit error, got: {}", msg);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added recursion depth limit to PropertyValue::deserialize to prevent DoS via deeply nested structures. Added unit tests and an integration test to verify the fix.

---
*PR created automatically by Jules for task [4194703712599261484](https://jules.google.com/task/4194703712599261484) started by @madmax983*