### PR TITLE
🛡️ Sentry: Fix sparse vector precision loss and add config serialization tests

### DIFF
--- a/src/core/vector/sparse.rs
+++ b/src/core/vector/sparse.rs
@@ -527,8 +527,9 @@ pub fn sparse_cosine_similarity(a: &SparseVec, b: &SparseVec) -> Result<f32> {
 /// squared_distance = ||a - b||² = Σ(a_i - b_i)²
 /// ```
 ///
-/// For sparse vectors, we only need to compute:
-/// - ||a||² + ||b||² - 2*dot(a,b)
+/// This implementation uses a direct difference computation (merge-based) rather than the
+/// expanded form `||a||² + ||b||² - 2*dot(a,b)` to ensure numerical stability when
+/// vectors are close to each other (preventing catastrophic cancellation).
 ///
 /// # Example
 ///
@@ -557,12 +558,51 @@ pub fn sparse_squared_euclidean_distance(a: &SparseVec, b: &SparseVec) -> Result
         .into());
     }
 
-    // ||a - b||² = ||a||² + ||b||² - 2*dot(a,b)
-    let dot = sparse_dot_product(a, b)?;
-    let mag_a_sq = a.squared_magnitude();
-    let mag_b_sq = b.squared_magnitude();
+    let mut sum_sq = 0.0f32;
+    let mut i = 0;
+    let mut j = 0;
 
-    Ok(mag_a_sq + mag_b_sq - 2.0 * dot)
+    let a_indices = a.indices();
+    let a_values = a.values();
+    let b_indices = b.indices();
+    let b_values = b.values();
+
+    // Merge-like algorithm since indices are sorted
+    while i < a_indices.len() && j < b_indices.len() {
+        if a_indices[i] == b_indices[j] {
+            // Indices match - compute difference squared
+            let diff = a_values[i] - b_values[j];
+            sum_sq += diff * diff;
+            i += 1;
+            j += 1;
+        } else if a_indices[i] < b_indices[j] {
+            // a's index is smaller (implicit zero in b)
+            let val = a_values[i];
+            sum_sq += val * val;
+            i += 1;
+        } else {
+            // b's index is smaller (implicit zero in a)
+            let val = b_values[j];
+            sum_sq += val * val;
+            j += 1;
+        }
+    }
+
+    // Process remaining elements in a
+    while i < a_indices.len() {
+        let val = a_values[i];
+        sum_sq += val * val;
+        i += 1;
+    }
+
+    // Process remaining elements in b
+    while j < b_indices.len() {
+        let val = b_values[j];
+        sum_sq += val * val;
+        j += 1;
+    }
+
+    Ok(sum_sq)
 }
 
 /// Computes Euclidean distance between two sparse vectors.

