### PR TITLE
Enforce start <= end invariant in TimeRange::close_at

### DIFF
--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -38,12 +38,12 @@ pub(crate) fn create_temporal_interval(
     valid_from: Timestamp,
     tx_time: Timestamp,
     is_tombstone: bool,
-) -> BiTemporalInterval {
+) -> Result<BiTemporalInterval> {
     let mut temporal = BiTemporalInterval::with_valid_time(valid_from, tx_time);
     if is_tombstone {
-        temporal = temporal.close_valid_time(valid_from);
+        temporal = temporal.close_valid_time(valid_from)?;
     }
-    temporal
+    Ok(temporal)
 }
 
 /// Apply a node creation or update to storage.
@@ -94,7 +94,7 @@ pub(crate) fn apply_node_write(
     )?;
 
     // Index in temporal indexes with bi-temporal interval
-    let temporal = create_temporal_interval(valid_from, commit_timestamp, false);
+    let temporal = create_temporal_interval(valid_from, commit_timestamp, false)?;
     tx.temporal_indexes
         .insert_node_version(node_id, version_id, temporal)?;
 
@@ -162,7 +162,7 @@ pub(crate) fn apply_edge_write(
     )?;
 
     // Index in temporal indexes with bi-temporal interval
-    let temporal = create_temporal_interval(valid_from, commit_timestamp, false);
+    let temporal = create_temporal_interval(valid_from, commit_timestamp, false)?;
     tx.temporal_indexes
         .insert_edge_version(edge_id, version_id, temporal)?;
 
@@ -198,7 +198,7 @@ pub(crate) fn apply_node_delete(
     }
 
     // Create tombstone interval using centralized logic
