### PR TITLE
docs: Fix broken README examples and improve InternedString DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ db.write(|tx| {
 
 // Read current state
 let alice = db.get_node(alice_id)?;
+println!("Created Alice: {:?}", alice);
 ```
 
 ### Time-Travel Queries
@@ -369,9 +370,7 @@ let historical_alice = db.get_node_at_time(
 )?;
 
 // Track how properties changed
-if let Some(old_alice) = historical_alice {
-    println!("Alice's age was: {:?}", old_alice.properties.get("age"));
-}
+println!("Alice's age was: {:?}", historical_alice.properties.get("age"));
 ```
 
 ### Vector Search with HNSW
@@ -386,6 +385,8 @@ let db = GallifreyDB::new().unwrap();
 db.vector_index("embedding")
     .hnsw(HnswConfig::new(384, DistanceMetric::Cosine))
     .enable()?;
+
+let embedding = vec![0.1f32; 384];
 
 // Store node with embedding - automatically indexed!
 let doc_id = db.create_node("Document",
@@ -613,7 +614,7 @@ use std::sync::Arc;
 let cold = RedbColdStorage::new("data/cold.redb", RedbConfig::default())?;
 
 // Create tiered storage
-let tiered = TieredStorage::with_default_config(Box::new(cold));
+let tiered = TieredStorage::with_default_config(Arc::new(cold));
 
 // Configure historical storage
 let mut historical = HistoricalStorage::new();

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -1097,4 +1097,18 @@ mod tests {
         hasher.write(&bytes);
         assert_eq!(hasher.finish(), 3); // Should use len()
     }
+
+    #[test]
+    fn test_display_impl() {
+        // Test successful resolution via GLOBAL_INTERNER
+        let s = "display_test_string";
+        let id = GLOBAL_INTERNER.intern(s).unwrap();
+        assert_eq!(format!("{}", id), s);
+
+        // Test fallback (ID not in GLOBAL_INTERNER)
+        // We assume 1 billion is not used yet
+        let raw_id = 1_000_000_000;
+        let id = InternedString::from_raw(raw_id);
+        assert_eq!(format!("{}", id), format!("Interned({})", raw_id));
+    }
 }

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -62,7 +62,16 @@ impl InternedString {
 
 impl fmt::Display for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Interned({})", self.0)
+        // Try to resolve using the global interner first
+        // This makes debugging much easier by showing the actual string
+        // We use resolve_with to avoid allocating a new String just for display
+        let result = GLOBAL_INTERNER.resolve_with(*self, |s| write!(f, "{}", s));
+
+        // If resolution failed (e.g. ID from a local interner), fallback to showing ID
+        match result {
+            Some(res) => res,
+            None => write!(f, "Interned({})", self.0),
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes several broken code examples in the `README.md` that were identified during a Developer Experience (DX) audit. It also improves the developer experience by making `InternedString` print the actual string content when using `Display` (`{}`), resolving it via the `GLOBAL_INTERNER`.

**Changes:**
- **README.md**:
  - Fixed "Time-Travel Queries" example to correctly handle `Result<Node>` return type.
  - Added missing `embedding` variable definition to "Vector Search" example.
  - Corrected `TieredStorage` instantiation to use `Arc` instead of `Box`.
  - Added `println!` to "Basic Graph Operations" to silence unused variable warning and show output.
- **src/core/interning.rs**:
  - Updated `impl fmt::Display for InternedString` to attempt resolution via `GLOBAL_INTERNER`. This means `println!("{}", node.label)` will now print "Person" instead of "Interned(11)". Fallback to ID format is preserved if resolution fails.

**Verification:**
- Verified all corrected examples by compiling and running them as temporary standalone files in `examples/`.
- Verified `InternedString` display improvement using a test script.
- Ran existing unit tests for `core::interning`.

---
*PR created automatically by Jules for task [1763530970919221762](https://jules.google.com/task/1763530970919221762) started by @madmax983*