--- a/tests/hnsw_config_persistence.rs
+++ b/tests/hnsw_config_persistence.rs
@@ -1,0 +1,132 @@
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, Quantization, StorageMode};
+use proptest::prelude::*;
+use std::path::PathBuf;
+
+// 🛡️ Sentry: HNSW Config Serialization Tests
+//
+// 🎯 Target: `HnswConfig::serialize_into` and `deserialize_from`.
+// 💣 Risk: Configuration loss during persistence/recovery, especially with version changes.
+// 🧪 Strategy: Property-based testing for round-trip correctness and specific regression tests for edge cases.
+
+proptest! {
+    #[test]
+    fn test_hnsw_config_roundtrip(
+        dimensions in 1usize..4096,
+        m in 2usize..64,
+        ef_construction in 10usize..500,
+        ef_search in 10usize..500,
+        capacity in 0usize..100_000,
+        metric_idx in 0usize..6,
+        quant_idx in 0usize..3,
+    ) {
+        let metric = match metric_idx {
+            0 => DistanceMetric::Cosine,
+            1 => DistanceMetric::Euclidean,
+            2 => DistanceMetric::DotProduct,
+            3 => DistanceMetric::Haversine,
+            4 => DistanceMetric::Hamming,
+            5 => DistanceMetric::Tanimoto,
+            _ => unreachable!(),
+        };
+
+        let quantization = match quant_idx {
+            0 => Quantization::F32,
+            1 => Quantization::F16,
+            2 => Quantization::I8,
+            _ => unreachable!(),
+        };
+
+        // Create config with non-default values and transient fields set
+        let config = HnswConfig::new(dimensions, metric)
+            .with_m(m)
+            .with_ef_construction(ef_construction)
+            .with_ef_search(ef_search)
+            .with_capacity(capacity)
+            .with_quantization(quantization)
+            // Transient fields (should not be serialized or should be reset)
+            .with_storage(StorageMode::MemoryMapped { path: PathBuf::from("/tmp/test") });
+
+        let mut buffer = Vec::new();
+        config.serialize_into(&mut buffer).unwrap();
+
+        let mut reader = &buffer[..];
+        let loaded_config = HnswConfig::deserialize_from(&mut reader).unwrap();
+
+        // Check persisted fields
+        assert_eq!(loaded_config.dimensions, config.dimensions, "Dimensions mismatch");
+        assert_eq!(loaded_config.metric, config.metric, "Metric mismatch");
+        assert_eq!(loaded_config.m, config.m, "M mismatch");
+        assert_eq!(loaded_config.ef_construction, config.ef_construction, "ef_construction mismatch");
+        assert_eq!(loaded_config.ef_search, config.ef_search, "ef_search mismatch");
+        assert_eq!(loaded_config.capacity, config.capacity, "Capacity mismatch");
+        assert_eq!(loaded_config.quantization, config.quantization, "Quantization mismatch");
+
+        // Verify transient fields are reset to defaults
+        assert!(matches!(loaded_config.storage, StorageMode::InMemory), "Storage should reset to InMemory");
+        assert!(loaded_config.custom_metric.is_none(), "Custom metric should be None");
+    }
+}
+
+#[test]
+fn test_hnsw_config_custom_metric_handling() {
+    // 🧪 Strategy: Verify that having a custom metric doesn't break serialization,
+    // and that it is correctly ignored (not persisted).
+
+    let config = HnswConfig::new(128, DistanceMetric::Cosine)
+        .with_quantization(Quantization::F32) // Custom metrics require F32
+        .with_custom_metric("test_metric", |a, b| {
+            a.iter().zip(b.iter()).map(|(x, y)| (x - y).abs()).sum()
+        });
+
+    let mut buffer = Vec::new();
+    config.serialize_into(&mut buffer).unwrap();
+
+    let mut reader = &buffer[..];
+    let loaded_config = HnswConfig::deserialize_from(&mut reader).unwrap();
+
+    // Basic fields preserved
+    assert_eq!(loaded_config.dimensions, 128);
+    assert_eq!(loaded_config.metric, DistanceMetric::Cosine);
+
+    // Custom metric lost (as expected)
+    assert!(loaded_config.custom_metric.is_none());
+}
+
+#[test]
+fn test_hnsw_config_v1_compatibility() {
+    // 🧪 Strategy: Manually construct a V1 buffer (missing quantization byte)
+    // and verify it deserializes correctly with default quantization.
+
+    use std::io::Write;
+
+    let mut buffer = Vec::new();
+
+    // V1 fields:
+    // dimensions (u64)
+    buffer.write_all(&(128u64).to_le_bytes()).unwrap();
+    // metric (u8)
+    buffer.write_all(&[DistanceMetric::Euclidean.to_u8()]).unwrap();
+    // m (u64)
+    buffer.write_all(&(16u64).to_le_bytes()).unwrap();
+    // ef_construction (u64)
+    buffer.write_all(&(100u64).to_le_bytes()).unwrap();
+    // ef_search (u64)
+    buffer.write_all(&(50u64).to_le_bytes()).unwrap();
+    // capacity (u64)
+    buffer.write_all(&(1000u64).to_le_bytes()).unwrap();
+
+    // STOP here. No quantization byte.
+
+    let mut reader = &buffer[..];
+    let loaded_config = HnswConfig::deserialize_from(&mut reader).unwrap();
+
+    assert_eq!(loaded_config.dimensions, 128);
+    assert_eq!(loaded_config.metric, DistanceMetric::Euclidean);
+    assert_eq!(loaded_config.m, 16);
+    assert_eq!(loaded_config.ef_construction, 100);
+    assert_eq!(loaded_config.ef_search, 50);
+    assert_eq!(loaded_config.capacity, 1000);
+
+    // Check fallback to default
+    assert_eq!(loaded_config.quantization, Quantization::default());
+}

