### PR TITLE
👺 Havoc: Fix HNSW config serialization & torture tests

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -294,6 +294,7 @@ impl HnswConfig {
         writer.write_all(&(self.ef_construction as u64).to_le_bytes())?;
         writer.write_all(&(self.ef_search as u64).to_le_bytes())?;
         writer.write_all(&(self.capacity as u64).to_le_bytes())?;
+        writer.write_all(&[self.quantization.to_u8()])?;
         Ok(())
     }
 
@@ -320,6 +321,16 @@ impl HnswConfig {
         reader.read_exact(&mut buf_u64)?;
         let capacity = u64::from_le_bytes(buf_u64) as usize;
 
+        // Try read quantization (for backward compatibility)
+        let quantization = match reader.read_exact(&mut buf_u8) {
+            Ok(_) => Quantization::from_u8(buf_u8[0])?,
+            Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                // Old format (v1) didn't have quantization, assume F32 default
+                Quantization::default()
+            }
+            Err(e) => return Err(e.into()),
+        };
+
         Ok(HnswConfig {
             dimensions,
             metric,
@@ -327,6 +338,7 @@ impl HnswConfig {
             ef_construction,
             ef_search,
             capacity,
+            quantization,
             ..Default::default()
         })
     }

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -109,6 +109,40 @@ pub enum Quantization {
     I8,
 }
 
+impl Quantization {
+    /// Encode quantization level as a byte for serialization.
+    ///
+    /// Encoding:
+    /// - 0 = F32
+    /// - 1 = F16
+    /// - 2 = I8
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Quantization::F32 => 0,
+            Quantization::F16 => 1,
+            Quantization::I8 => 2,
+        }
+    }
+
+    /// Decode quantization level from a byte.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the byte value is not a valid quantization encoding (>= 3).
+    pub fn from_u8(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(Quantization::F32),
+            1 => Ok(Quantization::F16),
+            2 => Ok(Quantization::I8),
+            _ => Err(crate::utils::error::StorageError::CorruptedData(format!(
+                "Invalid quantization encoding: {}",
+                value
+            ))
+            .into()),
+        }
+    }
+}
+
 /// Storage mode for the vector index.
 ///
 /// - InMemory: All data in RAM (default, fastest queries)

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -1346,9 +1346,10 @@ mod tests {
         // - Magic (4) + Version (4) = 8
         // - LSN (8) + Timestamp (12) + NodeCount (8) + EdgeCount (8) + VersionCount (8) = 44
         //   (Phase 2: Timestamp is now HybridTimestamp: 8-byte wallclock + 4-byte logical = 12 bytes)
-        // - Vector config: enabled (1) + name_len (4) + "test_property" (13) + HnswConfig (41) = 59
-        // Total = 111 bytes (was 107 before Phase 2)
-        assert_eq!(metadata.len(), 111);
+        // - Vector config: enabled (1) + name_len (4) + "test_property" (13) + HnswConfig (42) = 60
+        //   (HnswConfig grew from 41 to 42 bytes due to quantization field)
+        // Total = 112 bytes
+        assert_eq!(metadata.len(), 112);
 
         Ok(())
     }

