### PR TITLE
🛡️ Sentry: Fix VectorDelta NaN handling and add regression tests

### DIFF
--- a/examples/russian_writers.rs
+++ b/examples/russian_writers.rs
@@ -1713,20 +1713,26 @@ fn timewarp_book(demo: &DemoData, book_title: &str, year: i64) -> Result<()> {
         match demo.db.get_node_history(book_id) {
             Ok(history) => {
                 // Find the version whose valid_time interval contains the query year
-                let version_at_time = history.versions.iter().find(|v| {
-                    v.temporal.valid_time().contains(query_timestamp)
-                });
+                let version_at_time = history
+                    .versions
+                    .iter()
+                    .find(|v| v.temporal.valid_time().contains(query_timestamp));
 
                 match version_at_time {
                     Some(version_info) => {
                         // Reconstruct the node at this version
-                        match demo.db.get_node_at_version(book_id, version_info.version_number) {
+                        match demo
+                            .db
+                            .get_node_at_version(book_id, version_info.version_number)
+                        {
                             Ok(historical_node) => {
                                 let historical_interp = historical_node
                                     .properties
                                     .get("interpretation")
                                     .map(format_value)
-                                    .unwrap_or_else(|| "No interpretation recorded yet".to_string());
+                                    .unwrap_or_else(|| {
+                                        "No interpretation recorded yet".to_string()
+                                    });
 
                                 println!("Interpretation in {}:", year);
                                 println!("  {}\n", historical_interp);
@@ -1738,7 +1744,9 @@ fn timewarp_book(demo: &DemoData, book_title: &str, year: i64) -> Result<()> {
                                 // Show temporal context
                                 if year < 1900 {
                                     println!("In {}, literary criticism was still emerging.", year);
-                                    println!("The work would have been viewed through a 19th century lens.");
+                                    println!(
+                                        "The work would have been viewed through a 19th century lens."
+                                    );
                                 } else if year < 1950 {
                                     println!(
                                         "In {}, modernist and early psychoanalytic interpretations",
@@ -1752,8 +1760,13 @@ fn timewarp_book(demo: &DemoData, book_title: &str, year: i64) -> Result<()> {
                                     );
                                     println!("dominated literary interpretation.");
                                 } else {
-                                    println!("In {}, contemporary criticism emphasizes diverse", year);
-                                    println!("perspectives including trauma studies, postcolonial theory, etc.");
+                                    println!(
+                                        "In {}, contemporary criticism emphasizes diverse",
+                                        year
+                                    );
+                                    println!(
+                                        "perspectives including trauma studies, postcolonial theory, etc."
+                                    );
                                 }
                             }
                             Err(e) => {
@@ -1763,7 +1776,9 @@ fn timewarp_book(demo: &DemoData, book_title: &str, year: i64) -> Result<()> {
                     }
                     None => {
                         println!("⚠️  No version of this book exists at year {}", year);
-                        println!("The book may not have been published yet, or no updates were recorded.");
+                        println!(
+                            "The book may not have been published yet, or no updates were recorded."
+                        );
                     }
                 }
             }
@@ -2489,9 +2504,10 @@ fn show_personality_evolution(demo: &DemoData, book_title: &str) -> Result<()> {
             let timestamp = year_to_timestamp(year as i64);
 
             // Find the version whose valid_time interval contains this year
-            let version_at_time = history.versions.iter().find(|v| {
-                v.temporal.valid_time().contains(timestamp)
-            });
+            let version_at_time = history
+                .versions
+                .iter()
+                .find(|v| v.temporal.valid_time().contains(timestamp));
 
             match version_at_time {
                 Some(version_info) => {
@@ -2499,7 +2515,8 @@ fn show_personality_evolution(demo: &DemoData, book_title: &str) -> Result<()> {
                     match timed!(
                         demo,
                         &format!("Version lookup (year {})", year),
-                        demo.db.get_node_at_version(book_id, version_info.version_number)
+                        demo.db
+                            .get_node_at_version(book_id, version_info.version_number)
                     ) {
                         Ok(historical_node) => {
                             // Debug: show available properties
@@ -2515,11 +2532,7 @@ fn show_personality_evolution(demo: &DemoData, book_title: &str) -> Result<()> {
                             {
                                 let interp_text = format_value(interpretation);
 
-                                println!(
-                                    "┌─ {} {}",
-                                    year,
-                                    "─".repeat(60 - year.to_string().len())
-                                );
+                                println!("┌─ {} {}", year, "─".repeat(60 - year.to_string().len()));
                                 println!("│");
                                 let wrapped = wrap_text(&interp_text, 68, "│ ");
                                 println!("{}", wrapped);

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -2096,7 +2096,10 @@ mod sentry_tests {
         let old = vec![1.0f32];
         let new = vec![f32::INFINITY];
         let delta = VectorDelta::from_diff(&old, &new);
-        assert!(delta.is_some(), "Change from 1.0 to Infinity should be detected");
+        assert!(
+            delta.is_some(),
+            "Change from 1.0 to Infinity should be detected"
+        );
     }
 
     #[test]
@@ -2105,10 +2108,7 @@ mod sentry_tests {
         // Apply should not panic or corrupt memory.
         let dimension = 10;
         let changes = std::sync::Arc::new(vec![(100, 1.0f32)]); // Index 100 > dimension 10
-        let delta = VectorDelta::Sparse {
-            dimension,
-            changes,
-        };
+        let delta = VectorDelta::Sparse { dimension, changes };
 
         let base = vec![0.0f32; 10];
         let result = delta.apply(&base);

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -74,6 +74,26 @@ impl Default for VersionMetadata {
 /// embedding use cases while avoiding spurious deltas.
 const VECTOR_EPSILON: f32 = 1e-7;
 
+/// Helper for approximate float equality that handles NaN and Infinity correctly.
+///
+/// Ensures that:
+/// - NaN == NaN (treated as equal for change detection)
+/// - NaN != Finite
+/// - Inf == Inf (same sign)
+/// - Finite values compared with epsilon
+fn floats_approx_equal(a: f32, b: f32) -> bool {
+    if a.is_nan() {
+        return b.is_nan();
+    }
+    if b.is_nan() {
+        return false;
+    }
+    if a.is_infinite() || b.is_infinite() {
+        return a == b;
+    }
+    (a - b).abs() <= VECTOR_EPSILON
+}
+
 /// Sparse representation of vector changes.
 ///
 /// Stores only the changed elements to minimize storage overhead when
@@ -140,7 +160,7 @@ impl VectorDelta {
         let mut changes = Vec::new();
         for (idx, (old_val, new_val)) in old.iter().zip(new.iter()).enumerate() {
             // Use epsilon-based comparison to avoid spurious deltas from floating-point precision
-            if (old_val - new_val).abs() > VECTOR_EPSILON {
+            if !floats_approx_equal(*old_val, *new_val) {
                 // Validate index fits in u32 (should always pass given MAX_VECTOR_DIMENSIONS check)
                 let idx_u32 = u32::try_from(idx).ok()?;
                 changes.push((idx_u32, *new_val));
@@ -255,7 +275,7 @@ impl PartialEq for VectorDelta {
 
                 // Compare each (index, value) pair with epsilon for floats
                 for ((idx1, val1), (idx2, val2)) in changes1.iter().zip(changes2.iter()) {
-                    if idx1 != idx2 || (val1 - val2).abs() > VECTOR_EPSILON {
+                    if idx1 != idx2 || !floats_approx_equal(*val1, *val2) {
                         return false;
                     }
                 }
@@ -270,7 +290,7 @@ impl PartialEq for VectorDelta {
 
                 // Compare each element with epsilon
                 for (v1, v2) in vec1.iter().zip(vec2.iter()) {
-                    if (v1 - v2).abs() > VECTOR_EPSILON {
+                    if !floats_approx_equal(*v1, *v2) {
                         return false;
                     }
                 }
@@ -2058,4 +2078,43 @@ mod sentry_tests {
         let result = VectorDelta::from_diff(&v1, &v2);
         assert!(result.is_none());
     }
-}
+
+    #[test]
+    fn test_vector_delta_from_diff_nan_change() {
+        // 💣 Risk: (a - b).abs() > EPSILON returns false if one is NaN.
+        // This means changes involving NaN are silently ignored!
+        let old = vec![1.0f32];
+        let new = vec![f32::NAN];
+        let delta = VectorDelta::from_diff(&old, &new);
+        assert!(delta.is_some(), "Change from 1.0 to NaN should be detected");
+
+        let old = vec![f32::NAN];
+        let new = vec![1.0f32];
+        let delta = VectorDelta::from_diff(&old, &new);
+        assert!(delta.is_some(), "Change from NaN to 1.0 should be detected");
+
+        let old = vec![1.0f32];
+        let new = vec![f32::INFINITY];
+        let delta = VectorDelta::from_diff(&old, &new);
+        assert!(delta.is_some(), "Change from 1.0 to Infinity should be detected");
+    }
+
+    #[test]
+    fn test_vector_delta_apply_manual_construction_oob() {
+        // 💣 Risk: Manual construction or deserialization could create invalid indices.
+        // Apply should not panic or corrupt memory.
+        let dimension = 10;
+        let changes = std::sync::Arc::new(vec![(100, 1.0f32)]); // Index 100 > dimension 10
+        let delta = VectorDelta::Sparse {
+            dimension,
+            changes,
+        };
+
+        let base = vec![0.0f32; 10];
+        let result = delta.apply(&base);
+
+        // Should return base unchanged or with ignored OOB updates
+        assert_eq!(result.len(), 10);
+        assert_eq!(result[0], 0.0);
+    }
+} // End of sentry_tests mod (wait, verify existing file structure)


### PR DESCRIPTION
This PR fixes a correctness issue in `VectorDelta` where changes to or from `NaN` values were ignored because standard float comparison with epsilon fails for `NaN`.

I introduced a `floats_approx_equal` helper that robustly handles `NaN` (treating `NaN == NaN` as true for stability, but `Finite != NaN` as true) and `Infinity`.

I also added regression tests in `src/core/version.rs`'s `sentry_tests` module to verify:
1. `VectorDelta` correctly detects changes involving `NaN`.
2. `VectorDelta::apply` is safe against manually constructed out-of-bounds indices (it ignores them).

Verified by running `cargo test --package aletheiadb --lib -- core::version`.

---
*PR created automatically by Jules for task [14610093652767170457](https://jules.google.com/task/14610093652767170457) started by @madmax983*