### PR TITLE
⚡ Bolt: Pre-allocate vectors in query converter

### DIFF
--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -382,7 +382,9 @@ impl AstConverter {
     /// }
     /// ```
     pub fn convert(&self, ast: &QueryAst) -> Result<Query> {
-        let mut ops = Vec::new();
+        // OPTIMIZATION: Pre-allocate vector to avoid reallocations.
+        // Most queries produce at least a few operations (Scan, Return, etc.), so 8 is a conservative start.
+        let mut ops = Vec::with_capacity(8);
         let hints = QueryHints::default();
 
         // 1. Convert temporal clause to context
@@ -759,7 +761,8 @@ impl AstConverter {
 
     /// Convert RETURN clause to projection list.
     fn convert_return(&self, return_clause: &ReturnClause) -> Result<Vec<String>> {
-        let mut projections = Vec::new();
+        // OPTIMIZATION: Pre-allocate vector with exact size to avoid reallocations.
+        let mut projections = Vec::with_capacity(return_clause.items.len());
         for item in &return_clause.items {
             match &item.expression {
                 Expression::Property(prop) => {


### PR DESCRIPTION
⚡ Bolt: Pre-allocate vectors in query converter

💡 What: Changed `Vec::new()` to `Vec::with_capacity()` in `src/query/converter.rs`.
🎯 Why: Heap reallocations during query parsing were unnecessary overhead. `Vec::new()` allocates 0 capacity, leading to immediate reallocation when items are pushed.
📊 Impact: Reduces allocations for every single query parsed. For `RETURN` clauses, it eliminates reallocations entirely. For operations, it avoids the initial small growth steps (0->4->8).
🔬 Measurement: Verified with `cargo test`.


---
*PR created automatically by Jules for task [17837251632301003827](https://jules.google.com/task/17837251632301003827) started by @madmax983*