### PR TITLE
Fix deadlock in HNSW index by enforcing strict lock ordering

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -671,6 +671,10 @@ impl VectorIndex for HnswIndex {
             }));
         }
 
+        // Acquire inner lock FIRST to prevent deadlocks (PR #751).
+        // This respects the lock ordering invariant: inner > id_mapping.
+        let index = self.inner.write();
+
         // Get or create key for this NodeId
         // Use entry API for atomic check-and-update to prevent race conditions
         match self.id_mapping.entry(id) {
@@ -679,12 +683,6 @@ impl VectorIndex for HnswIndex {
                 // Optimization (Issue #207): Only call remove() if key actually exists in usearch.
                 // This avoids unnecessary FFI calls during recovery or when mappings are out of sync.
                 let existing_key = *entry.get();
-
-                // CRITICAL: Hold write lock continuously from remove to add to prevent race conditions
-                // where multiple threads try to update the same node concurrently (PR #575).
-                // Without this, thread A could remove, thread B could remove (fail), then both try to add,
-                // causing "Duplicate keys not allowed" error.
-                let index = self.inner.write();
 
                 // Check if key exists before removing to avoid wasteful FFI call
                 if index.contains(existing_key) {
@@ -752,7 +750,6 @@ impl VectorIndex for HnswIndex {
                 };
 
                 // Insert into usearch index (auto-expand capacity if needed)
-                let index = self.inner.write();
 
                 // Check if we need to expand capacity
                 if index.size() >= index.capacity() {
@@ -1024,6 +1021,13 @@ impl VectorIndex for HnswIndex {
 
 // Private helper methods for HnswIndex
 impl HnswIndex {
+    /// Helper for chaos testing to verify lock ordering.
+    /// Accesses id_mapping only (Lock A).
+    #[doc(hidden)]
+    pub fn inspect_ids(&self) -> usize {
+        self.id_mapping.len()
+    }
+
     /// Internal implementation of index saving.
     ///
     /// This method performs the actual blocking I/O operations for saving the index

--- a/tests/havoc_deadlock_hnsw.rs
+++ b/tests/havoc_deadlock_hnsw.rs
@@ -1,0 +1,108 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+use tempfile::tempdir;
+
+#[test]
+fn test_havoc_deadlock_search_add() {
+    // 🧨 DEADLOCK REPRODUCTION 🧨
+    // Scenario:
+    // Thread 1 (Search): Acquires `inner` (Read) -> Calls Predicate -> Spawns T3 -> T3 calls `save` -> T3 Iterates `id_mapping` (Wants A).
+    // Thread 2 (Add): Acquires `id_mapping` (Write) -> Wants `inner` (Write).
+    //
+    // Cycle: T1 (Inner) -> Waits T3 -> T3 (Wants IdMap) -> Blocked by T2 -> T2 (IdMap) -> Wants Inner (Held by T1).
+    // Note: T2 waits for Inner(Write). T1 holds Inner(Read). T2 cannot proceed.
+    // T3 needs IdMap. T2 holds IdMap. T3 cannot proceed.
+    // T1 waits for T3. T1 cannot proceed.
+
+    let _dir = tempdir().unwrap();
+
+    // Create index
+    let index = Arc::new(
+        HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap()
+    );
+
+    // Populate with one node (Node 1) so we can update it (Occupied path)
+    let node1 = NodeId::new(1).unwrap();
+    index.add(node1, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+    let start_barrier = Arc::new(Barrier::new(2));
+
+    let index_clone1 = index.clone();
+    let start_barrier1 = start_barrier.clone();
+
+    // Thread 1: Search with evil predicate
+    let t1 = thread::spawn(move || {
+        start_barrier1.wait();
+        // Reduced iterations to make it run faster but still trigger
+        for _ in 0..100 {
+            let index_clone2 = index_clone1.clone();
+
+            let _ = index_clone1.search_with_filter(
+                &[1.0, 0.0, 0.0, 0.0],
+                1,
+                |_id| {
+                    // Spawn T3 to access id_mapping (via inspect_ids)
+                    // We spawn to avoid holding T1's stack, but T3 runs concurrently.
+                    let index_clone3 = index_clone2.clone();
+                    let t3 = thread::spawn(move || {
+                         // Calls inspect_ids(), which iterates id_mapping.
+                         // This requires id_mapping read lock.
+                         // It does NOT require inner lock.
+                         let _ = index_clone3.inspect_ids();
+                    });
+
+                    // Wait for T3. This keeps T1 blocked (holding Inner Read lock).
+                    t3.join().unwrap();
+                    true
+                }
+            );
+            thread::yield_now();
+        }
+    });
+
+    let index_clone2 = index.clone();
+    let start_barrier2 = start_barrier.clone();
+
+    // Thread 2: Add loop (Occupied)
+    let t2 = thread::spawn(move || {
+        start_barrier2.wait();
+        let node1 = NodeId::new(1).unwrap();
+        for i in 0..100 {
+            // Update node1 repeatedly
+            // Occupied path: Holds IdMap lock -> Acquires Inner(Write)
+            // Use different vectors to ensure actual updates
+            let val = (i % 10) as f32 / 10.0;
+            let _ = index_clone2.add(node1, &[val, 1.0 - val, 0.0, 0.0]);
+            thread::yield_now();
+        }
+    });
+
+    // Verification wrapper
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let tx1 = tx.clone();
+    thread::spawn(move || {
+        t1.join().unwrap();
+        let _ = tx1.send("T1 done");
+    });
+
+    let tx2 = tx.clone();
+    thread::spawn(move || {
+        t2.join().unwrap();
+        let _ = tx2.send("T2 done");
+    });
+
+    // We expect 2 completions. Timeout 10s.
+    println!("Waiting for threads...");
+    for i in 0..2 {
+        if rx.recv_timeout(Duration::from_secs(10)).is_err() {
+            panic!("DEADLOCK DETECTED: Threads failed to complete within 10 seconds. Iteration {}", i);
+        }
+        println!("Thread completed.");
+    }
+}

--- a/tests/havoc_deadlock_hnsw.rs
+++ b/tests/havoc_deadlock_hnsw.rs
@@ -23,7 +23,7 @@ fn test_havoc_deadlock_search_add() {
     let index = Arc::new(
         HnswIndexBuilder::new(4, DistanceMetric::Cosine)
             .build()
-            .unwrap()
+            .unwrap(),
     );
 
     // Populate with one node (Node 1) so we can update it (Occupied path)
@@ -42,25 +42,21 @@ fn test_havoc_deadlock_search_add() {
         for _ in 0..100 {
             let index_clone2 = index_clone1.clone();
 
-            let _ = index_clone1.search_with_filter(
-                &[1.0, 0.0, 0.0, 0.0],
-                1,
-                |_id| {
-                    // Spawn T3 to access id_mapping (via inspect_ids)
-                    // We spawn to avoid holding T1's stack, but T3 runs concurrently.
-                    let index_clone3 = index_clone2.clone();
-                    let t3 = thread::spawn(move || {
-                         // Calls inspect_ids(), which iterates id_mapping.
-                         // This requires id_mapping read lock.
-                         // It does NOT require inner lock.
-                         let _ = index_clone3.inspect_ids();
-                    });
+            let _ = index_clone1.search_with_filter(&[1.0, 0.0, 0.0, 0.0], 1, |_id| {
+                // Spawn T3 to access id_mapping (via inspect_ids)
+                // We spawn to avoid holding T1's stack, but T3 runs concurrently.
+                let index_clone3 = index_clone2.clone();
+                let t3 = thread::spawn(move || {
+                    // Calls inspect_ids(), which iterates id_mapping.
+                    // This requires id_mapping read lock.
+                    // It does NOT require inner lock.
+                    let _ = index_clone3.inspect_ids();
+                });
 
-                    // Wait for T3. This keeps T1 blocked (holding Inner Read lock).
-                    t3.join().unwrap();
-                    true
-                }
-            );
+                // Wait for T3. This keeps T1 blocked (holding Inner Read lock).
+                t3.join().unwrap();
+                true
+            });
             thread::yield_now();
         }
     });
@@ -101,7 +97,10 @@ fn test_havoc_deadlock_search_add() {
     println!("Waiting for threads...");
     for i in 0..2 {
         if rx.recv_timeout(Duration::from_secs(10)).is_err() {
-            panic!("DEADLOCK DETECTED: Threads failed to complete within 10 seconds. Iteration {}", i);
+            panic!(
+                "DEADLOCK DETECTED: Threads failed to complete within 10 seconds. Iteration {}",
+                i
+            );
         }
         println!("Thread completed.");
     }


### PR DESCRIPTION
Resolved an AB-BA deadlock between HnswIndex::add and search operations involving callbacks.
        
        Detailed changes:
        - Moved `inner` lock acquisition to the top of `HnswIndex::add` to enforce "Inner > DashMap" lock ordering invariant.
        - Added `inspect_ids` helper method (doc hidden) to allow verifying state without acquiring `inner` lock.
        - Added regression test `tests/havoc_deadlock_hnsw.rs` simulating the concurrency scenario.
        
        This prevents system hangs when high-contention add operations coincide with searches that trigger index introspection.

---
*PR created automatically by Jules for task [14190452213892638009](https://jules.google.com/task/14190452213892638009) started by @madmax983*