### PR TITLE
🔒 Warden: Fix HnswConfig serialization data loss

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -306,6 +306,7 @@ impl HnswConfig {
         writer.write_all(&(self.ef_construction as u64).to_le_bytes())?;
         writer.write_all(&(self.ef_search as u64).to_le_bytes())?;
         writer.write_all(&(self.capacity as u64).to_le_bytes())?;
+        writer.write_all(&[self.quantization.to_u8()])?;
         Ok(())
     }
 
@@ -332,6 +333,17 @@ impl HnswConfig {
         reader.read_exact(&mut buf_u64)?;
         let capacity = u64::from_le_bytes(buf_u64) as usize;
 
+        // Try to read quantization, default to F32 if EOF (backward compatibility)
+        let quantization = match reader.read_exact(&mut buf_u8) {
+            Ok(_) => Quantization::from_u8(buf_u8[0])?,
+            Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                // Backward compatibility: Old configs don't have quantization byte.
+                // Default to F32 (which was the implicit behavior before).
+                Quantization::F32
+            }
+            Err(e) => return Err(e.into()),
+        };
+
         Ok(HnswConfig {
             dimensions,
             metric,
@@ -339,6 +351,7 @@ impl HnswConfig {
             ef_construction,
             ef_search,
             capacity,
+            quantization,
             ..Default::default()
         })
     }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -2644,4 +2644,61 @@ mod tests {
             panic!("Expected IndexError, got {:?}", result);
         }
     }
