### PR TITLE
docs: ADR-0034 Standardize on Redb Cold Storage

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,17 +84,16 @@ classDiagram
         }
     }
     namespace Core {
+        class GallifreyDB
         class QueryEngine
         class TemporalPlanner
         class TraversalEngine
-        class StorageTrait {
-            <<interface>>
-        }
     }
     namespace Storage {
         class CurrentStorage
         class HistoricalStorage
-        class RedbImplementation
+        class TieredStorage
+        class RedbColdStorage
     }
     namespace Observability {
         class HoneycombClient {
@@ -103,11 +102,11 @@ classDiagram
     }
 
     MCPServer --> QueryEngine : Uses
-    QueryEngine --> StorageTrait : Uses (Trait Bound)
-    %% Removed the circular dependency arrow
-    RedbImplementation ..|> StorageTrait : Implements
-    CurrentStorage --|> StorageTrait : Implements
-    HistoricalStorage --|> StorageTrait : Implements
+    QueryEngine --> GallifreyDB : Uses
+    GallifreyDB --> CurrentStorage : Composes
+    GallifreyDB --> HistoricalStorage : Composes
+    HistoricalStorage --> TieredStorage : Uses
+    TieredStorage --> RedbColdStorage : Uses
 ```
 
 **When to Use Each:**

--- a/docs/adr/0034-standardize-redb-cold-storage.md
+++ b/docs/adr/0034-standardize-redb-cold-storage.md
@@ -1,0 +1,46 @@
+# ADR-0034: Standardize on Redb for Cold Storage
+
+**Status:** Accepted
+**Date:** 2026-01-28
+**Deciders:** GallifreyDB Core Team
+**Categories:** storage, architecture, simplification
+
+## Context
+
+ADR-0027 ("Decouple Storage from Core") proposed defining architectural boundaries via storage traits (e.g., `StorageEngine`) to allow for pluggable backends. Following this, a `ColdStorage` trait was introduced to abstract the cold storage layer, with `RedbColdStorage` and `FileColdStorage` as implementations.
+
+However, as development progressed, several issues emerged with this abstraction:
+
+1.  **Premature Abstraction:** `Redb` (Rust Embedded Database) has proven to be the only viable embedded backend that meets our performance and ACID requirements. The `FileColdStorage` implementation was limited and rarely used.
+2.  **Performance Overhead:** The trait required dynamic dispatch (`Arc<dyn ColdStorage>`), preventing compiler optimizations like inlining and specialization, which are critical for the "Performance First" principle (<1µs targets).
+3.  **Complexity:** `TieredStorage` and `MigrationService` had to deal with trait objects, complicating the type system and error handling.
+4.  **Leakiness:** The `ColdStorage` trait had to expose `redb`-specific types or concepts (like LSNs) to support the WAL architecture, making the abstraction leaky.
+
+## Decision
+
+We will **remove the `ColdStorage` trait** and standardize on `RedbColdStorage` as the sole concrete implementation for cold storage.
+
+Specific changes:
+1.  **Remove Trait:** Delete the `ColdStorage` trait definition.
+2.  **Concrete Types:** Update `TieredStorage`, `MigrationService`, and `HistoricalStorage` to own `Arc<RedbColdStorage>` directly instead of `Arc<dyn ColdStorage>`.
+3.  **Remove Dead Code:** Delete `FileColdStorage` and any other unused implementations.
+
+This decision refines ADR-0027 by favoring **concrete modularity** (separate modules/crates but concrete types) over **abstract modularity** (traits) for the storage layer.
+
+## Consequences
+
+### Positive
+
+-   **Performance:** Removes virtual dispatch overhead. Calls to storage are now static dispatch, allowing inlining.
+-   **Simplicity:** Codebase is easier to read and navigate. `TieredStorage` logic is more straightforward.
+-   **Robustness:** `RedbColdStorage` provides ACID guarantees that ad-hoc file implementations lacked.
+-   **Maintainability:** We focus all optimization efforts on a single, high-quality storage backend.
+
+### Negative
+
+-   **Reduced Pluggability:** Swapping the storage engine now requires code changes rather than just a configuration switch. However, given GallifreyDB's embedded nature, supporting multiple distinct storage engines simultaneously is a non-goal (YAGNI).
+-   **Tight Coupling:** The system is now explicitly coupled to `redb`. If `redb` becomes unmaintained, replacing it will be harder (though still manageable due to module boundaries).
+
+## Compliance
+
+This ADR aligns with the "Razor" persona's directive to "Enforce KISS/YAGNI" and "prefer concrete types over single-impl traits".


### PR DESCRIPTION
**Context:**
The codebase has evolved to remove the `ColdStorage` trait in favor of using `RedbColdStorage` directly, but this decision was not formally recorded in an ADR, and the architecture diagram still showed the trait.

**Changes:**
- Created `docs/adr/0034-standardize-redb-cold-storage.md` explaining the rationale (performance, simplicity, YAGNI) for removing the trait.
- Updated `docs/ARCHITECTURE.md` diagrams to show the concrete relationships between `GallifreyDB`, `HistoricalStorage`, `TieredStorage`, and `RedbColdStorage`.

**Verification:**
- Verified the content of the new ADR.
- Verified the updated diagram matches the code structure.
- Ran `cargo doc --no-deps` to ensure no documentation build errors.

---
*PR created automatically by Jules for task [16379424202961631839](https://jules.google.com/task/16379424202961631839) started by @madmax983*