### PR TITLE
🔒 Warden: Hardening FindNode API against DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -164,3 +164,19 @@ Added `tests/repro_allocation_dos.rs` simulating malicious payloads. Confirmed t
 
 **Verification:** Regression Test
 Added `tests/warden_vector_safety.rs` which attempts to insert and serialize oversized vectors using the `try_` methods. Verified that they now return `VectorError::DimensionTooLarge` instead of crashing the test runner.
+
+## 2026-02-23 - API Unbounded Allocation DoS Hardening
+
+**Threat:** Unbounded Allocation DoS in FindNode
+The `FindNode` HTTP endpoint lacked upper bounds on `limit` and `offset`. A malicious client could request `limit: 1_000_000_000`, causing the server to attempt massive vector allocation during response construction (Out-Of-Memory DoS) or exhaust CPU via deep pagination.
+
+**Defense:** Mandatory Limits
+Enforced strict limits in `src/http/handlers.rs`:
+- `MAX_RESULT_LIMIT = 1000` (clamped).
+- `MAX_PAGINATION_LIMIT = 10_000` (offset + limit).
+- Refactored `FindNeighbors` to use these shared constants.
+
+**Verification:** Reproduction Test
+Added `tests/warden_dos_find_node.rs`.
+- Confirmed that requesting 2000 items now returns 1000 items (clamped).
+- Confirmed that requesting `offset=9999, limit=100` returns 400 Bad Request.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -35,6 +35,14 @@ pub fn configure_health_routes(cfg: &mut web::ServiceConfig) {
 // Query Endpoint
 // ============================================================================
 
+/// Maximum number of results to return in a single response.
+/// Prevents OOM attacks via unbounded result set collection.
+const MAX_RESULT_LIMIT: usize = 1000;
+
+/// Maximum offset + limit for pagination.
+/// Prevents CPU DoS via deep pagination attacks.
+const MAX_PAGINATION_LIMIT: usize = 10_000;
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum QueryRequest {
@@ -193,11 +201,21 @@ pub async fn handle_query(
             }
 
             // Issue 4: Pagination
+            let limit_val = limit.unwrap_or(100).min(MAX_RESULT_LIMIT);
+            let offset_val = offset.unwrap_or(0);
+
+            // Prevent deep pagination attacks (DoS)
+            if offset_val + limit_val > MAX_PAGINATION_LIMIT {
+                return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+                    "Pagination limit exceeded: offset + limit must be <= {}",
+                    MAX_PAGINATION_LIMIT
+                )));
+            }
+
             if let Some(skip) = offset {
                 builder = builder.skip(skip);
             }
 
