### PR TITLE
👺 Havoc: Fix HNSW Save/Add Deadlock

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -987,27 +987,43 @@ impl HnswIndex {
     /// and its mappings. It is separated from `save()` to allow the latter to use
     /// `tokio::task::block_in_place` when running within a Tokio runtime.
     fn save_internal(&self, path: &Path) -> Result<()> {
-        let index = self.inner.read();
-        index
-            .save(path.to_str().ok_or_else(|| {
-                Error::Vector(VectorError::IndexError(
-                    "Path contains invalid UTF-8".to_string(),
-                ))
-            })?)
-            .map_err(|e| {
-                Error::Vector(VectorError::IndexError(format!(
-                    "Failed to save index: {}",
-                    e
-                )))
-            })?;
-
-        // Save mappings to companion file with integrity checks
-        // Format: [MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]
-        let mappings_path = path.with_extension("usearch.mappings");
+        // Collect mappings first to avoid deadlock with add() (Issue #deadlock)
+        // deadlock happens if we hold inner lock (waiting for add to release)
+        // and add holds map lock (waiting for inner to release)
+        //
+        // NOTE: This introduces a "split snapshot" where mappings and index
+        // might be slightly out of sync if an add/remove happens in between.
+        // This is acceptable because:
+        // 1. Orphan vectors (in index, not map) are filtered out by
+        //    convert_and_sort_matches() which checks reverse_mapping.
+        // 2. Dangling mappings (in map, not index) are handled gracefully
+        //    by add() (checks contains() before remove) and are harmless
+        //    for search (not returned by index).
         let mut mappings = Vec::with_capacity(self.id_mapping.len());
         for entry in self.id_mapping.iter() {
             mappings.push((*entry.key(), *entry.value()));
         }
+
+        // Save index (requires inner lock)
+        {
+            let index = self.inner.read();
+            index
+                .save(path.to_str().ok_or_else(|| {
+                    Error::Vector(VectorError::IndexError(
+                        "Path contains invalid UTF-8".to_string(),
+                    ))
+                })?)
+                .map_err(|e| {
+                    Error::Vector(VectorError::IndexError(format!(
+                        "Failed to save index: {}",
+                        e
+                    )))
+                })?;
+        }
+
+        // Save mappings to companion file with integrity checks
+        // Format: [MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]
+        let mappings_path = path.with_extension("usearch.mappings");
 
         let count = mappings.len() as u64;
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -2055,4 +2055,45 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_save_invalid_utf8_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+        // Invalid UTF-8 byte sequence
+        let bytes = b"foo\xffbar";
+        let path = Path::new(OsStr::from_bytes(bytes));
+
+        let result = index.save(path);
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(msg.contains("invalid UTF-8"));
+            }
+            _ => panic!("Expected invalid UTF-8 error"),
+        }
+    }
+
+    #[test]
+    fn test_save_failure_path_is_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path(); // Directory, not file
+
+        let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+        let result = index.save(path);
+
+        assert!(result.is_err());
+        // Exact error message depends on OS/usearch, but it should be an IndexError
+        match result {
+            Err(Error::Vector(VectorError::IndexError(_))) => {}
+            _ => panic!("Expected IndexError when saving to directory"),
+        }
+    }
 }

--- a/tests/havoc_hnsw_deadlock.rs
+++ b/tests/havoc_hnsw_deadlock.rs
@@ -3,7 +3,6 @@ use gallifreydb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use gallifreydb::index::VectorIndex;
 use std::sync::{Arc, Barrier};
 use std::thread;
