### PR TITLE
🔒 Warden: Fix DoS via HNSW metric panic propagation

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -11,6 +11,11 @@
 **2026-02-15 - Redundant Alignment Checks in HNSW Metric Wrapper**
 **Threat:** The `create_metric_wrapper` function in `src/index/vector/hnsw.rs` contained redundant alignment checks. While not a security vulnerability per se, it added complexity and potential for confusion. The bitwise check `(ptr as usize) & (align - 1)` is sufficient and more performant than `ptr.align_offset(align)`.
 **Defense:** Removed the redundant `align_offset` check, relying on the bitwise check for safety. Also added `test_load_mappings_count_limit` to `src/index/vector/hnsw.rs` to verify OOM protection for Version 2 mapping files, complementing the existing Version 1 test.
+
 **2026-02-15 - LSN Allocator Overflow**
 **Threat:** The atomic LSN allocator used `fetch_add` without overflow checking. While requiring ~5000 years at 100M/sec to overflow `u64`, a large batch allocation (e.g. `u64::MAX`) or eventual wraparound would cause duplicate LSNs, breaking WAL ordering and data consistency.
 **Defense:** Replaced `fetch_add` with `fetch_update` (CAS loop) in `src/storage/wal/lsn_allocator.rs` to atomically check for overflow *before* modifying the state. Added `tests/warden_security_tests.rs` to verify panic behavior on overflow attempts.
+
+**2026-02-15 - HNSW Metric Panic Propagation (DoS)**
+**Threat:** A panic within a user-provided custom metric function (in `HnswIndex`) would propagate unwinding across the FFI boundary into the C++ `usearch` library. Rust panics crossing FFI boundaries result in undefined behavior, typically manifesting as an immediate process abort (`SIGABRT`). This provided a Denial of Service vector where a malicious or buggy metric function could crash the entire database process.
+**Defense:** Wrapped the execution of the user's distance function in `std::panic::catch_unwind` within `create_metric_wrapper` in `src/index/vector/hnsw.rs`. If a panic occurs, it is caught, an error is logged to stderr, and `f32::MAX` is returned to signal maximum dissimilarity. This allows the search to complete safely without crashing. Added `tests/warden_security_resilience.rs` to verify that searches survive panicking metrics.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1929,6 +1929,38 @@ mod sentry_tests {
         ));
         assert!(!is_retryable_usearch_error("Other error"));
     }
+
+    #[test]
+    fn test_metric_wrapper_panic_handling() {
+        // This test ensures that the catch_unwind logic in create_metric_wrapper works correctly.
+        // It should catch the panic and return f32::MAX.
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            panic!("Simulated metric panic");
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let vec_a = [0.0f32; 4];
+        let vec_b = [0.0f32; 4];
+
+        // This call should NOT panic, but return f32::MAX
+        let result = wrapper(vec_a.as_ptr(), vec_b.as_ptr());
+        assert_eq!(result, f32::MAX);
+    }
+
+    #[test]
+    fn test_metric_wrapper_success() {
+        // Verify happy path works as expected
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            42.0
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let vec_a = [0.0f32; 4];
+        let vec_b = [0.0f32; 4];
+
+        let result = wrapper(vec_a.as_ptr(), vec_b.as_ptr());
+        assert_eq!(result, 42.0);
+    }
 }
 
 #[cfg(test)]

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -463,7 +463,9 @@ where
             Err(_) => {
                 // Log error to stderr (cannot panic here as that would be UB)
                 // We return f32::MAX to indicate maximum dissimilarity
-                eprintln!("CRITICAL: Panic in custom metric function caught at FFI boundary. Returning f32::MAX.");
+                eprintln!(
+                    "CRITICAL: Panic in custom metric function caught at FFI boundary. Returning f32::MAX."
+                );
                 f32::MAX
             }
         }
@@ -1950,9 +1952,7 @@ mod sentry_tests {
     #[test]
     fn test_metric_wrapper_success() {
         // Verify happy path works as expected
-        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
-            42.0
-        });
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 { 42.0 });
         let wrapper = create_metric_wrapper(4, distance_fn);
 
         let vec_a = [0.0f32; 4];

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -450,9 +450,23 @@ where
         // SAFETY: usearch guarantees pointers are valid for `dims` elements.
         // We verified they are not null above.
 
-        let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
-        let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
-        distance_fn(slice_a, slice_b)
+        // Wrap user code in catch_unwind to prevent UB from unwinding into C++
+        // Use AssertUnwindSafe because raw pointers are not UnwindSafe, but they are Copy/trivially safe here.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
+            let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
+            distance_fn(slice_a, slice_b)
+        }));
+
+        match result {
+            Ok(dist) => dist,
+            Err(_) => {
+                // Log error to stderr (cannot panic here as that would be UB)
+                // We return f32::MAX to indicate maximum dissimilarity
+                eprintln!("CRITICAL: Panic in custom metric function caught at FFI boundary. Returning f32::MAX.");
+                f32::MAX
+            }
+        }
     })
 }
 

