### PR TITLE
docs(wal): correct ring buffer wraparound limitation and add panic safety tests

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -60,7 +60,8 @@
 
 **Recommendations:**
 1.  None. This module is well-tested for its complexity level.
-# Elenchus Journal
+
+# Elenchus Journal - Recent Audits
 
 **[TimeRange Validation Gap]**
 **Module:** `aletheiadb::core::temporal`
@@ -118,7 +119,7 @@
 **Module:** `src/core/version.rs`
 **Severity:** 🔴 Critical
 **Finding:** `PropertyDelta::from_diff` silently ignored vector updates if `VectorDelta::from_diff` returned `None` (e.g., due to dimension mismatch). This resulted in data loss where the new vector value was discarded and the old value preserved.
-**Evidence:** Created reproduction test `test_property_delta_silently_ignores_dimension_change` which confirmed that changing a vector's dimension resulted in no change being recorded in the delta.
+**Evidence:** Created reproduction test `test_property_delta_silently_ignores_dimension_change` which confirmed that changing a vector's dimension resulted in no change and no error.
 **Resolution:** Modified `PropertyDelta::from_diff` to strictly fall back to a full value replacement in `delta.changed` when `VectorDelta` cannot be computed (e.g. dimension mismatch), while still respecting epsilon-equality for identical vectors. Added regression test to `sentry_tests`.
 
 **[HNSW Compilation Repair]**
@@ -134,3 +135,17 @@
 **Finding:** Critical recovery methods `IdGenerator::reset_to` and `ensure_at_least` were `pub(crate)` and completely untested. These are the foundation of crash recovery.
 **Evidence:** Code audit revealed these methods had no unit tests in `mod tests` or `mod proptests`.
 **Recommendation:** Added `mod sentry_tests` with concurrency tests for `ensure_at_least` and verification for `reset_to`.
+
+**[Ring Buffer Wraparound Fear]**
+**Module:** `src/storage/wal/ring_buffer.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** The documentation warned of a "Theoretical limitation" where `u64` overflow would break the buffer after ~1.2 million years. Audit revealed the code correctly uses `wrapping_sub` for modular arithmetic, handling overflow safely. The warning was false.
+**Evidence:** `test_wraparound_logic` verifies correct behavior across `u64` boundaries.
+**Resolution:** Updated documentation to reflect reality and removed the false warning.
+
+**[Ring Buffer Config Panic Gaps]**
+**Module:** `src/storage/wal/ring_buffer.rs`
+**Severity:** 🟡 Suspect
+**Finding:** `WalRingBuffer::with_config` and `new` panicked on invalid input (capacity 0, spins 0) but these panics were not covered by tests, leaving the API contract unverified against regression.
+**Evidence:** Added 3 `#[should_panic]` tests (`test_new_zero_capacity_panics`, `test_config_initial_spins_zero_panics`, `test_config_max_less_than_initial_panics`).
+**Resolution:** Tests now enforce the panic contract.

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -37,20 +37,22 @@
 //! wrap around after 2^64 operations using `wrapping_add`. At 500K operations
 //! per second, overflow would occur after approximately 1.2 million years.
 //!
-//! **Theoretical limitation**: The sequence-based slot availability logic uses
-//! direct integer comparison (`==`, `<`, `>`). After position counter wraparound,
-//! these comparisons would produce incorrect results, causing the buffer to
-//! become unusable. This is a documented theoretical limitation rather than a
-//! practical concern.
+//! The implementation uses modular arithmetic (`wrapping_sub`) for sequence comparisons,
+//! ensuring correctness even after `u64` overflow, provided the buffer capacity is
+//! significantly smaller than `u64::MAX`.
 //!
 //! **Sequence number lifecycle**:
 //! 1. Initially: `sequence[i] = i` for each slot
 //! 2. After write: `sequence = pos + 1` (signals data ready)
 //! 3. After read: `sequence = pos + capacity` (signals slot available)
 //!
-//! The comparison `current_seq < expected_seq` at line 526 assumes monotonic
-//! growth, which breaks after u64 wraparound. For systems requiring true
-//! infinite operation, a restart-based reset mechanism would be needed.
+//! # Panic Safety
+//!
+//! **This data structure is not panic-safe.** If a writer thread panics while holding
+//! a slot claim (after incrementing `write_pos` but before updating the slot's sequence),
+//! the buffer will permanently stall. The consumer will wait indefinitely for the
+//! sequence to be updated. It is the caller's responsibility to ensure that `try_append`
+//! does not panic or that the process aborts on panic.
 
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1366,5 +1368,32 @@ mod tests {
         let final_drained = buf.drain();
         assert_eq!(final_drained.len(), 1);
         assert_eq!(final_drained[0].data, vec![100]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Ring buffer capacity must be > 0")]
+    fn test_new_zero_capacity_panics() {
+        WalRingBuffer::new(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "initial_spins must be > 0")]
+    fn test_config_initial_spins_zero_panics() {
+        let config = BackpressureConfig {
+            initial_spins: 0,
+            ..BackpressureConfig::default()
+        };
+        WalRingBuffer::with_config(1024, config);
+    }
+
+    #[test]
+    #[should_panic(expected = "max_spins must be >= initial_spins")]
+    fn test_config_max_less_than_initial_panics() {
+        let config = BackpressureConfig {
+            initial_spins: 100,
+            max_spins: 10,
+            ..BackpressureConfig::default()
+        };
+        WalRingBuffer::with_config(1024, config);
     }
 }


### PR DESCRIPTION
This PR addresses findings from the Elenchus test audit of `src/storage/wal/ring_buffer.rs`.

1.  **Documentation Correction**: The documentation previously claimed a "Theoretical limitation" where the buffer would fail after `u64` overflow (~1.2 million years). Code analysis confirmed that `wrapping_sub` is used correctly for modular arithmetic, so this warning was false and has been removed.
2.  **Panic Safety Warning**: Explicitly documented that the lock-free ring buffer is not panic-safe; if a writer panics while holding a slot claim, the buffer will stall.
3.  **Regression Tests**: Added `#[should_panic]` tests to `mod tests` to ensure that `WalRingBuffer::with_config` and `new` strictly enforce validation rules (e.g., preventing `initial_spins: 0` which would cause infinite loops in backpressure logic).
4.  **Audit Record**: Updated `.jules/elenchus.md`.

---
*PR created automatically by Jules for task [7630643934643955711](https://jules.google.com/task/7630643934643955711) started by @madmax983*