### PR TITLE
🗺️ Atlas: Decouple QueryBuilder from GallifreyDB

### DIFF
--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -2,9 +2,15 @@ use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;
 use crate::db::GallifreyDB;
 use crate::query::builder::state::Initial;
-use crate::query::{Query, QueryBuilder, QueryExecutor, QueryPlanner, QueryResults};
+use crate::query::{Query, QueryBuilder, QueryExecutor, QueryPlanner, QueryResults, QueryRunner};
 use crate::utils::error::Result;
 use std::sync::Arc;
+
+impl QueryRunner for GallifreyDB {
+    fn execute_query(&self, query: Query) -> Result<QueryResults> {
+        self.execute_query(query)
+    }
+}
 
 impl GallifreyDB {
     /// Create a new query builder for constructing hybrid queries.

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -57,9 +57,9 @@ use crate::core::NodeId;
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::index::vector::DistanceMetric;
 
+use super::QueryRunner;
 use super::ir::{Predicate, QueryOp, TraversalDepth};
 use super::plan::{IndexHint, QueryHints, TemporalContext};
-use super::QueryRunner;
 
 /// A fully constructed query ready for execution.
 #[derive(Debug, Clone)]

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -59,6 +59,7 @@ use crate::index::vector::DistanceMetric;
 
 use super::ir::{Predicate, QueryOp, TraversalDepth};
 use super::plan::{IndexHint, QueryHints, TemporalContext};
+use super::QueryRunner;
 
 /// A fully constructed query ready for execution.
 #[derive(Debug, Clone)]
@@ -737,7 +738,7 @@ impl<S: QueryState> QueryBuilder<S> {
     ///
     /// # Arguments
     ///
-    /// * `db` - Reference to the database to execute against
+    /// * `runner` - Reference to the database (or other query runner) to execute against
     ///
     /// # Returns
     ///
@@ -775,10 +776,10 @@ impl<S: QueryState> QueryBuilder<S> {
     /// ```
     pub fn execute(
         self,
-        db: &crate::GallifreyDB,
+        runner: &impl QueryRunner,
     ) -> crate::utils::error::Result<super::executor::QueryResults> {
         let query = self.build();
-        db.execute_query(query)
+        runner.execute_query(query)
     }
     /// Build the final query
     #[must_use]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -102,7 +102,6 @@ pub mod semantic_pathfinding;
 
 // Re-export commonly used types
 pub use ast::QueryAst;
-pub use runner::QueryRunner;
 pub use builder::{Query, QueryBuilder};
 pub use converter::{AstConverter, ParameterValue, parse_query, parse_query_with_params};
 pub use executor::{QueryExecutor, QueryResults, QueryRow};
@@ -113,4 +112,5 @@ pub use parser::{ParseError, Parser};
 pub use plan::{LogicalOp, LogicalPlan};
 pub use planner::{PhysicalPlan, QueryPlanner};
 pub use result::{EntityHistory, VersionDiff, VersionInfo, VersionSummary};
+pub use runner::QueryRunner;
 pub use semantic_pathfinding::SemanticPathfinder;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -97,10 +97,12 @@ pub mod parser;
 pub mod plan;
 pub mod planner;
 pub mod result;
+pub mod runner;
 pub mod semantic_pathfinding;
 
 // Re-export commonly used types
 pub use ast::QueryAst;
+pub use runner::QueryRunner;
 pub use builder::{Query, QueryBuilder};
 pub use converter::{AstConverter, ParameterValue, parse_query, parse_query_with_params};
 pub use executor::{QueryExecutor, QueryResults, QueryRow};

--- a/src/query/runner.rs
+++ b/src/query/runner.rs
@@ -1,0 +1,16 @@
+//! Query Runner Trait
+//!
+//! Defines the interface for executing queries, decoupling the query builder
+//! from the specific database implementation.
+
+use super::{Query, QueryResults};
+use crate::utils::error::Result;
+
+/// Trait for executing queries.
+///
+/// This trait allows the `QueryBuilder` to execute queries without
+/// depending directly on `GallifreyDB`.
+pub trait QueryRunner {
+    /// Execute a compiled query and return results.
+    fn execute_query(&self, query: Query) -> Result<QueryResults>;
+}

--- a/src/query/runner.rs
+++ b/src/query/runner.rs
@@ -5,6 +5,7 @@
 
 use super::{Query, QueryResults};
 use crate::utils::error::Result;
+use std::sync::Arc;
 
 /// Trait for executing queries.
 ///
@@ -13,4 +14,11 @@ use crate::utils::error::Result;
 pub trait QueryRunner {
     /// Execute a compiled query and return results.
     fn execute_query(&self, query: Query) -> Result<QueryResults>;
+}
+
+/// Implement QueryRunner for Arc<T> to allow passing Arc<GallifreyDB> directly.
+impl<T: QueryRunner + ?Sized> QueryRunner for Arc<T> {
+    fn execute_query(&self, query: Query) -> Result<QueryResults> {
+        (**self).execute_query(query)
+    }
 }


### PR DESCRIPTION
This PR addresses a structural smell (circular dependency) between the `query` and `db` modules.
Previously, `QueryBuilder` in `query` depended on `GallifreyDB` in `db` for its `execute` method, while `db` depended on `query` for `QueryBuilder`.

Changes:
1.  **New Trait**: Introduced `QueryRunner` trait in `src/query/runner.rs`.
2.  **Dependency Inversion**: `QueryBuilder::execute` now accepts `&impl QueryRunner` instead of a concrete `&GallifreyDB`.
3.  **Implementation**: `GallifreyDB` implements `QueryRunner`, ensuring backward compatibility for `query.execute(&db)`.

This aligns with Atlas's philosophy of high cohesion and low coupling, moving towards a DAG structure.

---
*PR created automatically by Jules for task [7531345305433729631](https://jules.google.com/task/7531345305433729631) started by @madmax983*