--- a/tests/warden_security_resilience.rs
+++ b/tests/warden_security_resilience.rs
@@ -1,6 +1,6 @@
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization};
-use aletheiadb::index::VectorIndex;
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, Quantization};
 
 #[test]
 fn test_metric_panic_resilience() {
@@ -30,8 +30,16 @@ fn test_metric_panic_resilience() {
     // We expect add() to succeed (or at least not crash), even if the metric panics.
     // Useach might return an error if distance calculation fails?
     // No, we return f32::MAX, so usearch sees a valid (large) distance.
-    assert!(res1.is_ok(), "add() failed during panic scenario: {:?}", res1.err());
-    assert!(res2.is_ok(), "add() failed during panic scenario: {:?}", res2.err());
+    assert!(
+        res1.is_ok(),
+        "add() failed during panic scenario: {:?}",
+        res1.err()
+    );
+    assert!(
+        res2.is_ok(),
+        "add() failed during panic scenario: {:?}",
+        res2.err()
+    );
 
     // Trigger search which calls the metric
     println!("Starting search with panicking metric...");
@@ -43,11 +51,17 @@ fn test_metric_panic_resilience() {
             // We expect results, but with very low similarity (due to f32::MAX distance)
             // Cosine similarity = 1.0 - distance = 1.0 - f32::MAX = -inf
             if !search_res.is_empty() {
-                assert!(search_res[0].1 < -1.0e30, "Expected extremely low similarity due to panic fallback");
+                assert!(
+                    search_res[0].1 < -1.0e30,
+                    "Expected extremely low similarity due to panic fallback"
+                );
             }
         }
         Err(e) => {
-            panic!("Search returned error instead of handling panic gracefully: {}", e);
+            panic!(
+                "Search returned error instead of handling panic gracefully: {}",
+                e
+            );
         }
     }
 }

--- a/tests/warden_security_resilience.rs
+++ b/tests/warden_security_resilience.rs
@@ -1,0 +1,53 @@
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization};
+use aletheiadb::index::VectorIndex;
+use aletheiadb::core::id::NodeId;
+
+#[test]
+fn test_metric_panic_resilience() {
+    // This test verifies that a panic in a custom metric function does not abort the process.
+    // Instead, it should be caught at the FFI boundary, logged, and return a safe fallback value.
+
+    // Define a panicking metric
+    let metric_fn = |_: &[f32], _: &[f32]| -> f32 {
+        panic!("Malicious metric panic!");
+    };
+
+    let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+        .quantization(Quantization::F32)
+        .with_custom_metric("panic_metric", metric_fn)
+        .build()
+        .unwrap();
+
+    // Add nodes
+    let n1 = NodeId::new(1).unwrap();
+    let n2 = NodeId::new(2).unwrap();
+
+    // Note: add() might also trigger distance calculations during insertion if ef_construction > 0
+    // So we should verify add() is also safe.
+    let res1 = index.add(n1, &[1.0, 0.0, 0.0, 0.0]);
+    let res2 = index.add(n2, &[0.0, 1.0, 0.0, 0.0]);
+
+    // We expect add() to succeed (or at least not crash), even if the metric panics.
+    // Useach might return an error if distance calculation fails?
+    // No, we return f32::MAX, so usearch sees a valid (large) distance.
+    assert!(res1.is_ok(), "add() failed during panic scenario: {:?}", res1.err());
+    assert!(res2.is_ok(), "add() failed during panic scenario: {:?}", res2.err());
+
+    // Trigger search which calls the metric
+    println!("Starting search with panicking metric...");
+    let result = index.search(&[1.0, 0.0, 0.0, 0.0], 2);
+
+    match result {
+        Ok(search_res) => {
+            println!("Search returned successfully: {:?}", search_res);
+            // We expect results, but with very low similarity (due to f32::MAX distance)
+            // Cosine similarity = 1.0 - distance = 1.0 - f32::MAX = -inf
+            if !search_res.is_empty() {
+                assert!(search_res[0].1 < -1.0e30, "Expected extremely low similarity due to panic fallback");
+            }
+        }
+        Err(e) => {
+            panic!("Search returned error instead of handling panic gracefully: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
Prevents database crash (SIGABRT) when a user-defined custom metric panics during HNSW search operations. This fixes a Denial of Service vulnerability where FFI panic propagation causes undefined behavior.

---
*PR created automatically by Jules for task [6006388663943564946](https://jules.google.com/task/6006388663943564946) started by @madmax983*