### PR TITLE
🔒 Warden: Prevent buffer over-read in custom vector metrics

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -77,3 +77,14 @@ The JSON converter `json_to_property_value` and its inverse `property_value_to_j
 
 **Defense:** Recursion Depth Limit
 Refactored both functions to use recursive helpers that track depth. Enforced `MAX_JSON_RECURSION_DEPTH = 100` (strictly `>=`). Changed `property_value_to_json` to return `Result` to propagate errors. Verified with unit tests covering deserialization, serialization, and boundary conditions (depth 99 vs 100).
+
+## 2026-02-15 - Vector Index Memory Safety Lockdown
+
+**Threat:** Buffer Over-read in Custom Metrics
+The `usearch` library supports quantized vector storage (I8, F16), which reduces memory usage. However, user-defined custom metrics are defined to operate on `f32` slices. When using a custom metric with quantized storage, `usearch` passes pointers to the quantized data (e.g., `i8*`), but the Rust wrapper blindly cast these to `f32*`. This resulted in reading 4x (for I8) or 2x (for F16) more memory than allocated, leading to potential crashes (DoS) or information leakage (reading uninitialized/unrelated memory).
+
+**Defense:** Configuration Validation
+Enforced a strict validation rule in `HnswIndexBuilder::build` and `HnswIndex::load`: Custom metrics are now **only** allowed when using `Quantization::F32`. Attempting to combine `custom_metric` with `I8` or `F16` quantization now returns a specific `InvalidVector` error instead of proceeding with unsafe memory access.
+
+**Verification:** Regression Test
+Added `tests/security_custom_metric.rs` which attempts to build and load an index with this dangerous combination. Verified that the operation fails safely with the expected error message, whereas previously it would read out-of-bounds memory.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -443,6 +443,15 @@ impl HnswIndexBuilder {
         self
     }
 
+    /// Sets a custom distance metric function.
+    pub fn with_custom_metric<F>(mut self, name: &str, f: F) -> Self
+    where
+        F: Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static,
+    {
+        self.config = self.config.with_custom_metric(name, f);
+        self
+    }
+
     /// Builds the HNSW index with the configured parameters.
     pub fn build(self) -> Result<HnswIndex> {
         // Validate dimensions
@@ -456,6 +465,22 @@ impl HnswIndexBuilder {
         if self.config.m == 0 || self.config.m > 64 {
             return Err(Error::Vector(VectorError::InvalidVector {
                 reason: format!("M must be in range [1, 64], got {}", self.config.m),
+            }));
+        }
+
+        // Security Check: Custom metrics require F32 quantization
+        // This is critical because usearch passes raw pointers to the metric function.
+        // If quantization is not F32 (e.g., I8 or F16), the pointers will point to
+        // compressed data, but our metric wrapper casts them to `*const f32`.
+        // This would cause a buffer over-read (reading 4x or 2x memory), leading to
+        // potential crashes (DoS) or information leakage.
+        if self.config.custom_metric.is_some() && self.config.quantization != Quantization::F32 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!(
+                    "Custom metrics are only supported with F32 quantization (requested {:?}). \
+                     Using other quantization levels with custom metrics causes memory safety issues.",
+                    self.config.quantization
+                ),
             }));
         }
 
@@ -1246,6 +1271,17 @@ impl HnswIndex {
 
     /// Loads an index from a file path.
     pub fn load(path: &Path, config: HnswConfig) -> Result<Self> {
+        // Security Check: Custom metrics require F32 quantization
+        if config.custom_metric.is_some() && config.quantization != Quantization::F32 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!(
+                    "Custom metrics are only supported with F32 quantization (requested {:?}). \
+                     Using other quantization levels with custom metrics causes memory safety issues.",
+                    config.quantization
+                ),
+            }));
+        }
+
         let options = IndexOptions {
             dimensions: config.dimensions,
             metric: to_usearch_metric(config.metric),

--- a/tests/security_custom_metric.rs
+++ b/tests/security_custom_metric.rs
@@ -1,0 +1,81 @@
+use gallifreydb::core::id::NodeId;
+use gallifreydb::index::vector::{
+    DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization, VectorIndex,
+};
+use gallifreydb::utils::error::VectorError;
+use gallifreydb::utils::{Error, Result};
+
+#[test]
+fn test_custom_metric_with_quantization_crash() -> Result<()> {
+    // This test attempts to trigger a buffer over-read by using I8 quantization
+    // with a custom metric. It should now be prevented by a security check.
+
+    let dims = 1000;
+
+    // We can now use the builder directly since we added the method
+    let index_res = HnswIndexBuilder::new(dims, DistanceMetric::Cosine)
+        .quantization(Quantization::I8)
+        .with_custom_metric("test", move |a: &[f32], b: &[f32]| {
+            let mut sum = 0.0;
+            for i in 0..a.len() {
+                sum += a[i] + b[i];
+            }
+            sum
+        })
+        .build();
+
+    // Assert that we get an error
+    match index_res {
+        Ok(_) => panic!("Expected build() to fail due to security check, but it succeeded!"),
+        Err(Error::Vector(VectorError::InvalidVector { reason })) => {
+            // Verify the error message contains relevant info
+            assert!(
+                reason.contains("only supported with F32 quantization"),
+                "Unexpected error message: {}",
+                reason
+            );
+            assert!(
+                reason.contains("memory safety"),
+                "Unexpected error message: {}",
+                reason
+            );
+        }
+        Err(e) => panic!("Expected InvalidVector error, got: {:?}", e),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_load_with_unsafe_config() -> Result<()> {
+    // Create a temp file
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test_index.usearch");
+
+    // Create a valid index (without custom metric)
+    let index = HnswIndexBuilder::new(10, DistanceMetric::Cosine)
+        .quantization(Quantization::I8)
+        .build()?;
+
+    let node1 = NodeId::new(1).unwrap();
+    let vec1 = vec![0.1f32; 10];
+    index.add(node1, &vec1)?;
+
+    index.save(&path)?;
+
+    // Try to load it with a dangerous config
+    let mut config = HnswConfig::new(10, DistanceMetric::Cosine);
+    config = config.with_quantization(Quantization::I8);
+    config = config.with_custom_metric("test", |_, _| 0.0);
+
+    let res = HnswIndex::load(&path, config);
+
+    assert!(res.is_err());
+    if let Err(Error::Vector(VectorError::InvalidVector { reason })) = res {
+        assert!(reason.contains("only supported with F32 quantization"));
+    } else {
+        panic!("Expected InvalidVector error");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
**Threat:** Buffer Over-read in Custom Metrics
The `usearch` library supports quantized vector storage (I8, F16). However, the Rust wrapper's custom metric interface expects `f32` slices. When combining quantized storage with a custom metric, the wrapper would interpret pointers to `i8` or `f16` arrays as `f32` arrays, reading 2x or 4x past the allocated buffer. This could lead to DoS (crashes) or information leakage.

**Defense:**
Implemented a security check in `HnswIndexBuilder::build` and `HnswIndex::load` to strictly disallow `custom_metric` when `quantization` is not `F32`. Attempts to use this dangerous combination now return a descriptive `InvalidVector` error.

**Verification:**
Added `tests/security_custom_metric.rs` which verifies that:
1. Building an index with `Quantization::I8` + `custom_metric` fails safely.
2. Loading an index with `Quantization::I8` + `custom_metric` fails safely.
3. Verified via manual testing (prior to fix) that this combination did indeed read garbage memory (denormalized floats from integer bytes).

---
*PR created automatically by Jules for task [7295595432609390547](https://jules.google.com/task/7295595432609390547) started by @madmax983*