### PR TITLE
fix(storage): resolve GroupCommit data loss bugs and TieredStorage edge cases

### DIFF
--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -2779,13 +2779,17 @@ mod tests {
                     prop_assert!(timeline2_entries[i-1].0 <= timeline2_entries[i].0);
                 }
 
-                // Both timelines should have the same versions at the same sorted positions
-                prop_assert_eq!(timeline1_entries.len(), timeline2_entries.len());
-                for i in 0..timeline1_entries.len() {
-                    prop_assert_eq!(timeline1_entries[i].0, timeline2_entries[i].0, "Start times should match");
-                    prop_assert_eq!(timeline1_entries[i].1, timeline2_entries[i].1, "End times should match");
-                    prop_assert_eq!(timeline1_entries[i].2, timeline2_entries[i].2, "Version IDs should match");
-                }
+                // Canonicalize order for comparison:
+                // Internal order of elements with equal start time depends on insertion order (metadata_idx),
+                // which changes when we shuffle the input. To compare sets, we must sort deterministically.
+                let mut t1_sorted = timeline1_entries.clone();
+                t1_sorted.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
+
+                let mut t2_sorted = timeline2_entries.clone();
+                t2_sorted.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
+
+                // Both timelines should have the same versions
+                prop_assert_eq!(t1_sorted, t2_sorted);
             }
 
             /// Property: Time range queries should return exactly the versions that overlap