+
+    #[test]
+    fn test_deserialize_legacy_config() {
+        // Construct a legacy buffer (missing quantization byte)
+        // Format: [dimensions:8][metric:1][m:8][ef_construction:8][ef_search:8][capacity:8]
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&128u64.to_le_bytes()); // dimensions
+        buffer.push(DistanceMetric::Cosine.to_u8()); // metric
+        buffer.extend_from_slice(&16u64.to_le_bytes()); // m
+        buffer.extend_from_slice(&200u64.to_le_bytes()); // ef_construction
+        buffer.extend_from_slice(&100u64.to_le_bytes()); // ef_search
+        buffer.extend_from_slice(&1000u64.to_le_bytes()); // capacity
+
+        // Attempt to deserialize
+        let mut cursor = std::io::Cursor::new(buffer);
+        let config = HnswConfig::deserialize_from(&mut cursor).expect("Legacy deserialization failed");
+
+        // Should default to F32
+        assert_eq!(config.quantization, Quantization::F32);
+        assert_eq!(config.dimensions, 128);
+        assert_eq!(config.metric, DistanceMetric::Cosine);
+    }
+
+    #[test]
+    fn test_deserialize_config_io_error() {
+        // Construct a buffer that is truncated before quantization byte
+        // Format: [dimensions:8][metric:1]...
+        // But let's make it fail *during* reading quantization byte with a non-EOF error
+        // Since Cursor only returns EOF, we need a custom reader to simulate other errors.
+        // Alternatively, we can just verify that truncation *earlier* in the stream fails correctly,
+        // but to hit the specific quantization error path (not EOF), we need a custom reader.
+
+        struct ErrorReader;
+        impl Read for ErrorReader {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(std::io::ErrorKind::Other, "Custom IO error"))
+            }
+        }
+
+        // We need the reader to succeed for the first fields then fail at quantization.
+        // Let's use a chain of Cursor and ErrorReader.
+        let mut valid_part = Vec::new();
+        valid_part.extend_from_slice(&128u64.to_le_bytes());
+        valid_part.push(DistanceMetric::Cosine.to_u8());
+        valid_part.extend_from_slice(&16u64.to_le_bytes());
+        valid_part.extend_from_slice(&200u64.to_le_bytes());
+        valid_part.extend_from_slice(&100u64.to_le_bytes());
+        valid_part.extend_from_slice(&1000u64.to_le_bytes());
+
+        let cursor = std::io::Cursor::new(valid_part);
+        let mut reader = cursor.chain(ErrorReader);
+
+        let result = HnswConfig::deserialize_from(&mut reader);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Custom IO error"));
+    }
 }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -2659,7 +2659,8 @@ mod tests {
 
         // Attempt to deserialize
         let mut cursor = std::io::Cursor::new(buffer);
-        let config = HnswConfig::deserialize_from(&mut cursor).expect("Legacy deserialization failed");
+        let config =
+            HnswConfig::deserialize_from(&mut cursor).expect("Legacy deserialization failed");
 
         // Should default to F32
         assert_eq!(config.quantization, Quantization::F32);
@@ -2679,7 +2680,10 @@ mod tests {
         struct ErrorReader;
         impl Read for ErrorReader {
             fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-                Err(std::io::Error::new(std::io::ErrorKind::Other, "Custom IO error"))
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Custom IO error",
+                ))
             }
         }
 

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -706,9 +706,9 @@ mod tests {
         let result = Quantization::from_u8(3);
         assert!(result.is_err());
         match result {
-            Err(crate::utils::Error::Storage(crate::utils::error::StorageError::CorruptedData(
-                msg,
-            ))) => {
+            Err(crate::utils::Error::Storage(
+                crate::utils::error::StorageError::CorruptedData(msg),
+            )) => {
                 assert!(msg.contains("Invalid quantization encoding: 3"));
             }
             _ => panic!("Expected CorruptedData error"),

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -689,6 +689,31 @@ mod tests {
             DistanceMetric::Tanimoto
         );
     }
+
+    #[test]
+    fn test_quantization_encoding() {
+        // Test encoding
+        assert_eq!(Quantization::F32.to_u8(), 0);
+        assert_eq!(Quantization::F16.to_u8(), 1);
+        assert_eq!(Quantization::I8.to_u8(), 2);
+
+        // Test decoding
+        assert_eq!(Quantization::from_u8(0).unwrap(), Quantization::F32);
+        assert_eq!(Quantization::from_u8(1).unwrap(), Quantization::F16);
+        assert_eq!(Quantization::from_u8(2).unwrap(), Quantization::I8);
+
+        // Test invalid decoding
+        let result = Quantization::from_u8(3);
+        assert!(result.is_err());
+        match result {
+            Err(crate::utils::Error::Storage(crate::utils::error::StorageError::CorruptedData(
+                msg,
+            ))) => {
+                assert!(msg.contains("Invalid quantization encoding: 3"));
+            }
+            _ => panic!("Expected CorruptedData error"),
+        }
+    }
 }
 
 // HNSW implementation

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -109,6 +109,31 @@ pub enum Quantization {
     I8,
 }
 
+impl Quantization {
+    /// Encode quantization as a byte for serialization.
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Quantization::F32 => 0,
+            Quantization::F16 => 1,
+            Quantization::I8 => 2,
+        }
+    }
+
+    /// Decode quantization from a byte.
+    pub fn from_u8(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(Quantization::F32),
+            1 => Ok(Quantization::F16),
+            2 => Ok(Quantization::I8),
+            _ => Err(crate::utils::error::StorageError::CorruptedData(format!(
+                "Invalid quantization encoding: {}",
+                value
+            ))
+            .into()),
+        }
+    }
+}
+
 /// Storage mode for the vector index.
 ///
 /// - InMemory: All data in RAM (default, fastest queries)

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -107,7 +107,7 @@ impl VectorIndexCheckpointData {
     /// - enabled: 1 byte (0 or 1)
     /// - property_name_len: 4 bytes (u32 LE)
     /// - property_name: variable bytes (UTF-8)
-    /// - config: 41 bytes (HnswConfig serialization)
+    /// - config: 42 bytes (HnswConfig serialization, updated with quantization byte)
     pub fn serialize_into<W: Write>(&self, writer: &mut W) -> Result<()> {
         writer.write_all(&[if self.enabled { 1 } else { 0 }])?;
 
@@ -1346,9 +1346,10 @@ mod tests {
         // - Magic (4) + Version (4) = 8
         // - LSN (8) + Timestamp (12) + NodeCount (8) + EdgeCount (8) + VersionCount (8) = 44
         //   (Phase 2: Timestamp is now HybridTimestamp: 8-byte wallclock + 4-byte logical = 12 bytes)
-        // - Vector config: enabled (1) + name_len (4) + "test_property" (13) + HnswConfig (41) = 59
-        // Total = 111 bytes (was 107 before Phase 2)
-        assert_eq!(metadata.len(), 111);
+        // - Vector config: enabled (1) + name_len (4) + "test_property" (13) + HnswConfig (42) = 60
+        //   (HnswConfig grew from 41 to 42 bytes with quantization field)
+        // Total = 112 bytes (was 111)
+        assert_eq!(metadata.len(), 112);
 
         Ok(())
     }

--- a/tests/warden_serialization.rs
+++ b/tests/warden_serialization.rs
@@ -1,4 +1,3 @@
-
 use aletheiadb::index::vector::hnsw::HnswConfig;
 use aletheiadb::index::vector::{DistanceMetric, Quantization};
 use std::io::Cursor;

--- a/tests/warden_serialization.rs
+++ b/tests/warden_serialization.rs
@@ -1,0 +1,49 @@
+
+use aletheiadb::index::vector::hnsw::HnswConfig;
+use aletheiadb::index::vector::{DistanceMetric, Quantization};
+use std::io::Cursor;
+
+/// 🔒 Warden Security Regression Test
+///
+/// Threat: Metadata corruption via incomplete serialization
+/// Description: HnswConfig serialization was dropping the `Quantization` setting,
+/// effectively reverting any non-default quantization (e.g. I8) to F32 upon reload.
+/// This could lead to buffer over-reads if a custom metric wrapper expects F32 pointers
+/// but receives I8 pointers from the underlying index (which is correctly I8).
+#[test]
+fn test_warden_hnsw_config_quantization_persistence() {
+    // 1. Create a config with non-default quantization (I8)
+    let original = HnswConfig::new(128, DistanceMetric::Cosine)
+        .with_quantization(Quantization::I8) // Explicitly set to I8
+        .with_m(32)
+        .with_ef_construction(200);
+
+    // Verify setup
+    assert_eq!(
+        original.quantization,
+        Quantization::I8,
+        "Setup failed: quantization not set"
+    );
+
+    // 2. Serialize to buffer
+    let mut buffer = Vec::new();
+    original
+        .serialize_into(&mut buffer)
+        .expect("Serialization failed");
+
+    // 3. Deserialize back
+    let mut cursor = Cursor::new(buffer);
+    let restored = HnswConfig::deserialize_from(&mut cursor).expect("Deserialization failed");
+
+    // 4. Assert correctness (this is expected to FAIL before the fix)
+    assert_eq!(
+        restored.quantization, original.quantization,
+        "SECURITY REGRESSION: Quantization setting lost during serialization! \
+         Expected {:?}, got {:?}. This can lead to memory safety violations.",
+        original.quantization, restored.quantization
+    );
+
+    // Verify other fields still work
+    assert_eq!(restored.dimensions, 128);
+    assert_eq!(restored.m, 32);
+}


### PR DESCRIPTION
**Threat:** `HnswConfig` serialization was dropping the `Quantization` setting. When reloading a persisted index configuration, it would revert to `Quantization::F32` (default). If the underlying index was actually `I8` or `F16`, this mismatch could lead to undefined behavior (buffer over-reads) when custom metrics are used, as they rely on the config to determine pointer types.

**Defense:**
1.  Updated `HnswConfig::serialize_into` to persist the quantization setting.
2.  Updated `HnswConfig::deserialize_from` to restore it.
3.  Added backward compatibility logic: if the serialized data ends early (legacy format), it defaults to `F32`, preserving existing behavior for old indexes.

**Severity:** High (Memory Safety / UB potential with custom metrics).

**Verification:**
- Added `tests/warden_serialization.rs` which reproduces the data loss bug and verifies the fix.
- Ran existing HNSW tests to ensure no regressions.

---
*PR created automatically by Jules for task [14455688157125308579](https://jules.google.com/task/14455688157125308579) started by @madmax983*