### PR TITLE
security: mitigate allocation bomb DoS vulnerability

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -107,3 +107,20 @@ Refactored `OpenAIConfig::from_env` and `HuggingFaceConfig::from_env` to use an 
 - **Audited:** Verified that `serialize_vector_into` and `deserialize_vector` perform strict bounds checking (`data_slice.len() == dimension * 4`) and handle alignment correctly via `Vec::with_capacity`.
 - **Documented:** Added "Verified by Warden" comments explaining the safety proofs (validity of f32 bit patterns, alignment guarantees).
 - **Verified:** Added `tests/warden_property_safety.rs` to fuzz truncated and malformed inputs, confirming that safe guards trigger before `unsafe` blocks are reached.
+
+## 2026-02-16 - Allocation Bomb DoS Hardening
+
+**Threat:** Allocation Bomb in Property Deserialization
+`PropertyMap::deserialize` and `deserialize_sparse_vector` blindly trusted the declared count/size fields from the input buffer.
+- `PropertyMap::deserialize` would call `HashMap::with_capacity(count)`. A malicious payload declaring `count = 4_000_000_000` would cause the server to attempt a massive allocation (32GB+), leading to an immediate OOM crash (DoS).
+- `deserialize_sparse_vector` had a similar issue with `nnz` (number of non-zero elements).
+
+**Defense:** Capacity Limits
+Enforced strict capacity limits during deserialization:
+- `PropertyMap`: `count` must be <= `MAX_PROPERTY_MAP_CAPACITY` (10,000).
+- `SparseVector`: `nnz` must be <= `MAX_VECTOR_DIMENSIONS` (100,000).
+
+**Verification:** Reproduction Test
+Added `tests/warden_dos_repro.rs` which simulates malicious payloads with excessive counts.
+- Before fix: Code attempted allocation (and failed with "Buffer too short" or potentially OOM).
+- After fix: Code immediately returns `StorageError::CorruptedData` citing the capacity limit, protecting memory resources.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -52,6 +52,10 @@ pub const MAX_ARRAY_ELEMENTS: usize = 1_000_000;
 /// Set to 100,000 - far exceeds typical embedding sizes (384-4096 dimensions).
 pub const MAX_VECTOR_DIMENSIONS: usize = 100_000;
 
+/// Maximum capacity allowed for a deserialized property map.
+/// Set to 10,000 to prevent OOM DoS attacks via malicious count fields.
+pub const MAX_PROPERTY_MAP_CAPACITY: usize = 10_000;
+
 /// Maximum recursion depth for nested properties (e.g., arrays of arrays).
 /// Set to 100 to prevent stack overflow from malicious input.
 pub const MAX_RECURSION_DEPTH: usize = 100;
@@ -1133,6 +1137,15 @@ pub fn deserialize_sparse_vector(bytes: &[u8]) -> Result<(Arc<SparseVec>, usize)
         .into());
     }
 
+    // Prevent DoS via memory exhaustion from malicious input
+    if nnz > MAX_VECTOR_DIMENSIONS {
+        return Err(StorageError::CorruptedData(format!(
+            "Sparse vector nnz {} exceeds maximum allowed {}",
+            nnz, MAX_VECTOR_DIMENSIONS
+        ))
+        .into());
+    }
+
     // Calculate required size
     let data_start: usize = 9;
     let indices_len = nnz
@@ -1564,6 +1577,16 @@ impl PropertyMap {
         }
 
         let count = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
+
+        // Prevent DoS via memory exhaustion from malicious input
+        if count > MAX_PROPERTY_MAP_CAPACITY {
+            return Err(StorageError::CorruptedData(format!(
+                "PropertyMap count {} exceeds maximum allowed {}",
+                count, MAX_PROPERTY_MAP_CAPACITY
+            ))
+            .into());
+        }
+
         let mut offset = 4;
         let mut map = HashMap::with_capacity(count);
         // Track the actual logical size of the map to validate against consumed bytes

