### PR TITLE
🎨 Mosaic: [UI Polish] Colorize boolean true in CLI output

### DIFF
--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -20,7 +20,7 @@ use super::planner::physical::{PhysicalOp, PhysicalPlan};
 pub use iterators::NodeScanIterator;
 pub use iterators::ResultIterator;
 pub use iterators::TemporalNodeScanIterator;
-pub use results::{EntityId, EntityResult, QueryResults, QueryRow};
+pub use results::{EntityId, EntityResult, QueryResult, QueryResults, QueryRow};
 
 /// Configuration for query execution.
 #[derive(Debug, Clone)]

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -1436,3 +1436,32 @@ mod tests {
         assert_eq!(versions[2], VersionId::new(0).unwrap());
     }
 }
+    #[test]
+    fn test_query_result_display_colorized_boolean() {
+        use crossterm::style::Stylize;
+        use crate::core::property::PropertyMapBuilder;
+
+        // Create a property map with boolean values
+        let props = PropertyMapBuilder::new()
+            .insert("active", true)
+            .insert("deleted", false)
+            .build();
+
+        let nodes = vec![NodeId::new(1).unwrap()];
+        let result = QueryResult::with_nodes(nodes).with_properties(vec![props]);
+
+        let display = format!("{}", result);
+
+        // "true" should be green (ANSI escape code: \u{1b}[38;5;10m)
+        let expected_green_true = "true".green().to_string();
+        assert!(display.contains(&expected_green_true), "Display should contain green 'true'");
+
+        // "false" should be plain (no ANSI escape codes for it directly)
+        // Note: We check for "false" and verify it's NOT green if we want,
+        // but just checking it exists is enough for the `_` match arm coverage.
+        assert!(display.contains("false"), "Display should contain 'false'");
+
+        // Ensure "false" is not colorized green (just to be sure)
+        let green_false = "false".green().to_string();
+        assert!(!display.contains(&green_false), "Display should NOT contain green 'false'");
+}

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -408,6 +408,7 @@ impl Default for QueryResult {
 }
 
 impl std::fmt::Display for QueryResult {
+    #[inline(never)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.nodes.is_empty() {
             return write!(f, "QueryResult {{ 0 items }}");

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -8,6 +8,7 @@ use crate::core::property::PropertyMap;
 use crate::core::temporal::Timestamp;
 use crate::core::{EdgeId, NodeId};
 use crate::utils::error::Result;
+use crossterm::style::Stylize;
 
 use super::iterators::ResultIterator;
 
@@ -466,7 +467,12 @@ impl std::fmt::Display for QueryResult {
                             let k_str = crate::core::interning::GLOBAL_INTERNER
                                 .resolve_with(*k, |s| s.to_string())
                                 .unwrap_or_else(|| format!("key:{}", k.as_u32()));
-                            format!("{}: {}", k_str, v)
+
+                            let val_str = match v {
+                                crate::core::PropertyValue::Bool(true) => "true".green().to_string(),
+                                _ => format!("{}", v),
+                            };
+                            format!("{}: {}", k_str, val_str)
                         })
                         .collect();
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -103,7 +103,7 @@ pub mod semantic_pathfinding;
 pub use ast::QueryAst;
 pub use builder::{Query, QueryBuilder};
 pub use converter::{AstConverter, ParameterValue, parse_query, parse_query_with_params};
-pub use executor::{QueryExecutor, QueryResults, QueryRow};
+pub use executor::{QueryExecutor, QueryResult, QueryResults, QueryRow};
 pub use hybrid::traverse_and_rank;
 pub use ir::{Direction, Predicate, QueryOp, SortKey, TraversalDepth};
 pub use lexer::{Lexer, LexerError, Token};


### PR DESCRIPTION
* 🖌️ **Before:** Boolean values in `QueryResult` output were plain text (e.g., `true`, `false`).
* ✨ **After:** Boolean `true` values are now colorized green using `crossterm::style::Stylize` within the `comfy-table` rendering.
* 🛠️ **Fix:** Exported `QueryResult` struct in `src/query/mod.rs` and `src/query/executor/mod.rs` to allow external usage and testing.

---
*PR created automatically by Jules for task [16657695643186910586](https://jules.google.com/task/16657695643186910586) started by @madmax983*