### PR TITLE
🎻 Bard: Fix broken transaction docs

### DIFF
--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -130,12 +130,20 @@ pub trait ReadOps {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::{ReadOps, WriteOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let node_id = db.write(|tx| tx.create_node("Person", properties!()))?;
+    /// # let tx = db.read_transaction()?;
     /// let edges = tx.get_outgoing_edges(node_id);
     /// for edge_id in edges {
     ///     let edge = tx.get_edge(edge_id)?;
     ///     println!("-> {}", edge.target);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
 
@@ -224,11 +232,18 @@ pub trait WriteOps: ReadOps {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::WriteOps;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let mut tx = db.write_transaction()?;
     /// let node_id = tx.create_node(
     ///     "Person",
     ///     properties! { "name" => "Alice", "age" => 30 }
     /// )?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn create_node(&mut self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         self.create_node_with_valid_time(label, properties, None)
@@ -250,13 +265,22 @@ pub trait WriteOps: ReadOps {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::WriteOps;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let mut tx = db.write_transaction()?;
+    /// # let alice_id = tx.create_node("Person", properties! { "name" => "Alice" })?;
+    /// # let bob_id = tx.create_node("Person", properties! { "name" => "Bob" })?;
     /// let edge_id = tx.create_edge(
     ///     alice_id,
     ///     bob_id,
     ///     "KNOWS",
     ///     properties! { "since" => 2024 }
     /// )?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn create_edge(
         &mut self,
@@ -287,12 +311,20 @@ pub trait WriteOps: ReadOps {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::WriteOps;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let mut tx = db.write_transaction()?;
+    /// # let node_id = tx.create_node("Person", properties! { "name" => "Alice", "age" => 30 })?;
     /// // Only updates "age", preserves "name"
     /// tx.update_node(
     ///     node_id,
     ///     properties! { "age" => 31 }
     /// )?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn update_node(&mut self, node_id: NodeId, properties: PropertyMap) -> Result<()> {
         self.update_node_with_valid_time(node_id, properties, None)
@@ -315,11 +347,21 @@ pub trait WriteOps: ReadOps {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::WriteOps;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
+    /// # let mut tx = db.write_transaction()?;
+    /// # let n1 = tx.create_node("Person", properties!())?;
+    /// # let n2 = tx.create_node("Person", properties!())?;
+    /// # let edge_id = tx.create_edge(n1, n2, "KNOWS", properties! { "strength" => 0.5 })?;
     /// tx.update_edge(
     ///     edge_id,
     ///     properties! { "strength" => 0.95 }
     /// )?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn update_edge(&mut self, edge_id: EdgeId, properties: PropertyMap) -> Result<()> {
         self.update_edge_with_valid_time(edge_id, properties, None)

--- a/src/api/transaction/write_tx.rs
+++ b/src/api/transaction/write_tx.rs
@@ -57,11 +57,18 @@ const MAX_VALID_TIME_FUTURE_OFFSET_US: i64 = 365 * 24 * 60 * 60 * 1_000_000; // 
 ///
 /// # Example
 ///
-/// ```ignore
-/// let mut tx = db.write_transaction();
-/// let node_id = tx.create_node("Person", props)?;
-/// tx.create_edge(node_id, other, "KNOWS", edge_props)?;
+/// ```rust,no_run
+/// # use gallifreydb::{GallifreyDB, properties};
+/// # use gallifreydb::api::transaction::WriteOps;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let db = GallifreyDB::new()?;
+/// # let other = db.write(|tx| tx.create_node("Person", properties!()))?;
+/// let mut tx = db.write_transaction()?;
+/// let node_id = tx.create_node("Person", properties! { "name" => "Alice" })?;
+/// tx.create_edge(node_id, other, "KNOWS", properties!())?;
 /// tx.commit()?;  // or tx.rollback()
+/// # Ok(())
+/// # }
 /// ```
 pub struct WriteTransaction {
     tx_id: TxId,
@@ -196,13 +203,20 @@ impl WriteTransaction {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```rust,no_run
+    /// # use gallifreydb::{GallifreyDB, properties};
+    /// # use gallifreydb::api::transaction::WriteOps;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = GallifreyDB::new()?;
     /// let mut tx = db.write_transaction()?;
-    /// let node_id = tx.create_node("Person", properties)?;
+    /// let node_id = tx.create_node("Person", properties! { "name" => "Alice" })?;
     /// let commit_ts = tx.commit_with_timestamp()?;
     ///
     /// // Query at exact commit timestamp
+    /// // Note: This uses the transaction time path
     /// let node = db.get_node_at_time(node_id, commit_ts, commit_ts)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Durability Modes


### PR DESCRIPTION
* 📖 Chapter: The `transaction` module documentation.
* 🔦 Insight: Removed `ignore` tags from examples and added necessary boilerplate imports to make them executable via `cargo test`.
* 🧪 Example: `WriteOps::create_node` example now compiles and is checked by CI.

---
*PR created automatically by Jules for task [10803008294226397506](https://jules.google.com/task/10803008294226397506) started by @madmax983*