### PR TITLE
Performance: Optimize Arc cloning in string interner lookups

### DIFF
--- a/benches/current_state.rs
+++ b/benches/current_state.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Benchmarks for storage layer primitives (fast path)
 //!
 //! This file covers:
@@ -358,7 +359,7 @@ fn bench_id_full_lifecycle(c: &mut Criterion) {
 // String Interning Benchmarks
 // ============================================================================
 
-/// Benchmark single string access using resolve() vs with_str().
+/// Benchmark single string access using resolve() vs resolve_with().
 fn bench_string_single_access(c: &mut Criterion) {
     let mut group = c.benchmark_group("string_access_single");
 
@@ -372,8 +373,8 @@ fn bench_string_single_access(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("with_str", |b| {
-        b.iter(|| interner.with_str(id, |s| black_box(s.len())));
+    group.bench_function("resolve_with", |b| {
+        b.iter(|| interner.resolve_with(id, |s| black_box(s.len())));
     });
 
     group.finish();
@@ -395,8 +396,8 @@ fn bench_string_length(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("with_str", |b| {
-        b.iter(|| interner.with_str(id, |s| black_box(s.len())));
+    group.bench_function("resolve_with", |b| {
+        b.iter(|| interner.resolve_with(id, |s| black_box(s.len())));
     });
 
     group.finish();
@@ -416,8 +417,8 @@ fn bench_string_comparison(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("with_str", |b| {
-        b.iter(|| interner.with_str(id, |s| black_box(s == "Person")));
+    group.bench_function("resolve_with", |b| {
+        b.iter(|| interner.resolve_with(id, |s| black_box(s == "Person")));
     });
 
     group.finish();
@@ -441,10 +442,10 @@ fn bench_string_multiple_accesses(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("with_str_100", |b| {
+    group.bench_function("resolve_with_100", |b| {
         b.iter(|| {
             for &id in &ids {
-                interner.with_str(id, |s| black_box(s.len()));
+                interner.resolve_with(id, |s| black_box(s.len()));
             }
         });
     });
@@ -478,12 +479,12 @@ fn bench_string_serialization(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("with_str", |b| {
+    group.bench_function("resolve_with", |b| {
         b.iter(|| {
             let mut total_len = 0;
             for _ in 0..1000 {
                 for &key_id in &property_keys {
-                    interner.with_str(key_id, |key| {
+                    interner.resolve_with(key_id, |key| {
                         // Simulate serialization by computing length and hashing
                         total_len += key.len();
                         black_box(key);
@@ -516,7 +517,7 @@ fn bench_string_arc_overhead(c: &mut Criterion) {
     // Measure direct access without Arc clone
     group.bench_function("direct_access", |b| {
         b.iter(|| {
-            interner.with_str(id, |s| {
+            interner.resolve_with(id, |s| {
                 black_box(s);
             });
         });
@@ -547,12 +548,12 @@ fn bench_string_hot_path(c: &mut Criterion) {
         );
 
         group.bench_with_input(
-            BenchmarkId::new("with_str", iterations),
+            BenchmarkId::new("resolve_with", iterations),
             &iterations,
             |b, &iterations| {
                 b.iter(|| {
                     for _ in 0..iterations {
-                        interner.with_str(id, |s| black_box(s.len()));
+                        interner.resolve_with(id, |s| black_box(s.len()));
                     }
                 });
             },

--- a/examples/doctor_who_demo.rs
+++ b/examples/doctor_who_demo.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Doctor Who Demo - A fun exploration of GallifreyDB's bi-temporal capabilities
 //!
 //! This demo creates a knowledge graph about the Doctor Who universe,

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -250,8 +250,8 @@ mod tests {
         assert!(diff.removed.is_empty());
         assert_eq!(diff.modified.len(), 1);
         use crate::core::GLOBAL_INTERNER;
-        let key_str = GLOBAL_INTERNER.resolve(diff.modified[0].0).unwrap();
-        assert_eq!(key_str.as_ref(), "name");
+        let key_str = GLOBAL_INTERNER.resolve_with(diff.modified[0].0, |s| s.to_string()).unwrap();
+        assert_eq!(key_str, "name");
     }
 
     #[test]
@@ -283,8 +283,8 @@ mod tests {
         assert!(diff.removed.contains_key("status"));
 
         assert_eq!(diff.modified.len(), 1);
-        let key_str = GLOBAL_INTERNER.resolve(diff.modified[0].0).unwrap();
-        assert_eq!(key_str.as_ref(), "age");
+        let key_str = GLOBAL_INTERNER.resolve_with(diff.modified[0].0, |s| s.to_string()).unwrap();
+        assert_eq!(key_str, "age");
     }
 
     #[test]

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -250,7 +250,9 @@ mod tests {
         assert!(diff.removed.is_empty());
         assert_eq!(diff.modified.len(), 1);
         use crate::core::GLOBAL_INTERNER;
-        let key_str = GLOBAL_INTERNER.resolve_with(diff.modified[0].0, |s| s.to_string()).unwrap();
+        let key_str = GLOBAL_INTERNER
+            .resolve_with(diff.modified[0].0, |s| s.to_string())
+            .unwrap();
         assert_eq!(key_str, "name");
     }
 
@@ -283,7 +285,9 @@ mod tests {
         assert!(diff.removed.contains_key("status"));
 
         assert_eq!(diff.modified.len(), 1);
-        let key_str = GLOBAL_INTERNER.resolve_with(diff.modified[0].0, |s| s.to_string()).unwrap();
+        let key_str = GLOBAL_INTERNER
+            .resolve_with(diff.modified[0].0, |s| s.to_string())
+            .unwrap();
         assert_eq!(key_str, "age");
     }
 

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -188,6 +188,18 @@ impl StringInterner {
     /// Resolve an interned string ID back to the original string.
     ///
     /// Returns None if the ID is not valid (was never interned).
+    ///
+    /// # Performance Note
+    ///
+    /// This method clones the underlying `Arc<str>`, which involves atomic reference
+    /// counting operations.
+    ///
+    /// - **For read-only access**: Use [`resolve_with`](Self::resolve_with) to avoid Arc cloning.
+    /// - **When an owned Arc is needed**: Use this method (`resolve`).
+    #[deprecated(
+        since = "0.1.0",
+        note = "Use resolve_with() for read-only access; use resolve() only when an owned Arc<str> is strictly required"
+    )]
     pub fn resolve(&self, id: InternedString) -> Option<Arc<str>> {
         self.id_to_string
             .get(&id)
@@ -198,7 +210,7 @@ impl StringInterner {
     ///
     /// This is useful when you just need to read the string temporarily.
     ///
-    /// **Note:** For read-only access, prefer [`with_str`](Self::with_str) to avoid Arc cloning overhead.
+    /// **Note:** For read-only access, prefer [`resolve_with`](Self::resolve_with) to avoid Arc cloning overhead.
     /// This method still clones the Arc internally.
     pub fn get(&self, id: InternedString) -> Option<impl AsRef<str> + '_> {
         self.id_to_string.get(&id).map(|entry| {
@@ -228,7 +240,7 @@ impl StringInterner {
     /// serializer.serialize_str(key_str.as_ref())?; // Arc clone overhead
     ///
     /// // Use:
-    /// interner.with_str(key_id, |s| serializer.serialize_str(s))?;
+    /// interner.resolve_with(key_id, |s| serializer.serialize_str(s))?;
     /// ```
     ///
     /// # Examples
@@ -240,20 +252,29 @@ impl StringInterner {
     /// let id = interner.intern("hello").unwrap();
     ///
     /// // Efficient: no Arc clone
-    /// let len = interner.with_str(id, |s| s.len()).unwrap();
+    /// let len = interner.resolve_with(id, |s| s.len()).unwrap();
     /// assert_eq!(len, 5);
     ///
     /// // Can return any type from the callback
-    /// let uppercase = interner.with_str(id, |s| s.to_uppercase()).unwrap();
+    /// let uppercase = interner.resolve_with(id, |s| s.to_uppercase()).unwrap();
     /// assert_eq!(uppercase, "HELLO");
     /// ```
-    pub fn with_str<F, R>(&self, id: InternedString, f: F) -> Option<R>
+    pub fn resolve_with<F, R>(&self, id: InternedString, f: F) -> Option<R>
     where
         F: FnOnce(&str) -> R,
     {
         self.id_to_string
             .get(&id)
             .map(|entry| f(entry.value().as_ref()))
+    }
+
+    /// Access the interned string via a callback (deprecated - use [`resolve_with`](Self::resolve_with)).
+    #[deprecated(since = "0.1.0", note = "Use resolve_with() instead")]
+    pub fn with_str<F, R>(&self, id: InternedString, f: F) -> Option<R>
+    where
+        F: FnOnce(&str) -> R,
+    {
+        self.resolve_with(id, f)
     }
 
     /// Check if a string has been interned.
@@ -556,12 +577,12 @@ mod tests {
     }
 
     #[test]
-    fn test_with_str_basic() {
+    fn test_resolve_with_basic() {
         let interner = StringInterner::new();
         let id = interner.intern("hello").unwrap();
 
         // Test basic access
-        let result = interner.with_str(id, |s| {
+        let result = interner.resolve_with(id, |s| {
             assert_eq!(s, "hello");
             s.len()
         });
@@ -570,34 +591,34 @@ mod tests {
     }
 
     #[test]
-    fn test_with_str_invalid_id() {
+    fn test_resolve_with_invalid_id() {
         let interner = StringInterner::new();
         let invalid_id = InternedString::from_raw(999);
 
-        let result = interner.with_str(invalid_id, |s| s.len());
+        let result = interner.resolve_with(invalid_id, |s| s.len());
         assert_eq!(result, None);
     }
 
     #[test]
-    fn test_with_str_return_types() {
+    fn test_resolve_with_return_types() {
         let interner = StringInterner::new();
         let id = interner.intern("test string").unwrap();
 
         // Return usize
-        let len = interner.with_str(id, |s| s.len()).unwrap();
+        let len = interner.resolve_with(id, |s| s.len()).unwrap();
         assert_eq!(len, 11);
 
         // Return String
-        let uppercase = interner.with_str(id, |s| s.to_uppercase()).unwrap();
+        let uppercase = interner.resolve_with(id, |s| s.to_uppercase()).unwrap();
         assert_eq!(uppercase, "TEST STRING");
 
         // Return bool
-        let contains = interner.with_str(id, |s| s.contains("test")).unwrap();
+        let contains = interner.resolve_with(id, |s| s.contains("test")).unwrap();
         assert!(contains);
 
         // Return Vec (must own the data since it outlives the callback)
         let words: Vec<String> = interner
-            .with_str(id, |s| {
+            .resolve_with(id, |s| {
                 s.split_whitespace().map(|w| w.to_string()).collect()
             })
             .unwrap();
@@ -605,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_str_no_arc_clone() {
+    fn test_resolve_with_no_arc_clone() {
         let interner = StringInterner::new();
         let id = interner.intern("performance test").unwrap();
 
@@ -614,9 +635,9 @@ mod tests {
         let s_arc = interner.resolve(id).unwrap();
         let baseline_count = Arc::strong_count(&s_arc);
 
-        // This test verifies that with_str works without cloning by checking the refcount.
+        // This test verifies that resolve_with works without cloning by checking the refcount.
         let mut call_count = 0;
-        let result = interner.with_str(id, |s| {
+        let result = interner.resolve_with(id, |s| {
             call_count += 1;
             // The count should not increase during the callback.
             assert_eq!(Arc::strong_count(&s_arc), baseline_count);
@@ -630,7 +651,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_str_concurrent() {
+    fn test_resolve_with_concurrent() {
         use std::thread;
 
         let interner = Arc::new(StringInterner::new());
@@ -643,7 +664,7 @@ mod tests {
                 let interner_clone = Arc::clone(&interner);
                 handles.push(s.spawn(move || {
                     interner_clone
-                        .with_str(id, |s| {
+                        .resolve_with(id, |s| {
                             assert_eq!(s, "concurrent");
                             format!("{}-{}", s, i)
                         })
@@ -660,41 +681,41 @@ mod tests {
     }
 
     #[test]
-    fn test_with_str_vs_resolve_equivalence() {
+    fn test_resolve_with_vs_resolve_equivalence() {
         let interner = StringInterner::new();
         let id = interner.intern("equivalence test").unwrap();
 
         // Both methods should give the same string content
-        let via_with_str = interner.with_str(id, |s| s.to_string()).unwrap();
+        let via_resolve_with = interner.resolve_with(id, |s| s.to_string()).unwrap();
         let via_resolve = interner.resolve(id).unwrap();
 
-        assert_eq!(via_with_str, via_resolve.as_ref());
+        assert_eq!(via_resolve_with, via_resolve.as_ref());
     }
 
     #[test]
-    fn test_with_str_empty_string() {
+    fn test_resolve_with_empty_string() {
         let interner = StringInterner::new();
         let id = interner.intern("").unwrap();
 
-        let len = interner.with_str(id, |s| s.len()).unwrap();
+        let len = interner.resolve_with(id, |s| s.len()).unwrap();
         assert_eq!(len, 0);
 
-        let is_empty = interner.with_str(id, |s| s.is_empty()).unwrap();
+        let is_empty = interner.resolve_with(id, |s| s.is_empty()).unwrap();
         assert!(is_empty);
     }
 
     #[test]
-    fn test_with_str_panic_safety() {
+    fn test_resolve_with_panic_safety() {
         let interner = StringInterner::new();
         let id = interner.intern("panic test").unwrap();
 
         // Verify the interner works before panic
-        let before = interner.with_str(id, |s| s.to_string()).unwrap();
+        let before = interner.resolve_with(id, |s| s.to_string()).unwrap();
         assert_eq!(before, "panic test");
 
         // Cause a panic in the callback
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            interner.with_str(id, |_s| {
+            interner.resolve_with(id, |_s| {
                 panic!("intentional panic in callback");
             })
         }));
@@ -704,12 +725,12 @@ mod tests {
 
         // Verify the interner is still usable after the panic
         // The DashMap entry guard should have been properly dropped
-        let after = interner.with_str(id, |s| s.to_string()).unwrap();
+        let after = interner.resolve_with(id, |s| s.to_string()).unwrap();
         assert_eq!(after, "panic test");
 
         // Verify we can still intern new strings
         let new_id = interner.intern("after panic").unwrap();
-        let new_str = interner.with_str(new_id, |s| s.to_string()).unwrap();
+        let new_str = interner.resolve_with(new_id, |s| s.to_string()).unwrap();
         assert_eq!(new_str, "after panic");
     }
 

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -450,6 +450,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_resolve() {
         let interner = StringInterner::new();
 
@@ -460,6 +461,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_resolve_invalid_id() {
         let interner = StringInterner::new();
 
@@ -506,6 +508,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_clear() {
         let interner = StringInterner::new();
 
@@ -566,6 +569,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_global_interner() {
         let id1 = GLOBAL_INTERNER.intern("global").unwrap();
         let id2 = GLOBAL_INTERNER.intern("global").unwrap();
@@ -626,6 +630,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_resolve_with_no_arc_clone() {
         let interner = StringInterner::new();
         let id = interner.intern("performance test").unwrap();
@@ -681,6 +686,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_resolve_with_vs_resolve_equivalence() {
         let interner = StringInterner::new();
         let id = interner.intern("equivalence test").unwrap();
@@ -940,6 +946,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_warm_common_strings_with_existing_data() {
         let interner = StringInterner::new();
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1545,7 +1545,7 @@ impl PropertyMap {
             // Serialize key: resolve InternedString to actual string
             // Use with_str to avoid Arc cloning overhead
             GLOBAL_INTERNER
-                .with_str(*key, |key_str| {
+                .resolve_with(*key, |key_str| {
                     let key_bytes = key_str.as_bytes();
                     buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
                     buffer.extend_from_slice(key_bytes);
@@ -1715,7 +1715,7 @@ impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
 
         for (key, value) in iter {
             // Need key size for serialization
-            let key_len = GLOBAL_INTERNER.with_str(key, |s| s.len()).unwrap_or(256);
+            let key_len = GLOBAL_INTERNER.resolve_with(key, |s| s.len()).unwrap_or(256);
             let key_size = 4 + key_len;
             let val_size = value
                 .serialized_size()
@@ -1827,7 +1827,7 @@ impl PropertyMapBuilder {
             // This is a tradeoff: we pay lookup cost for new keys, but
             // avoid it for updates and for subsequent serialization size checks.
             let key_len = GLOBAL_INTERNER
-                .with_str(key, |s| s.len())
+                .resolve_with(key, |s| s.len())
                 .unwrap_or_else(|| {
                     // This should be unreachable if the PropertyKey is valid (which it should be).
                     // In debug builds, we panic to catch this state corruption.
@@ -1904,7 +1904,7 @@ impl PropertyMapBuilder {
     pub fn try_remove_by_key(mut self, key: &PropertyKey) -> Result<Self> {
         let old_val = self.map.remove(key);
         if let Some(old_val) = old_val {
-            let key_len = GLOBAL_INTERNER.with_str(*key, |s| s.len()).unwrap_or(256);
+            let key_len = GLOBAL_INTERNER.resolve_with(*key, |s| s.len()).unwrap_or(256);
             let key_size = 4 + key_len;
             self.current_size = self
                 .current_size
@@ -3004,8 +3004,7 @@ mod tests {
         for key_str in &expected_keys {
             let exists = first_keys.iter().any(|key| {
                 GLOBAL_INTERNER
-                    .resolve(*key)
-                    .map(|s| s.as_ref() == *key_str)
+                    .resolve_with(*key, |s| s == *key_str)
                     .unwrap_or(false)
             });
             assert!(

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1715,7 +1715,9 @@ impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
 
         for (key, value) in iter {
             // Need key size for serialization
-            let key_len = GLOBAL_INTERNER.resolve_with(key, |s| s.len()).unwrap_or(256);
+            let key_len = GLOBAL_INTERNER
+                .resolve_with(key, |s| s.len())
+                .unwrap_or(256);
             let key_size = 4 + key_len;
             let val_size = value
                 .serialized_size()
@@ -1904,7 +1906,9 @@ impl PropertyMapBuilder {
     pub fn try_remove_by_key(mut self, key: &PropertyKey) -> Result<Self> {
         let old_val = self.map.remove(key);
         if let Some(old_val) = old_val {
-            let key_len = GLOBAL_INTERNER.resolve_with(*key, |s| s.len()).unwrap_or(256);
+            let key_len = GLOBAL_INTERNER
+                .resolve_with(*key, |s| s.len())
+                .unwrap_or(256);
             let key_size = 4 + key_len;
             self.current_size = self
                 .current_size

--- a/src/experimental/graph_context.rs
+++ b/src/experimental/graph_context.rs
@@ -42,8 +42,7 @@ impl<'a> GraphContextBuilder<'a> {
 
     fn resolve(s: InternedString) -> String {
         GLOBAL_INTERNER
-            .resolve(s)
-            .map(|x| x.to_string())
+            .resolve_with(s, |s| s.to_string())
             .unwrap_or_else(|| format!("<interned:{}>", s.as_u32()))
     }
 

--- a/src/experimental/temporal_narrative.rs
+++ b/src/experimental/temporal_narrative.rs
@@ -33,8 +33,7 @@ impl<'a> NarrativeGenerator<'a> {
     /// Helper to resolve interned keys to strings.
     fn resolve_key(key_id: InternedString) -> String {
         GLOBAL_INTERNER
-            .resolve(key_id)
-            .map(|s| s.to_string())
+            .resolve_with(key_id, |s| s.to_string())
             .unwrap_or_else(|| "unknown".to_string())
     }
 

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -28,8 +28,7 @@ const MAX_JSON_RECURSION_DEPTH: usize = 100;
 /// the interned string cannot be found (which should not happen in normal operation).
 pub fn interned_to_string(interned: crate::core::InternedString) -> String {
     GLOBAL_INTERNER
-        .resolve(interned)
-        .map(|s| s.to_string())
+        .resolve_with(interned, |s| s.to_string())
         .unwrap_or_else(|| format!("<unknown:{}>", interned.as_u32()))
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -249,8 +249,7 @@ impl GallifreyMcpServer {
 
     fn interned_to_string(&self, interned: crate::core::InternedString) -> String {
         GLOBAL_INTERNER
-            .resolve(interned)
-            .map(|s| s.to_string())
+            .resolve_with(interned, |s| s.to_string())
             .unwrap_or_else(|| format!("<unknown:{}>", interned.as_u32()))
     }
 
@@ -387,7 +386,7 @@ impl GallifreyMcpServer {
 
     fn matches_label(&self, interned: crate::core::InternedString, label: &str) -> bool {
         GLOBAL_INTERNER
-            .with_str(interned, |s| s == label)
+            .resolve_with(interned, |s| s == label)
             .unwrap_or(false)
     }
 
@@ -1406,8 +1405,7 @@ impl GallifreyMcpServer {
             .iter()
             .map(|(key, old_val, new_val)| {
                 let key_str = GLOBAL_INTERNER
-                    .resolve(*key)
-                    .map(|s| s.as_ref().to_string())
+                    .resolve_with(*key, |s| s.to_string())
                     .unwrap_or_else(|| format!("{:?}", key));
 
                 json!({

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -464,8 +464,7 @@ impl std::fmt::Display for QueryResult {
                         .map(|(k, v)| {
                             // resolve key
                             let k_str = crate::core::interning::GLOBAL_INTERNER
-                                .resolve(*k)
-                                .map(|s| s.to_string())
+                                .resolve_with(*k, |s| s.to_string())
                                 .unwrap_or_else(|| format!("key:{}", k.as_u32()));
                             format!("{}: {}", k_str, v)
                         })

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2026,9 +2026,10 @@ impl CurrentStorage {
             let (candidates, stats) = self.calculate_adaptive_candidates(k, label);
 
             let mut results = index.search_with_filter(query, candidates, |node_id| {
+                // HOT PATH: Use zero-copy label lookup to avoid cloning entire Node
                 self.indexes
-                    .get_node(*node_id)
-                    .map(|n| n.label == label_id)
+                    .get_node_label(*node_id)
+                    .map(|l| l == label_id)
                     .unwrap_or(false)
             })?;
 

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2057,8 +2057,7 @@ impl HistoricalStorage {
                     temporal: version.temporal,
                     properties,
                     label: GLOBAL_INTERNER
-                        .resolve(version.label)
-                        .map(|s| s.to_string())
+                        .resolve_with(version.label, |s| s.to_string())
                         .unwrap_or_else(|| version.label.to_string()),
                 });
             }
@@ -2204,8 +2203,7 @@ impl HistoricalStorage {
                     temporal: version.temporal,
                     properties,
                     label: GLOBAL_INTERNER
-                        .resolve(version.label)
-                        .map(|s| s.to_string())
+                        .resolve_with(version.label, |s| s.to_string())
                         .unwrap_or_else(|| version.label.to_string()),
                 });
             }

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -69,6 +69,10 @@ pub fn restore_property_value(persisted: &PersistedPropertyValue) -> Result<Prop
         PersistedPropertyValue::Int(i) => PropertyValue::Int(*i),
         PersistedPropertyValue::Float(f) => PropertyValue::Float(*f),
         PersistedPropertyValue::String(idx) => {
+            // Note: Use resolve() instead of resolve_with() here because PropertyValue::String
+            // requires an owned Arc<str>. Cloning the existing Arc is more efficient
+            // than allocating a new one from a &str.
+            #[allow(deprecated)]
             let s = GLOBAL_INTERNER
                 .resolve(crate::core::InternedString::from_raw(*idx))
                 .ok_or_else(|| {
@@ -122,14 +126,16 @@ pub fn restore_property_map(persisted: &PersistedPropertyMap) -> Result<Property
     let mut builder = PropertyMapBuilder::new();
     for (key_idx, value) in &persisted.entries {
         let key_id = crate::core::InternedString::from_raw(*key_idx);
-        let key_arc = GLOBAL_INTERNER.resolve(key_id).ok_or_else(|| {
-            IndexPersistenceError::Serialization(format!(
-                "Failed to resolve interned property key with ID: {}. \
+        let val = restore_property_value(value)?;
+        builder = GLOBAL_INTERNER
+            .resolve_with(key_id, |key_str| builder.insert(key_str, val))
+            .ok_or_else(|| {
+                IndexPersistenceError::Serialization(format!(
+                    "Failed to resolve interned property key with ID: {}. \
                  This likely indicates data corruption.",
-                key_idx
-            ))
-        })?;
-        builder = builder.insert(key_arc.as_ref(), restore_property_value(value)?);
+                    key_idx
+                ))
+            })?;
     }
     Ok(builder.build())
 }

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -593,8 +593,9 @@ pub(crate) fn load_indexes_startup(
                 // Restore nodes with explicit error tracking
                 for persisted_node in &graph_data.nodes {
                     // Validate label exists in string interner
-                    let label_str = match GLOBAL_INTERNER.resolve(
+                    let label_str = match GLOBAL_INTERNER.resolve_with(
                         crate::core::InternedString::from_raw(persisted_node.label_idx),
+                        |s| s.to_string(),
                     ) {
                         Some(s) => s,
                         None => {
@@ -651,8 +652,9 @@ pub(crate) fn load_indexes_startup(
                 // Restore edges with explicit error tracking
                 for persisted_edge in &graph_data.edges {
                     // Validate label exists in string interner
-                    let label_str = match GLOBAL_INTERNER.resolve(
+                    let label_str = match GLOBAL_INTERNER.resolve_with(
                         crate::core::InternedString::from_raw(persisted_edge.label_idx),
+                        |s| s.to_string(),
                     ) {
                         Some(s) => s,
                         None => {

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -726,7 +726,7 @@ impl PersistenceManager {
     ) -> Result<()> {
         // Validate that the InternedString ID exists in the interner
         // This protects against corrupted WAL files or missing checkpoint data
-        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+        GLOBAL_INTERNER.resolve_with(label, |_| ()).ok_or_else(|| {
             StorageError::CorruptedData(format!(
                 "InternedString ID {} for node_id={} not found in interner. \
                  This indicates corrupted WAL or missing checkpoint data.",
@@ -790,7 +790,7 @@ impl PersistenceManager {
         next_version_id: &mut u64,
     ) -> Result<()> {
         // Validate that the InternedString ID exists in the interner
-        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+        GLOBAL_INTERNER.resolve_with(label, |_| ()).ok_or_else(|| {
             StorageError::CorruptedData(format!(
                 "InternedString ID {} for edge_id={} not found in interner. \
                  This indicates corrupted WAL or missing checkpoint data.",
@@ -856,7 +856,7 @@ impl PersistenceManager {
         tx_time: Timestamp,
     ) -> Result<()> {
         // Validate that the InternedString ID exists in the interner
-        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+        GLOBAL_INTERNER.resolve_with(label, |_| ()).ok_or_else(|| {
             StorageError::CorruptedData(format!(
                 "InternedString ID {} for node_id={} version_id={} not found in interner. \
                  This indicates corrupted WAL or missing checkpoint data.",
@@ -923,7 +923,7 @@ impl PersistenceManager {
         tx_time: Timestamp,
     ) -> Result<()> {
         // Validate that the InternedString ID exists in the interner
-        GLOBAL_INTERNER.resolve(label).ok_or_else(|| {
+        GLOBAL_INTERNER.resolve_with(label, |_| ()).ok_or_else(|| {
             StorageError::CorruptedData(format!(
                 "InternedString ID {} for edge_id={} version_id={} not found in interner. \
                  This indicates corrupted WAL or missing checkpoint data.",

--- a/src/storage/redb_cold_storage.rs
+++ b/src/storage/redb_cold_storage.rs
@@ -1220,7 +1220,9 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
                 .iter()
                 .map(|(k, v)| {
                     (
-                        GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()).unwrap_or_default(),
+                        GLOBAL_INTERNER
+                            .resolve_with(*k, |s| s.to_string())
+                            .unwrap_or_default(),
                         encode_property_value(v),
                     )
                 })
@@ -1233,7 +1235,9 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
                 .iter()
                 .map(|(k, v)| {
                     (
-                        GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()).unwrap_or_default(),
+                        GLOBAL_INTERNER
+                            .resolve_with(*k, |s| s.to_string())
+                            .unwrap_or_default(),
                         encode_property_value(v),
                     )
                 })
@@ -1241,7 +1245,11 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
             removed: delta
                 .removed
                 .iter()
-                .map(|k| GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()).unwrap_or_default())
+                .map(|k| {
+                    GLOBAL_INTERNER
+                        .resolve_with(*k, |s| s.to_string())
+                        .unwrap_or_default()
+                })
                 .collect(),
         },
     }

--- a/src/storage/redb_cold_storage.rs
+++ b/src/storage/redb_cold_storage.rs
@@ -1075,9 +1075,8 @@ pub fn encode_node_version(version: &NodeVersion) -> Vec<u8> {
         temporal_tx_start: version.temporal.transaction_time().start().wallclock(),
         temporal_tx_end: version.temporal.transaction_time().end().wallclock(),
         label: GLOBAL_INTERNER
-            .resolve(version.label)
-            .unwrap_or_default()
-            .to_string(),
+            .resolve_with(version.label, |s| s.to_string())
+            .unwrap_or_default(),
         data: encode_version_data(&version.data),
         next_version: version.next_version.map(|v| v.as_u64()),
         prev_version: version.prev_version.map(|v| v.as_u64()),
@@ -1146,9 +1145,8 @@ pub fn encode_edge_version(version: &EdgeVersion) -> Vec<u8> {
         temporal_tx_start: version.temporal.transaction_time().start().wallclock(),
         temporal_tx_end: version.temporal.transaction_time().end().wallclock(),
         label: GLOBAL_INTERNER
-            .resolve(version.label)
-            .unwrap_or_default()
-            .to_string(),
+            .resolve_with(version.label, |s| s.to_string())
+            .unwrap_or_default(),
         source: version.source.as_u64(),
         target: version.target.as_u64(),
         data: encode_version_data(&version.data),
@@ -1222,7 +1220,7 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
                 .iter()
                 .map(|(k, v)| {
                     (
-                        GLOBAL_INTERNER.resolve(*k).unwrap_or_default().to_string(),
+                        GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()).unwrap_or_default(),
                         encode_property_value(v),
                     )
                 })
@@ -1235,7 +1233,7 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
                 .iter()
                 .map(|(k, v)| {
                     (
-                        GLOBAL_INTERNER.resolve(*k).unwrap_or_default().to_string(),
+                        GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()).unwrap_or_default(),
                         encode_property_value(v),
                     )
                 })
@@ -1243,7 +1241,7 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
             removed: delta
                 .removed
                 .iter()
-                .map(|k| GLOBAL_INTERNER.resolve(*k).unwrap_or_default().to_string())
+                .map(|k| GLOBAL_INTERNER.resolve_with(*k, |s| s.to_string()).unwrap_or_default())
                 .collect(),
         },
     }

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Integration tests for durability modes.
 //!
 //! Tests the three durability modes (Synchronous, Async, GroupCommit)

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+#![allow(deprecated)]
 
 use gallifreydb::PropertyMapBuilder;
 use gallifreydb::core::GLOBAL_INTERNER;


### PR DESCRIPTION
Optimized string interner lookups and vector search filtering to reduce Arc cloning overhead. Introduced `resolve_with` for high-performance callback-based access and updated the storage engine hot path to use zero-copy label lookups.

Fixes #333

---
*PR created automatically by Jules for task [6029853963863341565](https://jules.google.com/task/6029853963863341565) started by @madmax983*