### PR TITLE
🎻 Bard: Fix broken intra-doc links and formatting warnings

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -429,14 +429,14 @@ impl PropertyValue {
     ///
     /// | Type   | Format                                      |
     /// |--------|---------------------------------------------|
-    /// | Null   | [tag:1]                                     |
-    /// | Bool   | [tag:1][value:1]                           |
-    /// | Int    | [tag:1][i64:8]                             |
-    /// | Float  | [tag:1][f64:8]                             |
-    /// | String | [tag:1][len:4][utf8_bytes:len]             |
-    /// | Bytes  | [tag:1][len:4][bytes:len]                  |
-    /// | Array  | [tag:1][count:4][elements...]              |
-    /// | Vector | [tag:1][dim:4][f32_values:dim*4]           |
+    /// | Null   | `[tag:1]`                                     |
+    /// | Bool   | `[tag:1][value:1]`                           |
+    /// | Int    | `[tag:1][i64:8]`                             |
+    /// | Float  | `[tag:1][f64:8]`                             |
+    /// | String | `[tag:1][len:4][utf8_bytes:len]`             |
+    /// | Bytes  | `[tag:1][len:4][bytes:len]`                  |
+    /// | Array  | `[tag:1][count:4][elements...]`              |
+    /// | Vector | `[tag:1][dim:4][f32_values:dim*4]`           |
     pub fn serialize(&self) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(self.serialized_size());
         self.serialize_into(&mut buffer);

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -6,7 +6,7 @@
 //! # Overview
 //!
 //! GallifreyDB supports storing vectors as property values on nodes via
-//! [`PropertyValue::Vector`]. This module provides the utilities needed
+//! [`crate::core::property::PropertyValue::Vector`]. This module provides the utilities needed
 //! to work with those vectors effectively:
 //!
 //! - **Type definitions**: [`VectorDimension`] for expressing vector sizes
@@ -35,7 +35,7 @@
 //!
 //! # Design Notes
 //!
-//! Vectors in GallifreyDB are stored as `Arc<[f32]>` within [`PropertyValue::Vector`].
+//! Vectors in GallifreyDB are stored as `Arc<[f32]>` within [`crate::core::property::PropertyValue::Vector`].
 //! This design enables:
 //!
 //! - **Efficient cloning**: Multiple versions can share the same vector data
@@ -1760,7 +1760,7 @@ pub fn squared_magnitude(v: &[f32]) -> f32 {
 /// Unlike two-vector functions like [`cosine_similarity`], normalization functions
 /// do not validate against `MAX_VECTOR_DIMENSIONS`. This is intentional because:
 /// - Single-vector operations don't have dimension mismatch issues
-/// - Dimension limits are enforced at storage time (see [`PropertyValue::vector`])
+/// - Dimension limits are enforced at storage time (see [`crate::core::property::PropertyValue::vector`])
 /// - Additional checks would add overhead without safety benefit
 #[inline]
 pub fn normalize(v: &[f32]) -> Vec<f32> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1661,7 +1661,7 @@ impl GallifreyDB {
 
     /// Find similar vectors at a specific point in time for a specific property.
     ///
-    /// This is the property-specific version of [`find_similar_as_of()`].
+    /// This is the property-specific version of [`Self::find_similar_as_of()`].
     /// It validates that the requested property matches the property for which
     /// the temporal vector index was enabled.
     ///

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -7,8 +7,8 @@
 //! # CSR Format
 //!
 //! The CSR format stores the graph as two arrays:
-//! - `offsets[i]`: Starting position in `edges` for node i's adjacency list
-//! - `edges`: Flat array of (target_node, edge_id, edge_label) tuples
+//! - `offsets[i]`: Starting position in `edges` for node `i`'s adjacency list
+//! - `edges`: Flat array of `(target_node, edge_id, edge_label)` tuples
 //!
 //! This layout is cache-friendly because traversing from a node requires
 //! sequential access to a contiguous region of memory.
@@ -51,9 +51,9 @@ pub struct AdjacencyIndex {
     /// Sorted list of node IDs that have outgoing edges.
     /// Used for binary search to map node_id -> index in offsets array.
     node_ids: Vec<NodeId>,
-    /// Offsets into the edges array for each node in node_ids.
-    /// offsets[i] = start index in edges array for node_ids[i]
-    /// offsets[i + 1] = end index (exclusive)
+    /// Offsets into the edges array for each node in `node_ids`.
+    /// `offsets[i]` = start index in edges array for `node_ids[i]`
+    /// `offsets[i + 1]` = end index (exclusive)
     offsets: Vec<usize>,
     /// Flat array of adjacency entries, sorted by source node.
     edges: Vec<AdjacencyEntry>,

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -977,7 +977,7 @@ impl HnswIndex {
             })?;
 
         // Save mappings to companion file with integrity checks
-        // Format: [MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]
+        // Format: `[MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]`
         let mappings_path = path.with_extension("usearch.mappings");
         let mut mappings = Vec::with_capacity(self.id_mapping.len());
         for entry in self.id_mapping.iter() {
@@ -1095,7 +1095,7 @@ impl HnswIndex {
 
 /// Load and verify mappings from a companion file.
 /// Returns (id_mapping, reverse_mapping, max_key) or error if integrity check fails.
-/// Format: [MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]
+/// Format: `[MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]`
 #[allow(clippy::type_complexity)]
 fn load_mappings_with_integrity(
     mappings_path: &Path,

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -989,7 +989,7 @@ struct PersistedSparseVector {
 
 /// Root data structure for sparse index persistence.
 ///
-/// File format: [magic:4][version:2][bitcode_data:N][crc32:4]
+/// File format: `[magic:4][version:2][bitcode_data:N][crc32:4]`
 #[derive(Debug, Clone, Encode, Decode)]
 struct SparseIndexData {
     /// Magic bytes for validation (checked separately, not in bitcode)

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -208,9 +208,9 @@ impl Pattern {
 /// An element in a pattern (either a node or relationship).
 #[derive(Debug, Clone, PartialEq)]
 pub enum PatternElement {
-    /// A node pattern: (n:Label {props})
+    /// A node pattern: `(n:Label {props})`
     Node(NodePattern),
-    /// A relationship pattern: -[:REL]->
+    /// A relationship pattern: `-[:REL]->`
     Relationship(RelationshipPattern),
 }
 
@@ -295,7 +295,7 @@ impl RelationshipPattern {
         }
     }
 
-    /// Create a bidirectional relationship: -[]-
+    /// Create a bidirectional relationship: `-[]-`
     pub fn both() -> Self {
         RelationshipPattern {
             variable: None,
@@ -305,21 +305,21 @@ impl RelationshipPattern {
         }
     }
 
-    /// Add a relationship type: -[:KNOWS]->
+    /// Add a relationship type: `-[:KNOWS]->`
     #[must_use]
     pub fn with_type(mut self, rel_type: impl Into<String>) -> Self {
         self.rel_type = Some(rel_type.into());
         self
     }
 
-    /// Add a variable binding: -[r:KNOWS]->
+    /// Add a variable binding: `-[r:KNOWS]->`
     #[must_use]
     pub fn with_variable(mut self, var: impl Into<String>) -> Self {
         self.variable = Some(var.into());
         self
     }
 
-    /// Add a depth specification: -[:KNOWS*1..3]->
+    /// Add a depth specification: `-[:KNOWS*1..3]->`
     #[must_use]
     pub fn with_depth(mut self, depth: DepthSpec) -> Self {
         self.depth = Some(depth);

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -239,7 +239,7 @@ impl CurrentStorage {
     /// Returns `Some(property_name)` if a vector index is enabled,
     /// or `None` if no index is configured.
     ///
-    /// Note: For multi-property setups, use [`list_vector_indexes`] instead.
+    /// Note: For multi-property setups, use [`Self::list_vector_indexes`] instead.
     pub fn get_indexed_property_name(&self) -> Option<String> {
         self.get_default_vector_property_name()
     }
@@ -590,7 +590,7 @@ impl CurrentStorage {
     ///
     /// This method does NOT delete edges connected to the node. This may leave
     /// orphaned edges in the graph. For most use cases, prefer using
-    /// [`WriteTransaction::delete_node_cascade`] which automatically removes
+    /// [`crate::api::transaction::WriteOps::delete_node_cascade`] which automatically removes
     /// all connected edges to maintain referential integrity.
     ///
     /// Only use this method if you explicitly need to preserve edges for some
@@ -1697,7 +1697,7 @@ impl CurrentStorage {
 
     /// Find k most similar nodes at a specific point in time for a specific property.
     ///
-    /// This is the property-specific version of [`find_similar_as_of()`].
+    /// This is the property-specific version of [`Self::find_similar_as_of()`].
     /// It validates that the requested property matches the property for which
     /// the temporal vector index was enabled.
     ///


### PR DESCRIPTION
📖 Chapter: Documentation Maintenance
🔦 Insight: Fixed numerous `cargo doc` warnings where Rustdoc was interpreting bracketed text (like `[tag:1]` or `[:REL]`) as broken links. Also resolved actual broken links to methods and types by using fully qualified paths or `Self::`.
🧪 Example: N/A (Documentation fixes only)


---
*PR created automatically by Jules for task [3161350184878091779](https://jules.google.com/task/3161350184878091779) started by @madmax983*