### PR TITLE
Harden FindNeighbors API against DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -124,3 +124,14 @@ Enforced strict capacity limits during deserialization:
 Added `tests/warden_dos_repro.rs` which simulates malicious payloads with excessive counts.
 - Before fix: Code attempted allocation (and failed with "Buffer too short" or potentially OOM).
 - After fix: Code immediately returns `StorageError::CorruptedData` citing the capacity limit, protecting memory resources.
+
+## 2026-02-17 - API DoS Hardening
+
+**Threat:** Unbounded Allocation in FindNeighbors
+The `FindNeighbors` endpoint allocated a `Vec` containing all neighbor nodes before serializing them. For highly connected nodes (supernodes), this could cause OOM crashes or massive latency (DoS). It also lacked pagination support.
+
+**Defense:** Pagination & Zero-Allocation Iterators
+- Enforced strict pagination in `QueryRequest::FindNeighbors` with `limit` (default 100, max 1000) and `offset`.
+- Exposed zero-allocation iterators (`get_outgoing_edges_iter`) in `GallifreyDB` to traverse edges without intermediate allocations.
+- Implemented streaming deduplication and pagination pipeline.
+- Added safety check for deep pagination (`offset + limit <= 10,000`) to prevent CPU DoS.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -3,6 +3,7 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::property::PropertyMap;
 use crate::db::GallifreyDB;
+use crate::storage::current::{IncomingEdgesIter, OutgoingEdgesIter};
 use crate::utils::error::Result;
 
 impl GallifreyDB {
@@ -97,9 +98,23 @@ impl GallifreyDB {
         self.current.get_outgoing_edges(node_id)
     }
 
+    /// Get outgoing edges from a node as an iterator (current state).
+    ///
+    /// This provides zero-allocation traversal.
+    pub fn get_outgoing_edges_iter(&self, node_id: NodeId) -> OutgoingEdgesIter<'_> {
+        self.current.get_outgoing_edges_iter(node_id)
+    }
+
     /// Get incoming edges to a node (current state).
     pub fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
         self.current.get_incoming_edges(node_id)
+    }
+
+    /// Get incoming edges to a node as an iterator (current state).
+    ///
+    /// This provides zero-allocation traversal.
+    pub fn get_incoming_edges_iter(&self, node_id: NodeId) -> IncomingEdgesIter<'_> {
+        self.current.get_incoming_edges_iter(node_id)
     }
 
     /// Get outgoing edges with a specific label (current state).

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -80,6 +80,43 @@ fn test_graph_traversal() {
 }
 
 #[test]
