### PR TITLE
Improve Story Demo DX and fix label resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,28 @@ for (node_id, drift_score) in drifted_nodes {
 }
 ```
 
+### Narrative Generation (Experimental)
+
+> **Note**: This feature requires the `nova` feature flag enabled in `Cargo.toml`.
+
+```rust
+use gallifreydb::experimental::temporal_narrative::NarrativeGenerator;
+
+// Generate natural language history of a node
+let generator = NarrativeGenerator::new(&db);
+let narrative = generator.generate_node_narrative(node_id)?;
+
+for event in narrative {
+    println!("Version {}: {}", event.version_number, event.description);
+    // Output: "Version 1: Node created with label 'Person'."
+
+    for change in event.changes {
+        println!("  - {}", change);
+        // Output: "  - Initial property 'name': 'Alice'"
+    }
+}
+```
+
 ### Index Persistence (Fast Cold Starts)
 
 ```rust

--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -1,3 +1,27 @@
+//! Narrative Generation Example (Story Demo)
+//!
+//! This example demonstrates how to use the experimental Narrative Generation feature
+//! to create natural language histories of graph nodes.
+//!
+//! # Prerequisites
+//!
+//! This feature is experimental and requires the `nova` feature flag.
+//!
+//! ## Running this example
+//!
+//! ```bash
+//! cargo run --features nova --example story_demo
+//! ```
+//!
+//! ## Using in your project
+//!
+//! Add the `nova` feature to your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! gallifreydb = { version = "0.1", features = ["nova"] }
+//! ```
+
 use gallifreydb::GallifreyDB;
 use gallifreydb::PropertyMapBuilder;
 use gallifreydb::WriteOps;

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -13,7 +13,7 @@
 use crate::core::graph::{Edge, Node};
 use crate::core::history::{EntityHistory, VersionDiff, VersionInfo};
 use crate::core::id::{EdgeId, NodeId, VersionId};
-use crate::core::interning::InternedString;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
 use crate::core::observer::{Observer, StorageEvent, notify_observers};
 use crate::core::property::PropertyMap;
 use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, Timestamp};
@@ -2056,7 +2056,10 @@ impl HistoricalStorage {
                     version_id: *version_id,
                     temporal: version.temporal,
                     properties,
-                    label: version.label.to_string(),
+                    label: GLOBAL_INTERNER
+                        .resolve(version.label)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| version.label.to_string()),
                 });
             }
         }
@@ -2200,7 +2203,10 @@ impl HistoricalStorage {
                     version_id: *version_id,
                     temporal: version.temporal,
                     properties,
-                    label: version.label.to_string(),
+                    label: GLOBAL_INTERNER
+                        .resolve(version.label)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| version.label.to_string()),
                 });
             }
         }


### PR DESCRIPTION
This PR addresses Developer Experience (DX) issues identified during an audit of the "Narrative Generation" (Nova) feature.

Changes:
1.  **Documentation**: Added clear instructions to `examples/story_demo.rs` and `README.md` stating that the `nova` feature flag is required to run the story demo.
2.  **Bug Fix**: Modified `src/storage/historical/mod.rs` to properly resolve `InternedString` labels to human-readable `String`s when constructing `VersionInfo`. This fixes the issue where `get_node_history` returned labels like `"Interned(11)"` instead of `"Person"`.
3.  **Example**: Added a "Narrative Generation" code snippet to the `README.md` Usage Examples section.

Verified by running `cargo run --features nova --example story_demo` which now outputs clean, readable text.

---
*PR created automatically by Jules for task [4521127347127176386](https://jules.google.com/task/4521127347127176386) started by @madmax983*