### PR TITLE
Harden HNSW index loading with strict metadata validation

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1268,7 +1268,11 @@ impl HnswIndex {
         write_and_hash(writer, &mut hasher, &[MAPPING_VERSION])?;
 
         // Version 2 fields: Dimensions, Quantization, Metric
-        write_and_hash(writer, &mut hasher, &(config.dimensions as u64).to_le_bytes())?;
+        write_and_hash(
+            writer,
+            &mut hasher,
+            &(config.dimensions as u64).to_le_bytes(),
+        )?;
         write_and_hash(writer, &mut hasher, &[config.quantization.to_u8()])?;
         write_and_hash(writer, &mut hasher, &[config.metric.to_u8()])?;
 
@@ -1528,13 +1532,11 @@ fn load_mappings_with_integrity(
             "Mapping count too large (overflow)".to_string(),
         ))
     })?;
-    let expected_size = data_size
-        .checked_add(header_overhead)
-        .ok_or_else(|| {
-            Error::Vector(VectorError::IndexError(
-                "Mapping file size too large (overflow)".to_string(),
-            ))
-        })?;
+    let expected_size = data_size.checked_add(header_overhead).ok_or_else(|| {
+        Error::Vector(VectorError::IndexError(
+            "Mapping file size too large (overflow)".to_string(),
+        ))
+    })?;
 
     // Critical Security Check: Verify file size matches expected size BEFORE reading data.
     // This prevents reading until EOF if the file is truncated or huge.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -125,7 +125,14 @@ impl Drop for FilterCallbackGuard {
 /// Magic bytes for mapping file identification
 const MAPPING_MAGIC: &[u8; 4] = b"GMAP";
 /// Current mapping file format version
-const MAPPING_VERSION: u8 = 1;
+const MAPPING_VERSION: u8 = 2;
+
+/// Metadata stored in the mappings file (Version 2+)
+struct IndexMetadata {
+    dimensions: usize,
+    quantization: Quantization,
+    metric: DistanceMetric,
+}
 
 /// Maximum number of results that can be requested in a search.
 ///
@@ -1194,16 +1201,16 @@ impl HnswIndex {
         drop(index);
 
         // Save mappings to companion file with integrity checks
-        // Format: [MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]
+        // Format: [MAGIC:4][VERSION:2][DIMS:8][QUANT:1][METRIC:1][COUNT:8][DATA:16*count][CRC32:4]
         let mappings_path = path.with_extension("usearch.mappings");
 
-        // Calculate total size: Magic(4) + Version(1) + Count(8) + Data(count * 16) + CRC(4)
+        // Calculate total size: Magic(4) + Version(1) + Dims(8) + Quant(1) + Metric(1) + Count(8) + Data(count * 16) + CRC(4)
         // Use checked arithmetic to prevent overflow
         let count_size = count
             .checked_mul(16)
             .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
         let _total_size = count_size
-            .checked_add(4 + 1 + 8 + 4)
+            .checked_add(4 + 1 + 8 + 1 + 1 + 8 + 4)
             .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
 
         // Open file with streaming writer
@@ -1216,12 +1223,17 @@ impl HnswIndex {
         let mut writer = BufWriter::new(file);
 
         // Use Vec iterator instead of DashMap iterator
-        Self::write_mappings_to_writer(&mut writer, mappings.into_iter(), count)
+        Self::write_mappings_to_writer(&mut writer, mappings.into_iter(), count, &self.config)
     }
 
     /// Helper method to stream mappings to a writer with CRC calculation.
     /// Extracted for testability of error paths.
-    fn write_mappings_to_writer<W, I>(writer: &mut W, mappings_iter: I, count: usize) -> Result<()>
+    fn write_mappings_to_writer<W, I>(
+        writer: &mut W,
+        mappings_iter: I,
+        count: usize,
+        config: &HnswConfig,
+    ) -> Result<()>
     where
         W: Write,
         I: Iterator<Item = (NodeId, u64)>,
@@ -1254,6 +1266,12 @@ impl HnswIndex {
         // Write header
         write_and_hash(writer, &mut hasher, MAPPING_MAGIC)?;
         write_and_hash(writer, &mut hasher, &[MAPPING_VERSION])?;
+
+        // Version 2 fields: Dimensions, Quantization, Metric
+        write_and_hash(writer, &mut hasher, &(config.dimensions as u64).to_le_bytes())?;
+        write_and_hash(writer, &mut hasher, &[config.quantization.to_u8()])?;
+        write_and_hash(writer, &mut hasher, &[config.metric.to_u8()])?;
+
         write_and_hash(writer, &mut hasher, &count_u64.to_le_bytes())?;
 
         // Write data directly
@@ -1278,6 +1296,41 @@ impl HnswIndex {
             )))
         })?;
 
