### PR TITLE
Unify Historical and Anchor configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::storage::index_persistence::PersistenceConfig;
+use crate::storage::version::AnchorConfig;
 
 /// Configuration for WAL (Write-Ahead Log) system.
 ///
@@ -332,14 +333,25 @@ pub struct HistoricalConfig {
     /// Larger cache improves temporal query performance.
     /// Default: 10000
     pub reconstruction_cache_size: usize,
+
+    /// Create an anchor every N versions (default: 10).
+    /// Smaller intervals mean faster reconstruction but more storage.
+    pub anchor_interval: u32,
+
+    /// Maximum delta chain length before forcing an anchor (default: 20).
+    /// Ensures reconstruction cost is bounded.
+    pub max_delta_chain: u32,
 }
 
 impl Default for HistoricalConfig {
     fn default() -> Self {
+        let anchor_defaults = AnchorConfig::default();
         Self {
             max_versions_per_entity: 1000,
             max_reconstruction_depth: 100,
             reconstruction_cache_size: 10000,
+            anchor_interval: anchor_defaults.anchor_interval,
+            max_delta_chain: anchor_defaults.max_delta_chain,
         }
     }
 }
@@ -408,6 +420,36 @@ impl HistoricalConfigBuilder {
             ));
         }
         self.config.reconstruction_cache_size = size;
+        Ok(self)
+    }
+
+    /// Set the anchor interval.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidValue` if `interval` is 0.
+    pub fn anchor_interval(mut self, interval: u32) -> Result<Self, ConfigError> {
+        if interval == 0 {
+            return Err(ConfigError::InvalidValue(
+                "anchor_interval must be greater than 0".into(),
+            ));
+        }
+        self.config.anchor_interval = interval;
+        Ok(self)
+    }
+
+    /// Set the maximum delta chain length.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidValue` if `max` is 0.
+    pub fn max_delta_chain(mut self, max: u32) -> Result<Self, ConfigError> {
+        if max == 0 {
+            return Err(ConfigError::InvalidValue(
+                "max_delta_chain must be greater than 0".into(),
+            ));
+        }
+        self.config.max_delta_chain = max;
         Ok(self)
     }
 
@@ -773,6 +815,8 @@ mod tests {
         assert_eq!(config.max_versions_per_entity, 1000);
         assert_eq!(config.max_reconstruction_depth, 100);
         assert_eq!(config.reconstruction_cache_size, 10000);
+        assert_eq!(config.anchor_interval, 10);
+        assert_eq!(config.max_delta_chain, 20);
     }
 
     #[test]
@@ -784,11 +828,17 @@ mod tests {
             .unwrap()
             .reconstruction_cache_size(20000)
             .unwrap()
+            .anchor_interval(5)
+            .unwrap()
+            .max_delta_chain(10)
+            .unwrap()
             .build();
 
         assert_eq!(config.max_versions_per_entity, 5000);
         assert_eq!(config.max_reconstruction_depth, 200);
         assert_eq!(config.reconstruction_cache_size, 20000);
+        assert_eq!(config.anchor_interval, 5);
+        assert_eq!(config.max_delta_chain, 10);
     }
 
     #[test]
@@ -950,6 +1000,7 @@ mod tests {
         assert!(toml_string.contains("num_stripes"));
         assert!(toml_string.contains("max_versions_per_entity"));
         assert!(toml_string.contains("max_k"));
+        assert!(toml_string.contains("anchor_interval"));
     }
 
     #[test]
@@ -994,6 +1045,8 @@ flush_interval_ms = 20
 max_versions_per_entity = 5000
 max_reconstruction_depth = 200
 reconstruction_cache_size = 20000
+anchor_interval = 5
+max_delta_chain = 10
 
 [vector]
 max_k = 20000
@@ -1013,6 +1066,8 @@ max_layer = 32
         assert_eq!(config.historical.max_versions_per_entity, 5000);
         assert_eq!(config.historical.max_reconstruction_depth, 200);
         assert_eq!(config.historical.reconstruction_cache_size, 20000);
+        assert_eq!(config.historical.anchor_interval, 5);
+        assert_eq!(config.historical.max_delta_chain, 10);
 
         // Vector config
         assert_eq!(config.vector.max_k, 20000);
@@ -1275,6 +1330,20 @@ wal_dir = "/custom/path/to/wal"
     #[test]
     fn test_historical_config_zero_cache_size() {
         let result = HistoricalConfigBuilder::new().reconstruction_cache_size(0);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConfigError::InvalidValue(_)));
+    }
+
+    #[test]
+    fn test_historical_config_zero_anchor_interval() {
+        let result = HistoricalConfigBuilder::new().anchor_interval(0);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConfigError::InvalidValue(_)));
+    }
+
+    #[test]
+    fn test_historical_config_zero_max_delta_chain() {
+        let result = HistoricalConfigBuilder::new().max_delta_chain(0);
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ConfigError::InvalidValue(_)));
     }

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -324,8 +324,13 @@ impl HistoricalStorage {
             DEFAULT_MAX_VERSION_AGE_MS, // Keep existing default for age
         );
 
