### PR TITLE
🔒 Warden: DoS hardening for graph index loading

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -70,3 +70,14 @@ Internal SIMD helper functions in `src/core/vector.rs` used `debug_assert_eq!` t
 
 **Defense:** Runtime Assertion
 Replaced `debug_assert_eq!` with `assert_eq!` in `dot_and_magnitudes`, `squared_diff_sum`, and `dot_product_sum`. This ensures that even in optimized release builds, dimension mismatches trigger a safe panic rather than UB. Verified with a regression test `test_internal_safety_in_release`.
+
+## 2026-02-18 - DoS Hardening in Graph Index Loading
+
+**Threat:** Resource Exhaustion via Memory Map
+The `load_graph_index_mmap` function in `src/storage/index_persistence/graph.rs` used `unsafe` memory mapping without validating the file size. A malicious user could supply a massive file (e.g., a sparse file > 4GB) to cause a Denial of Service via address space exhaustion (on 32-bit systems) or OOM.
+
+**Defense:** Size Check & Safety Hardening
+- Implemented a `MAX_GRAPH_INDEX_SIZE` limit (4GB in production, 10MB in tests).
+- Added explicit file size validation before calling `Mmap::map`.
+- Added safety comments to the `unsafe` block justifying the operation (read-only access).
+- Verified with `test_load_graph_index_mmap_too_large`.

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -825,6 +825,32 @@ mod tests {
             _ => panic!("Expected SizeLimitExceeded error, got {:?}", result),
         }
     }
+
+    #[test]
+    fn test_load_graph_index_mmap_success() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("valid_mmap.idx");
+
+        // Create a valid index (small enough to pass size check)
+        let mut data = new_graph_index_data();
+        data.node_count = 1;
+        data.nodes.push(PersistedNode {
+            id: 1,
+            label_idx: GLOBAL_INTERNER.intern("MmapNode").unwrap().as_u32(),
+            version_id: 1,
+            properties: PersistedPropertyMap { entries: vec![] },
+        });
+
+        save_graph_index(&data, &path).unwrap();
+
+        // Attempt load via mmap
+        let result = load_graph_index_mmap(&path);
+
+        assert!(result.is_ok());
+        let loaded = result.unwrap();
+        assert_eq!(loaded.node_count, 1);
+        assert_eq!(loaded.magic, super::GRAPH_MAGIC);
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -15,6 +15,13 @@ use super::formats::{
 };
 use super::{DELTA_MAGIC, GRAPH_MAGIC, MANIFEST_VERSION};
 
+/// Maximum size for memory-mapped graph index files.
+/// 4GB in production, 10MB in tests for easier validation.
+#[cfg(not(test))]
+const MAX_GRAPH_INDEX_SIZE: u64 = 4 * 1024 * 1024 * 1024; // 4GB
+#[cfg(test)]
+const MAX_GRAPH_INDEX_SIZE: u64 = 10 * 1024 * 1024; // 10MB
+
 /// Convert PropertyValue to PersistedPropertyValue.
 ///
 /// # Errors
@@ -312,8 +319,24 @@ pub fn load_graph_index_mmap(path: &Path) -> Result<GraphIndexData> {
     use memmap2::Mmap;
     use std::fs::File;
 
-    // Open file and create memory map
+    // Open file
     let file = File::open(path)?;
+
+    // Validate file size before mapping to prevent DoS/OOM
+    let metadata = file.metadata()?;
+    if metadata.len() > MAX_GRAPH_INDEX_SIZE {
+        return Err(IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "Graph index too large: {} bytes (max: {} bytes)",
+                metadata.len(),
+                MAX_GRAPH_INDEX_SIZE
+            ),
+        });
+    }
+
+    // SAFETY: We checked the file size against a reasonable limit (MAX_GRAPH_INDEX_SIZE)
+    // to prevent address space exhaustion. We only read from the map, never write.
+    // The file is opened read-only.
     let mmap = unsafe { Mmap::map(&file)? };
 
     // Check minimum size (must have at least 4 bytes for CRC)
@@ -775,6 +798,31 @@ mod tests {
             assert_eq!(v.len(), super::super::MAX_VECTOR_DIMENSIONS);
         } else {
             panic!("Expected vector property");
+        }
+    }
+
+    #[test]
+    fn test_load_graph_index_mmap_too_large() {
+        use std::fs::File;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("oversized_index.idx");
+
+        let file = File::create(&path).unwrap();
+
+        // Create a sparse file > MAX_GRAPH_INDEX_SIZE (10MB in test)
+        let size = super::MAX_GRAPH_INDEX_SIZE + 1024 * 1024; // +1MB
+        file.set_len(size).unwrap();
+
+        // Attempt load
+        let result = load_graph_index_mmap(&path);
+
+        assert!(result.is_err());
+        match result {
+            Err(IndexPersistenceError::SizeLimitExceeded { message }) => {
+                assert!(message.contains("Graph index too large"));
+            }
+            _ => panic!("Expected SizeLimitExceeded error, got {:?}", result),
         }
     }
 }


### PR DESCRIPTION
🦠 Threat: Resource Exhaustion via Memory Map
The `load_graph_index_mmap` function used `unsafe` memory mapping without validating the file size. A malicious user could supply a massive file to cause a Denial of Service via address space exhaustion or OOM.

🛡️ Defense: Size Check & Safety Hardening
- Implemented a `MAX_GRAPH_INDEX_SIZE` limit (4GB in production, 10MB in tests).
- Added explicit file size validation before calling `Mmap::map`.
- Added safety comments to the `unsafe` block.

💥 Severity: High (DoS vector)

🧪 Verification: Added `test_load_graph_index_mmap_too_large` which verifies the size check works.

---
*PR created automatically by Jules for task [17027592659430047909](https://jules.google.com/task/17027592659430047909) started by @madmax983*