### PR TITLE
🎨 Mosaic: UI Polish for CLI Query Results

### DIFF
--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -20,7 +20,7 @@ use super::planner::physical::{PhysicalOp, PhysicalPlan};
 pub use iterators::NodeScanIterator;
 pub use iterators::ResultIterator;
 pub use iterators::TemporalNodeScanIterator;
-pub use results::{EntityId, EntityResult, QueryResults, QueryRow};
+pub use results::{EntityId, EntityResult, QueryResult, QueryResults, QueryRow};
 
 /// Configuration for query execution.
 #[derive(Debug, Clone)]

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -1449,8 +1449,7 @@ mod tests {
             .insert("inactive", false)
             .build();
 
-        let result = QueryResult::with_nodes(vec![node_id])
-            .with_properties(vec![props]);
+        let result = QueryResult::with_nodes(vec![node_id]).with_properties(vec![props]);
 
         let display = format!("{}", result);
 
@@ -1458,11 +1457,17 @@ mod tests {
         // We verify that "active: true" is NOT present as plain text
         // because there should be ANSI codes.
         let plain_true = "active: true";
-        assert!(!display.contains(plain_true), "Display should contain color codes for true");
+        assert!(
+            !display.contains(plain_true),
+            "Display should contain color codes for true"
+        );
 
         // For false, we did NOT add color, so it should be plain text
         let plain_false = "inactive: false";
-        assert!(display.contains(plain_false), "Display should NOT contain color codes for false");
+        assert!(
+            display.contains(plain_false),
+            "Display should NOT contain color codes for false"
+        );
 
         // Verify it contains "true" content
         assert!(display.contains("true"));

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -10,6 +10,7 @@ use crate::core::{EdgeId, NodeId};
 use crate::utils::error::Result;
 
 use super::iterators::ResultIterator;
+use crossterm::style::Stylize;
 
 /// A path through the graph, represented as a sequence of entity IDs.
 pub type Path = Vec<EntityId>;
@@ -466,7 +467,15 @@ impl std::fmt::Display for QueryResult {
                             let k_str = crate::core::interning::GLOBAL_INTERNER
                                 .resolve_with(*k, |s| s.to_string())
                                 .unwrap_or_else(|| format!("key:{}", k.as_u32()));
-                            format!("{}: {}", k_str, v)
+
+                            let v_str = match v {
+                                crate::core::property::PropertyValue::Bool(true) => {
+                                    format!("{}", v.to_string().green())
+                                }
+                                _ => format!("{}", v),
+                            };
+
+                            format!("{}: {}", k_str, v_str)
                         })
                         .collect();
 
@@ -1428,5 +1437,34 @@ mod tests {
         assert_eq!(versions[0], VersionId::new(100).unwrap());
         assert_eq!(versions[1], VersionId::new(0).unwrap()); // Clamped
         assert_eq!(versions[2], VersionId::new(0).unwrap());
+    }
+
+    #[test]
+    fn test_query_result_display_boolean_color() {
+        use crate::core::property::PropertyMapBuilder;
+
+        let node_id = NodeId::new(1).unwrap();
+        let props = PropertyMapBuilder::new()
+            .insert("active", true)
+            .insert("inactive", false)
+            .build();
+
+        let result = QueryResult::with_nodes(vec![node_id])
+            .with_properties(vec![props]);
+
+        let display = format!("{}", result);
+
+        // "true" should be colorized (green)
+        // We verify that "active: true" is NOT present as plain text
+        // because there should be ANSI codes.
+        let plain_true = "active: true";
+        assert!(!display.contains(plain_true), "Display should contain color codes for true");
+
+        // For false, we did NOT add color, so it should be plain text
+        let plain_false = "inactive: false";
+        assert!(display.contains(plain_false), "Display should NOT contain color codes for false");
+
+        // Verify it contains "true" content
+        assert!(display.contains("true"));
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -103,7 +103,7 @@ pub mod semantic_pathfinding;
 pub use ast::QueryAst;
 pub use builder::{Query, QueryBuilder};
 pub use converter::{AstConverter, ParameterValue, parse_query, parse_query_with_params};
-pub use executor::{QueryExecutor, QueryResults, QueryRow};
+pub use executor::{QueryExecutor, QueryResult, QueryResults, QueryRow};
 pub use hybrid::traverse_and_rank;
 pub use ir::{Direction, Predicate, QueryOp, SortKey, TraversalDepth};
 pub use lexer::{Lexer, LexerError, Token};


### PR DESCRIPTION
Polished the CLI output for `QueryResult`.
- **Before:** `QueryResult` (structured) was private, and property maps were displayed as plain key-value strings.
- **After:** `QueryResult` is public. Boolean `true` values in properties are now rendered in green ANSI color in the CLI table output.
- **Verification:** Added a unit test ensuring "true" is present and colorized (contains ANSI codes). Verified visually with a reproduction script.

---
*PR created automatically by Jules for task [11445189152317852187](https://jules.google.com/task/11445189152317852187) started by @madmax983*