### PR TITLE
CI: Add cargo-mutants for mutation testing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,19 @@
+# cargo-mutants configuration for AletheiaDB
+# See: https://mutants.rs/config.html
+
+# Timeout per mutant — scales relative to the baseline test time
+timeout_multiplier = 1.5
+minimum_test_timeout = 60
+
+# Exclude low-value mutation targets
+exclude_globs = [
+    "benches/**",           # Benchmark harnesses
+    "examples/**",          # Example code
+    "tests/**",             # Integration test helpers
+    "src/mcp/**",           # MCP server (IO-heavy, tested via integration)
+]
+
+exclude_re = [
+    "impl (Debug|Display) for",   # Display/Debug impls
+    "fn fmt\\(",                    # fmt methods
+]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -2,7 +2,7 @@
 # See: https://mutants.rs/config.html
 
 # Timeout per mutant — scales relative to the baseline test time
-timeout_multiplier = 1.5
+timeout_multiplier = 3.0
 minimum_test_timeout = 60
 
 # Exclude low-value mutation targets

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,179 @@
+name: Mutation Testing
+
+on:
+  pull_request:
+    branches: [trunk]
+  schedule:
+    # Weekly full run: Sunday at 03:00 UTC
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run mode"
+        required: true
+        default: "full"
+        type: choice
+        options:
+          - full
+          - diff
+
+# Auto-cancel old runs when new commits are pushed to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── PR mode: test only changed code (informational) ──────────────────
+  mutants-pr:
+    name: Mutants (PR diff)
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'diff')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-mutants-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-mutants-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-mutants-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-mutants-target-
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@cargo-mutants
+
+      - name: Generate diff against base branch
+        run: git diff origin/${{ github.base_ref }}..HEAD > mutants-diff.patch
+
+      - name: Run mutation tests on diff
+        run: |
+          cargo mutants --in-place -vV \
+            --features "config-toml,mcp-server,sharding-rpc" \
+            --in-diff mutants-diff.patch
+
+      - name: Upload mutation results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-pr-results
+          path: mutants.out/
+          retention-days: 14
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## Mutation Testing (PR diff)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f mutants.out/caught.txt ]; then
+            CAUGHT=$(wc -l < mutants.out/caught.txt)
+            echo "Caught: **$CAUGHT** mutants" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -f mutants.out/missed.txt ]; then
+            MISSED=$(wc -l < mutants.out/missed.txt)
+            echo "Missed: **$MISSED** mutants" >> $GITHUB_STEP_SUMMARY
+            if [ "$MISSED" -gt 0 ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "<details><summary>Missed mutants (click to expand)</summary>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              cat mutants.out/missed.txt >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+          if [ -f mutants.out/timeout.txt ]; then
+            TIMEOUT=$(wc -l < mutants.out/timeout.txt)
+            echo "Timeout: **$TIMEOUT** mutants" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -f mutants.out/unviable.txt ]; then
+            UNVIABLE=$(wc -l < mutants.out/unviable.txt)
+            echo "Unviable: **$UNVIABLE** mutants" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ── Full mode: sharded across 4 runners (weekly + manual) ────────────
+  mutants-full:
+    name: Mutants (full shard ${{ matrix.shard }}/4)
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-mutants-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-mutants-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-mutants-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-mutants-target-
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@cargo-mutants
+
+      - name: Run mutation tests (shard ${{ matrix.shard }}/4)
+        run: |
+          cargo mutants --in-place -vV \
+            --features "config-toml,mcp-server,sharding-rpc" \
+            --shard ${{ matrix.shard }}/4
+
+      - name: Upload mutation results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-full-shard-${{ matrix.shard }}
+          path: mutants.out/
+          retention-days: 30
+
+      - name: Post shard summary
+        if: always()
+        run: |
+          echo "## Mutation Testing (shard ${{ matrix.shard }}/4)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f mutants.out/caught.txt ]; then
+            echo "Caught: **$(wc -l < mutants.out/caught.txt)** mutants" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -f mutants.out/missed.txt ]; then
+            echo "Missed: **$(wc -l < mutants.out/missed.txt)** mutants" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -f mutants.out/timeout.txt ]; then
+            echo "Timeout: **$(wc -l < mutants.out/timeout.txt)** mutants" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -63,8 +63,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-mutants-target-
 
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
+
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@cargo-mutants
+        run: cargo binstall --no-confirm cargo-mutants
 
       - name: Generate diff against base branch
         run: git diff origin/${{ github.base_ref }}..HEAD > mutants-diff.patch
