### PR TITLE
docs: Fix run instructions for story_demo example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,12 @@ for (node_id, drift_score) in drifted_nodes {
 
 ### Narrative Generation (Experimental)
 
-> **Note**: This feature requires the `nova` feature flag enabled in `Cargo.toml`.
+> **Requires `nova` feature**
+>
+> Run the demo:
+> ```bash
+> cargo run --example story_demo --features nova
+> ```
 
 ```rust
 use gallifreydb::experimental::temporal_narrative::NarrativeGenerator;
@@ -790,7 +795,7 @@ See `docs/adr/` for all architectural decisions.
 **Other Examples:**
 - `examples/observability_demo.rs` - Production observability features
 - `examples/doctor_who_demo.rs` - Temporal graph modeling example
-- `examples/story_demo.rs` - Narrative generation example (requires `nova` feature)
+- `examples/story_demo.rs` - Narrative generation example (Run: `cargo run --example story_demo --features nova`)
 
 ## Use Cases
 


### PR DESCRIPTION
This PR addresses DX friction identified during an audit. Users attempting to run the `story_demo` example might miss the feature flag requirement. 

Changes:
- Added a clear, copy-pasteable command block in `README.md` for running the `story_demo`.
- Updated the examples list to reference the command/feature flag more explicitly.

Verified that the example runs correctly with the provided command.

---
*PR created automatically by Jules for task [2295399769157888683](https://jules.google.com/task/2295399769157888683) started by @madmax983*