### PR TITLE
🛡️ Sentry: Add rigorous SIMD correctness tests

### DIFF
--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -93,6 +93,8 @@ pub(crate) mod simd;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod sentry_tests;
 
 pub use constants::*;
 pub use metric::*;

--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -92,9 +92,9 @@ pub mod validation;
 pub(crate) mod simd;
 
 #[cfg(test)]
-mod tests;
-#[cfg(test)]
 mod sentry_tests;
+#[cfg(test)]
+mod tests;
 
 pub use constants::*;
 pub use metric::*;

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -62,15 +62,24 @@ fn test_dot_and_magnitudes_correctness_all_lengths() {
 
         assert!(
             (dot_actual - dot_expected).abs() < tolerance,
-            "Len {}: dot mismatch. Expected {}, got {}", len, dot_expected, dot_actual
+            "Len {}: dot mismatch. Expected {}, got {}",
+            len,
+            dot_expected,
+            dot_actual
         );
         assert!(
             (mag_a_actual - mag_a_expected).abs() < tolerance,
-            "Len {}: mag_a mismatch. Expected {}, got {}", len, mag_a_expected, mag_a_actual
+            "Len {}: mag_a mismatch. Expected {}, got {}",
+            len,
+            mag_a_expected,
+            mag_a_actual
         );
         assert!(
             (mag_b_actual - mag_b_expected).abs() < tolerance,
-            "Len {}: mag_b mismatch. Expected {}, got {}", len, mag_b_expected, mag_b_actual
+            "Len {}: mag_b mismatch. Expected {}, got {}",
+            len,
+            mag_b_expected,
+            mag_b_actual
         );
     }
 }
@@ -92,14 +101,22 @@ fn test_squared_diff_sum_correctness_all_lengths() {
         // SIMD FMA accumulation can differ from scalar sum.
         let abs_diff = (actual - expected).abs();
         let max_val = actual.abs().max(expected.abs());
-        let rel_err = if max_val > 1e-6 { abs_diff / max_val } else { 0.0 };
+        let rel_err = if max_val > 1e-6 {
+            abs_diff / max_val
+        } else {
+            0.0
+        };
 
         // Allow up to 2e-6 relative error (approx 20 epsilons accumulated)
         // or 1e-3 absolute error (whichever passes).
         assert!(
             abs_diff < 1e-3 || rel_err < 2e-6,
             "Len {}: squared_diff_sum mismatch. Expected {}, got {}, abs_diff {}, rel_err {}",
-            len, expected, actual, abs_diff, rel_err
+            len,
+            expected,
+            actual,
+            abs_diff,
+            rel_err
         );
     }
 }
@@ -124,7 +141,11 @@ fn test_scale_in_place_correctness_all_lengths() {
         for i in 0..len {
             assert!(
                 (actual[i] - expected[i]).abs() < 1e-6,
-                "Len {}: mismatch at index {}. Expected {}, got {}", len, i, expected[i], actual[i]
+                "Len {}: mismatch at index {}. Expected {}, got {}",
+                len,
+                i,
+                expected[i],
+                actual[i]
             );
         }
     }
