### PR TITLE
👺 Havoc: Fix deadlock in HnswIndex::add by enforcing lock ordering

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -97,7 +97,15 @@ use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
+
+// Test hook to inject delay for race condition testing
+#[cfg(test)]
+pub(crate) static TEST_RACE_HOOK: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+pub(crate) static TEST_RACE_WAITING: AtomicBool = AtomicBool::new(false);
 
 // Thread-local flag to detect re-entrant modification attempts during filtered search.
 // This prevents deadlocks when user filter callbacks try to modify the index.
@@ -774,6 +782,17 @@ impl VectorIndex for HnswIndex {
                 // Lock Ordering Invariant: inner (RwLock) -> id_mapping (DashMap).
                 // Previous implementation held DashMap -> inner, causing deadlock with search/save/vacant-add.
                 drop(entry);
+
+                #[cfg(test)]
+                {
+                    if TEST_RACE_HOOK.load(Ordering::SeqCst) {
+                        TEST_RACE_WAITING.store(true, Ordering::SeqCst);
+                        // Sleep to allow the test controller to modify the map.
+                        // The test controller waits for TEST_RACE_WAITING=true before proceeding.
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                        TEST_RACE_WAITING.store(false, Ordering::SeqCst);
+                    }
+                }
 
                 // Acquire inner write lock (follows invariant: Inner first)
                 let index = self.inner.write();
@@ -2827,6 +2846,84 @@ mod tests {
         // Search for k=5 to force more comparisons
         let results = index.search(&[0.9, 0.1, 0.0, 0.0], 5).unwrap();
         assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn test_add_race_retry_coverage() -> Result<()> {
+        // This test deterministically triggers the retry logic in add()
+        // when the mapping changes or is removed between dropping entry lock
+        // and acquiring inner lock.
+
+        let index = Arc::new(HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?);
+        let id = NodeId::new(1).unwrap();
+
+        // Initial add
+        index.add(id, &[1.0, 0.0, 0.0, 0.0])?;
+
+        // Enable hook to pause thread in the critical gap
+        TEST_RACE_HOOK.store(true, Ordering::SeqCst);
+        // Ensure waiting flag is clear
+        TEST_RACE_WAITING.store(false, Ordering::SeqCst);
+
+        // Scenario 1: Mapping removed while waiting
+        let index_clone = index.clone();
+        let handle = std::thread::spawn(move || {
+            // This will pause after dropping entry lock
+            index_clone.add(id, &[0.0, 1.0, 0.0, 0.0])
+        });
+
+        // Wait for helper thread to enter the critical section
+        while !TEST_RACE_WAITING.load(Ordering::SeqCst) {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        // Remove the mapping (concurrent modification) while helper is waiting
+        index.remove(id)?;
+
+        // Wait for thread to finish (should retry and succeed)
+        handle.join().unwrap()?;
+
+        // Verify vector was added (re-added after removal)
+        let results = index.search(&[0.0, 1.0, 0.0, 0.0], 1)?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, id);
+        assert!(results[0].1 > 0.99);
+
+        // Scenario 2: Mapping changed (updated) while waiting
+        // Reset state
+        TEST_RACE_HOOK.store(true, Ordering::SeqCst);
+        TEST_RACE_WAITING.store(false, Ordering::SeqCst);
+
+        let index_clone = index.clone();
+        let handle = std::thread::spawn(move || {
+            // This will pause after dropping entry lock
+            // Trying to set to [0.0, 0.0, 1.0, 0.0]
+            index_clone.add(id, &[0.0, 0.0, 1.0, 0.0])
+        });
+
+        // Wait for helper thread to enter the critical section
+        while !TEST_RACE_WAITING.load(Ordering::SeqCst) {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        // Update the mapping directly (simulate another thread changing the key)
+        // We can't easily change the key without add/remove, so let's remove and add back
+        // which allocates a NEW key.
+        index.remove(id)?;
+        index.add(id, &[1.0, 1.0, 1.0, 1.0])?; // New key
+
+        // Wait for thread to finish (should detect key mismatch and retry)
+        handle.join().unwrap()?;
+
+        // Verify the final state matches the thread's update
+        let results = index.search(&[0.0, 0.0, 1.0, 0.0], 1)?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, id);
+        assert!(results[0].1 > 0.99);
+
+        // Cleanup
+        TEST_RACE_HOOK.store(false, Ordering::SeqCst);
+        Ok(())
     }
 }
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -96,9 +96,9 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(test)]
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicU64, Ordering};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
 
 // Test hook to inject delay for race condition testing
