### PR TITLE
🔒 Warden: Prevent FFI panic abort in HNSW custom metrics

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -14,3 +14,7 @@
 **2026-02-15 - LSN Allocator Overflow**
 **Threat:** The atomic LSN allocator used `fetch_add` without overflow checking. While requiring ~5000 years at 100M/sec to overflow `u64`, a large batch allocation (e.g. `u64::MAX`) or eventual wraparound would cause duplicate LSNs, breaking WAL ordering and data consistency.
 **Defense:** Replaced `fetch_add` with `fetch_update` (CAS loop) in `src/storage/wal/lsn_allocator.rs` to atomically check for overflow *before* modifying the state. Added `tests/warden_security_tests.rs` to verify panic behavior on overflow attempts.
+
+**2026-02-15 - FFI Panic Abort Prevention**
+**Threat:** User-provided custom distance metrics can panic. Since these are called via FFI from C++ (usearch), unwinding across the FFI boundary causes a hard process abort (SIGABRT), acting as a DoS vector.
+**Defense:** Wrapped the metric callback in `std::panic::catch_unwind`. If a panic occurs, it is caught, logged to stderr, and `f32::MAX` is returned to signal infinite distance, preventing the crash.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -449,10 +449,24 @@ where
 
         // SAFETY: usearch guarantees pointers are valid for `dims` elements.
         // We verified they are not null above.
+        //
+        // We wrap the user callback in catch_unwind to prevent panics from unwinding
+        // across the FFI boundary into C++, which is Undefined Behavior and causes aborts.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
+            let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
+            distance_fn(slice_a, slice_b)
+        }));
 
-        let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
-        let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
-        distance_fn(slice_a, slice_b)
+        match result {
+            Ok(distance) => distance,
+            Err(_) => {
+                // Log the error to stderr since we can't propagate it through FFI.
+                // We return f32::MAX to indicate "infinite distance" (no match).
+                eprintln!("CRITICAL: Panic in custom metric function caught by HNSW wrapper. Returning f32::MAX to prevent UB.");
+                f32::MAX
+            }
+        }
     })
 }
 
@@ -1914,6 +1928,21 @@ mod sentry_tests {
             "Error: No available threads to lock for search"
         ));
         assert!(!is_retryable_usearch_error("Other error"));
+    }
+
+    #[test]
+    fn test_metric_wrapper_panic_handling() {
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            panic!("Test panic in metric");
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let v1 = [1.0f32, 0.0, 0.0, 0.0];
+        let v2 = [0.0f32, 1.0, 0.0, 0.0];
+
+        // Should return f32::MAX instead of unwinding
+        let result = wrapper(v1.as_ptr(), v2.as_ptr());
+        assert_eq!(result, f32::MAX);
     }
 }
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -452,13 +452,13 @@ where
         //
         // We wrap the user callback in catch_unwind to prevent panics from unwinding
         // across the FFI boundary into C++, which is Undefined Behavior and causes aborts.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let safe_closure = std::panic::AssertUnwindSafe(|| {
             let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
             let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
             distance_fn(slice_a, slice_b)
-        }));
+        });
 
