### PR TITLE
🔭 Vantage: Spec for Semantic Pathfinding & Associative Retrieval

### DIFF
--- a/docs/specs/001_semantic_pathfinding.md
+++ b/docs/specs/001_semantic_pathfinding.md
@@ -3,17 +3,17 @@
 | Metadata | Details |
 | :--- | :--- |
 | **ID** | SPEC-001 |
-| **Status** | 🚧 Draft |
+| **Status** | 🔍 Review |
 | **Owner** | Vantage (Product) |
 | **Implementer** | Nova (Engineering) |
 | **Priority** | P1 (High) |
-| **Related Code** | `src/experimental/semantic_pathfinding.rs` |
+| **Related Code** | `src/experimental/semantic_pathfinding.rs` (Planned) |
 
 ## 1. 👤 User Story
 
 > **As a** RAG (Retrieval-Augmented Generation) Developer,
-> **I want to** find paths between entities that are semantically consistent with a specific concept or topic,
-> **So that** I can retrieve multi-hop context for an LLM that explains *how* two things are related without polluting the context window with irrelevant ("off-topic") structural connections.
+> **I want to** find nodes that are semantically similar but structurally distant, and the paths connecting them,
+> **So that** I can discover and explain non-obvious relationships without polluting the context window with irrelevant ("off-topic") structural connections.
 
 ## 2. 🧐 The "So What?" (Business Value)
 
