### PR TITLE
test(core): Strengthen HLC property tests and assertions

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -13,3 +13,17 @@
 **Finding:** `PropertyMap` lacked explicit tests for capacity limits (`MAX_PROPERTY_MAP_CAPACITY`), correctness of removal operations (builder pattern), and DoS protection against pre-allocation attacks with insufficient buffer size.
 **Evidence:** Audit revealed `MAX_PROPERTY_MAP_CAPACITY` was checked in code but never exercised in tests. `PropertyMapBuilder::remove` was only tested for size consistency, not actual removal.
 **Recommendation:** Added 4 safety tests in `src/core/property.rs` (`mod sentry_tests`) covering capacity enforcement, removal correctness, trailing bytes handling, and pre-allocation DoS protection.
+
+**[HLC Causality Blind Spot]**
+**Module:** `aletheiadb::core::hlc`
+**Severity:** 🔴 Critical
+**Finding:** The property test `prop_receive_causality` provided false confidence. It generated random timestamps from a large `i64` space, making the probability of generating colliding wallclocks (where the core complexity of HLC lies) effectively zero. The logic for resolving `local.wallclock == msg.wallclock == physical` was untested by the property suite.
+**Evidence:** Mutation testing (Mutation 2: ignoring `msg.logical` in collision case) passed the original test suite but failed the new `prop_receive_causality_collision` test.
+**Recommendation:** Added `prop_receive_causality_collision` to `src/core/hlc.rs` to specifically target the collision scenario.
+
+**[HLC Assertion Weakness]**
+**Module:** `tests/hlc_tests.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Integration tests relied on weak assertions like `assert!(result.is_err())` and string matching for error messages. This made tests brittle and capable of passing for the wrong reasons (e.g., panics or different errors).
+**Evidence:** `test_deserialize_truncated_buffer` only checked `is_err()`. `test_send_logical_overflow` checked `error_msg.contains`.
+**Recommendation:** Refactored tests to use `matches!(result, Err(StorageError::CorruptedData(_)))` and `Err(TemporalError::LogicalCounterOverflow { .. })` for robust, type-safe verification. Removed redundant "mirror tests" that duplicated unit test coverage.

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -536,5 +536,31 @@ mod proptests {
             let is_invalid = matches!(result, Err(TemporalError::InvalidTimestamp { .. }));
             prop_assert!(is_invalid);
         }
+
+        /// Property: receive() preserves causality even when wallclocks collide.
+        /// This specifically targets the "logical counter increment" logic when
+        /// local.wallclock == msg.wallclock == physical_clock.
+        #[test]
+        fn prop_receive_causality_collision(
+            wallclock in valid_wallclock(),
+            local_logical in any::<u32>(),
+            msg_logical in any::<u32>()
+        ) {
+            let local = HybridTimestamp::new(wallclock, local_logical).unwrap();
+            let msg = HybridTimestamp::new(wallclock, msg_logical).unwrap();
+
+            // Force physical clock to match, triggering the collision path
+            if let Ok(next) = local.receive(msg, wallclock) {
+                prop_assert!(next > local, "next > local (collision)");
+                prop_assert!(next > msg, "next > msg (collision)");
+                prop_assert_eq!(next.wallclock(), wallclock);
+
+                // Specifically verify the logical counter logic: max(l1, l2) + 1
+                let expected_logical = local_logical.max(msg_logical).checked_add(1);
+                if let Some(expected) = expected_logical {
+                    prop_assert_eq!(next.logical(), expected);
+                }
+            }
+        }
     }
 }

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -496,12 +496,22 @@ mod proptests {
             msg in valid_timestamp(),
             physical in valid_wallclock()
         ) {
-            if let Ok(next) = local.receive(msg, physical) {
-                prop_assert!(next > local, "next > local");
-                prop_assert!(next > msg, "next > msg");
-                prop_assert!(next.wallclock() >= local.wallclock());
-                prop_assert!(next.wallclock() >= msg.wallclock());
-                prop_assert!(next.wallclock() >= physical);
+            let result = local.receive(msg, wallclock);
+            let expected_logical_opt = local_logical.max(msg_logical).checked_add(1);
+
+            if let Some(expected_logical) = expected_logical_opt {
+                // If no overflow is expected, receive() must succeed.
+                let next = result.expect("receive() should succeed when no overflow is expected");
+                prop_assert!(next > local, "next > local (collision)");
+                prop_assert!(next > msg, "next > msg (collision)");
+                prop_assert_eq!(next.wallclock(), wallclock);
+                prop_assert_eq!(next.logical(), expected_logical);
+            } else {
+                // If overflow is expected, receive() must fail with LogicalCounterOverflow.
+                prop_assert!(
+                    matches!(result, Err(TemporalError::LogicalCounterOverflow { .. })),
+                    "Expected LogicalCounterOverflow on overflow"
+                );
             }
         }
 

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -496,22 +496,12 @@ mod proptests {
             msg in valid_timestamp(),
             physical in valid_wallclock()
         ) {
-            let result = local.receive(msg, wallclock);
-            let expected_logical_opt = local_logical.max(msg_logical).checked_add(1);
-
-            if let Some(expected_logical) = expected_logical_opt {
-                // If no overflow is expected, receive() must succeed.
-                let next = result.expect("receive() should succeed when no overflow is expected");
-                prop_assert!(next > local, "next > local (collision)");
-                prop_assert!(next > msg, "next > msg (collision)");
-                prop_assert_eq!(next.wallclock(), wallclock);
-                prop_assert_eq!(next.logical(), expected_logical);
-            } else {
-                // If overflow is expected, receive() must fail with LogicalCounterOverflow.
-                prop_assert!(
-                    matches!(result, Err(TemporalError::LogicalCounterOverflow { .. })),
-                    "Expected LogicalCounterOverflow on overflow"
-                );
+            if let Ok(next) = local.receive(msg, physical) {
+                prop_assert!(next > local, "next > local");
+                prop_assert!(next > msg, "next > msg");
+                prop_assert!(next.wallclock() >= local.wallclock());
+                prop_assert!(next.wallclock() >= msg.wallclock());
+                prop_assert!(next.wallclock() >= physical);
             }
         }
 
@@ -554,7 +544,7 @@ mod proptests {
         fn prop_receive_causality_collision(
             wallclock in valid_wallclock(),
             local_logical in any::<u32>(),
-            msg_logical in any::<u32>()
+            msg_logical in any::<u32>(),
         ) {
             let local = HybridTimestamp::new(wallclock, local_logical).unwrap();
             let msg = HybridTimestamp::new(wallclock, msg_logical).unwrap();

--- a/tests/hlc_tests.rs
+++ b/tests/hlc_tests.rs
@@ -100,7 +100,10 @@ fn test_deserialize_truncated_buffer() {
     let short_buffer = vec![0u8; 11]; // Need 12 bytes
 
     let result = HybridTimestamp::deserialize(&short_buffer);
-    assert!(matches!(result, Err(StorageError::CorruptedData(_))), "Expected CorruptedData error");
+    assert!(
+        matches!(result, Err(StorageError::CorruptedData(_))),
+        "Expected CorruptedData error"
+    );
 }
 
 #[test]

--- a/tests/hlc_tests.rs
+++ b/tests/hlc_tests.rs
@@ -7,19 +7,8 @@
 
 use aletheiadb::core::hlc::HybridTimestamp;
 use aletheiadb::core::temporal::MAX_VALID_TIMESTAMP;
+use aletheiadb::utils::error::{StorageError, TemporalError};
 use proptest::prelude::*;
-
-#[test]
-fn test_hybrid_timestamp_creation() {
-    // Test creating a HybridTimestamp with wallclock and logical components
-    let wallclock = 1_000_000_000_000i64; // 1 second in microseconds
-    let logical = 0u32;
-
-    let hlc = HybridTimestamp::new(wallclock, logical).unwrap();
-
-    assert_eq!(hlc.wallclock(), wallclock);
-    assert_eq!(hlc.logical(), logical);
-}
 
 #[test]
 fn test_new_validates_wallclock() {
@@ -33,11 +22,17 @@ fn test_new_validates_wallclock() {
 
     // Wallclock exceeding MAX_VALID_TIMESTAMP should fail
     let invalid = HybridTimestamp::new(MAX_VALID_TIMESTAMP + 1, 0);
-    assert!(invalid.is_err());
+    assert!(matches!(
+        invalid,
+        Err(TemporalError::InvalidTimestamp { .. })
+    ));
 
     // i64::MAX should fail
     let max_i64 = HybridTimestamp::new(i64::MAX, 0);
-    assert!(max_i64.is_err());
+    assert!(matches!(
+        max_i64,
+        Err(TemporalError::InvalidTimestamp { .. })
+    ));
 }
 
 #[test]
@@ -83,54 +78,6 @@ fn test_send_when_wallclock_regresses() {
 }
 
 #[test]
-fn test_ordering_by_wallclock() {
-    // HLCs should order by wallclock first
-    let earlier = HybridTimestamp::new(1000, 10).unwrap();
-    let later = HybridTimestamp::new(2000, 0).unwrap();
-
-    assert!(earlier < later);
-    assert!(later > earlier);
-    assert_ne!(earlier, later);
-}
-
-#[test]
-fn test_ordering_by_logical_when_wallclock_same() {
-    // When wallclock is same, order by logical counter
-    let first = HybridTimestamp::new(1000, 5).unwrap();
-    let second = HybridTimestamp::new(1000, 6).unwrap();
-
-    assert!(first < second);
-    assert!(second > first);
-    assert_ne!(first, second);
-}
-
-#[test]
-fn test_ordering_equality() {
-    // HLCs with same wallclock and logical are equal
-    let hlc1 = HybridTimestamp::new(1000, 5).unwrap();
-    let hlc2 = HybridTimestamp::new(1000, 5).unwrap();
-
-    assert_eq!(hlc1, hlc2);
-    assert!(hlc1 >= hlc2);
-    assert!(hlc1 <= hlc2);
-}
-
-#[test]
-fn test_serialization_roundtrip() {
-    // Serialize and deserialize should preserve exact values
-    let original = HybridTimestamp::new(1_234_567_890_123_456i64, 42).unwrap();
-
-    let bytes = original.serialize();
-    assert_eq!(bytes.len(), 12); // 8 bytes wallclock + 4 bytes logical
-
-    let (deserialized, consumed) = HybridTimestamp::deserialize(&bytes).unwrap();
-    assert_eq!(consumed, 12);
-    assert_eq!(deserialized, original);
-    assert_eq!(deserialized.wallclock(), 1_234_567_890_123_456i64);
-    assert_eq!(deserialized.logical(), 42);
-}
-
-#[test]
 fn test_serialization_into_buffer() {
     // serialize_into should append to existing buffer
     let hlc = HybridTimestamp::new(1000, 5).unwrap();
@@ -153,7 +100,7 @@ fn test_deserialize_truncated_buffer() {
     let short_buffer = vec![0u8; 11]; // Need 12 bytes
 
     let result = HybridTimestamp::deserialize(&short_buffer);
-    assert!(result.is_err());
+    assert!(matches!(result, Err(StorageError::CorruptedData(_))), "Expected CorruptedData error");
 }
 
 #[test]
@@ -169,7 +116,7 @@ fn test_deserialize_validates_wallclock() {
 
     let result = HybridTimestamp::deserialize(&buffer);
     assert!(
-        result.is_err(),
+        matches!(result, Err(StorageError::CorruptedData(_))),
         "deserialize should reject wallclock > MAX_VALID_TIMESTAMP (except i64::MAX sentinel)"
     );
 
@@ -206,22 +153,9 @@ fn test_send_logical_overflow() {
     // This should return Err because logical counter would overflow
     let result = prev.send(1000);
     assert!(
-        result.is_err(),
-        "send should return Err on logical counter overflow"
+        matches!(result, Err(TemporalError::LogicalCounterOverflow { .. })),
+        "send should return LogicalCounterOverflow error"
     );
-
-    // Verify it's the right error type
-    match result {
-        Err(ref e) => {
-            let error_msg = format!("{}", e);
-            assert!(
-                error_msg.contains("logical counter overflow"),
-                "Expected LogicalCounterOverflow error, got: {}",
-                error_msg
-            );
-        }
-        Ok(_) => panic!("Expected Err, got Ok"),
-    }
 }
 
 #[test]


### PR DESCRIPTION
Performed an audit of the `hlc` (Hybrid Logical Clock) module as 'Elenchus'. 

Key improvements:
1.  **Causality Verification:** Identified that the existing `prop_receive_causality` test rarely exercised the logic for resolving wallclock collisions due to the large input space. Added `prop_receive_causality_collision` which forces `local.wallclock == msg.wallclock == physical` to verify the logical counter increment logic (`max(l1, l2) + 1`). This was verified by mutation testing (ignoring `msg.logical` in collision case caused the new test to fail while the old one passed).
2.  **Assertion Strengthening:** Replaced brittle string matching and generic `is_err()` assertions in `tests/hlc_tests.rs` with type-safe `matches!` on `TemporalError` and `StorageError` variants.
3.  **Cleanup:** Removed tautological "mirror tests" from `tests/hlc_tests.rs` that simply duplicated unit test logic without adding integration value.

---
*PR created automatically by Jules for task [6264155991157103136](https://jules.google.com/task/6264155991157103136) started by @madmax983*