-        match result {
+        match std::panic::catch_unwind(safe_closure) {
             Ok(distance) => distance,
             Err(_) => {
                 // Log the error to stderr since we can't propagate it through FFI.
@@ -2026,6 +2026,40 @@ mod tests {
     }
 
     #[test]
+    fn test_metric_wrapper_panic_handling() {
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            panic!("Test panic in metric");
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let v1 = [1.0f32, 0.0, 0.0, 0.0];
+        let v2 = [0.0f32, 1.0, 0.0, 0.0];
+
+        // Should return f32::MAX instead of unwinding
+        let result = wrapper(v1.as_ptr(), v2.as_ptr());
+        assert_eq!(result, f32::MAX);
+    }
+
+    #[test]
+    fn test_metric_wrapper_success() {
+        // Simple Euclidean distance
+        let distance_fn = Arc::new(|a: &[f32], b: &[f32]| -> f32 {
+            a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let v1 = [1.0f32, 2.0, 3.0, 4.0];
+        let v2 = [1.0f32, 2.0, 3.0, 4.0]; // Identical, dist should be 0.0
+
+        let result = wrapper(v1.as_ptr(), v2.as_ptr());
+        assert_eq!(result, 0.0);
+
+        let v3 = [2.0f32, 2.0, 3.0, 4.0]; // diff is 1.0 in first dim, squared is 1.0
+        let result = wrapper(v1.as_ptr(), v3.as_ptr());
+        assert_eq!(result, 1.0);
+    }
+
+    #[test]
     fn test_hnsw_config_new_fields() {
         let config = HnswConfig::new(384, DistanceMetric::Cosine)
             .with_quantization(Quantization::F16)
@@ -2937,39 +2971,5 @@ mod coverage_tests {
 
         drop(guard);
         assert!(!IN_FILTER_CALLBACK.with(|flag| flag.get()));
-    }
-
-    #[test]
-    fn test_metric_wrapper_panic_handling() {
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
-            panic!("Test panic in metric");
-        });
-        let wrapper = create_metric_wrapper(4, distance_fn);
-
-        let v1 = [1.0f32, 0.0, 0.0, 0.0];
-        let v2 = [0.0f32, 1.0, 0.0, 0.0];
-
-        // Should return f32::MAX instead of unwinding
-        let result = wrapper(v1.as_ptr(), v2.as_ptr());
-        assert_eq!(result, f32::MAX);
-    }
-
-    #[test]
-    fn test_metric_wrapper_success() {
-        // Simple Euclidean distance
-        let distance_fn = Arc::new(|a: &[f32], b: &[f32]| -> f32 {
-            a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
-        });
-        let wrapper = create_metric_wrapper(4, distance_fn);
-
-        let v1 = [1.0f32, 2.0, 3.0, 4.0];
-        let v2 = [1.0f32, 2.0, 3.0, 4.0]; // Identical, dist should be 0.0
-
-        let result = wrapper(v1.as_ptr(), v2.as_ptr());
-        assert_eq!(result, 0.0);
-
-        let v3 = [2.0f32, 2.0, 3.0, 4.0]; // diff is 1.0 in first dim, squared is 1.0
-        let result = wrapper(v1.as_ptr(), v3.as_ptr());
-        assert_eq!(result, 1.0);
     }
 }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -420,6 +420,58 @@ fn is_retryable_usearch_error(error_msg: &str) -> bool {
     error_msg.contains("No available threads to lock")
 }
 
+// Helper logic to execute the metric function safely.
+// Extracted to a helper function to improve test coverage attribution and reduce code bloat.
+fn execute_metric_safe<F>(
+    a: *const f32,
+    b: *const f32,
+    dims: usize,
+    distance_fn: &F,
+) -> f32
+where
+    F: Fn(&[f32], &[f32]) -> f32 + ?Sized,
+{
+    // Check for null pointers to prevent UB
+    if a.is_null() || b.is_null() {
+        // This should never happen with a correct usearch implementation.
+        // If it does, we panic to prevent UB from dereferencing null.
+        panic!("usearch passed null pointer to metric function");
+    }
+
+    // Check for alignment to prevent UB
+    // Use bitwise check for power-of-2 alignment (f32 align is 4)
+    let align_mask = std::mem::align_of::<f32>() - 1;
+    if (a as usize) & align_mask != 0 || (b as usize) & align_mask != 0 {
+        panic!(
+            "usearch passed unaligned pointer to metric function (expected alignment {})",
+            std::mem::align_of::<f32>()
+        );
+    }
+
+    // SAFETY: usearch guarantees pointers are valid for `dims` elements.
+    // We verified they are not null above.
+    //
+    // We wrap the user callback in catch_unwind to prevent panics from unwinding
+    // across the FFI boundary into C++, which is Undefined Behavior and causes aborts.
+    let safe_closure = std::panic::AssertUnwindSafe(|| {
+        let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
+        let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
+        distance_fn(slice_a, slice_b)
+    });
+
+    match std::panic::catch_unwind(safe_closure) {
+        Ok(distance) => distance,
+        Err(_) => {
+            // Log the error to stderr since we can't propagate it through FFI.
+            // We return f32::MAX to indicate "infinite distance" (no match).
+            eprintln!(
+                "CRITICAL: Panic in custom metric function caught by HNSW wrapper. Returning f32::MAX to prevent UB."
+            );
+            f32::MAX
+        }
+    }
+}
+
 // Helper to create the metric wrapper - extracted for testing
 fn create_metric_wrapper<F>(
     dims: usize,
@@ -429,46 +481,7 @@ where
     F: Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static + ?Sized,
 {
     Box::new(move |a: *const f32, b: *const f32| {
-        // Check for null pointers to prevent UB
-        if a.is_null() || b.is_null() {
-            // This should never happen with a correct usearch implementation.
-            // If it does, we panic to prevent UB from dereferencing null.
-            // We cannot return an error here because the signature is fixed by usearch trait.
-            panic!("usearch passed null pointer to metric function");
-        }
-
-        // Check for alignment to prevent UB
-        // Use bitwise check for power-of-2 alignment (f32 align is 4)
-        let align_mask = std::mem::align_of::<f32>() - 1;
-        if (a as usize) & align_mask != 0 || (b as usize) & align_mask != 0 {
-            panic!(
-                "usearch passed unaligned pointer to metric function (expected alignment {})",
-                std::mem::align_of::<f32>()
-            );
-        }
-
-        // SAFETY: usearch guarantees pointers are valid for `dims` elements.
-        // We verified they are not null above.
-        //
-        // We wrap the user callback in catch_unwind to prevent panics from unwinding
-        // across the FFI boundary into C++, which is Undefined Behavior and causes aborts.
-        let safe_closure = std::panic::AssertUnwindSafe(|| {
-            let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
-            let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
-            distance_fn(slice_a, slice_b)
-        });
-
-        match std::panic::catch_unwind(safe_closure) {
-            Ok(distance) => distance,
-            Err(_) => {
-                // Log the error to stderr since we can't propagate it through FFI.
-                // We return f32::MAX to indicate "infinite distance" (no match).
-                eprintln!(
-                    "CRITICAL: Panic in custom metric function caught by HNSW wrapper. Returning f32::MAX to prevent UB."
-                );
-                f32::MAX
-            }
-        }
+        execute_metric_safe(a, b, dims, &*distance_fn)
     })
 }
 
@@ -2027,9 +2040,11 @@ mod tests {
 
     #[test]
     fn test_metric_wrapper_panic_handling() {
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
-            panic!("Test panic in metric");
-        });
+        // Use unsized trait object to match production usage and ensure correct coverage attribution
+        let distance_fn: Arc<dyn Fn(&[f32], &[f32]) -> f32 + Send + Sync> =
+            Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+                panic!("Test panic in metric");
+            });
         let wrapper = create_metric_wrapper(4, distance_fn);
 
         let v1 = [1.0f32, 0.0, 0.0, 0.0];
@@ -2043,9 +2058,11 @@ mod tests {
     #[test]
     fn test_metric_wrapper_success() {
         // Simple Euclidean distance
-        let distance_fn = Arc::new(|a: &[f32], b: &[f32]| -> f32 {
-            a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
-        });
+        // Use unsized trait object to match production usage and ensure correct coverage attribution
+        let distance_fn: Arc<dyn Fn(&[f32], &[f32]) -> f32 + Send + Sync> =
+            Arc::new(|a: &[f32], b: &[f32]| -> f32 {
+                a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
+            });
         let wrapper = create_metric_wrapper(4, distance_fn);
 
         let v1 = [1.0f32, 2.0, 3.0, 4.0];

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1929,21 +1929,6 @@ mod sentry_tests {
         ));
         assert!(!is_retryable_usearch_error("Other error"));
     }
-
-    #[test]
-    fn test_metric_wrapper_panic_handling() {
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
-            panic!("Test panic in metric");
-        });
-        let wrapper = create_metric_wrapper(4, distance_fn);
-
-        let v1 = [1.0f32, 0.0, 0.0, 0.0];
-        let v2 = [0.0f32, 1.0, 0.0, 0.0];
-
-        // Should return f32::MAX instead of unwinding
-        let result = wrapper(v1.as_ptr(), v2.as_ptr());
-        assert_eq!(result, f32::MAX);
-    }
 }
 
 #[cfg(test)]
