### PR TITLE
🔒 Warden: Eliminated unsafe env var modification in tests

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -88,3 +88,22 @@ Enforced a strict validation rule in `HnswIndexBuilder::build` and `HnswIndex::l
 
 **Verification:** Regression Test
 Added `tests/security_custom_metric.rs` which attempts to build and load an index with this dangerous combination. Verified that the operation fails safely with the expected error message, whereas previously it would read out-of-bounds memory.
+
+## 2026-02-15 - Race Condition & Unsafe Audit
+
+**Threat:** Race Condition / UB in Environment Variable Tests
+Tests in `src/embeddings/providers` were using `unsafe { std::env::set_var(...) }` to mock configuration. Since `set_var` is not thread-safe and tests run in parallel by default, this could lead to data races (Undefined Behavior) and flaky tests across the entire suite.
+
+**Defense:** Dependency Injection for Config
+Refactored `OpenAIConfig::from_env` and `HuggingFaceConfig::from_env` to use an internal helper `from_env_with_provider` that accepts a closure for environment lookup.
+- Removed all `unsafe` blocks and `std::env::set_var` calls from tests.
+- Removed the `Mutex` serialization hack.
+- Tests now use a mock closure to simulate environment variables safely.
+
+**Threat:** Potential Buffer Over-read in Vector Deserialization
+`src/core/property.rs` contains `unsafe` blocks for optimizing vector serialization/deserialization by casting byte slices to f32 slices. While theoretically sound on little-endian systems, incorrect length checks could lead to buffer over-reads.
+
+**Verification:** Audit & Fuzz Test
+- **Audited:** Verified that `serialize_vector_into` and `deserialize_vector` perform strict bounds checking (`data_slice.len() == dimension * 4`) and handle alignment correctly via `Vec::with_capacity`.
+- **Documented:** Added "Verified by Warden" comments explaining the safety proofs (validity of f32 bit patterns, alignment guarantees).
+- **Verified:** Added `tests/warden_property_safety.rs` to fuzz truncated and malformed inputs, confirming that safe guards trigger before `unsafe` blocks are reached.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -833,6 +833,8 @@ pub fn serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) {
         // 3. The slice lengths are correctly calculated. With the dimension check,
         //    overflow is not possible on 64-bit or 32-bit systems.
         // 4. Alignment is not an issue - we're copying to a Vec<u8>
+        //
+        // Verified by Warden (2026-02-15): Input slice 'v' is valid &[f32]. size_of_val is correct. u8 alignment is 1.
         let byte_slice = unsafe {
             std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v))
         };
@@ -937,6 +939,8 @@ pub fn deserialize_vector(bytes: &[u8]) -> Result<(Arc<[f32]>, usize)> {
         //    `data_slice` into the aligned `Vec` buffer.
         // 4. After the copy, the memory is initialized, so calling `set_len` is safe.
         // 5. Any bit pattern is valid for f32 (including NaN, infinity).
+        //
+        // Verified by Warden (2026-02-15): Destination buffer is allocated via Vec::with_capacity(dimension), ensuring correct f32 alignment. Source buffer length is explicitly checked against capacity * 4.
         let mut values = Vec::with_capacity(dimension);
         if dimension > 0 {
             unsafe {

--- a/src/embeddings/providers/huggingface.rs
+++ b/src/embeddings/providers/huggingface.rs
@@ -79,7 +79,19 @@ impl HuggingFaceConfig {
     /// )?;
     /// ```
     pub fn from_env(model_id: String, dimensions: usize) -> Result<Self, EmbeddingError> {
-        let api_token = std::env::var("HF_TOKEN").map_err(|_| {
+        Self::from_env_with_provider(model_id, dimensions, |k| std::env::var(k))
+    }
+
+    /// Internal helper to allow mocking environment variables in tests
+    pub(crate) fn from_env_with_provider<F>(
+        model_id: String,
+        dimensions: usize,
+        env_provider: F,
+    ) -> Result<Self, EmbeddingError>
+    where
+        F: Fn(&str) -> Result<String, std::env::VarError>,
+    {
+        let api_token = env_provider("HF_TOKEN").map_err(|_| {
             EmbeddingError::ConfigError("HF_TOKEN environment variable not set".to_string())
         })?;
 
@@ -336,22 +348,15 @@ impl EmbeddingProvider for HuggingFaceProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    lazy_static::lazy_static! {
-        static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
-    }
 
     #[test]
     fn test_config_from_missing_env() {
-        let _guard = ENV_MUTEX.lock().unwrap(); // Lock before manipulating env
-        let original_var = std::env::var("HF_TOKEN").ok();
+        // Simulate missing environment variable using the provider pattern
+        let result =
+            HuggingFaceConfig::from_env_with_provider("test-model".to_string(), 384, |_| {
+                Err(std::env::VarError::NotPresent)
+            });
 
-        unsafe {
-            std::env::remove_var("HF_TOKEN");
-        }
-
-        let result = HuggingFaceConfig::from_env("test-model".to_string(), 384);
         assert!(result.is_err());
         match result {
             Err(EmbeddingError::ConfigError(msg)) => {
@@ -359,14 +364,7 @@ mod tests {
             }
             _ => panic!("Expected ConfigError"),
         }
-
-        // Restore original value
-        if let Some(val) = original_var {
-            unsafe {
-                std::env::set_var("HF_TOKEN", val);
-            }
-        }
-    } // Mutex is unlocked when _guard goes out of scope
+    }
 
     #[test]
     fn test_config_builder() {

--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -99,7 +99,18 @@ impl OpenAIConfig {
     /// let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
     /// ```
     pub fn from_env(model: OpenAIModel) -> Result<Self, EmbeddingError> {
-        let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+        Self::from_env_with_provider(model, |k| std::env::var(k))
+    }
+
+    /// Internal helper to allow mocking environment variables in tests
+    pub(crate) fn from_env_with_provider<F>(
+        model: OpenAIModel,
+        env_provider: F,
+    ) -> Result<Self, EmbeddingError>
+    where
+        F: Fn(&str) -> Result<String, std::env::VarError>,
+    {
+        let api_key = env_provider("OPENAI_API_KEY").map_err(|_| {
             EmbeddingError::ConfigError("OPENAI_API_KEY environment variable not set".to_string())
         })?;
 
@@ -335,11 +346,6 @@ impl EmbeddingProvider for OpenAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    lazy_static::lazy_static! {
-        static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
-    }
 
     #[test]
     fn test_model_dimensions() {
@@ -363,15 +369,11 @@ mod tests {
 
     #[test]
     fn test_config_from_missing_env() {
-        let _guard = ENV_MUTEX.lock().unwrap(); // Lock before manipulating env
-        let original_var = std::env::var("OPENAI_API_KEY").ok();
+        // Simulate missing environment variable using the provider pattern
+        let result = OpenAIConfig::from_env_with_provider(OpenAIModel::Ada002, |_| {
+            Err(std::env::VarError::NotPresent)
+        });
 
-        // SAFETY: Only used in single-threaded test context protected by mutex
-        unsafe {
-            std::env::remove_var("OPENAI_API_KEY");
-        }
-
-        let result = OpenAIConfig::from_env(OpenAIModel::Ada002);
         assert!(result.is_err());
         match result {
             Err(EmbeddingError::ConfigError(msg)) => {
@@ -379,15 +381,7 @@ mod tests {
             }
             _ => panic!("Expected ConfigError"),
         }
-
-        // Restore original value
-        if let Some(val) = original_var {
-            // SAFETY: Only used in single-threaded test context protected by mutex
-            unsafe {
-                std::env::set_var("OPENAI_API_KEY", val);
-            }
-        }
-    } // Mutex is unlocked when _guard goes out of scope
+    }
 
     #[test]
     fn test_config_builder() {

--- a/tests/warden_property_safety.rs
+++ b/tests/warden_property_safety.rs
@@ -1,0 +1,49 @@
+use gallifreydb::core::property::{PropertyValue, deserialize_vector, serialize_vector};
+
+#[test]
+fn test_vector_deserialization_safety_truncated() {
+    // Valid vector
+    let vec_data = vec![1.0f32, 2.0, 3.0];
+    let bytes = serialize_vector(&vec_data);
+
+    // Truncate the buffer (remove last byte)
+    let truncated = &bytes[0..bytes.len() - 1];
+
+    // This should fail gracefully, NOT panic or UB
+    let result = deserialize_vector(truncated);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_vector_deserialization_safety_malformed_header() {
+    // Malformed dimension that would cause overflow if not checked
+    // [TAG_VECTOR, u32::MAX, ...]
+    let mut bytes = vec![7u8]; // TAG_VECTOR
+    bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Add some dummy data
+    bytes.extend_from_slice(&[0u8; 100]);
+
+    // Should fail due to max dimension check or size mismatch
+    let result = deserialize_vector(&bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_property_map_deserialization_safety_recursion() {
+    // Construct a deeply nested property to test recursion limits
+    // Array of Array of ...
+
+    let mut bytes = Vec::new();
+    let depth = 200; // Above limit 100
+
+    for _ in 0..depth {
+        bytes.push(6); // TAG_ARRAY
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // Count 1
+    }
+    bytes.push(0); // TAG_NULL at the bottom
+
+    let result = PropertyValue::deserialize(&bytes);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(format!("{}", err).contains("recursion"));
+}


### PR DESCRIPTION
This PR addresses a critical race condition in the test suite where environment variables were being modified using `unsafe` blocks in parallel tests. 

**Changes:**
1.  **Refactored Config Loading:** Introduced `from_env_with_provider` in `OpenAIConfig` and `HuggingFaceConfig` to allow injecting a mock environment lookup function.
2.  **Safe Tests:** Updated tests to use this mock mechanism instead of modifying the global process environment with `std::env::set_var`, removing the need for `unsafe` and `Mutex` locks.
3.  **Security Audit:** Audited `unsafe` blocks in `src/core/property.rs` related to vector optimization. Added detailed comments confirming their safety (alignment, validity) and added a regression test (`tests/warden_property_safety.rs`) to verify bounds checking behavior.
4.  **Documentation:** Updated `.jules/warden.md` with the security findings and fixes.

**Verification:**
- Ran `cargo test --features embedding-openai,embedding-huggingface` to verify provider tests pass without unsafe code.
- Ran `cargo test --test warden_property_safety` to verify vector deserialization safety.
- `cargo clippy` and `cargo fmt` checks passed.

---
*PR created automatically by Jules for task [9878064957368705889](https://jules.google.com/task/9878064957368705889) started by @madmax983*