### PR TITLE
[Sentry] Fix WAL data loss by persisting label strings (V2 format)

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -47,7 +47,7 @@ use crate::utils::error::{Error, Result, StorageError};
 const WAL_MAGIC: [u8; 4] = *b"GWAL";
 
 /// Current WAL format version.
-const WAL_VERSION: u8 = 1;
+const WAL_VERSION: u8 = 2;
 
 /// Size of the WAL segment header (magic + version).
 const WAL_HEADER_SIZE: usize = 5;

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -306,7 +306,7 @@ pub(crate) fn parse_entry_at(
     let operation = match op_type {
         1 => {
             // CreateNode
-            if current_offset.checked_add(12).ok_or_else(|| {
+            if current_offset.checked_add(8).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
                 ))
@@ -404,7 +404,7 @@ pub(crate) fn parse_entry_at(
         }
         2 => {
             // CreateEdge
-            if current_offset.checked_add(28).ok_or_else(|| {
+            if current_offset.checked_add(24).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
                 ))
@@ -509,7 +509,7 @@ pub(crate) fn parse_entry_at(
         }
         3 => {
             // UpdateNode
-            if current_offset.checked_add(20).ok_or_else(|| {
+            if current_offset.checked_add(16).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
                 ))
@@ -1752,5 +1752,184 @@ mod tests {
         } else {
             panic!("Wrong operation type");
         }
+    }
+
+    // =============================================================================
+    // V2 Error Handling Coverage Tests
+    // These tests specifically target error paths in V2 label deserialization
+    // =============================================================================
+
+    fn construct_v2_header(buffer: &mut Vec<u8>) {
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // LSN
+        time::now().serialize_into(buffer); // Timestamp
+        buffer.extend_from_slice(&0u32.to_le_bytes()); // Checksum placeholder
+    }
+
+    #[test]
+    fn test_wal_v2_create_node_truncated_label_length() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(1); // Op: CreateNode
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // NodeId
+
+        // Truncate here (missing 4 bytes for label length)
+        buffer.push(0);
+
+        let result = parse_entry_at(&buffer, 0, 2); // Version 2
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for CreateNode label length"));
+    }
+
+    #[test]
+    fn test_wal_v2_create_node_truncated_label_data() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(1); // Op: CreateNode
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // NodeId
+
+        // Label length: 10 bytes
+        buffer.extend_from_slice(&10u32.to_le_bytes());
+
+        // Label data: only 5 bytes provided
+        buffer.extend_from_slice(b"short");
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for CreateNode label data"));
+    }
+
+    #[test]
+    fn test_wal_v2_create_node_invalid_utf8() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(1); // Op: CreateNode
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // NodeId
+
+        // Label length: 4 bytes
+        buffer.extend_from_slice(&4u32.to_le_bytes());
+
+        // Invalid UTF-8 sequence
+        buffer.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Invalid UTF-8 in label"));
+    }
+
+    #[test]
+    fn test_wal_v2_create_edge_truncated_label_length() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(2); // Op: CreateEdge
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // EdgeId
+        buffer.extend_from_slice(&2u64.to_le_bytes()); // Source
+        buffer.extend_from_slice(&3u64.to_le_bytes()); // Target
+
+        // Truncate here
+        buffer.push(0);
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for CreateEdge label length"));
+    }
+
+    #[test]
+    fn test_wal_v2_create_edge_truncated_label_data() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(2); // Op: CreateEdge
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // EdgeId
+        buffer.extend_from_slice(&2u64.to_le_bytes()); // Source
+        buffer.extend_from_slice(&3u64.to_le_bytes()); // Target
+
+        // Length 10
+        buffer.extend_from_slice(&10u32.to_le_bytes());
+        // Data too short
+        buffer.extend_from_slice(b"short");
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for CreateEdge label data"));
+    }
+
+    #[test]
+    fn test_wal_v2_update_node_truncated_label_length() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(3); // Op: UpdateNode
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // NodeId
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // VersionId
+
+        // Truncate
+        buffer.push(0);
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for UpdateNode label length"));
+    }
+
+    #[test]
+    fn test_wal_v2_update_node_truncated_label_data() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(3); // Op: UpdateNode
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // NodeId
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // VersionId
+
+        buffer.extend_from_slice(&10u32.to_le_bytes());
+        buffer.extend_from_slice(b"short");
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for UpdateNode label data"));
+    }
+
+    #[test]
+    fn test_wal_v2_update_edge_truncated_label_length() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(4); // Op: UpdateEdge
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // EdgeId
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // VersionId
+
+        buffer.push(0);
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for UpdateEdge label length"));
+    }
+
+    #[test]
+    fn test_wal_v2_update_edge_truncated_label_data() {
+        let mut buffer = Vec::new();
+        construct_v2_header(&mut buffer);
+
+        buffer.push(4); // Op: UpdateEdge
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // EdgeId
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // VersionId
+
+        buffer.extend_from_slice(&10u32.to_le_bytes());
+        buffer.extend_from_slice(b"short");
+
+        let result = parse_entry_at(&buffer, 0, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Insufficient buffer size for UpdateEdge label data"));
     }
 }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -30,7 +30,7 @@ use super::{LSN, WalEntry, WalOperation};
 const WAL_MAGIC: [u8; 4] = *b"GWAL";
 
 /// Current WAL format version.