--- a/tests/havoc_concurrency.rs
+++ b/tests/havoc_concurrency.rs
@@ -1,0 +1,71 @@
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
+use aletheiadb::index::VectorIndex;
+use aletheiadb::core::id::NodeId;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn test_havoc_deadlock_scenario() {
+    let index = Arc::new(
+        HnswIndexBuilder::new(128, DistanceMetric::Cosine)
+            .build()
+            .unwrap()
+    );
+
+    let start_time = std::time::Instant::now();
+    let duration = Duration::from_secs(5); // Run for 5 seconds
+
+    // Thread A: Adds/Updates a single node repeatedly (Occupied path)
+    // This acquires id_mapping lock -> inner lock
+    let index_clone_a = Arc::clone(&index);
+    let handle_a = thread::spawn(move || {
+        let node_id = NodeId::new(1).unwrap();
+        let vector = vec![0.0f32; 128];
+        // Ensure initial add is done so we hit Occupied path
+        index_clone_a.add(node_id, &vector).unwrap();
+
+        while start_time.elapsed() < duration {
+            // This triggers the Occupied path because we use the same ID repeatedly
+            index_clone_a.add(node_id, &vector).unwrap();
+        }
+    });
+
+    // Thread B: Searches repeatedly (Read path)
+    // This acquires inner lock (read) -> reverse_mapping lock (read)
+    let index_clone_b = Arc::clone(&index);
+    let handle_b = thread::spawn(move || {
+        let vector = vec![0.0f32; 128];
+        while start_time.elapsed() < duration {
+            let _ = index_clone_b.search(&vector, 10);
+        }
+    });
+
+    // Thread C: Saves repeatedly (Save path)
+    // This iterates id_mapping (read) -> acquires inner lock (read)
+    let index_clone_c = Arc::clone(&index);
+    let handle_c = thread::spawn(move || {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.usearch");
+        while start_time.elapsed() < duration {
+            let _ = index_clone_c.save(&path);
+            thread::sleep(Duration::from_millis(10)); // Slight delay
+        }
+    });
+
+    // Thread D: Filtered Search
+    // This acquires inner lock (read) -> reverse_mapping lock (read) via callback
+    let index_clone_d = Arc::clone(&index);
+    let handle_d = thread::spawn(move || {
+        let vector = vec![0.0f32; 128];
+        while start_time.elapsed() < duration {
+             let _ = index_clone_d.search_with_filter(&vector, 10, |_| true);
+        }
+    });
+
+    // Wait for threads
+    handle_a.join().unwrap();
+    handle_b.join().unwrap();
+    handle_c.join().unwrap();
+    handle_d.join().unwrap();
+}

--- a/tests/havoc_concurrency.rs
+++ b/tests/havoc_concurrency.rs
@@ -1,6 +1,6 @@
-use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
-use aletheiadb::index::VectorIndex;
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -10,7 +10,7 @@ fn test_havoc_deadlock_scenario() {
     let index = Arc::new(
         HnswIndexBuilder::new(128, DistanceMetric::Cosine)
             .build()
-            .unwrap()
+            .unwrap(),
     );
 
     let start_time = std::time::Instant::now();
@@ -59,7 +59,7 @@ fn test_havoc_deadlock_scenario() {
     let handle_d = thread::spawn(move || {
         let vector = vec![0.0f32; 128];
         while start_time.elapsed() < duration {
-             let _ = index_clone_d.search_with_filter(&vector, 10, |_| true);
+            let _ = index_clone_d.search_with_filter(&vector, 10, |_| true);
         }
     });
 

--- a/tests/havoc_config_serialization.rs
+++ b/tests/havoc_config_serialization.rs
@@ -1,0 +1,39 @@
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, Quantization, StorageMode};
+use aletheiadb::utils::Result;
+use std::io::Cursor;
+
+#[test]
+fn test_config_serialization_round_trip() -> Result<()> {
+    // Create a config with non-default values, especially quantization
+    let original = HnswConfig::new(128, DistanceMetric::Cosine)
+        .with_m(32)
+        .with_ef_construction(200)
+        .with_ef_search(100)
+        .with_capacity(5000)
+        .with_quantization(Quantization::F16) // The critical part
+        .with_storage(StorageMode::InMemory); // Storage mode is not serialized, but quantization should be
+
+    // Serialize to buffer
+    let mut buffer = Vec::new();
+    original.serialize_into(&mut buffer)?;
+
+    // Deserialize from buffer
+    let mut cursor = Cursor::new(buffer);
+    let deserialized = HnswConfig::deserialize_from(&mut cursor)?;
+
+    // Assert equality
+    assert_eq!(original.dimensions, deserialized.dimensions);
+    assert_eq!(original.metric, deserialized.metric);
+    assert_eq!(original.m, deserialized.m);
+    assert_eq!(original.ef_construction, deserialized.ef_construction);
+    assert_eq!(original.ef_search, deserialized.ef_search);
+    assert_eq!(original.capacity, deserialized.capacity);
+
+    // This assertion is expected to fail currently
+    assert_eq!(
+        original.quantization, deserialized.quantization,
+        "Quantization should be preserved after round-trip serialization"
+    );
+
+    Ok(())
+}

--- a/tests/vector_quantization_coverage.rs
+++ b/tests/vector_quantization_coverage.rs
@@ -1,4 +1,4 @@
-use aletheiadb::index::vector::{HnswConfig, Quantization, DistanceMetric};
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, Quantization};
 use aletheiadb::utils::Result;
 use std::io::Cursor;
 
