### PR TITLE
🔒 Warden: Fix DoS in FindNode via unbounded limit

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -164,3 +164,17 @@ Added `tests/repro_allocation_dos.rs` simulating malicious payloads. Confirmed t
 
 **Verification:** Regression Test
 Added `tests/warden_vector_safety.rs` which attempts to insert and serialize oversized vectors using the `try_` methods. Verified that they now return `VectorError::DimensionTooLarge` instead of crashing the test runner.
+
+## 2026-02-19 - FindNode DoS Lockdown
+
+**Threat:** Memory Exhaustion (DoS) in FindNode
+The `FindNode` HTTP endpoint accepted an unbounded `limit` parameter from the user. This was passed directly to the query executor, which could potentially attempt to collect a massive number of results into a `Vec` before serialization, leading to Out Of Memory (OOM) crashes.
+
+**Defense:** Global Result Limits
+- Defined `MAX_RESULT_LIMIT = 1000` and `MAX_PAGINATION_LIMIT = 10,000` constants in `src/http/handlers.rs`.
+- Enforced these limits on `FindNode`: `limit` is capped at `MAX_RESULT_LIMIT`, and `offset + limit` must not exceed `MAX_PAGINATION_LIMIT`.
+- Standardized `FindNeighbors` to use these shared constants.
+
+**Verification:** Reproduction Test
+Added `tests/warden_dos_find_node.rs` which requests 2000 nodes when 1500 exist.
+- Verified that the response is capped at 1000 nodes, confirming the defense is active.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -10,6 +10,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 
+/// Maximum number of results to return in a single query.
+const MAX_RESULT_LIMIT: usize = 1_000;
+
+/// Maximum allowable sum of offset + limit to prevent CPU DoS via deep pagination.
+const MAX_PAGINATION_LIMIT: usize = 10_000;
+
 /// Health check response structure.
 #[derive(Debug, Serialize)]
 pub struct HealthResponse {
@@ -197,7 +203,18 @@ pub async fn handle_query(
                 builder = builder.skip(skip);
             }
 
-            let limit_val = limit.unwrap_or(100);
+            // Safety limits to prevent DoS
+            let limit_val = limit.unwrap_or(100).min(MAX_RESULT_LIMIT);
+            let offset_val = offset.unwrap_or(0);
+
+            // Prevent deep pagination attacks (CPU DoS)
+            if offset_val.saturating_add(limit_val) > MAX_PAGINATION_LIMIT {
+                return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+                    "Pagination limit exceeded: offset + limit must be <= {}",
+                    MAX_PAGINATION_LIMIT
+                )));
+            }
+
             match builder.limit(limit_val).execute(db) {
                 Ok(results) => {
                     let mut nodes = Vec::new();
@@ -232,17 +249,14 @@ pub async fn handle_query(
             match NodeId::new(node_id) {
                 Ok(nid) => {
                     // Safety limits to prevent DoS
-                    let max_limit = 1000;
-                    let max_deep_pagination = 10_000;
-
-                    let limit_val = limit.unwrap_or(100).min(max_limit);
+                    let limit_val = limit.unwrap_or(100).min(MAX_RESULT_LIMIT);
                     let offset_val = offset.unwrap_or(0);
 
                     // Prevent deep pagination attacks (CPU DoS)
-                    if offset_val + limit_val > max_deep_pagination {
+                    if offset_val.saturating_add(limit_val) > MAX_PAGINATION_LIMIT {
                         return HttpResponse::BadRequest().json(ApiResponse::error(format!(
                             "Pagination limit exceeded: offset + limit must be <= {}",
-                            max_deep_pagination
+                            MAX_PAGINATION_LIMIT
                         )));
                     }
 

--- a/tests/havoc_deadlock.rs
+++ b/tests/havoc_deadlock.rs
@@ -1,6 +1,6 @@
-use gallifreydb::core::id::NodeId;
-use gallifreydb::index::VectorIndex;
-use gallifreydb::index::vector::{DistanceMetric, HnswIndexBuilder};
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -89,7 +89,7 @@ fn run_deadlock_stress_test() {
             for _ in 0..ITERATIONS {
                 // Filter that accesses node ID (reverse mapping)
                 // We access the node ID to force the closure to actually do something with the mapping
-                let result = index.search_with_filter(&query, 10, |id| id.as_u64() % 2 == 0);
+                let result = index.search_with_filter(&query, 10, |id: &NodeId| id.as_u64() & 1 == 0);
                 if result.is_ok() {
                     counter.fetch_add(1, Ordering::Relaxed);
                 }

--- a/tests/havoc_deadlock.rs
+++ b/tests/havoc_deadlock.rs
@@ -89,7 +89,8 @@ fn run_deadlock_stress_test() {
             for _ in 0..ITERATIONS {
                 // Filter that accesses node ID (reverse mapping)
                 // We access the node ID to force the closure to actually do something with the mapping
-                let result = index.search_with_filter(&query, 10, |id: &NodeId| id.as_u64() & 1 == 0);
+                let result =
+                    index.search_with_filter(&query, 10, |id: &NodeId| id.as_u64() & 1 == 0);
                 if result.is_ok() {
                     counter.fetch_add(1, Ordering::Relaxed);
                 }

--- a/tests/havoc_property.rs
+++ b/tests/havoc_property.rs
@@ -1,5 +1,5 @@
-use gallifreydb::core::PropertyValue;
-use gallifreydb::core::property::MAX_VECTOR_DIMENSIONS;
+use aletheiadb::core::PropertyValue;
+use aletheiadb::core::property::MAX_VECTOR_DIMENSIONS;
 use proptest::prelude::*;
 
 const TAG_VECTOR: u8 = 7;

--- a/tests/warden_dos_find_node.rs
+++ b/tests/warden_dos_find_node.rs
@@ -1,0 +1,65 @@
+#[cfg(feature = "http-server")]
+mod tests {
+    use actix_web::{App, test, web};
+    use aletheiadb::AletheiaDB;
+    use aletheiadb::http::{AppState, configure_app};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[actix_rt::test]
+    async fn test_find_node_result_limit_enforcement() {
+        // Setup in-memory DB
+        let db = Arc::new(AletheiaDB::new().expect("Failed to create DB"));
+        let state = AppState::new(db.clone());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state.clone()))
+                .configure(configure_app),
+        )
+        .await;
+
+        // Populate DB with 1500 nodes (exceeding the standard 1000 limit)
+        // We use a label "DosTarget" to easily scan them
+        let count = 1500;
+        for i in 0..count {
+            db.create_node(
+                "DosTarget",
+                aletheiadb::core::PropertyMapBuilder::new()
+                    .insert("idx", i as i64)
+                    .build(),
+            )
+            .unwrap();
+        }
+
+        // Send FindNode request with limit > 1000
+        let find_req = json!({
+            "operation": "find_node",
+            "label": "DosTarget",
+            "limit": 2000,
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&find_req)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 200, "Find node request failed");
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["success"], true);
+
+        let nodes = body["data"].as_array().expect("Data should be array");
+
+        // VULNERABILITY CHECK:
+        // If vulnerabilities exists: returns 1500 (all nodes) because we asked for 2000
+        // If fortified: returns 1000 (MAX_RESULT_LIMIT)
+        let returned_count = nodes.len();
+        println!("Returned count: {}", returned_count);
+
+        // This assertion expects the SAFE behavior (1000).
+        // It will FAIL initially (Red Phase).
+        assert_eq!(returned_count, 1000, "Should cap results at 1000 to prevent DoS");
+    }
+}

--- a/tests/warden_dos_find_node.rs
+++ b/tests/warden_dos_find_node.rs
@@ -60,6 +60,9 @@ mod tests {
 
         // This assertion expects the SAFE behavior (1000).
         // It will FAIL initially (Red Phase).
-        assert_eq!(returned_count, 1000, "Should cap results at 1000 to prevent DoS");
+        assert_eq!(
+            returned_count, 1000,
+            "Should cap results at 1000 to prevent DoS"
+        );
     }
 }


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability in the `FindNode` endpoint where an unbounded `limit` parameter could lead to memory exhaustion (OOM).

**Changes:**
- Defined `MAX_RESULT_LIMIT = 1000` and `MAX_PAGINATION_LIMIT = 10,000` in `src/http/handlers.rs`.
- Updated `FindNode` and `FindNeighbors` handlers to clamp the `limit` parameter and validate pagination depth using `saturating_add` (security fix for integer overflow).
- Added `tests/warden_dos_find_node.rs` to verify the fix.
- Fixed stale imports (`gallifreydb`) in `tests/havoc_deadlock.rs` and `tests/havoc_property.rs`.
- Addressed a clippy lint in `tests/havoc_deadlock.rs` by optimizing a modulo check.

**Verification:**
- `cargo test --test warden_dos_find_node` passes (caps results at 1000).
- `cargo test --test http_api` passes.
- `cargo clippy` is clean.

---
*PR created automatically by Jules for task [3023299516218983927](https://jules.google.com/task/3023299516218983927) started by @madmax983*