-const WAL_VERSION: u8 = 1;
+const WAL_VERSION: u8 = 2;
 
 /// Size of the WAL segment header (magic + version).
 const WAL_HEADER_SIZE: usize = 5;
@@ -320,32 +320,71 @@ pub(crate) fn parse_entry_at(
             let node_id = deserialize_node_id(buffer, current_offset, "CreateNode")?;
             add_offset!(8);
 
-            // Read 4-byte InternedString ID
-            if current_offset.checked_add(4).ok_or_else(|| {
-                Error::Storage(StorageError::CorruptedData(
-                    "WAL offset overflow".to_string(),
-                ))
-            })? > buffer.len()
-            {
-                return Err(StorageError::CorruptedData(
-                    "Insufficient buffer size for CreateNode label".to_string(),
-                )
-                .into());
-            }
-            let label_id = u32::from_le_bytes(
-                buffer[current_offset..current_offset + 4]
-                    .try_into()
-                    .unwrap(), // Safe due to buffer length check above
-            );
-            add_offset!(4);
+            let label = if version >= 2 {
+                // Read 4-byte string length
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for CreateNode label length".to_string(),
+                    )
+                    .into());
+                }
+                let label_len = u32::from_le_bytes(
+                    buffer[current_offset..current_offset + 4]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                add_offset!(4);
 
-            // Reconstruct InternedString from ID
-            // During recovery, the string should already be in the interner
-            // (either from checkpoint or previous WAL entries)
-            let label = crate::core::interning::InternedString::from_raw(label_id);
+                // Read string bytes
+                if current_offset.checked_add(label_len).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for CreateNode label data".to_string(),
+                    )
+                    .into());
+                }
+                let label_bytes = &buffer[current_offset..current_offset + label_len];
+                let label_str = std::str::from_utf8(label_bytes).map_err(|e| {
+                    StorageError::CorruptedData(format!("Invalid UTF-8 in label: {}", e))
+                })?;
+                add_offset!(label_len);
+
+                // Intern it (recovering the string mapping)
+                crate::core::interning::GLOBAL_INTERNER.intern(label_str)?
+            } else {
+                // Read 4-byte InternedString ID
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for CreateNode label".to_string(),
+                    )
+                    .into());
+                }
+                let label_id = u32::from_le_bytes(
+                    buffer[current_offset..current_offset + 4]
+                        .try_into()
+                        .unwrap(), // Safe due to buffer length check above
+                );
+                add_offset!(4);
+
+                crate::core::interning::InternedString::from_raw(label_id)
+            };
 
             // V1+: deserialize properties and temporal
