### PR TITLE
fix(core): treat NaN property values as semantically equal in VersionDiff

### DIFF
--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -546,4 +546,125 @@ mod semantic_equality_tests {
 
         assert!(!diff.has_changes(), "Vector with NaN -> Same Vector should NOT be treated as a change");
     }
+
+    #[test]
+    fn test_version_diff_vector_len_mismatch() {
+        // Test that vectors of different lengths are considered changed
+        // This covers line 160 (if a_vec.len() != b_vec.len())
+        let vec1 = vec![1.0, 2.0, 3.0];
+        let vec2 = vec![1.0, 2.0]; // Different length
+
+        let from_props = PropertyMapBuilder::new()
+            .insert_vector("emb", &vec1)
+            .build();
+
+        // Note: We can't use insert_vector for vec2 directly if we enforce dimension consistency
+        // in PropertyMapBuilder/PropertyValue construction, but PropertyValue::vector handles
+        // dimensions dynamically. The critical part is VersionDiff comparing two PropertyValues
+        // that happen to be vectors of different lengths.
+        //
+        // However, PropertyValue::vector() checks MAX_VECTOR_DIMENSIONS but doesn't enforce
+        // a specific schema. So we can create two vectors of different lengths.
+        let to_props = PropertyMapBuilder::new()
+            .insert_vector("emb", &vec2)
+            .build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+
+        assert!(diff.has_changes(), "Vectors of different lengths should be treated as a change");
+    }
+
+    #[test]
+    fn test_version_diff_sparse_vector_nan_behavior() {
+        use crate::core::vector::SparseVec;
+
+        // Note: SparseVec::new usually checks for NaNs, so we need to ensure we can construct one
+        // for testing if possible, or verify that we handle it if it somehow gets in.
+        // However, if SparseVec::new() prevents NaNs, then the code handling NaNs in VersionDiff
+        // is technically dead code for "newly created" vectors, but might be relevant for legacy/corrupted data.
+        //
+        // Let's check SparseVec::new implementation. It returns `VectorError::ContainsNaN`.
+        // So we can't easily construct a SparseVec with NaN using `new`.
+        //
+        // But for coverage purposes, we should test the equality logic for valid sparse vectors first,
+        // and check the dimension/indices mismatch paths.
+
+        let sv1 = SparseVec::new(vec![0, 2], vec![1.0, 2.0], 5).unwrap();
+        let sv2 = SparseVec::new(vec![0, 2], vec![1.0, 2.0], 5).unwrap();
+
+        let from_props = PropertyMapBuilder::new()
+            .insert("sparse", PropertyValue::sparse_vector(sv1.clone()))
+            .build();
+
+        let to_props = PropertyMapBuilder::new()
+            .insert("sparse", PropertyValue::sparse_vector(sv2))
+            .build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+
+        assert!(!diff.has_changes(), "Identical sparse vectors should not be treated as a change");
+
+        // Test dimension mismatch
+        let sv_dim_mismatch = SparseVec::new(vec![0, 2], vec![1.0, 2.0], 6).unwrap();
+        let to_props_dim = PropertyMapBuilder::new()
+            .insert("sparse", PropertyValue::sparse_vector(sv_dim_mismatch))
+            .build();
+        let diff_dim = VersionDiff::compute(
+            &from_props,
+            &to_props_dim,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+        assert!(diff_dim.has_changes(), "Sparse vectors with different dimensions should be different");
+
+        // Test indices mismatch
+        let sv_idx_mismatch = SparseVec::new(vec![0, 3], vec![1.0, 2.0], 5).unwrap();
+        let to_props_idx = PropertyMapBuilder::new()
+            .insert("sparse", PropertyValue::sparse_vector(sv_idx_mismatch))
+            .build();
+        let diff_idx = VersionDiff::compute(
+            &from_props,
+            &to_props_idx,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+        assert!(diff_idx.has_changes(), "Sparse vectors with different indices should be different");
+
+        // Test values mismatch
+        let sv_val_mismatch = SparseVec::new(vec![0, 2], vec![1.0, 3.0], 5).unwrap();
+        let to_props_val = PropertyMapBuilder::new()
+            .insert("sparse", PropertyValue::sparse_vector(sv_val_mismatch))
+            .build();
+        let diff_val = VersionDiff::compute(
+            &from_props,
+            &to_props_val,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+        assert!(diff_val.has_changes(), "Sparse vectors with different values should be different");
+
+        // Testing the NaN path specifically would require constructing a SparseVec with NaNs,
+        // which the constructor forbids. We can try to bypass constructor validation or accept
+        // that the NaN check in `property_values_semantically_equal` for SparseVector is defensive.
+        //
+        // However, we CAN test that if we *could* have NaNs, they would be equal.
+        // Since we can't easily construct invalid SparseVecs without unsafe or mocking,
+        // we'll rely on the fact that we've covered the structure of the function.
+        //
+        // The lines covered by this test are:
+        // - if a_sv.dimension() != b_sv.dimension() || a_sv.indices() != b_sv.indices() { return false; }
+        // - let a_vals = a_sv.values(); let b_vals = b_sv.values();
+        // - if a_vals.len() != b_vals.len() { return false; } (Implicitly covered since indices equal -> values len equal)
+        // - a_vals.iter().zip(b_vals.iter()).all(...) (Normal comparison)
+    }
 }

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -502,18 +502,14 @@ mod tests {
 #[cfg(test)]
 mod semantic_equality_tests {
     use super::*;
-    use crate::core::property::{PropertyMapBuilder, PropertyValue};
     use crate::core::id::VersionId;
+    use crate::core::property::{PropertyMapBuilder, PropertyValue};
 
     #[test]
     fn test_version_diff_nan_behavior() {
-        let from_props = PropertyMapBuilder::new()
-            .insert("score", f64::NAN)
-            .build();
+        let from_props = PropertyMapBuilder::new().insert("score", f64::NAN).build();
 
-        let to_props = PropertyMapBuilder::new()
-            .insert("score", f64::NAN)
-            .build();
+        let to_props = PropertyMapBuilder::new().insert("score", f64::NAN).build();
 
         let diff = VersionDiff::compute(
             &from_props,
@@ -523,7 +519,10 @@ mod semantic_equality_tests {
         );
 
         // Currently this fails (returns true) because NaN != NaN
-        assert!(!diff.has_changes(), "NaN -> NaN should NOT be treated as a change");
+        assert!(
+            !diff.has_changes(),
+            "NaN -> NaN should NOT be treated as a change"
+        );
     }
 
     #[test]
@@ -544,7 +543,10 @@ mod semantic_equality_tests {
             VersionId::new(2).unwrap(),
         );
 
-        assert!(!diff.has_changes(), "Vector with NaN -> Same Vector should NOT be treated as a change");
+        assert!(
+            !diff.has_changes(),
+            "Vector with NaN -> Same Vector should NOT be treated as a change"
+        );
     }
 
     #[test]
@@ -576,7 +578,10 @@ mod semantic_equality_tests {
             VersionId::new(2).unwrap(),
         );
 
-        assert!(diff.has_changes(), "Vectors of different lengths should be treated as a change");
+        assert!(
+            diff.has_changes(),
+            "Vectors of different lengths should be treated as a change"
+        );
     }
 
     #[test]
@@ -612,7 +617,10 @@ mod semantic_equality_tests {
             VersionId::new(2).unwrap(),
         );
 
-        assert!(!diff.has_changes(), "Identical sparse vectors should not be treated as a change");
+        assert!(
+            !diff.has_changes(),
+            "Identical sparse vectors should not be treated as a change"
+        );
 
         // Test dimension mismatch
         let sv_dim_mismatch = SparseVec::new(vec![0, 2], vec![1.0, 2.0], 6).unwrap();
@@ -625,7 +633,10 @@ mod semantic_equality_tests {
             VersionId::new(1).unwrap(),
             VersionId::new(2).unwrap(),
         );
-        assert!(diff_dim.has_changes(), "Sparse vectors with different dimensions should be different");
+        assert!(
+            diff_dim.has_changes(),
+            "Sparse vectors with different dimensions should be different"
+        );
 
         // Test indices mismatch
         let sv_idx_mismatch = SparseVec::new(vec![0, 3], vec![1.0, 2.0], 5).unwrap();
@@ -638,7 +649,10 @@ mod semantic_equality_tests {
             VersionId::new(1).unwrap(),
             VersionId::new(2).unwrap(),
         );
-        assert!(diff_idx.has_changes(), "Sparse vectors with different indices should be different");
+        assert!(
+            diff_idx.has_changes(),
+            "Sparse vectors with different indices should be different"
+        );
 
         // Test values mismatch
         let sv_val_mismatch = SparseVec::new(vec![0, 2], vec![1.0, 3.0], 5).unwrap();
@@ -651,7 +665,10 @@ mod semantic_equality_tests {
             VersionId::new(1).unwrap(),
             VersionId::new(2).unwrap(),
         );
-        assert!(diff_val.has_changes(), "Sparse vectors with different values should be different");
+        assert!(
+            diff_val.has_changes(),
+            "Sparse vectors with different values should be different"
+        );
 
         // Testing the NaN path specifically would require constructing a SparseVec with NaNs,
         // which the constructor forbids. We can try to bypass constructor validation or accept

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -100,7 +100,7 @@ impl VersionDiff {
                     // Property was added
                     added_builder = added_builder.insert_by_key(*key, to_value.clone());
                 }
-                Some(from_value) if from_value != to_value => {
+                Some(from_value) if !property_values_semantically_equal(from_value, to_value) => {
                     // Property was modified
                     modified.push((*key, from_value.clone(), to_value.clone()));
                 }
@@ -136,6 +136,57 @@ impl VersionDiff {
     #[must_use]
     pub fn change_count(&self) -> usize {
         self.added.len() + self.removed.len() + self.modified.len()
+    }
+}
+
+/// Helper to check if two property values are semantically equal.
+///
+/// This handles NaN equality for floating point types (Float, Vector, SparseVector),
+/// treating NaN as equal to NaN. This is important for history tracking to avoid
+/// detecting changes when values are effectively the same (undefined).
+fn property_values_semantically_equal(a: &PropertyValue, b: &PropertyValue) -> bool {
+    use crate::core::property::PropertyValue::*;
+
+    match (a, b) {
+        (Float(a_val), Float(b_val)) => {
+            if a_val.is_nan() && b_val.is_nan() {
+                true
+            } else {
+                a_val == b_val
+            }
+        }
+        (Vector(a_vec), Vector(b_vec)) => {
+            if a_vec.len() != b_vec.len() {
+                return false;
+            }
+            a_vec.iter().zip(b_vec.iter()).all(|(x, y)| {
+                if x.is_nan() && y.is_nan() {
+                    true
+                } else {
+                    x == y
+                }
+            })
+        }
+        (SparseVector(a_sv), SparseVector(b_sv)) => {
+            if a_sv.dimension() != b_sv.dimension() || a_sv.indices() != b_sv.indices() {
+                return false;
+            }
+            // Compare values with NaN handling
+            let a_vals = a_sv.values();
+            let b_vals = b_sv.values();
+            if a_vals.len() != b_vals.len() {
+                return false;
+            }
+            a_vals.iter().zip(b_vals.iter()).all(|(x, y)| {
+                if x.is_nan() && y.is_nan() {
+                    true
+                } else {
+                    x == y
+                }
+            })
+        }
+        // All other types use standard equality
+        _ => a == b,
     }
 }
 
@@ -445,5 +496,54 @@ mod tests {
                 .build(),
             label: "Test".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod semantic_equality_tests {
+    use super::*;
+    use crate::core::property::{PropertyMapBuilder, PropertyValue};
+    use crate::core::id::VersionId;
+
+    #[test]
+    fn test_version_diff_nan_behavior() {
+        let from_props = PropertyMapBuilder::new()
+            .insert("score", f64::NAN)
+            .build();
+
+        let to_props = PropertyMapBuilder::new()
+            .insert("score", f64::NAN)
+            .build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+
+        // Currently this fails (returns true) because NaN != NaN
+        assert!(!diff.has_changes(), "NaN -> NaN should NOT be treated as a change");
+    }
+
+    #[test]
+    fn test_version_diff_vector_nan_behavior() {
+        let vec_nan = vec![1.0, f32::NAN, 2.0];
+        let from_props = PropertyMapBuilder::new()
+            .insert_vector("emb", &vec_nan)
+            .build();
+
+        let to_props = PropertyMapBuilder::new()
+            .insert_vector("emb", &vec_nan)
+            .build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            VersionId::new(1).unwrap(),
+            VersionId::new(2).unwrap(),
+        );
+
+        assert!(!diff.has_changes(), "Vector with NaN -> Same Vector should NOT be treated as a change");
     }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `src/core/history.rs` (`VersionDiff::compute`)

💣 Risk: Previously, updating a property from `NaN` to `NaN` (float or vector) was recorded as a modification because `NaN != NaN` in IEEE 754. This caused noise in entity history tracking.

🧪 Strategy:
- Added reproduction tests verifying that `NaN` -> `NaN` transitions are detected as "no change".
- Implemented `property_values_semantically_equal` helper to handle `NaN` equality for `Float`, `Vector`, and `SparseVector` variants.
- Updated `VersionDiff::compute` to use this helper.

🔬 Verification: `cargo test core::history::semantic_equality_tests` passes.

---
*PR created automatically by Jules for task [10473968626338135093](https://jules.google.com/task/10473968626338135093) started by @madmax983*