### PR TITLE
🛡️ Sentry: Harden hybrid search against NaN and DoS

### DIFF
--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -30,9 +30,13 @@
 use crate::core::id::NodeId;
 use crate::core::vector::{cosine_similarity, validate_vector};
 use crate::db::AletheiaDB;
-use crate::utils::Result;
+use crate::utils::{error::VectorError, Error, Result};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
+
+/// Maximum allowed value for k (results count) to prevent DoS attacks via memory exhaustion.
+/// This matches the limit in the HNSW index implementation.
+const MAX_HYBRID_K: usize = 100_000;
 
 /// A candidate node with its similarity score, ordered by similarity (min-heap).
 ///
@@ -119,6 +123,14 @@ pub fn traverse_and_rank(
     target_embedding: &[f32],
     k: usize,
 ) -> Result<Vec<(NodeId, f32)>> {
+    // Validate k to prevent DoS
+    if k > MAX_HYBRID_K {
+        return Err(Error::Vector(VectorError::IndexError(format!(
+            "Requested k={} exceeds maximum allowed {}",
+            k, MAX_HYBRID_K
+        ))));
+    }
+
     // Validate target embedding
     validate_vector(target_embedding)?;
 
@@ -162,6 +174,17 @@ pub fn traverse_and_rank(
         // Compute cosine similarity
         match cosine_similarity(target_embedding, embedding) {
             Ok(similarity) => {
+                // SENTRY: Filter out NaN results to prevent undefined sorting/heap behavior.
+                // NaNs can occur if the stored vector is invalid (e.g. legacy data or corruption)
+                if similarity.is_nan() {
+                    #[cfg(feature = "observability")]
+                    tracing::warn!(
+                        target_id = %target_id,
+                        "Skipping node in traverse_and_rank due to NaN similarity result"
+                    );
+                    continue;
+                }
+
                 let candidate = ScoredCandidate::new(target_id, similarity);
 
                 if top_k_heap.len() < k {
@@ -954,6 +977,72 @@ mod tests {
             results.len(),
             0,
             "Should return empty results for empty database"
+        );
+    }
+
+    #[test]
+    fn test_traverse_and_rank_with_nan_in_db() {
+        use crate::core::property::PropertyValue;
+        use std::sync::Arc;
+
+        // Use a DB without vector index to simulate stored NaN data (bypassing index validation)
+        let db = AletheiaDB::new().unwrap();
+
+        // Create start node
+        let start = db
+            .create_node(
+                "Start",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &[1.0, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+
+        // Create neighbor with NaN embedding
+        let nan_vec = vec![f32::NAN, 0.0, 0.0, 0.0];
+        let nan_node = db
+            .create_node(
+                "NaN",
+                PropertyMapBuilder::new()
+                    .insert("embedding", PropertyValue::Vector(Arc::from(nan_vec.into_boxed_slice())))
+                    .build(),
+            )
+            .unwrap();
+
+        // Create edge
+        db.create_edge(start, nan_node, "LINK", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        // Query
+        let target = [1.0, 0.0, 0.0, 0.0];
+        let results = traverse_and_rank(&db, start, "LINK", &target, 10).unwrap();
+
+        // SENTRY VERIFICATION:
+        // NaNs should be filtered out by traverse_and_rank.
+        // So the results should NOT contain the nan_node.
+        for (id, _) in results {
+            if id == nan_node {
+                panic!("Should not return node with NaN similarity");
+            }
+        }
+    }
+
+    #[test]
+    fn test_traverse_and_rank_huge_k() {
+        let db = create_test_db();
+        let start = db
+            .create_node("Start", PropertyMapBuilder::new().build())
+            .unwrap();
+        let target = [1.0, 0.0, 0.0, 0.0];
+
+        // Huge k should be rejected gracefully
+        let result = traverse_and_rank(&db, start, "LINK", &target, usize::MAX);
+
+        assert!(result.is_err(), "Should return error for huge k");
+        let err = result.unwrap_err();
+        assert!(
+            format!("{}", err).contains("exceeds maximum allowed"),
+            "Error message should mention limit"
         );
     }
 }

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -30,7 +30,7 @@
 use crate::core::id::NodeId;
 use crate::core::vector::{cosine_similarity, validate_vector};
 use crate::db::AletheiaDB;
-use crate::utils::{error::VectorError, Error, Result};
+use crate::utils::{Error, Result, error::VectorError};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
 
@@ -1004,7 +1004,10 @@ mod tests {
             .create_node(
                 "NaN",
                 PropertyMapBuilder::new()
-                    .insert("embedding", PropertyValue::Vector(Arc::from(nan_vec.into_boxed_slice())))
+                    .insert(
+                        "embedding",
+                        PropertyValue::Vector(Arc::from(nan_vec.into_boxed_slice())),
+                    )
                     .build(),
             )
             .unwrap();

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -254,11 +254,7 @@ impl<'a> SemanticPathfinder<'a> {
                         let semantic_cost = if let Some(emb) = target_embedding {
                             let sim = cosine_similarity(emb, query_embedding)?;
                             // SENTRY: Handle NaN similarity by assigning high cost
-                            if sim.is_nan() {
-                                1.0
-                            } else {
-                                1.0 - sim
-                            }
+                            if sim.is_nan() { 1.0 } else { 1.0 - sim }
                         } else {
                             1.0 // High cost if no embedding
                         };
@@ -565,7 +561,10 @@ mod tests {
             .create_node(
                 "NaN",
                 PropertyMapBuilder::new()
-                    .insert("embedding", PropertyValue::Vector(Arc::from(nan_vec.into_boxed_slice())))
+                    .insert(
+                        "embedding",
+                        PropertyValue::Vector(Arc::from(nan_vec.into_boxed_slice())),
+                    )
                     .build(),
             )
             .unwrap();
@@ -580,9 +579,7 @@ mod tests {
         let query = [1.0, 0.0, 0.0];
 
         // Should find path even with NaN, but treat NaN node as high cost.
-        let path = pathfinder
-            .find_path(start, end, &query, 10, false)
-            .unwrap();
+        let path = pathfinder.find_path(start, end, &query, 10, false).unwrap();
 
         assert!(path.is_some(), "Should find path");
         let p = path.unwrap();

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -48,6 +48,29 @@ impl PartialOrd for State {
     }
 }
 
+/// Helper function to calculate semantic cost from an embedding.
+///
+/// Handles `NaN` similarity scores by assigning a high cost (1.0), which prevents
+/// pathfinding from getting stuck or panicking on invalid data.
+fn calculate_semantic_cost_from_embedding(
+    embedding: Option<&[f32]>,
+    query: &[f32],
+) -> Result<f32> {
+    if let Some(emb) = embedding {
+        let sim = cosine_similarity(emb, query)?;
+        // SENTRY: Handle NaN similarity by returning max cost (1.0)
+        // This ensures the pathfinder doesn't get stuck or propagate NaNs
+        // which would break the priority queue ordering.
+        if sim.is_nan() {
+            Ok(1.0)
+        } else {
+            Ok(1.0 - sim)
+        }
+    } else {
+        Ok(1.0) // High cost if no embedding
+    }
+}
+
 /// A pathfinder that uses semantic similarity as a heuristic/cost.
 pub struct SemanticPathfinder<'a> {
     db: &'a AletheiaDB,
@@ -251,13 +274,8 @@ impl<'a> SemanticPathfinder<'a> {
                             .get(&self.vector_property)
                             .and_then(|v| v.as_vector());
 
-                        let semantic_cost = if let Some(emb) = target_embedding {
-                            let sim = cosine_similarity(emb, query_embedding)?;
-                            // SENTRY: Handle NaN similarity by assigning high cost
-                            if sim.is_nan() { 1.0 } else { 1.0 - sim }
-                        } else {
-                            1.0 // High cost if no embedding
-                        };
+                        let semantic_cost =
+                            calculate_semantic_cost_from_embedding(target_embedding, query_embedding)?;
 
                         let new_cost = cost + semantic_cost + 0.1;
 
@@ -283,28 +301,12 @@ impl<'a> SemanticPathfinder<'a> {
     fn calculate_semantic_cost(&self, node_id: NodeId, query: &[f32]) -> Result<f32> {
         let node = self.db.get_node(node_id)?;
 
-        #[allow(clippy::collapsible_if)]
-        if let Some(prop) = node.properties.get(&self.vector_property) {
-            if let Some(vec) = prop.as_vector() {
-                let sim = cosine_similarity(vec, query)?;
+        let target_embedding = node
+            .properties
+            .get(&self.vector_property)
+            .and_then(|v| v.as_vector());
 
-                // SENTRY: Handle NaN similarity by returning max cost (1.0)
-                // This ensures the pathfinder doesn't get stuck or propagate NaNs
-                // which would break the priority queue ordering.
-                if sim.is_nan() {
-                    return Ok(1.0);
-                }
-
-                // Clamp to [0, 2] (cosine sim is [-1, 1])
-                // We want high similarity -> low cost
-                // 1.0 - 1.0 = 0.0 (perfect match)
-                // 1.0 - (-1.0) = 2.0 (opposite)
-                return Ok(1.0 - sim);
-            }
-        }
-
-        // Penalize nodes without embeddings
-        Ok(1.0)
+        calculate_semantic_cost_from_embedding(target_embedding, query)
     }
 
     fn reconstruct_path(&self, came_from: HashMap<NodeId, NodeId>, current: NodeId) -> Vec<NodeId> {

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -252,7 +252,13 @@ impl<'a> SemanticPathfinder<'a> {
                             .and_then(|v| v.as_vector());
 
                         let semantic_cost = if let Some(emb) = target_embedding {
-                            1.0 - cosine_similarity(emb, query_embedding)?
+                            let sim = cosine_similarity(emb, query_embedding)?;
+                            // SENTRY: Handle NaN similarity by assigning high cost
+                            if sim.is_nan() {
+                                1.0
+                            } else {
+                                1.0 - sim
+                            }
                         } else {
                             1.0 // High cost if no embedding
                         };
@@ -285,6 +291,14 @@ impl<'a> SemanticPathfinder<'a> {
         if let Some(prop) = node.properties.get(&self.vector_property) {
             if let Some(vec) = prop.as_vector() {
                 let sim = cosine_similarity(vec, query)?;
+
+                // SENTRY: Handle NaN similarity by returning max cost (1.0)
+                // This ensures the pathfinder doesn't get stuck or propagate NaNs
+                // which would break the priority queue ordering.
+                if sim.is_nan() {
+                    return Ok(1.0);
+                }
+
                 // Clamp to [0, 2] (cosine sim is [-1, 1])
                 // We want high similarity -> low cost
                 // 1.0 - 1.0 = 0.0 (perfect match)
@@ -516,5 +530,63 @@ mod tests {
         );
         // Verify it's the original middle node, not new_middle
         assert_eq!(path_t0_check.as_ref().unwrap()[1], middle);
+    }
+
+    #[test]
+    fn test_semantic_pathfinding_with_nan() {
+        use crate::core::property::PropertyValue;
+        use std::sync::Arc;
+
+        // Use a fresh DB without vector index to simulate stored NaN data (bypassing validation)
+        let db = AletheiaDB::new().unwrap();
+
+        let start = db
+            .create_node(
+                "Start",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+
+        let end = db
+            .create_node(
+                "End",
+                PropertyMapBuilder::new()
+                    .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+
+        // Intermediate node with NaN embedding
+        // 3 dimensions to match create_test_db config
+        let nan_vec = vec![f32::NAN, 0.0, 0.0];
+        let nan_node = db
+            .create_node(
+                "NaN",
+                PropertyMapBuilder::new()
+                    .insert("embedding", PropertyValue::Vector(Arc::from(nan_vec.into_boxed_slice())))
+                    .build(),
+            )
+            .unwrap();
+
+        // Path: Start -> NaN -> End
+        db.create_edge(start, nan_node, "NEXT", PropertyMapBuilder::new().build())
+            .unwrap();
+        db.create_edge(nan_node, end, "NEXT", PropertyMapBuilder::new().build())
+            .unwrap();
+
+        let pathfinder = SemanticPathfinder::new(&db, "embedding");
+        let query = [1.0, 0.0, 0.0];
+
+        // Should find path even with NaN, but treat NaN node as high cost.
+        let path = pathfinder
+            .find_path(start, end, &query, 10, false)
+            .unwrap();
+
+        assert!(path.is_some(), "Should find path");
+        let p = path.unwrap();
+        assert_eq!(p.len(), 3);
+        assert_eq!(p[1], nan_node);
     }
 }

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -52,20 +52,13 @@ impl PartialOrd for State {
 ///
 /// Handles `NaN` similarity scores by assigning a high cost (1.0), which prevents
 /// pathfinding from getting stuck or panicking on invalid data.
-fn calculate_semantic_cost_from_embedding(
-    embedding: Option<&[f32]>,
-    query: &[f32],
-) -> Result<f32> {
+fn calculate_semantic_cost_from_embedding(embedding: Option<&[f32]>, query: &[f32]) -> Result<f32> {
     if let Some(emb) = embedding {
         let sim = cosine_similarity(emb, query)?;
         // SENTRY: Handle NaN similarity by returning max cost (1.0)
         // This ensures the pathfinder doesn't get stuck or propagate NaNs
         // which would break the priority queue ordering.
-        if sim.is_nan() {
-            Ok(1.0)
-        } else {
-            Ok(1.0 - sim)
-        }
+        if sim.is_nan() { Ok(1.0) } else { Ok(1.0 - sim) }
     } else {
         Ok(1.0) // High cost if no embedding
     }
@@ -274,8 +267,10 @@ impl<'a> SemanticPathfinder<'a> {
                             .get(&self.vector_property)
                             .and_then(|v| v.as_vector());
 
-                        let semantic_cost =
-                            calculate_semantic_cost_from_embedding(target_embedding, query_embedding)?;
+                        let semantic_cost = calculate_semantic_cost_from_embedding(
+                            target_embedding,
+                            query_embedding,
+                        )?;
 
                         let new_cost = cost + semantic_cost + 0.1;
 


### PR DESCRIPTION
Hardened the hybrid search (`traverse_and_rank`) and semantic pathfinding logic against invalid vector data (NaNs) and excessive resource consumption.

Changes:
- `traverse_and_rank` now validates `k` against `MAX_HYBRID_K` (100,000) to prevent OOM DoS.
- `traverse_and_rank` filters out candidates with `NaN` similarity scores (which can occur from corrupted stored data) to prevent undefined sorting behavior.
- `SemanticPathfinder::calculate_semantic_cost` now returns a safe fallback cost (1.0) when `cosine_similarity` returns `NaN`, preventing priority queue corruption.
- Added comprehensive tests in `src/query/hybrid.rs` and `src/query/semantic_pathfinding.rs` verifying these fixes, including tests that bypass standard validation to simulate data corruption.

---
*PR created automatically by Jules for task [4029855929144920958](https://jules.google.com/task/4029855929144920958) started by @madmax983*