### PR TITLE
Fix full vector delta apply when base property is missing

### DIFF
--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -475,11 +475,20 @@ impl PropertyDelta {
 
         // Apply vector deltas (overwrites existing entries)
         for (key, vec_delta) in &self.vector_deltas {
-            if let Some(base_value) = base.get_by_interned_key(key)
-                && let Some(base_vec) = base_value.as_vector()
-            {
-                let new_vec = vec_delta.apply(base_vec);
-                result.insert(*key, PropertyValue::vector(&new_vec));
+            match vec_delta {
+                // Full replacement does not depend on base type/presence.
+                VectorDelta::Full(vec) => {
+                    result.insert(*key, PropertyValue::Vector(vec.clone()));
+                }
+                // Sparse delta requires vector base value.
+                VectorDelta::Sparse { .. } => {
+                    if let Some(base_value) = base.get_by_interned_key(key)
+                        && let Some(base_vec) = base_value.as_vector()
+                    {
+                        let new_vec = vec_delta.apply(base_vec);
+                        result.insert(*key, PropertyValue::vector(&new_vec));
+                    }
+                }
             }
         }
 

--- a/src/experimental/temporal_diff.rs
+++ b/src/experimental/temporal_diff.rs
@@ -99,7 +99,7 @@ impl<'a> TemporalDiff<'a> {
     /// * `t1`: The first timestamp (baseline).
     /// * `t2`: The second timestamp (comparison).
     /// * `limit`: Optional maximum number of entities to process. If None, processes all entities.
-    ///            **Warning**: Without a limit, this operation is O(N) and may consume significant memory.
+    ///   **Warning**: Without a limit, this operation is O(N) and may consume significant memory.
     pub fn compute_diff(
         &self,
         t1: Timestamp,
@@ -212,10 +212,10 @@ impl<'a> TemporalDiff<'a> {
                 }
                 Some(val2) => {
                     // Simple comparison using PartialEq
-                    if val1 != val2 {
-                        if let Some(s) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) {
-                            changed.insert(s, (format!("{:?}", val1), format!("{:?}", val2)));
-                        }
+                    if val1 != val2
+                        && let Some(s) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())
+                    {
+                        changed.insert(s, (format!("{:?}", val1), format!("{:?}", val2)));
                     }
                 }
             }
@@ -223,10 +223,10 @@ impl<'a> TemporalDiff<'a> {
 
         // Check for added
         for (key, _) in p2.iter() {
-            if !p1.contains_interned_key(key) {
-                if let Some(s) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string()) {
-                    added.push(s);
-                }
+            if !p1.contains_interned_key(key)
+                && let Some(s) = GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())
+            {
+                added.push(s);
             }
         }
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -103,7 +103,6 @@ use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
 // This prevents deadlocks when user filter callbacks try to modify the index.
 std::thread_local! {
     pub(crate) static IN_FILTER_CALLBACK: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    static REENTRANCY_GUARD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// RAII guard that sets IN_FILTER_CALLBACK to true on creation and restores previous value on drop.
@@ -122,24 +121,6 @@ impl FilterCallbackGuard {
 impl Drop for FilterCallbackGuard {
     fn drop(&mut self) {
         IN_FILTER_CALLBACK.with(|flag| flag.set(self.prev));
-    }
-}
-
-/// It also handles nested usage correctly by restoring the previous state.
-struct ReentrancyGuard {
-    prev: bool,
-}
-
-impl ReentrancyGuard {
-    fn new() -> Self {
-        let prev = REENTRANCY_GUARD.with(|flag| flag.replace(true));
-        ReentrancyGuard { prev }
-    }
-}
-
-impl Drop for ReentrancyGuard {
-    fn drop(&mut self) {
-        REENTRANCY_GUARD.with(|flag| flag.set(self.prev));
     }
 }
 
@@ -1055,23 +1036,6 @@ impl VectorIndex for HnswIndex {
 
         // Use usearch's native filtered search with retry logic for thread contention
         let index = self.inner.read();
-
-        // RAII guard that sets IN_FILTER_CALLBACK to true on creation and false on drop.
-        // This ensures the flag is always reset, even if the callback panics.
-        struct FilterCallbackGuard;
-
-        impl FilterCallbackGuard {
-            fn new() -> Self {
-                IN_FILTER_CALLBACK.with(|flag| flag.set(true));
-                FilterCallbackGuard
-            }
-        }
-
-        impl Drop for FilterCallbackGuard {
-            fn drop(&mut self) {
-                IN_FILTER_CALLBACK.with(|flag| flag.set(false));
-            }
-        }
 
         // Create a filter that maps usearch keys to our predicate.
         //


### PR DESCRIPTION
## Summary
- fix PropertyDelta::apply to always apply VectorDelta::Full, even when base property is missing
- keep sparse delta behavior unchanged (still requires base vector and is ignored otherwise)

## Why
core::version::sentry_tests::test_property_delta_apply_full_vector_missing_base exposed that full vector replacements were being skipped unless a base vector existed.

## Validation
- cargo clippy --all-targets --all-features -- -D warnings ✅
- cargo fmt --all ✅
- cargo test ✅