@@ -785,12 +785,18 @@ impl VectorIndex for HnswIndex {
 
                 #[cfg(test)]
                 {
-                    if TEST_RACE_HOOK.load(Ordering::SeqCst) {
+                    // Use swap to ensure we only trigger once, preventing deadlock during recursion
+                    if TEST_RACE_HOOK.swap(false, Ordering::SeqCst) {
                         TEST_RACE_WAITING.store(true, Ordering::SeqCst);
-                        // Sleep to allow the test controller to modify the map.
-                        // The test controller waits for TEST_RACE_WAITING=true before proceeding.
-                        std::thread::sleep(std::time::Duration::from_millis(500));
-                        TEST_RACE_WAITING.store(false, Ordering::SeqCst);
+                        // Wait for test controller to perform modification and clear the flag.
+                        // This ensures deterministic ordering: helper pauses -> controller modifies -> helper retries.
+                        let start = std::time::Instant::now();
+                        while TEST_RACE_WAITING.load(Ordering::SeqCst) {
+                            if start.elapsed() > std::time::Duration::from_secs(10) {
+                                panic!("Test helper timed out waiting for controller to release lock");
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(1));
+                        }
                     }
                 }
 
@@ -2873,12 +2879,20 @@ mod tests {
         });
 
         // Wait for helper thread to enter the critical section
+        let start = std::time::Instant::now();
         while !TEST_RACE_WAITING.load(Ordering::SeqCst) {
+            if start.elapsed() > std::time::Duration::from_secs(5) {
+                // Prevent hanging CI if hook is somehow missed
+                panic!("Timeout waiting for helper thread to enter critical section");
+            }
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
 
         // Remove the mapping (concurrent modification) while helper is waiting
         index.remove(id)?;
+
+        // Release the helper thread to proceed and retry
+        TEST_RACE_WAITING.store(false, Ordering::SeqCst);
 
         // Wait for thread to finish (should retry and succeed)
         handle.join().unwrap()?;
@@ -2902,7 +2916,11 @@ mod tests {
         });
 
         // Wait for helper thread to enter the critical section
+        let start = std::time::Instant::now();
         while !TEST_RACE_WAITING.load(Ordering::SeqCst) {
+            if start.elapsed() > std::time::Duration::from_secs(5) {
+                panic!("Timeout waiting for helper thread to enter critical section");
+            }
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
 
@@ -2911,6 +2929,9 @@ mod tests {
         // which allocates a NEW key.
         index.remove(id)?;
         index.add(id, &[1.0, 1.0, 1.0, 1.0])?; // New key
+
+        // Release the helper thread
+        TEST_RACE_WAITING.store(false, Ordering::SeqCst);
 
         // Wait for thread to finish (should detect key mismatch and retry)
         handle.join().unwrap()?;

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -793,7 +793,9 @@ impl VectorIndex for HnswIndex {
                         let start = std::time::Instant::now();
                         while TEST_RACE_WAITING.load(Ordering::SeqCst) {
                             if start.elapsed() > std::time::Duration::from_secs(10) {
-                                panic!("Test helper timed out waiting for controller to release lock");
+                                panic!(
+                                    "Test helper timed out waiting for controller to release lock"
+                                );
                             }
                             std::thread::sleep(std::time::Duration::from_millis(1));
                         }
@@ -2927,8 +2929,11 @@ mod tests {
         // Update the mapping directly (simulate another thread changing the key)
         // We can't easily change the key without add/remove, so let's remove and add back
         // which allocates a NEW key.
+        let old_key = index.id_mapping.get(&id).map(|k| *k);
         index.remove(id)?;
         index.add(id, &[1.0, 1.0, 1.0, 1.0])?; // New key
+        let new_key = index.id_mapping.get(&id).map(|k| *k);
+        assert_ne!(old_key, new_key, "Setup failed: Key should have changed");
 
         // Release the helper thread
         TEST_RACE_WAITING.store(false, Ordering::SeqCst);
@@ -2940,7 +2945,11 @@ mod tests {
         let results = index.search(&[0.0, 0.0, 1.0, 0.0], 1)?;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, id);
-        assert!(results[0].1 > 0.99);
+        assert!(
+            results[0].1 > 0.99,
+            "Expected similarity > 0.99, got {}. Vector probably not updated by retry logic.",
+            results[0].1
+        );
 
         // Cleanup
         TEST_RACE_HOOK.store(false, Ordering::SeqCst);

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -770,11 +770,31 @@ impl VectorIndex for HnswIndex {
                 // This avoids unnecessary FFI calls during recovery or when mappings are out of sync.
                 let existing_key = *entry.get();
 
-                // CRITICAL: Hold write lock continuously from remove to add to prevent race conditions
-                // where multiple threads try to update the same node concurrently (PR #575).
-                // Without this, thread A could remove, thread B could remove (fail), then both try to add,
-                // causing "Duplicate keys not allowed" error.
+                // DEADLOCK FIX: Drop DashMap shard lock BEFORE acquiring inner lock.
+                // Lock Ordering Invariant: inner (RwLock) -> id_mapping (DashMap).
+                // Previous implementation held DashMap -> inner, causing deadlock with search/save/vacant-add.
+                drop(entry);
+
+                // Acquire inner write lock (follows invariant: Inner first)
                 let index = self.inner.write();
+
+                // Re-verify mapping under Inner lock.
+                // We must ensure the mapping hasn't changed or been removed while we switched locks.
+                // This is safe because acquiring id_mapping (read) while holding inner (write)
+                // respects the Inner -> DashMap order.
+                if let Some(current_key) = self.id_mapping.get(&id) {
+                    if *current_key != existing_key {
+                        // Mapping changed by another thread (update/remove).
+                        // Release lock and retry the operation from scratch.
+                        drop(index);
+                        return self.add(id, vector);
+                    }
+                } else {
+                    // Mapping removed by another thread.
+                    // Release lock and retry (will likely take Vacant path).
+                    drop(index);
+                    return self.add(id, vector);
+                }
 
                 // Check if key exists before removing to avoid wasteful FFI call
                 if index.contains(existing_key) {

--- a/tests/havoc_hnsw_deadlock.rs
+++ b/tests/havoc_hnsw_deadlock.rs
@@ -1,7 +1,7 @@
 use aletheiadb::core::id::NodeId;
 use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 

--- a/tests/havoc_hnsw_deadlock.rs
+++ b/tests/havoc_hnsw_deadlock.rs
@@ -1,5 +1,6 @@
 use aletheiadb::core::id::NodeId;
 use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -58,5 +59,72 @@ fn test_hnsw_reentrant_deadlock_prevented() {
     // Wait for 2 seconds. The operation should complete quickly now.
     if rx.recv_timeout(Duration::from_secs(2)).is_err() {
         panic!("Test timed out! The re-entrancy prevention may not be working correctly.");
+    }
+}
+
+#[test]
+fn havoc_hnsw_deadlock_repro() {
+    // Chaos Test: Concurrent Add (Occupied) vs Add (Vacant) Deadlock
+    // Ideally this runs with many iterations to catch the race.
+
+    // Reduce iterations for CI to avoid timeout flakes, but enough to trigger race locally
+    let _iterations = 1000;
+    let num_threads = 16;
+
+    let index = Arc::new(
+        HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap(),
+    );
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut handles = vec![];
+
+    // Thread Group A: Repeatedly update the SAME ID (Occupied path)
+    // This holds the shard lock for ID 1 continuously.
+    for i in 0..num_threads {
+        let index = index.clone();
+        let stop = stop.clone();
+        handles.push(thread::spawn(move || {
+            let id = NodeId::new(1).unwrap();
+            let mut vec = vec![1.0, 0.0, 0.0, 0.0];
+            while !stop.load(Ordering::Relaxed) {
+                // Mutate vector slightly to force updates
+                vec[0] = (i as f32) * 0.1;
+                if let Err(e) = index.add(id, &vec) {
+                    eprintln!("Update failed: {}", e);
+                }
+                // Yield to increase contention
+                thread::yield_now();
+            }
+        }));
+    }
+
+    // Thread Group B: Add NEW IDs (Vacant path)
+    // This holds the INNER lock, then tries to acquire shard lock.
+    for i in 0..num_threads {
+        let index = index.clone();
+        let stop = stop.clone();
+        handles.push(thread::spawn(move || {
+            let mut id_val = 1000 * (i as u64) + 2;
+            let vec = vec![0.0, 1.0, 0.0, 0.0];
+            while !stop.load(Ordering::Relaxed) {
+                let id = NodeId::new(id_val).unwrap();
+                if let Err(e) = index.add(id, &vec) {
+                    eprintln!("Add failed: {}", e);
+                }
+                id_val += 1;
+                // Yield to increase contention
+                thread::yield_now();
+            }
+        }));
+    }
+
+    // Run for a bit
+    thread::sleep(Duration::from_secs(5));
+    stop.store(true, Ordering::Relaxed);
+
+    for handle in handles {
+        handle.join().unwrap();
     }
 }


### PR DESCRIPTION
👺 Havoc Report: HnswIndex Deadlock

🧨 **The Trigger:** 
Concurrent `add(id, vector)` calls where:
1. Thread A updates an existing ID (Occupied path). It holds `id_mapping` shard lock (DashMap).
2. Thread B adds a new ID (Vacant path). It holds `Inner` lock (RwLock) and tries to acquire `id_mapping` shard lock.
3. If they hit the same shard, Thread A waits for `Inner` (held by B), and Thread B waits for `id_mapping` (held by A). Deadlock.

📉 **The Fix:** 
Enforced strict lock ordering: `Inner` -> `DashMap`.
- In `add` (Occupied path), we now **drop** the DashMap entry lock *before* acquiring the `Inner` lock.
- We then re-verify the mapping under the `Inner` lock (safe because `Inner` -> `DashMap` is allowed).
- If the mapping changed or was removed during the gap, we retry the operation.

🧪 **Reproduction:** 
Added `tests/havoc_hnsw_deadlock.rs` which spawns threads to hammer this race condition.
Restored original regression test `test_hnsw_reentrant_deadlock_prevented` in the same file.

😈 **Comment:** "You violated the sacred lock order. Chaos ensures you pay the price."

---
*PR created automatically by Jules for task [8710835331301081897](https://jules.google.com/task/8710835331301081897) started by @madmax983*