@@ -62,7 +62,10 @@ fn test_hnsw_config_deserialize_io_error_propagation() {
     struct ErrorReader;
     impl std::io::Read for ErrorReader {
         fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "Generic failure"))
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Generic failure",
+            ))
         }
     }
 
@@ -86,7 +89,10 @@ fn test_hnsw_config_deserialize_io_error_propagation() {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
             if self.pos >= self.data.len() {
                 // If we've read all data (41 bytes), return an error instead of 0 (EOF)
-                return Err(std::io::Error::new(std::io::ErrorKind::Other, "Simulated read error"));
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Simulated read error",
+                ));
             }
             let len = std::cmp::min(buf.len(), self.data.len() - self.pos);
             buf[..len].copy_from_slice(&self.data[self.pos..self.pos + len]);

--- a/tests/vector_quantization_coverage.rs
+++ b/tests/vector_quantization_coverage.rs
@@ -1,0 +1,114 @@
+use aletheiadb::index::vector::{HnswConfig, Quantization, DistanceMetric};
+use aletheiadb::utils::Result;
+use std::io::Cursor;
+
+#[test]
+fn test_quantization_conversion_coverage() {
+    // Test all to_u8 variants
+    assert_eq!(Quantization::F32.to_u8(), 0);
+    assert_eq!(Quantization::F16.to_u8(), 1);
+    assert_eq!(Quantization::I8.to_u8(), 2);
+
+    // Test all from_u8 valid variants
+    assert_eq!(Quantization::from_u8(0).unwrap(), Quantization::F32);
+    assert_eq!(Quantization::from_u8(1).unwrap(), Quantization::F16);
+    assert_eq!(Quantization::from_u8(2).unwrap(), Quantization::I8);
+
+    // Test from_u8 invalid variants (error path)
+    assert!(Quantization::from_u8(3).is_err());
+    assert!(Quantization::from_u8(255).is_err());
+}
+
+#[test]
+fn test_hnsw_config_deserialize_backward_compatibility() -> Result<()> {
+    // Manually construct a serialized config WITHOUT the quantization byte (old format)
+    let dimensions = 128u64;
+    let metric = DistanceMetric::Cosine;
+    let m = 16u64;
+    let ef_construction = 100u64;
+    let ef_search = 50u64;
+    let capacity = 1000u64;
+
+    let mut buffer = Vec::new();
+    // dimensions (8)
+    buffer.extend_from_slice(&dimensions.to_le_bytes());
+    // metric (1)
+    buffer.push(metric.to_u8());
+    // m (8)
+    buffer.extend_from_slice(&m.to_le_bytes());
+    // ef_construction (8)
+    buffer.extend_from_slice(&ef_construction.to_le_bytes());
+    // ef_search (8)
+    buffer.extend_from_slice(&ef_search.to_le_bytes());
+    // capacity (8)
+    buffer.extend_from_slice(&capacity.to_le_bytes());
+
+    // STOP HERE: Do not write quantization byte. This simulates an old file ending at 41 bytes.
+
+    let mut cursor = Cursor::new(buffer);
+
+    // Deserialize should succeed and default to F32
+    let config = HnswConfig::deserialize_from(&mut cursor)?;
+
+    assert_eq!(config.dimensions, 128);
+    assert_eq!(config.quantization, Quantization::F32); // Default behavior triggered by UnexpectedEof
+
+    Ok(())
+}
+
+#[test]
+fn test_hnsw_config_deserialize_io_error_propagation() {
+    // Create a reader that returns a generic IO error (not UnexpectedEof)
+    struct ErrorReader;
+    impl std::io::Read for ErrorReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "Generic failure"))
+        }
+    }
+
+    // We need to pass the first few reads to get to the quantization part?
+    // Actually, deserialize_from reads many fields first.
+    // If we want to test the specific error path at the END (quantization read),
+    // we need a reader that succeeds for 41 bytes then fails with Other.
+
+    struct FailAtEndReader {
+        data: Vec<u8>,
+        pos: usize,
+    }
+
+    impl FailAtEndReader {
+        fn new(data: Vec<u8>) -> Self {
+            Self { data, pos: 0 }
+        }
+    }
+
+    impl std::io::Read for FailAtEndReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.pos >= self.data.len() {
+                // If we've read all data (41 bytes), return an error instead of 0 (EOF)
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, "Simulated read error"));
+            }
+            let len = std::cmp::min(buf.len(), self.data.len() - self.pos);
+            buf[..len].copy_from_slice(&self.data[self.pos..self.pos + len]);
+            self.pos += len;
+            Ok(len)
+        }
+    }
+
+    // Construct valid 41-byte data
+    let mut buffer = Vec::new();
+    buffer.extend_from_slice(&128u64.to_le_bytes());
+    buffer.push(0); // Cosine
+    buffer.extend_from_slice(&16u64.to_le_bytes());
+    buffer.extend_from_slice(&100u64.to_le_bytes());
+    buffer.extend_from_slice(&50u64.to_le_bytes());
+    buffer.extend_from_slice(&1000u64.to_le_bytes());
+
+    let mut reader = FailAtEndReader::new(buffer);
+    let result = HnswConfig::deserialize_from(&mut reader);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    // Should be our simulated error, not UnexpectedEof
+    assert!(err.to_string().contains("Simulated read error"));
+}

