### PR TITLE
🔒 Warden: Prevent memory exhaustion DoS in deserialization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -135,3 +135,17 @@ The `FindNeighbors` endpoint allocated a `Vec` containing all neighbor nodes bef
 - Exposed zero-allocation iterators (`get_outgoing_edges_iter`) in `GallifreyDB` to traverse edges without intermediate allocations.
 - Implemented streaming deduplication and pagination pipeline.
 - Added safety check for deep pagination (`offset + limit <= 10,000`) to prevent CPU DoS.
+
+## 2026-02-18 - Allocation Amplification DoS Hardening
+
+**Threat:** Allocation Amplification (DoS)
+`deserialize_recursive` (for Arrays) and `PropertyMap::deserialize` in `src/core/property.rs` were vulnerable to allocation amplification. They allocated memory based on a `count` field read from the input before verifying that sufficient data existed in the buffer. An attacker could send a tiny payload (e.g., 5 bytes) claiming to have 1,000,000 elements, causing the server to allocate ~16MB. With concurrent requests, this leads to rapid memory exhaustion.
+
+**Defense:** Pre-allocation Validation
+Implemented strict validation logic that checks the remaining buffer size against the minimum possible size for the requested number of elements:
+- Arrays: `remaining_bytes >= count` (min 1 byte/element).
+- Maps: `remaining_bytes >= count * 5` (min 5 bytes/entry).
+This ensures memory is only allocated if the client has actually sent a proportional amount of data.
+
+**Verification:** Reproduction Test
+Added `tests/repro_allocation_dos.rs` simulating malicious payloads. Confirmed that the new logic returns `StorageError::CorruptedData` ("Insufficient buffer size") *before* attempting allocation.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -667,6 +667,18 @@ impl PropertyValue {
                     .into());
                 }
 
+                // Prevent DoS via pre-allocation amplification:
+                // Ensure we have at least 1 byte per element in the buffer
+                // before allocating the vector.
+                if bytes.len().saturating_sub(offset) < count {
+                    return Err(StorageError::CorruptedData(format!(
+                        "Insufficient buffer size for Array elements: need {} bytes, have {}",
+                        count,
+                        bytes.len().saturating_sub(offset)
+                    ))
+                    .into());
+                }
+
                 let mut items = Vec::with_capacity(count);
                 for _ in 0..count {
                     if offset >= bytes.len() {
@@ -1588,6 +1600,21 @@ impl PropertyMap {
         }
 
         let mut offset = 4;
+
+        // Prevent DoS via pre-allocation amplification:
+        // Ensure we have at least 5 bytes per entry (minimum size)
+        // Key length (4) + Key data (0) + Value tag (1) = 5 bytes
+        // Use checked arithmetic to prevent overflow in count * 5
+        let min_required_bytes = count.saturating_mul(5);
+        if bytes.len().saturating_sub(offset) < min_required_bytes {
+            return Err(StorageError::CorruptedData(format!(
+                "Insufficient buffer size for PropertyMap entries: need {} bytes, have {}",
+                min_required_bytes,
+                bytes.len().saturating_sub(offset)
+            ))
+            .into());
+        }
+
         let mut map = HashMap::with_capacity(count);
         // Track the actual logical size of the map to validate against consumed bytes
         let mut calculated_size: usize = 4;

--- a/tests/repro_allocation_dos.rs
+++ b/tests/repro_allocation_dos.rs
@@ -1,0 +1,57 @@
+use gallifreydb::core::property::{PropertyMap, PropertyValue, TAG_ARRAY};
+use gallifreydb::utils::error::StorageError;
+
+#[test]
+fn test_array_preallocation_dos_protection() {
+    // Scenario: Attacker sends a payload claiming 1,000,000 elements.
+    // 1,000,000 is allowed by MAX_ARRAY_ELEMENTS (which is 1,000,000).
+    // But the payload is only 5 bytes long (Tag + Count).
+
+    let count: u32 = 1_000_000;
+    let mut payload = Vec::new();
+    payload.push(TAG_ARRAY);
+    payload.extend_from_slice(&count.to_le_bytes());
+
+    // We expect an error.
+    let result = PropertyValue::deserialize(&payload);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+
+    println!("Array Error received: {:?}", err);
+
+    if let gallifreydb::utils::error::Error::Storage(StorageError::CorruptedData(msg)) = err {
+        // Verify we hit the NEW protection check (before allocation)
+        assert!(msg.contains("Insufficient buffer size for Array elements"));
+    } else {
+        panic!("Expected StorageError::CorruptedData, got {:?}", err);
+    }
+}
+
+#[test]
+fn test_propertymap_preallocation_dos_protection() {
+    // Scenario: Attacker sends a PropertyMap payload claiming 10,000 entries.
+    // 10,000 is allowed by MAX_PROPERTY_MAP_CAPACITY.
+    // Each entry is minimum 5 bytes. 10,000 * 5 = 50,000 bytes.
+    // Payload is only 4 bytes (Count).
+
+    let count: u32 = 10_000;
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&count.to_le_bytes());
+
+    let result = PropertyMap::deserialize(&payload);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+
+    println!("Map Error received: {:?}", err);
+
+    if let gallifreydb::utils::error::Error::Storage(StorageError::CorruptedData(msg)) = err {
+        // Verify we hit the NEW protection check
+        // "Insufficient buffer size for PropertyMap entries: need 50000 bytes, have 0"
+        assert!(msg.contains("Insufficient buffer size for PropertyMap entries"));
+        assert!(msg.contains("need 50000 bytes"));
+    } else {
+        panic!("Expected StorageError::CorruptedData, got {:?}", err);
+    }
+}


### PR DESCRIPTION
**Threat:** Allocation Amplification (DoS)
`deserialize_recursive` (for Arrays) and `PropertyMap::deserialize` allocated memory based on a `count` field before verifying sufficient data existed in the buffer.

**Defense:** Pre-allocation Validation
Implemented validation logic:
- Arrays: `remaining_bytes >= count`
- Maps: `remaining_bytes >= count * 5`

**Verification:**
Added `tests/repro_allocation_dos.rs` which confirms the fix.

---
*PR created automatically by Jules for task [13298374026532354826](https://jules.google.com/task/13298374026532354826) started by @madmax983*