### PR TITLE
🔒 Warden: Harden HNSW FFI metric wrapper against null/unaligned pointers

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -451,14 +451,14 @@ where
                 std::ptr::copy_nonoverlapping(
                     a as *const u8,
                     vec_a.as_mut_ptr() as *mut u8,
-                    dims * std::mem::size_of::<f32>(),
+                    dims * 4,
                 );
                 vec_a.set_len(dims);
 
                 std::ptr::copy_nonoverlapping(
                     b as *const u8,
                     vec_b.as_mut_ptr() as *mut u8,
-                    dims * std::mem::size_of::<f32>(),
+                    dims * 4,
                 );
                 vec_b.set_len(dims);
             }
@@ -1894,20 +1894,52 @@ mod sentry_tests {
 
     #[test]
     fn test_metric_wrapper_handles_unaligned() {
-        // Updated to verify safe handling (copy fallback) instead of panic
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 42.0);
-        let wrapper = create_metric_wrapper(4, distance_fn);
+        // Updated to verify safe handling (copy fallback) and CORRECTNESS.
+        // We use a real distance function to ensure the copy logic is correct.
+        // This catches mutants like replacing `dims * 4` with `dims + 4`.
+        let distance_fn = Arc::new(|a: &[f32], b: &[f32]| {
+            a.iter()
+                .zip(b.iter())
+                .map(|(x, y)| (x - y).powi(2))
+                .sum::<f32>()
+        });
 
-        // Create a buffer and get an unaligned pointer
-        let buffer = [0u8; 32];
-        // Address + 1 is definitely unaligned for f32 (align 4)
-        let unaligned_ptr = unsafe { buffer.as_ptr().add(1) } as *const f32;
-        let aligned_vec = [0.0f32; 4];
-        let aligned_ptr = aligned_vec.as_ptr();
+        let dims = 10;
+        let wrapper = create_metric_wrapper(dims, distance_fn);
 
-        // Should not panic, and return expected value
-        let result = wrapper(unaligned_ptr, aligned_ptr);
-        assert_eq!(result, 42.0);
+        // Prepare data:
+        // A = [1.0, ..., 1.0]
+        // B = [2.0, ..., 2.0]
+        // Expected Squared L2 = 10 * (1-2)^2 = 10.0
+        let vec_a_data = vec![1.0f32; dims];
+        let vec_b_data = vec![2.0f32; dims];
+
+        // Create misaligned buffers
+        // Need space for data + 1 byte offset
+        let mut buffer_a = vec![0u8; dims * 4 + 1];
+        let mut buffer_b = vec![0u8; dims * 4 + 1];
+
+        // Write data at offset 1
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                vec_a_data.as_ptr() as *const u8,
+                buffer_a.as_mut_ptr().add(1),
+                dims * 4,
+            );
+            std::ptr::copy_nonoverlapping(
+                vec_b_data.as_ptr() as *const u8,
+                buffer_b.as_mut_ptr().add(1),
+                dims * 4,
+            );
+        }
+
+        // Get unaligned pointers
+        let ptr_a = unsafe { buffer_a.as_ptr().add(1) as *const f32 };
+        let ptr_b = unsafe { buffer_b.as_ptr().add(1) as *const f32 };
+
+        // Should not panic, and return CORRECT distance
+        let result = wrapper(ptr_a, ptr_b);
+        assert!((result - 10.0).abs() < 1e-5, "Expected 10.0, got {}", result);
     }
 
     #[test]

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -430,32 +430,44 @@ where
         // Check for null pointers to prevent UB
         if a.is_null() || b.is_null() {
             // This should never happen with a correct usearch implementation.
-            // If it does, we panic to prevent UB from dereferencing null.
-            // We cannot return an error here because the signature is fixed by usearch trait.
-            panic!("usearch passed null pointer to metric function");
+            // Returning MAX to indicate "infinite" distance is safer than panicking (UB across FFI).
+            return f32::MAX;
         }
 
         // Check for alignment to prevent UB
-        // Use bitwise check for power-of-2 alignment (f32 align is 4)
-        let align_mask = std::mem::align_of::<f32>() - 1;
-        if (a as usize) & align_mask != 0 || (b as usize) & align_mask != 0 {
-            panic!(
-                "usearch passed unaligned pointer to metric function (expected alignment {})",
-                std::mem::align_of::<f32>()
-            );
-        }
-
-        // SAFETY: usearch guarantees pointers are valid for `dims` elements.
-        // We verified they are not null above.
-
-        // Strict alignment check to prevent UB (Sentry Directive)
         // f32 requires 4-byte alignment. accessing unaligned data via slice is UB.
         if a.align_offset(std::mem::align_of::<f32>()) != 0
             || b.align_offset(std::mem::align_of::<f32>()) != 0
         {
-            panic!("usearch passed unaligned pointer to metric function");
+            // Slow path: copy to aligned buffer
+            // We use Vec because stack allocation of variable size is tricky/unsafe in Rust.
+            // Given this is an error path/edge case, the allocation overhead is acceptable safety cost.
+            let mut vec_a = Vec::with_capacity(dims);
+            let mut vec_b = Vec::with_capacity(dims);
+            unsafe {
+                // Copy bytes directly to handle unaligned read
+                // SAFETY: We assume 'a' and 'b' are valid for 'dims' f32s (dims * 4 bytes),
+                // as guaranteed by usearch contract. We copy as u8 to avoid unaligned load UB.
+                std::ptr::copy_nonoverlapping(
+                    a as *const u8,
+                    vec_a.as_mut_ptr() as *mut u8,
+                    dims * 4,
+                );
+                vec_a.set_len(dims);
+
+                std::ptr::copy_nonoverlapping(
+                    b as *const u8,
+                    vec_b.as_mut_ptr() as *mut u8,
+                    dims * 4,
+                );
+                vec_b.set_len(dims);
+            }
+            return distance_fn(&vec_a, &vec_b);
         }
 
