### PR TITLE
feat: Add node scanning/iteration API (Issue #825)

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -67,6 +67,47 @@ impl AletheiaDB {
         self.current.get_edge(edge_id)
     }
 
+    /// Scan all nodes with a specific label, returning an iterator over node IDs.
+    ///
+    /// This method provides efficient iteration over all nodes matching a given label/type.
+    /// Useful for operations that need to process all entities of a certain type.
+    ///
+    /// # Arguments
+    ///
+    /// * `label` - The label/type to filter by (e.g., "Person", "Product", "Event")
+    ///
+    /// # Returns
+    ///
+    /// An iterator yielding `NodeId` for all nodes with the specified label.
+    ///
+    /// # Performance
+    ///
+    /// - **Time**: O(n) scan of all nodes with efficient label filtering
+    /// - **Space**: O(1) - lazy iterator, no allocation
+    /// - **Comparison**: Uses interned string pointer equality (very fast)
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Process all Person nodes
+    /// for node_id in db.scan_nodes_by_label("Person") {
+    ///     let node = db.get_node(node_id)?;
+    ///     println!("Person: {:?}", node.properties.get("name"));
+    /// }
+    ///
+    /// // Count nodes by label
+    /// let person_count = db.scan_nodes_by_label("Person").count();
+    /// let product_count = db.scan_nodes_by_label("Product").count();
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// - [`find_nodes_by_property`](Self::find_nodes_by_property) - Find nodes by label + property value
+    /// - [`node_count`](Self::node_count) - Total node count across all labels
+    pub fn scan_nodes_by_label(&self, label: &str) -> impl Iterator<Item = NodeId> + '_ {
+        self.current.scan_nodes_by_label(label)
+    }
+
     // ========================================================================
     // Zero-copy access methods (Issue #190)
     // ========================================================================

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1940,6 +1940,49 @@ impl CurrentStorage {
         self.indexes.iter_edges().map(|e| e.clone())
     }
 
+    /// Scan nodes by label, returning an iterator over matching node IDs.
+    ///
+    /// This method efficiently filters the node collection to find all nodes
+    /// with the specified label.
+    ///
+    /// # Arguments
+    ///
+    /// * `label` - The label/type to filter by (e.g., "Person", "Product")
+    ///
+    /// # Returns
+    ///
+    /// An iterator yielding `NodeId` for all nodes matching the label.
+    ///
+    /// # Performance
+    ///
+    /// - **Time Complexity**: O(n) where n is the total number of nodes
+    /// - **Space Complexity**: O(1) - iterator, no allocation
+    /// - **Filtering**: Uses interned string comparison (pointer equality)
+    ///
+    /// Note: This operation scans all nodes. For workloads with frequent label scans,
+    /// consider using the query engine's optimized label index lookups.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Scan all Person nodes
+    /// for node_id in storage.scan_nodes_by_label("Person") {
+    ///     println!("Found Person: {}", node_id);
+    /// }
+    /// ```
+    pub fn scan_nodes_by_label(&self, label: &str) -> impl Iterator<Item = NodeId> + '_ {
+        // Look up the label in the interner without creating a new entry
+        // If the label was never interned, no nodes with that label exist
+        let interned_label = GLOBAL_INTERNER.get_id(label);
+
+        self.indexes
+            .iter_nodes()
+            .filter(move |node_ref| {
+                interned_label.is_some_and(|label_id| node_ref.label == label_id)
+            })
+            .map(|node_ref| node_ref.id)
+    }
+
     /// Create an MVCC snapshot at the specified LSN.
     ///
     /// This provides snapshot isolation for checkpoint operations, preventing