@@ -155,17 +176,23 @@ fn test_simd_alignment_agnostic() {
         assert!(
             (dot_actual - dot_expected).abs() < tolerance,
             "Offset {}: dot mismatch with unaligned slice. Expected {}, got {}",
-            offset, dot_expected, dot_actual
+            offset,
+            dot_expected,
+            dot_actual
         );
         assert!(
             (mag_a_actual - mag_a_expected).abs() < tolerance,
             "Offset {}: mag_a mismatch with unaligned slice. Expected {}, got {}",
-            offset, mag_a_expected, mag_a_actual
+            offset,
+            mag_a_expected,
+            mag_a_actual
         );
         assert!(
             (mag_b_actual - mag_b_expected).abs() < tolerance,
             "Offset {}: mag_b mismatch with unaligned slice. Expected {}, got {}",
-            offset, mag_b_expected, mag_b_actual
+            offset,
+            mag_b_expected,
+            mag_b_actual
         );
 
         // 2. Test squared_diff_sum
@@ -173,11 +200,19 @@ fn test_simd_alignment_agnostic() {
         let actual_sq_diff = simd::squared_diff_sum(slice_a, slice_b);
         let abs_diff = (actual_sq_diff - expected_sq_diff).abs();
         let max_val = actual_sq_diff.abs().max(expected_sq_diff.abs());
-        let rel_err = if max_val > 1e-6 { abs_diff / max_val } else { 0.0 };
+        let rel_err = if max_val > 1e-6 {
+            abs_diff / max_val
+        } else {
+            0.0
+        };
         assert!(
             abs_diff < 1e-3 || rel_err < 2e-6,
             "Offset {}: squared_diff_sum mismatch. Expected {}, got {}, abs_diff {}, rel_err {}",
-            offset, expected_sq_diff, actual_sq_diff, abs_diff, rel_err
+            offset,
+            expected_sq_diff,
+            actual_sq_diff,
+            abs_diff,
+            rel_err
         );
 
         // 3. Test scale_in_place
@@ -195,7 +230,10 @@ fn test_simd_alignment_agnostic() {
                 assert!(
                     (act - exp).abs() < 1e-6,
                     "Offset {}: scale_in_place mismatch at index {}. Expected {}, got {}",
-                    offset, i, exp, act
+                    offset,
+                    i,
+                    exp,
+                    act
                 );
             });
     }

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -1,0 +1,158 @@
+use super::simd;
+
+// ============================================================================
+// Ground Truth Implementations (Scalar)
+// ============================================================================
+
+fn scalar_dot_and_magnitudes(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
+    let mut dot = 0.0;
+    let mut mag_a = 0.0;
+    let mut mag_b = 0.0;
+
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        dot += ai * bi;
+        mag_a += ai * ai;
+        mag_b += bi * bi;
+    }
+    (dot, mag_a, mag_b)
+}
+
+fn scalar_squared_diff_sum(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&ai, &bi)| {
+            let diff = ai - bi;
+            diff * diff
+        })
+        .sum()
+}
+
+fn scalar_scale_in_place(v: &mut [f32], scalar: f32) {
+    for x in v.iter_mut() {
+        *x *= scalar;
+    }
+}
+
+// ============================================================================
+// Correctness Tests
+// ============================================================================
+
+#[test]
+fn test_dot_and_magnitudes_correctness_all_lengths() {
+    // 💣 Risk: SIMD implementations (AVX2/SSE2) often process data in chunks (8 or 4).
+    // Edge cases occur when vector length is not a multiple of the chunk size.
+    // Incorrect handling of the remainder loop can lead to wrong results or out-of-bounds reads.
+
+    // Test every length from 1 to 128 to cover all remainder possibilities (0..7) multiple times.
+    for len in 1..=128 {
+        // Generate deterministic test vectors
+        let a: Vec<f32> = (0..len).map(|i| (i as f32 * 0.1).sin()).collect();
+        let b: Vec<f32> = (0..len).map(|i| (i as f32 * 0.1).cos()).collect();
+
+        // 1. Compute Ground Truth
+        let (dot_expected, mag_a_expected, mag_b_expected) = scalar_dot_and_magnitudes(&a, &b);
+
+        // 2. Compute SIMD (which dispatches to AVX2/SSE2/Scalar based on CPU)
+        let (dot_actual, mag_a_actual, mag_b_actual) = simd::dot_and_magnitudes(&a, &b);
+
+        // 3. Verify
+        // Use 1e-4 tolerance because FMA (Fused Multiply-Add) in AVX2 has higher precision
+        // than scalar multiply-then-add, leading to slight divergence.
+        let tolerance = 1e-4;
+
+        assert!(
+            (dot_actual - dot_expected).abs() < tolerance,
+            "Len {}: dot mismatch. Expected {}, got {}", len, dot_expected, dot_actual
+        );
+        assert!(
+            (mag_a_actual - mag_a_expected).abs() < tolerance,
+            "Len {}: mag_a mismatch. Expected {}, got {}", len, mag_a_expected, mag_a_actual
+        );
+        assert!(
+            (mag_b_actual - mag_b_expected).abs() < tolerance,
+            "Len {}: mag_b mismatch. Expected {}, got {}", len, mag_b_expected, mag_b_actual
+        );
+    }
+}
+
+#[test]
+fn test_squared_diff_sum_correctness_all_lengths() {
+    // 💣 Risk: SIMD accumulation of differences.
+
+    for len in 1..=128 {
+        let a: Vec<f32> = (0..len).map(|i| (i as f32 * 0.2).sin() * 10.0).collect();
+        let b: Vec<f32> = (0..len).map(|i| (i as f32 * 0.2).cos() * 10.0).collect();
+
+        let expected = scalar_squared_diff_sum(&a, &b);
+        let actual = simd::squared_diff_sum(&a, &b);
+
+        // Use a relative tolerance for larger values, or a larger absolute tolerance.
+        // For f32, machine epsilon is ~1.19e-7.
+        // For a value ~3000, error can be ~3000 * 1.2e-7 ≈ 3.6e-4.
+        // SIMD FMA accumulation can differ from scalar sum.
+        let abs_diff = (actual - expected).abs();
+        let max_val = actual.abs().max(expected.abs());
+        let rel_err = if max_val > 1e-6 { abs_diff / max_val } else { 0.0 };
+
+        // Allow up to 2e-6 relative error (approx 20 epsilons accumulated)
+        // or 1e-3 absolute error (whichever passes).
+        assert!(
+            abs_diff < 1e-3 || rel_err < 2e-6,
+            "Len {}: squared_diff_sum mismatch. Expected {}, got {}, abs_diff {}, rel_err {}",
+            len, expected, actual, abs_diff, rel_err
+        );
+    }
+}
+
+#[test]
+fn test_scale_in_place_correctness_all_lengths() {
+    // 💣 Risk: In-place modification with SIMD.
+
+    for len in 1..=128 {
+        let original: Vec<f32> = (0..len).map(|i| i as f32).collect();
+        let scale = 2.5;
+
+        // Ground Truth
+        let mut expected = original.clone();
+        scalar_scale_in_place(&mut expected, scale);
+
+        // SIMD
+        let mut actual = original.clone();
+        simd::scale_in_place(&mut actual, scale);
+
+        // Verify element-wise
+        for i in 0..len {
+            assert!(
+                (actual[i] - expected[i]).abs() < 1e-6,
+                "Len {}: mismatch at index {}. Expected {}, got {}", len, i, expected[i], actual[i]
+            );
+        }
+    }
+}
+
+#[test]
+fn test_simd_alignment_agnostic() {
+    // 💣 Risk: unsafe SIMD loads often require aligned memory.
+    // Rust Vecs are aligned, but slices into them might not be (if we slice from odd offsets).
+    // The implementation uses _mm_loadu_ps (unaligned load), so it should work.
+
+    // Create a buffer larger than needed
+    let buffer: Vec<f32> = (0..200).map(|i| i as f32).collect();
+
+    // Test various unaligned offsets
+    for offset in 1..8 {
+        let len = 100;
+        let slice = &buffer[offset..offset+len];
+
+        // Use the slice as input. slice.as_ptr() will likely be unaligned relative to 32-byte (AVX) boundary.
+        // e.g. f32 is 4 bytes. If buffer is aligned to 32, buffer[1] is at offset 4 (not 32-aligned).
+
+        let expected_mag = scalar_dot_and_magnitudes(slice, slice).1; // mag_a
+        let actual_mag = simd::dot_and_magnitudes(slice, slice).1;
+
+        assert!(
+            (actual_mag - expected_mag).abs() < 1e-4,
+            "Offset {}: magnitude mismatch with unaligned slice", offset
+        );
+    }
+}

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -121,12 +121,12 @@ fn test_scale_in_place_correctness_all_lengths() {
         simd::scale_in_place(&mut actual, scale);
 
         // Verify element-wise
-        actual.iter().zip(expected.iter()).enumerate().for_each(|(i, (act, exp))| {
+        for i in 0..len {
             assert!(
-                (act - exp).abs() < 1e-6,
-                "Len {}: mismatch at index {}. Expected {}, got {}", len, i, exp, act
+                (actual[i] - expected[i]).abs() < 1e-6,
+                "Len {}: mismatch at index {}. Expected {}, got {}", len, i, expected[i], actual[i]
             );
-        });
+        }
     }
 }
 
