### PR TITLE
Fix interner/index snapshot mismatch on restart

### DIFF
--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -119,8 +119,11 @@ impl<'a> Sherlock<'a> {
                     let prev_event_time = *current_sequence.last().unwrap();
 
                     // Search forward from current_version_idx + 1
-                    for j in (current_version_idx + 1)..versions.len() {
-                        let candidate = &versions[j];
+                    for (j, candidate) in versions
+                        .iter()
+                        .enumerate()
+                        .skip(current_version_idx + 1)
+                    {
                         let candidate_time = candidate.temporal.valid_time().start();
 
                         // Enforce strictly increasing time (if required) or just monotonic?
@@ -189,7 +192,6 @@ impl<'a> Sherlock<'a> {
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
-    use crate::core::hlc::HybridTimestamp;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::time;
 

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -118,11 +118,11 @@ impl<'a> Sherlock<'a> {
                     let mut found_next = false;
                     let prev_event_time = *current_sequence.last().unwrap();
 
-                    // Search forward from current_version_idx + 1
+                    // Search forward from the next index (saturating to avoid overflow edge cases).
                     for (j, candidate) in versions
                         .iter()
                         .enumerate()
-                        .skip(current_version_idx + 1)
+                        .skip(current_version_idx.saturating_add(1))
                     {
                         let candidate_time = candidate.temporal.valid_time().start();
 
@@ -198,31 +198,33 @@ mod tests {
     #[test]
     fn test_sherlock_detects_sequence() {
         let db = AletheiaDB::new().unwrap();
-        let _start_time = time::now();
+        let t0 = time::from_millis(1_000);
+        let t1 = time::from_millis(1_050);
+        let t2 = time::from_millis(1_100);
 
         // 1. Create Node (Status: Pending)
         let props = PropertyMapBuilder::new()
             .insert("status", "Pending")
             .build();
-        let node_id = db.create_node("Order", props).unwrap();
+        let node_id = db
+            .write(|tx| tx.create_node_with_valid_time("Order", props, Some(t0)))
+            .unwrap();
 
-        // 2. Update to "Shipped" (after 10ms)
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        // 2. Update to "Shipped" at explicit valid time.
         db.write(|tx| {
             let p = PropertyMapBuilder::new()
                 .insert("status", "Shipped")
                 .build();
-            tx.update_node(node_id, p)
+            tx.update_node_with_valid_time(node_id, p, Some(t1))
         })
         .unwrap();
 
-        // 3. Update to "Delivered" (after 10ms)
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        // 3. Update to "Delivered" at explicit valid time.
         db.write(|tx| {
             let p = PropertyMapBuilder::new()
                 .insert("status", "Delivered")
                 .build();
-            tx.update_node(node_id, p)
+            tx.update_node_with_valid_time(node_id, p, Some(t2))
         })
         .unwrap();
 
@@ -247,24 +249,26 @@ mod tests {
         let results = sherlock.investigate(node_id, &mystery).unwrap();
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].event_times.len(), 3);
+        assert_eq!(results[0].node_id, node_id);
+        assert_eq!(results[0].event_times, vec![t0, t1, t2]);
     }
 
     #[test]
     fn test_sherlock_time_window_constraint() {
         let db = AletheiaDB::new().unwrap();
+        let t0 = time::from_millis(10_000);
+        let t1 = time::from_millis(10_100); // 100ms after t0
 
         // 1. Create Node (State A)
         let props = PropertyMapBuilder::new().insert("state", "A").build();
-        let node_id = db.create_node("Machine", props).unwrap();
-
-        // 2. Wait 100ms
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        let node_id = db
+            .write(|tx| tx.create_node_with_valid_time("Machine", props, Some(t0)))
+            .unwrap();
 
         // 3. Update to State B
         db.write(|tx| {
             let p = PropertyMapBuilder::new().insert("state", "B").build();
-            tx.update_node(node_id, p)
+            tx.update_node_with_valid_time(node_id, p, Some(t1))
         })
         .unwrap();
 
@@ -300,5 +304,7 @@ mod tests {
 
         let results_pass = sherlock.investigate(node_id, &possible_mystery).unwrap();
         assert_eq!(results_pass.len(), 1, "Should match within 500ms");
+        assert_eq!(results_pass[0].node_id, node_id);
+        assert_eq!(results_pass[0].event_times, vec![t0, t1]);
     }
 }

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -310,6 +310,14 @@ pub(crate) fn persist_graph_index(
     graph_data.incoming_offsets = incoming_offsets;
     graph_data.incoming_neighbors = incoming_neighbors;
 
+    // Persist string interner AFTER graph conversion.
+    // Property serialization can intern previously unseen string values, so
+    // the interner snapshot must be updated before writing graph data that
+    // references those IDs.
+    manager.save_string_interner().map_err(|e| {
+        StorageError::PersistenceError(format!("Failed to save string interner: {}", e))
+    })?;
+
     // Save to disk
     let graph_path = manager.graph_path().join("adjacency.idx");
 
@@ -337,11 +345,6 @@ pub(crate) fn persist_temporal_index(
     use crate::storage::index_persistence::temporal::{
         convert_edge_version, convert_node_version, new_temporal_index_data, save_temporal_index,
     };
-
-    // First save string interner (versions depend on interned strings)
-    manager.save_string_interner().map_err(|e| {
-        StorageError::PersistenceError(format!("Failed to save string interner: {}", e))
-    })?;
 
     // Get read lock on historical storage
     let historical_guard = historical.read();
@@ -381,6 +384,14 @@ pub(crate) fn persist_temporal_index(
 
     // Drop the lock before disk I/O
     drop(historical_guard);
+
+    // Persist string interner AFTER converting temporal data.
+    // Conversion can intern previously unseen string values from version payloads.
+    // Saving the interner before conversion can leave temporal entries pointing to
+    // IDs that are missing from the persisted interner snapshot.
+    manager.save_string_interner().map_err(|e| {
+        StorageError::PersistenceError(format!("Failed to save string interner: {}", e))
+    })?;
 
     // Save to disk
     let temporal_path = manager.indexes_path().join("temporal").join("versions.idx");

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -1,7 +1,19 @@
 use super::*;
+use crate::core::GLOBAL_INTERNER;
+use crate::core::id::{NodeId, VersionId};
+use crate::core::property::PropertyMapBuilder;
+use crate::core::temporal::time;
+use crate::index::temporal::TemporalIndexes;
 use crate::storage::current::CurrentStorage;
+use crate::storage::historical::HistoricalStorage;
+use crate::storage::index_persistence::formats::PersistedPropertyValue;
+use crate::storage::index_persistence::graph::load_graph_index;
+use crate::storage::index_persistence::strings::load_string_interner;
+use crate::storage::index_persistence::temporal::load_temporal_index;
 use crate::storage::index_persistence::tracker::PersistenceTracker;
+use parking_lot::RwLock;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn test_persist_vector_indexes_with_none_tracker() {
@@ -44,4 +56,133 @@ fn test_persist_vector_indexes_with_tracker() {
     // NOTE: In the current implementation, if persistence fails early (e.g. IO),
     // the tracker reset might NOT be reached because of `?`.
     // This test mainly verifies signature compatibility.
+}
+
+#[test]
+fn test_graph_persist_keeps_interner_consistent_with_graph_string_ids() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    let current = Arc::new(CurrentStorage::new());
+
+    let unique_value = format!(
+        "graph-persist-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos()
+    );
+
+    assert!(
+        GLOBAL_INTERNER.get_id(&unique_value).is_none(),
+        "unique test string unexpectedly already interned: {}",
+        unique_value
+    );
+
+    let properties = PropertyMapBuilder::new()
+        .insert("payload", unique_value.as_str())
+        .build();
+
+    current
+        .create_node("GraphPersistConsistency", properties)
+        .expect("failed to create test node");
+
+    persist_graph_index(&current, &manager, None).expect("failed to persist graph index");
+
+    let interner_data =
+        load_string_interner(&manager.interner_path()).expect("failed to load persisted interner");
+    let graph_data = load_graph_index(&manager.graph_path().join("adjacency.idx"))
+        .expect("failed to load persisted graph index");
+
+    let persisted_string_id = graph_data
+        .nodes
+        .iter()
+        .flat_map(|node| node.properties.entries.iter())
+        .find_map(|(_, value)| match value {
+            PersistedPropertyValue::String(id) => Some(*id),
+            _ => None,
+        })
+        .expect("expected at least one persisted string property in graph index");
+
+    assert!(
+        (persisted_string_id as u64) < interner_data.string_count,
+        "graph index references string ID {} but interner contains only {} strings",
+        persisted_string_id,
+        interner_data.string_count
+    );
+
+    let resolved = interner_data
+        .strings
+        .get(persisted_string_id as usize)
+        .expect("persisted string id should index into persisted interner");
+    assert_eq!(resolved, &unique_value);
+}
+
+#[test]
+fn test_temporal_persist_keeps_interner_consistent_with_temporal_string_ids() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    let tracker = Arc::new(PersistenceTracker::new());
+    let temporal_indexes = Arc::new(TemporalIndexes::new());
+    let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+
+    let unique_value = format!(
+        "temporal-persist-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos()
+    );
+
+    assert!(
+        GLOBAL_INTERNER.get_id(&unique_value).is_none(),
+        "unique test string unexpectedly already interned: {}",
+        unique_value
+    );
+
+    let label = GLOBAL_INTERNER
+        .intern("TemporalPersistConsistency")
+        .expect("failed to intern test label");
+    let node_id = NodeId::new(1).expect("invalid node id");
+    let version_id = VersionId::new(1).expect("invalid version id");
+    let now = time::now();
+
+    let properties = PropertyMapBuilder::new()
+        .insert("payload", unique_value.as_str())
+        .build();
+
+    historical
+        .write()
+        .add_node_version(node_id, version_id, now, now, label, properties, false)
+        .expect("failed to add node version");
+
+    persist_temporal_index(&historical, &temporal_indexes, &manager, &tracker)
+        .expect("failed to persist temporal index");
+
+    let interner_data =
+        load_string_interner(&manager.interner_path()).expect("failed to load persisted interner");
+    let temporal_data = load_temporal_index(&manager.temporal_path().join("versions.idx"))
+        .expect("failed to load persisted temporal index");
+
+    let persisted_string_id = temporal_data
+        .node_versions
+        .iter()
+        .flat_map(|entry| entry.properties.entries.iter())
+        .find_map(|(_, value)| match value {
+            PersistedPropertyValue::String(id) => Some(*id),
+            _ => None,
+        })
+        .expect("expected at least one persisted string property in temporal index");
+
+    assert!(
+        (persisted_string_id as u64) < interner_data.string_count,
+        "temporal index references string ID {} but interner contains only {} strings",
+        persisted_string_id,
+        interner_data.string_count
+    );
+
+    let resolved = interner_data
+        .strings
+        .get(persisted_string_id as usize)
+        .expect("persisted string id should index into persisted interner");
+    assert_eq!(resolved, &unique_value);
 }


### PR DESCRIPTION
## Summary
- fix index persistence ordering so string interner snapshots are saved after graph/temporal conversion and before writing index files
- add regression tests that verify persisted string IDs in graph and temporal indexes are always resolvable from persisted interner data
- fix strict clippy issues in experimental::sherlock (
eedless_range_loop, unused_imports)

## Root Cause
persist_graph_index and persist_temporal_index could intern new strings while converting properties/versions, but interner snapshots were not guaranteed to include those IDs before writing index files. After restart, restore could fail with unresolved interned IDs.

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --offline
- cargo test --offline storage::index_persistence::operations::tests:: --lib
