### PR TITLE
feat(dx): Make Node and Property Debug output human-readable

### DIFF
--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -428,4 +428,74 @@ mod tests {
             "Interner should not contain 'NeverInternedEdge' after has_label_str call"
         );
     }
+
+    #[test]
+    fn test_node_debug() {
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        let node = Node::new(
+            NodeId::new(1).unwrap(),
+            label,
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        let debug_str = format!("{:?}", node);
+        assert!(debug_str.contains("Person"), "Debug output should contain resolved label");
+        assert!(debug_str.contains("Alice"), "Debug output should contain property value");
+    }
+
+    #[test]
+    fn test_node_debug_fallback() {
+        // Create a Node with a raw InternedString that doesn't exist in the interner
+        // InternedString(u32::MAX) is extremely unlikely to exist
+        let raw_label = InternedString::from_raw(u32::MAX);
+        let node = Node::new(
+            NodeId::new(99).unwrap(),
+            raw_label,
+            PropertyMapBuilder::new().build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        let debug_str = format!("{:?}", node);
+        // Should fallback to InternedString(4294967295)
+        assert!(debug_str.contains("InternedString(4294967295)"), "Debug output should fallback to raw ID for unknown label");
+    }
+
+    #[test]
+    fn test_edge_debug() {
+        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+        let edge = Edge::new(
+            EdgeId::new(10).unwrap(),
+            label,
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
+            PropertyMapBuilder::new()
+                .insert("since", 2024)
+                .build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        let debug_str = format!("{:?}", edge);
+        assert!(debug_str.contains("KNOWS"), "Debug output should contain resolved label");
+        assert!(debug_str.contains("2024"), "Debug output should contain property value");
+    }
+
+    #[test]
+    fn test_edge_debug_fallback() {
+        // Create an Edge with a raw InternedString that doesn't exist
+        let raw_label = InternedString::from_raw(u32::MAX - 1);
+        let edge = Edge::new(
+            EdgeId::new(10).unwrap(),
+            raw_label,
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
+            PropertyMapBuilder::new().build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        let debug_str = format!("{:?}", edge);
+        assert!(debug_str.contains("InternedString(4294967294)"), "Debug output should fallback to raw ID for unknown label");
+    }
 }

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -435,15 +435,19 @@ mod tests {
         let node = Node::new(
             NodeId::new(1).unwrap(),
             label,
-            PropertyMapBuilder::new()
-                .insert("name", "Alice")
-                .build(),
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
             VersionId::new(1).unwrap(),
         );
 
         let debug_str = format!("{:?}", node);
-        assert!(debug_str.contains("Person"), "Debug output should contain resolved label");
-        assert!(debug_str.contains("Alice"), "Debug output should contain property value");
+        assert!(
+            debug_str.contains("Person"),
+            "Debug output should contain resolved label"
+        );
+        assert!(
+            debug_str.contains("Alice"),
+            "Debug output should contain property value"
+        );
     }
 
     #[test]
@@ -460,7 +464,10 @@ mod tests {
 
         let debug_str = format!("{:?}", node);
         // Should fallback to InternedString(4294967295)
-        assert!(debug_str.contains("InternedString(4294967295)"), "Debug output should fallback to raw ID for unknown label");
+        assert!(
+            debug_str.contains("InternedString(4294967295)"),
+            "Debug output should fallback to raw ID for unknown label"
+        );
     }
 
     #[test]
@@ -471,15 +478,19 @@ mod tests {
             label,
             NodeId::new(1).unwrap(),
             NodeId::new(2).unwrap(),
-            PropertyMapBuilder::new()
-                .insert("since", 2024)
-                .build(),
+            PropertyMapBuilder::new().insert("since", 2024).build(),
             VersionId::new(1).unwrap(),
         );
 
         let debug_str = format!("{:?}", edge);
-        assert!(debug_str.contains("KNOWS"), "Debug output should contain resolved label");
-        assert!(debug_str.contains("2024"), "Debug output should contain property value");
+        assert!(
+            debug_str.contains("KNOWS"),
+            "Debug output should contain resolved label"
+        );
+        assert!(
+            debug_str.contains("2024"),
+            "Debug output should contain property value"
+        );
     }
 
     #[test]
@@ -496,6 +507,9 @@ mod tests {
         );
 
         let debug_str = format!("{:?}", edge);
-        assert!(debug_str.contains("InternedString(4294967294)"), "Debug output should fallback to raw ID for unknown label");
+        assert!(
+            debug_str.contains("InternedString(4294967294)"),
+            "Debug output should fallback to raw ID for unknown label"
+        );
     }
 }

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -13,7 +13,7 @@ use crate::core::version::VersionMetadata;
 ///
 /// This represents the current version of a node, optimized for fast access.
 /// Historical versions are stored separately in the temporal storage layer.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Node {
     /// Unique identifier for this node.
     pub id: NodeId,