+fn test_iterator_access() {
+    let db = GallifreyDB::new().unwrap();
+
+    let n0 = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n1 = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let e1 = db
+        .create_edge(n0, n1, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+    let e2 = db
+        .create_edge(n0, n2, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Test outgoing iterators
+    let outgoing: Vec<_> = db.get_outgoing_edges_iter(n0).collect();
+    assert_eq!(outgoing.len(), 2);
+    assert!(outgoing.contains(&e1));
+    assert!(outgoing.contains(&e2));
+
+    // Test incoming iterators
+    let incoming1: Vec<_> = db.get_incoming_edges_iter(n1).collect();
+    assert_eq!(incoming1.len(), 1);
+    assert_eq!(incoming1[0], e1);
+
+    let incoming2: Vec<_> = db.get_incoming_edges_iter(n2).collect();
+    assert_eq!(incoming2.len(), 1);
+    assert_eq!(incoming2[0], e2);
+}
+
+#[test]
 fn test_historical_stats() {
     let db = GallifreyDB::new().unwrap();
 

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -239,7 +239,7 @@ pub async fn handle_query(
                     let offset_val = offset.unwrap_or(0);
 
                     // Prevent deep pagination attacks (CPU DoS)
-                    if offset_val.saturating_add(limit_val) > max_deep_pagination {
+                    if offset_val + limit_val > max_deep_pagination {
                         return HttpResponse::BadRequest().json(ApiResponse::error(format!(
                             "Pagination limit exceeded: offset + limit must be <= {}",
                             max_deep_pagination

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -239,7 +239,7 @@ pub async fn handle_query(
                     let offset_val = offset.unwrap_or(0);
 
                     // Prevent deep pagination attacks (CPU DoS)
-                    if offset_val + limit_val > max_deep_pagination {
+                    if offset_val.saturating_add(limit_val) > max_deep_pagination {
                         return HttpResponse::BadRequest().json(ApiResponse::error(format!(
                             "Pagination limit exceeded: offset + limit must be <= {}",
                             max_deep_pagination

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -53,6 +53,10 @@ pub enum QueryRequest {
     },
     FindNeighbors {
         node_id: u64,
+        #[serde(default)]
+        limit: Option<usize>,
+        #[serde(default)]
+        offset: Option<usize>,
     },
 }
 
@@ -220,23 +224,54 @@ pub async fn handle_query(
                 }
             }
         }
-        QueryRequest::FindNeighbors { node_id } => {
+        QueryRequest::FindNeighbors {
+            node_id,
+            limit,
+            offset,
+        } => {
             match NodeId::new(node_id) {
                 Ok(nid) => {
-                    // Issue 2: Deduplication
-                    // Use a HashSet to track seen node IDs
-                    let mut seen_ids = HashSet::new();
-                    let mut neighbors = Vec::new();
+                    // Safety limits to prevent DoS
+                    let max_limit = 1000;
+                    let max_deep_pagination = 10_000;
 
-                    // Outgoing
-                    let outgoing = db.get_outgoing_edges(nid);
-                    for edge_id in outgoing {
-                        if let Ok(node) = db
-                            .get_edge_target(edge_id)
-                            .and_then(|target| db.get_node(target))
-                        {
-                            let id = node.id.as_u64();
-                            if seen_ids.insert(id) {
+                    let limit_val = limit.unwrap_or(100).min(max_limit);
+                    let offset_val = offset.unwrap_or(0);
+
+                    // Prevent deep pagination attacks (CPU DoS)
+                    if offset_val + limit_val > max_deep_pagination {
+                        return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+                            "Pagination limit exceeded: offset + limit must be <= {}",
+                            max_deep_pagination
+                        )));
+                    }
+
+                    // Deduplication
+                    let mut seen_ids = HashSet::new();
+                    let mut neighbors = Vec::with_capacity(limit_val);
+
+                    // Use zero-allocation iterators
+                    // Outgoing: edge -> target node
+                    let outgoing_iter = db.get_outgoing_edges_iter(nid).map(|edge_id| {
+                        db.get_edge_target(edge_id).ok()
+                    });
+
+                    // Incoming: edge -> source node
+                    let incoming_iter = db.get_incoming_edges_iter(nid).map(|edge_id| {
+                        db.get_edge_source(edge_id).ok()
+                    });
+
+                    // Chain iterators -> filter valid -> filter duplicates -> skip -> take
+                    let combined_iter = outgoing_iter
+                        .chain(incoming_iter)
+                        .flatten() // remove None (failed lookups)
+                        .filter(|&neighbor_id| seen_ids.insert(neighbor_id)) // deduplicate
+                        .skip(offset_val)
+                        .take(limit_val);
+
+                    for neighbor_id in combined_iter {
+                        match db.get_node(neighbor_id) {
+                            Ok(node) => {
                                 let props_json = match property_map_to_json(&node.properties) {
                                     Ok(p) => p,
                                     Err(e) => {
@@ -245,35 +280,15 @@ pub async fn handle_query(
                                     }
                                 };
                                 neighbors.push(json!({
-                                    "id": id,
+                                    "id": node.id.as_u64(),
                                     "label": interned_to_string(node.label),
                                     "properties": props_json
                                 }));
                             }
-                        }
-                    }
-
-                    // Incoming
-                    let incoming = db.get_incoming_edges(nid);
-                    for edge_id in incoming {
-                        if let Ok(node) = db
-                            .get_edge_source(edge_id)
-                            .and_then(|source| db.get_node(source))
-                        {
-                            let id = node.id.as_u64();
-                            if seen_ids.insert(id) {
-                                let props_json = match property_map_to_json(&node.properties) {
-                                    Ok(p) => p,
-                                    Err(e) => {
-                                        return HttpResponse::InternalServerError()
-                                            .json(ApiResponse::error(e));
-                                    }
-                                };
-                                neighbors.push(json!({
-                                    "id": id,
-                                    "label": interned_to_string(node.label),
-                                    "properties": props_json
-                                }));
+                            Err(e) => {
+                                // Node ID found in edge but not in node index? Should be impossible unless corrupted
+                                return HttpResponse::InternalServerError()
+                                    .json(ApiResponse::error(e.to_string()));
                             }
                         }
                     }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -252,14 +252,14 @@ pub async fn handle_query(
 
                     // Use zero-allocation iterators
                     // Outgoing: edge -> target node
-                    let outgoing_iter = db.get_outgoing_edges_iter(nid).map(|edge_id| {
-                        db.get_edge_target(edge_id).ok()
-                    });
+                    let outgoing_iter = db
+                        .get_outgoing_edges_iter(nid)
+                        .map(|edge_id| db.get_edge_target(edge_id).ok());
 
                     // Incoming: edge -> source node
-                    let incoming_iter = db.get_incoming_edges_iter(nid).map(|edge_id| {
-                        db.get_edge_source(edge_id).ok()
-                    });
+                    let incoming_iter = db
+                        .get_incoming_edges_iter(nid)
+                        .map(|edge_id| db.get_edge_source(edge_id).ok());
 
                     // Chain iterators -> filter valid -> filter duplicates -> skip -> take
                     let combined_iter = outgoing_iter


### PR DESCRIPTION
Hardened the `FindNeighbors` API endpoint against Denial of Service (DoS) attacks caused by unbounded memory allocation when querying supernodes.

Changes:
- **API Hardening:** Updated `QueryRequest::FindNeighbors` to support `limit` (default 100, max 1000) and `offset` parameters. Added `#[serde(default)]` to ensure backward compatibility.
- **Zero-Allocation Traversal:** Exposed `get_outgoing_edges_iter` and `get_incoming_edges_iter` in `GallifreyDB` to allow iterating over edges without allocating intermediate vectors.
- **Pagination Logic:** Implemented efficient streaming pagination with deduplication in `handle_query`, enforcing strict safety limits (max 10,000 items scanned).
- **Security Journal:** Updated `.jules/warden.md` with the new finding.

This fix prevents potential OOM crashes and CPU exhaustion when querying nodes with millions of connections.

---
*PR created automatically by Jules for task [11410143193185494599](https://jules.google.com/task/11410143193185494599) started by @madmax983*