+        Ok(())
+    }
+
+    /// Validate loaded index metadata against configuration.
+    fn validate_metadata(metadata: Option<IndexMetadata>, config: &HnswConfig) -> Result<()> {
+        if let Some(meta) = metadata {
+            if meta.dimensions != config.dimensions {
+                return Err(Error::Vector(VectorError::IndexError(format!(
+                    "Index dimension mismatch: expected {}, found {}",
+                    config.dimensions, meta.dimensions
+                ))));
+            }
+            if meta.quantization != config.quantization {
+                return Err(Error::Vector(VectorError::IndexError(format!(
+                    "Index quantization mismatch: expected {:?}, found {:?}",
+                    config.quantization, meta.quantization
+                ))));
+            }
+            if meta.metric != config.metric {
+                return Err(Error::Vector(VectorError::IndexError(format!(
+                    "Index metric mismatch: expected {:?}, found {:?}",
+                    config.metric, meta.metric
+                ))));
+            }
+        } else {
+            // Legacy index (Version 1)
+            // Prevent usage of custom metric with legacy index to avoid buffer over-read vulnerability
+            // (since we cannot verify dimensions/quantization)
+            if config.custom_metric.is_some() {
+                return Err(Error::Vector(VectorError::IndexError(
+                    "Cannot use custom metric with legacy index (missing metadata validation)"
+                        .to_string(),
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -1350,18 +1403,24 @@ impl HnswIndex {
 }
 
 /// Load and verify mappings from a companion file.
-/// Returns (id_mapping, reverse_mapping, max_key) or error if integrity check fails.
-/// Format: `[MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]`
+/// Returns (id_mapping, reverse_mapping, max_key, metadata) or error if integrity check fails.
+/// Format V1: `[MAGIC:4][VERSION:1][COUNT:8][DATA:16*count][CRC32:4]`
+/// Format V2: `[MAGIC:4][VERSION:2][DIMS:8][QUANT:1][METRIC:1][COUNT:8][DATA:16*count][CRC32:4]`
 #[allow(clippy::type_complexity)]
 fn load_mappings_with_integrity(
     mappings_path: &Path,
-) -> Result<(DashMap<NodeId, u64>, DashMap<u64, NodeId>, u64)> {
+) -> Result<(
+    DashMap<NodeId, u64>,
+    DashMap<u64, NodeId>,
+    u64,
+    Option<IndexMetadata>,
+)> {
     let id_mapping = DashMap::new();
     let reverse_mapping = DashMap::new();
     let mut max_key = 0u64;
 
     if !mappings_path.exists() {
-        return Ok((id_mapping, reverse_mapping, max_key));
+        return Ok((id_mapping, reverse_mapping, max_key, None));
     }
 
     // Use streaming (File + BufReader) instead of reading entire file to memory (fs::read).
@@ -1383,7 +1442,8 @@ fn load_mappings_with_integrity(
         })?
         .len();
 
-    // Minimum size: magic(4) + version(1) + count(8) + crc(4) = 17 bytes
+    // Minimum size check (V1 min size)
+    // Magic(4) + Version(1) + Count(8) + CRC(4) = 17 bytes
     if file_len < 17 {
         return Err(Error::Vector(VectorError::IndexError(
             "Mapping file too small or corrupted".to_string(),
@@ -1393,36 +1453,73 @@ fn load_mappings_with_integrity(
     let mut reader = std::io::BufReader::new(file);
     let mut hasher = Hasher::new();
 
-    // 1. Read Header (13 bytes)
-    let mut header = [0u8; 13];
-    reader.read_exact(&mut header).map_err(|e| {
+    // 1. Read Start of Header (5 bytes: Magic + Version)
+    let mut header_start = [0u8; 5];
+    reader.read_exact(&mut header_start).map_err(|e| {
         Error::Vector(VectorError::IndexError(format!(
-            "Failed to read mappings header: {}",
+            "Failed to read mappings header start: {}",
             e
         )))
     })?;
 
-    // Update hasher with header
-    hasher.update(&header);
+    hasher.update(&header_start);
 
     // Verify magic bytes
-    if &header[0..4] != MAPPING_MAGIC {
+    if &header_start[0..4] != MAPPING_MAGIC {
         return Err(Error::Vector(VectorError::IndexError(
             "Invalid mapping file: bad magic bytes".to_string(),
         )));
     }
 
-    // Check version
-    let version = header[4];
-    if version != MAPPING_VERSION {
-        return Err(Error::Vector(VectorError::IndexError(format!(
-            "Unsupported mapping file version: {} (expected {})",
-            version, MAPPING_VERSION
-        ))));
-    }
+    let version = header_start[4];
 
-    // Parse count
-    let count = u64::from_le_bytes(header[5..13].try_into().unwrap()) as usize;
+    // Read remaining header based on version
+    let (count, metadata, header_overhead) = match version {
+        1 => {
+            // V1: Count(8)
+            let mut buf = [0u8; 8];
+            reader.read_exact(&mut buf).map_err(|e| {
+                Error::Vector(VectorError::IndexError(format!(
+                    "Failed to read V1 header fields: {}",
+                    e
+                )))
+            })?;
+            hasher.update(&buf);
+            let count = u64::from_le_bytes(buf) as usize;
+            // Overhead: Magic(4) + Version(1) + Count(8) + CRC(4) = 17
+            (count, None, 17)
+        }
+        2 => {
+            // V2: Dims(8) + Quant(1) + Metric(1) + Count(8)
+            let mut buf = [0u8; 18];
+            reader.read_exact(&mut buf).map_err(|e| {
+                Error::Vector(VectorError::IndexError(format!(
+                    "Failed to read V2 header fields: {}",
+                    e
+                )))
+            })?;
+            hasher.update(&buf);
+
+            let dims = u64::from_le_bytes(buf[0..8].try_into().unwrap()) as usize;
+            let quant = Quantization::from_u8(buf[8])?;
+            let metric = DistanceMetric::from_u8(buf[9])?;
+            let count = u64::from_le_bytes(buf[10..18].try_into().unwrap()) as usize;
+
+            let meta = IndexMetadata {
+                dimensions: dims,
+                quantization: quant,
+                metric,
+            };
+            // Overhead: Magic(4) + Version(1) + Dims(8) + Quant(1) + Metric(1) + Count(8) + CRC(4) = 27
+            (count, Some(meta), 27)
+        }
+        v => {
+            return Err(Error::Vector(VectorError::IndexError(format!(
+                "Unsupported mapping file version: {} (expected 1 or {})",
+                v, MAPPING_VERSION
+            ))));
+        }
+    };
 
     // Verify data size with checked arithmetic
     // Cast to u64 for file size comparison
@@ -1431,11 +1528,13 @@ fn load_mappings_with_integrity(
             "Mapping count too large (overflow)".to_string(),
         ))
     })?;
-    let expected_size = data_size.checked_add(4 + 1 + 8 + 4).ok_or_else(|| {
-        Error::Vector(VectorError::IndexError(
-            "Mapping file size too large (overflow)".to_string(),
-        ))
-    })?;
+    let expected_size = data_size
+        .checked_add(header_overhead)
+        .ok_or_else(|| {
+            Error::Vector(VectorError::IndexError(
+                "Mapping file size too large (overflow)".to_string(),
+            ))
+        })?;
 
     // Critical Security Check: Verify file size matches expected size BEFORE reading data.
     // This prevents reading until EOF if the file is truncated or huge.
@@ -1501,7 +1600,7 @@ fn load_mappings_with_integrity(
         ))));
     }
 
-    Ok((id_mapping, reverse_mapping, max_key))
+    Ok((id_mapping, reverse_mapping, max_key, metadata))
 }
 
 impl HnswIndex {
@@ -1613,7 +1712,11 @@ impl HnswIndex {
 
         // Load mappings from companion file with integrity verification
         let mappings_path = path.with_extension("usearch.mappings");
-        let (id_mapping, reverse_mapping, max_key) = load_mappings_with_integrity(&mappings_path)?;
+        let (id_mapping, reverse_mapping, max_key, metadata) =
+            load_mappings_with_integrity(&mappings_path)?;
+
+        // Validate metadata
+        Self::validate_metadata(metadata, &config)?;
 
         Ok(HnswIndex {
             inner: Arc::new(RwLock::new(index)),
@@ -1654,13 +1757,31 @@ impl HnswIndex {
 
         // Load mappings from companion file with integrity verification
         let mappings_path = path.with_extension("usearch.mappings");
-        let (id_mapping, reverse_mapping, max_key) = load_mappings_with_integrity(&mappings_path)?;
+        let (id_mapping, reverse_mapping, max_key, metadata) =
+            load_mappings_with_integrity(&mappings_path)?;
+
+        // Restore configuration from metadata if available
+        let (quantization, metric) = if let Some(meta) = metadata {
+            // Verify dimensions match what usearch reports
+            if meta.dimensions != dimensions {
+                return Err(Error::Vector(VectorError::IndexError(format!(
+                    "Index dimension mismatch: usearch reported {}, metadata says {}",
+                    dimensions, meta.dimensions
+                ))));
+            }
+            (meta.quantization, meta.metric)
+        } else {
+            // Legacy index: fallback to defaults
+            (Quantization::default(), DistanceMetric::Cosine)
+        };
 
         Ok(HnswIndex {
             inner: Arc::new(RwLock::new(index)),
             config: HnswConfig {
                 dimensions,
                 m: connectivity,
+                quantization,
+                metric,
                 storage: StorageMode::MemoryMapped {
                     path: path.to_path_buf(),
                 },
@@ -2292,10 +2413,11 @@ mod tests {
 
         // Corrupt data (which invalidates CRC)
         let mut data = std::fs::read(&mappings_path).unwrap();
-        // Modify the node ID part of the data (after header: 4+1+8 = 13 bytes)
-        // Data format: [NodeId:8][Key:8]...
-        if data.len() > 13 {
-            data[13] = data[13].wrapping_add(1);
+        // Modify the node ID part of the data
+        // Header V2 size: 4(Magic) + 1(Ver) + 8(Dims) + 1(Quant) + 1(Metric) + 8(Count) = 23 bytes
+        let header_size = 23;
+        if data.len() > header_size {
+            data[header_size] = data[header_size].wrapping_add(1);
         }
         std::fs::write(&mappings_path, &data).unwrap();
 
@@ -2350,9 +2472,9 @@ mod tests {
 
         // Modify count to be larger (mismatch with actual size), then fix CRC to pass CRC check
         let mut data = std::fs::read(&mappings_path).unwrap();
-        // Count is at offset 5 (Magic 4 + Version 1)
+        // Count is at offset 15 (Magic 4 + Version 1 + Dims 8 + Quant 1 + Metric 1)
         // Original count is 1. Let's make it 2.
-        let count_offset = 5;
+        let count_offset = 15;
         data[count_offset] = 2;
 
         // Recompute CRC so we pass the CRC check and hit the size check
@@ -2396,7 +2518,7 @@ mod tests {
 
         // Modify count to be HUGE (u64::MAX) to trigger arithmetic overflow check
         let mut data = std::fs::read(&mappings_path).unwrap();
-        let count_offset = 5;
+        let count_offset = 15; // V2 offset
         let huge_count = u64::MAX;
 
         // Write huge count
@@ -2496,6 +2618,8 @@ mod tests {
             (NodeId::new(2).unwrap(), 200),
         ];
 
+        let config = HnswConfig::default();
+
         // Case 1: Fail during header (MAGIC)
         // Magic is 4 bytes. Fail at byte 3.
         let mut writer = MockFailWriter::new(3);
@@ -2503,6 +2627,7 @@ mod tests {
             &mut writer,
             mappings.iter().copied(),
             mappings.len(),
+            &config,
         );
         assert!(result.is_err());
         if let Err(Error::Vector(VectorError::IndexError(msg))) = result {
@@ -2512,14 +2637,15 @@ mod tests {
         }
 
         // Case 2: Fail during data writing
-        // Magic(4) + Version(1) + Count(8) = 13 bytes header
+        // V2 Header: Magic(4) + Version(1) + Dims(8) + Quant(1) + Metric(1) + Count(8) = 23 bytes
         // Data is 16 bytes per item.
         // Fail after header + 1st item (16 bytes) + 1 byte
-        let mut writer = MockFailWriter::new(13 + 16 + 1);
+        let mut writer = MockFailWriter::new(23 + 16 + 1);
         let result = HnswIndex::write_mappings_to_writer(
             &mut writer,
             mappings.iter().copied(),
             mappings.len(),
+            &config,
         );
         assert!(result.is_err());
         if let Err(Error::Vector(VectorError::IndexError(msg))) = result {
@@ -2527,14 +2653,15 @@ mod tests {
         }
 
         // Case 3: Fail during CRC writing
-        // Total data size = 13 + 32 = 45 bytes.
+        // Total data size = 23 + 32 = 55 bytes.
         // CRC is 4 bytes.
-        // Fail at 45 + 1 byte (during CRC write)
-        let mut writer = MockFailWriter::new(45 + 1);
+        // Fail at 55 + 1 byte (during CRC write)
+        let mut writer = MockFailWriter::new(55 + 1);
         let result = HnswIndex::write_mappings_to_writer(
             &mut writer,
             mappings.iter().copied(),
             mappings.len(),
+            &config,
         );
         assert!(result.is_err());
         if let Err(Error::Vector(VectorError::IndexError(msg))) = result {
@@ -2555,11 +2682,13 @@ mod tests {
     #[test]
     fn test_save_mappings_flush_error() {
         let mappings = [];
+        let config = HnswConfig::default();
         let mut writer = MockFlushFailWriter;
         let result = HnswIndex::write_mappings_to_writer(
             &mut writer,
             mappings.iter().copied(),
             mappings.len(),
+            &config,
         );
         assert!(result.is_err());
         if let Err(Error::Vector(VectorError::IndexError(msg))) = result {

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -109,6 +109,40 @@ pub enum Quantization {
     I8,
 }
 
+impl Quantization {
+    /// Encode quantization level as a byte for serialization.
+    ///
+    /// Encoding:
+    /// - 0 = F32
+    /// - 1 = F16
+    /// - 2 = I8
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Quantization::F32 => 0,
+            Quantization::F16 => 1,
+            Quantization::I8 => 2,
+        }
+    }
+
+    /// Decode quantization level from a byte.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the byte value is not a valid quantization encoding (>= 3).
+    pub fn from_u8(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(Quantization::F32),
+            1 => Ok(Quantization::F16),
+            2 => Ok(Quantization::I8),
+            _ => Err(crate::utils::error::StorageError::CorruptedData(format!(
+                "Invalid quantization encoding: {}",
+                value
+            ))
+            .into()),
+        }
+    }
+}
+
 /// Storage mode for the vector index.
 ///
 /// - InMemory: All data in RAM (default, fastest queries)

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -698,6 +698,19 @@ mod tests {
             DistanceMetric::Tanimoto
         );
     }
+
+    #[test]
+    fn test_quantization_variants() {
+        assert_eq!(Quantization::F32.to_u8(), 0);
+        assert_eq!(Quantization::F16.to_u8(), 1);
+        assert_eq!(Quantization::I8.to_u8(), 2);
+
+        assert_eq!(Quantization::from_u8(0).unwrap(), Quantization::F32);
+        assert_eq!(Quantization::from_u8(1).unwrap(), Quantization::F16);
+        assert_eq!(Quantization::from_u8(2).unwrap(), Quantization::I8);
+
+        assert!(Quantization::from_u8(3).is_err());
+    }
 }
 
 // HNSW implementation

--- a/tests/warden_hnsw_metadata_validation.rs
+++ b/tests/warden_hnsw_metadata_validation.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, Quantization};
 use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, Quantization};
 
 #[test]
 fn test_havoc_quantization_mismatch_crash() {
@@ -9,8 +9,7 @@ fn test_havoc_quantization_mismatch_crash() {
     let index_path = dir.path().join("quantized.index");
 
     {
-        let config = HnswConfig::new(4, DistanceMetric::Cosine)
-            .with_quantization(Quantization::I8); // Use I8
+        let config = HnswConfig::new(4, DistanceMetric::Cosine).with_quantization(Quantization::I8); // Use I8
 
         let index = HnswIndex::new(config).unwrap();
 
@@ -36,14 +35,19 @@ fn test_havoc_quantization_mismatch_crash() {
 
     match result {
         Ok(idx) => {
-             // If we loaded successfully, we are vulnerable!
-             println!("Index loaded successfully. Quantization: {:?}", idx.quantization());
+            // If we loaded successfully, we are vulnerable!
+            println!(
+                "Index loaded successfully. Quantization: {:?}",
+                idx.quantization()
+            );
 
-             // Trigger search to demonstrate crash/garbage
-             let query = vec![0.0; 4];
-             let _ = idx.search(&query, 1);
+            // Trigger search to demonstrate crash/garbage
+            let query = vec![0.0; 4];
+            let _ = idx.search(&query, 1);
 
-             panic!("Security Vulnerability: Successfully loaded I8 index with F32 config and custom metric! This allows buffer over-read.");
+            panic!(
+                "Security Vulnerability: Successfully loaded I8 index with F32 config and custom metric! This allows buffer over-read."
+            );
         }
         Err(e) => {
             println!("Load failed as expected: {}", e);
@@ -59,8 +63,7 @@ fn test_havoc_dimension_mismatch_rejection() {
     let index_path = dir.path().join("small_dim.index");
 
     {
-        let index = HnswIndex::new(HnswConfig::new(4, DistanceMetric::Cosine))
-            .unwrap();
+        let index = HnswIndex::new(HnswConfig::new(4, DistanceMetric::Cosine)).unwrap();
 
         let node1 = NodeId::new(1).unwrap();
         // Add a vector
@@ -79,7 +82,7 @@ fn test_havoc_dimension_mismatch_rejection() {
     // We want this to fail at load time, not search time
     match result {
         Ok(_) => {
-             panic!("Security Vulnerability: Successfully loaded 4-dim index with 1024-dim config!");
+            panic!("Security Vulnerability: Successfully loaded 4-dim index with 1024-dim config!");
         }
         Err(e) => {
             println!("Load failed as expected: {}", e);

--- a/tests/warden_hnsw_metadata_validation.rs
+++ b/tests/warden_hnsw_metadata_validation.rs
@@ -1,0 +1,88 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, Quantization};
+use aletheiadb::index::VectorIndex;
+
+#[test]
+fn test_havoc_quantization_mismatch_crash() {
+    // 1. Create a valid index with I8 quantization
+    let dir = tempfile::tempdir().unwrap();
+    let index_path = dir.path().join("quantized.index");
+
+    {
+        let config = HnswConfig::new(4, DistanceMetric::Cosine)
+            .with_quantization(Quantization::I8); // Use I8
+
+        let index = HnswIndex::new(config).unwrap();
+
+        let node1 = NodeId::new(1).unwrap();
+        // Add a vector
+        index.add(node1, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+        index.save(&index_path).unwrap();
+    }
+
+    // 2. Load the index but claim it is F32 (which is required for custom metric)
+    // The file has I8 data. We say it's F32.
+    let config = HnswConfig::new(4, DistanceMetric::Cosine)
+        .with_quantization(Quantization::F32) // Claim F32
+        .with_custom_metric("crash_test", |a, b| {
+            // This shouldn't be called if validation works
+            println!("Metric called! a[0]={}, b[0]={}", a[0], b[0]);
+            0.0
+        });
+
+    println!("Attempting to load I8 index as F32...");
+    let result = HnswIndex::load(&index_path, config);
+
+    match result {
+        Ok(idx) => {
+             // If we loaded successfully, we are vulnerable!
+             println!("Index loaded successfully. Quantization: {:?}", idx.quantization());
+
+             // Trigger search to demonstrate crash/garbage
+             let query = vec![0.0; 4];
+             let _ = idx.search(&query, 1);
+
+             panic!("Security Vulnerability: Successfully loaded I8 index with F32 config and custom metric! This allows buffer over-read.");
+        }
+        Err(e) => {
+            println!("Load failed as expected: {}", e);
+            // This is what we want
+        }
+    }
+}
+
+#[test]
+fn test_havoc_dimension_mismatch_rejection() {
+    // 1. Create a valid index with small dimensions (e.g., 4)
+    let dir = tempfile::tempdir().unwrap();
+    let index_path = dir.path().join("small_dim.index");
+
+    {
+        let index = HnswIndex::new(HnswConfig::new(4, DistanceMetric::Cosine))
+            .unwrap();
+
+        let node1 = NodeId::new(1).unwrap();
+        // Add a vector
+        index.add(node1, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+        index.save(&index_path).unwrap();
+    }
+
+    // 2. Load the index but claim it has LARGE dimensions (e.g., 1024)
+    let large_dims = 1024;
+    let config = HnswConfig::new(large_dims, DistanceMetric::Cosine);
+
+    println!("Attempting to load index with mismatching dimensions...");
+    let result = HnswIndex::load(&index_path, config);
+
+    // We want this to fail at load time, not search time
+    match result {
+        Ok(_) => {
+             panic!("Security Vulnerability: Successfully loaded 4-dim index with 1024-dim config!");
+        }
+        Err(e) => {
+            println!("Load failed as expected: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
Hardened `HnswIndex` serialization logic to prevent memory safety vulnerabilities (buffer over-reads) arising from mismatched index configurations.

Previously, `usearch` indexes could be loaded with a configuration different from their on-disk state (e.g., claiming F32 quantization for an I8 index). This allowed custom metric wrappers to cast raw pointers incorrectly, leading to out-of-bounds reads.

This change:
1.  Upgrades the `usearch.mappings` file format to **Version 2**, which now includes `dimensions` (u64), `quantization` (u8), and `metric` (u8) in the header.
2.  Updates `load_mappings_with_integrity` to parse these new fields.
3.  Updates `HnswIndex::load` to validate the loaded metadata against the user-provided `HnswConfig`. Any mismatch (especially dimensions or quantization) now returns an error.
4.  Updates `HnswIndex::open_mmap` to prioritize the metadata from the file, ensuring the runtime `HnswIndex` accurately reflects the on-disk data.
5.  Adds `to_u8`/`from_u8` serialization helpers to `Quantization`.
6.  Adds "Warden" regression tests (`tests/warden_hnsw_metadata_validation.rs`) confirming that attempts to exploit this mismatch are now rejected.

This effectively neutralizes the "Havoc" scenario where corrupted or malicious configs could crash the system or leak memory.

---
*PR created automatically by Jules for task [8409026397144827413](https://jules.google.com/task/8409026397144827413) started by @madmax983*