+        let anchor_config = AnchorConfig {
+            anchor_interval: config.anchor_interval,
+            max_delta_chain: config.max_delta_chain,
+        };
+
         let mut storage = Self::with_config_retention_and_cache_size(
-            AnchorConfig::default(),
+            anchor_config,
             retention_policy,
             config.reconstruction_cache_size,
         );

--- a/tests/regression_config_anchor.rs
+++ b/tests/regression_config_anchor.rs
@@ -1,0 +1,59 @@
+use gallifreydb::config::{GallifreyDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+use gallifreydb::storage::index_persistence::PersistenceConfig;
+use gallifreydb::{GallifreyDB, PropertyMapBuilder, WriteOps};
+use tempfile::tempdir;
+
+#[test]
+fn test_reproduce_config_gap() {
+    let dir = tempdir().unwrap();
+    let wal_dir = dir.path().join("wal");
+
+    // Create config with disabled persistence
+    // NOW: We CAN set anchor_interval here!
+    let config = GallifreyDBConfig::builder()
+        .wal(WalConfigBuilder::new().wal_dir(wal_dir).build())
+        .historical(
+            HistoricalConfigBuilder::new()
+                .anchor_interval(5).unwrap() // Setting custom interval
+                .build()
+        )
+        .persistence(PersistenceConfig {
+            enabled: false,
+            ..PersistenceConfig::default()
+        })
+        .build();
+
+    let db = GallifreyDB::with_unified_config(config).unwrap();
+
+    // Create a node (Version 1 - Anchor)
+    let node_id = db
+        .create_node("Test", PropertyMapBuilder::new().insert("v", 1).build())
+        .unwrap();
+
+    // Add 5 more versions (Total 6 versions)
+    for i in 2..=6 {
+        db.write(|tx| {
+            tx.update_node(
+                node_id,
+                PropertyMapBuilder::new().insert("v", i).build(),
+            )
+        })
+        .unwrap();
+    }
+
+    // Verify stats
+    let stats = db.historical_stats().unwrap();
+    println!("Stats: {:?}", stats);
+
+    // If interval is 5:
+    // v1: Anchor (always)
+    // v2: Delta (since anchor: 1)
+    // v3: Delta (since anchor: 2)
+    // v4: Delta (since anchor: 3)
+    // v5: Delta (since anchor: 4)
+    // v6: Anchor (since anchor: 5 >= 5)
+    // Total Anchors: 2
+
+    assert_eq!(stats.node_anchor_count, 2, "Should have 2 anchors with interval 5 (v1 and v6)");
+    assert_eq!(stats.node_delta_count, 4, "Should have 4 deltas");
+}

--- a/tests/regression_config_anchor.rs
+++ b/tests/regression_config_anchor.rs
@@ -14,8 +14,9 @@ fn test_reproduce_config_gap() {
         .wal(WalConfigBuilder::new().wal_dir(wal_dir).build())
         .historical(
             HistoricalConfigBuilder::new()
-                .anchor_interval(5).unwrap() // Setting custom interval
-                .build()
+                .anchor_interval(5)
+                .unwrap() // Setting custom interval
+                .build(),
         )
         .persistence(PersistenceConfig {
             enabled: false,
@@ -32,13 +33,8 @@ fn test_reproduce_config_gap() {
 
     // Add 5 more versions (Total 6 versions)
     for i in 2..=6 {
-        db.write(|tx| {
-            tx.update_node(
-                node_id,
-                PropertyMapBuilder::new().insert("v", i).build(),
-            )
-        })
-        .unwrap();
+        db.write(|tx| tx.update_node(node_id, PropertyMapBuilder::new().insert("v", i).build()))
+            .unwrap();
     }
 
     // Verify stats
@@ -54,6 +50,9 @@ fn test_reproduce_config_gap() {
     // v6: Anchor (since anchor: 5 >= 5)
     // Total Anchors: 2
 
-    assert_eq!(stats.node_anchor_count, 2, "Should have 2 anchors with interval 5 (v1 and v6)");
+    assert_eq!(
+        stats.node_anchor_count, 2,
+        "Should have 2 anchors with interval 5 (v1 and v6)"
+    );
     assert_eq!(stats.node_delta_count, 4, "Should have 4 deltas");
 }


### PR DESCRIPTION
* 🕸️ Tangle: `HistoricalConfig` (Unified Config) was missing fields `anchor_interval` and `max_delta_chain`, forcing users to rely on hardcoded defaults even when using the unified configuration system. `AnchorConfig` (Legacy) was the only way to set these, but it wasn't exposed in the unified path.
* 📐 Blueprint: Added missing fields to `HistoricalConfig` and its builder in `src/config.rs`. Updated `HistoricalStorage::from_unified_config` in `src/storage/historical/mod.rs` to correctly propagate these values to the internal `AnchorConfig`.
* 🧱 Stability: Backward compatible (defaults match previous hardcoded values).
* 🔬 Verification: Added `tests/regression_config_anchor.rs` to verify that `anchor_interval` can now be configured via `GallifreyDBConfig`. Run all tests and clippy.

---
*PR created automatically by Jules for task [7506758526057976842](https://jules.google.com/task/7506758526057976842) started by @madmax983*