### PR TITLE
🎨 Mosaic: UI Polish & Experimental Widgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ memmap2 = "0.9"
 thiserror = "2.0"
 smallvec = "1.13"
 chrono = "0.4"
+comfy-table = "7.1"
+crossterm = "0.27"
 
 # Configuration support (optional TOML config files)
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/experimental/arthropod.rs
+++ b/src/experimental/arthropod.rs
@@ -1,0 +1,84 @@
+use crossterm::style::{Color, Stylize};
+
+/// State of a UI button.
+pub enum ButtonState {
+    /// Normal state.
+    Idle,
+    /// Mouse over state.
+    Hover,
+    /// Active/Pressed state.
+    Clicked,
+}
+
+/// A reusable button component.
+///
+/// Refactored from previous implementation to separate state from rendering.
+pub struct Button {
+    /// Text label on the button.
+    pub label: String,
+    /// Current interaction state.
+    pub state: ButtonState,
+}
+
+impl Button {
+    /// Create a new button with the given label.
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            state: ButtonState::Idle,
+        }
+    }
+
+    /// Set the button state (builder pattern).
+    pub fn with_state(mut self, state: ButtonState) -> Self {
+        self.state = state;
+        self
+    }
+
+    /// Render the button as a styled string.
+    pub fn render(&self) -> String {
+        match self.state {
+            ButtonState::Idle => {
+                // [ Label ]
+                format!("[ {} ]", self.label)
+            }
+            ButtonState::Hover => {
+                // [ Label ] with background
+                format!("{}", format!("[ {} ]", self.label).with(Color::White).on(Color::DarkGrey))
+            }
+            ButtonState::Clicked => {
+                // [ LABEL ] with highlight
+                format!("{}", format!("[ {} ]", self.label.to_uppercase()).with(Color::Black).on(Color::Green))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_button_render_idle() {
+        let btn = Button::new("OK");
+        assert_eq!(btn.render(), "[ OK ]");
+    }
+
+    #[test]
+    fn test_button_render_hover() {
+        let btn = Button::new("OK").with_state(ButtonState::Hover);
+        let rendered = btn.render();
+        // Check for ANSI codes (basic check)
+        assert_ne!(rendered, "[ OK ]");
+        assert!(rendered.contains("OK"));
+    }
+
+    #[test]
+    fn test_button_render_clicked() {
+        let btn = Button::new("ok").with_state(ButtonState::Clicked);
+        let rendered = btn.render();
+        // Check for uppercase transformation
+        assert!(rendered.contains("OK"));
+        assert!(!rendered.contains("ok"));
+    }
+}

--- a/src/experimental/fishing_ui.rs
+++ b/src/experimental/fishing_ui.rs
@@ -1,0 +1,130 @@
+use crossterm::style::{Color, Stylize};
+
+/// Visual component representing the fishing line tension.
+pub struct TensionBar {
+    /// Current tension value (0.0 to max_tension).
+    pub current_tension: f32,
+    /// Maximum tension before the line breaks.
+    pub max_tension: f32,
+    /// Start of the safe tension zone (green zone).
+    pub safe_zone_start: f32,
+    /// End of the safe tension zone.
+    pub safe_zone_end: f32,
+}
+
+impl TensionBar {
+    /// Create a new tension bar.
+    pub fn new(current: f32, max: f32, safe_start: f32, safe_end: f32) -> Self {
+        Self {
+            current_tension: current,
+            max_tension: max,
+            safe_zone_start: safe_start,
+            safe_zone_end: safe_end,
+        }
+    }
+
+    /// Render the tension bar as a styled ASCII string.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - Total width of the bar in characters (including brackets).
+    pub fn render(&self, width: usize) -> String {
+        let mut bar = String::new();
+        bar.push('[');
+
+        let total_chars = width.saturating_sub(2);
+        let current_pos = ((self.current_tension / self.max_tension).clamp(0.0, 1.0) * total_chars as f32) as usize;
+        let safe_start_pos = ((self.safe_zone_start / self.max_tension).clamp(0.0, 1.0) * total_chars as f32) as usize;
+        let safe_end_pos = ((self.safe_zone_end / self.max_tension).clamp(0.0, 1.0) * total_chars as f32) as usize;
+
+        for i in 0..total_chars {
+            let ch = if i < current_pos { '|' } else { ' ' };
+
+            // Coloring logic
+            let styled_char = if i >= safe_start_pos && i <= safe_end_pos {
+                // Inside Safe zone
+                if i < current_pos {
+                    // Tension inside safe zone - Good!
+                    format!("{}", ch.with(Color::Green))
+                } else {
+                    // Empty safe zone marker (use a different char or color)
+                    // Let's use '-' for empty safe zone to make it visible
+                    let marker = if i < current_pos { ch } else { '-' };
+                    format!("{}", marker.with(Color::DarkGreen))
+                }
+            } else if i < current_pos {
+                // Tension outside safe zone
+                if i > safe_end_pos {
+                    // High tension (danger)
+                     format!("{}", ch.with(Color::Red))
+                } else {
+                    // Low tension (too slack)
+                     format!("{}", ch.with(Color::Yellow))
+                }
+            } else {
+                // Empty space outside safe zone
+                format!("{}", ch)
+            };
+
+            bar.push_str(&styled_char);
+        }
+
+        bar.push(']');
+        bar
+    }
+}
+
+/// State of the fishing bobber.
+pub enum BobberState {
+    /// Bobber is floating calmly.
+    Floating,
+    /// Bobber is dipping (fish nibbling).
+    Dipping,
+    /// Fish is hooked!
+    Hooked,
+}
+
+/// Icon representing the fishing bobber.
+pub struct BobberIcon {
+    /// Current state of the bobber.
+    pub state: BobberState,
+}
+
+impl BobberIcon {
+    /// Create a new bobber icon.
+    pub fn new(state: BobberState) -> Self {
+        Self { state }
+    }
+
+    /// Render the bobber icon as a styled string.
+    pub fn render(&self) -> String {
+        match self.state {
+            BobberState::Floating => format!("{}", "O".with(Color::Cyan)),
+            BobberState::Dipping => format!("{}", "o".with(Color::Blue)),
+            BobberState::Hooked => format!("{}", "!".with(Color::Red).bold()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tension_bar_render() {
+        let bar = TensionBar::new(50.0, 100.0, 40.0, 60.0);
+        let rendered = bar.render(20);
+        assert!(rendered.starts_with('['));
+        assert!(rendered.ends_with(']'));
+        // We can't easily assert colors in string without parsing ANSI codes,
+        // but we can check the length (it will be longer due to ANSI codes).
+        assert!(rendered.len() > 20);
+    }
+
+    #[test]
+    fn test_bobber_render() {
+        let bobber = BobberIcon::new(BobberState::Hooked);
+        let rendered = bobber.render();
+        assert!(rendered.contains('!'));
+    }
+}

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -8,3 +8,9 @@ pub mod semantic_pathfinding;
 #[cfg(feature = "nova")]
 /// Temporal narrative generator for natural language history logs.
 pub mod temporal_narrative;
+#[cfg(feature = "nova")]
+/// UI components for the Fishing Minigame.
+pub mod fishing_ui;
+#[cfg(feature = "nova")]
+/// Arthropod GUI widgets.
+pub mod arthropod;

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -6,9 +6,14 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::VersionId;
 use crate::core::temporal::Timestamp;
 use crate::core::{EdgeId, NodeId};
+use crate::core::property::PropertyMap;
+use crate::core::interning::GLOBAL_INTERNER;
 use crate::utils::error::Result;
 
 use super::iterators::ResultIterator;
+
+use comfy_table::{Table, Row, Cell, Attribute};
+use crossterm::style::{Color, Stylize};
 
 /// A path through the graph, represented as a sequence of entity IDs.
 pub type Path = Vec<EntityId>;
@@ -272,6 +277,7 @@ impl Iterator for QueryResults {
 /// - Missing scores are padded with `0.0`
 /// - Missing paths are padded with empty vectors (`vec![]`)
 /// - Missing versions are padded with `VersionId(0)`
+/// - Missing properties are padded with empty `PropertyMap`
 ///
 /// **Important**: Users should check the source query type to distinguish padding from actual values.
 /// For example, a score of `0.0` could be either a padding value or an actual similarity score of zero.
@@ -287,6 +293,8 @@ impl Iterator for QueryResults {
 pub struct QueryResult {
     /// Node IDs from the query results
     pub nodes: Vec<NodeId>,
+    /// Properties for the nodes (optional)
+    pub properties: Option<Vec<PropertyMap>>,
     /// Similarity scores for ranked results (e.g., vector search)
     pub scores: Option<Vec<f32>>,
     /// Paths for traversal results
@@ -301,6 +309,7 @@ impl QueryResult {
     pub fn new() -> Self {
         QueryResult {
             nodes: Vec::new(),
+            properties: None,
             scores: None,
             paths: None,
             versions: None,
@@ -312,10 +321,18 @@ impl QueryResult {
     pub fn with_nodes(nodes: Vec<NodeId>) -> Self {
         QueryResult {
             nodes,
+            properties: None,
             scores: None,
             paths: None,
             versions: None,
         }
+    }
+
+    /// Add properties to this result
+    #[must_use]
+    pub fn with_properties(mut self, properties: Vec<PropertyMap>) -> Self {
+        self.properties = Some(properties);
+        self
     }
 
     /// Add scores to this result
@@ -396,42 +413,75 @@ impl Default for QueryResult {
 
 impl std::fmt::Display for QueryResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "QueryResult {{")?;
-        writeln!(f, "  nodes: {} items", self.nodes.len())?;
+        let mut table = Table::new();
+        table.load_preset(comfy_table::presets::UTF8_FULL);
+        table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
 
-        if let Some(scores) = &self.scores {
-            writeln!(f, "  scores: {} items", scores.len())?;
-            if !scores.is_empty() {
-                // Check if any value is not normal (NaN or Inf)
-                let has_abnormal = scores.iter().any(|s| !s.is_finite());
-                if !has_abnormal {
-                    let min = scores.iter().copied().fold(f32::INFINITY, f32::min);
-                    let max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-                    writeln!(f, "    range: [{:.3}, {:.3}]", min, max)?;
+        let mut headers = vec![Cell::new("Node ID").add_attribute(Attribute::Bold)];
+        if self.properties.is_some() {
+            headers.push(Cell::new("Properties").add_attribute(Attribute::Bold));
+        }
+        if self.scores.is_some() {
+            headers.push(Cell::new("Score").add_attribute(Attribute::Bold));
+        }
+        if self.paths.is_some() {
+            headers.push(Cell::new("Path").add_attribute(Attribute::Bold));
+        }
+        if self.versions.is_some() {
+            headers.push(Cell::new("Version").add_attribute(Attribute::Bold));
+        }
+        table.set_header(headers);
+
+        for i in 0..self.nodes.len() {
+            let mut row = Row::new();
+            row.add_cell(Cell::new(format!("{}", self.nodes[i])));
+
+            if let Some(props) = &self.properties {
+                let mut prop_str = String::new();
+                let prop_map = &props[i];
+                if prop_map.is_empty() {
+                    prop_str = "{}".to_string();
+                } else {
+                    prop_str.push_str("{ ");
+                    for (j, (key, value)) in prop_map.iter().enumerate() {
+                        if j > 0 {
+                            prop_str.push_str(", ");
+                        }
+
+                        let key_str = GLOBAL_INTERNER.with_str(*key, |s| s.to_string()).unwrap_or_else(|| "UNKNOWN".to_string());
+                        prop_str.push_str(&format!("{}: ", key_str));
+
+                        if let Some(b) = value.as_bool() {
+                            if b {
+                                prop_str.push_str(&format!("{}", "true".with(Color::Green)));
+                            } else {
+                                prop_str.push_str("false");
+                            }
+                        } else {
+                             prop_str.push_str(&format!("{}", value));
+                        }
+                    }
+                    prop_str.push_str(" }");
                 }
+                row.add_cell(Cell::new(prop_str));
             }
-        } else {
-            writeln!(f, "  scores: None")?;
-        }
 
-        if let Some(paths) = &self.paths {
-            writeln!(f, "  paths: {} items", paths.len())?;
-            if !paths.is_empty() {
-                let total_hops: usize = paths.iter().map(|p| p.len()).sum();
-                let avg_hops = total_hops as f32 / paths.len() as f32;
-                writeln!(f, "    avg path length: {:.1}", avg_hops)?;
+            if let Some(scores) = &self.scores {
+                row.add_cell(Cell::new(format!("{:.4}", scores[i])));
             }
-        } else {
-            writeln!(f, "  paths: None")?;
+
+            if let Some(paths) = &self.paths {
+                 row.add_cell(Cell::new(format!("{:?}", paths[i])));
+            }
+
+            if let Some(versions) = &self.versions {
+                 row.add_cell(Cell::new(format!("{}", versions[i])));
+            }
+
+            table.add_row(row);
         }
 
-        if let Some(versions) = &self.versions {
-            writeln!(f, "  versions: {} items", versions.len())?;
-        } else {
-            writeln!(f, "  versions: None")?;
-        }
-
-        write!(f, "}}")
+        write!(f, "{}", table)
     }
 }
 
@@ -467,6 +517,7 @@ impl QueryResults {
         let has_any_scores = rows.iter().any(|r| r.score.is_some());
         let has_any_paths = rows.iter().any(|r| r.path.is_some());
         let has_any_versions = rows.iter().any(|r| r.timestamp.is_some());
+        let has_any_properties = rows.iter().any(|r| r.entity.as_node().is_some());
 
         // Second pass: extract data with padding
         let mut nodes = Vec::new();
@@ -485,11 +536,33 @@ impl QueryResults {
         } else {
             None
         };
+        let mut properties = if has_any_properties {
+            Some(Vec::new())
+        } else {
+            None
+        };
 
         for row in rows {
             // Extract node ID
             if let Some(node_id) = row.entity.node_id() {
                 nodes.push(node_id);
+            }
+
+            // Extract properties
+            if let Some(ref mut props) = properties {
+                if let Some(node) = row.entity.as_node() {
+                    props.push(node.properties.clone());
+                } else {
+                    // Pad with empty properties for Edge or just ID
+                    // For edges we might want to support properties too in the future,
+                    // but EntityResult doesn't easily expose them if it's EdgeId.
+                    // If it's Edge(e), we could extract.
+                    if let Some(edge) = row.entity.as_edge() {
+                        props.push(edge.properties.clone());
+                    } else {
+                        props.push(PropertyMap::default());
+                    }
+                }
             }
 
             // Extract or pad scores
@@ -538,6 +611,7 @@ impl QueryResults {
 
         Ok(QueryResult {
             nodes,
+            properties,
             scores,
             paths,
             versions,
@@ -895,6 +969,7 @@ mod tests {
         assert!(result.scores.is_none());
         assert!(result.paths.is_none());
         assert!(result.versions.is_none());
+        assert!(result.properties.is_none());
     }
 
     #[test]
@@ -956,17 +1031,20 @@ mod tests {
         let path2 = vec![EntityId::Node(NodeId::new(2).unwrap())];
         let paths = vec![path1, path2];
         let versions = vec![VersionId::new(100).unwrap(), VersionId::new(101).unwrap()];
+        let props = vec![PropertyMap::default(), PropertyMap::default()];
 
         let result = QueryResult::with_nodes(nodes.clone())
             .with_scores(scores.clone())
             .with_paths(paths.clone())
-            .with_versions(versions.clone());
+            .with_versions(versions.clone())
+            .with_properties(props.clone());
 
         assert_eq!(result.len(), 2);
         assert_eq!(result.nodes, nodes);
         assert_eq!(result.scores, Some(scores));
         assert_eq!(result.paths, Some(paths));
         assert_eq!(result.versions, Some(versions));
+        assert_eq!(result.properties, Some(props));
     }
 
     #[test]
@@ -1049,22 +1127,20 @@ mod tests {
         let result = QueryResult::with_nodes(nodes).with_scores(scores);
 
         let display = format!("{}", result);
-        assert!(display.contains("QueryResult"));
-        assert!(display.contains("nodes: 2 items"));
-        assert!(display.contains("scores: 2 items"));
-        assert!(display.contains("range:"));
+        // Table output contains borders
+        assert!(display.contains("Node ID"));
+        assert!(display.contains("Score"));
+        // We can't easily check for exact table layout without mocking terminal,
+        // but we can check if it contains the data.
+        assert!(display.contains("1"));
+        assert!(display.contains("0.9"));
     }
 
     #[test]
     fn test_query_result_display_empty() {
         let result = QueryResult::new();
         let display = format!("{}", result);
-
-        assert!(display.contains("QueryResult"));
-        assert!(display.contains("nodes: 0 items"));
-        assert!(display.contains("scores: None"));
-        assert!(display.contains("paths: None"));
-        assert!(display.contains("versions: None"));
+        assert!(display.contains("Node ID"));
     }
 
     #[test]
@@ -1083,8 +1159,7 @@ mod tests {
         let result = QueryResult::with_nodes(nodes).with_paths(paths);
 
         let display = format!("{}", result);
-        assert!(display.contains("paths: 2 items"));
-        assert!(display.contains("avg path length:"));
+        assert!(display.contains("Path"));
     }
 
     #[test]
@@ -1300,11 +1375,7 @@ mod tests {
         let result = QueryResult::with_nodes(nodes).with_scores(scores);
 
         let display = format!("{}", result);
-        assert!(display.contains("QueryResult"));
-        assert!(display.contains("nodes: 2 items"));
-        assert!(display.contains("scores: 2 items"));
-        // Should NOT contain "range:" because min/max are not finite
-        assert!(!display.contains("range:"));
+        assert!(display.contains("Score"));
     }
 
     #[test]
@@ -1314,9 +1385,7 @@ mod tests {
         let result = QueryResult::with_nodes(nodes).with_scores(scores);
 
         let display = format!("{}", result);
-        assert!(display.contains("scores: 1 items"));
-        // Should NOT contain "range:" because max is infinite
-        assert!(!display.contains("range:"));
+        assert!(display.contains("Score"));
     }
 
     #[test]
@@ -1339,5 +1408,47 @@ mod tests {
         assert_eq!(versions[0], VersionId::new(100).unwrap());
         assert_eq!(versions[1], VersionId::new(0).unwrap()); // Clamped
         assert_eq!(versions[2], VersionId::new(0).unwrap());
+    }
+
+    #[test]
+    fn test_collect_structured_with_properties() {
+        let mut props1 = PropertyMapBuilder::new();
+        props1 = props1.insert("name", "Alice").insert("age", 30);
+
+        let mut props2 = PropertyMapBuilder::new();
+        props2 = props2.insert("name", "Bob");
+
+        let node1 = Node::new(
+            NodeId::new(1).unwrap(),
+            GLOBAL_INTERNER.intern("Person").unwrap(),
+            props1.build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        let node2 = Node::new(
+            NodeId::new(2).unwrap(),
+            GLOBAL_INTERNER.intern("Person").unwrap(),
+            props2.build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        let rows = vec![
+            QueryRow::from_entity(EntityResult::Node(node1)),
+            QueryRow::from_entity(EntityResult::Node(node2)),
+        ];
+
+        let results = QueryResults::new(Box::new(MockIterator::new(rows)));
+        let structured = results.collect_structured().unwrap();
+
+        assert!(structured.properties.is_some());
+        let props = structured.properties.unwrap();
+        assert_eq!(props.len(), 2);
+
+        assert_eq!(
+            props[0].get("name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
+        assert_eq!(props[0].get("age").and_then(|v| v.as_int()), Some(30));
+        assert_eq!(props[1].get("name").and_then(|v| v.as_str()), Some("Bob"));
     }
 }


### PR DESCRIPTION
This PR addresses the "Mosaic" design tasks:
1.  **Fishing Minigame UI**: Added `TensionBar` and `BobberIcon` in `src/experimental/fishing_ui.rs`.
2.  **CLI Polish**: Enhanced `QueryResult` display in `src/query/executor/results.rs` using `comfy-table` to render results in a grid, including properties, and colorizing boolean true values green.
3.  **Arthropod Widget**: Added `Button` component in `src/experimental/arthropod.rs` with distinct states (Idle, Hover, Clicked).

All new UI components are gated behind the `nova` feature flag. CLI changes affect the core library's `Display` implementation for query results.

---
*PR created automatically by Jules for task [1384659453910622550](https://jules.google.com/task/1384659453910622550) started by @madmax983*