### PR TITLE
🛡️ Sentry: Ensure get_all_strings returns consistent snapshot

### DIFF
--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -350,7 +350,11 @@ impl StringInterner {
     /// Returns a vector of strings sorted by their InternedString IDs.
     /// This is useful for persistence where we need to save and restore
     /// the interner state.
-    pub fn get_all_strings(&self) -> Vec<String> {
+    ///
+    /// # Errors
+    /// Returns `Error::Storage(StorageError::InconsistentState)` if a consistent snapshot
+    /// cannot be obtained after 1000 retries due to high concurrency or state corruption.
+    pub fn get_all_strings(&self) -> crate::utils::error::Result<Vec<String>> {
         // Retry loop to ensure snapshot consistency under concurrent modifications.
         // DashMap iterators are not guaranteed to be consistent snapshots, so we
         // might miss items that were inserted during iteration or just before.
@@ -377,16 +381,18 @@ impl StringInterner {
             // strictly before string_to_id (which drives `count`), any item counted in
             // `len()` MUST exist in `id_to_string`. Missing it means we need to retry.
             if found_count == count {
-                return strings;
+                return Ok(strings);
             }
 
             // Liveness safety: prevent infinite loop if interner state is inconsistent
             // (e.g. if len() > id_to_string.len() permanently due to a bug).
             attempts += 1;
             if attempts > 1000 {
-                // Return best effort (may contain holes/empty strings)
-                // This is better than hanging indefinitely.
-                return strings;
+                return Err(crate::utils::error::Error::Storage(
+                    crate::utils::error::StorageError::InconsistentState {
+                        reason: "Failed to obtain a consistent snapshot of the string interner after 1000 attempts due to high concurrency".to_string(),
+                    }
+                ));
             }
 
             // Backoff slightly to let concurrent operations settle
@@ -1221,7 +1227,7 @@ mod mutant_kill_tests {
         assert_eq!(second.as_u32(), 1);
         assert_eq!(third.as_u32(), 2);
 
-        let all = interner.get_all_strings();
+        let all = interner.get_all_strings().unwrap();
         assert_eq!(all.len(), interner.len());
         assert_eq!(
             all,
@@ -1299,14 +1305,18 @@ mod sentry_consistency_tests {
             thread::spawn(move || {
                 barrier.wait();
                 while running.load(std::sync::atomic::Ordering::Relaxed) {
-                    let all_strings = interner.get_all_strings();
-                    for (id, s) in all_strings.iter().enumerate() {
-                        assert!(
-                            !s.is_empty(),
-                            "Found empty string (hole) at ID {}! len={}",
-                            id,
-                            all_strings.len()
-                        );
+                    if let Ok(all_strings) = interner.get_all_strings() {
+                        for (id, s) in all_strings.iter().enumerate() {
+                            assert!(
+                                !s.is_empty(),
+                                "Found empty string (hole) at ID {}! len={}",
+                                id,
+                                all_strings.len()
+                            );
+                        }
+                    } else {
+                        // It is acceptable to fail to get a consistent snapshot under high load
+                        // But if we do get one (Ok), it MUST be consistent
                     }
                     // Yield to let writers proceed
                     thread::yield_now();

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -1271,7 +1271,6 @@ mod sentry_consistency_tests {
     use super::*;
     use std::sync::{Arc, Barrier};
     use std::thread;
-    use std::time::Duration;
 
     #[test]
     fn test_get_all_strings_consistency_under_load() {

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -1333,4 +1333,35 @@ mod sentry_consistency_tests {
         running.store(false, std::sync::atomic::Ordering::Relaxed);
         reader_handle.join().unwrap();
     }
+
+    #[test]
+    fn test_get_all_strings_consistency_failure_coverage() {
+        // This test artificially creates an inconsistent state to verify the error path
+        // of get_all_strings (retry limit exceeded).
+        let interner = StringInterner::new();
+
+        // 1. Intern a string normally to set up initial state
+        interner.intern("valid").unwrap();
+
+        // 2. Artificially insert into string_to_id WITHOUT adding to id_to_string.
+        // This increases len() (which uses string_to_id.len()) but creates a "hole"
+        // in id_to_string lookup.
+        // get_all_strings will see count=2, but only find 1 item in id_to_string.
+        // It will retry and eventually fail.
+        interner
+            .string_to_id
+            .insert(Arc::from("corrupt"), InternedString(1));
+
+        // 3. Verify get_all_strings fails
+        let result = interner.get_all_strings();
+        assert!(result.is_err());
+        match result {
+            Err(crate::utils::error::Error::Storage(
+                crate::utils::error::StorageError::InconsistentState { reason },
+            )) => {
+                assert!(reason.contains("Failed to obtain a consistent snapshot"));
+            }
+            _ => panic!("Expected InconsistentState error"),
+        }
+    }
 }

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -351,18 +351,47 @@ impl StringInterner {
     /// This is useful for persistence where we need to save and restore
     /// the interner state.
     pub fn get_all_strings(&self) -> Vec<String> {
-        let count = self.len();
-        let mut strings = vec![String::new(); count];
+        // Retry loop to ensure snapshot consistency under concurrent modifications.
+        // DashMap iterators are not guaranteed to be consistent snapshots, so we
+        // might miss items that were inserted during iteration or just before.
+        let mut attempts = 0;
+        loop {
+            // Get expected count from string_to_id (which is populated LAST during intern)
+            let count = self.len();
+            let mut strings = vec![String::new(); count];
+            let mut found_count = 0;
 
-        // Collect all (id, string) pairs
-        for entry in self.id_to_string.iter() {
-            let id = entry.key().as_u32() as usize;
-            if id < count {
-                strings[id] = entry.value().to_string();
+            // Iterate id_to_string directly to fill the vector.
+            // This avoids allocating intermediate tuples.
+            for entry in self.id_to_string.iter() {
+                let id = entry.key().as_u32() as usize;
+                if id < count {
+                    strings[id] = entry.value().to_string();
+                    found_count += 1;
+                }
             }
-        }
 
-        strings
+            // Consistency Check:
+            // We must find exactly `count` items. If we find fewer, it means our iteration
+            // missed some concurrent inserts (holes). Since id_to_string is populated
+            // strictly before string_to_id (which drives `count`), any item counted in
+            // `len()` MUST exist in `id_to_string`. Missing it means we need to retry.
+            if found_count == count {
+                return strings;
+            }
+
+            // Liveness safety: prevent infinite loop if interner state is inconsistent
+            // (e.g. if len() > id_to_string.len() permanently due to a bug).
+            attempts += 1;
+            if attempts > 1000 {
+                // Return best effort (may contain holes/empty strings)
+                // This is better than hanging indefinitely.
+                return strings;
+            }
+
+            // Backoff slightly to let concurrent operations settle
+            std::thread::yield_now();
+        }
     }
 
     /// Pre-intern common strings at startup to avoid initial allocation overhead.
@@ -1234,5 +1263,65 @@ mod mutant_kill_tests {
         }
 
         writer.join().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod sentry_consistency_tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_get_all_strings_consistency_under_load() {
+        let interner = Arc::new(StringInterner::new());
+        let barrier = Arc::new(Barrier::new(11)); // 10 writers + 1 reader
+        let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+
+        // Spawn 10 writers
+        let mut handles = vec![];
+        for i in 0..10 {
+            let interner = Arc::clone(&interner);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                for j in 0..1000 {
+                    interner.intern(format!("w{}_s{}", i, j)).unwrap();
+                }
+            }));
+        }
+
+        // Reader thread
+        let reader_handle = {
+            let interner = Arc::clone(&interner);
+            let barrier = Arc::clone(&barrier);
+            let running = Arc::clone(&running);
+            thread::spawn(move || {
+                barrier.wait();
+                while running.load(std::sync::atomic::Ordering::Relaxed) {
+                    let all_strings = interner.get_all_strings();
+                    for (id, s) in all_strings.iter().enumerate() {
+                        assert!(
+                            !s.is_empty(),
+                            "Found empty string (hole) at ID {}! len={}",
+                            id,
+                            all_strings.len()
+                        );
+                    }
+                    // Yield to let writers proceed
+                    thread::yield_now();
+                }
+            })
+        };
+
+        // Wait for writers
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Stop reader
+        running.store(false, std::sync::atomic::Ordering::Relaxed);
+        reader_handle.join().unwrap();
     }
 }

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -16,7 +16,9 @@ use super::{INTERNER_MAGIC, MANIFEST_VERSION};
 ///
 /// Uses write-temp-then-rename to prevent corruption on crash.
 pub fn save_string_interner(path: &Path) -> Result<()> {
-    let strings = GLOBAL_INTERNER.get_all_strings();
+    let strings = GLOBAL_INTERNER.get_all_strings().map_err(|e| {
+        IndexPersistenceError::Serialization(format!("Failed to get interned strings: {}", e))
+    })?;
 
     let data = StringInternerData {
         magic: INTERNER_MAGIC,


### PR DESCRIPTION
This PR addresses a data corruption risk in `StringInterner::get_all_strings`. 

 Previously, this method relied on `len()` to pre-allocate a vector and then iterated over `id_to_string` to fill it. Under concurrent insertions, `DashMap` does not guarantee that iteration sees items counted by `len()` (especially if `len()` sees items in `string_to_id` which are inserted *after* `id_to_string`). This could result in "holes" (empty strings) in the returned vector for valid IDs, which would lead to data corruption if persisted and reloaded.

 **Changes:**
 *   Refactored `get_all_strings` to use a consistency retry loop.
 *   The loop collects all entries from `id_to_string` and verifies that the number of unique items found matches `self.len()`.
 *   If a mismatch occurs (due to concurrent modification), it retries with a `yield_now`.
 *   Added a safety limit (1000 retries) to prevent infinite loops if the interner state becomes permanently inconsistent.
 *   Added `sentry_consistency_tests` module to reproduce the issue and verify the fix under high concurrency.

 **Verification:**
 *   Added `test_get_all_strings_consistency_under_load` which spawns 10 writer threads and a concurrent reader thread.
 *   Verified that the test failed before the fix (panicking on empty string/hole) and passes after the fix.


---
*PR created automatically by Jules for task [10715530123196229913](https://jules.google.com/task/10715530123196229913) started by @madmax983*