### PR TITLE
🛡️ Sentry: Fix numerical instability in sparse Euclidean distance

### DIFF
--- a/src/core/vector/sparse.rs
+++ b/src/core/vector/sparse.rs
@@ -557,12 +557,49 @@ pub fn sparse_squared_euclidean_distance(a: &SparseVec, b: &SparseVec) -> Result
         .into());
     }
 
-    // ||a - b||² = ||a||² + ||b||² - 2*dot(a,b)
-    let dot = sparse_dot_product(a, b)?;
-    let mag_a_sq = a.squared_magnitude();
-    let mag_b_sq = b.squared_magnitude();
+    let mut sum_sq_diff = 0.0f32;
+    let mut i = 0;
+    let mut j = 0;
 
-    Ok(mag_a_sq + mag_b_sq - 2.0 * dot)
+    let a_indices = a.indices();
+    let a_values = a.values();
+    let b_indices = b.indices();
+    let b_values = b.values();
+
+    // Merge-like algorithm since indices are sorted
+    while i < a_indices.len() && j < b_indices.len() {
+        if a_indices[i] == b_indices[j] {
+            // Indices match - compute difference
+            let diff = a_values[i] - b_values[j];
+            sum_sq_diff += diff * diff;
+            i += 1;
+            j += 1;
+        } else if a_indices[i] < b_indices[j] {
+            // a's index is smaller (b has 0 at this index)
+            let val = a_values[i];
+            sum_sq_diff += val * val;
+            i += 1;
+        } else {
+            // b's index is smaller (a has 0 at this index)
+            let val = b_values[j];
+            sum_sq_diff += val * val;
+            j += 1;
+        }
+    }
+
+    // Process remaining elements
+    while i < a_indices.len() {
+        let val = a_values[i];
+        sum_sq_diff += val * val;
+        i += 1;
+    }
+    while j < b_indices.len() {
+        let val = b_values[j];
+        sum_sq_diff += val * val;
+        j += 1;
+    }
+
+    Ok(sum_sq_diff)
 }
 
 /// Computes Euclidean distance between two sparse vectors.

--- a/tests/sentry_sparse_precision.rs
+++ b/tests/sentry_sparse_precision.rs
@@ -1,0 +1,38 @@
+use aletheiadb::core::vector::{SparseVec, sparse_squared_euclidean_distance};
+
+#[test]
+fn test_sparse_euclidean_precision_vs_expanded_formula() {
+    // Demonstration of precision loss with the expanded formula ||a||^2 + ||b||^2 - 2ab
+    // vs the stable direct formula sum((a-b)^2).
+
+    let val = 1000.0f32;
+    let epsilon = 1e-4f32;
+
+    // a = [1000.0 + epsilon]
+    // b = [1000.0]
+    // Note: 1000.0 + 0.0001 is represented as 1000.00012207... in f32
+    // So the actual difference is ~1.22e-4, and squared difference is ~1.49e-8.
+    let val_plus_eps = val + epsilon;
+    let actual_diff = val_plus_eps - val;
+    let expected_sq_diff = actual_diff * actual_diff;
+
+    let a = SparseVec::new(vec![0], vec![val_plus_eps], 10).unwrap();
+    let b = SparseVec::new(vec![0], vec![val], 10).unwrap();
+
+    let dist_sq = sparse_squared_euclidean_distance(&a, &b).unwrap();
+
+    println!("Computed squared distance: {}", dist_sq);
+    println!("Expected (based on f32 rep): {}", expected_sq_diff);
+
+    // With expanded formula, this is 0.0.
+    // With direct formula, this should match expected_sq_diff exactly.
+
+    assert!(
+        dist_sq > 0.0,
+        "Squared distance should be positive (precision loss detected!)"
+    );
+    assert!(
+        (dist_sq - expected_sq_diff).abs() < 1e-12,
+        "Should match exact f32 difference squared"
+    );
+}


### PR DESCRIPTION
Identified and fixed a numerical instability in `sparse_squared_euclidean_distance` where calculating the distance between very similar vectors resulted in precision loss due to catastrophic cancellation in the expanded formula `||a||^2 + ||b||^2 - 2ab`.

Implemented the numerically stable direct difference method `sum((a_i - b_i)^2)` using an O(N+M) merge algorithm over the sorted indices of the sparse vectors.

Added `tests/sentry_sparse_precision.rs` to verify the fix and prevent regression. Verified that existing tests pass.

---
*PR created automatically by Jules for task [12214473725095317348](https://jules.google.com/task/12214473725095317348) started by @madmax983*