### PR TITLE
🔒 Warden: Fix Panic DoS in Vector Insertion

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -149,3 +149,14 @@ This ensures memory is only allocated if the client has actually sent a proporti
 
 **Verification:** Reproduction Test
 Added `tests/repro_allocation_dos.rs` simulating malicious payloads. Confirmed that the new logic returns `StorageError::CorruptedData` ("Insufficient buffer size") *before* attempting allocation.
+
+## 2026-02-18 - Property DoS Hardening
+
+**Threat:** Panic DoS in Vector Insertion
+`PropertyMapBuilder::try_insert_vector` and `PropertyValue::vector` panicked when vector dimensions exceeded `MAX_VECTOR_DIMENSIONS`. Since `try_insert_vector` is often exposed to user input (e.g. via API), an attacker could crash the server by sending an oversized vector.
+
+**Defense:** Fallible Constructors
+Refactored vector creation to use `PropertyValue::try_vector` which returns `Result` instead of panicking. Updated `try_insert_vector` to propagate this error. Also implemented `try_serialize_vector_into` to prevent panics during serialization of manually constructed oversized vectors.
+
+**Verification:** Regression Test
+Added `tests/security_dos_property.rs` which attempts to insert an oversized vector using `try_insert_vector`. Verified that it now returns `Err` instead of panicking.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -179,17 +179,29 @@ impl PropertyValue {
     ///
     /// Panics if the vector dimension exceeds [`MAX_VECTOR_DIMENSIONS`].
     /// This validation ensures that vectors can be serialized without error.
+    ///
+    /// For a fallible version that returns `Result` instead of panicking,
+    /// use [`try_vector`](Self::try_vector).
     #[inline]
     pub fn vector<V: AsRef<[f32]>>(v: V) -> Self {
+        Self::try_vector(v).unwrap_or_else(|e| panic!("{}", e))
+    }
+
+    /// Create a vector property value from a slice (fallible).
+    ///
+    /// Returns `Err` if the vector dimension exceeds [`MAX_VECTOR_DIMENSIONS`].
+    #[inline]
+    pub fn try_vector<V: AsRef<[f32]>>(v: V) -> Result<Self> {
         let slice = v.as_ref();
         if slice.len() > MAX_VECTOR_DIMENSIONS {
-            panic!(
+            return Err(StorageError::CorruptedData(format!(
                 "Vector dimension {} exceeds maximum allowed {}",
                 slice.len(),
                 MAX_VECTOR_DIMENSIONS
-            );
+            ))
+            .into());
         }
-        PropertyValue::Vector(Arc::from(slice))
+        Ok(PropertyValue::Vector(Arc::from(slice)))
     }
 
     /// Returns true if this value is null.
@@ -515,10 +527,7 @@ impl PropertyValue {
                 }
                 Ok(())
             }
-            PropertyValue::Vector(v) => {
-                serialize_vector_into(v, buffer);
-                Ok(())
-            }
+            PropertyValue::Vector(v) => try_serialize_vector_into(v, buffer),
             PropertyValue::SparseVector(sv) => {
                 serialize_sparse_vector_into(sv, buffer);
                 Ok(())
@@ -883,14 +892,25 @@ pub fn serialize_vector(v: &[f32]) -> Vec<u8> {
 /// Panics if the vector dimension exceeds `MAX_VECTOR_DIMENSIONS`.
 /// This is a defensive check; vectors should be validated at construction
 /// time via [`PropertyValue::vector()`] which enforces this limit.
+///
+/// For a fallible version that returns `Result` instead of panicking,
+/// use [`try_serialize_vector_into`].
 pub fn serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) {
+    try_serialize_vector_into(v, buffer).unwrap_or_else(|e| panic!("{}", e))
+}
+
+/// Serialize a vector into an existing buffer (fallible).
+///
+/// Returns `Err` if the vector dimension exceeds `MAX_VECTOR_DIMENSIONS`.
+pub fn try_serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) -> Result<()> {
     // Defensive check: vectors should be validated at construction via PropertyValue::vector()
     if v.len() > MAX_VECTOR_DIMENSIONS {
-        panic!(
+        return Err(StorageError::CorruptedData(format!(
             "Vector dimension {} exceeds maximum allowed {}",
             v.len(),
             MAX_VECTOR_DIMENSIONS
-        );
+        ))
+        .into());
     }
 
     // Pre-allocate space to avoid multiple reallocations
@@ -929,6 +949,7 @@ pub fn serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) {
             buffer.extend_from_slice(&value.to_le_bytes());
         }
     }
