### PR TITLE
🔒 Warden: Fix pagination integer overflow and missing checks

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -164,3 +164,18 @@ Added `tests/repro_allocation_dos.rs` simulating malicious payloads. Confirmed t
 
 **Verification:** Regression Test
 Added `tests/warden_vector_safety.rs` which attempts to insert and serialize oversized vectors using the `try_` methods. Verified that they now return `VectorError::DimensionTooLarge` instead of crashing the test runner.
+
+## 2026-02-19 - Pagination DoS Hardening
+
+**Threat:** Integer Overflow Bypass for DoS Protection
+The `FindNeighbors` endpoint had a deep pagination check `if offset + limit > 10000`. However, a malicious request with `offset = usize::MAX` and `limit = 1` would cause an integer overflow (wrapping to 0), bypassing the check. This would force the server to attempt an iteration of `usize::MAX` items (CPU DoS).
+Additionally, `FindNode` endpoint completely lacked this deep pagination check.
+
+**Defense:** Saturating Arithmetic & Validation
+- Replaced `+` with `saturating_add` in `FindNeighbors` to safely saturate at `usize::MAX` on overflow, correctly triggering the limit check.
+- Added strict pagination validation to `FindNode` endpoint using the same logic.
+
+**Verification:** Regression Test
+Added `test_warden_find_neighbors_overflow` and `test_warden_find_node_deep_pagination` in `src/http/handlers.rs`.
+- Confirmed that `offset = usize::MAX` now returns `400 Bad Request` instead of bypassing the check.
+- Confirmed that deep pagination in `FindNode` now returns `400 Bad Request`.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -193,11 +193,23 @@ pub async fn handle_query(
             }
 
             // Issue 4: Pagination
+            let limit_val = limit.unwrap_or(100);
+            let offset_val = offset.unwrap_or(0);
+
+            // Prevent deep pagination attacks (CPU DoS)
+            // Use saturating_add to prevent integer overflow bypass
+            let max_deep_pagination = 10_000;
+            if offset_val.saturating_add(limit_val) > max_deep_pagination {
+                return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+                    "Pagination limit exceeded: offset + limit must be <= {}",
+                    max_deep_pagination
+                )));
+            }
+
             if let Some(skip) = offset {
                 builder = builder.skip(skip);
             }
 
