### PR TITLE
fix: CI-aware havoc deadlock stress test

### DIFF
--- a/tests/havoc_deadlock.rs
+++ b/tests/havoc_deadlock.rs
@@ -11,9 +11,20 @@ const NUM_SEARCHERS: usize = 4;
 const NUM_ADDERS_VACANT: usize = 2;
 const NUM_ADDERS_OCCUPIED: usize = 2;
 const NUM_SAVERS: usize = 1;
-// Reduced iterations to prevent CI timeouts while still exercising concurrency
-const ITERATIONS: usize = 100;
-const TEST_TIMEOUT_SECS: u64 = 60;
+
+fn is_ci() -> bool {
+    std::env::var("CI").is_ok()
+}
+
+/// Returns reduced iterations in CI to avoid timeouts on slow runners.
+fn iterations() -> usize {
+    if is_ci() { 30 } else { 100 }
+}
+
+/// Returns a longer timeout in CI to accommodate slow shared runners.
+fn test_timeout_secs() -> u64 {
+    if is_ci() { 120 } else { 60 }
+}
 
 /// Chaos Engineering: Concurrency Stress Test
 ///
@@ -41,11 +52,12 @@ fn havoc_deadlock_stress_test() {
     });
 
     // Watchdog: If test takes longer than timeout, it's likely deadlocked
-    match rx.recv_timeout(Duration::from_secs(TEST_TIMEOUT_SECS)) {
+    let timeout = test_timeout_secs();
+    match rx.recv_timeout(Duration::from_secs(timeout)) {
         Ok(_) => (), // Success
         Err(_) => panic!(
             "Deadlock detected or test too slow: Timed out after {}s",
-            TEST_TIMEOUT_SECS
+            timeout
         ),
     }
 }
@@ -86,7 +98,7 @@ fn run_deadlock_stress_test() {
         handles.push(thread::spawn(move || {
             barrier.wait();
             let query = vec![0.1f32; VECTOR_DIM];
-            for _ in 0..ITERATIONS {
+            for _ in 0..iterations() {
                 // Filter that accesses node ID (reverse mapping)
                 // We access the node ID to force the closure to actually do something with the mapping
                 let result = index.search_with_filter(&query, 10, |id| id.as_u64() % 2 == 0);
@@ -106,7 +118,7 @@ fn run_deadlock_stress_test() {
         handles.push(thread::spawn(move || {
             barrier.wait();
             let vec = vec![0.1f32; VECTOR_DIM];
-            for i in 0..ITERATIONS {
+            for i in 0..iterations() {
                 let id_val = 1000 + (t * 1000) + i;
                 let id = NodeId::new(id_val as u64).unwrap();
                 match index.add(id, &vec) {
@@ -128,7 +140,7 @@ fn run_deadlock_stress_test() {
         handles.push(thread::spawn(move || {
             barrier.wait();
             let vec = vec![0.2f32; VECTOR_DIM];
-            for i in 0..ITERATIONS {
+            for i in 0..iterations() {
                 // Update existing nodes 1..100
                 // Use a different node each time to hit different shards
                 let id_val = (i % 100) + 1;
@@ -177,9 +189,9 @@ fn run_deadlock_stress_test() {
     assert!(successes > 0, "No operations succeeded during stress test");
 
     // Verify index consistency
-    // We added 100 initial nodes + (NUM_ADDERS_VACANT * ITERATIONS) new nodes
+    // We added 100 initial nodes + (NUM_ADDERS_VACANT * iterations()) new nodes
     // Updates do not change count
-    let expected_len = 100 + (NUM_ADDERS_VACANT * ITERATIONS);
+    let expected_len = 100 + (NUM_ADDERS_VACANT * iterations());
     assert_eq!(
         index.len(),
         expected_len,
@@ -187,7 +199,7 @@ fn run_deadlock_stress_test() {
     );
 
     // Verify a random sample of nodes exists
-    for i in 0..ITERATIONS {
+    for i in 0..iterations() {
         let id_val = 1000 + i; // From first adder
         let id = NodeId::new(id_val as u64).unwrap();
         // Just verify we can remove it (it exists)


### PR DESCRIPTION
## Summary
Detects CI environment and reduces stress test iterations (100 → 30) while increasing timeout (60s → 120s) to prevent flaky timeouts on slow shared runners. Local runs unchanged.

---
Created from worktree workflow.