@@ -110,11 +110,27 @@ impl Node {
     }
 }
 
+impl std::fmt::Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label_str = crate::core::interning::GLOBAL_INTERNER
+            .resolve_with(self.label, |s| s.to_string())
+            .unwrap_or_else(|| format!("{:?}", self.label));
+
+        f.debug_struct("Node")
+            .field("id", &self.id)
+            .field("label", &label_str)
+            .field("properties", &self.properties)
+            .field("current_version", &self.current_version)
+            .field("metadata", &self.metadata)
+            .finish()
+    }
+}
+
 /// An edge in the current state of the graph.
 ///
 /// Edges are directed relationships between nodes with properties.
 /// This represents the current version, optimized for fast traversals.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Edge {
     /// Unique identifier for this edge.
     pub id: EdgeId,
@@ -226,6 +242,24 @@ impl Edge {
     #[inline]
     pub fn connects(&self, source: NodeId, target: NodeId) -> bool {
         self.source == source && self.target == target
+    }
+}
+
+impl std::fmt::Debug for Edge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label_str = crate::core::interning::GLOBAL_INTERNER
+            .resolve_with(self.label, |s| s.to_string())
+            .unwrap_or_else(|| format!("{:?}", self.label));
+
+        f.debug_struct("Edge")
+            .field("id", &self.id)
+            .field("label", &label_str)
+            .field("source", &self.source)
+            .field("target", &self.target)
+            .field("properties", &self.properties)
+            .field("current_version", &self.current_version)
+            .field("metadata", &self.metadata)
+            .finish()
     }
 }
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1380,7 +1380,7 @@ impl From<SparseVec> for PropertyValue {
 /// The underlying HashMap is wrapped in an Arc, making clones very cheap
 /// (just incrementing a reference count). This enables efficient sharing
 /// of unchanged properties across versions.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct PropertyMap {
     inner: Arc<HashMap<PropertyKey, PropertyValue>>,
     /// Cached serialized size in bytes.
@@ -1726,6 +1726,32 @@ impl PropertyMap {
     #[inline(always)]
     pub fn serialized_size(&self) -> usize {
         self.cached_size
+    }
+}
+
+impl fmt::Debug for PropertyMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = f.debug_map();
+        // Collect entries to sort them for deterministic output
+        let mut entries: Vec<_> = self.inner.iter().collect();
+        // Sort by key string representation if possible, or ID if not
+        entries.sort_by(|(k1, _), (k2, _)| {
+            let s1 = GLOBAL_INTERNER.resolve_with(**k1, |s| s.to_string());
+            let s2 = GLOBAL_INTERNER.resolve_with(**k2, |s| s.to_string());
+            match (s1, s2) {
+                (Some(a), Some(b)) => a.cmp(&b),
+                _ => k1.cmp(k2),
+            }
+        });
+
+        for (key, value) in entries {
+            if let Some(key_str) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) {
+                map.entry(&key_str, value);
+            } else {
+                map.entry(key, value);
+            }
+        }
+        map.finish()
     }
 }
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -3915,8 +3915,14 @@ mod tests {
         let pos_b = debug_str.find("\"b\"").unwrap();
         let pos_c = debug_str.find("\"c\"").unwrap();
 
-        assert!(pos_a < pos_b, "Debug output should be sorted: 'a' before 'b'");
-        assert!(pos_b < pos_c, "Debug output should be sorted: 'b' before 'c'");
+        assert!(
+            pos_a < pos_b,
+            "Debug output should be sorted: 'a' before 'b'"
+        );
+        assert!(
+            pos_b < pos_c,
+            "Debug output should be sorted: 'b' before 'c'"
+        );
     }
 
     #[test]