-            let limit_val = limit.unwrap_or(100);
             match builder.limit(limit_val).execute(db) {
                 Ok(results) => {
                     let mut nodes = Vec::new();
@@ -239,7 +251,8 @@ pub async fn handle_query(
                     let offset_val = offset.unwrap_or(0);
 
                     // Prevent deep pagination attacks (CPU DoS)
-                    if offset_val + limit_val > max_deep_pagination {
+                    // Use saturating_add to prevent integer overflow bypass
+                    if offset_val.saturating_add(limit_val) > max_deep_pagination {
                         return HttpResponse::BadRequest().json(ApiResponse::error(format!(
                             "Pagination limit exceeded: offset + limit must be <= {}",
                             max_deep_pagination
@@ -330,5 +343,78 @@ mod tests {
             serde_json::from_slice(&body).expect("Response body should be valid JSON");
 
         assert_eq!(json["status"], "healthy");
+    }
+
+    // Warden: Reproduction of integer overflow in FindNeighbors
+    #[actix_rt::test]
+    async fn test_warden_find_neighbors_overflow() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+        let state = web::Data::new(AppState::new(db));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query))
+        ).await;
+
+        // Malicious payload: offset = usize::MAX, limit = 1
+        // offset + limit = usize::MAX + 1 = 0 (wrapped), which is < max_deep_pagination (10000)
+        let payload = json!({
+            "operation": "find_neighbors",
+            "node_id": 1,
+            "offset": usize::MAX,
+            "limit": 1
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+
+        // VULNERABLE: Returns 200 OK because the check was bypassed
+        // SECURE: Should return 400 Bad Request
+
+        assert!(resp.status().is_client_error(), "Should reject overflow attempt");
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let error = json["error"].as_str().unwrap();
+        assert!(error.contains("Pagination limit exceeded"), "Error: {}", error);
+    }
+
+    // Warden: Check if FindNode allows deep pagination
+    #[actix_rt::test]
+    async fn test_warden_find_node_deep_pagination() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+        let state = web::Data::new(AppState::new(db));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query))
+        ).await;
+
+        // Deep pagination request
+        let payload = json!({
+            "operation": "find_node",
+            "label": "Person",
+            "offset": 100_000,
+            "limit": 10
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+
+        // SECURE: Should return 400 Bad Request
+        assert!(resp.status().is_client_error(), "Should reject deep pagination");
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let error = json["error"].as_str().unwrap();
+        assert!(error.contains("Pagination limit exceeded"), "Error: {}", error);
     }
 }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -354,8 +354,9 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(state)
-                .route("/query", web::post().to(handle_query))
-        ).await;
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
 
         // Malicious payload: offset = usize::MAX, limit = 1
         // offset + limit = usize::MAX + 1 = 0 (wrapped), which is < max_deep_pagination (10000)
@@ -376,11 +377,18 @@ mod tests {
         // VULNERABLE: Returns 200 OK because the check was bypassed
         // SECURE: Should return 400 Bad Request
 
-        assert!(resp.status().is_client_error(), "Should reject overflow attempt");
+        assert!(
+            resp.status().is_client_error(),
+            "Should reject overflow attempt"
+        );
         let body = test::read_body(resp).await;
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let error = json["error"].as_str().unwrap();
-        assert!(error.contains("Pagination limit exceeded"), "Error: {}", error);
+        assert!(
+            error.contains("Pagination limit exceeded"),
+            "Error: {}",
+            error
+        );
     }
 
     // Warden: Check if FindNode allows deep pagination
@@ -392,8 +400,9 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(state)
-                .route("/query", web::post().to(handle_query))
-        ).await;
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
 
         // Deep pagination request
         let payload = json!({
@@ -411,10 +420,17 @@ mod tests {
         let resp = test::call_service(&app, req).await;
 
         // SECURE: Should return 400 Bad Request
-        assert!(resp.status().is_client_error(), "Should reject deep pagination");
+        assert!(
+            resp.status().is_client_error(),
+            "Should reject deep pagination"
+        );
         let body = test::read_body(resp).await;
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let error = json["error"].as_str().unwrap();
-        assert!(error.contains("Pagination limit exceeded"), "Error: {}", error);
+        assert!(
+            error.contains("Pagination limit exceeded"),
+            "Error: {}",
+            error
+        );
     }
 }


### PR DESCRIPTION
# Security Fix: Pagination DoS Hardening

## Threat
Two vulnerabilities were identified in the HTTP API pagination logic:
1.  **Integer Overflow Bypass:** In `FindNeighbors`, the check `offset + limit > max` was vulnerable to integer overflow. A malicious request with `offset = usize::MAX` and `limit = 1` would wrap to `0`, bypassing the check and causing the server to attempt an expensive skip operation (CPU DoS).
2.  **Missing Validation:** The `FindNode` endpoint lacked any deep pagination check, allowing unbounded `offset` values.

## Defense
- **Saturating Arithmetic:** Replaced `+` with `saturating_add` in `FindNeighbors` to ensure overflow saturates at `MAX` rather than wrapping, correctly triggering the limit check.
- **Validation Added:** Implemented the same strict pagination limit (offset + limit <= 10,000) in `FindNode`.

## Verification
Added regression tests `test_warden_find_neighbors_overflow` and `test_warden_find_node_deep_pagination` which confirm that malicious requests are now rejected with `400 Bad Request`.

---
*PR created automatically by Jules for task [15585995186545845479](https://jules.google.com/task/15585995186545845479) started by @madmax983*