@@ -2950,5 +2935,39 @@ mod coverage_tests {
 
         drop(guard);
         assert!(!IN_FILTER_CALLBACK.with(|flag| flag.get()));
+    }
+
+    #[test]
+    fn test_metric_wrapper_panic_handling() {
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            panic!("Test panic in metric");
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let v1 = [1.0f32, 0.0, 0.0, 0.0];
+        let v2 = [0.0f32, 1.0, 0.0, 0.0];
+
+        // Should return f32::MAX instead of unwinding
+        let result = wrapper(v1.as_ptr(), v2.as_ptr());
+        assert_eq!(result, f32::MAX);
+    }
+
+    #[test]
+    fn test_metric_wrapper_success() {
+        // Simple Euclidean distance
+        let distance_fn = Arc::new(|a: &[f32], b: &[f32]| -> f32 {
+            a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let v1 = [1.0f32, 2.0, 3.0, 4.0];
+        let v2 = [1.0f32, 2.0, 3.0, 4.0]; // Identical, dist should be 0.0
+
+        let result = wrapper(v1.as_ptr(), v2.as_ptr());
+        assert_eq!(result, 0.0);
+
+        let v3 = [2.0f32, 2.0, 3.0, 4.0]; // diff is 1.0 in first dim, squared is 1.0
+        let result = wrapper(v1.as_ptr(), v3.as_ptr());
+        assert_eq!(result, 1.0);
     }
 }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -422,15 +422,13 @@ fn is_retryable_usearch_error(error_msg: &str) -> bool {
 
 // Helper logic to execute the metric function safely.
 // Extracted to a helper function to improve test coverage attribution and reduce code bloat.
-fn execute_metric_safe<F>(
+// Takes a trait object to avoid monomorphization issues with coverage tools.
+fn execute_metric_safe(
     a: *const f32,
     b: *const f32,
     dims: usize,
-    distance_fn: &F,
-) -> f32
-where
-    F: Fn(&[f32], &[f32]) -> f32 + ?Sized,
-{
+    distance_fn: &dyn Fn(&[f32], &[f32]) -> f32,
+) -> f32 {
     // Check for null pointers to prevent UB
     if a.is_null() || b.is_null() {
         // This should never happen with a correct usearch implementation.
@@ -473,13 +471,10 @@ where
 }
 
 // Helper to create the metric wrapper - extracted for testing
-fn create_metric_wrapper<F>(
+fn create_metric_wrapper(
     dims: usize,
-    distance_fn: Arc<F>,
-) -> Box<dyn Fn(*const f32, *const f32) -> f32 + Send + Sync>
-where
-    F: Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static + ?Sized,
-{
+    distance_fn: Arc<dyn Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static>,
+) -> Box<dyn Fn(*const f32, *const f32) -> f32 + Send + Sync> {
     Box::new(move |a: *const f32, b: *const f32| {
         execute_metric_safe(a, b, dims, &*distance_fn)
     })

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -463,7 +463,9 @@ where
             Err(_) => {
                 // Log the error to stderr since we can't propagate it through FFI.
                 // We return f32::MAX to indicate "infinite distance" (no match).
-                eprintln!("CRITICAL: Panic in custom metric function caught by HNSW wrapper. Returning f32::MAX to prevent UB.");
+                eprintln!(
+                    "CRITICAL: Panic in custom metric function caught by HNSW wrapper. Returning f32::MAX to prevent UB."
+                );
                 f32::MAX
             }
         }

--- a/tests/warden_ffi_panic.rs
+++ b/tests/warden_ffi_panic.rs
@@ -1,7 +1,6 @@
 use aletheiadb::core::id::NodeId;
 use aletheiadb::index::VectorIndex;
 use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, Quantization};
-use std::sync::Arc;
 
 #[test]
 fn test_ffi_panic_in_custom_metric() {

--- a/tests/warden_ffi_panic.rs
+++ b/tests/warden_ffi_panic.rs
@@ -1,0 +1,23 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization};
+use aletheiadb::index::VectorIndex;
+use std::sync::Arc;
+
+#[test]
+fn test_ffi_panic_in_custom_metric() {
+    let metric_fn = |_: &[f32], _: &[f32]| -> f32 {
+        panic!("Intentionally panicking in custom metric");
+    };
+
+    let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+        .quantization(Quantization::F32)
+        .with_custom_metric("panicking_metric", metric_fn)
+        .build()
+        .expect("Failed to build index");
+
+    let node1 = NodeId::new(1).unwrap();
+    index.add(node1, &[1.0, 0.0, 0.0, 0.0]).expect("Failed to add vector");
+
+    // This search should trigger the panic inside the metric
+    let _ = index.search(&[1.0, 0.0, 0.0, 0.0], 1);
+}

--- a/tests/warden_ffi_panic.rs
+++ b/tests/warden_ffi_panic.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization};
 use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, Quantization};
 use std::sync::Arc;
 
 #[test]
@@ -16,7 +16,9 @@ fn test_ffi_panic_in_custom_metric() {
         .expect("Failed to build index");
 
     let node1 = NodeId::new(1).unwrap();
-    index.add(node1, &[1.0, 0.0, 0.0, 0.0]).expect("Failed to add vector");
+    index
+        .add(node1, &[1.0, 0.0, 0.0, 0.0])
+        .expect("Failed to add vector");
 
     // This search should trigger the panic inside the metric
     let _ = index.search(&[1.0, 0.0, 0.0, 0.0], 1);


### PR DESCRIPTION
Prevents SIGABRT caused by panics in user-provided custom distance metrics unwinding into C++ code. The fix catches the panic at the Rust/C++ boundary and returns `f32::MAX` to signal infinite distance.

---
*PR created automatically by Jules for task [7554298623522014546](https://jules.google.com/task/7554298623522014546) started by @madmax983*