### PR TITLE
Refactor: Remove redundant StorageObserver and VectorIndexObserver

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+
+## [Reduction]
+**Bloat:** `StorageObserver` trait, `StorageEvent` enum, and `VectorIndexObserver` (Over-engineered "One-Time Trait" pattern).
+**Cut:** Removed the entire Observer infrastructure. Used existing `PreAnchorHook` closures for the only actual use case (vector index synchronization).
+**Saved:** ~300 lines of code + removed redundant double-invocation of snapshot logic + simplified HistoricalStorage architecture.


### PR DESCRIPTION
Removed `StorageObserver` and `VectorIndexObserver` as they were redundant abstractions. The vector snapshot functionality is already handled by `PreAnchorHook`. This reduction simplifies the codebase and aligns with KISS principles.

---
*PR created automatically by Jules for task [13308447521336884322](https://jules.google.com/task/13308447521336884322) started by @madmax983*