-            let (properties, valid_from) = if version >= WAL_VERSION {
+            let (properties, valid_from) = if version >= 1 {
                 let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
                 add_offset!(props_len);
                 let (valid_from_ts, ts_len) =
@@ -385,29 +424,70 @@ pub(crate) fn parse_entry_at(
             let target = deserialize_node_id(buffer, current_offset, "CreateEdge target")?;
             add_offset!(8);
 
-            // Read 4-byte InternedString ID
-            if current_offset.checked_add(4).ok_or_else(|| {
-                Error::Storage(StorageError::CorruptedData(
-                    "WAL offset overflow".to_string(),
-                ))
-            })? > buffer.len()
-            {
-                return Err(StorageError::CorruptedData(
-                    "Insufficient buffer size for CreateEdge label".to_string(),
-                )
-                .into());
-            }
-            let label_id = u32::from_le_bytes(
-                buffer[current_offset..current_offset + 4]
-                    .try_into()
-                    .unwrap(), // Safe due to buffer length check above
-            );
-            add_offset!(4);
+            let label = if version >= 2 {
+                // Read 4-byte string length
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for CreateEdge label length".to_string(),
+                    )
+                    .into());
+                }
+                let label_len = u32::from_le_bytes(
+                    buffer[current_offset..current_offset + 4]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                add_offset!(4);
 
-            // Reconstruct InternedString from ID
-            let label = crate::core::interning::InternedString::from_raw(label_id);
+                // Read string bytes
+                if current_offset.checked_add(label_len).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for CreateEdge label data".to_string(),
+                    )
+                    .into());
+                }
+                let label_bytes = &buffer[current_offset..current_offset + label_len];
+                let label_str = std::str::from_utf8(label_bytes).map_err(|e| {
+                    StorageError::CorruptedData(format!("Invalid UTF-8 in label: {}", e))
+                })?;
+                add_offset!(label_len);
 
