### PR TITLE
Fix flaky temporal batch insert equivalence test

### DIFF
--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -272,8 +272,8 @@ impl EntityTimeline {
     ///
     /// # Deduplication Policy
     ///
-    /// After merging and sorting by `start` time, consecutive entries with duplicate
-    /// `metadata_idx` are handled according to the provided `policy`.
+    /// After merging and sorting by `start` time, entries with duplicate `metadata_idx`
+    /// are deduplicated globally according to the provided `policy`.
     ///
     /// | Policy | Behavior | Use Case |
     /// |--------|----------|----------|
@@ -332,15 +332,25 @@ impl EntityTimeline {
 
         match policy {
             DeduplicationPolicy::FirstOccurrence => {
-                // Deduplicate by metadata_idx to prevent memory leaks during recovery or bulk updates.
-                // Keeps the first occurrence when duplicates exist.
-                self.versions.dedup_by_key(|e| e.metadata_idx);
+                // Keep the earliest occurrence for each metadata_idx.
+                // Uses global deduplication (not just consecutive runs) to preserve idempotence
+                // even when duplicates are separated by other entries after sorting.
+                let mut seen = std::collections::HashSet::with_capacity(self.versions.len());
+                self.versions
+                    .retain(|entry| seen.insert(entry.metadata_idx));
             }
             DeduplicationPolicy::LastOccurrence => {
-                // Reverse, dedup, reverse back to keep the last occurrence (latest start time)
-                self.versions.reverse();
-                self.versions.dedup_by_key(|e| e.metadata_idx);
-                self.versions.reverse();
+                // Keep the latest occurrence for each metadata_idx by scanning in reverse.
+                // Reverse scan avoids O(n^2) lookups and preserves sorted order after reverse().
+                let mut seen = std::collections::HashSet::with_capacity(self.versions.len());
+                let mut deduped = Vec::with_capacity(self.versions.len());
+                for entry in self.versions.iter().rev() {
+                    if seen.insert(entry.metadata_idx) {
+                        deduped.push(*entry);
+                    }
+                }
+                deduped.reverse();
+                self.versions = deduped;
             }
             DeduplicationPolicy::Reject => {
                 // Already checked above, no further deduplication needed.
@@ -1801,6 +1811,135 @@ mod tests {
             1000.into(),
             "Should keep first occurrence (end=1000)"
         );
+    }
+
+    #[test]
+    fn test_batch_insert_deduplication_non_consecutive_first_occurrence() {
+        let indexes = TemporalIndexes::new();
+        let node_id = NodeId::new(1).unwrap();
+        let v1 = VersionId::new(200).unwrap();
+        let v2 = VersionId::new(201).unwrap();
+
+        indexes
+            .insert_node_version(
+                node_id,
+                v1,
+                BiTemporalInterval::new(
+                    TimeRange::new(0.into(), 1000.into()).unwrap(),
+                    TimeRange::new(0.into(), TIMESTAMP_MAX).unwrap(),
+                ),
+            )
+            .unwrap();
+        indexes
+            .insert_node_version(
+                node_id,
+                v2,
+                BiTemporalInterval::new(
+                    TimeRange::new(1000.into(), 2000.into()).unwrap(),
+                    TimeRange::new(0.into(), TIMESTAMP_MAX).unwrap(),
+                ),
+            )
+            .unwrap();
+
+        let mut timelines = indexes.index.get_mut(&EntityId::Node(node_id)).unwrap();
+        let v3 = VersionId::new(202).unwrap();
+        let new_metadata_idx = timelines
+            .add_version_metadata(VersionMetadata::new(v3))
+            .unwrap();
+
+        timelines
+            .valid
+            .insert_batch(
+                vec![
+                    TimelineEntry {
+                        // Duplicate of metadata_idx=0 but with later start, so duplicate entries
+                        // are non-consecutive after sorting by start.
+                        start: 1500.into(),
+                        end: 2500.into(),
+                        metadata_idx: 0,
+                    },
+                    TimelineEntry {
+                        start: 2000.into(),
+                        end: 3000.into(),
+                        metadata_idx: new_metadata_idx,
+                    },
+                ],
+                DeduplicationPolicy::FirstOccurrence,
+            )
+            .unwrap();
+
+        assert_eq!(
+            timelines.valid.versions.len(),
+            3,
+            "FirstOccurrence must deduplicate non-consecutive duplicate metadata indices"
+        );
+        let idx0_entries: Vec<_> = timelines
+            .valid
+            .versions
+            .iter()
+            .filter(|e| e.metadata_idx == 0)
+            .collect();
+        assert_eq!(idx0_entries.len(), 1);
+        assert_eq!(idx0_entries[0].start, 0.into());
+        assert_eq!(idx0_entries[0].end, 1000.into());
+    }
+
+    #[test]
+    fn test_batch_insert_deduplication_non_consecutive_last_occurrence() {
+        let indexes = TemporalIndexes::new();
+        let node_id = NodeId::new(2).unwrap();
+        let v1 = VersionId::new(300).unwrap();
+        let v2 = VersionId::new(301).unwrap();
+
+        indexes
+            .insert_node_version(
+                node_id,
+                v1,
+                BiTemporalInterval::new(
+                    TimeRange::new(0.into(), 1000.into()).unwrap(),
+                    TimeRange::new(0.into(), TIMESTAMP_MAX).unwrap(),
+                ),
+            )
+            .unwrap();
+        indexes
+            .insert_node_version(
+                node_id,
+                v2,
+                BiTemporalInterval::new(
+                    TimeRange::new(1000.into(), 2000.into()).unwrap(),
+                    TimeRange::new(0.into(), TIMESTAMP_MAX).unwrap(),
+                ),
+            )
+            .unwrap();
+
+        let mut timelines = indexes.index.get_mut(&EntityId::Node(node_id)).unwrap();
+        timelines
+            .valid
+            .insert_batch(
+                vec![TimelineEntry {
+                    // Duplicate of metadata_idx=0 appears after metadata_idx=1 in sorted order.
+                    start: 1500.into(),
+                    end: 2500.into(),
+                    metadata_idx: 0,
+                }],
+                DeduplicationPolicy::LastOccurrence,
+            )
+            .unwrap();
+
+        assert_eq!(
+            timelines.valid.versions.len(),
+            2,
+            "LastOccurrence must deduplicate non-consecutive duplicate metadata indices"
+        );
+        let idx0_entries: Vec<_> = timelines
+            .valid
+            .versions
+            .iter()
+            .filter(|e| e.metadata_idx == 0)
+            .collect();
+        assert_eq!(idx0_entries.len(), 1);
+        assert_eq!(idx0_entries[0].start, 1500.into());
+        assert_eq!(idx0_entries[0].end, 2500.into());
     }
 
     #[test]

--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -183,7 +183,7 @@ struct EntityTimeline {
 }
 
 impl EntityTimeline {
-    /// Insert a new version into the timeline, maintaining sorted order by start time.
+    /// Insert a new version into the timeline, maintaining sorted order.
     ///
     /// # Arguments
     ///
@@ -197,15 +197,23 @@ impl EntityTimeline {
             metadata_idx,
         };
 
-        // Optimization: if this version starts after the last one (common case), just push it.
-        if self.versions.last().is_none_or(|last| last.start <= start) {
+        // Optimization: if this version belongs at the end (common case), just push it.
+        // We sort by (start, metadata_idx) to make ordering deterministic for equal starts.
+        let new_key = (start, metadata_idx);
+        if self
+            .versions
+            .last()
+            .is_none_or(|last| (last.start, last.metadata_idx) <= new_key)
+        {
             let position = self.versions.len();
             self.versions.push(entry);
             self.metadata_to_position.insert(metadata_idx, position);
             return;
         }
 
-        let idx = self.versions.partition_point(|e| e.start < start);
+        let idx = self
+            .versions
+            .partition_point(|e| (e.start, e.metadata_idx) < new_key);
         self.versions.insert(idx, entry);
 
         // Rebuild position map after insertion (positions shifted)
@@ -318,8 +326,9 @@ impl EntityTimeline {
         // Critical for bulk recovery/migration (10K+ versions per entity).
         self.versions.reserve(entries.len());
         self.versions.append(&mut entries);
-        // Sort by start time. Timsort exploits existing order in the timeline.
-        self.versions.sort_by_key(|e| e.start);
+        // Sort by start time with metadata_idx tie-breaker for deterministic ordering.
+        // Timsort exploits existing order in the timeline.
+        self.versions.sort_by_key(|e| (e.start, e.metadata_idx));
 
         match policy {
             DeduplicationPolicy::FirstOccurrence => {
@@ -2042,6 +2051,77 @@ mod tests {
         // Both should have start time 1000
         assert_eq!(timelines.valid.versions[0].start, 1000.into());
         assert_eq!(timelines.valid.versions[1].start, 1000.into());
+    }
+
+    #[test]
+    fn test_batch_insert_equivalence_with_same_start_retroactive_pattern() {
+        let node_id = NodeId::new(1).unwrap();
+        let versions = vec![
+            (
+                VersionId::new(1).unwrap(),
+                BiTemporalInterval::new(
+                    TimeRange::new(10.into(), 15.into()).unwrap(),
+                    TimeRange::from(0.into()),
+                ),
+            ),
+            (
+                VersionId::new(2).unwrap(),
+                BiTemporalInterval::new(
+                    TimeRange::new(20.into(), 25.into()).unwrap(),
+                    TimeRange::from(0.into()),
+                ),
+            ),
+            (
+                VersionId::new(3).unwrap(),
+                BiTemporalInterval::new(
+                    TimeRange::new(10.into(), 12.into()).unwrap(),
+                    TimeRange::from(0.into()),
+                ),
+            ),
+        ];
+
+        let indexes_individual = TemporalIndexes::new();
+        for (version_id, temporal) in &versions {
+            indexes_individual
+                .insert_node_version(node_id, *version_id, *temporal)
+                .unwrap();
+        }
+
+        let indexes_batch = TemporalIndexes::new();
+        indexes_batch
+            .insert_node_versions_batch(node_id, versions)
+            .unwrap();
+
+        let entity_id = EntityId::Node(node_id);
+        let timelines_individual = indexes_individual.index.get(&entity_id).unwrap();
+        let timelines_batch = indexes_batch.index.get(&entity_id).unwrap();
+
+        let individual_entries: Vec<_> = timelines_individual
+            .valid
+            .versions
+            .iter()
+            .map(|entry| {
+                (
+                    entry.start,
+                    entry.end,
+                    timelines_individual.resolve_version_id(entry.metadata_idx),
+                )
+            })
+            .collect();
+        let batch_entries: Vec<_> = timelines_batch
+            .valid
+            .versions
+            .iter()
+            .map(|entry| {
+                (
+                    entry.start,
+                    entry.end,
+                    timelines_batch.resolve_version_id(entry.metadata_idx),
+                )
+            })
+            .collect();
+
+        assert_eq!(individual_entries, batch_entries);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make temporal timeline ordering deterministic using (start, metadata_idx) in both single and batch insert paths
- add a deterministic regression test for equal-start retroactive inserts to prevent prop_batch_insert_equivalence ordering flake
- apply minimal sherlock clippy cleanup required by -D warnings (unused import removal + iterator loop rewrite)

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all
- cargo test
- cargo test --lib index::temporal::tests::proptests::prop_batch_insert_equivalence -- --nocapture
- cargo test --lib test_batch_insert_equivalence_with_same_start_retroactive_pattern -- --nocapture