--- a/tests/node_scanning_api.rs
+++ b/tests/node_scanning_api.rs
@@ -1,0 +1,257 @@
+//! Tests for the node scanning API (Issue #825).
+//!
+//! Validates the `scan_nodes_by_label()` method for iterating over nodes by label.
+
+use aletheiadb::api::transaction::WriteOps;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+
+#[test]
+fn test_scan_nodes_by_label_empty() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Scanning for nodes with a label that doesn't exist should return empty
+    let person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    assert_eq!(person_ids.len(), 0);
+}
+
+#[test]
+fn test_scan_nodes_by_label_single() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Create a single Person node
+    let alice_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30)
+                .build(),
+        )
+        .expect("Failed to create node");
+
+    // Scan should find exactly one Person
+    let person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    assert_eq!(person_ids.len(), 1);
+    assert_eq!(person_ids[0], alice_id);
+}
+
+#[test]
+fn test_scan_nodes_by_label_multiple() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Create multiple Person nodes
+    let alice_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("Failed to create node");
+
+    let bob_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .expect("Failed to create node");
+
+    let carol_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Carol").build(),
+        )
+        .expect("Failed to create node");
+
+    // Scan should find all three Person nodes
+    let mut person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    person_ids.sort(); // DashMap iteration order is not guaranteed
+    assert_eq!(person_ids.len(), 3);
+
+    let mut expected = vec![alice_id, bob_id, carol_id];
+    expected.sort();
+    assert_eq!(person_ids, expected);
+}
+
+#[test]
+fn test_scan_nodes_by_label_multiple_labels() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Create nodes with different labels
+    let alice_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("Failed to create node");
+
+    let rust_book_id = db
+        .create_node(
+            "Product",
+            PropertyMapBuilder::new()
+                .insert("title", "The Rust Programming Language")
+                .insert("price", 39.99)
+                .build(),
+        )
+        .expect("Failed to create node");
+
+    let bob_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .expect("Failed to create node");
+
+    let laptop_id = db
+        .create_node(
+            "Product",
+            PropertyMapBuilder::new()
+                .insert("title", "ThinkPad X1")
+                .insert("price", 1299.99)
+                .build(),
+        )
+        .expect("Failed to create node");
+
+    // Scan for Person nodes
+    let mut person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    person_ids.sort();
+    assert_eq!(person_ids.len(), 2);
+
+    let mut expected_persons = vec![alice_id, bob_id];
+    expected_persons.sort();
+    assert_eq!(person_ids, expected_persons);
+
+    // Scan for Product nodes
+    let mut product_ids: Vec<_> = db.scan_nodes_by_label("Product").collect();
+    product_ids.sort();
+    assert_eq!(product_ids.len(), 2);
+
+    let mut expected_products = vec![rust_book_id, laptop_id];
+    expected_products.sort();
+    assert_eq!(product_ids, expected_products);
+
+    // Scan for non-existent label
+    let event_ids: Vec<_> = db.scan_nodes_by_label("Event").collect();
+    assert_eq!(event_ids.len(), 0);
+}
+
+#[test]
+fn test_scan_nodes_by_label_iterator_ops() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Create several Person nodes
+    for i in 0..10 {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("id", i as i64).build(),
+        )
+        .expect("Failed to create node");
+    }
+
+    // Test iterator operations
+
+    // Count
+    let count = db.scan_nodes_by_label("Person").count();
+    assert_eq!(count, 10);
+
+    // Take
+    let first_five: Vec<_> = db.scan_nodes_by_label("Person").take(5).collect();
+    assert_eq!(first_five.len(), 5);
+
+    // Filter
+    let filtered: Vec<_> = db
+        .scan_nodes_by_label("Person")
+        .filter(|node_id| {
+            let node = db.get_node(*node_id).unwrap();
+            let id_value = node.properties.get("id").unwrap();
+            if let Some(id) = id_value.as_int() {
+                id % 2 == 0
+            } else {
+                false
+            }
+        })
+        .collect();
+    assert_eq!(filtered.len(), 5); // 0, 2, 4, 6, 8
+}
+
+#[test]
+fn test_scan_nodes_by_label_with_updates() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Create initial Person nodes
+    let alice_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("Failed to create node");
+
+    let bob_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+        )
+        .expect("Failed to create node");
+
+    // Initial scan
+    let person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    assert_eq!(person_ids.len(), 2);
+
+    // Update a node's properties (label stays the same)
+    db.write(|tx| {
+        tx.update_node(
+            alice_id,
+            PropertyMapBuilder::new()
+                .insert("name", "Alice Updated")
+                .insert("age", 31)
+                .build(),
+        )
+    })
+    .expect("Failed to update node");
+
+    // Scan should still find both nodes
+    let person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    assert_eq!(person_ids.len(), 2);
+
+    // Delete a node
+    db.write(|tx| tx.delete_node(bob_id))
+        .expect("Failed to delete node");
+
+    // Scan should now find only Alice
+    let person_ids: Vec<_> = db.scan_nodes_by_label("Person").collect();
+    assert_eq!(person_ids.len(), 1);
+    assert_eq!(person_ids[0], alice_id);
+}
+
+#[test]
+fn test_scan_nodes_by_label_large_dataset() {
+    let db = AletheiaDB::new().expect("Failed to create database");
+
+    // Create a larger dataset with multiple labels
+    const PERSON_COUNT: usize = 1000;
+    const PRODUCT_COUNT: usize = 500;
+
+    for i in 0..PERSON_COUNT {
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("id", i as i64).build(),
+        )
+        .expect("Failed to create node");
+    }
+
+    for i in 0..PRODUCT_COUNT {
+        db.create_node(
+            "Product",
+            PropertyMapBuilder::new().insert("id", i as i64).build(),
+        )
+        .expect("Failed to create node");
+    }
+
+    // Verify counts
+    let person_count = db.scan_nodes_by_label("Person").count();
+    assert_eq!(person_count, PERSON_COUNT);
+
+    let product_count = db.scan_nodes_by_label("Product").count();
+    assert_eq!(product_count, PRODUCT_COUNT);
+
+    // Total node count should match
+    assert_eq!(db.node_count(), PERSON_COUNT + PRODUCT_COUNT);
+}


