### PR TITLE
security: Prevent DoS via zstd decompression bomb

### DIFF
--- a/src/storage/compression.rs
+++ b/src/storage/compression.rs
@@ -6,6 +6,7 @@
 
 use crate::storage::redb_cold_storage::ColdStorageConfig;
 use crate::utils::error::{Result, StorageError};
+use std::io::Read;
 
 /// Compress data according to the configuration.
 ///
@@ -87,6 +88,64 @@ pub fn decompress(data: &[u8], config: &ColdStorageConfig) -> Result<Vec<u8>> {
     }
 }
 
+/// Decompress zstd data with a strict output size limit.
+///
+/// Uses a streaming decoder with chunked reads to prevent unbounded allocation
+/// attacks (e.g., "zip bombs") where a small compressed payload expands to fill
+/// all available memory. Unlike `read_to_end`, this reads in fixed-size chunks
+/// and aborts as soon as the limit is exceeded.
+///
+/// # Arguments
+///
+/// * `data` - The compressed zstd data
+/// * `limit` - The maximum allowed decompressed size in bytes
+///
+/// # Errors
+///
+/// Returns `StorageError::CapacityExceeded` if the decompressed size exceeds `limit`.
+/// Returns `StorageError::IoError` if decompression fails.
+pub fn decompress_with_limit(data: &[u8], limit: usize) -> Result<Vec<u8>> {
+    let mut decoder = zstd::stream::read::Decoder::new(data).map_err(|e| {
+        crate::utils::error::Error::Storage(StorageError::io_error(format!(
+            "Failed to create zstd decoder: {}",
+            e
+        )))
+    })?;
+
+    // Read in chunks to avoid allocating the full limit upfront.
+    // 1MB chunks balance syscall overhead vs memory usage.
+    const CHUNK_SIZE: usize = 1024 * 1024;
+    let mut buffer = Vec::new();
+    let mut chunk = vec![0u8; CHUNK_SIZE];
+
+    loop {
+        let bytes_read = decoder.read(&mut chunk).map_err(|e| {
+            crate::utils::error::Error::Storage(StorageError::io_error(format!(
+                "Decompression failed: {}",
+                e
+            )))
+        })?;
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        buffer.extend_from_slice(&chunk[..bytes_read]);
+
+        if buffer.len() > limit {
+            return Err(crate::utils::error::Error::Storage(
+                StorageError::CapacityExceeded {
+                    resource: "decompressed_size".to_string(),
+                    current: buffer.len(),
+                    limit,
+                },
+            ));
+        }
+    }
+
+    Ok(buffer)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,5 +208,63 @@ mod tests {
                 .to_string()
                 .contains("Checksum mismatch")
         );
+    }
+
+    #[test]
+    fn test_decompress_with_limit_success() {
+        let data = [42u8; 100];
+        let compressed = zstd::encode_all(&data[..], 1).unwrap();
+
+        let decompressed = decompress_with_limit(&compressed, 200).unwrap();
+        assert_eq!(decompressed.len(), 100);
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn test_decompress_with_limit_exact_boundary() {
+        let data = [42u8; 100];
+        let compressed = zstd::encode_all(&data[..], 1).unwrap();
+
+        // Exactly at the limit should succeed
+        let decompressed = decompress_with_limit(&compressed, 100).unwrap();
+        assert_eq!(decompressed.len(), 100);
+    }
+
+    #[test]
+    fn test_decompress_with_limit_exceeded() {
+        let data = [0u8; 200];
+        let compressed = zstd::encode_all(&data[..], 1).unwrap();
+
+        let result = decompress_with_limit(&compressed, 100);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::utils::error::Error::Storage(StorageError::CapacityExceeded {
+                resource,
+                limit,
+                ..
+            }) => {
+                assert_eq!(resource, "decompressed_size");
+                assert_eq!(limit, 100);
+            }
+            e => panic!("Expected CapacityExceeded, got: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_decompress_with_limit_zstd_bomb() {
+        // Simulate a zip bomb: 10MB of zeros compresses to very few bytes
+        let data = vec![0u8; 10 * 1024 * 1024];
+        let compressed = zstd::encode_all(&data[..], 1).unwrap();
+
+        // The compressed payload should be tiny
+        assert!(compressed.len() < 1000, "Bomb should compress well");
+
+        // But decompression with a 1MB limit should fail fast
+        let result = decompress_with_limit(&compressed, 1024 * 1024);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            crate::utils::error::Error::Storage(StorageError::CapacityExceeded { .. })
+        ));
     }
 }

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -9,11 +9,29 @@ use crc32fast::Hasher;
 use crate::core::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
 
+use crate::storage::compression::decompress_with_limit;
+
 use super::error::{IndexPersistenceError, Result};
 use super::formats::{
     GraphIndexData, GraphIndexDelta, PersistedPropertyMap, PersistedPropertyValue,
 };
 use super::{DELTA_MAGIC, GRAPH_MAGIC, MANIFEST_VERSION};