--- a/tests/warden_dos_protection.rs
+++ b/tests/warden_dos_protection.rs
@@ -1,6 +1,4 @@
-use gallifreydb::core::property::{
-    deserialize_sparse_vector, PropertyMap, TAG_SPARSE_VECTOR,
-};
+use gallifreydb::core::property::{PropertyMap, TAG_SPARSE_VECTOR, deserialize_sparse_vector};
 
 #[test]
 fn test_property_map_allocation_limit() {
@@ -11,8 +9,9 @@ fn test_property_map_allocation_limit() {
     buffer.extend_from_slice(&count.to_le_bytes());
 
     // We don't provide the actual data.
-    // Without the fix, this would allocate HashMap(1_000_001) and then fail with "Buffer too short".
-    // With the fix, this should fail immediately with "exceeds maximum allowed".
+    // Without the fix, this would allocate HashMap(1_000_001) and then fail with
+    // "Buffer too short". With the fix, this should fail immediately with
+    // "exceeds maximum allowed".
 
     let result = PropertyMap::deserialize(&buffer);
 
@@ -20,7 +19,8 @@ fn test_property_map_allocation_limit() {
     let err = result.unwrap_err().to_string();
     assert!(
         err.contains("exceeds maximum allowed"),
-        "Expected error about maximum capacity, got: {}", err
+        "Expected error about maximum capacity, got: {}",
+        err
     );
 }
 
@@ -45,6 +45,7 @@ fn test_sparse_vector_allocation_limit() {
     let err = result.unwrap_err().to_string();
     assert!(
         err.contains("exceeds maximum allowed"),
-        "Expected error about maximum capacity, got: {}", err
+        "Expected error about maximum capacity, got: {}",
+        err
     );
 }

--- a/tests/warden_dos_protection.rs
+++ b/tests/warden_dos_protection.rs
@@ -1,0 +1,50 @@
+use gallifreydb::core::property::{
+    deserialize_sparse_vector, PropertyMap, TAG_SPARSE_VECTOR,
+};
+
+#[test]
+fn test_property_map_allocation_limit() {
+    // Attempt to deserialize a PropertyMap with count = 1,000,001
+    // This should trigger the new security check (limit 10,000)
+    let count = 1_000_001u32;
+    let mut buffer = Vec::new();
+    buffer.extend_from_slice(&count.to_le_bytes());
+
+    // We don't provide the actual data.
+    // Without the fix, this would allocate HashMap(1_000_001) and then fail with "Buffer too short".
+    // With the fix, this should fail immediately with "exceeds maximum allowed".
+
+    let result = PropertyMap::deserialize(&buffer);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("exceeds maximum allowed"),
+        "Expected error about maximum capacity, got: {}", err
+    );
+}
+
+#[test]
+fn test_sparse_vector_allocation_limit() {
+    // Attempt to deserialize a SparseVector with nnz = 100,001
+    // This should trigger the check against MAX_VECTOR_DIMENSIONS (100,000)
+    let dimension = 200_000u32; // Valid dimension
+    let nnz = 100_001u32; // Invalid nnz (over limit)
+
+    let mut buffer = Vec::new();
+    buffer.push(TAG_SPARSE_VECTOR);
+    buffer.extend_from_slice(&dimension.to_le_bytes());
+    buffer.extend_from_slice(&nnz.to_le_bytes());
+
+    // Without fix: allocates Vec(100_001) -> fail "Buffer too short"
+    // With fix: fail "exceeds maximum allowed"
+
+    let result = deserialize_sparse_vector(&buffer);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("exceeds maximum allowed"),
+        "Expected error about maximum capacity, got: {}", err
+    );
+}


### PR DESCRIPTION
Identified and fixed a Denial of Service (DoS) vulnerability where malicious inputs could cause massive memory allocations ("Allocation Bomb") during property deserialization. 

- Enforced `MAX_PROPERTY_MAP_CAPACITY` (10,000) for PropertyMap deserialization.
- Enforced `MAX_VECTOR_DIMENSIONS` (100,000) limit for SparseVector `nnz` deserialization.
- Added regression tests `tests/warden_dos_protection.rs` which simulate the attack and verify safe rejection.
- Verified fix passes all tests.

---
*PR created automatically by Jules for task [1600320464079801072](https://jules.google.com/task/1600320464079801072) started by @madmax983*