### PR TITLE
🛡️ Sentry: Fix missing Quantization persistence in HnswConfig

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -265,6 +265,8 @@ impl HnswConfig {
         writer.write_all(&(self.ef_construction as u64).to_le_bytes())?;
         writer.write_all(&(self.ef_search as u64).to_le_bytes())?;
         writer.write_all(&(self.capacity as u64).to_le_bytes())?;
+        // Append quantization (backward compatible: appended at end)
+        writer.write_all(&[self.quantization.to_u8()])?;
         Ok(())
     }
 
@@ -291,6 +293,16 @@ impl HnswConfig {
         reader.read_exact(&mut buf_u64)?;
         let capacity = u64::from_le_bytes(buf_u64) as usize;
 
+        // Try to read quantization byte.
+        // Use read() instead of read_exact() to handle legacy data (backward compatibility).
+        // If EOF, fallback to default (F32).
+        let quantization = match reader.read(&mut buf_u8) {
+            Ok(1) => Quantization::from_u8(buf_u8[0])?,
+            Ok(0) => Quantization::default(), // Legacy format (EOF)
+            Ok(_) => unreachable!("Buffer size is 1"),
+            Err(e) => return Err(e.into()),
+        };
+
         Ok(HnswConfig {
             dimensions,
             metric,
@@ -298,6 +310,7 @@ impl HnswConfig {
             ef_construction,
             ef_search,
             capacity,
+            quantization,
             ..Default::default()
         })
     }
@@ -1388,6 +1401,27 @@ mod tests {
     }
 
     #[test]
+    fn test_hnsw_config_serialization_quantization() -> Result<()> {
+        use std::io::Cursor;
+
+        // Create config with non-default quantization
+        let config = HnswConfig::new(384, DistanceMetric::Cosine)
+            .with_quantization(Quantization::I8);
+
+        // Serialize
+        let mut buffer = Vec::new();
+        config.serialize_into(&mut buffer)?;
+
+        // Deserialize
+        let mut cursor = Cursor::new(buffer);
+        let loaded = HnswConfig::deserialize_from(&mut cursor)?;
+
+        assert_eq!(loaded.quantization, Quantization::I8, "Quantization should be preserved");
+
+        Ok(())
+    }
+
+    #[test]
     fn test_hnsw_remove() -> Result<()> {
         let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
 
@@ -2001,6 +2035,32 @@ mod tests {
                 e
             ),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_hnsw_config_legacy_compatibility() -> Result<()> {
+        use std::io::Cursor;
+
+        // Construct legacy buffer (without quantization byte)
+        // Format: dimensions(8) + metric(1) + m(8) + ef_c(8) + ef_s(8) + capacity(8) = 41 bytes
+        let mut buffer = Vec::new();
+        buffer.write_all(&384u64.to_le_bytes())?; // dimensions
+        buffer.write_all(&[0])?; // metric (Cosine)
+        buffer.write_all(&16u64.to_le_bytes())?; // m
+        buffer.write_all(&128u64.to_le_bytes())?; // ef_construction
+        buffer.write_all(&64u64.to_le_bytes())?; // ef_search
+        buffer.write_all(&1000u64.to_le_bytes())?; // capacity
+        // NO quantization byte
+
+        let mut cursor = Cursor::new(buffer);
+        let loaded = HnswConfig::deserialize_from(&mut cursor)?;
+
+        // Should load successfully and default to F32
+        assert_eq!(loaded.dimensions, 384);
+        assert_eq!(loaded.metric, DistanceMetric::Cosine);
+        assert_eq!(loaded.quantization, Quantization::F32, "Legacy config should default to F32");
+
         Ok(())
     }
 }

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -109,6 +109,61 @@ pub enum Quantization {
     I8,
 }
 
+impl Quantization {
+    /// Encode quantization level as a byte for serialization.
+    ///
+    /// Encoding:
+    /// - 0 = F32
+    /// - 1 = F16
+    /// - 2 = I8
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gallifreydb::index::vector::Quantization;
+    ///
+    /// assert_eq!(Quantization::F32.to_u8(), 0);
+    /// assert_eq!(Quantization::F16.to_u8(), 1);
+    /// assert_eq!(Quantization::I8.to_u8(), 2);
+    /// ```
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Quantization::F32 => 0,
+            Quantization::F16 => 1,
+            Quantization::I8 => 2,
+        }
+    }
+
+    /// Decode quantization level from a byte.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the byte value is not a valid quantization encoding (>= 3).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gallifreydb::index::vector::Quantization;
+    ///
+    /// assert_eq!(Quantization::from_u8(0).unwrap(), Quantization::F32);
+    /// assert_eq!(Quantization::from_u8(1).unwrap(), Quantization::F16);
+    /// assert_eq!(Quantization::from_u8(2).unwrap(), Quantization::I8);
+    /// assert!(Quantization::from_u8(3).is_err());
+    /// ```
+    pub fn from_u8(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(Quantization::F32),
+            1 => Ok(Quantization::F16),
+            2 => Ok(Quantization::I8),
+            _ => Err(crate::utils::error::StorageError::CorruptedData(format!(
+                "Invalid quantization encoding: {}",
+                value
+            ))
+            .into()),
+        }
+    }
+}
+
 /// Storage mode for the vector index.
 ///
 /// - InMemory: All data in RAM (default, fastest queries)