-    let tombstone_temporal = create_temporal_interval(valid_from, commit_timestamp, true);
+    let tombstone_temporal = create_temporal_interval(valid_from, commit_timestamp, true)?;
 
     // Add tombstone version to historical storage
     historical.add_node_version(
@@ -241,7 +241,7 @@ pub(crate) fn apply_edge_delete(
     }
 
     // Create tombstone interval using centralized logic
-    let tombstone_temporal = create_temporal_interval(valid_from, commit_timestamp, true);
+    let tombstone_temporal = create_temporal_interval(valid_from, commit_timestamp, true)?;
 
     // Add tombstone version to historical storage
     historical.add_edge_version(

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -173,12 +173,21 @@ impl TimeRange {
     /// Close this range at the given timestamp.
     ///
     /// Returns a new TimeRange with the same start but the specified end.
+    ///
+    /// # Errors
+    /// Returns `TemporalError::InvalidTimeRange` if end < start.
     #[inline]
-    pub const fn close_at(self, end: Timestamp) -> Self {
-        TimeRange {
+    pub fn close_at(self, end: Timestamp) -> Result<Self, TemporalError> {
+        if end < self.start {
+            return Err(TemporalError::InvalidTimeRange {
+                start: self.start,
+                end,
+            });
+        }
+        Ok(TimeRange {
             start: self.start,
             end,
-        }
+        })
     }
 
     /// Returns the duration of this range in microseconds.
@@ -381,31 +390,35 @@ impl BiTemporalInterval {
     ///
     /// This marks a fact as no longer valid in the real world.
     #[inline]
-    pub fn close_valid_time(self, end: Timestamp) -> Self {
-        BiTemporalInterval {
-            valid_time: self.valid_time.close_at(end),
+    pub fn close_valid_time(self, end: Timestamp) -> Result<Self, TemporalError> {
+        Ok(BiTemporalInterval {
+            valid_time: self.valid_time.close_at(end)?,
             transaction_time: self.transaction_time,
-        }
+        })
     }
 
     /// Close the transaction time dimension at the given timestamp.
     ///
     /// This marks when we stopped believing this version of the fact.
     #[inline]
-    pub fn close_transaction_time(self, end: Timestamp) -> Self {
-        BiTemporalInterval {
+    pub fn close_transaction_time(self, end: Timestamp) -> Result<Self, TemporalError> {
+        Ok(BiTemporalInterval {
             valid_time: self.valid_time,
-            transaction_time: self.transaction_time.close_at(end),
-        }
+            transaction_time: self.transaction_time.close_at(end)?,
+        })
     }
 
     /// Close both time dimensions.
     #[inline]
-    pub fn close_both(self, valid_end: Timestamp, tx_end: Timestamp) -> Self {
-        BiTemporalInterval {
-            valid_time: self.valid_time.close_at(valid_end),
-            transaction_time: self.transaction_time.close_at(tx_end),
-        }
+    pub fn close_both(
+        self,
+        valid_end: Timestamp,
+        tx_end: Timestamp,
+    ) -> Result<Self, TemporalError> {
+        Ok(BiTemporalInterval {
+            valid_time: self.valid_time.close_at(valid_end)?,
+            transaction_time: self.transaction_time.close_at(tx_end)?,
+        })
     }
 
     /// Serialize this BiTemporalInterval to bytes.
@@ -601,12 +614,23 @@ mod tests {
     #[test]
     fn test_time_range_close_at() {
         let open = TimeRange::from(100.into());
-        let closed = open.close_at(200.into());
+        let closed = open.close_at(200.into()).unwrap();
 
         assert!(open.is_current());
         assert!(!closed.is_current());
         assert_eq!(closed.start(), 100.into());
         assert_eq!(closed.end(), 200.into());
+    }
+
+    #[test]
+    fn test_time_range_close_at_invalid() {
+        let open = TimeRange::from(100.into());
+        let result = open.close_at(50.into());
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            TemporalError::InvalidTimeRange { .. }
+        ));
     }
 
     #[test]
@@ -654,17 +678,17 @@ mod tests {
     fn test_bitemporal_close() {
         let interval = BiTemporalInterval::now(1000.into(), 2000.into());
 
-        let closed_valid = interval.close_valid_time(1500.into());
+        let closed_valid = interval.close_valid_time(1500.into()).unwrap();
         assert!(!closed_valid.is_currently_valid());
         assert!(closed_valid.is_currently_recorded());
         assert_eq!(closed_valid.valid_time().end(), 1500.into());
 
-        let closed_tx = interval.close_transaction_time(2500.into());
+        let closed_tx = interval.close_transaction_time(2500.into()).unwrap();
         assert!(closed_tx.is_currently_valid());
         assert!(!closed_tx.is_currently_recorded());
         assert_eq!(closed_tx.transaction_time().end(), 2500.into());
 
-        let closed_both = interval.close_both(1500.into(), 2500.into());
+        let closed_both = interval.close_both(1500.into(), 2500.into()).unwrap();
         assert!(!closed_both.is_currently_valid());
         assert!(!closed_both.is_currently_recorded());
     }
@@ -1262,7 +1286,7 @@ mod proptests {
             let interval = BiTemporalInterval::current(start);
             prop_assert!(interval.is_currently_valid());
 
-            let closed = interval.close_valid_time(close);
+            let closed = interval.close_valid_time(close).unwrap();
             prop_assert!(!closed.is_currently_valid());
             prop_assert_eq!(closed.valid_time().end(), close);
         }
@@ -1279,7 +1303,7 @@ mod proptests {
             let interval = BiTemporalInterval::current(start);
             prop_assert!(interval.is_currently_recorded());
 
-            let closed = interval.close_transaction_time(close);
+            let closed = interval.close_transaction_time(close).unwrap();
             prop_assert!(!closed.is_currently_recorded());
             prop_assert_eq!(closed.transaction_time().end(), close);
         }

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -13,6 +13,7 @@ use crate::core::id::{EdgeId, NodeId, TxId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::{MAX_VECTOR_DIMENSIONS, PropertyKey, PropertyMap, PropertyValue};
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
+use crate::utils::error::Result;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -318,9 +319,10 @@ pub trait TemporalVersion {
     ///
     /// This marks the version as no longer being the "current knowledge" after
     /// the specified timestamp. Used when a version is superseded or deleted.
-    fn close_transaction_time(&mut self, end_timestamp: Timestamp) {
+    fn close_transaction_time(&mut self, end_timestamp: Timestamp) -> Result<()> {
         let temporal = self.temporal_mut();
-        *temporal = temporal.close_transaction_time(end_timestamp);
+        *temporal = temporal.close_transaction_time(end_timestamp)?;
+        Ok(())
     }
 }
 
@@ -539,7 +541,10 @@ impl PropertyDelta {
     /// Moves materialized vectors from `vector_deltas` to `changed`, converting them
     /// to full `PropertyValue::Vector` instances. After this operation, `vector_deltas`
     /// will only contain `VectorDelta::Full` entries (which are then moved to `changed`).
-    pub fn materialize_vector_deltas(&mut self, base: &PropertyMap) -> Result<(), String> {
+    pub fn materialize_vector_deltas(
+        &mut self,
+        base: &PropertyMap,
+    ) -> std::result::Result<(), String> {
         // Materialize ALL vector deltas (both Sparse and Full) into regular changed properties
         // This is necessary for persistence since the persistence format doesn't support VectorDelta
         let keys: Vec<_> = self.vector_deltas.keys().copied().collect();
@@ -2522,7 +2527,7 @@ mod mutant_kill_tests {
         let mut node = make_node_anchor();
         let end = Timestamp::from(2_000);
 
-        node.close_transaction_time(end);
+        node.close_transaction_time(end).unwrap();
 
         assert_eq!(node.temporal().transaction_time().end(), end);
         assert_eq!(node.temporal().valid_time().end(), TIMESTAMP_MAX);

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -540,7 +540,7 @@ impl HistoricalStorage {
         // For tombstones, close the valid_time at valid_from to create an empty interval [valid_from, valid_from)
         // This represents "entity is no longer valid starting from this point"
         if is_tombstone {
-            temporal = temporal.close_valid_time(valid_from);
+            temporal = temporal.close_valid_time(valid_from)?;
         }
 
         // Check capacity limit using cached count (O(1) operation, DoS protection)
@@ -631,7 +631,7 @@ impl HistoricalStorage {
             // Capture the intervals before modification for temporal index update
             let old_temporal = *prev.temporal();
 
-            Self::close_previous_version_intervals(prev, version_id, &temporal);
+            Self::close_previous_version_intervals(prev, version_id, &temporal)?;
 
             // Update temporal indexes to reflect the closed intervals (Issue #209)
             if let Some(ref indexes) = self.temporal_indexes {
@@ -734,7 +734,7 @@ impl HistoricalStorage {
         // For tombstones, close the valid_time at valid_from to create an empty interval [valid_from, valid_from)
         // This represents "entity is no longer valid starting from this point"
         if is_tombstone {
-            temporal = temporal.close_valid_time(valid_from);
+            temporal = temporal.close_valid_time(valid_from)?;
         }
 
         // Check capacity limit using cached count (O(1) operation, DoS protection)
@@ -837,7 +837,7 @@ impl HistoricalStorage {
             // Capture the intervals before modification for temporal index update
             let old_temporal = *prev.temporal();
 
-            Self::close_previous_version_intervals(prev, version_id, &temporal);
+            Self::close_previous_version_intervals(prev, version_id, &temporal)?;
 
             // Update temporal indexes to reflect the closed intervals (Issue #209)
             if let Some(ref indexes) = self.temporal_indexes {
@@ -1709,7 +1709,7 @@ impl HistoricalStorage {
         let node_id = version.node_id;
 
         // Use TemporalVersion trait method
-        version.close_transaction_time(end_timestamp);
+        version.close_transaction_time(end_timestamp)?;
 
         // Update temporal index to reflect the closed interval (Issue #209)
         if let Some(ref indexes) = self.temporal_indexes {
@@ -1739,7 +1739,7 @@ impl HistoricalStorage {
         let target = version.target;
 
         // Use TemporalVersion trait method
-        version.close_transaction_time(end_timestamp);
+        version.close_transaction_time(end_timestamp)?;
 
         // Update temporal index to reflect the closed interval (Issue #209)
         if let Some(ref indexes) = self.temporal_indexes {
@@ -2398,7 +2398,7 @@ impl HistoricalStorage {
         prev_version: &mut V,
         new_version_id: VersionId,
         new_temporal: &BiTemporalInterval,
-    ) {
+    ) -> Result<()> {
         prev_version.set_next_version(Some(new_version_id));
 
         // Work on a local copy, apply modifications, then write back
@@ -2407,17 +2407,18 @@ impl HistoricalStorage {
         if prev_temporal.is_currently_valid()
             && new_temporal.valid_time().start() > prev_temporal.valid_time().start()
         {
-            prev_temporal = prev_temporal.close_valid_time(new_temporal.valid_time().start());
+            prev_temporal = prev_temporal.close_valid_time(new_temporal.valid_time().start())?;
         }
 
         if prev_temporal.is_currently_recorded()
             && new_temporal.transaction_time().start() > prev_temporal.transaction_time().start()
         {
             prev_temporal =
-                prev_temporal.close_transaction_time(new_temporal.transaction_time().start());
+                prev_temporal.close_transaction_time(new_temporal.transaction_time().start())?;
         }
 
         *prev_version.temporal_mut() = prev_temporal;
+        Ok(())
     }
 
     /// Extract version metadata and data for copy-out reconstruction (nodes).

--- a/tests/sentry_temporal_invariants.rs
+++ b/tests/sentry_temporal_invariants.rs
@@ -1,7 +1,6 @@
-
 #[cfg(test)]
 mod tests {
-    use aletheiadb::core::temporal::{TimeRange, BiTemporalInterval, time};
+    use aletheiadb::core::temporal::{BiTemporalInterval, TimeRange, time};
     use aletheiadb::utils::error::TemporalError;
 
     #[test]
@@ -15,7 +14,10 @@ mod tests {
 
         // This MUST fail now
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), TemporalError::InvalidTimeRange { .. }));
+        assert!(matches!(
+            result.unwrap_err(),
+            TemporalError::InvalidTimeRange { .. }
+        ));
     }
 
     #[test]
@@ -28,6 +30,9 @@ mod tests {
 
         // This MUST fail now
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), TemporalError::InvalidTimeRange { .. }));
+        assert!(matches!(
+            result.unwrap_err(),
+            TemporalError::InvalidTimeRange { .. }
+        ));
     }
 }

--- a/tests/sentry_temporal_invariants.rs
+++ b/tests/sentry_temporal_invariants.rs
@@ -1,0 +1,33 @@
+
+#[cfg(test)]
+mod tests {
+    use aletheiadb::core::temporal::{TimeRange, BiTemporalInterval, time};
+    use aletheiadb::utils::error::TemporalError;
+
+    #[test]
+    fn test_timerange_close_at_enforces_invariant() {
+        let start = time::from_secs(100);
+        let range = TimeRange::from(start);
+
+        // Attempt to close at a time BEFORE start
+        let invalid_end = time::from_secs(50);
+        let result = range.close_at(invalid_end);
+
+        // This MUST fail now
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), TemporalError::InvalidTimeRange { .. }));
+    }
+
+    #[test]
+    fn test_bitemporal_close_enforces_invariant() {
+        let start = time::from_secs(100);
+        let interval = BiTemporalInterval::current(start);
+
+        let invalid_end = time::from_secs(50);
+        let result = interval.close_valid_time(invalid_end);
+
+        // This MUST fail now
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), TemporalError::InvalidTimeRange { .. }));
+    }
+}


### PR DESCRIPTION
Enforced the `start <= end` invariant in `TimeRange::close_at` by changing it to return `Result<Self, TemporalError>`.
Updated `BiTemporalInterval` and `TemporalVersion` methods to propagate this result.
Updated all call sites in `src/storage/historical/mod.rs` and `src/api/transaction/write/apply.rs` to handle potential errors.
Fixed potential panic/invalid state where `close_at` could produce a range with negative duration.
Added regression tests in `tests/sentry_temporal_invariants.rs`.
Verified all tests pass.


---
*PR created automatically by Jules for task [5060962920902924701](https://jules.google.com/task/5060962920902924701) started by @madmax983*