-            let limit_val = limit.unwrap_or(100);
             match builder.limit(limit_val).execute(db) {
                 Ok(results) => {
                     let mut nodes = Vec::new();
@@ -231,18 +249,14 @@ pub async fn handle_query(
         } => {
             match NodeId::new(node_id) {
                 Ok(nid) => {
-                    // Safety limits to prevent DoS
-                    let max_limit = 1000;
-                    let max_deep_pagination = 10_000;
-
-                    let limit_val = limit.unwrap_or(100).min(max_limit);
+                    let limit_val = limit.unwrap_or(100).min(MAX_RESULT_LIMIT);
                     let offset_val = offset.unwrap_or(0);
 
                     // Prevent deep pagination attacks (CPU DoS)
-                    if offset_val + limit_val > max_deep_pagination {
+                    if offset_val + limit_val > MAX_PAGINATION_LIMIT {
                         return HttpResponse::BadRequest().json(ApiResponse::error(format!(
                             "Pagination limit exceeded: offset + limit must be <= {}",
-                            max_deep_pagination
+                            MAX_PAGINATION_LIMIT
                         )));
                     }
 

--- a/tests/warden_dos_find_node.rs
+++ b/tests/warden_dos_find_node.rs
@@ -1,0 +1,97 @@
+//! Security reproduction test for Unbounded Allocation DoS in FindNode.
+//!
+//! This test verifies that `FindNode` currently allows unbounded limits,
+//! which is a DoS vector. After the fix, it should verify that limits are enforced.
+
+#![cfg(feature = "http-server")]
+
+use actix_web::{App, test, web};
+use gallifreydb::{GallifreyDB, PropertyMapBuilder};
+use gallifreydb::http::{AppState, configure_app};
+use std::sync::Arc;
+use serde_json::Value;
+
+#[actix_rt::test]
+async fn test_find_node_limit_clamping() {
+    // 1. Setup DB with 1100 nodes
+    let db = Arc::new(GallifreyDB::new().unwrap());
+
+    for i in 0..1100 {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("id", i as i64)
+                .build()
+        ).unwrap();
+    }
+
+    let state = AppState::new(db);
+
+    // 2. Setup App using the public configuration function
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(configure_app)
+    ).await;
+
+    // 3. Send request with limit: 2000 (exceeding safety limit of 1000)
+    let req_body = serde_json::json!({
+        "operation": "find_node",
+        "label": "Person",
+        "limit": 2000
+    });
+
+    let req = test::TestRequest::post()
+        .uri("/query")
+        .set_json(&req_body)
+        .to_request();
+
+    // 4. Verify vulnerability protection: Returns 1000 nodes (clamped)
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let body: Value = test::read_body_json(resp).await;
+    let data = body.get("data").expect("Should have data").as_array().expect("Data should be array");
+
+    if data.len() == 1100 {
+        panic!("⚠️ VULNERABILITY CONFIRMED: FindNode returned 1100 nodes (unbounded limit).");
+    } else if data.len() == 1000 {
+        println!("✅ SECURE: FindNode clamped results to 1000.");
+    } else {
+        panic!("Unexpected result count: {}", data.len());
+    }
+}
+
+#[actix_rt::test]
+async fn test_find_node_deep_pagination_prevention() {
+    let db = Arc::new(GallifreyDB::new().unwrap());
+    let state = AppState::new(db);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(configure_app)
+    ).await;
+
+    // Request offset=9999, limit=100 -> Total 10099 > 10000 -> Bad Request
+    let req_body = serde_json::json!({
+        "operation": "find_node",
+        "limit": 100,
+        "offset": 9999
+    });
+
+    let req = test::TestRequest::post()
+        .uri("/query")
+        .set_json(&req_body)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+
+    // Expect 400 Bad Request
+    assert_eq!(resp.status().as_u16(), 400);
+
+    let body: Value = test::read_body_json(resp).await;
+    let error = body.get("error").expect("Should have error").as_str().expect("Error should be string");
+
+    assert!(error.contains("Pagination limit exceeded"));
+    println!("✅ SECURE: Deep pagination rejected.");
+}

--- a/tests/warden_dos_find_node.rs
+++ b/tests/warden_dos_find_node.rs
@@ -6,10 +6,10 @@
 #![cfg(feature = "http-server")]
 
 use actix_web::{App, test, web};
-use gallifreydb::{GallifreyDB, PropertyMapBuilder};
 use gallifreydb::http::{AppState, configure_app};
-use std::sync::Arc;
+use gallifreydb::{GallifreyDB, PropertyMapBuilder};
 use serde_json::Value;
+use std::sync::Arc;
 
 #[actix_rt::test]
 async fn test_find_node_limit_clamping() {
@@ -19,10 +19,9 @@ async fn test_find_node_limit_clamping() {
     for i in 0..1100 {
         db.create_node(
             "Person",
-            PropertyMapBuilder::new()
-                .insert("id", i as i64)
-                .build()
-        ).unwrap();
+            PropertyMapBuilder::new().insert("id", i as i64).build(),
+        )
+        .unwrap();
     }
 
     let state = AppState::new(db);
@@ -31,8 +30,9 @@ async fn test_find_node_limit_clamping() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(state))
-            .configure(configure_app)
-    ).await;
+            .configure(configure_app),
+    )
+    .await;
 
     // 3. Send request with limit: 2000 (exceeding safety limit of 1000)
     let req_body = serde_json::json!({
@@ -51,7 +51,11 @@ async fn test_find_node_limit_clamping() {
     assert!(resp.status().is_success());
 
     let body: Value = test::read_body_json(resp).await;
-    let data = body.get("data").expect("Should have data").as_array().expect("Data should be array");
+    let data = body
+        .get("data")
+        .expect("Should have data")
+        .as_array()
+        .expect("Data should be array");
 
     if data.len() == 1100 {
         panic!("⚠️ VULNERABILITY CONFIRMED: FindNode returned 1100 nodes (unbounded limit).");
@@ -69,8 +73,9 @@ async fn test_find_node_deep_pagination_prevention() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(state))
-            .configure(configure_app)
-    ).await;
+            .configure(configure_app),
+    )
+    .await;
 
     // Request offset=9999, limit=100 -> Total 10099 > 10000 -> Bad Request
     let req_body = serde_json::json!({
@@ -90,7 +95,11 @@ async fn test_find_node_deep_pagination_prevention() {
     assert_eq!(resp.status().as_u16(), 400);
 
     let body: Value = test::read_body_json(resp).await;
-    let error = body.get("error").expect("Should have error").as_str().expect("Error should be string");
+    let error = body
+        .get("error")
+        .expect("Should have error")
+        .as_str()
+        .expect("Error should be string");
 
     assert!(error.contains("Pagination limit exceeded"));
     println!("✅ SECURE: Deep pagination rejected.");


### PR DESCRIPTION
This PR addresses a Denial of Service vulnerability in the `FindNode` HTTP endpoint where `limit` and `offset` parameters were not bounded.

Changes:
- Added `MAX_RESULT_LIMIT` (1000) and `MAX_PAGINATION_LIMIT` (10,000) constants to `src/http/handlers.rs`.
- Updated `FindNode` handler to clamp `limit` and validate pagination depth.
- Refactored `FindNeighbors` to use the shared constants.
- Added regression test `tests/warden_dos_find_node.rs`.
- Updated Warden's Journal (`.jules/warden.md`).

---
*PR created automatically by Jules for task [17166772505387760688](https://jules.google.com/task/17166772505387760688) started by @madmax983*