### PR TITLE
🎨 Mosaic: UI Polish for QueryResult Display

### DIFF
--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -20,7 +20,7 @@ use super::planner::physical::{PhysicalOp, PhysicalPlan};
 pub use iterators::NodeScanIterator;
 pub use iterators::ResultIterator;
 pub use iterators::TemporalNodeScanIterator;
-pub use results::{EntityId, EntityResult, QueryResults, QueryRow};
+pub use results::{EntityId, EntityResult, QueryResult, QueryResults, QueryRow};
 
 /// Configuration for query execution.
 #[derive(Debug, Clone)]

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -1195,8 +1195,7 @@ mod tests {
             .insert("flag", false)
             .build();
 
-        let result = QueryResult::with_nodes(nodes)
-            .with_properties(vec![props]);
+        let result = QueryResult::with_nodes(nodes).with_properties(vec![props]);
 
         let display = format!("{}", result);
 

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -8,6 +8,7 @@ use crate::core::property::PropertyMap;
 use crate::core::temporal::Timestamp;
 use crate::core::{EdgeId, NodeId};
 use crate::utils::error::Result;
+use crossterm::style::Stylize;
 
 use super::iterators::ResultIterator;
 
@@ -466,7 +467,12 @@ impl std::fmt::Display for QueryResult {
                             let k_str = crate::core::interning::GLOBAL_INTERNER
                                 .resolve_with(*k, |s| s.to_string())
                                 .unwrap_or_else(|| format!("key:{}", k.as_u32()));
-                            format!("{}: {}", k_str, v)
+
+                            if let crate::core::property::PropertyValue::Bool(true) = v {
+                                format!("{}: {}", k_str, "true".green())
+                            } else {
+                                format!("{}: {}", k_str, v)
+                            }
                         })
                         .collect();
 

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -1186,6 +1186,30 @@ mod tests {
     }
 
     #[test]
+    fn test_query_result_display_boolean_coloring() {
+        use crate::core::property::PropertyMapBuilder;
+
+        let nodes = vec![NodeId::new(1).unwrap()];
+        let props = PropertyMapBuilder::new()
+            .insert("active", true)
+            .insert("flag", false)
+            .build();
+
+        let result = QueryResult::with_nodes(nodes)
+            .with_properties(vec![props]);
+
+        let display = format!("{}", result);
+
+        // Check that "true" is colored green
+        // Use crossterm to generate the expected string to be robust against env differences
+        let expected_true = format!("{}", "true".green());
+        assert!(display.contains(&expected_true));
+
+        // Check that "false" is present
+        assert!(display.contains("false"));
+    }
+
+    #[test]
     fn test_collect_structured_nodes_only() {
         let rows = vec![
             QueryRow::from_entity(EntityResult::NodeId(NodeId::new(1).unwrap())),


### PR DESCRIPTION
Implemented UI polish for `QueryResult` display formatting:
- Boolean `true` values in property maps are now rendered in green using ANSI escape codes via `crossterm`.
- `QueryResult` struct is now public via `gallifreydb::query::executor` re-export.
- Verified using `comfy-table` layout which was already in place.

---
*PR created automatically by Jules for task [14642982934332522353](https://jules.google.com/task/14642982934332522353) started by @madmax983*