### PR TITLE
🔒 Warden: Fix DoS in FindNeighbors endpoint

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -63,6 +63,7 @@ Arithmetic operations on file offsets (`src/storage/wal/segment_reader.rs`) and 
 - `usearch` FFI boundaries rely on the C++ library behaving correctly regarding pointer validity. We added panic guards for null pointers, but full memory safety depends on `usearch` correctness.
 - The `usearch` dependency points to a fork (`madmax983/USearch`). This fork contains Rust-specific fixes (move semantics) not yet in upstream. We have pinned the specific commit to ensure stability, but future upstream security patches will need manual cherry-picking.
 - `mmap` usage in `src/storage/wal/segment_reader.rs` is inherently unsafe against external file truncation (SIGBUS risk), though file size is checked before mapping.
+- `HnswIndex::load` validates configuration against the file, but we cannot currently verify that the underlying `usearch` index matches the expected quantization (API limitation). This creates a theoretical risk if a loaded index has different quantization than expected, potentially leading to memory safety issues with custom metrics.
 
 ## 2026-02-12 - SIMD Hardening
 **Threat:** Buffer Over-read in Release Builds
@@ -84,7 +85,7 @@ Refactored both functions to use recursive helpers that track depth. Enforced `M
 The `usearch` library supports quantized vector storage (I8, F16), which reduces memory usage. However, user-defined custom metrics are defined to operate on `f32` slices. When using a custom metric with quantized storage, `usearch` passes pointers to the quantized data (e.g., `i8*`), but the Rust wrapper blindly cast these to `f32*`. This resulted in reading 4x (for I8) or 2x (for F16) more memory than allocated, leading to potential crashes (DoS) or information leakage (reading uninitialized/unrelated memory).
 
 **Defense:** Configuration Validation
-Enforced a strict validation rule in `HnswIndexBuilder::build` and `HnswIndex::load`: Custom metrics are now **only** allowed when using `Quantization::F32`. Attempting to combine `custom_metric` with `I8` or `F16` quantization now returns a specific `InvalidVector` error instead of proceeding with unsafe memory access.
+Enforced a strict validation rule in `HnswIndexBuilder::build` and `HnswIndex::load`: Custom metrics are now **only** allowed when using `Quantization::F32`. Attempting to combine `custom_metric` with `I8` or `F16` quantization now returns a specific `InvalidVector` error instead of crashing.
 
 **Verification:** Regression Test
 Added `tests/security_custom_metric.rs` which attempts to build and load an index with this dangerous combination. Verified that the operation fails safely with the expected error message, whereas previously it would read out-of-bounds memory.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -249,6 +249,16 @@ pub async fn handle_query(
                     let limit_val = limit.unwrap_or(100).min(max_limit);
                     let offset_val = offset.unwrap_or(0);
 
+                    // Prevent deep pagination attacks (CPU DoS)
+                    // Use saturating_add to prevent integer overflow bypass
+                    let max_deep_pagination = 10_000;
+                    if offset_val.saturating_add(limit_val) > max_deep_pagination {
+                        return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+                            "Pagination limit exceeded: offset + limit must be <= {}",
+                            max_deep_pagination
+                        )));
+                    }
+
                     // Deduplication
                     let mut seen_ids = HashSet::new();
                     let mut neighbors = Vec::with_capacity(limit_val);


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability in the `FindNeighbors` HTTP endpoint.

**Vulnerability:**
The `FindNeighbors` handler lacked a check for deep pagination. An attacker could send a request with a massive `offset` (e.g., `usize::MAX`), causing the server to iterate and skip a huge number of edges, leading to CPU exhaustion.

**Fix:**
- Added a check: `if offset.saturating_add(limit) > 10_000`.
- This matches the protection already present in the `FindNode` endpoint.
- Uses `saturating_add` to prevent integer overflow attacks where `offset + limit` wraps around.

**Verification:**
- Verified using the existing regression test `test_warden_find_neighbors_overflow` in `src/http/handlers.rs`.
- The test previously failed (panicked), and now passes.

**Notes:**
- Attempted to harden `HnswIndex::load` against quantization mismatch but found that the `usearch` crate wrapper does not expose the necessary API to verify the loaded index's quantization. This remains an open risk logged in the journal.

---
*PR created automatically by Jules for task [13149695991803967977](https://jules.google.com/task/13149695991803967977) started by @madmax983*