### PR TITLE
👺 Havoc: Deadlock Reproduction in HnswIndex

### DIFF
--- a/tests/havoc_fuzz_wal.rs
+++ b/tests/havoc_fuzz_wal.rs
@@ -1,0 +1,17 @@
+use aletheiadb::storage::wal::segment_reader::read_segment;
+use aletheiadb::storage::wal::LSN;
+use std::io::Write;
+use tempfile::NamedTempFile;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn fuzz_read_segment(bytes in prop::collection::vec(any::<u8>(), 0..4096)) {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&bytes).unwrap();
+        let path = file.path();
+
+        // Should not panic
+        let _ = read_segment(path, LSN(0));
+    }
+}

--- a/tests/havoc_fuzz_wal.rs
+++ b/tests/havoc_fuzz_wal.rs
@@ -1,8 +1,8 @@
-use aletheiadb::storage::wal::segment_reader::read_segment;
 use aletheiadb::storage::wal::LSN;
+use aletheiadb::storage::wal::segment_reader::read_segment;
+use proptest::prelude::*;
 use std::io::Write;
 use tempfile::NamedTempFile;
-use proptest::prelude::*;
 
 proptest! {
     #[test]

--- a/tests/havoc_proptest.rs
+++ b/tests/havoc_proptest.rs
@@ -1,0 +1,29 @@
+use aletheiadb::core::property::{deserialize_vector, serialize_vector};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_deserialize_vector_random_bytes(bytes in prop::collection::vec(any::<u8>(), 0..1024)) {
+        // This should return Ok or Err, but NOT panic
+        let _ = deserialize_vector(&bytes);
+    }
+
+    #[test]
+    fn test_vector_roundtrip(vec in prop::collection::vec(any::<f32>(), 0..100)) {
+        // 💣 Risk: NaNs might break equality checks or serialization
+        let bytes = serialize_vector(&vec);
+        let (deserialized, _) = deserialize_vector(&bytes).unwrap();
+
+        // Check length
+        prop_assert_eq!(vec.len(), deserialized.len());
+
+        // Check values (handling NaN)
+        for (a, b) in vec.iter().zip(deserialized.iter()) {
+            if a.is_nan() {
+                prop_assert!(b.is_nan());
+            } else {
+                prop_assert_eq!(a, b);
+            }
+        }
+    }
+}

--- a/tests/repro_deadlock.rs
+++ b/tests/repro_deadlock.rs
@@ -1,0 +1,71 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
+use aletheiadb::index::VectorIndex;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+#[ignore = "Demonstrates deadlock via thread spawning in filter callback (Havoc)"]
+fn test_deadlock_in_filter_spawn() {
+    // 👺 Havoc: Threading deadlock demonstration
+    // "Users will spawn threads in callbacks because they can."
+    // This test demonstrates that while IN_FILTER_CALLBACK protects against
+    // recursive calls on the same thread, it cannot prevent deadlocks
+    // when the callback spawns a thread that waits on the index lock.
+
+    let index = Arc::new(
+        HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .expect("Failed to build index"),
+    );
+
+    let node1 = NodeId::new(1).unwrap();
+    index
+        .add(node1, &[1.0, 0.0, 0.0, 0.0])
+        .expect("Failed to add node");
+
+    let index_clone = Arc::clone(&index);
+
+    // Watchdog to detect deadlock
+    let (tx, rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(2));
+        if rx.try_recv().is_err() {
+            // If we haven't received success signal, we likely deadlocked.
+            // We panic to fail the test runner.
+            // Note: In a real test runner, this panic happens in a background thread
+            // and might not immediately stop the main test thread, but it logs the failure.
+            panic!("👺 HAVOC: Watchdog timed out! Deadlock detected.");
+        }
+    });
+
+    println!("Starting search with filter...");
+    let result = index.search_with_filter(&[1.0, 0.0, 0.0, 0.0], 10, move |_id| {
+        println!("Inside filter callback");
+
+        // Spawn a thread that tries to modify the index
+        // This thread will NOT have IN_FILTER_CALLBACK set (thread-local)
+        let index_inner = Arc::clone(&index_clone);
+        let handle = thread::spawn(move || {
+            println!("Spawned thread trying to add...");
+            let node2 = NodeId::new(2).unwrap();
+            // This attempts to acquire inner.write()
+            // Main thread holds inner.read()
+            // Main thread is waiting for this thread.
+            // --> DEADLOCK
+            index_inner.add(node2, &[0.0, 1.0, 0.0, 0.0])
+        });
+
+        println!("Waiting for spawned thread...");
+        // Join means we wait for the spawned thread to finish.
+        // The spawned thread is waiting for us to release the lock.
+        // We are waiting for the spawned thread.
+        let res = handle.join();
+        println!("Spawned thread finished: {:?}", res);
+        true
+    });
+
+    println!("Search result: {:?}", result);
+    tx.send(()).unwrap(); // Signal success
+}

--- a/tests/repro_deadlock.rs
+++ b/tests/repro_deadlock.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;


### PR DESCRIPTION
👺 Havoc: "Thread-safe is a lie until proven by loom."

This PR presents the wreckage from my chaos engineering session.

### 🧨 The Trigger: Deadlock in `search_with_filter`
I discovered that while `HnswIndex` has `IN_FILTER_CALLBACK` to prevent single-threaded recursion, it is vulnerable to deadlocks if the user spawns a thread inside the filter callback.

**The Exploit:**
1. Call `index.search_with_filter` (Acquires `inner.read()`).
2. Inside callback, spawn a thread.
3. Spawned thread calls `index.add()` (Acquires `inner.write()`).
4. Main thread waits for spawned thread (`join()`).
5. **DEADLOCK**: `add` waits for `read` lock; `search` (holding `read`) waits for `add` thread.

**Reproduction:**
See `tests/repro_deadlock.rs`. The test is marked `#[ignore]` to avoid breaking CI, but running it (`cargo test --test repro_deadlock -- --ignored`) will panic with "Watchdog timed out! Deadlock detected."

### 🔨 The Harness: Fuzzing and Proptests
I also added proptest harnesses to verify robustness of other components:
- `tests/havoc_fuzz_wal.rs`: Fuzzes `read_segment` with random bytes. (Passed - robust).
- `tests/havoc_proptest.rs`: Fuzzes `deserialize_vector` and `serialize_vector`. (Passed - robust).

### 😈 Comment
"You assumed users wouldn't spawn threads inside a tight-loop callback. You were wrong. Also, your WAL reader is surprisingly robust against garbage data. Boring."


---
*PR created automatically by Jules for task [17492897503968394474](https://jules.google.com/task/17492897503968394474) started by @madmax983*