### PR TITLE
DX: Fix README warnings and improve Timestamp ergonomics

### DIFF
--- a/DX_REPORT_2.md
+++ b/DX_REPORT_2.md
@@ -1,0 +1,57 @@
+# 🗣️ Echo DX Report: The Audit (Session 2)
+
+**Auditor:** Echo (Voice of the User)
+**Date:** 2026-02-02
+**Subject:** README Examples & API Friction
+
+## 🔍 The Walkthrough
+
+I attempted to run the examples from `README.md` by copy-pasting them into a fresh `main.rs` (simulated by `examples/echo_check.rs`).
+
+### 🚧 The Friction Points
+
+#### 1. Unused Imports in Examples (Minor Friction)
+
+**Scenario:** I copied the "Time-Travel Queries" example.
+**Code:** `use aletheiadb::core::temporal::{Timestamp, time};`
+**Warning:** `unused import: Timestamp`
+**Why this hurts:** It makes the example look sloppy. New users might think they need `Timestamp` for something but can't figure out what.
+
+**Scenario:** I copied the "Hybrid Queries" example.
+**Code:** `use aletheiadb::query::QueryBuilder;`
+**Warning:** `unused import: aletheiadb::query::QueryBuilder`
+**Why this hurts:** The example uses `db.query()`, which returns a builder, so the import isn't needed for the code shown.
+
+#### 2. The `NodeId` Mystery (Moderate Friction)
+
+**Scenario:** I tried to query a node by ID, assuming I could just pass an integer or construct an ID.
+**Code:** `let node_id = NodeId(99999);` or `use aletheiadb::core::types::NodeId;`
+**Error:** `unresolved import` and `private field`.
+**Reality:** `NodeId` is re-exported at the root, but the examples don't show this. To construct one, I need `NodeId::new(99999)?`.
+**Fix:** Ensure examples show where types come from if they aren't obvious.
+
+#### 3. Timestamp Ergonomics (Moderate Friction)
+
+**Scenario:** I wanted to manipulate a timestamp (e.g., add 10 seconds).
+**Code:** `ts.as_secs() + 10`
+**Error:** `no method named as_secs found for struct HybridTimestamp`.
+**Reality:** I have to use `aletheiadb::core::temporal::time::to_secs(ts)`.
+**Why this hurts:** Object-oriented usage (`ts.as_secs()`) is much more discoverable than functional usage (`time::to_secs(ts)`). I have to look up the `time` module docs instead of just hitting `.` and seeing autocomplete.
+
+## 💡 Recommendations
+
+### 1. Clean up README Imports
+
+**Recommendation:** Remove unused imports from the code blocks in `README.md`.
+
+### 2. Improve `HybridTimestamp` DX
+
+**Recommendation:** Add `as_secs()` and `as_millis()` methods directly to `HybridTimestamp` (and `Timestamp` alias) so users can easily convert without importing helper functions.
+
+### 3. Show `NodeId` Usage
+
+**Recommendation:** Add a small example or comment showing how to construct IDs manually if needed, or at least ensure `NodeId` is mentioned in the imports if it appears in the code.
+
+## 🏁 Conclusion
+
+The examples mostly work, which is great! But the unused imports and the clunky timestamp manipulation add unnecessary friction.

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ println!("Created Alice: {:?}", alice);
 ### Time-Travel Queries
 
 ```rust
-use aletheiadb::core::temporal::{Timestamp, time};
+use aletheiadb::core::temporal::time;
 
 // Get current time
 let now = time::now();
@@ -408,7 +408,6 @@ let similar = db.find_similar(doc_id, 10)?;
 ### Hybrid Queries (Graph + Vector + Temporal)
 
 ```rust
-use aletheiadb::query::QueryBuilder;
 use aletheiadb::query::ir::Predicate;
 
 // Setup query parameters

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -71,6 +71,18 @@ impl HybridTimestamp {
         self.logical
     }
 
+    /// Get the wallclock component in seconds since Unix epoch.
+    #[inline]
+    pub const fn as_secs(&self) -> i64 {
+        self.wallclock / 1_000_000
+    }
+
+    /// Get the wallclock component in milliseconds since Unix epoch.
+    #[inline]
+    pub const fn as_millis(&self) -> i64 {
+        self.wallclock / 1_000
+    }
+
     /// Helper: Increment logical counter with overflow check.
     ///
     /// This helper reduces duplication in `send()` and `receive()` methods.
@@ -444,6 +456,27 @@ mod tests {
         let sentinel = HybridTimestamp::new_unchecked(i64::MAX, 0);
         let bytes = sentinel.serialize();
         assert!(HybridTimestamp::deserialize(&bytes).is_ok());
+    }
+
+    #[test]
+    fn test_as_secs_and_millis() {
+        // Test basic conversion
+        let secs = 1234567890;
+        let ts = HybridTimestamp::new(secs * 1_000_000, 0).unwrap();
+        assert_eq!(ts.as_secs(), secs);
+        assert_eq!(ts.as_millis(), secs * 1000);
+
+        // Test with milliseconds precision
+        let millis = 1234567890123;
+        let ts = HybridTimestamp::new(millis * 1000, 0).unwrap();
+        assert_eq!(ts.as_secs(), millis / 1000);
+        assert_eq!(ts.as_millis(), millis);
+
+        // Test with microseconds precision (should truncate)
+        let micros = 1234567890123456;
+        let ts = HybridTimestamp::new(micros, 0).unwrap();
+        assert_eq!(ts.as_secs(), micros / 1_000_000);
+        assert_eq!(ts.as_millis(), micros / 1000);
     }
 }
 


### PR DESCRIPTION
This PR addresses Developer Experience (DX) friction points identified during an "Echo" audit.

1.  **Cleaner Examples:** The `README.md` examples contained unused imports (`Timestamp`, `QueryBuilder`) which caused compiler warnings when users copy-pasted them. These have been removed.
2.  **Better Timestamp API:** Users previously had to import `aletheiadb::core::temporal::time` and use functional style `time::to_secs(ts)` to get seconds from a timestamp. Now, `HybridTimestamp` has inherent `as_secs()` and `as_millis()` methods, allowing for more idiomatic `ts.as_secs()` usage.
3.  **Verification:** A test script `examples/echo_final.rs` (created during development) confirmed that the consolidated examples compile and run without warnings.

These changes lower the barrier to entry for new users and make the API feel more polished.

---
*PR created automatically by Jules for task [1219504264311374717](https://jules.google.com/task/1219504264311374717) started by @madmax983*