### PR TITLE
Docs/Example: Add story_demo and clarify nova feature usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,3 +361,8 @@ name = "edge_iteration"
 harness = false
 path = "benches/edge_iteration.rs"
 required-features = []
+
+# Experimental features
+[[example]]
+name = "story_demo"
+required-features = ["nova"]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ gallifreydb = { version = "0.1", features = ["sharding-rpc"] }
 |---------|-------------|--------------|
 | `sharding-rpc` | RPC client for sharding coordination | `reqwest`, `serde` |
 
+### Experimental Features
+```toml
+[dependencies]
+gallifreydb = { version = "0.1", features = ["nova"] }
+```
+
+| Feature | Description |
+|---------|-------------|
+| `nova` | Experimental features (Narrative Generator, Fishing, Semantic Pathfinding) |
+
 Note: Tiered storage with Redb cold storage backend is included by default (no feature flag needed).
 
 ## Performance & Benchmarks
@@ -758,6 +768,7 @@ See `docs/adr/` for all architectural decisions.
 **Other Examples:**
 - `examples/observability_demo.rs` - Production observability features
 - `examples/doctor_who_demo.rs` - Temporal graph modeling example
+- `examples/story_demo.rs` - Narrative generation example (requires `nova` feature)
 
 ## Use Cases
 

--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -1,7 +1,7 @@
 use gallifreydb::GallifreyDB;
-use gallifreydb::experimental::temporal_narrative::NarrativeGenerator;
 use gallifreydb::PropertyMapBuilder;
 use gallifreydb::WriteOps;
+use gallifreydb::experimental::temporal_narrative::NarrativeGenerator;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = GallifreyDB::new()?;

--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -1,0 +1,38 @@
+use gallifreydb::GallifreyDB;
+use gallifreydb::experimental::temporal_narrative::NarrativeGenerator;
+use gallifreydb::PropertyMapBuilder;
+use gallifreydb::WriteOps;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = GallifreyDB::new()?;
+
+    // 1. Create Node
+    let props1 = PropertyMapBuilder::new()
+        .insert("name", "Alice")
+        .insert("age", 30i64)
+        .build();
+    let node_id = db.create_node("Person", props1)?;
+
+    // 2. Update Node
+    db.write(|tx| {
+        let props2 = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 31i64)
+            .insert("city", "London")
+            .build();
+        tx.update_node(node_id, props2)
+    })?;
+
+    // 3. Generate Narrative
+    let generator = NarrativeGenerator::new(&db);
+    let narrative = generator.generate_node_narrative(node_id)?;
+
+    for event in narrative {
+        println!("Version {}: {}", event.version_number, event.description);
+        for change in event.changes {
+            println!("  - {}", change);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR addresses a DX issue where the `NarrativeGenerator` (part of the experimental `nova` feature set) was difficult to use due to missing examples and unclear feature flag requirements.

Changes:
1.  **Added `examples/story_demo.rs`**: A working example showing how to use `NarrativeGenerator` to create a history of node changes.
2.  **Updated `Cargo.toml`**: registered the `story_demo` example with `required-features = ["nova"]`. This ensures that running `cargo run --example story_demo` without the feature flag produces a helpful "requires features: nova" error message instead of a compilation error.
3.  **Updated `README.md`**: Added a new "Experimental Features" section to the Feature Flags table and listed the `story_demo` in the Examples section.


---
*PR created automatically by Jules for task [9442237626500516110](https://jules.google.com/task/9442237626500516110) started by @madmax983*