+        // Fast path: aligned pointers
+        // SAFETY: usearch guarantees pointers are valid for `dims` elements.
+        // We verified they are not null and aligned above.
         let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
         let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
         distance_fn(slice_a, slice_b)
@@ -1881,9 +1893,9 @@ mod sentry_tests {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "usearch passed unaligned pointer")]
-    fn test_metric_wrapper_panic_on_unaligned() {
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
+    fn test_metric_wrapper_handles_unaligned() {
+        // Updated to verify safe handling (copy fallback) instead of panic
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 42.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
 
         // Create a buffer and get an unaligned pointer
@@ -1893,7 +1905,9 @@ mod sentry_tests {
         let aligned_vec = [0.0f32; 4];
         let aligned_ptr = aligned_vec.as_ptr();
 
-        wrapper(unaligned_ptr, aligned_ptr);
+        // Should not panic, and return expected value
+        let result = wrapper(unaligned_ptr, aligned_ptr);
+        assert_eq!(result, 42.0);
     }
 
     #[test]
@@ -1928,10 +1942,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "usearch passed unaligned pointer")]
-    fn test_metric_wrapper_panic_on_unaligned() {
-        // This test ensures that the metric wrapper correctly detects unaligned pointers.
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
+    fn test_metric_wrapper_handles_unaligned() {
+        // This test ensures that the metric wrapper correctly handles unaligned pointers
+        // by falling back to a safe copy, rather than panicking or UB.
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 123.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
 
         // Create a buffer that we can misalign
@@ -1946,8 +1960,9 @@ mod tests {
         let unaligned_ptr = unsafe { aligned_ptr.add(1) } as *const f32;
         let valid_ptr = aligned_ptr as *const f32;
 
-        // Pass unaligned pointer - should panic
-        wrapper(valid_ptr, unaligned_ptr);
+        // Pass unaligned pointer - should not panic
+        let result = wrapper(valid_ptr, unaligned_ptr);
+        assert_eq!(result, 123.0);
     }
 
     #[test]
@@ -2364,10 +2379,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "usearch passed null pointer")]
-    fn test_metric_wrapper_panic_on_null() {
+    fn test_metric_wrapper_handles_null() {
         // This test ensures that the metric wrapper correctly detects null pointers
-        // and panics to prevent UB. This covers the safety check added for FFI.
+        // and returns a safe fallback (infinity) instead of panicking or UB.
         let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
 
@@ -2376,8 +2390,9 @@ mod tests {
         let valid_ptr = vec.as_ptr();
         let null_ptr = std::ptr::null();
 
-        // Pass null pointer - should panic
-        wrapper(valid_ptr, null_ptr);
+        // Pass null pointer - should return max distance
+        let result = wrapper(valid_ptr, null_ptr);
+        assert_eq!(result, f32::MAX);
     }
 
     #[test]

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -458,7 +458,7 @@ where
                 std::ptr::copy_nonoverlapping(
                     b as *const u8,
                     vec_b.as_mut_ptr() as *mut u8,
-                    dims * 4,
+                    dims * std::mem::size_of::<f32>(),
                 );
                 vec_b.set_len(dims);
             }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -451,7 +451,7 @@ where
                 std::ptr::copy_nonoverlapping(
                     a as *const u8,
                     vec_a.as_mut_ptr() as *mut u8,
-                    dims * 4,
+                    dims * std::mem::size_of::<f32>(),
                 );
                 vec_a.set_len(dims);
 


### PR DESCRIPTION
Hardened the `create_metric_wrapper` callback passed to `usearch` to prevent Undefined Behavior (UB) and process crashes. Previously, this function would panic on null or unaligned pointers. Since this callback is invoked from C/C++ code, panicking causes UB (unwinding across FFI). The fix changes the behavior to return a fallback value (`f32::MAX`) for null pointers and to perform a safe copy for unaligned pointers. Updated tests verify this safe behavior. Also ran `cargo update` to refresh dependencies.

---
*PR created automatically by Jules for task [5775308206343347989](https://jules.google.com/task/5775308206343347989) started by @madmax983*