### PR TITLE
docs: Fix Narrative Generation example in README to be self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,9 +473,21 @@ for (node_id, drift_score) in drifted_nodes {
 > ```
 
 ```rust
+use aletheiadb::{AletheiaDB, PropertyMapBuilder, WriteOps};
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
 
-// Generate natural language history of a node
+// Ensure you have features = ["nova"] enabled in Cargo.toml
+
+// 1. Setup database and node (for self-contained example)
+let db = AletheiaDB::new().unwrap();
+let node_id = db.write(|tx| {
+    tx.create_node("Person", PropertyMapBuilder::new()
+        .insert("name", "Alice")
+        .build()
+    )
+})?;
+
+// 2. Generate natural language history of a node
 let generator = NarrativeGenerator::new(&db);
 let narrative = generator.generate_node_narrative(node_id)?;
 


### PR DESCRIPTION
Improved the "Narrative Generation" example in `README.md` to be self-contained and runnable, addressing DX friction points identified during the audit. The example now includes database setup and node creation, and explicitly comments on the `nova` feature requirement.

---
*PR created automatically by Jules for task [12078026530109733452](https://jules.google.com/task/12078026530109733452) started by @madmax983*