+    Ok(())
 }
 
 /// Deserialize a vector from bytes.
@@ -1900,7 +1921,8 @@ impl PropertyMapBuilder {
 
     /// Insert a vector property (fallible).
     pub fn try_insert_vector(self, key: &str, vector: &[f32]) -> Result<Self> {
-        self.try_insert(key, PropertyValue::vector(vector))
+        let val = PropertyValue::try_vector(vector)?;
+        self.try_insert(key, val)
     }
 
     /// Remove a property.
@@ -3870,12 +3892,11 @@ mod sentry_tests {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "Vector dimension")]
-    fn test_try_insert_vector_panics_on_overflow() {
-        // 💣 Risk: try_insert_vector implies fallibility but panics on large inputs.
-        // This test documents this behavior to prevent regression or unexpected changes.
+    fn test_try_insert_vector_returns_error_on_overflow() {
+        // 🔒 Warden Fix: try_insert_vector now returns Result instead of panicking.
         let large_vector = vec![0.0; MAX_VECTOR_DIMENSIONS + 1];
-        let _ = PropertyMapBuilder::new().try_insert_vector("test", &large_vector);
+        let result = PropertyMapBuilder::new().try_insert_vector("test", &large_vector);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/tests/security_dos_property.rs
+++ b/tests/security_dos_property.rs
@@ -1,0 +1,37 @@
+use gallifreydb::core::property::{PropertyMapBuilder, MAX_VECTOR_DIMENSIONS, PropertyValue};
+use std::sync::Arc;
+
+#[test]
+fn test_try_insert_vector_returns_error() {
+    // This test verifies that try_insert_vector returns an error on overflow,
+    // rather than panicking.
+
+    let large_vector = vec![0.0; MAX_VECTOR_DIMENSIONS + 1];
+
+    let result = PropertyMapBuilder::new()
+        .try_insert_vector("test", &large_vector);
+
+    assert!(result.is_err(), "Expected try_insert_vector to return error");
+}
+
+#[test]
+fn test_serialize_returns_error_on_oversized_vector() {
+    // Manually construct an oversized PropertyValue::Vector
+    // This bypasses the PropertyValue::vector() checks but mimics a scenario
+    // where a user might construct the enum variant directly (it's public).
+
+    let large_vector = vec![0.0; MAX_VECTOR_DIMENSIONS + 1];
+    let val = PropertyValue::Vector(Arc::from(large_vector.into_boxed_slice()));
+
+    // Attempt to serialize
+    // Before fix: This would panic inside serialize_vector_into
+    // After fix: This should return Err
+    let result = val.serialize();
+
+    assert!(result.is_err(), "Expected serialize to return error for oversized vector");
+
+    // Verify error message
+    let err = result.unwrap_err();
+    let msg = format!("{}", err);
+    assert!(msg.contains("exceeds maximum allowed"), "Unexpected error message: {}", msg);
+}


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability where oversized vectors caused panics in `PropertyMapBuilder::try_insert_vector` and `PropertyValue::vector`.

**Changes:**
- Introduced `PropertyValue::try_vector` which returns `Result` instead of panicking.
- Updated `PropertyMapBuilder::try_insert_vector` to use the fallible constructor.
- Introduced `try_serialize_vector_into` to prevent panics during serialization.
- Updated `serialize_recursive` to use the fallible serialization.
- Preserved existing panicking behavior for `serialize_vector_into` and `vector` (via unwrap) for backward compatibility, but internal usage now prefers fallible paths.

**Verification:**
- Added `tests/security_dos_property.rs` to verify that oversized vectors now return `Err` instead of crashing.
- Updated unit tests in `src/core/property.rs`.

---
*PR created automatically by Jules for task [13015753807816615378](https://jules.google.com/task/13015753807816615378) started by @madmax983*