### PR TITLE
perf(graph): speed up has_label_str and add benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,6 +367,12 @@ harness = false
 path = "benches/edge_iteration.rs"
 required-features = []
 
+[[bench]]
+name = "graph_label_checks"
+harness = false
+path = "benches/graph_label_checks.rs"
+required-features = []
+
 # Experimental features
 [[example]]
 name = "story_demo"

--- a/benches/graph_label_checks.rs
+++ b/benches/graph_label_checks.rs
@@ -1,0 +1,90 @@
+//! Benchmarks for label-checking methods on `Node` and `Edge`.
+//!
+//! This compares the current `has_label_str` path against a candidate
+//! resolve-and-compare path to guide optimization decisions with measurement.
+
+use aletheiadb::core::graph::{Edge, Node};
+use aletheiadb::core::id::{EdgeId, NodeId, VersionId};
+use aletheiadb::core::interning::GLOBAL_INTERNER;
+use aletheiadb::core::property::PropertyMapBuilder;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn bench_node_label_checks(c: &mut Criterion) {
+    let person = GLOBAL_INTERNER.intern("Person").unwrap();
+    let node = Node::new(
+        NodeId::new(1).unwrap(),
+        person,
+        PropertyMapBuilder::new().build(),
+        VersionId::new(1).unwrap(),
+    );
+
+    let mut group = c.benchmark_group("node_label_checks");
+    group.bench_function("has_label_str_hit", |b| {
+        b.iter(|| black_box(node.has_label_str("Person")))
+    });
+    group.bench_function("resolve_with_hit", |b| {
+        b.iter(|| {
+            black_box(
+                GLOBAL_INTERNER
+                    .resolve_with(node.label, |s| s == "Person")
+                    .unwrap_or(false),
+            )
+        })
+    });
+    group.bench_function("has_label_str_miss", |b| {
+        b.iter(|| black_box(node.has_label_str("Company")))
+    });
+    group.bench_function("resolve_with_miss", |b| {
+        b.iter(|| {
+            black_box(
+                GLOBAL_INTERNER
+                    .resolve_with(node.label, |s| s == "Company")
+                    .unwrap_or(false),
+            )
+        })
+    });
+    group.finish();
+}
+
+fn bench_edge_label_checks(c: &mut Criterion) {
+    let knows = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let edge = Edge::new(
+        EdgeId::new(1).unwrap(),
+        knows,
+        NodeId::new(1).unwrap(),
+        NodeId::new(2).unwrap(),
+        PropertyMapBuilder::new().build(),
+        VersionId::new(1).unwrap(),
+    );
+
+    let mut group = c.benchmark_group("edge_label_checks");
+    group.bench_function("has_label_str_hit", |b| {
+        b.iter(|| black_box(edge.has_label_str("KNOWS")))
+    });
+    group.bench_function("resolve_with_hit", |b| {
+        b.iter(|| {
+            black_box(
+                GLOBAL_INTERNER
+                    .resolve_with(edge.label, |s| s == "KNOWS")
+                    .unwrap_or(false),
+            )
+        })
+    });
+    group.bench_function("has_label_str_miss", |b| {
+        b.iter(|| black_box(edge.has_label_str("LIKES")))
+    });
+    group.bench_function("resolve_with_miss", |b| {
+        b.iter(|| {
+            black_box(
+                GLOBAL_INTERNER
+                    .resolve_with(edge.label, |s| s == "LIKES")
+                    .unwrap_or(false),
+            )
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_node_label_checks, bench_edge_label_checks);
+criterion_main!(benches);

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -9,6 +9,14 @@ use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
 use crate::core::version::VersionMetadata;
 
+#[inline]
+fn matches_label(label_id: InternedString, label: &str) -> bool {
+    use crate::core::interning::GLOBAL_INTERNER;
+    GLOBAL_INTERNER
+        .resolve_with(label_id, |interned| interned == label)
+        .unwrap_or(false)
+}
+
 /// A node in the current state of the graph.
 ///
 /// This represents the current version of a node, optimized for fast access.
@@ -75,9 +83,8 @@ impl Node {
     /// Check if this node has a specific label using a string.
     ///
     /// This is a convenience method that accepts a `&str` instead of requiring
-    /// the caller to pre-intern the string. It uses `get_id()` internally,
-    /// which means it will NOT add the string to the interner if it doesn't
-    /// already exist - it will simply return `false`.
+    /// the caller to pre-intern the string. It compares against the existing
+    /// interned label and does NOT add the input string to the interner.
     ///
     /// # Performance Note
     ///
@@ -103,10 +110,7 @@ impl Node {
     /// ```
     #[inline]
     pub fn has_label_str(&self, label: &str) -> bool {
-        use crate::core::interning::GLOBAL_INTERNER;
-        GLOBAL_INTERNER
-            .get_id(label)
-            .is_some_and(|id| self.label == id)
+        matches_label(self.label, label)
     }
 }
 
@@ -204,9 +208,8 @@ impl Edge {
     /// Check if this edge has a specific label using a string.
     ///
     /// This is a convenience method that accepts a `&str` instead of requiring
-    /// the caller to pre-intern the string. It uses `get_id()` internally,
-    /// which means it will NOT add the string to the interner if it doesn't
-    /// already exist - it will simply return `false`.
+    /// the caller to pre-intern the string. It compares against the existing
+    /// interned label and does NOT add the input string to the interner.
     ///
     /// # Performance Note
     ///
@@ -232,10 +235,7 @@ impl Edge {
     /// ```
     #[inline]
     pub fn has_label_str(&self, label: &str) -> bool {
-        use crate::core::interning::GLOBAL_INTERNER;
-        GLOBAL_INTERNER
-            .get_id(label)
-            .is_some_and(|id| self.label == id)
+        matches_label(self.label, label)
     }
 
     /// Check if this edge connects the given source and target nodes.


### PR DESCRIPTION
## Summary
- speed up `Node::has_label_str` and `Edge::has_label_str` by comparing resolved interned label text directly
- add shared `matches_label` helper in `src/core/graph.rs`
- add criterion benchmark `benches/graph_label_checks.rs` and register it in `Cargo.toml`

## Benchmark
- node hit: ~15.2ns -> ~11.6ns (~24.6% faster)
- node miss: ~15.3ns -> ~11.7ns (~24.1% faster)
- edge hit: ~18.0ns -> ~11.7ns (~35.0% faster)
- edge miss: ~15.0ns -> ~11.6ns (~24.0% faster)

## Verification
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- `cargo test`