@@ -663,6 +718,21 @@ mod tests {
             DistanceMetric::from_u8(5).unwrap(),
             DistanceMetric::Tanimoto
         );
+    }
+
+    #[test]
+    fn test_quantization_encoding() {
+        // Test round-trip encoding for all variants
+        assert_eq!(Quantization::F32.to_u8(), 0);
+        assert_eq!(Quantization::F16.to_u8(), 1);
+        assert_eq!(Quantization::I8.to_u8(), 2);
+
+        assert_eq!(Quantization::from_u8(0).unwrap(), Quantization::F32);
+        assert_eq!(Quantization::from_u8(1).unwrap(), Quantization::F16);
+        assert_eq!(Quantization::from_u8(2).unwrap(), Quantization::I8);
+
+        // Test invalid value
+        assert!(Quantization::from_u8(99).is_err());
     }
 }
 

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -1171,14 +1171,15 @@ mod tests {
 
     #[test]
     fn test_hnsw_config_serialization_roundtrip() -> Result<()> {
-        use crate::index::vector::{DistanceMetric, HnswConfig};
+        use crate::index::vector::{DistanceMetric, HnswConfig, Quantization};
         use std::io::Cursor;
 
         let config = HnswConfig::new(384, DistanceMetric::Cosine)
             .with_m(32)
             .with_ef_construction(200)
             .with_ef_search(100)
-            .with_capacity(5000);
+            .with_capacity(5000)
+            .with_quantization(Quantization::I8); // Set non-default quantization
 
         // Serialize
         let mut buffer = Vec::new();
@@ -1194,6 +1195,7 @@ mod tests {
         assert_eq!(loaded.ef_construction, 200);
         assert_eq!(loaded.ef_search, 100);
         assert_eq!(loaded.capacity, 5000);
+        assert_eq!(loaded.quantization, Quantization::I8, "Quantization should be preserved");
 
         Ok(())
     }


### PR DESCRIPTION
Sentry 🛡️ discovered a coverage gap where `HnswConfig` serialization logic was ignoring the `quantization` field, causing indexes to revert to `F32` after a restart.

This PR:
1.  Enhances `Quantization` enum with serialization helpers.
2.  Updates `HnswConfig` serialization to include the quantization byte.
3.  Implements backward-compatible deserialization (defaults to F32 if byte is missing).
4.  Adds comprehensive tests for round-trip persistence and legacy file compatibility.

This ensures that quantized vector indexes (I8, F16) retain their configuration across restarts.

---
*PR created automatically by Jules for task [12615824246135837357](https://jules.google.com/task/12615824246135837357) started by @madmax983*