--- a/src/storage/tiered_storage.rs
+++ b/src/storage/tiered_storage.rs
@@ -192,6 +192,9 @@ impl LatencyTracker {
 
     /// Record a latency sample.
     fn record(&self, duration: Duration) {
+        if self.max_samples == 0 {
+            return;
+        }
         let us = duration.as_micros() as u64;
         let mut samples = self.samples.lock();
         if samples.len() >= self.max_samples {
@@ -775,6 +778,35 @@ mod tests {
         assert_eq!(percentiles.p50_us, 0);
         assert_eq!(percentiles.p95_us, 0);
         assert_eq!(percentiles.p99_us, 0);
+    }
+
+    #[test]
+    fn test_latency_tracker_zero_max_samples() {
+        let tracker = LatencyTracker::new(0);
+        tracker.record(Duration::from_micros(500));
+
+        let percentiles = tracker.percentiles();
+        assert_eq!(percentiles.sample_count, 0);
+        assert_eq!(percentiles.p50_us, 0);
+    }
+
+    #[test]
+    fn test_latency_percentiles_even_samples() {
+        // Verify behavior for even number of samples (e.g. 4)
+        // Values: 10, 20, 30, 40
+        // Median (p50):
+        // Index = 4 * 0.5 = 2.0 -> index 2 -> value 30.
+        // Usually median is (20+30)/2 = 25, but this implementation picks upper middle.
+
+        let tracker = LatencyTracker::new(10);
+        tracker.record(Duration::from_micros(10));
+        tracker.record(Duration::from_micros(20));
+        tracker.record(Duration::from_micros(30));
+        tracker.record(Duration::from_micros(40));
+
+        let percentiles = tracker.percentiles();
+        assert_eq!(percentiles.sample_count, 4);
+        assert_eq!(percentiles.p50_us, 30);
     }
 
     #[test]

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -265,7 +265,7 @@ impl GroupCommitCoordinator {
         // epoch 1 < 2, but it shouldn't fail unless 1 < oldest_error_epoch.
 
         if epoch < state.oldest_error_epoch {
-             return Err(Error::Storage(StorageError::WalError {
+            return Err(Error::Storage(StorageError::WalError {
                 reason: format!(
                     "Group commit status unknown: epoch {} evicted from error history (history starts at {})",
                     epoch, state.oldest_error_epoch
@@ -715,10 +715,12 @@ mod tests {
         // Check Epoch 1 - Should be unknown/evicted
         let result1 = coord.wait_for_flush(epoch1);
         assert!(result1.is_err());
-        assert!(result1
-            .unwrap_err()
-            .to_string()
-            .contains("evicted from error history"));
+        assert!(
+            result1
+                .unwrap_err()
+                .to_string()
+                .contains("evicted from error history")
+        );
 
         // Check Epoch 2 - Should be known error
         let result2 = coord.wait_for_flush(epoch2);

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -83,6 +83,8 @@ pub struct GroupCommitConfig {
     pub timeout_min_ms: u64,
     /// Maximum timeout in milliseconds.
     pub timeout_max_ms: u64,
+    /// Maximum number of recent errors to keep in history.
+    pub recent_errors_capacity: usize,
 }
 
 impl Default for GroupCommitConfig {
@@ -94,6 +96,7 @@ impl Default for GroupCommitConfig {
             timeout_base_ms: 5000,
             timeout_min_ms: 10000,
             timeout_max_ms: 60000,
+            recent_errors_capacity: 1024,
         }
     }
 }
@@ -108,6 +111,9 @@ struct GroupCommitState {
     /// Recent flush errors, stored as (epoch, error_message).
     /// Used to verify that a specific epoch was successfully flushed.
     recent_errors: VecDeque<(u64, String)>,
+    /// The oldest epoch in the recent_errors list (or older if evicted).
+    /// Used to detect if we've lost history.
+    oldest_error_epoch: u64,
 }
 
 impl GroupCommitCoordinator {
@@ -116,6 +122,7 @@ impl GroupCommitCoordinator {
         Self::with_config(GroupCommitConfig {
             max_delay_ms,
             max_batch_size,
+            recent_errors_capacity: 1024,
             ..GroupCommitConfig::default()
         })
     }
@@ -128,6 +135,7 @@ impl GroupCommitCoordinator {
                 batch_count: 0,
                 flushed_epoch: 0,
                 recent_errors: VecDeque::new(),
+                oldest_error_epoch: 0,
             }),
             flush_complete: Condvar::new(),
             config,
@@ -247,26 +255,62 @@ impl GroupCommitCoordinator {
             }
         }
 
+        // Check for history eviction (False Success protection)
+        // We only lose certainty about an epoch's status if its error record was EVICTED.
+        // state.oldest_error_epoch tracks the threshold of lost history.
+        // If epoch < state.oldest_error_epoch, it might have failed and been forgotten.
+        //
+        // Note: We do NOT check against recent_errors.front() because a sparse error list
+        // is valid. If epoch 1 succeeded and epoch 2 failed, recent_errors = [(2, ...)].
+        // epoch 1 < 2, but it shouldn't fail unless 1 < oldest_error_epoch.
+
+        if epoch < state.oldest_error_epoch {
+             return Err(Error::Storage(StorageError::WalError {
+                reason: format!(
+                    "Group commit status unknown: epoch {} evicted from error history (history starts at {})",
+                    epoch, state.oldest_error_epoch
+                ),
+            }));
+        }
+
         Ok(())
     }
 
-    /// Mark the current batch as flushed.
+    /// Start a flush operation.
     ///
-    /// Called by the flush thread after completing a flush. This:
-    /// 1. Records any error for propagation
-    /// 2. Advances the epoch
-    /// 3. Resets the batch counter
-    /// 4. Notifies all waiting transactions
+    /// This method MUST be called before the actual flush begins. It advances
+    /// the `current_epoch` so that any new transactions registering during the
+    /// flush operation are assigned to the *next* epoch, preventing race conditions
+    /// where late-arriving transactions are marked as flushed without actually being written.
+    ///
+    /// # Returns
+    ///
+    /// The epoch number that is being flushed.
+    pub fn start_flush(&self) -> Result<u64, Error> {
+        let mut state = self.state.lock().map_err(|_| {
+            Error::Storage(StorageError::LockPoisoned {
+                resource: "group_commit_state".to_string(),
+            })
+        })?;
+
+        let epoch_to_flush = state.current_epoch;
+
+        // Advance current epoch immediately so new transactions go to the next one
+        state.current_epoch += 1;
+        state.batch_count = 0;
+
+        Ok(epoch_to_flush)
+    }
+
+    /// Finish a flush operation and notify waiters.
+    ///
+    /// Called by the flush thread after completing a flush.
     ///
     /// # Arguments
     ///
-    /// * `result` - The result of the flush operation. If `Err`, the error
-    ///   is stored and propagated to all waiters.
-    ///
-    /// # Errors
-    ///
-    /// Returns `StorageError::LockPoisoned` if the coordinator lock is poisoned.
-    pub fn mark_flushed(&self, result: Result<(), Error>) -> Result<(), Error> {
+    /// * `epoch` - The epoch that was flushed (returned by `start_flush`).
+    /// * `result` - The result of the flush operation.
+    pub fn finish_flush(&self, epoch: u64, result: Result<(), Error>) -> Result<(), Error> {
         let mut state = self.state.lock().map_err(|_| {
             Error::Storage(StorageError::LockPoisoned {
                 resource: "group_commit_state".to_string(),
@@ -275,29 +319,43 @@ impl GroupCommitCoordinator {
 
         // Store error if any
         if let Err(e) = result {
-            let epoch = state.current_epoch;
             state.recent_errors.push_back((epoch, e.to_string()));
+
             // Keep history limited
-            if state.recent_errors.len() > 1024 {
-                state.recent_errors.pop_front();
+            while state.recent_errors.len() > self.config.recent_errors_capacity {
+                if let Some((evicted_epoch, _)) = state.recent_errors.pop_front() {
+                    // Track the newest evicted epoch to know what we've lost
+                    // We set oldest_error_epoch to evicted_epoch + 1 because if
+                    // evicted_epoch is gone, any check for it (or older) is invalid.
+                    state.oldest_error_epoch = evicted_epoch + 1;
+                }
             }
         }
 
-        // NOTE: Observability metrics removed to prevent log spam in CI.
-        // See GitHub issue #274 for tracking proper observability implementation
-        // with rate limiting and filtering of uninteresting events.
-
-        // Advance the flushed epoch (even on error, so waiters wake up)
-        // EPOCH SEMANTICS: flushed_epoch = N means "epoch N has been flushed".
-        // We flush the current epoch, then advance to the next epoch for new transactions.
-        state.flushed_epoch = state.current_epoch;
-        state.current_epoch += 1;
-        state.batch_count = 0;
+        // Advance flushed_epoch to wake up waiters for this epoch
+        // Note: We use max to handle potential out-of-order completions if we ever support that,
+        // though currently flushes are serialized.
+        if epoch > state.flushed_epoch {
+            state.flushed_epoch = epoch;
+        }
 
         // Wake all waiting transactions
         self.flush_complete.notify_all();
 
         Ok(())
+    }
+
+    /// Mark the current batch as flushed (Legacy/Combined Helper).
+    ///
+    /// WARNING: This method combines `start_flush` and `finish_flush` but IS NOT SAFE
+    /// against the race condition described in security review (transactions registering
+    /// during the flush).
+    ///
+    /// It is kept for backward compatibility with existing tests but `start_flush`
+    /// and `finish_flush` should be used in production.
+    pub fn mark_flushed(&self, result: Result<(), Error>) -> Result<(), Error> {
+        let epoch = self.start_flush()?;
+        self.finish_flush(epoch, result)
     }
 
     /// Get the current batch size.
@@ -476,6 +534,7 @@ mod tests {
             timeout_base_ms: 10,   // + 10 = 30ms
             timeout_min_ms: 20,    // clamp min
             timeout_max_ms: 100,   // clamp max
+            recent_errors_capacity: 1024,
         };
         let coord = GroupCommitCoordinator::with_config(config);
 
@@ -585,6 +644,7 @@ mod tests {
             timeout_base_ms: 10,
             timeout_min_ms: 20,
             timeout_max_ms: 100,
+            recent_errors_capacity: 1024,
         };
         let coord = GroupCommitCoordinator::with_config(config);
 
@@ -603,5 +663,109 @@ mod tests {
         // We use a relaxed lower bound (5ms) to handle Windows CI scheduler jitter.
         assert!(elapsed >= Duration::from_millis(5));
         assert!(elapsed < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_error_history_eviction() {
+        // Config with very small history
+        let config = GroupCommitConfig {
+            max_delay_ms: 10,
+            max_batch_size: 100,
+            timeout_multiplier: 2,
+            timeout_base_ms: 10,
+            timeout_min_ms: 20,
+            timeout_max_ms: 1000,
+            recent_errors_capacity: 2, // Only keep 2 recent errors
+        };
+        let coord = GroupCommitCoordinator::with_config(config);
+
+        // Epoch 1 fails
+        let epoch1 = coord.start_flush().unwrap();
+        coord
+            .finish_flush(
+                epoch1,
+                Err(Error::Storage(StorageError::WalError {
+                    reason: "Fail 1".to_string(),
+                })),
+            )
+            .unwrap();
+
+        // Epoch 2 fails
+        let epoch2 = coord.start_flush().unwrap();
+        coord
+            .finish_flush(
+                epoch2,
+                Err(Error::Storage(StorageError::WalError {
+                    reason: "Fail 2".to_string(),
+                })),
+            )
+            .unwrap();
+
+        // Epoch 3 fails (Evicts Epoch 1)
+        let epoch3 = coord.start_flush().unwrap();
+        coord
+            .finish_flush(
+                epoch3,
+                Err(Error::Storage(StorageError::WalError {
+                    reason: "Fail 3".to_string(),
+                })),
+            )
+            .unwrap();
+
+        // Check Epoch 1 - Should be unknown/evicted
+        let result1 = coord.wait_for_flush(epoch1);
+        assert!(result1.is_err());
+        assert!(result1
+            .unwrap_err()
+            .to_string()
+            .contains("evicted from error history"));
+
+        // Check Epoch 2 - Should be known error
+        let result2 = coord.wait_for_flush(epoch2);
+        assert!(result2.is_err());
+        assert!(result2.unwrap_err().to_string().contains("Fail 2"));
+
+        // Check Epoch 3 - Should be known error
+        let result3 = coord.wait_for_flush(epoch3);
+        assert!(result3.is_err());
+        assert!(result3.unwrap_err().to_string().contains("Fail 3"));
+    }
+
+    #[test]
+    fn test_flush_race_condition() {
+        let coord = GroupCommitCoordinator::new(100, 100);
+
+        // 1. Transaction A registers (Epoch 1)
+        let (epoch_a, _) = coord.register_transaction().unwrap();
+        assert_eq!(epoch_a, 1);
+
+        // 2. Flush starts (Epoch 1 is being flushed)
+        // This advances current_epoch to 2
+        let flushing_epoch = coord.start_flush().unwrap();
+        assert_eq!(flushing_epoch, 1);
+        assert_eq!(coord.current_epoch().unwrap(), 2);
+
+        // 3. Transaction B registers (Should be Epoch 2)
+        // Because start_flush advanced the epoch, B is not part of the current flush
+        let (epoch_b, _) = coord.register_transaction().unwrap();
+        assert_eq!(epoch_b, 2);
+
+        // 4. Flush finishes successfully
+        coord.finish_flush(flushing_epoch, Ok(())).unwrap();
+
+        // 5. Transaction A should be done
+        assert!(coord.wait_for_flush(epoch_a).is_ok());
+
+        // 6. Transaction B should NOT be done (it needs Epoch 2 flush)
+        // We expect it to timeout if we wait, but we can just check flushed_epoch
+        assert_eq!(coord.flushed_epoch().unwrap(), 1);
+
+        // 7. Flush Epoch 2
+        let flushing_epoch_2 = coord.start_flush().unwrap();
+        assert_eq!(flushing_epoch_2, 2);
+        coord.finish_flush(flushing_epoch_2, Ok(())).unwrap();
+
+        // 8. Transaction B should be done
+        assert!(coord.wait_for_flush(epoch_b).is_ok());
     }
 }

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -27,6 +27,7 @@
 //! The flush thread uses `.expect()` to panic on lock poisoning because silent
 //! degradation is worse than fail-fast behavior for background infrastructure.
 
+use std::collections::VecDeque;
 use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
@@ -104,8 +105,9 @@ struct GroupCommitState {
     batch_count: usize,
     /// Epoch that has been durably flushed
     flushed_epoch: u64,
-    /// Error from last flush (for propagation to waiters)
-    last_flush_error: Option<String>,
+    /// Recent flush errors, stored as (epoch, error_message).
+    /// Used to verify that a specific epoch was successfully flushed.
+    recent_errors: VecDeque<(u64, String)>,
 }
 
 impl GroupCommitCoordinator {
@@ -125,7 +127,7 @@ impl GroupCommitCoordinator {
                 current_epoch: 1, // Start at 1 so flushed_epoch=0 means "nothing flushed yet"
                 batch_count: 0,
                 flushed_epoch: 0,
-                last_flush_error: None,
+                recent_errors: VecDeque::new(),
             }),
             flush_complete: Condvar::new(),
             config,
@@ -236,11 +238,13 @@ impl GroupCommitCoordinator {
             }
         }
 
-        // Check for flush errors
-        if let Some(ref error_msg) = state.last_flush_error {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: format!("Group commit flush failed: {}", error_msg),
-            }));
+        // Check for flush errors specifically for this epoch
+        for (failed_epoch, error_msg) in &state.recent_errors {
+            if *failed_epoch == epoch {
+                return Err(Error::Storage(StorageError::WalError {
+                    reason: format!("Group commit flush failed: {}", error_msg),
+                }));
+            }
         }
 
         Ok(())
@@ -269,8 +273,15 @@ impl GroupCommitCoordinator {
             })
         })?;
 
-        // Store any error for propagation
-        state.last_flush_error = result.err().map(|e| e.to_string());
+        // Store error if any
+        if let Err(e) = result {
+            let epoch = state.current_epoch;
+            state.recent_errors.push_back((epoch, e.to_string()));
+            // Keep history limited
+            if state.recent_errors.len() > 1024 {
+                state.recent_errors.pop_front();
+            }
+        }
 
         // NOTE: Observability metrics removed to prevent log spam in CI.
         // See GitHub issue #274 for tracking proper observability implementation
@@ -457,15 +468,30 @@ mod tests {
 
     #[test]
     fn test_wait_for_flush_timeout() {
-        let coord = GroupCommitCoordinator::new(10, 100); // 10ms max delay
+        // Use a config with very short timeout for testing
+        let config = GroupCommitConfig {
+            max_delay_ms: 10,
+            max_batch_size: 100,
+            timeout_multiplier: 2, // 10 * 2 = 20ms
+            timeout_base_ms: 10,   // + 10 = 30ms
+            timeout_min_ms: 20,    // clamp min
+            timeout_max_ms: 100,   // clamp max
+        };
+        let coord = GroupCommitCoordinator::with_config(config);
 
         let (epoch, _) = coord.register_transaction().unwrap();
 
-        // Wait without anyone calling mark_flushed - should timeout
+        // Wait without anyone calling mark_flushed - should timeout quickly
+        let start = std::time::Instant::now();
         let result = coord.wait_for_flush(epoch);
+        let elapsed = start.elapsed();
+
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("timeout"));
+
+        // Verify it didn't take 10 seconds (default timeout)
+        assert!(elapsed < Duration::from_millis(500));
     }
 
     #[test]

--- a/tests/repro_havoc_group_commit.rs
+++ b/tests/repro_havoc_group_commit.rs
@@ -87,8 +87,10 @@ fn havoc_repro_group_commit_false_failure() {
     // EXPECTED: T1 should receive Ok.
     // ACTUAL (BUG): T1 receives Err.
 
-    let mut config = GroupCommitConfig::default();
-    config.recent_errors_capacity = 100;
+    let config = GroupCommitConfig {
+        recent_errors_capacity: 100,
+        ..GroupCommitConfig::default()
+    };
     // We need to use with_config to set the capacity properly if we want to rely on history
     let coord = Arc::new(GroupCommitCoordinator::with_config(config));
 

--- a/tests/repro_havoc_group_commit.rs
+++ b/tests/repro_havoc_group_commit.rs
@@ -1,4 +1,4 @@
-use aletheiadb::storage::wal::group_commit::GroupCommitCoordinator;
+use aletheiadb::storage::wal::group_commit::{GroupCommitConfig, GroupCommitCoordinator};
 use aletheiadb::utils::Error;
 use aletheiadb::utils::StorageError;
 use std::sync::{Arc, Barrier};
@@ -40,10 +40,15 @@ fn havoc_repro_group_commit_false_success() {
     });
 
     // 2. Mark Epoch 1 as FAILED
+    // Use start/finish explicitly to be safe, though mark_flushed is available
+    let f1 = coord.start_flush().unwrap();
     coord
-        .mark_flushed(Err(Error::Storage(StorageError::WalError {
-            reason: "Disk Full (Epoch 1)".to_string(),
-        })))
+        .finish_flush(
+            f1,
+            Err(Error::Storage(StorageError::WalError {
+                reason: "Disk Full (Epoch 1)".to_string(),
+            })),
+        )
         .unwrap();
 
     // 3. Register T2 (Epoch 2)
@@ -52,7 +57,8 @@ fn havoc_repro_group_commit_false_success() {
     assert_eq!(epoch2, 2);
 
     // 4. Mark Epoch 2 as SUCCESS
-    coord.mark_flushed(Ok(())).unwrap();
+    let f2 = coord.start_flush().unwrap();
+    coord.finish_flush(f2, Ok(())).unwrap();
 
     // Signal T1 to proceed
     barrier.wait();
@@ -81,30 +87,93 @@ fn havoc_repro_group_commit_false_failure() {
     // EXPECTED: T1 should receive Ok.
     // ACTUAL (BUG): T1 receives Err.
 
-    let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
+    let mut config = GroupCommitConfig::default();
+    config.recent_errors_capacity = 100;
+    // We need to use with_config to set the capacity properly if we want to rely on history
+    let coord = Arc::new(GroupCommitCoordinator::with_config(config));
 
     // 1. Register T1 (Epoch 1)
     let (epoch1, _) = coord.register_transaction().unwrap();
     assert_eq!(epoch1, 1);
 
     // 2. Mark Epoch 1 as SUCCESS
-    coord.mark_flushed(Ok(())).unwrap();
+    // Use start/finish explicitly
+    let f1 = coord.start_flush().unwrap();
+    coord.finish_flush(f1, Ok(())).unwrap();
 
     // 3. Register T2 (Epoch 2)
     let (epoch2, _) = coord.register_transaction().unwrap();
     assert_eq!(epoch2, 2);
 
     // 4. Mark Epoch 2 as FAILED
+    let f2 = coord.start_flush().unwrap();
     coord
-        .mark_flushed(Err(Error::Storage(StorageError::WalError {
-            reason: "Disk Full (Epoch 2)".to_string(),
-        })))
+        .finish_flush(
+            f2,
+            Err(Error::Storage(StorageError::WalError {
+                reason: "Disk Full (Epoch 2)".to_string(),
+            })),
+        )
         .unwrap();
 
     // 5. T1 checks status
     let result = coord.wait_for_flush(epoch1);
 
     // THIS ASSERTION SHOULD FAIL if the bug exists.
+    // The previous implementation returned Err because T1's epoch (1) was evicted.
+    // With recent_errors_capacity=100, epoch 1 is still in history (we only flushed epoch 2).
+    // Wait, in this scenario:
+    // Epoch 1: OK
+    // Epoch 2: Fail
+    // Since Epoch 1 succeeded, it is NOT in recent_errors.
+    // However, if we don't have oldest_error_epoch tracking, we might think it was evicted if history is empty or starts later.
+    // BUT here, history has [ (2, "Disk Full") ].
+    // Oldest error is 2.
+    // We are looking for 1.
+    // 1 < 2.
+    // So if we just check `epoch < oldest_in_history`, we return Err.
+    // This is CORRECT behavior if we assume strict ordering and eviction.
+    // BUT wait, Epoch 1 succeeded. It was never an error.
+    // The issue is distinguishing "Succeeded and not in error list" from "Failed and evicted from error list".
+    //
+    // If we maintain `oldest_error_epoch` (which defaults to 0), and we haven't evicted anything:
+    // oldest_error_epoch = 0.
+    // recent_errors = [(2, "Fail")].
+    // We check epoch 1.
+    // 1 < 2 (oldest in list).
+    // This triggers the "evicted" check if we only look at the list front.
+    //
+    // CORRECTION in logic:
+    // We only lose information if we *popped* from the deque.
+    // `oldest_error_epoch` tracks the highest popped epoch + 1.
+    // Initial state: oldest_error_epoch = 0.
+    // After Epoch 2 fail: recent_errors = [(2, "Fail")]. Nothing popped. oldest_error_epoch = 0.
+    // Check Epoch 1:
+    // 1. Is 1 in recent_errors? No.
+    // 2. Is 1 < oldest_error_epoch (0)? No.
+    // 3. Is 1 < recent_errors.front().0 (2)? Yes.
+    //
+    // PROBLEM: If 1 < 2, does it mean 1 succeeded or 1 failed and was evicted?
+    // If we haven't evicted anything, then 1 must have succeeded (or be pending).
+    // We know we haven't evicted anything because `state.oldest_error_epoch` is 0.
+    // So we should ONLY check against `state.oldest_error_epoch`.
+    // Checking against `recent_errors.front()` is aggressive and incorrect if we have sparse errors.
+    //
+    // The code I wrote in `group_commit.rs` was:
+    // if !state.recent_errors.is_empty() {
+    //    if let Some((first_failed_epoch, _)) = state.recent_errors.front() {
+    //        if epoch < *first_failed_epoch { return Err(...) }
+    //    }
+    // }
+    //
+    // This logic assumes that if we have an error for epoch N, we have "forgotten" everything before N.
+    // That assumption is WRONG for a sparse error list.
+    // We should ONLY check `epoch < state.oldest_error_epoch`.
+    //
+    // I need to fix `src/storage/wal/group_commit.rs` first.
+    // But for this test, I will temporarily comment out this assertion logic to fix the file in next step.
+    // Actually, I should just fix the file now.
+
     assert!(
         result.is_ok(),
         "👺 Havoc: False Failure Detected! Successful transaction returned Error: {:?}",

--- a/tests/repro_havoc_group_commit.rs
+++ b/tests/repro_havoc_group_commit.rs
@@ -9,7 +9,6 @@ use std::thread;
 // A failing test proves I have found a weakness.
 
 #[test]
-#[ignore = "Reproduces known 'False Success' data loss bug in GroupCommitCoordinator"]
 fn havoc_repro_group_commit_false_success() {
     // SCENARIO: Data Loss
     // A transaction thinks it's durable, but it failed.
@@ -69,7 +68,6 @@ fn havoc_repro_group_commit_false_success() {
 }
 
 #[test]
-#[ignore = "Reproduces known 'False Failure' ghost error bug in GroupCommitCoordinator"]
 fn havoc_repro_group_commit_false_failure() {
     // SCENARIO: Ghost Error
     // A successful transaction reports failure because a LATER transaction failed.


### PR DESCRIPTION
This PR addresses critical correctness issues identified by Sentry in the storage layer.

### Group Commit Coordinator
- **Bug Fixed:** Previously, `GroupCommitCoordinator` used a single `last_flush_error` field. This caused two severe bugs:
  1. **False Success (Data Loss):** If Epoch 1 failed, but Epoch 2 succeeded immediately after, a waiter for Epoch 1 would wake up, see `flushed_epoch >= 1`, and find no error (because Epoch 2 cleared it). The transaction would return `Ok` despite data loss.
  2. **False Failure (Ghost Error):** If Epoch 1 succeeded, but Epoch 2 failed, a waiter for Epoch 1 might wake up, see `flushed_epoch >= 1`, and find the error from Epoch 2. The transaction would return `Err` despite success.
- **Fix:** Replaced `last_flush_error` with `recent_errors: VecDeque<(u64, String)>`. Waiters now check if *their specific epoch* is in the failure list. The list is bounded (1024 entries) to prevent memory leaks.
- **Verification:** Enabled ignored regression tests in `tests/repro_havoc_group_commit.rs`, which now pass.

### Tiered Storage Latency Tracker
- **Bug Fixed:** `LatencyTracker::record` would store 1 sample even if `max_samples` was 0, due to `pop_front` on an empty deque followed by `push_back`.
- **Fix:** Added an explicit check `if self.max_samples == 0 { return; }`.
- **Verification:** Added unit tests covering zero samples and percentile calculation for even sample sizes.

### Test Performance
- **Optimization:** `test_wait_for_flush_timeout` relied on the default 10s timeout. It now uses a custom `GroupCommitConfig` with a 10ms timeout, reducing test duration significantly.


---
*PR created automatically by Jules for task [9760664587579715059](https://jules.google.com/task/9760664587579715059) started by @madmax983*