@@ -41,17 +41,19 @@ Real-world reasoning often requires traversing a graph but staying "in context".
 2.  **Time-Travel Support**:
     - Must expose `find_path_at_time(start, end, query, timestamp)`.
     - Must strictly respect the `valid_time` of edges and nodes (do not traverse edges that didn't exist or were deleted at `timestamp`).
-    - *Note:* The current experimental implementation has limitations regarding deleted edges in `CurrentStorage`. This must be fixed or documented as a known limitation for V1.
 
 3.  **Result Format**:
     - Returns an ordered `Vec<NodeId>` representing the path.
     - Should optionally return the "Semantic Cost" of the path (confidence score).
+    - Must handle cases where no path is found gracefully (return empty `Option` or specific Error, no panic).
 
 4.  **Configuration**:
     - Allow tuning the balance between Structural Weight vs. Semantic Weight (e.g., `alpha` parameter).
 
 ### Non-Functional Requirements (Constraints)
--   **Performance**: Must be significantly faster than exhaustive BFS for "deep" graphs when a strong semantic signal exists (heuristic pruning).
+-   **Performance**:
+    - Latency < 50ms for 5-hop paths on 1M node graph.
+    - Must be significantly faster than exhaustive BFS for "deep" graphs when a strong semantic signal exists.
 -   **Safety**: Must handle `NaN` in vectors gracefully (no panics).
 -   **Scale**: Must support paths up to 50 hops (configurable `max_depth`).
 
@@ -63,16 +65,16 @@ Real-world reasoning often requires traversing a graph but staying "in context".
 
 ## 5. 📝 Gap Analysis (Current vs. Spec)
 
-| Feature | Current State (`experimental`) | Required State (`core`) | Action |
+| Feature | Current State | Required State | Action |
 | :--- | :--- | :--- | :--- |
-| **Algorithm** | Manual `BinaryHeap` impl | Optimized generic `A*` | Refactor to use `pathfinding` crate or optimized internal struct |
-| **Time-Travel** | Broken for deleted edges | Robust | Fix `CurrentStorage` visibility logic or force `HistoricalStorage` lookup |
-| **API** | Internal Struct | Public `Graph` Trait method | Expose via `QueryBuilder` |
-| **Weighting** | Hardcoded `0.1` structural cost | Configurable | Add configuration struct |
+| **Code** | Missing (`src/experimental/semantic_pathfinding.rs`) | Implemented | Create experimental module |
+| **Algorithm** | None | Optimized `A*` | Implement heuristic traversal |
+| **Time-Travel** | N/A | Robust | Ensure `CurrentStorage` visibility logic handles deletions |
+| **API** | None | Public `Graph` Trait method | Expose via `QueryBuilder` |
 
 ## 6. 📅 Execution Plan
 
-1.  **Promote** `src/experimental/semantic_pathfinding.rs` to `src/algo/pathfinding.rs`.
-2.  **Refactor** to fix the Time-Travel edge deletion bug (Critical).
-3.  **Expose** via the main `GallifreyDB` struct and `QueryBuilder`.
+1.  **Create** `src/experimental/semantic_pathfinding.rs` (gated by `nova`).
+2.  **Implement** A* heuristic using `pathfinding` crate or internal structure.
+3.  **Refactor** `CurrentStorage` access to ensure time-travel correctness.
 4.  **Test** with the standard "Apple vs. Orange" dataset.

--- a/docs/specs/002_associative_retrieval.md
+++ b/docs/specs/002_associative_retrieval.md
@@ -1,0 +1,73 @@
+# 🔭 Vantage Spec: Associative Retrieval ("Fishing")
+
+| Metadata | Details |
+| :--- | :--- |
+| **ID** | SPEC-002 |
+| **Status** | 🔍 Review |
+| **Owner** | Vantage (Product) |
+| **Implementer** | Nova (Engineering) |
+| **Priority** | P2 (Medium) |
+| **Related Code** | `src/experimental/fishing.rs` |
+
+## 1. 👤 User Story
+
+> **As a** Researcher or Analyst,
+> **I want to** retrieve information by "casting a net" around a concept (vector) and expanding to its neighbors,
+> **So that** I can simulate human-like associative recall (finding things that are similar *or* related) without constructing complex multi-step queries.
+
+## 2. 🧐 The "So What?" (Business Value)
+
+Traditional queries are either:
+- **Precise**: `MATCH (n) WHERE n.id = 123` (Lookup)
+- **Semantic**: `SIMILAR TO vector` (Similarity)
+
+**The Gap:**
+Human memory is associative. If I think of "Apples", I might remember "Oranges" (similarity) and "Pie" (structural relationship).
+"Fishing" combines these into a single scored retrieval operation.
+
+**ROI:**
+- **Usability**: drastically simplifies "explore around this concept" workflows for UI/UX.
+- **RAG Enhancement**: Allows retrieving a "School" of related context that includes both synonyms and direct neighbors, providing richer context for LLMs.
+
+## 3. ✅ Acceptance Criteria
+
+### Functional Requirements
+1.  **Fishing API**:
+    - Must expose a `cast(bait, config)` method.
+    - `Bait` can be a Node ID (use its vector) or a raw Vector.
+    - Returns a list of `Catch` objects (Node + Score + Provenance).
+
+2.  **Scoring Algorithm**:
+    - Score = (Vector_Similarity * vector_weight) + (Graph_Connection * graph_weight) + (Freshness * freshness_weight).
+    - Must support customizable weights for each component.
+
+3.  **Freshness Bias**:
+    - Must optionally boost scores for recently modified nodes (Time Decay function).
+
+4.  **Provenance**:
+    - Each result must explain *why* it was caught (e.g., "Vector Similarity: 0.9" or "Linked from Node X").
+
+### Non-Functional Requirements
+-   **Performance**: Latency < 20ms for Depth=1 queries on 1M node graph.
+-   **Safety**: Must handle missing vector indexes gracefully (return specific error).
+
+## 4. 🚫 Out of Scope (Phase 1)
+
+-   **Deep Traversal**: Depth > 1 (Fishing deep into the graph). Currently limited to direct neighbors.
+-   **Complex Filters**: Filtering the "School" by complex predicates (e.g., `WHERE property > 10`) before expansion.
+
+## 5. 📝 Gap Analysis (Current vs. Spec)
+
+| Feature | Current State (`experimental`) | Required State (`core`) | Action |
+| :--- | :--- | :--- | :--- |
+| **Code** | Implemented (`fishing.rs`) | Implemented | Move to `src/algo/` or `src/query/` |
+| **Depth** | Limited to Depth 1 | Configurable | Implement BFS expansion for depth > 1 |
+| **API** | `FishingRod` struct | Integrated `QueryBuilder` | Add `.fish()` or `.associate()` to Query API |
+| **Tests** | Basic Unit Tests | Property Tests | Add randomized property tests |
+
+## 6. 📅 Execution Plan
+
+1.  **Review** `src/experimental/fishing.rs` implementation against metrics.
+2.  **Implement** Depth > 1 support (Backlog item).
+3.  **Integrate** into main `QueryBuilder` API.
+4.  **Promote** from `experimental` to `core`.


### PR DESCRIPTION
Refines SPEC-001 (Semantic Pathfinding) to align with RAG use cases for non-obvious relationships. Creates SPEC-002 (Associative Retrieval) to formalize the existing 'Fishing' experimental feature.

User Story (SPEC-001): As a RAG Developer, I want to find nodes that are semantically similar but structurally distant, so that I can discover and explain non-obvious relationships.

User Story (SPEC-002): As a Researcher, I want to retrieve information by 'casting a net' (similarity + links), so I can simulate human-like associative recall.

---
*PR created automatically by Jules for task [10950302258575064736](https://jules.google.com/task/10950302258575064736) started by @madmax983*