+
+/// Map decompression errors to `IndexPersistenceError`, preserving the
+/// specific `SizeLimitExceeded` variant for capacity violations.
+fn map_decompress_error(e: crate::utils::error::Error) -> IndexPersistenceError {
+    match e {
+        crate::utils::error::Error::Storage(
+            crate::utils::error::StorageError::CapacityExceeded { current, limit, .. },
+        ) => IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "Decompressed size {} exceeds limit {} (possible zip bomb)",
+                current, limit
+            ),
+        },
+        _ => IndexPersistenceError::Serialization(format!("zstd decompression failed: {}", e)),
+    }
+}
 
 /// Convert PropertyValue to PersistedPropertyValue.
 ///
@@ -200,10 +218,8 @@ pub fn load_graph_index(path: &Path) -> Result<GraphIndexData> {
     const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
     let decompressed_data;
     let data_to_verify = if data_slice.len() >= 4 && data_slice[..4] == ZSTD_MAGIC {
-        // Decompress the data
-        decompressed_data = zstd::decode_all(data_slice).map_err(|e| {
-            IndexPersistenceError::Serialization(format!("zstd decompression failed: {}", e))
-        })?;
+        decompressed_data = decompress_with_limit(data_slice, super::MAX_GRAPH_DECOMPRESSED_SIZE)
+            .map_err(map_decompress_error)?;
         &decompressed_data[..]
     } else {
         data_slice
@@ -368,10 +384,8 @@ pub fn load_graph_index_mmap(path: &Path) -> Result<GraphIndexData> {
     const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
     let decompressed_data;
     let data_to_verify = if data_slice.len() >= 4 && data_slice[..4] == ZSTD_MAGIC {
-        // Decompress the data
-        decompressed_data = zstd::decode_all(data_slice).map_err(|e| {
-            IndexPersistenceError::Serialization(format!("zstd decompression failed: {}", e))
-        })?;
+        decompressed_data = decompress_with_limit(data_slice, super::MAX_GRAPH_DECOMPRESSED_SIZE)
+            .map_err(map_decompress_error)?;
         &decompressed_data[..]
     } else {
         data_slice
@@ -629,10 +643,8 @@ pub fn load_graph_index_with_delta(base_path: &Path, delta_path: &Path) -> Resul
     const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
     let decompressed_data;
     let data_to_verify = if data_slice.len() >= 4 && data_slice[..4] == ZSTD_MAGIC {
-        // Decompress the data
-        decompressed_data = zstd::decode_all(data_slice).map_err(|e| {
-            IndexPersistenceError::Serialization(format!("zstd decompression failed: {}", e))
-        })?;
+        decompressed_data = decompress_with_limit(data_slice, super::MAX_GRAPH_DECOMPRESSED_SIZE)
+            .map_err(map_decompress_error)?;
         &decompressed_data[..]
     } else {
         data_slice
@@ -819,6 +831,104 @@ mod tests {
         } else {
             panic!("Expected vector property");
         }
+    }
+}
+
+/// Regression tests for zstd decompression bomb protection.
+#[cfg(test)]
+mod zstd_bomb_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+    use zstd::stream::write::Encoder;
+
+    /// Create a compressed zstd bomb: `uncompressed_mb` MB of zeros,
+    /// wrapped with a fake CRC32 trailer to look like our file format.
+    fn create_zstd_bomb(uncompressed_mb: usize) -> Vec<u8> {
+        let mut compressed = Vec::new();
+        {
+            let mut encoder = Encoder::new(&mut compressed, 1).unwrap();
+            let chunk = vec![0u8; 1024 * 1024]; // 1MB chunk
+            for _ in 0..uncompressed_mb {
+                encoder.write_all(&chunk).unwrap();
+            }
+            encoder.finish().unwrap();
+        }
+        // Append fake CRC32 (4 bytes) — the loader splits on trailing 4 bytes
+        compressed.extend_from_slice(&[0, 0, 0, 0]);
+        compressed
+    }
+
+    #[test]
+    fn test_zstd_bomb_blocked_by_load_graph_index() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bomb.idx");
+
+        // 200MB bomb, test limit is 100MB
+        let bomb = create_zstd_bomb(200);
+        // Bomb should be small on disk (zeros compress extremely well)
+        assert!(bomb.len() < 500_000, "Bomb compressed size: {}", bomb.len());
+
+        std::fs::write(&path, &bomb).unwrap();
+
+        let result = load_graph_index(&path);
+        assert!(
+            matches!(result, Err(IndexPersistenceError::SizeLimitExceeded { .. })),
+            "Expected SizeLimitExceeded, got: {:?}",
+            result,
+        );
+    }
+
+    #[test]
+    fn test_zstd_bomb_blocked_by_load_graph_index_mmap() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bomb_mmap.idx");
+
+        let bomb = create_zstd_bomb(200);
+        std::fs::write(&path, &bomb).unwrap();
+
+        let result = load_graph_index_mmap(&path);
+        assert!(
+            matches!(result, Err(IndexPersistenceError::SizeLimitExceeded { .. })),
+            "Expected SizeLimitExceeded, got: {:?}",
+            result,
+        );
+    }
+
+    #[test]
+    fn test_zstd_bomb_blocked_by_load_graph_index_with_delta() {
+        let dir = tempdir().unwrap();
+
+        // Create a valid base index
+        let base_path = dir.path().join("base.idx");
+        let base_data = new_graph_index_data();
+        save_graph_index(&base_data, &base_path).unwrap();
+
+        // Create a bomb as the delta
+        let delta_path = dir.path().join("bomb_delta.idx");
+        let bomb = create_zstd_bomb(200);
+        std::fs::write(&delta_path, &bomb).unwrap();
+
+        let result = load_graph_index_with_delta(&base_path, &delta_path);
+        assert!(
+            matches!(result, Err(IndexPersistenceError::SizeLimitExceeded { .. })),
+            "Expected SizeLimitExceeded, got: {:?}",
+            result,
+        );
+    }
+
+    #[test]
+    fn test_legitimate_compressed_index_loads_fine() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("compressed.idx");
+
+        // Create and save a legitimate compressed index
+        let data = new_graph_index_data();
+        save_graph_index_compressed(&data, &path, 3).unwrap();
+
+        // Should load without error
+        let loaded = load_graph_index(&path).unwrap();
+        assert_eq!(loaded.node_count, 0);
     }
 }
 

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -160,6 +160,28 @@ pub const MAX_GRAPH_INDEX_FILE_SIZE: u64 = if cfg!(test) {
     100 * 1024 * 1024 * 1024
 };
 
