### PR TITLE
🔒 Warden: DoS hardening for FindNode endpoint

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -149,3 +149,22 @@ This ensures memory is only allocated if the client has actually sent a proporti
 
 **Verification:** Reproduction Test
 Added `tests/repro_allocation_dos.rs` simulating malicious payloads. Confirmed that the new logic returns `StorageError::CorruptedData` ("Insufficient buffer size") *before* attempting allocation.
+
+## 2026-02-19 - FindNode DoS Hardening
+
+**Threat:** Unbounded Result Set & Deep Pagination (DoS)
+The `FindNode` endpoint allowed users to request an unlimited number of nodes (`limit: usize::MAX`) or perform deep pagination (`offset: 1_000_000`).
+- Unbounded limit leads to memory exhaustion (OOM) as the server attempts to fetch and serialize all nodes.
+- Deep pagination leads to high CPU usage as the server iterates through skipped records.
+- **Integer Overflow:** Malicious `offset + limit` could wrap around, bypassing simple checks.
+
+**Defense:** Pagination Limits & Helper
+- Enforced `MAX_LIMIT = 1000` for `FindNode` and `FindNeighbors`.
+- Enforced `MAX_DEEP_PAGINATION = 10_000`.
+- Implemented `validate_pagination` helper using `saturating_add` to safely check total items and prevent overflow bypass.
+
+**Verification:** Regression Test
+Added `tests/warden_query_dos.rs` which verifies:
+- `limit` is capped at 1000.
+- `offset + limit > 10,000` returns HTTP 400.
+- `offset = usize::MAX` is correctly rejected (no overflow).

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -35,6 +35,12 @@ pub fn configure_health_routes(cfg: &mut web::ServiceConfig) {
 // Query Endpoint
 // ============================================================================
 
+/// Maximum number of results to return in a single query page to prevent memory exhaustion.
+const MAX_LIMIT: usize = 1000;
+
+/// Maximum "deep pagination" (offset + limit) to prevent CPU DoS.
+const MAX_DEEP_PAGINATION: usize = 10_000;
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum QueryRequest {
@@ -102,6 +108,25 @@ fn json_to_predicate_value(v: &serde_json::Value) -> Option<PredicateValue> {
         serde_json::Value::String(s) => Some(PredicateValue::String(s.clone())),
         _ => None, // Arrays/Objects not supported for simple equality predicates yet
     }
+}
+
+/// Validate pagination parameters to prevent DoS and integer overflow.
+fn validate_pagination(
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<(usize, usize), HttpResponse> {
+    let offset_val = offset.unwrap_or(0);
+    let limit_val = limit.unwrap_or(100).min(MAX_LIMIT);
+
+    // Prevent deep pagination attacks (CPU DoS) and integer overflow bypass
+    if offset_val.saturating_add(limit_val) > MAX_DEEP_PAGINATION {
+        return Err(HttpResponse::BadRequest().json(ApiResponse::error(format!(
+            "Pagination limit exceeded: offset + limit must be <= {}",
+            MAX_DEEP_PAGINATION
+        ))));
+    }
+
+    Ok((offset_val, limit_val))
 }
 
 /// Query endpoint handler.
@@ -193,11 +218,15 @@ pub async fn handle_query(
             }
 
             // Issue 4: Pagination
-            if let Some(skip) = offset {
-                builder = builder.skip(skip);
+            let (offset_val, limit_val) = match validate_pagination(offset, limit) {
+                Ok(vals) => vals,
+                Err(resp) => return resp,
+            };
+
+            if offset_val > 0 {
+                builder = builder.skip(offset_val);
             }
 
-            let limit_val = limit.unwrap_or(100);
             match builder.limit(limit_val).execute(db) {
                 Ok(results) => {
                     let mut nodes = Vec::new();
@@ -231,20 +260,10 @@ pub async fn handle_query(
         } => {
             match NodeId::new(node_id) {
                 Ok(nid) => {
-                    // Safety limits to prevent DoS
-                    let max_limit = 1000;
-                    let max_deep_pagination = 10_000;
-
-                    let limit_val = limit.unwrap_or(100).min(max_limit);
-                    let offset_val = offset.unwrap_or(0);
-
-                    // Prevent deep pagination attacks (CPU DoS)
-                    if offset_val + limit_val > max_deep_pagination {
-                        return HttpResponse::BadRequest().json(ApiResponse::error(format!(
-                            "Pagination limit exceeded: offset + limit must be <= {}",
-                            max_deep_pagination
-                        )));
-                    }
+                    let (offset_val, limit_val) = match validate_pagination(offset, limit) {
+                        Ok(vals) => vals,
+                        Err(resp) => return resp,
+                    };
 
                     // Deduplication
                     let mut seen_ids = HashSet::new();

--- a/tests/warden_query_dos.rs
+++ b/tests/warden_query_dos.rs
@@ -1,0 +1,86 @@
+#[cfg(feature = "http-server")]
+mod tests {
+    use gallifreydb::GallifreyDB;
+    use gallifreydb::http::{AppState, configure_app};
+    use actix_web::{test, web, App};
+    use std::sync::Arc;
+    use serde_json::{json, Value};
+
+    #[actix_rt::test]
+    async fn test_find_node_dos_protection() {
+        let db = Arc::new(GallifreyDB::new().unwrap());
+        let state = AppState::new(db.clone());
+
+        // Insert 1005 nodes
+        for _ in 0..1005 {
+            let props = gallifreydb::core::PropertyMap::new();
+            // Add a property to ensure uniqueness if needed, but not required for simple count check
+            let _ = db.create_node("TestNode", props).unwrap();
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .configure(configure_app)
+        ).await;
+
+        // Test 1: Huge limit DoS
+        // Request limit 2000. Should be capped at 1000.
+        let req_payload = json!({
+            "operation": "find_node",
+            "label": "TestNode",
+            "limit": 2000
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&req_payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+
+        let body: Value = test::read_body_json(resp).await;
+        let data = body.get("data").unwrap().as_array().unwrap();
+
+        assert_eq!(data.len(), 1000, "Limit should be capped at 1000, got {}", data.len());
+
+        // Test 2: Deep pagination DoS
+        // Request offset 9500 + limit 1000 = 10500 > 10000 (max_deep_pagination)
+        let req_payload = json!({
+            "operation": "find_node",
+            "label": "TestNode",
+            "limit": 1000,
+            "offset": 9500
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&req_payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400, "Should reject deep pagination, got {}", resp.status().as_u16());
+
+        // Test 3: Integer Overflow DoS
+        // Request offset usize::MAX.
+        // With saturating_add, usize::MAX + limit > MAX_DEEP_PAGINATION.
+        // With wrapping add, (usize::MAX + 100) might be small.
+        let req_payload = json!({
+            "operation": "find_node",
+            "label": "TestNode",
+            "limit": 100,
+            "offset": usize::MAX
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&req_payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400, "Should reject overflow pagination, got {}", resp.status().as_u16());
+    }
+}


### PR DESCRIPTION
Hardened the `FindNode` and `FindNeighbors` HTTP endpoints against Denial of Service (DoS) attacks.
        - Enforced a maximum result limit of 1000 to prevent OOM.
        - Enforced a maximum deep pagination limit (offset + limit) of 10,000 to prevent CPU exhaustion.
        - Implemented a `validate_pagination` helper function using `saturating_add` to securely calculate totals and prevent integer overflow bypasses.
        - Added comprehensive regression tests to verify limits and overflow protection.

---
*PR created automatically by Jules for task [10824487382012616255](https://jules.google.com/task/10824487382012616255) started by @madmax983*