### PR TITLE
🛡️ Sentry: Fix vector dimension bypass and potential panic in JSON conversion

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - False Fallibility in PropertyMapBuilder
 **Learning:** API methods like `try_insert_vector` imply fallibility via `Result` but call underlying methods that panic on validation errors (e.g., `PropertyValue::vector`).
 **Action:** Document these panic points with `#[should_panic]` tests immediately. In the future, refactor to proper error propagation to match the function signature's promise.
+
+## 2026-02-15 - False Fallibility in JSON Conversion
+**Learning:** `serde_json` array conversion to `PropertyValue::Vector` was bypassing `MAX_VECTOR_DIMENSIONS` validation because it constructed the enum variant directly instead of using the validating constructor. Also, `PropertyMapBuilder::insert` panics on error, which is unsafe for public APIs.
+**Action:** Always validate dimensions when constructing `Vector` variants manually. Use `try_insert` in API layers and propagate errors.

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -135,7 +135,9 @@ pub fn json_to_property_map(
     let mut builder = PropertyMapBuilder::new();
     for (key, value) in json {
         let pv = json_to_property_value(value)?;
-        builder = builder.insert(key.as_str(), pv);
+        builder = builder
+            .try_insert(key.as_str(), pv)
+            .map_err(|e| e.to_string())?;
     }
     Ok(builder.build())
 }
@@ -207,6 +209,13 @@ fn json_to_property_value_recursive(
                     .collect();
 
                 if let Ok(floats) = floats {
+                    if floats.len() > crate::core::property::MAX_VECTOR_DIMENSIONS {
+                        return Err(format!(
+                            "Vector dimension {} exceeds limit {}",
+                            floats.len(),
+                            crate::core::property::MAX_VECTOR_DIMENSIONS
+                        ));
+                    }
                     return Ok(PropertyValue::Vector(Arc::from(floats)));
                 }
             }
@@ -290,6 +299,35 @@ mod tests {
                 "Unexpected error: {}",
                 e
             ),
+        }
+    }
+
+    #[test]
+    fn test_json_vector_dimension_bypass() {
+        use crate::core::property::MAX_VECTOR_DIMENSIONS;
+
+        // Create a JSON array that exceeds MAX_VECTOR_DIMENSIONS
+        // We use a small overflow to verify boundary condition
+        let too_large = MAX_VECTOR_DIMENSIONS + 1;
+
+        // Construct a large vector of numbers
+        // Note: generating this large structure in memory is acceptable for a test
+        let large_vec: Vec<serde_json::Value> =
+            std::iter::repeat_n(json!(1.0), too_large).collect();
+        let json_val = serde_json::Value::Array(large_vec);
+
+        let result = json_to_property_value(&json_val);
+
+        // This should now fail with a dimension limit error
+        match result {
+            Ok(_) => panic!("Validation failed: should have rejected large vector"),
+            Err(e) => {
+                assert!(
+                    e.contains("exceeds limit"),
+                    "Unexpected error message: {}",
+                    e
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `src/http/converters.rs` - `json_to_property_value` and `json_to_property_map`.
💣 Risk:
  1. Denial of Service via memory exhaustion: `MAX_VECTOR_DIMENSIONS` (100,000) was bypassed when converting JSON arrays to vectors, allowing arbitrarily large vectors to be created in memory and potentially fail during later serialization/persistence.
  2. Denial of Service via panic: `json_to_property_map` used `PropertyMapBuilder::insert`, which panics if recursion depth limits are exceeded during size calculation. A malicious nested JSON could trigger this panic and crash the HTTP server.
🧪 Strategy:
  - Added `test_json_vector_dimension_bypass` to `src/http/converters.rs` which attempts to create a vector larger than `MAX_VECTOR_DIMENSIONS` and asserts that it now returns an error.
  - Refactored `json_to_property_value` to explicitly validate vector dimensions.
  - Refactored `json_to_property_map` to use `try_insert` and map errors to strings.
  - Validated by running the new test case and existing tests.
🔬 Verification: `cargo test src/http/converters.rs` passed.

---
*PR created automatically by Jules for task [3029251041885075377](https://jules.google.com/task/3029251041885075377) started by @madmax983*