@@ -3934,7 +3940,10 @@ mod tests {
 
         let debug_str = format!("{:?}", prop_map);
         // Fallback format for unknown key: InternedString(4294967295)
-        assert!(debug_str.contains("InternedString(4294967295)"), "Debug output should fallback for unknown key");
+        assert!(
+            debug_str.contains("InternedString(4294967295)"),
+            "Debug output should fallback for unknown key"
+        );
     }
 }
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1732,23 +1732,31 @@ impl PropertyMap {
 impl fmt::Debug for PropertyMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut map = f.debug_map();
-        // Collect entries to sort them for deterministic output
-        let mut entries: Vec<_> = self.inner.iter().collect();
-        // Sort by key string representation if possible, or ID if not
-        entries.sort_by(|(k1, _), (k2, _)| {
-            let s1 = GLOBAL_INTERNER.resolve_with(**k1, |s| s.to_string());
-            let s2 = GLOBAL_INTERNER.resolve_with(**k2, |s| s.to_string());
-            match (s1, s2) {
-                (Some(a), Some(b)) => a.cmp(&b),
-                _ => k1.cmp(k2),
-            }
+        // Collect entries and pre-resolve keys to sort them for deterministic output
+        // We map to (resolved_str, raw_id, value)
+        let mut entries: Vec<_> = self
+            .inner
+            .iter()
+            .map(|(key, value)| {
+                let resolved = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string());
+                (resolved, *key, value)
+            })
+            .collect();
+
+        // Sort by resolved string if available, otherwise by ID
+        // Resolved keys always come before unresolved ones for consistency
+        entries.sort_by(|(s1, k1, _), (s2, k2, _)| match (s1, s2) {
+            (Some(a), Some(b)) => a.cmp(b),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => k1.cmp(k2),
         });
 
-        for (key, value) in entries {
-            if let Some(key_str) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) {
+        for (resolved, key, value) in entries {
+            if let Some(key_str) = resolved {
                 map.entry(&key_str, value);
             } else {
-                map.entry(key, value);
+                map.entry(&key, value);
             }
         }
         map.finish()
@@ -3888,6 +3896,45 @@ mod tests {
         let expected_min = 10 * min_vec_size + 4; // "data".len() = 4
 
         assert!(size >= expected_min);
+    }
+
+    #[test]
+    fn test_property_map_debug_sorting() {
+        // Use unsorted insert order: b, a, c
+        let map = PropertyMapBuilder::new()
+            .insert("b", 2)
+            .insert("a", 1)
+            .insert("c", 3)
+            .build();
+
+        let debug_str = format!("{:?}", map);
+        // Should sort keys alphabetically: a, b, c
+        // The output format is standard debug map: {"key": value, ...}
+        // We look for "a": ... "b": ... "c": ... in that order
+        let pos_a = debug_str.find("\"a\"").unwrap();
+        let pos_b = debug_str.find("\"b\"").unwrap();
+        let pos_c = debug_str.find("\"c\"").unwrap();
+
+        assert!(pos_a < pos_b, "Debug output should be sorted: 'a' before 'b'");
+        assert!(pos_b < pos_c, "Debug output should be sorted: 'b' before 'c'");
+    }
+
+    #[test]
+    fn test_property_map_debug_fallback() {
+        // Create a PropertyMap with a raw unresolved key
+        // We must bypass PropertyMapBuilder because it validates keys against the interner
+        let mut map = HashMap::new();
+        let raw_key = InternedString::from_raw(u32::MAX);
+        map.insert(raw_key, PropertyValue::Int(42));
+
+        let prop_map = PropertyMap {
+            inner: Arc::new(map),
+            cached_size: 0, // Not used for Debug
+        };
+
+        let debug_str = format!("{:?}", prop_map);
+        // Fallback format for unknown key: InternedString(4294967295)
+        assert!(debug_str.contains("InternedString(4294967295)"), "Debug output should fallback for unknown key");
     }
 }
 


### PR DESCRIPTION
This PR addresses a major Developer Experience (DX) friction point identified by the 'Echo' persona. Previously, debugging nodes and edges printed raw `InternedString(ID)` values (e.g., `InternedString(11)`), forcing users to manually resolve strings or guess their meaning.

Changes:
- Replaced `#[derive(Debug)]` with manual `impl fmt::Debug` for `Node`, `Edge`, and `PropertyMap`.
- The new implementation uses `GLOBAL_INTERNER.resolve_with` to print the actual string representation of labels and property keys.
- `PropertyMap` debug output is now sorted alphabetically by key, ensuring deterministic output for tests and easier reading for humans.
- `cached_size` in `PropertyMap` is hidden from debug output as it is an internal implementation detail irrelevant to most users.

Verification:
- Ran `cargo test core::graph` and `cargo test core::property` (all passed).
- Verified with a reproduction script (`examples/dx_readme_basic.rs`) that the output is now human-readable (e.g., `label: "Person"` instead of `label: InternedString(11)`).


---
*PR created automatically by Jules for task [2369467780797060039](https://jules.google.com/task/2369467780797060039) started by @madmax983*