### PR TITLE
🔒 Warden: Harden SIMD safety and fix normalization logic

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,6 @@ on:
 
 jobs:
   claude-review:
-    # Disable this job temporarily due to internal tool failure (SDK execution error)
-    if: false
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   claude-review:
+    # Disable this job temporarily due to internal tool failure (SDK execution error)
+    if: false
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -622,7 +622,8 @@ pub fn normalize_in_place(v: &mut [f32]) {
     // Use squared magnitude threshold to avoid denormal number issues.
     // See SQUARED_MAGNITUDE_THRESHOLD for details.
     if sq_mag < SQUARED_MAGNITUDE_THRESHOLD {
-        // Leave zero/near-zero vector unchanged
+        // Zero out the vector to match normalize() behavior and prevent garbage data
+        v.fill(0.0);
         return;
     }
     // Compute 1/sqrt(sq_mag) directly to avoid intermediate variable
@@ -691,4 +692,29 @@ pub fn is_normalized_default(v: &[f32]) -> bool {
     // We can't import NORMALIZATION_TOLERANCE from constants because of visibility/import loops?
     // Actually constants.rs is a sibling.
     is_normalized(v, super::constants::NORMALIZATION_TOLERANCE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_consistency_small_magnitude() {
+        // Create a vector with very small magnitude (below threshold)
+        // SQUARED_MAGNITUDE_THRESHOLD is likely small (e.g. 1e-12 or similar)
+        // Let's use 1e-20 to be safe.
+        let v_small = vec![1e-20, 0.0, 0.0];
+
+        // normalize() should return zero vector
+        let normalized = normalize(&v_small);
+        assert_eq!(normalized, vec![0.0, 0.0, 0.0], "normalize should return zero vector for small magnitude");
+
+        // normalize_in_place() should also zero out the vector
+        let mut v_in_place = v_small.clone();
+        normalize_in_place(&mut v_in_place);
+        assert_eq!(v_in_place, vec![0.0, 0.0, 0.0], "normalize_in_place should zero out vector for small magnitude");
+
+        // They should match
+        assert_eq!(normalized, v_in_place);
+    }
 }

--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -707,12 +707,20 @@ mod tests {
 
         // normalize() should return zero vector
         let normalized = normalize(&v_small);
-        assert_eq!(normalized, vec![0.0, 0.0, 0.0], "normalize should return zero vector for small magnitude");
+        assert_eq!(
+            normalized,
+            vec![0.0, 0.0, 0.0],
+            "normalize should return zero vector for small magnitude"
+        );
 
         // normalize_in_place() should also zero out the vector
         let mut v_in_place = v_small.clone();
         normalize_in_place(&mut v_in_place);
-        assert_eq!(v_in_place, vec![0.0, 0.0, 0.0], "normalize_in_place should zero out vector for small magnitude");
+        assert_eq!(
+            v_in_place,
+            vec![0.0, 0.0, 0.0],
+            "normalize_in_place should zero out vector for small magnitude"
+        );
 
         // They should match
         assert_eq!(normalized, v_in_place);

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -633,6 +633,7 @@ pub(crate) fn dot_product_sum(a: &[f32], b: &[f32]) -> f32 {
 
 #[inline]
 fn simsimd_dot(a: &[f32], b: &[f32]) -> Option<f32> {
+    assert_eq!(a.len(), b.len());
     let mut result = 0.0f64;
     // SAFETY: Pointers originate from valid slices with equal lengths.
     // SimSIMD writes a single distance scalar into `result`.
@@ -653,6 +654,7 @@ fn simsimd_dot(a: &[f32], b: &[f32]) -> Option<f32> {
 
 #[inline]
 fn simsimd_sqeuclidean(a: &[f32], b: &[f32]) -> Option<f32> {
+    assert_eq!(a.len(), b.len());
     let mut result = 0.0f64;
     // SAFETY: Pointers originate from valid slices with equal lengths.
     // SimSIMD writes a single distance scalar into `result`.
@@ -674,4 +676,27 @@ fn simsimd_sqeuclidean(a: &[f32], b: &[f32]) -> Option<f32> {
 unsafe extern "C" {
     fn simsimd_dot_f32(a: *const f32, b: *const f32, n: u64, d: *mut f64);
     fn simsimd_l2sq_f32(a: *const f32, b: *const f32, n: u64, d: *mut f64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_simsimd_dot_dimension_mismatch_panics() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0];
+        // This function is private, but we are inside the module (submodule tests)
+        let _ = simsimd_dot(&a, &b);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_simsimd_sqeuclidean_dimension_mismatch_panics() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0];
+        // This function is private, but we are inside the module
+        let _ = simsimd_sqeuclidean(&a, &b);
+    }
 }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -115,6 +115,15 @@ impl FilterCallbackGuard {
     pub(crate) fn new() -> Self {
         IN_FILTER_CALLBACK.with(|flag| flag.set(true));
         FilterCallbackGuard
+    }
+}
+
+impl Drop for FilterCallbackGuard {
+    fn drop(&mut self) {
+        IN_FILTER_CALLBACK.with(|flag| flag.set(false));
+    }
+}
+
 /// It also handles nested usage correctly by restoring the previous state.
 struct ReentrancyGuard {
     prev: bool,

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -448,6 +448,17 @@ pub(crate) fn parse_entry_at(
 
             let (label, properties, valid_from) = if version >= WAL_VERSION {
                 // Read 4-byte InternedString ID
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for UpdateEdge label".to_string(),
+                    )
+                    .into());
+                }
                 let label_id = u32::from_le_bytes([
                     buffer[current_offset],
                     buffer[current_offset + 1],
@@ -503,6 +514,17 @@ pub(crate) fn parse_entry_at(
 
             let (label, properties, valid_from) = if version >= WAL_VERSION {
                 // Read 4-byte InternedString ID
+                if current_offset.checked_add(4).ok_or_else(|| {
+                    Error::Storage(StorageError::CorruptedData(
+                        "WAL offset overflow".to_string(),
+                    ))
+                })? > buffer.len()
+                {
+                    return Err(StorageError::CorruptedData(
+                        "Insufficient buffer size for UpdateEdge label".to_string(),
+                    )
+                    .into());
+                }
                 let label_id = u32::from_le_bytes([
                     buffer[current_offset],
                     buffer[current_offset + 1],

--- a/tests/havoc_wal_fuzz_regression.rs
+++ b/tests/havoc_wal_fuzz_regression.rs
@@ -1,0 +1,30 @@
+use aletheiadb::storage::wal::LSN;
+use aletheiadb::storage::wal::segment_reader::read_segment;
+use std::fs::File;
+use std::io::Write;
+use tempfile::TempDir;
+
+#[test]
+fn test_fuzz_crash_578de513() {
+    // Reproduction for crash discovered by fuzzer
+    // Input: R1dBTAEAB1NB/wrh/////////////////0wAAAAEB+cFCuEmdgd5BwcHV0EHBwcH
+    // Cause: Index out of bounds in deserialize_node_id
+
+    let crash_data = vec![
+        71, 87, 65, 76, 1, 0, 7, 83, 65, 255, 10, 225, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 76, 0, 0, 0, 4, 7, 231, 5, 10, 225, 38, 118, 7, 121, 7, 7, 7, 87, 65,
+        7, 7, 7, 7,
+    ];
+
+    let dir = TempDir::new().unwrap();
+    let segment_path = dir.path().join("crash.log");
+
+    {
+        let mut file = File::create(&segment_path).unwrap();
+        file.write_all(&crash_data).unwrap();
+    }
+
+    // Should return an error, not panic
+    let result = read_segment(&segment_path, LSN(0));
+    assert!(result.is_err());
+}


### PR DESCRIPTION
This PR addresses potential memory safety issues in internal SIMD wrappers and a logic inconsistency in vector normalization.

**Hardening:**
- `src/core/vector/simd.rs`: Added explicit dimension checks in `simsimd_dot` and `simsimd_sqeuclidean`. These functions wrap `unsafe` FFI calls that assume equal lengths. Previously, this invariant was only checked by callers. Now it is enforced at the wrapper level to prevent potential buffer over-reads (UB).

**Bug Fix:**
- `src/core/vector/ops.rs`: `normalize_in_place` now correctly zeroes out vectors with negligible magnitude (< `SQUARED_MAGNITUDE_THRESHOLD`), matching the behavior of `normalize`. Previously, it would leave the vector unchanged (potentially containing garbage/subnormal values).

**Maintenance:**
- `src/index/vector/hnsw.rs`: Fixed a syntax error (missing closing braces and `Drop` implementation for `FilterCallbackGuard`) that appeared to be a regression or corruption in the codebase.

**Verification:**
- Added `test_normalize_consistency_small_magnitude` to verify `normalize` and `normalize_in_place` behave identically.
- Added `should_panic` tests to `src/core/vector/simd.rs` to verify safety assertions.
- Ran full vector test suite (`cargo test vector`).

---
*PR created automatically by Jules for task [10675614529692368504](https://jules.google.com/task/10675614529692368504) started by @madmax983*