### PR TITLE
👺 Havoc: Fix HnswIndex 'Phantom Vector' race condition

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -727,7 +727,7 @@ impl VectorIndex for HnswIndex {
                 // New node: allocate key with overflow protection
                 // Check BEFORE incrementing to avoid leaving next_key in invalid state
                 const MAX_VALID_KEY: u64 = u64::MAX - 1000;
-                let key = loop {
+                loop {
                     let current = self.next_key.load(Ordering::SeqCst);
                     if current > MAX_VALID_KEY {
                         return Err(Error::Vector(VectorError::IndexError(
@@ -743,38 +743,42 @@ impl VectorIndex for HnswIndex {
                         Ordering::SeqCst,
                     ) {
                         Ok(key) => {
-                            entry.insert(key);
+                            // Fix for race condition (Phantom Vector):
+                            // Hold the id_mapping lock (via the returned RefMut) until we have
+                            // updated the inner index. This prevents remove() from seeing the
+                            // new mapping before the vector is actually in the index.
+                            let _guard = entry.insert(key);
                             self.reverse_mapping.insert(key, id);
-                            break key;
+
+
+                            // Insert into usearch index (auto-expand capacity if needed)
+                            let index = self.inner.write();
+
+                            // Check if we need to expand capacity
+                            if index.size() >= index.capacity() {
+                                // Double capacity, minimum 1024
+                                let new_capacity = (index.capacity() * 2).max(1024);
+                                index.reserve(new_capacity).map_err(|e| {
+                                    Error::Vector(VectorError::IndexError(format!(
+                                        "Failed to expand capacity: {}",
+                                        e
+                                    )))
+                                })?;
+                            }
+
+                            index.add(key, vector).map_err(|e| {
+                                Error::Vector(VectorError::IndexError(format!(
+                                    "Failed to add vector: {}",
+                                    e
+                                )))
+                            })?;
+
+                            self.stats.vectors_added.fetch_add(1, Ordering::Relaxed);
+                            return Ok(());
                         }
                         Err(_) => continue, // Retry with new current value
                     }
-                };
-
-                // Insert into usearch index (auto-expand capacity if needed)
-                let index = self.inner.write();
-
-                // Check if we need to expand capacity
-                if index.size() >= index.capacity() {
-                    // Double capacity, minimum 1024
-                    let new_capacity = (index.capacity() * 2).max(1024);
-                    index.reserve(new_capacity).map_err(|e| {
-                        Error::Vector(VectorError::IndexError(format!(
-                            "Failed to expand capacity: {}",
-                            e
-                        )))
-                    })?;
                 }
-
-                index.add(key, vector).map_err(|e| {
-                    Error::Vector(VectorError::IndexError(format!(
-                        "Failed to add vector: {}",
-                        e
-                    )))
-                })?;
-
-                self.stats.vectors_added.fetch_add(1, Ordering::Relaxed);
-                Ok(())
             }
         }
     }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -750,7 +750,6 @@ impl VectorIndex for HnswIndex {
                             let _guard = entry.insert(key);
                             self.reverse_mapping.insert(key, id);
 
-
                             // Insert into usearch index (auto-expand capacity if needed)
                             let index = self.inner.write();
 

--- a/tests/havoc_race_inconsistency.rs
+++ b/tests/havoc_race_inconsistency.rs
@@ -1,5 +1,5 @@
-use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
@@ -75,7 +75,10 @@ fn havoc_race_phantom_vector() {
     }
 
     if phantom_count > 0 {
-        panic!("❌ FAILED: Leaked {} phantom vectors due to race condition.", phantom_count);
+        panic!(
+            "❌ FAILED: Leaked {} phantom vectors due to race condition.",
+            phantom_count
+        );
     } else {
         println!("✅ Survived without leaks (maybe lucky timing?)");
     }

--- a/tests/havoc_race_inconsistency.rs
+++ b/tests/havoc_race_inconsistency.rs
@@ -1,0 +1,82 @@
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
+use aletheiadb::core::id::NodeId;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+/// 👺 HAVOC RACE CONDITION TEST
+///
+/// Triggers the "Phantom Vector" race condition where a vector is added to the
+/// usearch index but its mapping is removed, causing a memory leak and state inconsistency.
+///
+/// Race Sequence:
+/// 1. Thread 1 (Add): Inserts into id_mapping (Vacant path) -> Releases lock
+/// 2. Thread 2 (Remove): Removes from id_mapping and reverse_mapping
+/// 3. Thread 2 (Remove): Removes from inner usearch index (no-op if key not yet added)
+/// 4. Thread 1 (Add): Adds to inner usearch index
+///
+/// Result: Vector exists in usearch but has no mapping. It is invisible to search
+/// (filtered out) but consumes memory and capacity.
+#[test]
+fn havoc_race_phantom_vector() {
+    let index = Arc::new(
+        HnswIndexBuilder::new(128, DistanceMetric::Cosine)
+            .build()
+            .expect("Failed to build index"),
+    );
+
+    let mut phantom_count = 0;
+    let iterations = 500;
+
+    println!("👺 Starting Havoc Race Test ({} iterations)...", iterations);
+
+    for i in 0..iterations {
+        let node_id = NodeId::new(i as u64 + 1).unwrap();
+        let vector = vec![1.0; 128];
+
+        let idx1 = index.clone();
+        let idx2 = index.clone();
+        let barrier = Arc::new(Barrier::new(2));
+        let b1 = barrier.clone();
+        let b2 = barrier.clone();
+
+        // Thread 1: Add
+        let t1 = thread::spawn(move || {
+            b1.wait();
+            idx1.add(node_id, &vector).unwrap();
+        });
+
+        // Thread 2: Remove
+        let t2 = thread::spawn(move || {
+            b2.wait();
+            // Busy wait to try to hit the race window
+            // The window is between mapping insertion and inner lock acquisition
+            // This is tight, so we yield a bit
+            if i % 2 == 0 {
+                thread::yield_now();
+            }
+            idx2.remove(node_id).unwrap();
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        // Attempt to clean up
+        // If the state is consistent, this should remove the vector (if it exists)
+        // If inconsistent (Phantom), this will fail to remove it because mapping is missing
+        let _ = index.remove(node_id);
+
+        let current_len = index.len();
+        if current_len > phantom_count {
+            phantom_count = current_len;
+            if phantom_count % 10 == 0 {
+                println!("🔥 Phantom Vector Leaked! Count: {}", phantom_count);
+            }
+        }
+    }
+
+    if phantom_count > 0 {
+        panic!("❌ FAILED: Leaked {} phantom vectors due to race condition.", phantom_count);
+    } else {
+        println!("✅ Survived without leaks (maybe lucky timing?)");
+    }
+}


### PR DESCRIPTION
This PR fixes a race condition in `HnswIndex::add` where a vector could be added to the underlying `usearch` index *after* its ID mapping had been removed by a concurrent thread. This resulted in "phantom vectors" that consumed memory and capacity but were invisible to search queries (because the reverse mapping was missing).

The fix involves holding the `id_mapping` shard lock (via `RefMut`) throughout the entire addition process, including the update to the `inner` index. This serializes operations on the same shard, ensuring atomicity.

A regression test `tests/havoc_race_inconsistency.rs` has been added.

---
*PR created automatically by Jules for task [13994010680944121919](https://jules.google.com/task/13994010680944121919) started by @madmax983*