-            let (properties, valid_from) = if version >= WAL_VERSION {
+                // Intern it (recovering the string mapping)
+                crate::core::interning::GLOBAL_INTERNER.intern(label_str)?
+            } else {
+                // Read 4-byte InternedString ID
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for CreateEdge label".to_string(),
+                    )
+                    .into());
+                }
+                let label_id = u32::from_le_bytes(
+                    buffer[current_offset..current_offset + 4]
+                        .try_into()
+                        .unwrap(), // Safe due to buffer length check above
+                );
+                add_offset!(4);
+
+                crate::core::interning::InternedString::from_raw(label_id)
+            };
+
+            let (properties, valid_from) = if version >= 1 {
                 let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
                 add_offset!(props_len);
                 let (valid_from_ts, ts_len) =
@@ -446,7 +526,54 @@ pub(crate) fn parse_entry_at(
             let version_id = deserialize_version_id(buffer, current_offset, "UpdateNode")?;
             add_offset!(8);
 
-            let (label, properties, valid_from) = if version >= WAL_VERSION {
+            let (label, properties, valid_from) = if version >= 2 {
+                // Read 4-byte string length
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for UpdateNode label length".to_string(),
+                    )
+                    .into());
+                }
+                let label_len = u32::from_le_bytes(
+                    buffer[current_offset..current_offset + 4]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                add_offset!(4);
+
+                // Read string bytes
+                if current_offset.checked_add(label_len).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for UpdateNode label data".to_string(),
+                    )
+                    .into());
+                }
+                let label_bytes = &buffer[current_offset..current_offset + label_len];
+                let label_str = std::str::from_utf8(label_bytes).map_err(|e| {
+                    StorageError::CorruptedData(format!("Invalid UTF-8 in label: {}", e))
+                })?;
+                add_offset!(label_len);
+
+                // Intern it (recovering the string mapping)
+                let lbl = crate::core::interning::GLOBAL_INTERNER.intern(label_str)?;
+
+                let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
+                add_offset!(props_len);
+                let (valid_from_ts, ts_len) =
+                    HybridTimestamp::deserialize(&buffer[current_offset..])?;
+                add_offset!(ts_len);
+                (lbl, props, valid_from_ts)
+            } else if version >= 1 {
                 // Read 4-byte InternedString ID
                 let label_id = u32::from_le_bytes([
                     buffer[current_offset],
@@ -501,7 +628,54 @@ pub(crate) fn parse_entry_at(
             let version_id = deserialize_version_id(buffer, current_offset, "UpdateEdge")?;
             add_offset!(8);
 
-            let (label, properties, valid_from) = if version >= WAL_VERSION {
+            let (label, properties, valid_from) = if version >= 2 {
+                // Read 4-byte string length
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for UpdateEdge label length".to_string(),
+                    )
+                    .into());
+                }
+                let label_len = u32::from_le_bytes(
+                    buffer[current_offset..current_offset + 4]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                add_offset!(4);
+
+                // Read string bytes
+                if current_offset.checked_add(label_len).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for UpdateEdge label data".to_string(),
+                    )
+                    .into());
+                }
+                let label_bytes = &buffer[current_offset..current_offset + label_len];
+                let label_str = std::str::from_utf8(label_bytes).map_err(|e| {
+                    StorageError::CorruptedData(format!("Invalid UTF-8 in label: {}", e))
+                })?;
+                add_offset!(label_len);
+
+                // Intern it (recovering the string mapping)
+                let lbl = crate::core::interning::GLOBAL_INTERNER.intern(label_str)?;
+
+                let (props, props_len) = PropertyMap::deserialize(&buffer[current_offset..])?;
+                add_offset!(props_len);
+                let (valid_from_ts, ts_len) =
+                    HybridTimestamp::deserialize(&buffer[current_offset..])?;
+                add_offset!(ts_len);
+                (lbl, props, valid_from_ts)
+            } else if version >= 1 {
                 // Read 4-byte InternedString ID
                 let label_id = u32::from_le_bytes([
                     buffer[current_offset],
@@ -1485,6 +1659,98 @@ mod tests {
                 assert_eq!(msg, "WAL offset overflow");
             }
             _ => panic!("Expected WAL offset overflow error, got: {:?}", result),
+        }
+    }
+
+    /// 🎯 Target: WAL Label Interning Persistence
+    /// 💣 Risk: WAL V1 format only stored the 4-byte InternedString ID. V2 stores the string.
+    /// 🧪 Strategy: Serialize an entry with a long unique label. Verify the buffer size
+    ///    includes the string content. Verify that parsing it restores the string.
+    #[test]
+    fn test_wal_v2_label_persistence() {
+        let unique_label = "Sentry_V2_Persistence_Test_Label";
+        let label_id = GLOBAL_INTERNER.intern(unique_label).unwrap();
+
+        let operation = WalOperation::CreateNode {
+            node_id: NodeId::new(1).unwrap(),
+            label: label_id,
+            properties: PropertyMap::new(),
+            valid_from: time::now(),
+        };
+        let entry = WalEntry::new(LSN(100), operation);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+
+        // Check size: Header (24) + Op (1) + NodeId (8) + LabelLen (4) + LabelBytes + Props (4) + ValidFrom (12)
+        // = 53 + LabelBytes.len()
+        let expected_size = 53 + unique_label.len();
+        assert_eq!(
+            buffer.len(),
+            expected_size,
+            "WAL V2 buffer should include label string"
+        );
+
+        // Parse it back (using V2)
+        // Note: we can't easily clear GLOBAL_INTERNER safely here, but we can check that
+        // parsing works and returns the correct label ID (which matches the existing one)
+        let (parsed_entry, consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        assert_eq!(consumed, expected_size);
+
+        if let WalOperation::CreateNode { label, .. } = parsed_entry.operation {
+            assert_eq!(label, label_id);
+            // Verify resolution works (though it was already there)
+            let resolved = GLOBAL_INTERNER
+                .resolve_with(label, |s| s.to_string())
+                .unwrap();
+            assert_eq!(resolved, unique_label);
+        } else {
+            panic!("Wrong operation type");
+        }
+    }
+
+    /// 🎯 Target: WAL V1 Backward Compatibility
+    /// 💣 Risk: We must be able to read old V1 WAL files (even if labels are unrecoverable, we shouldn't crash).
+    /// 🧪 Strategy: Manually construct a V1 buffer (with ID only) and parse it with version=1.
+    #[test]
+    fn test_wal_v1_backward_compatibility() {
+        let mut buffer = Vec::new();
+
+        // Header
+        buffer.extend_from_slice(&100u64.to_le_bytes()); // LSN
+        time::now().serialize_into(&mut buffer); // Timestamp
+        let checksum_offset = buffer.len();
+        buffer.extend_from_slice(&0u32.to_le_bytes()); // Checksum placeholder
+
+        // Op: CreateNode
+        buffer.push(1);
+        buffer.extend_from_slice(&1u64.to_le_bytes()); // NodeId
+
+        // V1 Label: ID only (4 bytes)
+        // We use a known ID (e.g., for "name" which is common) or just 0
+        let label_id = GLOBAL_INTERNER.intern("name").unwrap();
+        buffer.extend_from_slice(&label_id.as_u32().to_le_bytes());
+
+        // Props (empty)
+        PropertyMap::new().serialize_into(&mut buffer).unwrap();
+        // ValidFrom
+        time::now().serialize_into(&mut buffer);
+
+        // Compute checksum
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&buffer[0..checksum_offset]);
+        hasher.update(&buffer[checksum_offset + 4..]);
+        let checksum = hasher.finalize();
+        buffer[checksum_offset..checksum_offset + 4].copy_from_slice(&checksum.to_le_bytes());
+
+        // Parse with version=1
+        let (parsed_entry, _) = parse_entry_at(&buffer, 0, 1).unwrap();
+
+        // Should succeed and return the ID
+        if let WalOperation::CreateNode { label, .. } = parsed_entry.operation {
+            assert_eq!(label, label_id);
+        } else {
+            panic!("Wrong operation type");
         }
     }
 }

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -7,10 +7,28 @@ use crate::core::interning::InternedString;
 use crate::core::temporal::Timestamp;
 use crate::utils::error::Result;
 