### PR DESCRIPTION
## Summary

Implements the node scanning/iteration API requested in #825. This feature provides an efficient way to iterate over all nodes with a specific label.

## Changes

### New API Methods

**Public API (`AletheiaDB`):**
```rust
pub fn scan_nodes_by_label(&self, label: &str) -> impl Iterator<Item = NodeId>
```

**Storage Layer (`CurrentStorage`):**
```rust
pub fn scan_nodes_by_label(&self, label: &str) -> impl Iterator<Item = NodeId>
```

### Implementation Details

- **Label Lookup**: Uses `GLOBAL_INTERNER.get_id()` to check if label was ever interned
- **Empty Results**: Returns empty iterator if label doesn't exist (never interned)
- **Filtering**: Uses interned string comparison (pointer equality) for efficiency
- **Zero Allocation**: Returns lazy iterator, no intermediate buffers

### Performance

- **Time Complexity**: O(n) where n is total nodes (scans all nodes, filters by label)
- **Space Complexity**: O(1) - lazy iterator pattern
- **Comparison**: Fast pointer equality via interned strings

Note: This is a full scan operation. For high-frequency label queries, consider using the query engine's optimized label indexes.

## Tests

Comprehensive test suite in `tests/node_scanning_api.rs`:

✅ Empty result for non-existent labels  
✅ Single node scanning  
✅ Multiple nodes with same label  
✅ Multiple labels with independent filtering  
✅ Iterator operations (count, take, filter)  
✅ Updates and deletions  
✅ Large dataset (1000+ nodes)

**7 tests, all passing**

## Examples

```rust
// Scan all Person nodes
for node_id in db.scan_nodes_by_label("Person") {
    let node = db.get_node(node_id)?;
    println!("Found: {:?}", node.properties.get("name"));
}

// Count nodes by label
let person_count = db.scan_nodes_by_label("Person").count();
let product_count = db.scan_nodes_by_label("Product").count();

// Filter while scanning
let filtered: Vec<_> = db
    .scan_nodes_by_label("Person")
    .filter(|id| {
        let node = db.get_node(*id).unwrap();
        node.properties.get("age").unwrap().as_int().unwrap() > 30
    })
    .collect();
```

## Quality Checks

✅ **Clippy**: Passes with no warnings  
✅ **Formatting**: Code formatted with `cargo fmt`  
✅ **Tests**: All 7 new tests pass  
✅ **Integration**: No breaking changes to existing APIs

---

Closes #825

🤖 Generated with Claude Code