### PR TITLE
Fix HNSW re-entrancy deadlock vulnerability

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -952,6 +952,15 @@ impl VectorIndex for HnswIndex {
     }
 
     fn search(&self, query: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>> {
+        // Check for re-entrant access during filtered search (prevents deadlock)
+        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
+            return Err(Error::Vector(VectorError::IndexError(
+                "Cannot perform search from within a search_with_filter callback. \
+                 This prevents deadlocks when concurrent writers are pending."
+                    .to_string(),
+            )));
+        }
+
         // Validate query vector
         validate_vector(query)?;
 
@@ -1022,6 +1031,15 @@ impl VectorIndex for HnswIndex {
     where
         F: Fn(&NodeId) -> bool + Send + Sync,
     {
+        // Check for re-entrant access during filtered search (prevents deadlock)
+        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
+            return Err(Error::Vector(VectorError::IndexError(
+                "Cannot perform search_with_filter from within a search_with_filter callback. \
+                 This prevents deadlocks when concurrent writers are pending."
+                    .to_string(),
+            )));
+        }
+
         // Validate query vector
         validate_vector(query)?;
 

--- a/tests/havoc_hnsw_reentrancy.rs
+++ b/tests/havoc_hnsw_reentrancy.rs
@@ -1,0 +1,62 @@
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, VectorIndex};
+use aletheiadb::core::id::NodeId;
+
+#[test]
+fn test_reentrant_search_returns_error() {
+    let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+        .build()
+        .unwrap();
+
+    // Add data so search has something to iterate
+    index.add(NodeId::new(1).unwrap(), &[0.1, 0.2, 0.3, 0.4]).unwrap();
+
+    let q = vec![0.1, 0.2, 0.3, 0.4];
+
+    // Perform filtered search with a predicate that calls search recursively
+    let result = index.search_with_filter(&q, 10, |_id| {
+        // Attempt recursive search
+        let inner_result = index.search(&q, 1);
+
+        // Assert it failed with correct error
+        assert!(inner_result.is_err(), "Recursive search should fail");
+        let err = inner_result.unwrap_err();
+        assert!(
+            err.to_string().contains("Cannot perform search from within"),
+            "Error message should indicate re-entrancy prevention, got: {}",
+            err
+        );
+
+        true
+    });
+
+    // The outer search should succeed
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_reentrant_search_with_filter_returns_error() {
+    let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+        .build()
+        .unwrap();
+
+    index.add(NodeId::new(1).unwrap(), &[0.1, 0.2, 0.3, 0.4]).unwrap();
+
+    let q = vec![0.1, 0.2, 0.3, 0.4];
+
+    let result = index.search_with_filter(&q, 10, |_id| {
+        // Attempt recursive search_with_filter
+        let inner_result = index.search_with_filter(&q, 1, |_| true);
+
+        assert!(inner_result.is_err(), "Recursive search_with_filter should fail");
+        let err = inner_result.unwrap_err();
+        assert!(
+            err.to_string().contains("Cannot perform search_with_filter from within"),
+            "Error message should indicate re-entrancy prevention, got: {}",
+            err
+        );
+
+        true
+    });
+
+    assert!(result.is_ok());
+}

--- a/tests/havoc_hnsw_reentrancy.rs
+++ b/tests/havoc_hnsw_reentrancy.rs
@@ -1,5 +1,5 @@
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, VectorIndex};
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
 
 #[test]
 fn test_reentrant_search_returns_error() {
@@ -8,7 +8,9 @@ fn test_reentrant_search_returns_error() {
         .unwrap();
 
     // Add data so search has something to iterate
-    index.add(NodeId::new(1).unwrap(), &[0.1, 0.2, 0.3, 0.4]).unwrap();
+    index
+        .add(NodeId::new(1).unwrap(), &[0.1, 0.2, 0.3, 0.4])
+        .unwrap();
 
     let q = vec![0.1, 0.2, 0.3, 0.4];
 
@@ -21,7 +23,8 @@ fn test_reentrant_search_returns_error() {
         assert!(inner_result.is_err(), "Recursive search should fail");
         let err = inner_result.unwrap_err();
         assert!(
-            err.to_string().contains("Cannot perform search from within"),
+            err.to_string()
+                .contains("Cannot perform search from within"),
             "Error message should indicate re-entrancy prevention, got: {}",
             err
         );
@@ -39,7 +42,9 @@ fn test_reentrant_search_with_filter_returns_error() {
         .build()
         .unwrap();
 
-    index.add(NodeId::new(1).unwrap(), &[0.1, 0.2, 0.3, 0.4]).unwrap();
+    index
+        .add(NodeId::new(1).unwrap(), &[0.1, 0.2, 0.3, 0.4])
+        .unwrap();
 
     let q = vec![0.1, 0.2, 0.3, 0.4];
 
@@ -47,10 +52,14 @@ fn test_reentrant_search_with_filter_returns_error() {
         // Attempt recursive search_with_filter
         let inner_result = index.search_with_filter(&q, 1, |_| true);
 
-        assert!(inner_result.is_err(), "Recursive search_with_filter should fail");
+        assert!(
+            inner_result.is_err(),
+            "Recursive search_with_filter should fail"
+        );
         let err = inner_result.unwrap_err();
         assert!(
-            err.to_string().contains("Cannot perform search_with_filter from within"),
+            err.to_string()
+                .contains("Cannot perform search_with_filter from within"),
             "Error message should indicate re-entrancy prevention, got: {}",
             err
         );


### PR DESCRIPTION
Identified a deadlock vulnerability in `HnswIndex` where a recursive read lock (via `search` inside a filter) could deadlock if a concurrent writer is pending, due to `parking_lot::RwLock`'s fairness policy. Implemented a fix by explicitly detecting and rejecting re-entrant search attempts using the existing `IN_FILTER_CALLBACK` mechanism. Added a regression test to verify the fix.

---
*PR created automatically by Jules for task [9249418253417612770](https://jules.google.com/task/9249418253417612770) started by @madmax983*