--- a/tests/vector_quantization_coverage.rs
+++ b/tests/vector_quantization_coverage.rs
@@ -58,17 +58,6 @@ fn test_hnsw_config_deserialize_backward_compatibility() -> Result<()> {
 
 #[test]
 fn test_hnsw_config_deserialize_io_error_propagation() {
-    // Create a reader that returns a generic IO error (not UnexpectedEof)
-    struct ErrorReader;
-    impl std::io::Read for ErrorReader {
-        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Generic failure",
-            ))
-        }
-    }
-
     // We need to pass the first few reads to get to the quantization part?
     // Actually, deserialize_from reads many fields first.
     // If we want to test the specific error path at the END (quantization read),
@@ -89,10 +78,7 @@ fn test_hnsw_config_deserialize_io_error_propagation() {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
             if self.pos >= self.data.len() {
                 // If we've read all data (41 bytes), return an error instead of 0 (EOF)
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Simulated read error",
-                ));
+                return Err(std::io::Error::other("Simulated read error"));
             }
             let len = std::cmp::min(buf.len(), self.data.len() - self.pos);
             buf[..len].copy_from_slice(&self.data[self.pos..self.pos + len]);


### PR DESCRIPTION
This PR addresses a data loss issue in `HnswConfig` serialization where the `Quantization` level was not being persisted. It also includes a new concurrency torture test to verify thread safety.

## Changes
- Implemented `Quantization::to_u8` and `Quantization::from_u8`.
- Updated `HnswConfig::serialize_into` to write the quantization byte.
- Updated `HnswConfig::deserialize_from` to read the quantization byte, with fallback for backward compatibility.
- Added `tests/havoc_config_serialization.rs` regression test.
- Added `tests/havoc_concurrency.rs` stress test.

## Verification
- `cargo test --test havoc_config_serialization` PASS
- `cargo test --test havoc_concurrency` PASS
- `cargo test index::vector::hnsw` PASS

---
*PR created automatically by Jules for task [1846771738989616785](https://jules.google.com/task/1846771738989616785) started by @madmax983*