### PR TITLE
🔒 Warden: Enforce MAX_ARRAY_ELEMENTS in JSON input

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -124,3 +124,16 @@ Enforced strict capacity limits during deserialization:
 Added `tests/warden_dos_repro.rs` which simulates malicious payloads with excessive counts.
 - Before fix: Code attempted allocation (and failed with "Buffer too short" or potentially OOM).
 - After fix: Code immediately returns `StorageError::CorruptedData` citing the capacity limit, protecting memory resources.
+
+## 2026-02-16 - JSON Input Validation Hardening
+
+**Threat:** Inconsistent Input Validation (JSON vs WAL)
+User input via JSON API allowed arrays larger than `MAX_ARRAY_ELEMENTS`. This data could be written to the WAL but would fail validation during recovery deserialization, leading to potential data loss or inability to recover.
+
+**Defense:** Input Validation
+Enforced `MAX_ARRAY_ELEMENTS` limit in `json_to_property_value` in `src/http/converters.rs`. Now, attempts to create property arrays exceeding the limit are rejected at the API boundary.
+
+**Verification:** Reproduction Test
+Added `test_json_array_element_limit` in `src/http/converters.rs`.
+- Before fix: Test asserted failure, but operation succeeded (test failed).
+- After fix: Test asserted failure, and operation returned error (test passed).

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -1,3 +1,4 @@
+use crate::core::property::MAX_ARRAY_ELEMENTS;
 use crate::core::{GLOBAL_INTERNER, PropertyMap, PropertyMapBuilder, PropertyValue};
 use serde_json::json;
 use std::collections::HashMap;
@@ -109,6 +110,15 @@ fn json_to_property_value_recursive(
         }
         serde_json::Value::String(s) => Ok(PropertyValue::String(Arc::from(s.as_str()))),
         serde_json::Value::Array(arr) => {
+            // Prevent DoS via memory exhaustion from massive arrays
+            if arr.len() > MAX_ARRAY_ELEMENTS {
+                return Err(format!(
+                    "Array count {} exceeds maximum allowed {}",
+                    arr.len(),
+                    MAX_ARRAY_ELEMENTS
+                ));
+            }
+
             if arr.iter().all(|v| v.is_number()) && !arr.is_empty() {
                 let floats: Result<Vec<f32>, String> = arr
                     .iter()
@@ -205,3 +215,20 @@ mod tests {
         }
     }
 }
+
+    #[test]
+    fn test_json_array_element_limit() {
+        use crate::core::property::MAX_ARRAY_ELEMENTS;
+        // Construct a JSON array that exceeds the limit
+        // 1M elements. This might take a bit of memory but is necessary to verify.
+        let limit = MAX_ARRAY_ELEMENTS;
+        let mut vec = Vec::with_capacity(limit + 1);
+        for _ in 0..=limit {
+            vec.push(json!(1));
+        }
+        let json_arr = serde_json::Value::Array(vec);
+
+        let result = json_to_property_value(&json_arr);
+        assert!(result.is_err(), "Should fail due to array element limit");
+        assert!(result.unwrap_err().contains("exceeds maximum allowed"));
+    }


### PR DESCRIPTION
**Threat:** Inconsistent Input Validation (JSON vs WAL)
User input via JSON API allowed arrays larger than `MAX_ARRAY_ELEMENTS`. This data could be written to the WAL but would fail validation during recovery deserialization, leading to potential data loss or inability to recover.

**Defense:** Input Validation
Enforced `MAX_ARRAY_ELEMENTS` limit in `json_to_property_value` in `src/http/converters.rs`. Now, attempts to create property arrays exceeding the limit are rejected at the API boundary.

**Verification:** Reproduction Test
Added `test_json_array_element_limit` in `src/http/converters.rs`.
- Before fix: Test asserted failure, but operation succeeded (test failed).
- After fix: Test asserted failure, and operation returned error (test passed).

---
*PR created automatically by Jules for task [2693085537449470710](https://jules.google.com/task/2693085537449470710) started by @madmax983*