-use std::time::Duration;
 
 #[test]
 fn test_hnsw_save_add_deadlock() {

--- a/tests/havoc_hnsw_deadlock.rs
+++ b/tests/havoc_hnsw_deadlock.rs
@@ -1,8 +1,9 @@
 use gallifreydb::core::id::NodeId;
-use gallifreydb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use gallifreydb::index::VectorIndex;
+use gallifreydb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use std::sync::{Arc, Barrier};
 use std::thread;
+use std::time::Duration;
 
 #[test]
 fn test_hnsw_save_add_deadlock() {

--- a/tests/havoc_hnsw_deadlock.rs
+++ b/tests/havoc_hnsw_deadlock.rs
@@ -1,0 +1,82 @@
+use gallifreydb::core::id::NodeId;
+use gallifreydb::index::vector::{DistanceMetric, HnswIndexBuilder};
+use gallifreydb::index::VectorIndex;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn test_hnsw_save_add_deadlock() {
+    // 👺 HAVOC: Triggering AB-BA Deadlock between save() and add()
+    //
+    // save(): Locks inner(Read) -> Locks id_mapping(Shard) (via iter)
+    // add():  Locks id_mapping(Shard) -> Locks inner(Write)
+    //
+    // If they interleave, they deadlock.
+
+    let dim = 4;
+    let index = Arc::new(
+        HnswIndexBuilder::new(dim, DistanceMetric::Cosine)
+            .m(16)
+            .ef_construction(100)
+            .build()
+            .unwrap(),
+    );
+
+    // Pre-populate with enough nodes to hit multiple shards
+    let num_nodes = 1000;
+    for i in 0..num_nodes {
+        let id = NodeId::new(i as u64 + 1).unwrap();
+        let vec = vec![0.1; dim];
+        index.add(id, &vec).unwrap();
+    }
+
+    let iterations = 100;
+    let barrier = Arc::new(Barrier::new(2));
+
+    // Thread A: Continuously save
+    let index_clone_a = index.clone();
+    let barrier_clone_a = barrier.clone();
+    let handle_a = thread::spawn(move || {
+        barrier_clone_a.wait();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.index");
+
+        for _ in 0..iterations {
+            // This takes the inner Read lock, then iterates the map
+            if let Err(e) = index_clone_a.save(&path) {
+                println!("Save error: {}", e);
+            }
+        }
+    });
+
+    // Thread B: Continuously update existing nodes
+    let index_clone_b = index.clone();
+    let barrier_clone_b = barrier.clone();
+    let handle_b = thread::spawn(move || {
+        barrier_clone_b.wait();
+        for i in 0..iterations * 100 {
+            // Pick a random node to update (Occupied path)
+            // We use simple modulo to cycle through nodes
+            let id = NodeId::new((i % num_nodes) as u64 + 1).unwrap();
+            let vec = vec![0.2; dim];
+
+            // This takes the map Shard lock, then tries to take inner Write lock
+            index_clone_b.add(id, &vec).unwrap();
+
+            // Small sleep to allow interleaving, but not too much
+            if i % 10 == 0 {
+                thread::yield_now();
+            }
+        }
+    });
+
+    // Join threads
+    // If deadlock occurs, these will never return.
+    // We can't easily enforce a timeout in a standard test without a wrapper,
+    // but the test runner has a default timeout.
+    println!("👺 Havoc: Starting deadlock torture...");
+    handle_a.join().unwrap();
+    handle_b.join().unwrap();
+    println!("👺 Havoc: Survived! (Deadlock fixed?)");
+}

--- a/tests/havoc_hnsw_deadlock.rs
+++ b/tests/havoc_hnsw_deadlock.rs
@@ -3,7 +3,6 @@ use gallifreydb::index::VectorIndex;
 use gallifreydb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use std::sync::{Arc, Barrier};
 use std::thread;
-use std::time::Duration;
 
 #[test]
 fn test_hnsw_save_add_deadlock() {


### PR DESCRIPTION
* 🧨 **The Trigger:** Concurrent `save()` (locks inner, then map) and `add()` (locks map, then inner) operations.
* 📉 **The Stack Trace:** (Test `tests/havoc_hnsw_deadlock.rs` hung indefinitely).
* 🧪 **Reproduction:** `cargo test --test havoc_hnsw_deadlock`
* 😈 **Comment:** "I broke your toy. Then I fixed it. You're welcome."
* **Fix:** Implemented a split-snapshot strategy in `save()`: collect mappings first, then save the index. This breaks the lock inversion cycle. Includes a regression test.

---
*PR created automatically by Jules for task [7004901679122332303](https://jules.google.com/task/7004901679122332303) started by @madmax983*