-/// Helper to serialize an InternedString into the buffer (4-byte ID)
+/// Helper to serialize an InternedString into the buffer (length + UTF-8 bytes)
+///
+/// This supports WAL V2 format which stores the actual string content to ensure
+/// recovery even if the interner state is lost.
 #[inline(always)]
-fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
-    buffer.extend_from_slice(&s.as_u32().to_le_bytes());
+fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) -> Result<()> {
+    use crate::utils::error::{Error, StorageError};
+    crate::core::interning::GLOBAL_INTERNER
+        .resolve_with(s, |s_str| {
+            let bytes = s_str.as_bytes();
+            buffer.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(bytes);
+        })
+        .ok_or_else(|| {
+            Error::Storage(StorageError::InconsistentState {
+                reason: format!(
+                    "WAL Serialization: InternedString ID {} not found",
+                    s.as_u32()
+                ),
+            })
+        })?;
+    Ok(())
 }
 
 /// Estimate the required buffer capacity for serializing a WAL entry.
@@ -28,13 +46,13 @@ fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
 /// - Total fixed: 24 bytes
 ///
 /// Variable sizes by operation:
-/// - `CreateNode`: 1 (op type) + 8 (node_id) + 4 (label ID) +
+/// - `CreateNode`: 1 (op type) + 8 (node_id) + label size +
 ///   properties size + 12 (Timestamp)
 /// - `CreateEdge`: 1 (op type) + 8 (edge_id) + 8 (source) + 8 (target) +
-///   4 (label ID) + properties size + 12 (Timestamp)
-/// - `UpdateNode`: 1 (op type) + 8 (node_id) + 8 (version_id) + 4 (label ID) +
+///   label size + properties size + 12 (Timestamp)
+/// - `UpdateNode`: 1 (op type) + 8 (node_id) + 8 (version_id) + label size +
 ///   properties size + 12 (Timestamp)
-/// - `UpdateEdge`: 1 (op type) + 8 (edge_id) + 8 (version_id) + 4 (label ID) +
+/// - `UpdateEdge`: 1 (op type) + 8 (edge_id) + 8 (version_id) + label size +
 ///   properties size + 12 (Timestamp)
 /// - `DeleteNode`: 1 (op type) + 8 (node_id) + 12 (Timestamp) = 21 bytes
 /// - `DeleteEdge`: 1 (op type) + 8 (edge_id) + 12 (Timestamp) = 21 bytes
@@ -56,25 +74,42 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
     // Timestamp (HybridTimestamp) is always 12 bytes (wallclock + logical)
     const TIMESTAMP_SIZE: usize = 12;
 