@@ -136,23 +136,67 @@ fn test_simd_alignment_agnostic() {
     // Rust Vecs are aligned, but slices into them might not be (if we slice from odd offsets).
     // The implementation uses _mm_loadu_ps (unaligned load), so it should work.
 
-    // Create a buffer larger than needed
-    let buffer: Vec<f32> = (0..200).map(|i| i as f32).collect();
+    // Create buffers larger than needed
+    let buffer_a: Vec<f32> = (0..200).map(|i| (i as f32 * 0.1).sin()).collect();
+    let buffer_b: Vec<f32> = (0..200).map(|i| (i as f32 * 0.1).cos()).collect();
 
     // Test various unaligned offsets
     for offset in 1..8 {
         let len = 100;
-        let slice = &buffer[offset..offset+len];
+        let slice_a = &buffer_a[offset..offset + len];
+        let slice_b = &buffer_b[offset..offset + len];
 
-        // Use the slice as input. slice.as_ptr() will likely be unaligned relative to 32-byte (AVX) boundary.
-        // e.g. f32 is 4 bytes. If buffer is aligned to 32, buffer[1] is at offset 4 (not 32-aligned).
+        // 1. Test dot_and_magnitudes
+        let (dot_expected, mag_a_expected, mag_b_expected) =
+            scalar_dot_and_magnitudes(slice_a, slice_b);
+        let (dot_actual, mag_a_actual, mag_b_actual) = simd::dot_and_magnitudes(slice_a, slice_b);
 
-        let expected_mag = scalar_dot_and_magnitudes(slice, slice).1; // mag_a
-        let actual_mag = simd::dot_and_magnitudes(slice, slice).1;
-
+        let tolerance = 1e-4;
         assert!(
-            (actual_mag - expected_mag).abs() < 1e-4,
-            "Offset {}: magnitude mismatch with unaligned slice", offset
+            (dot_actual - dot_expected).abs() < tolerance,
+            "Offset {}: dot mismatch with unaligned slice. Expected {}, got {}",
+            offset, dot_expected, dot_actual
         );
+        assert!(
+            (mag_a_actual - mag_a_expected).abs() < tolerance,
+            "Offset {}: mag_a mismatch with unaligned slice. Expected {}, got {}",
+            offset, mag_a_expected, mag_a_actual
+        );
+        assert!(
+            (mag_b_actual - mag_b_expected).abs() < tolerance,
+            "Offset {}: mag_b mismatch with unaligned slice. Expected {}, got {}",
+            offset, mag_b_expected, mag_b_actual
+        );
+
+        // 2. Test squared_diff_sum
+        let expected_sq_diff = scalar_squared_diff_sum(slice_a, slice_b);
+        let actual_sq_diff = simd::squared_diff_sum(slice_a, slice_b);
+        let abs_diff = (actual_sq_diff - expected_sq_diff).abs();
+        let max_val = actual_sq_diff.abs().max(expected_sq_diff.abs());
+        let rel_err = if max_val > 1e-6 { abs_diff / max_val } else { 0.0 };
+        assert!(
+            abs_diff < 1e-3 || rel_err < 2e-6,
+            "Offset {}: squared_diff_sum mismatch. Expected {}, got {}, abs_diff {}, rel_err {}",
+            offset, expected_sq_diff, actual_sq_diff, abs_diff, rel_err
+        );
+
+        // 3. Test scale_in_place
+        let mut actual_scaled = slice_a.to_vec();
+        let mut expected_scaled = slice_a.to_vec();
+        let scale = 1.5;
+        simd::scale_in_place(&mut actual_scaled, scale);
+        scalar_scale_in_place(&mut expected_scaled, scale);
+
+        actual_scaled
+            .iter()
+            .zip(expected_scaled.iter())
+            .enumerate()
+            .for_each(|(i, (act, exp))| {
+                assert!(
+                    (act - exp).abs() < 1e-6,
+                    "Offset {}: scale_in_place mismatch at index {}. Expected {}, got {}",
+                    offset, i, exp, act
+                );
+            });
     }
 }

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -121,12 +121,12 @@ fn test_scale_in_place_correctness_all_lengths() {
         simd::scale_in_place(&mut actual, scale);
 
         // Verify element-wise
-        for i in 0..len {
+        actual.iter().zip(expected.iter()).enumerate().for_each(|(i, (act, exp))| {
             assert!(
-                (actual[i] - expected[i]).abs() < 1e-6,
-                "Len {}: mismatch at index {}. Expected {}, got {}", len, i, expected[i], actual[i]
+                (act - exp).abs() < 1e-6,
+                "Len {}: mismatch at index {}. Expected {}, got {}", len, i, exp, act
             );
-        }
+        });
     }
 }
 