--- a/tests/hnsw_config_persistence.rs
+++ b/tests/hnsw_config_persistence.rs
@@ -105,7 +105,9 @@ fn test_hnsw_config_v1_compatibility() {
     // dimensions (u64)
     buffer.write_all(&(128u64).to_le_bytes()).unwrap();
     // metric (u8)
-    buffer.write_all(&[DistanceMetric::Euclidean.to_u8()]).unwrap();
+    buffer
+        .write_all(&[DistanceMetric::Euclidean.to_u8()])
+        .unwrap();
     // m (u64)
     buffer.write_all(&(16u64).to_le_bytes()).unwrap();
     // ef_construction (u64)

--- a/tests/sparse_vector_precision.rs
+++ b/tests/sparse_vector_precision.rs
@@ -1,5 +1,5 @@
-use aletheiadb::core::vector::sparse_squared_euclidean_distance;
 use aletheiadb::core::vector::SparseVec;
+use aletheiadb::core::vector::sparse_squared_euclidean_distance;
 
 #[test]
 fn test_sparse_precision_loss() {
@@ -23,6 +23,14 @@ fn test_sparse_precision_loss() {
 
     // We expect it to be close to 0.0001.
     // If it's 0.0, it failed.
-    assert!(dist_sq > 1e-5, "Distance should be non-zero (got {})", dist_sq);
-    assert!((dist_sq - 0.0001).abs() < 1e-5, "Distance should be approx 0.0001 (got {})", dist_sq);
+    assert!(
+        dist_sq > 1e-5,
+        "Distance should be non-zero (got {})",
+        dist_sq
+    );
+    assert!(
+        (dist_sq - 0.0001).abs() < 1e-5,
+        "Distance should be approx 0.0001 (got {})",
+        dist_sq
+    );
 }

--- a/tests/sparse_vector_precision.rs
+++ b/tests/sparse_vector_precision.rs
@@ -1,0 +1,28 @@
+use aletheiadb::core::vector::sparse_squared_euclidean_distance;
+use aletheiadb::core::vector::SparseVec;
+
+#[test]
+fn test_sparse_precision_loss() {
+    // 🧪 Strategy: Create sparse vectors that cause catastrophic cancellation
+    // using the expanded form ||a||^2 + ||b||^2 - 2ab.
+    // 💣 Risk: If the implementation uses the expanded form, it will return 0.0 instead of correct small distance.
+
+    // a = [1000.0]
+    // b = [1000.01]
+    // Expected squared distance = (0.01)^2 = 0.0001
+
+    let a = SparseVec::new(vec![0], vec![1000.0], 100).unwrap();
+    let b = SparseVec::new(vec![0], vec![1000.01], 100).unwrap();
+
+    let dist_sq = sparse_squared_euclidean_distance(&a, &b).unwrap();
+
+    // Direct computation gives ~0.0001
+    // Expanded form gives 0.0 (due to precision loss)
+
+    println!("Computed distance: {}", dist_sq);
+
+    // We expect it to be close to 0.0001.
+    // If it's 0.0, it failed.
+    assert!(dist_sq > 1e-5, "Distance should be non-zero (got {})", dist_sq);
+    assert!((dist_sq - 0.0001).abs() < 1e-5, "Distance should be approx 0.0001 (got {})", dist_sq);
+}


### PR DESCRIPTION
This PR addresses a numerical instability issue in `sparse_squared_euclidean_distance` where catastrophic cancellation occurred for vectors with large magnitudes and small differences. The fix implements a direct `sum((a-b)^2)` computation.

Additionally, it improves test coverage for `HnswConfig` serialization with property-based tests to ensure configuration parameters are correctly persisted and restored, including handling of transient fields and backward compatibility.

Target: `src/core/vector/sparse.rs`, `src/index/vector/hnsw.rs`
Risk: Low (correctness fix, non-breaking change)
Verification: `cargo test --test sparse_vector_precision`, `cargo test --test hnsw_config_persistence`

---
*PR created automatically by Jules for task [8991598460013613716](https://jules.google.com/task/8991598460013613716) started by @madmax983*