### PR TITLE
🔒 Warden: Hardened SIMD vector wrappers

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -63,3 +63,10 @@ Arithmetic operations on file offsets (`src/storage/wal/segment_reader.rs`) and 
 - `usearch` FFI boundaries rely on the C++ library behaving correctly regarding pointer validity. We added panic guards for null pointers, but full memory safety depends on `usearch` correctness.
 - The `usearch` dependency points to a fork (`madmax983/USearch`). This fork contains Rust-specific fixes (move semantics) not yet in upstream. We have pinned the specific commit to ensure stability, but future upstream security patches will need manual cherry-picking.
 - `mmap` usage in `src/storage/wal/segment_reader.rs` is inherently unsafe against external file truncation (SIGBUS risk), though file size is checked before mapping.
+
+## 2026-02-12 - SIMD Hardening
+**Threat:** Buffer Over-read in Release Builds
+Internal SIMD helper functions in `src/core/vector.rs` used `debug_assert_eq!` to check dimension equality. In release builds, this check is stripped, allowing `unsafe` SIMD intrinsics to potentially read past the end of a buffer if dimensions mismatch (Undefined Behavior/Crash).
+
+**Defense:** Runtime Assertion
+Replaced `debug_assert_eq!` with `assert_eq!` in `dot_and_magnitudes`, `squared_diff_sum`, and `dot_product_sum`. This ensures that even in optimized release builds, dimension mismatches trigger a safe panic rather than UB. Verified with a regression test `test_internal_safety_in_release`.

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -1105,7 +1105,7 @@ fn scale_in_place(v: &mut [f32], scalar: f32) {
 /// - Scalar implementation on other platforms
 #[inline]
 fn dot_and_magnitudes(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
-    debug_assert_eq!(a.len(), b.len());
+    assert_eq!(a.len(), b.len());
     #[cfg(target_arch = "x86_64")]
     {
         // Use runtime detection for best available instruction set
@@ -1148,7 +1148,7 @@ fn dot_and_magnitudes(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
 /// - Scalar implementation on other platforms
 #[inline]
 fn squared_diff_sum(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
+    assert_eq!(a.len(), b.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         // Use runtime detection for best available instruction set.
@@ -1176,7 +1176,7 @@ fn squared_diff_sum(a: &[f32], b: &[f32]) -> f32 {
 /// - Scalar implementation on other platforms
 #[inline]
 fn dot_product_sum(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
+    assert_eq!(a.len(), b.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         // Use runtime detection for best available instruction set.
@@ -5302,5 +5302,15 @@ mod proptests {
         let dense_dist = euclidean_distance(&dense_a, &dense_b).unwrap();
 
         assert!((sparse_dist - dense_dist).abs() < 1e-5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_internal_safety_in_release() {
+        let a = vec![1.0; 4];
+        let b = vec![1.0; 3]; // Mismatch
+        // This calls dot_and_magnitudes internally
+        // We use dot_and_magnitudes because it is one of the functions we are hardening
+        let _ = super::dot_and_magnitudes(&a, &b);
     }
 }


### PR DESCRIPTION
**Threat:** Internal SIMD helper functions in `src/core/vector.rs` used `debug_assert_eq!` to validate input dimensions. In release builds, these assertions are stripped. If the caller (or future code) violates the length contract, the `unsafe` SIMD intrinsics could read past the buffer end, causing Undefined Behavior or segfaults.

**Defense:** Promoted `debug_assert_eq!` to `assert_eq!` in:
- `dot_and_magnitudes`
- `squared_diff_sum`
- `dot_product_sum`

This ensures that dimension invariants are strictly enforced at runtime, even in release builds, failing safely with a panic instead of memory corruption.

**Verification:** Added a regression test `test_internal_safety_in_release` that deliberately calls the internal function with mismatched lengths. Verified that it panics safely in both debug and release modes.

**Journal:** Updated `.jules/warden.md` with this finding.

---
*PR created automatically by Jules for task [1632811970208745696](https://jules.google.com/task/1632811970208745696) started by @madmax983*