--- a/tests/hnsw_allocation_tests.rs
+++ b/tests/hnsw_allocation_tests.rs
@@ -119,7 +119,8 @@ fn test_filtered_search_accepts_slices() -> Result<()> {
 
     // Multiple filtered searches with the same buffer
     for _ in 0..20 {
-        let results = index.search_with_filter(&query_buffer, 5, |id: &NodeId| id.as_u64() % 2 == 0)?;
+        let results =
+            index.search_with_filter(&query_buffer, 5, |id: &NodeId| id.as_u64() % 2 == 0)?;
 
         // Verify only even IDs were returned
         for (node_id, _similarity) in results {

--- a/tests/hnsw_allocation_tests.rs
+++ b/tests/hnsw_allocation_tests.rs
@@ -119,7 +119,7 @@ fn test_filtered_search_accepts_slices() -> Result<()> {
 
     // Multiple filtered searches with the same buffer
     for _ in 0..20 {
-        let results = index.search_with_filter(&query_buffer, 5, |id| id.as_u64() % 2 == 0)?;
+        let results = index.search_with_filter(&query_buffer, 5, |id: &NodeId| id.as_u64() % 2 == 0)?;
 
         // Verify only even IDs were returned
         for (node_id, _similarity) in results {

--- a/tests/hnsw_hot_path_optimization_tests.rs
+++ b/tests/hnsw_hot_path_optimization_tests.rs
@@ -54,7 +54,7 @@ fn test_search_with_filter_hot_path_correctness() {
     // This exercises the filter callback on many candidate nodes
     let k = 10;
     let results = index
-        .search_with_filter(&query, k, |id| id.as_u64() % 2 == 0)
+        .search_with_filter(&query, k, |id: &NodeId| id.as_u64() % 2 == 0)
         .expect("Search should succeed");
 
     // Verify all results satisfy the filter predicate
@@ -101,7 +101,7 @@ fn test_search_with_filter_nodeid_safety() {
 
     // Filter that exercises NodeId methods
     let results = index
-        .search_with_filter(&query, 5, |id| {
+        .search_with_filter(&query, 5, |id: &NodeId| {
             // These operations should work without validation overhead
             let raw_id = id.as_u64();
             let is_valid = raw_id < 100;
@@ -208,7 +208,7 @@ fn test_search_vs_search_with_filter_consistency() {
 
     // Search with filter that accepts all nodes
     let filtered_results = index
-        .search_with_filter(&query, k, |_| true)
+        .search_with_filter(&query, k, |_: &NodeId| true)
         .expect("Filtered search should succeed");
 
     // Both should return the same results (since filter accepts all)
@@ -267,7 +267,7 @@ fn test_search_with_filter_performance_sanity_check() {
     let start = std::time::Instant::now();
     for _ in 0..num_searches {
         let _results = index
-            .search_with_filter(&query, k, |id| {
+            .search_with_filter(&query, k, |id: &NodeId| {
                 id.as_u64() % 2 == 0 // Filter to even IDs
             })
             .expect("Search should succeed");

--- a/tests/property_dos.rs
+++ b/tests/property_dos.rs
@@ -25,7 +25,7 @@ fn test_recursive_array_stack_overflow_protection() {
     match result {
         Ok(_) => panic!("Deserialization should have failed due to recursion depth limit"),
         Err(e) => {
-            let msg = e.to_string();
+            let msg: String = e.to_string();
             if !msg.contains("recursion depth limit exceeded") {
                 panic!("Expected recursion limit error, got: {}", msg);
             }

--- a/tests/vector_edge_case_tests.rs
+++ b/tests/vector_edge_case_tests.rs
@@ -86,7 +86,7 @@ fn test_search_with_filter_empty_index() {
         .unwrap();
 
     let results = index
-        .search_with_filter(&[1.0, 0.0, 0.0, 0.0], 10, |_| true)
+        .search_with_filter(&[1.0, 0.0, 0.0, 0.0], 10, |_: &NodeId| true)
         .unwrap();
     assert!(results.is_empty());
 }
@@ -141,7 +141,7 @@ fn test_search_with_filter_no_matches() {
 
     // Filter that matches nothing
     let results = index
-        .search_with_filter(&[0.0, 0.0, 0.0, 0.0], 10, |_| false)
+        .search_with_filter(&[0.0, 0.0, 0.0, 0.0], 10, |_: &NodeId| false)
         .unwrap();
     assert!(results.is_empty());
 }
@@ -408,7 +408,7 @@ fn test_search_with_filter_haversine() {
     }
 
     let results = index
-        .search_with_filter(&[0.0, 0.0], 5, |id| id.as_u64() <= 5)
+        .search_with_filter(&[0.0, 0.0], 5, |id: &NodeId| id.as_u64() <= 5)
         .unwrap();
 
     for (id, _) in &results {
@@ -438,7 +438,7 @@ fn test_search_with_filter_hamming() {
     }
 
     let results = index
-        .search_with_filter(&[1.0, 1.0, 1.0, 1.0], 3, |id| id.as_u64() % 2 == 0)
+        .search_with_filter(&[1.0, 1.0, 1.0, 1.0], 3, |id: &NodeId| id.as_u64() % 2 == 0)
         .unwrap();
 
     for (id, _) in &results {

--- a/tests/vector_hnsw_coverage_tests.rs
+++ b/tests/vector_hnsw_coverage_tests.rs
@@ -536,7 +536,7 @@ fn test_search_with_filter_euclidean() {
 
     // Filter to only IDs > 5
     let results = index
-        .search_with_filter(&[5.0, 0.0, 0.0, 0.0], 5, |id| id.as_u64() > 5)
+        .search_with_filter(&[5.0, 0.0, 0.0, 0.0], 5, |id: &NodeId| id.as_u64() > 5)
         .unwrap();
 
     for (id, _) in &results {
@@ -556,7 +556,7 @@ fn test_search_with_filter_dot_product() {
     }
 
     let results = index
-        .search_with_filter(&[1.0, 0.0, 0.0, 0.0], 3, |id| id.as_u64() % 2 == 0)
+        .search_with_filter(&[1.0, 0.0, 0.0, 0.0], 3, |id: &NodeId| id.as_u64() % 2 == 0)
         .unwrap();
 
     for (id, _) in &results {
@@ -603,7 +603,7 @@ fn test_dimension_mismatch_on_search_with_filter() {
     let node = NodeId::new(1).unwrap();
     index.add(node, &[1.0, 0.0, 0.0, 0.0]).unwrap();
 
-    let result = index.search_with_filter(&[1.0, 0.0], 1, |_| true);
+    let result = index.search_with_filter(&[1.0, 0.0], 1, |_: &NodeId| true);
     assert!(result.is_err());
 }
 
@@ -654,7 +654,7 @@ fn test_search_with_filter_tanimoto() {
     }
 
     let results = index
-        .search_with_filter(&[1.0, 1.0, 1.0, 1.0], 3, |id| id.as_u64() <= 5)
+        .search_with_filter(&[1.0, 1.0, 1.0, 1.0], 3, |id: &NodeId| id.as_u64() <= 5)
         .unwrap();
 
     for (id, similarity) in &results {


### PR DESCRIPTION
This PR introduces a comprehensive test suite for the `src/core/vector/simd.rs` module, addressing the risk of bugs in `unsafe` SIMD operations (AVX2/SSE2).

**🎯 Target:** `src/core/vector/simd.rs` (SIMD vector operations).

**💣 Risk:**
- Off-by-one errors in loop boundaries handling remainder elements (when length is not a multiple of 4 or 8).
- Alignment issues with unsafe `_mm_loadu_ps` usage.
- Precision discrepancies between FMA (Fused Multiply-Add) and scalar operations.

**🧪 Strategy:**
- Created `src/core/vector/sentry_tests.rs` containing local scalar "ground truth" implementations.
- Implemented `test_dot_and_magnitudes_correctness_all_lengths` which iterates through vector lengths 1 to 128 (covering all remainder possibilities).
- Implemented `test_simd_alignment_agnostic` to verify robustness against unaligned memory slices.
- Used relative error checks to accommodate the higher precision of AVX2 FMA instructions compared to scalar accumulation.

**🔬 Verification:**
- `cargo test core::vector::sentry_tests` passes.
- `cargo test core::vector` passes (no regressions).

---
*PR created automatically by Jules for task [10875723791503128823](https://jules.google.com/task/10875723791503128823) started by @madmax983*