### PR TITLE
🔒 Warden: Fix infinite spin loop DoS in WalRingBuffer

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -94,6 +94,19 @@ pub struct BackpressureConfig {
     pub max_sleep_us: u64,
 }
 
+impl BackpressureConfig {
+    /// Validate the configuration to prevent invalid states (e.g. infinite loops).
+    pub fn validate(&self) -> Result<(), String> {
+        if self.initial_spins == 0 {
+            return Err("initial_spins must be > 0 to prevent infinite spin loops".to_string());
+        }
+        if self.max_spins < self.initial_spins {
+            return Err("max_spins must be >= initial_spins".to_string());
+        }
+        Ok(())
+    }
+}
+
 impl Default for BackpressureConfig {
     fn default() -> Self {
         Self {
@@ -452,6 +465,7 @@ impl WalRingBuffer {
     /// Panics if `capacity` is 0.
     pub fn with_config(capacity: usize, backpressure: BackpressureConfig) -> Self {
         assert!(capacity > 0, "Ring buffer capacity must be > 0");
+        backpressure.validate().expect("Invalid BackpressureConfig");
 
         // Round up to power of 2
         let capacity = capacity.next_power_of_two();
@@ -588,8 +602,9 @@ impl WalRingBuffer {
                             return Err(entry);
                         }
                         // Exponential backoff: double the spin limit
-                        current_spin_limit =
-                            (current_spin_limit.saturating_mul(2)).min(self.backpressure.max_spins);
+                        // Warden: Use max(1) to ensure progress even if initial_spins was 0 (defense in depth)
+                        current_spin_limit = (current_spin_limit.max(1).saturating_mul(2))
+                            .min(self.backpressure.max_spins);
                         spin_count = 0;
                     }
 

--- a/tests/warden_backpressure_dos.rs
+++ b/tests/warden_backpressure_dos.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
-use aletheiadb::storage::wal::ring_buffer::{WalRingBuffer, BackpressureConfig, PendingEntry};
 use aletheiadb::storage::wal::LSN;
+use aletheiadb::storage::wal::ring_buffer::{BackpressureConfig, PendingEntry, WalRingBuffer};
+use std::sync::Arc;
 
 #[test]
 #[should_panic(expected = "Invalid BackpressureConfig")]
@@ -28,8 +28,10 @@ fn test_valid_low_latency_config() {
     let buf = Arc::new(WalRingBuffer::with_config(2, config));
 
     // Should work normally
-    buf.try_append(PendingEntry::new_async(LSN(1), vec![])).unwrap();
-    buf.try_append(PendingEntry::new_async(LSN(2), vec![])).unwrap();
+    buf.try_append(PendingEntry::new_async(LSN(1), vec![]))
+        .unwrap();
+    buf.try_append(PendingEntry::new_async(LSN(2), vec![]))
+        .unwrap();
 
     // Buffer full, should return Err immediately or after short backoff (and not hang)
     // 1 -> 2 -> 4 ... -> 100 spins. Should be very fast.

--- a/tests/warden_backpressure_dos.rs
+++ b/tests/warden_backpressure_dos.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+use aletheiadb::storage::wal::ring_buffer::{WalRingBuffer, BackpressureConfig, PendingEntry};
+use aletheiadb::storage::wal::LSN;
+
+#[test]
+#[should_panic(expected = "Invalid BackpressureConfig")]
+fn test_prevent_invalid_config_panic() {
+    let config = BackpressureConfig {
+        initial_spins: 0, // Invalid!
+        max_spins: 100,
+        base_sleep_us: 1,
+        max_sleep_us: 10,
+    };
+
+    // This should panic now, preventing the DoS vulnerability
+    let _buf = WalRingBuffer::with_config(2, config);
+}
+
+#[test]
+fn test_valid_low_latency_config() {
+    let config = BackpressureConfig {
+        initial_spins: 1, // Valid (minimum)
+        max_spins: 100,
+        base_sleep_us: 1,
+        max_sleep_us: 10,
+    };
+
+    let buf = Arc::new(WalRingBuffer::with_config(2, config));
+
+    // Should work normally
+    buf.try_append(PendingEntry::new_async(LSN(1), vec![])).unwrap();
+    buf.try_append(PendingEntry::new_async(LSN(2), vec![])).unwrap();
+
+    // Buffer full, should return Err immediately or after short backoff (and not hang)
+    // 1 -> 2 -> 4 ... -> 100 spins. Should be very fast.
+    let result = buf.try_append(PendingEntry::new_async(LSN(3), vec![]));
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Prevents a DoS vulnerability in `WalRingBuffer` where `initial_spins = 0` causes an infinite loop. Adds validation to `BackpressureConfig` and hardens the backoff logic. Verified with regression tests.

---
*PR created automatically by Jules for task [9810072406108733846](https://jules.google.com/task/9810072406108733846) started by @madmax983*