### PR TITLE
feat(core): Enforce strict timestamp validation in TimeRange

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -1,0 +1,8 @@
+# Elenchus Journal
+
+**[TimeRange Validation Gap]**
+**Module:** `aletheiadb::core::temporal`
+**Severity:** 🟡 Suspect
+**Finding:** `TimeRange::new` relied on `Timestamp` (HybridTimestamp) validity, but `From<i64>` allowed constructing invalid timestamps via `new_unchecked`, bypassing `MAX_VALID_TIMESTAMP` checks. This allowed creating invalid `TimeRange`s.
+**Evidence:** `tests/warden_temporal_safety.rs` demonstrated that `TimeRange::new` accepted timestamps > `MAX_VALID_TIMESTAMP`.
+**Recommendation:** Added validation to `TimeRange::new` to strictly enforce `MAX_VALID_TIMESTAMP` for both start and end times. Added `tests/warden_temporal_safety.rs` as a permanent regression test.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -64,6 +64,29 @@ impl TimeRange {
         if start > end {
             return Err(TemporalError::InvalidTimeRange { start, end });
         }
+
+        // Warden: Validate that timestamps don't exceed MAX_VALID_TIMESTAMP
+        // This prevents invalid timestamps from entering via unchecked constructors
+        if start.wallclock() > MAX_VALID_TIMESTAMP && start != TIMESTAMP_MAX {
+            return Err(TemporalError::InvalidTimestamp {
+                timestamp: start,
+                reason: format!(
+                    "Start timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                    MAX_VALID_TIMESTAMP
+                ),
+            });
+        }
+
+        if end.wallclock() > MAX_VALID_TIMESTAMP && end != TIMESTAMP_MAX {
+            return Err(TemporalError::InvalidTimestamp {
+                timestamp: end,
+                reason: format!(
+                    "End timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                    MAX_VALID_TIMESTAMP
+                ),
+            });
+        }
+
         Ok(TimeRange { start, end })
     }
 

--- a/tests/warden_temporal_safety.rs
+++ b/tests/warden_temporal_safety.rs
@@ -1,0 +1,50 @@
+//! Warden: Temporal Safety Audit Tests
+//!
+//! These tests verify that the system correctly rejects invalid temporal states
+//! and prevents time-travel paradoxes or DoS attacks via malicious timestamps.
+
+use aletheiadb::core::temporal::{TimeRange, MAX_VALID_TIMESTAMP, TIMESTAMP_MAX};
+use aletheiadb::core::hlc::HybridTimestamp;
+use aletheiadb::utils::error::TemporalError;
+
+/// 🎯 Target: TimeRange::new validation
+/// 💣 Risk: Creating TimeRange with invalid timestamps via unchecked constructors
+///    could allow invalid state to propagate through the system, potentially
+///    causing panics or logical errors in query execution.
+/// 🧪 Strategy: Construct invalid timestamps using From<i64> (which bypasses validation)
+///    and attempt to create a TimeRange.
+/// 🔬 Verification: TimeRange::new should return Err(InvalidTimestamp).
+#[test]
+fn test_warden_timerange_rejects_invalid_timestamps() {
+    // Create an invalid timestamp (one past MAX_VALID_TIMESTAMP)
+    // using the internal new_unchecked via the From<i64> impl.
+    let invalid_val = MAX_VALID_TIMESTAMP + 1;
+    let invalid_ts: HybridTimestamp = invalid_val.into();
+
+    // Attempt to create a TimeRange with the invalid start timestamp
+    let result = TimeRange::new(invalid_ts, TIMESTAMP_MAX);
+
+    // Should fail with InvalidTimestamp error
+    assert!(result.is_err(), "TimeRange::new accepted invalid start timestamp");
+
+    match result {
+        Err(TemporalError::InvalidTimestamp { timestamp, .. }) => {
+            assert_eq!(timestamp.wallclock(), invalid_val);
+        }
+        _ => panic!("Expected InvalidTimestamp error, got {:?}", result),
+    }
+
+    // Attempt to create a TimeRange with the invalid end timestamp
+    let valid_ts: HybridTimestamp = 100.into();
+    let result = TimeRange::new(valid_ts, invalid_ts);
+
+    // Should fail with InvalidTimestamp error
+    assert!(result.is_err(), "TimeRange::new accepted invalid end timestamp");
+
+    match result {
+        Err(TemporalError::InvalidTimestamp { timestamp, .. }) => {
+            assert_eq!(timestamp.wallclock(), invalid_val);
+        }
+        _ => panic!("Expected InvalidTimestamp error, got {:?}", result),
+    }
+}

--- a/tests/warden_temporal_safety.rs
+++ b/tests/warden_temporal_safety.rs
@@ -3,8 +3,8 @@
 //! These tests verify that the system correctly rejects invalid temporal states
 //! and prevents time-travel paradoxes or DoS attacks via malicious timestamps.
 
-use aletheiadb::core::temporal::{TimeRange, MAX_VALID_TIMESTAMP, TIMESTAMP_MAX};
 use aletheiadb::core::hlc::HybridTimestamp;
+use aletheiadb::core::temporal::{MAX_VALID_TIMESTAMP, TIMESTAMP_MAX, TimeRange};
 use aletheiadb::utils::error::TemporalError;
 
 /// 🎯 Target: TimeRange::new validation
@@ -25,7 +25,10 @@ fn test_warden_timerange_rejects_invalid_timestamps() {
     let result = TimeRange::new(invalid_ts, TIMESTAMP_MAX);
 
     // Should fail with InvalidTimestamp error
-    assert!(result.is_err(), "TimeRange::new accepted invalid start timestamp");
+    assert!(
+        result.is_err(),
+        "TimeRange::new accepted invalid start timestamp"
+    );
 
     match result {
         Err(TemporalError::InvalidTimestamp { timestamp, .. }) => {
@@ -39,7 +42,10 @@ fn test_warden_timerange_rejects_invalid_timestamps() {
     let result = TimeRange::new(valid_ts, invalid_ts);
 
     // Should fail with InvalidTimestamp error
-    assert!(result.is_err(), "TimeRange::new accepted invalid end timestamp");
+    assert!(
+        result.is_err(),
+        "TimeRange::new accepted invalid end timestamp"
+    );
 
     match result {
         Err(TemporalError::InvalidTimestamp { timestamp, .. }) => {


### PR DESCRIPTION
Performed a security audit of `src/core/temporal.rs` under the "Elenchus" persona.
Identified that `TimeRange::new` did not validate that timestamps were within the allowable range (`MAX_VALID_TIMESTAMP`), relying on the caller to provide valid `Timestamp`s. However, `HybridTimestamp::from(i64)` (used for testing and legacy support) bypasses validation, allowing invalid timestamps to be created and used in `TimeRange`.

This PR adds strict validation to `TimeRange::new` and adds a regression test to prevent future regressions.

---
*PR created automatically by Jules for task [6827691287468848708](https://jules.google.com/task/6827691287468848708) started by @madmax983*