@@ -149,8 +152,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-mutants-target-
 
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
+
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@cargo-mutants
+        run: cargo binstall --no-confirm cargo-mutants
 
       - name: Run mutation tests (shard ${{ matrix.shard }}/4)
         run: |

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,5 +1,8 @@
 name: Mutation Testing
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [trunk]

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ final_cleanup.sh
 # Debug output files
 *_output.txt
 test_output_*.txt
+
+# Mutation testing output
+mutants.out/
+mutants.out.old/

--- a/TESTING.md
+++ b/TESTING.md
@@ -162,6 +162,63 @@ exclude = [
 ]
 ```
 
+## Mutation Testing
+
+Mutation testing validates that tests actually *assert correctness*, not just execute code. [cargo-mutants](https://mutants.rs/) introduces small changes (mutants) to source code and checks whether at least one test fails. A surviving mutant means code was executed but not meaningfully verified.
+
+See [ADR-0035](docs/adr/0035-mutation-testing.md) for the full rationale.
+
+### Installation
+
+```bash
+cargo install cargo-mutants
+# or faster with pre-built binaries:
+cargo binstall cargo-mutants
+```
+
+### Running Locally
+
+```bash
+# Mutation test only uncommitted changes (fast)
+just mutants-diff
+
+# Mutation test changes vs trunk (useful before opening a PR)
+just mutants-branch
+
+# Full mutation test run (slow — tests every function in scope)
+just mutants
+```
+
+### Interpreting Results
+
+Results are written to `mutants.out/`:
+
+| File | Meaning |
+|------|---------|
+| `caught.txt` | Mutants killed by tests (good) |
+| `missed.txt` | Mutants that survived (investigate these) |
+| `timeout.txt` | Mutants that caused test timeouts |
+| `unviable.txt` | Mutants that failed to compile (neutral) |
+
+Focus on **`missed.txt`** — each entry is a code location where a behavioral change went undetected. Common fixes:
+
+- Add an assertion for the return value or side effect
+- Add a test case that exercises the specific branch or condition
+- If the mutant is genuinely equivalent (behavior can't differ), it can be ignored
+
+### CI Integration
+
+- **On PRs**: `cargo mutants --in-diff` runs on changed code only (informational, non-blocking)
+- **Weekly**: Full sharded run across 4 runners for comprehensive mutation score tracking
+- Results are uploaded as artifacts and summarized in the GitHub job summary
+
+### Configuration
+
+Exclusions are configured in `.cargo/mutants.toml`. Currently excluded:
+- Benchmarks, examples, and integration test helpers
+- MCP server (IO-heavy, tested via integration)
+- `Display`/`Debug` impls and `fmt` methods
+
 ## Profiling
 
 ### Tracy Profiling

--- a/docs/adr/0035-mutation-testing.md
+++ b/docs/adr/0035-mutation-testing.md
@@ -1,0 +1,163 @@
+# ADR-0035: Mutation Testing with cargo-mutants
+
+**Status:** Accepted
+**Date:** 2026-02-07
+**Deciders:** madmax983, Claude
+**Categories:** Testing, CI/CD, Quality Assurance
+
+## Context
+
+AletheiaDB has 2,490 tests and 86.45% line coverage, meeting our quality thresholds. However, code coverage only measures whether code was *executed* during tests — it does not measure whether tests actually *assert correctness*. A test that calls a function but never checks its return value achieves 100% coverage while catching zero bugs.
+
+Mutation testing addresses this gap by introducing small changes (mutants) to source code — flipping conditions, replacing return values, removing statements — and checking whether at least one test fails. A surviving mutant reveals a test gap: code that is executed but not meaningfully validated.
+
+Key motivations:
+
+1. **Test quality validation**: Coverage says "this code ran", mutation testing says "this code is actually tested"
+2. **Correctness-critical domain**: Bi-temporal invariants, ACID guarantees, and graph consistency require tests that truly verify behavior, not just exercise paths
+3. **Regression confidence**: Surviving mutants in WAL, MVCC, or temporal logic could mask real bugs
+4. **CI integration need**: Must be practical for both PR feedback and comprehensive weekly analysis
+
+## Decision
+
+We will adopt **cargo-mutants** for mutation testing with a two-tier CI strategy:
+
+### Tool Choice: cargo-mutants
+
+We will use [cargo-mutants](https://mutants.rs/) as our mutation testing tool.
+
+- Pure Rust, cargo-native — no JVM or external runtime
+- Supports `--in-diff` for incremental testing of only changed code
+- Supports `--shard` for parallelizing full runs across CI runners
+- Configurable exclusions via `.cargo/mutants.toml`
+- Active maintenance and Rust ecosystem alignment
+
+### CI Strategy: Two Tiers
+
+**Tier 1 — PR Diff (on every pull request):**
+- Runs `cargo mutants --in-diff` against only the changed code
+- Informational only (`continue-on-error: true`) — does not block merge
+- Provides fast feedback on whether new/modified code has meaningful test coverage
+- Results uploaded as artifacts and summarized in GitHub job summary
+
+**Tier 2 — Full Sharded (weekly schedule + manual dispatch):**
+- Runs full mutation testing sharded across 4 CI runners (`--shard k/4`)
+- Comprehensive mutation score tracking for the entire codebase
+- Per-shard artifacts uploaded for analysis
+- Can be triggered manually via `workflow_dispatch`
+
+### Exclusions
+
+Low-value mutation targets are excluded via `.cargo/mutants.toml`:
+- `benches/**`, `examples/**`, `tests/**` — not production code
+- `src/mcp/**` — IO-heavy MCP server, validated via integration tests
+- `Display`/`Debug` impls and `fmt` methods — formatting output rarely has correctness implications
+
+### Local Recipes
+
+Three `just` recipes for local mutation testing:
+- `just mutants` — full run
+- `just mutants-diff` — uncommitted changes only
+- `just mutants-branch` — changes vs trunk
+
+## Consequences
+
+### Positive
+
+- **Identifies weak tests**: Finds code where tests execute but don't assert, revealing false confidence from coverage metrics
+- **Targeted PR feedback**: `--in-diff` keeps PR runs fast by only testing changed code
+- **Scalable full analysis**: Sharding across 4 runners makes weekly full runs practical
+- **Non-blocking adoption**: PR runs are informational, so adoption doesn't slow development velocity
+- **Local developer workflow**: `just mutants-diff` enables pre-push mutation testing on changed code
+- **Complements existing coverage**: Works alongside cargo-llvm-cov, not replacing it
+
+### Negative
+
+- **CI cost**: Weekly full runs consume significant runner minutes (4 parallel 90-minute jobs)
+- **False positives**: Some surviving mutants are genuinely equivalent (e.g., changing `>=` to `>` in a context where equality never occurs) — requires triage
+- **Slow local runs**: Full `just mutants` is impractical for quick iteration; use `mutants-diff` or `mutants-branch` instead
+- **New tool dependency**: Adds cargo-mutants (via cargo-binstall) to CI toolchain
+
+### Neutral
+
+- **Informational-only on PRs**: Surviving mutants on PRs don't block merge — this is intentional during adoption but could be tightened later
+- **Timeout tuning**: `timeout_multiplier = 3.0` may need adjustment as the test suite evolves
+- **Exclusion scope**: MCP server exclusion may be revisited if integration test coverage improves
+
+## Alternatives Considered
+
+### Alternative 1: mutagen (Rust mutation testing)
+
+An older Rust mutation testing tool using compiler plugin injection.
+
+**Rejected because:**
+- Requires nightly Rust compiler
+- Less actively maintained than cargo-mutants
+- No `--in-diff` support for incremental testing
+- No built-in sharding for CI parallelization
+
+### Alternative 2: Coverage-only (status quo)
+
+Continue relying solely on line/function/region coverage thresholds.
+
+**Rejected because:**
+- Coverage does not validate assertion quality
+- A test with zero assertions achieves full coverage while catching zero bugs
+- For a database with ACID guarantees, "code was executed" is insufficient — "code was verified" is the bar
+
+### Alternative 3: Blocking mutation testing on PRs
+
+Require all mutants to be caught before merging.
+
+**Rejected because:**
+- Equivalent mutants create unavoidable false positives
+- Would significantly slow PR velocity
+- Better to adopt incrementally: informational first, then tighten thresholds as the team builds experience with triage
+- Can revisit once baseline mutation score is established
+
+### Alternative 4: Single full run (no sharding)
+
+Run the full mutation test suite on a single runner.
+
+**Rejected because:**
+- Full runs on a large codebase easily exceed GitHub Actions' 6-hour job limit
+- Sharding across 4 runners keeps each shard under 90 minutes
+- Parallel execution provides results faster
+
+## Implementation Notes
+
+### Installation
+
+cargo-mutants is installed via `cargo-binstall` in CI (pre-built binaries, no compilation):
+
+```yaml
+- uses: taiki-e/install-action@cargo-binstall
+- run: cargo binstall --no-confirm cargo-mutants
+```
+
+Locally: `cargo install cargo-mutants` or `cargo binstall cargo-mutants`.
+
+### Interpreting Results
+
+Results are written to `mutants.out/` with these files:
+- `caught.txt` — mutants killed by tests (good)
+- `missed.txt` — mutants that survived (needs investigation)
+- `timeout.txt` — mutants that caused test timeouts
+- `unviable.txt` — mutants that failed to compile (neutral)
+
+Focus on `missed.txt` — each entry indicates code where a behavioral change went undetected by tests.
+
+### Future Considerations
+
+- **Enforce mutation score**: Once a baseline is established, consider adding a minimum mutation score threshold
+- **Per-module tracking**: Track mutation scores per module to identify weak areas
+- **PR comments**: Add a bot that posts mutation results as PR comments for visibility
+- **Revisit exclusions**: As MCP server tests mature, consider removing the `src/mcp/**` exclusion
+
+## References
+
+- PR #888: Implementation
+- [cargo-mutants documentation](https://mutants.rs/)
+- [Mutation Testing overview (Wikipedia)](https://en.wikipedia.org/wiki/Mutation_testing)
+- ADR-0015: CI/CD Automation Workflow
+- TESTING.md: Testing and coverage guide

--- a/justfile
+++ b/justfile
@@ -224,6 +224,26 @@ outdated:
 audit:
     cargo audit
 
+# === Mutation Testing ===
+
+# Run mutation tests on all code
+mutants:
+    cargo mutants --in-place -vV
+
+# Run mutation tests only on uncommitted changes
+mutants-diff:
+    #!/usr/bin/env bash
+    git diff HEAD > mutants-diff.tmp
+    cargo mutants --in-place -vV --in-diff mutants-diff.tmp
+    rm -f mutants-diff.tmp
+
+# Run mutation tests on changes vs trunk
+mutants-branch:
+    #!/usr/bin/env bash
+    git diff origin/trunk.. > mutants-diff.tmp
+    cargo mutants --in-place -vV --in-diff mutants-diff.tmp
+    rm -f mutants-diff.tmp
+
 # === Git Worktree Commands ===
 # These commands enable parallel development with multiple Claude instances
 

--- a/justfile
+++ b/justfile
@@ -233,16 +233,16 @@ mutants:
 # Run mutation tests only on uncommitted changes
 mutants-diff:
     #!/usr/bin/env bash
+    trap 'rm -f mutants-diff.tmp' EXIT
     git diff HEAD > mutants-diff.tmp
     cargo mutants --in-place -vV --in-diff mutants-diff.tmp
-    rm -f mutants-diff.tmp
 
 # Run mutation tests on changes vs trunk
 mutants-branch:
     #!/usr/bin/env bash
+    trap 'rm -f mutants-diff.tmp' EXIT
     git diff origin/trunk.. > mutants-diff.tmp
     cargo mutants --in-place -vV --in-diff mutants-diff.tmp
-    rm -f mutants-diff.tmp
 
 # === Git Worktree Commands ===
 # These commands enable parallel development with multiple Claude instances


### PR DESCRIPTION
## Summary

- Add `cargo-mutants` configuration (`.cargo/mutants.toml`) excluding low-value targets (benchmarks, examples, MCP server, Display/Debug impls)
- Add GitHub Actions workflow with two modes:
  - **PR**: Fast `--in-diff` testing of only changed code (informational, non-blocking)
  - **Weekly**: Full sharded run across 4 runners for comprehensive mutation score tracking
- Add `just mutants`, `just mutants-diff`, `just mutants-branch` local recipes
- Add `mutants.out/` and `mutants.out.old/` to `.gitignore`

## Test plan

- [ ] Verify `.cargo/mutants.toml` is picked up: `cargo mutants --list | head -20`
- [ ] Run `just mutants-diff` locally on any uncommitted changes
- [ ] Inspect `mutants.out/` for correct results structure
- [ ] Verify workflow runs on this PR (informational, `continue-on-error: true`)
- [ ] Trigger manual `workflow_dispatch` with mode=full to test sharding

🤖 Generated with [Claude Code](https://claude.com/claude-code)