### PR TITLE
🛡️ Sentry: Add correctness tests for vector delta materialization

### DIFF
--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -2295,4 +2295,90 @@ mod sentry_tests {
         );
         assert_eq!(applied_vec, &new_vec[..]);
     }
+
+    #[test]
+    fn test_materialize_vector_deltas_correctness() {
+        // 🧪 Strategy: Verify that materialize_vector_deltas correctly applies sparse deltas
+        // and moves them to the 'changed' map as full vectors.
+
+        let key = GLOBAL_INTERNER.intern("embedding").unwrap();
+        let mut delta = PropertyDelta::new();
+
+        // 1. Create a sparse delta: change index 1 to 5.0
+        // Base will be [1.0, 2.0, 3.0]
+        let changes = Arc::new(vec![(1, 5.0f32)]);
+        let vec_delta = VectorDelta::Sparse {
+            dimension: 3,
+            changes,
+        };
+        delta.vector_deltas.insert(key, vec_delta);
+
+        // 2. Create base property map
+        let base_vec = vec![1.0f32, 2.0, 3.0];
+        let base = PropertyMapBuilder::new()
+            .insert("embedding", PropertyValue::vector(&base_vec))
+            .build();
+
+        // 3. Materialize
+        delta
+            .materialize_vector_deltas(&base)
+            .expect("Materialization should succeed");
+
+        // 4. Verify 'vector_deltas' is empty
+        assert!(
+            delta.vector_deltas.is_empty(),
+            "vector_deltas should be empty after materialization"
+        );
+
+        // 5. Verify 'changed' has the full vector
+        let materialized_val = delta
+            .changed
+            .get(&key)
+            .expect("Materialized vector should be in changed");
+        let materialized_vec = materialized_val
+            .as_vector()
+            .expect("Should be a vector value");
+
+        // 6. Verify values: [1.0, 5.0, 3.0]
+        assert_eq!(materialized_vec, &[1.0, 5.0, 3.0]);
+    }
+
+    #[test]
+    fn test_materialize_vector_deltas_full_delta() {
+        // 🧪 Strategy: Verify that VectorDelta::Full is also moved to 'changed' correctly.
+
+        let key = GLOBAL_INTERNER.intern("embedding").unwrap();
+        let mut delta = PropertyDelta::new();
+
+        // 1. Create a Full delta
+        let new_vec = vec![4.0f32, 5.0, 6.0];
+        let vec_delta = VectorDelta::Full(Arc::from(new_vec.clone()));
+        delta.vector_deltas.insert(key, vec_delta);
+
+        // 2. Create base (can be empty for Full delta, but let's provide one to be safe)
+        let base = PropertyMapBuilder::new().build();
+
+        // 3. Materialize
+        delta
+            .materialize_vector_deltas(&base)
+            .expect("Materialization should succeed");
+
+        // 4. Verify 'vector_deltas' is empty
+        assert!(
+            delta.vector_deltas.is_empty(),
+            "vector_deltas should be empty after materialization"
+        );
+
+        // 5. Verify 'changed' has the full vector
+        let materialized_val = delta
+            .changed
+            .get(&key)
+            .expect("Materialized vector should be in changed");
+        let materialized_vec = materialized_val
+            .as_vector()
+            .expect("Should be a vector value");
+
+        // 6. Verify values match the full delta
+        assert_eq!(materialized_vec, &new_vec[..]);
+    }
 }


### PR DESCRIPTION
🛡️ **Sentry: Vector Delta Materialization Tests**

🎯 **Target:** `src/core/version.rs` - `materialize_vector_deltas`

💣 **Risk:** Incorrect materialization of vector deltas could lead to data corruption or loss during persistence, specifically if sparse deltas are not correctly applied to the base vector or if full deltas are not correctly promoted to the changed map.

🧪 **Strategy:** Added two regression tests to the `sentry_tests` module:
1.  `test_materialize_vector_deltas_correctness`: Verifies that a `VectorDelta::Sparse` is correctly applied to a base vector and the resulting full vector is stored in `changed`, while `vector_deltas` is cleared.
2.  `test_materialize_vector_deltas_full_delta`: Verifies that a `VectorDelta::Full` is correctly moved from `vector_deltas` to `changed`.

🔬 **Verification:**
Run the specific tests:
`cargo test core::version::sentry_tests::test_materialize_vector_deltas --lib`

---
*PR created automatically by Jules for task [9752039991362875016](https://jules.google.com/task/9752039991362875016) started by @madmax983*