+/// Maximum allowed decompressed size for graph index files (DoS protection).
+///
+/// Prevents "zip bomb" attacks where a small compressed file expands to fill memory.
+/// The compressed file size is already checked by `MAX_GRAPH_INDEX_FILE_SIZE`, but a
+/// crafted file with extreme compression ratios could still expand to gigabytes.
+///
+/// Default: 16GB in production (64-bit), 2GB (32-bit), 100MB in tests.
+#[cfg(target_pointer_width = "64")]
+pub const MAX_GRAPH_DECOMPRESSED_SIZE: usize = if cfg!(test) {
+    100 * 1024 * 1024
+} else {
+    16 * 1024 * 1024 * 1024
+};
+
+/// See 64-bit variant for documentation.
+#[cfg(not(target_pointer_width = "64"))]
+pub const MAX_GRAPH_DECOMPRESSED_SIZE: usize = if cfg!(test) {
+    100 * 1024 * 1024
+} else {
+    2 * 1024 * 1024 * 1024
+};
+
 /// Maximum size of a vector index metadata/mappings file (DoS protection).
 ///
 /// Limits the amount of memory allocated when loading vector index metadata.


### PR DESCRIPTION
## Summary

Replaces unbounded `zstd::decode_all` calls in graph index loading with a new `decompress_with_limit` streaming decoder that reads in **1MB chunks** and aborts immediately when the decompressed output exceeds the limit. This prevents "zip bomb" attacks where a tiny compressed file expands to gigabytes and causes OOM.

Supersedes #867 (Jules bot PR) — addresses the same vulnerability but fixes several issues from the original:
- **Chunked reading** instead of allocating the full limit into a Vec before checking
- **Preserves `delta_tests` module** (Jules accidentally deleted it)
- **Extracted `map_decompress_error` helper** instead of 3x copy-pasted error mapping
- **No dead code** (removed commented-out debug prints)
- **Clean test assertions** using `matches!` instead of multi-arm string matching
- **Doesn't touch `compression::decompress()`** — the cold storage path has separate file-size limits and different concerns

### Changes

| File | What |
|------|------|
| `src/storage/compression.rs` | Add `decompress_with_limit()` with chunked streaming reads |
| `src/storage/index_persistence/mod.rs` | Add `MAX_GRAPH_DECOMPRESSED_SIZE` (16GB prod, 2GB 32-bit, 100MB test) |
| `src/storage/index_persistence/graph.rs` | Replace 3x `zstd::decode_all` + add `map_decompress_error` helper + bomb regression tests |

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] 4 new `decompress_with_limit` unit tests (success, exact boundary, exceeded, bomb)
- [x] 4 new graph index bomb regression tests (load, mmap, delta, legitimate round-trip)
- [x] All 8 existing DoS tests pass
- [x] All 7 delta tests preserved and passing
- [x] All 6 original graph tests passing
- [x] **Total: 19 graph persistence tests, 7 compression tests — all green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)