### PR TITLE
🔒 Warden: Hardened FFI boundary against panics

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -14,3 +14,7 @@
 **2026-02-15 - LSN Allocator Overflow**
 **Threat:** The atomic LSN allocator used `fetch_add` without overflow checking. While requiring ~5000 years at 100M/sec to overflow `u64`, a large batch allocation (e.g. `u64::MAX`) or eventual wraparound would cause duplicate LSNs, breaking WAL ordering and data consistency.
 **Defense:** Replaced `fetch_add` with `fetch_update` (CAS loop) in `src/storage/wal/lsn_allocator.rs` to atomically check for overflow *before* modifying the state. Added `tests/warden_security_tests.rs` to verify panic behavior on overflow attempts.
+
+**2026-02-15 - FFI Boundary Panic Resilience**
+**Threat:** A custom distance metric function provided by the user could panic (e.g., due to division by zero or explicit panic). Since this function is called from the C++ `usearch` library via FFI, allowing the panic to unwind across the FFI boundary causes Undefined Behavior (UB), typically aborting the process.
+**Defense:** Wrapped the user-provided metric closure in `std::panic::catch_unwind` within `create_metric_wrapper` in `src/index/vector/hnsw.rs`. If a panic occurs, it is caught, logged to stderr, and `f32::MAX` is returned to indicate infinite distance (no match), preserving process stability.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -2959,4 +2959,22 @@ mod coverage_tests {
         // Should return max distance
         assert_eq!(result, f32::MAX);
     }
+
+    #[test]
+    fn test_metric_wrapper_success_direct() {
+        // Ensure that a non-panicking metric function works correctly.
+        // This provides direct coverage of the Ok path in catch_unwind.
+        let distance_fn = Arc::new(|a: &[f32], b: &[f32]| -> f32 {
+            a.iter().zip(b.iter()).map(|(x, y)| (x - y).abs()).sum()
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let data_a = [1.0f32, 2.0, 3.0, 4.0];
+        let data_b = [1.5f32, 2.5, 3.5, 4.5];
+
+        let result = wrapper(data_a.as_ptr(), data_b.as_ptr());
+
+        // |1.0-1.5| + |2.0-2.5| + |3.0-3.5| + |4.0-4.5| = 0.5 * 4 = 2.0
+        assert!((result - 2.0).abs() < f32::EPSILON);
+    }
 }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -465,7 +465,9 @@ where
             Ok(val) => val,
             Err(_) => {
                 // Log error to stderr so operator is aware of the issue
-                eprintln!("Panic in custom metric function - returning max distance to avoid FFI UB");
+                eprintln!(
+                    "Panic in custom metric function - returning max distance to avoid FFI UB"
+                );
                 f32::MAX
             }
         }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -452,7 +452,23 @@ where
 
         let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
         let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
-        distance_fn(slice_a, slice_b)
+
+        // SAFETY: We wrap the user-provided closure in catch_unwind to prevent
+        // panics from unwinding across the FFI boundary into C++ code, which is UB.
+        // If a panic occurs, we return f32::MAX (infinite distance) to effectively
+        // ignore this comparison.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            distance_fn(slice_a, slice_b)
+        }));
+
+        match result {
+            Ok(val) => val,
+            Err(_) => {
+                // Log error to stderr so operator is aware of the issue
+                eprintln!("Panic in custom metric function - returning max distance to avoid FFI UB");
+                f32::MAX
+            }
+        }
     })
 }
 
@@ -2921,5 +2937,24 @@ mod coverage_tests {
 
         drop(guard);
         assert!(!IN_FILTER_CALLBACK.with(|flag| flag.get()));
+    }
+
+    #[test]
+    fn test_metric_wrapper_panic_resilience() {
+        // Ensure that a panicking metric function doesn't crash the process
+        // but returns f32::MAX instead.
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            panic!("Test panic");
+        });
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let data = [0.0f32; 4];
+        let ptr = data.as_ptr();
+
+        // This should NOT panic
+        let result = wrapper(ptr, ptr);
+
+        // Should return max distance
+        assert_eq!(result, f32::MAX);
     }
 }


### PR DESCRIPTION
Hardened the HNSW index metric wrapper to prevent FFI panic unwinding.
- Wrapped metric closure in `catch_unwind`.
- Returns `f32::MAX` on panic to fail safe.
- Added unit test to verify resilience.
- Updated Warden's Journal.

---
*PR created automatically by Jules for task [13747916201249620251](https://jules.google.com/task/13747916201249620251) started by @madmax983*