### PR TITLE
Eliminate unnecessary PropertyMap clones in storage layer

### DIFF
--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -446,15 +446,13 @@ impl CurrentStorage {
         let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
         let label_interned = GLOBAL_INTERNER.intern(label)?;
 
-        let node = Node::new(node_id, label_interned, properties.clone(), version_id);
-        self.indexes.insert_node(node.clone());
+        // CRITICAL: Index vector BEFORE inserting node. If vector indexing fails,
+        // we have not modified any graph state, so we can safely return error without rollback.
+        // This also avoids unnecessary clones of Node and PropertyMap.
+        self.try_index_vector(node_id, &properties)?;
 
-        // Try to index vector property if enabled
-        if let Err(e) = self.try_index_vector(node_id, &properties) {
-            // Rollback: remove node from indexes
-            self.indexes.remove_node(node_id);
-            return Err(e);
-        }
+        let node = Node::new(node_id, label_interned, properties, version_id);
+        self.indexes.insert_node(node);
 
         Ok(node_id)
     }
@@ -654,23 +652,20 @@ impl CurrentStorage {
 
     /// Update a node directly (used by WriteTransaction).
     pub fn update_node_direct(&self, node: Node, timestamp: Timestamp) -> Result<()> {
-        // Save old node for potential rollback
+        // Save old node for vector index update
         let old_node = self.indexes.get_node(node.id);
 
-        // Update node
-        self.indexes.insert_node(node.clone());
-
-        // Update vector index
-        if let Some(ref old) = old_node
-            && let Err(e) = self.update_vector_index(node.id, &node.properties, &old.properties)
-        {
-            // Rollback: restore the original node
-            self.indexes.insert_node(old.clone());
-            return Err(e);
+        // Update vector index BEFORE updating node in main indexes.
+        // If vector indexing fails, we haven't modified any state yet.
+        if let Some(ref old) = old_node {
+            self.update_vector_index(node.id, &node.properties, &old.properties)?;
         }
 
         // Update temporal vector index if enabled
         self.try_index_temporal_vector(node.id, &node.properties, timestamp)?;
+
+        // Finally, insert node into main indexes. This avoids node.clone().
+        self.indexes.insert_node(node);
 
         Ok(())
     }

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -572,8 +572,13 @@ impl HistoricalStorage {
             if versions_since_anchor >= self.config.anchor_interval as usize {
                 // Create anchor with link to previous version
                 // Use properties.clone() here as we need original for caching later
-                let mut anchor =
-                    NodeVersion::new_anchor(version_id, node_id, temporal, label, properties.clone());
+                let mut anchor = NodeVersion::new_anchor(
+                    version_id,
+                    node_id,
+                    temporal,
+                    label,
+                    properties.clone(),
+                );
                 anchor.prev_version = Some(prev_id);
                 // Reset counter to 0 after creating anchor
                 self.node_versions_since_anchor.insert(node_id, 0);

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -553,9 +553,6 @@ impl HistoricalStorage {
         // Check if this node already has versions
         let prev_version_id = self.node_version_heads.get(&node_id).copied();
 
-        // Clone properties for hook call and caching (since new_anchor takes ownership)
-        let properties_for_hook = properties.clone();
-
         // Create version (anchor or delta based on chain length)
         let mut version = if let Some(prev_id) = prev_version_id {
             // Verify previous version exists (properties reconstructed later via reconstruct_node_properties)
@@ -574,8 +571,9 @@ impl HistoricalStorage {
 
             if versions_since_anchor >= self.config.anchor_interval as usize {
                 // Create anchor with link to previous version
+                // Use properties.clone() here as we need original for caching later
                 let mut anchor =
-                    NodeVersion::new_anchor(version_id, node_id, temporal, label, properties);
+                    NodeVersion::new_anchor(version_id, node_id, temporal, label, properties.clone());
                 anchor.prev_version = Some(prev_id);
                 // Reset counter to 0 after creating anchor
                 self.node_versions_since_anchor.insert(node_id, 0);
@@ -600,7 +598,7 @@ impl HistoricalStorage {
             // First version is always an anchor
             // Initialize counter to 0
             self.node_versions_since_anchor.insert(node_id, 0);
-            NodeVersion::new_anchor(version_id, node_id, temporal, label, properties)
+            NodeVersion::new_anchor(version_id, node_id, temporal, label, properties.clone())
         };
 
         // Handle pre-anchor hook (BEFORE storing)
@@ -610,7 +608,7 @@ impl HistoricalStorage {
                     entity_type: "node",
                     entity_id: node_id.as_u64(),
                     timestamp: temporal.transaction_time().start(),
-                    properties: &properties_for_hook,
+                    properties: &properties,
                 },
                 &mut version.data,
                 &self.pre_node_anchor_hook,
@@ -672,7 +670,7 @@ impl HistoricalStorage {
         //         the previous delta's properties even though we just added them.
         // AFTER:  All versions are cached in the main property cache, eliminating
         //         unnecessary reconstructions during consecutive writes.
-        let props_arc = Arc::new(properties_for_hook);
+        let props_arc = Arc::new(properties);
         self.node_property_cache
             .insert(version_id, props_arc.clone());
 
@@ -744,9 +742,6 @@ impl HistoricalStorage {
         // Check if this edge already has versions
         let prev_version_id = self.edge_version_heads.get(&edge_id).copied();
 
-        // Clone properties for hook call and caching (since new_anchor takes ownership)
-        let properties_for_hook = properties.clone();
-
         // Create version (anchor or delta based on chain length)
         let mut version = if let Some(prev_id) = prev_version_id {
             // Verify previous version exists (properties reconstructed later via reconstruct_edge_properties)
@@ -765,8 +760,15 @@ impl HistoricalStorage {
 
             if versions_since_anchor >= self.config.anchor_interval as usize {
                 // Create anchor with link to previous version
+                // Use properties.clone() here as we need original for caching later
                 let mut anchor = EdgeVersion::new_anchor(
-                    version_id, edge_id, temporal, label, source, target, properties,
+                    version_id,
+                    edge_id,
+                    temporal,
+                    label,
+                    source,
+                    target,
+                    properties.clone(),
                 );
                 anchor.prev_version = Some(prev_id);
                 // Reset counter to 0 after creating anchor
@@ -795,7 +797,13 @@ impl HistoricalStorage {
             // Initialize counter to 0
             self.edge_versions_since_anchor.insert(edge_id, 0);
             EdgeVersion::new_anchor(
-                version_id, edge_id, temporal, label, source, target, properties,
+                version_id,
+                edge_id,
+                temporal,
+                label,
+                source,
+                target,
+                properties.clone(),
             )
         };
 
@@ -806,7 +814,7 @@ impl HistoricalStorage {
                     entity_type: "edge",
                     entity_id: edge_id.as_u64(),
                     timestamp: temporal.transaction_time().start(),
-                    properties: &properties_for_hook,
+                    properties: &properties,
                 },
                 &mut version.data,
                 &self.pre_edge_anchor_hook,
@@ -876,7 +884,7 @@ impl HistoricalStorage {
 
         // Issue #210: Cache properties for ALL versions (anchors and deltas) to avoid
         // reconstructing properties we just added when creating the next delta.
-        let props_arc = Arc::new(properties_for_hook);
+        let props_arc = Arc::new(properties);
         self.edge_property_cache
             .insert(version_id, props_arc.clone());
 


### PR DESCRIPTION
Eliminated unnecessary clones of PropertyMap and Node objects in the storage layer (current and historical) by reordering operations to use move semantics. Reduced clones in CurrentStorage::create_node from 2 to 0, and in HistoricalStorage::add_*_version delta paths from 1 to 0.

Fixes #335

---
*PR created automatically by Jules for task [8614815557960562251](https://jules.google.com/task/8614815557960562251) started by @madmax983*