+    // Helper to estimate label size (4 bytes len + string len)
+    // If not found, assume reasonable default (256 bytes) to avoid panic/error here
+    // (it will fail later during actual serialization if invalid)
+    let label_size = |label: InternedString| -> usize {
+        crate::core::interning::GLOBAL_INTERNER
+            .resolve_with(label, |s| 4 + s.len())
+            .unwrap_or(4 + 256)
+    };
+
     let variable_size = match operation {
-        WalOperation::CreateNode { properties, .. } => {
-            // op type (1) + node_id (8) + label (4-byte InternedString ID) + properties + valid_from (12)
-            let base = 1 + 8 + 4 + TIMESTAMP_SIZE;
+        WalOperation::CreateNode {
+            label, properties, ..
+        } => {
+            // op type (1) + node_id (8) + label size + properties + valid_from (12)
+            let base = 1 + 8 + label_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size()
         }
-        WalOperation::CreateEdge { properties, .. } => {
-            // op type (1) + edge_id (8) + source (8) + target (8) + label (4-byte InternedString ID) + properties + valid_from (12)
-            let base = 1 + 8 + 8 + 8 + 4 + TIMESTAMP_SIZE;
+        WalOperation::CreateEdge {
+            label, properties, ..
+        } => {
+            // op type (1) + edge_id (8) + source (8) + target (8) + label size + properties + valid_from (12)
+            let base = 1 + 8 + 8 + 8 + label_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size()
         }
-        WalOperation::UpdateNode { properties, .. } => {
-            // op type (1) + node_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12)
-            let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
+        WalOperation::UpdateNode {
+            label, properties, ..
+        } => {
+            // op type (1) + node_id (8) + version_id (8) + label size + properties + valid_from (12)
+            let base = 1 + 8 + 8 + label_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size()
         }
-        WalOperation::UpdateEdge { properties, .. } => {
-            // op type (1) + edge_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12)
-            let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
+        WalOperation::UpdateEdge {
+            label, properties, ..
+        } => {
+            // op type (1) + edge_id (8) + version_id (8) + label size + properties + valid_from (12)
+            let base = 1 + 8 + 8 + label_size(*label) + TIMESTAMP_SIZE;
             base + properties.serialized_size()
         }
         WalOperation::DeleteNode { .. } => {
@@ -123,7 +158,7 @@ pub(crate) fn serialize_operation_into(
         } => {
             buffer.push(1); // operation type
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_interned_string(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
         }
@@ -139,7 +174,7 @@ pub(crate) fn serialize_operation_into(
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&source.as_u64().to_le_bytes());
             buffer.extend_from_slice(&target.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_interned_string(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
         }
@@ -153,7 +188,7 @@ pub(crate) fn serialize_operation_into(
             buffer.push(3); // operation type
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_interned_string(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
         }
@@ -167,7 +202,7 @@ pub(crate) fn serialize_operation_into(
             buffer.push(4); // operation type
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
-            serialize_interned_string(*label, buffer);
+            serialize_interned_string(*label, buffer)?;
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
         }
@@ -311,8 +346,8 @@ mod tests {
     fn test_estimate_capacity_create_node_empty_properties() {
         // CreateNode with empty properties:
         // Fixed: 24 bytes (LSN + Timestamp + Checksum)
-        // op type (1) + node_id (8) + label (4-byte InternedString) + properties (4 for empty count) + valid_from (12)
-        // = 24 + 1 + 8 + 4 + 4 + 12 = 53 bytes
+        // op type (1) + node_id (8) + label (string "test": 4+4=8 bytes) + properties (4 for empty count) + valid_from (12)
+        // = 24 + 1 + 8 + 8 + 4 + 12 = 57 bytes
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
             label: GLOBAL_INTERNER.intern("test").unwrap(),
@@ -322,8 +357,8 @@ mod tests {
 
         let estimated = estimate_entry_capacity(&op);
         assert_eq!(
-            estimated, 53,
-            "CreateNode with empty properties should be 53 bytes"
+            estimated, 57,
+            "CreateNode with empty properties should be 57 bytes (V2)"
         );
 
         // Verify by actually serializing

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -53,8 +53,15 @@ pub fn create_test_db() -> Result<(tempfile::TempDir, AletheiaDB)> {
     let temp_dir = tempfile::tempdir().map_err(crate::utils::error::Error::Io)?;
 
     let wal_dir = temp_dir.path().join("wal");
+    let data_dir = temp_dir.path().join("data");
+
+    use crate::storage::index_persistence::PersistenceConfig;
 
     let config = AletheiaDBConfig::builder()
+        .persistence(PersistenceConfig {
+            data_dir,
+            ..Default::default()
+        })
         .wal(
             WalConfigBuilder::new()
                 .wal_dir(wal_dir)
@@ -114,6 +121,8 @@ pub fn create_test_db_with_config(
 
     // Override wal_dir to use temp directory
     config.wal.wal_dir = temp_dir.path().join("wal");
+    // Override persistence data_dir to use temp directory
+    config.persistence.data_dir = temp_dir.path().join("data");
 
     let db = AletheiaDB::with_unified_config(config)?;
 

--- a/tests/issue_225_wal_validation.rs
+++ b/tests/issue_225_wal_validation.rs
@@ -11,7 +11,6 @@ use aletheiadb::core::temporal::time;
 use aletheiadb::storage::persistence::{CheckpointConfig, PersistenceManager};
 use aletheiadb::storage::wal::WalOperation;
 use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
-use aletheiadb::utils::error::Error;
 use tempfile::TempDir;
 
 /// Test that WAL replay rejects invalid InternedString IDs
@@ -37,33 +36,20 @@ fn test_wal_replay_rejects_invalid_interned_string() {
     };
 
     // Write the operation to WAL
-    wal.append(op).unwrap();
-    wal.flush().unwrap();
+    // This should fail immediately because we need to resolve the string to serialize it (V2 format)
+    let result = wal.append(op);
+    assert!(
+        result.is_err(),
+        "WAL append should fail for invalid label ID"
+    );
 
-    // Now try to recover from this WAL
-    // This should fail with a CorruptedData error because the InternedString ID
-    // doesn't exist in the interner
-    let config = CheckpointConfig {
-        checkpoint_dir: temp_dir.path().join("checkpoints"),
-        ..Default::default()
-    };
-    let mut manager = PersistenceManager::new(config).unwrap();
-    let recovery_result = manager.recover(&wal);
-
-    match recovery_result {
-        Err(Error::Storage(storage_err)) => {
-            let err_msg = format!("{}", storage_err);
-            assert!(
-                err_msg.contains("InternedString ID") && err_msg.contains("not found in interner"),
-                "Expected error message about InternedString not found, got: {}",
-                err_msg
-            );
-        }
-        Err(other) => panic!("Expected StorageError::CorruptedData, got: {:?}", other),
-        Ok(_) => {
-            panic!("Expected recovery to fail with corrupted InternedString ID, but it succeeded")
-        }
-    }
+    // Check error message
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("InternedString ID") && err_msg.contains("not found"),
+        "Expected error message about InternedString not found, got: {}",
+        err_msg
+    );
 }
 
 /// Test that valid InternedString IDs are accepted during WAL replay
@@ -135,30 +121,11 @@ fn test_wal_replay_rejects_corrupted_interned_string() {
             valid_from: time::now(),
         };
 
-        wal.append(op).unwrap();
-    }
-
-    wal.flush().unwrap();
-
-    // Recovery should fail on the first corrupted entry
-    let config = CheckpointConfig {
-        checkpoint_dir: temp_dir.path().join("checkpoints"),
-        ..Default::default()
-    };
-    let mut manager = PersistenceManager::new(config).unwrap();
-    let recovery_result = manager.recover(&wal);
-
-    assert!(
-        recovery_result.is_err(),
-        "Expected recovery to fail with corrupted WAL, but it succeeded"
-    );
-
-    if let Err(e) = recovery_result {
-        let err_msg = format!("{}", e);
+        // Should fail to append
+        let result = wal.append(op);
         assert!(
-            err_msg.contains("InternedString ID") && err_msg.contains("not found"),
-            "Expected error about InternedString not found, got: {}",
-            err_msg
+            result.is_err(),
+            "WAL append should fail for invalid label ID"
         );
     }
 }


### PR DESCRIPTION
Identified and fixed a critical issue where WAL entries stored ephemeral `InternedString` IDs instead of the string content. This caused data corruption/loss during recovery if the in-memory string interner state was not separately persisted (e.g., during a crash before checkpoint).

Implemented WAL V2 format which serializes the full label string. Updated the WAL reader to support both V2 (new) and V1 (legacy) formats.

Also fixed a pre-existing issue in `test_utils.rs` where tests shared the default persistence directory, causing flaky failures.

---
*PR created automatically by Jules for task [8290018008509768579](https://jules.google.com/task/8290018008509768579) started by @madmax983*