### PR TITLE
👺 Havoc: Prevent Process Abort on FFI Panic

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -2947,3 +2947,47 @@ mod coverage_tests {
         assert!(!IN_FILTER_CALLBACK.with(|flag| flag.get()));
     }
 }
+
+#[cfg(test)]
+mod panic_resilience_tests {
+    use super::*;
+
+    #[test]
+    fn test_metric_wrapper_panic_handling() {
+        // This test ensures that the metric wrapper correctly catches panics and returns f32::MAX
+        // This directly covers the Err path in create_metric_wrapper
+        let distance_fn = Arc::new(|_: &[f32], _: &[f32]| -> f32 {
+            panic!("Panic in custom metric!");
+        });
+
+        let wrapper = create_metric_wrapper(4, distance_fn);
+
+        let vec = [0.0f32; 4];
+        let ptr = vec.as_ptr();
+
+        // This should not panic the test, but return f32::MAX
+        let result = wrapper(ptr, ptr);
+        assert_eq!(result, f32::MAX);
+    }
+
+    #[test]
+    fn test_search_filter_panic_handling() -> Result<()> {
+        // This test ensures that search_with_filter catches panics in the predicate
+        // This directly covers the Err path in search_with_filter
+        let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build()?;
+
+        let node1 = NodeId::new(1).unwrap();
+        index.add(node1, &[1.0, 0.0, 0.0, 0.0])?;
+
+        let query = [1.0, 0.0, 0.0, 0.0];
+
+        // Search with a panicking filter
+        let results = index.search_with_filter(&query, 1, |_| {
+            panic!("Panic in filter!");
+        })?;
+
+        // Should return empty results as the node was filtered out due to panic
+        assert!(results.is_empty());
+        Ok(())
+    }
+}

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -97,6 +97,7 @@ use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::panic::AssertUnwindSafe;
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
 
 // Thread-local flag to detect re-entrant modification attempts during filtered search.
@@ -452,7 +453,20 @@ where
 
         let slice_a = unsafe { std::slice::from_raw_parts(a, dims) };
         let slice_b = unsafe { std::slice::from_raw_parts(b, dims) };
-        distance_fn(slice_a, slice_b)
+
+        // Wrap user-provided metric function to prevent panics from unwinding through FFI boundaries (UB)
+        // If the user's function panics, we catch it and return a safe fallback (f32::MAX)
+        // to prevent the process from aborting.
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| distance_fn(slice_a, slice_b)));
+
+        match result {
+            Ok(val) => val,
+            Err(_) => {
+                // Log error to stderr as fallback
+                eprintln!("Panic caught in custom metric function! Preventing process abort.");
+                f32::MAX
+            }
+        }
     })
 }
 
@@ -1066,7 +1080,17 @@ impl VectorIndex for HnswIndex {
             if let Some(node_id_ref) = reverse_mapping.get(&key) {
                 // Set flag to prevent modifications during callback
                 let _guard = FilterCallbackGuard::new();
-                predicate(node_id_ref.value())
+
+                // Wrap user-provided predicate to prevent panics from unwinding through FFI boundaries (UB)
+                let result = std::panic::catch_unwind(AssertUnwindSafe(|| predicate(node_id_ref.value())));
+
+                match result {
+                    Ok(val) => val,
+                    Err(_) => {
+                        eprintln!("Panic caught in search filter predicate! Preventing process abort.");
+                        false // Filter out the node safely
+                    }
+                }
             } else {
                 false
             }

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -94,10 +94,10 @@ use dashmap::DashMap;
 use parking_lot::RwLock;
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};
+use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::panic::AssertUnwindSafe;
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
 
 // Thread-local flag to detect re-entrant modification attempts during filtered search.
@@ -1082,12 +1082,15 @@ impl VectorIndex for HnswIndex {
                 let _guard = FilterCallbackGuard::new();
 
                 // Wrap user-provided predicate to prevent panics from unwinding through FFI boundaries (UB)
-                let result = std::panic::catch_unwind(AssertUnwindSafe(|| predicate(node_id_ref.value())));
+                let result =
+                    std::panic::catch_unwind(AssertUnwindSafe(|| predicate(node_id_ref.value())));
 
                 match result {
                     Ok(val) => val,
                     Err(_) => {
-                        eprintln!("Panic caught in search filter predicate! Preventing process abort.");
+                        eprintln!(
+                            "Panic caught in search filter predicate! Preventing process abort."
+                        );
                         false // Filter out the node safely
                     }
                 }

--- a/tests/havoc_ffi_panic.rs
+++ b/tests/havoc_ffi_panic.rs
@@ -1,0 +1,55 @@
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization};
+use aletheiadb::index::VectorIndex;
+use aletheiadb::core::id::NodeId;
+
+#[test]
+fn test_ffi_panic_resilience_metric() {
+    // This test verifies that panics in custom metrics don't cause undefined behavior (UB)
+    // by unwinding through FFI boundaries.
+
+    let builder = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+        .quantization(Quantization::F32)
+        .with_custom_metric("panic_metric", |_, _| {
+            panic!("Panic in custom metric!");
+        });
+
+    let index = builder.build().expect("Failed to build index");
+
+    let node1 = NodeId::new(1).unwrap();
+    let vec1 = vec![1.0, 0.0, 0.0, 0.0];
+    index.add(node1, &vec1).expect("Failed to add vector");
+
+    let query = vec![1.0, 0.0, 0.0, 0.0];
+
+    // This search calls the metric, which panics.
+    // The wrapper should catch the panic and return f32::MAX.
+    // The process should NOT abort.
+    let results = index.search(&query, 10).expect("Search failed");
+
+    // Since we return f32::MAX (dissimilar), results should be valid but likely have low similarity
+    // or be empty if thresholding is applied (though search returns k results regardless of score usually).
+    println!("Search results: {:?}", results);
+}
+
+#[test]
+fn test_ffi_panic_resilience_filter() {
+    // This test verifies that panics in search filters don't cause UB.
+
+    let builder = HnswIndexBuilder::new(4, DistanceMetric::Cosine);
+    let index = builder.build().expect("Failed to build index");
+
+    let node1 = NodeId::new(1).unwrap();
+    let vec1 = vec![1.0, 0.0, 0.0, 0.0];
+    index.add(node1, &vec1).expect("Failed to add vector");
+
+    let query = vec![1.0, 0.0, 0.0, 0.0];
+
+    // Search with a filter that panics
+    let results = index.search_with_filter(&query, 10, |_| {
+        panic!("Panic in filter predicate!");
+    }).expect("Search failed");
+
+    // The wrapper should catch panic and return false (filter out).
+    // So results should be empty.
+    assert!(results.is_empty(), "Expected empty results due to filter panic");
+}

--- a/tests/havoc_ffi_panic.rs
+++ b/tests/havoc_ffi_panic.rs
@@ -1,6 +1,6 @@
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization};
-use aletheiadb::index::VectorIndex;
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, Quantization};
 
 #[test]
 fn test_ffi_panic_resilience_metric() {
@@ -45,11 +45,16 @@ fn test_ffi_panic_resilience_filter() {
     let query = vec![1.0, 0.0, 0.0, 0.0];
 
     // Search with a filter that panics
-    let results = index.search_with_filter(&query, 10, |_| {
-        panic!("Panic in filter predicate!");
-    }).expect("Search failed");
+    let results = index
+        .search_with_filter(&query, 10, |_| {
+            panic!("Panic in filter predicate!");
+        })
+        .expect("Search failed");
 
     // The wrapper should catch panic and return false (filter out).
     // So results should be empty.
-    assert!(results.is_empty(), "Expected empty results due to filter panic");
+    assert!(
+        results.is_empty(),
+        "Expected empty results due to filter panic"
+    );
 }


### PR DESCRIPTION
This PR addresses a critical denial-of-service vulnerability where a panic inside a user-defined custom metric or search filter would unwind across FFI boundaries into the `usearch` C++ library, causing the entire process to abort (SIGABRT).

I have wrapped the user callbacks in `std::panic::catch_unwind` to intercept the panic before it reaches the FFI boundary. In case of a panic, we now log an error to stderr and return a safe fallback value (`f32::MAX` for metrics, `false` for filters) to allow the search to proceed (albeit with degraded results for that specific operation) instead of crashing the database.

A new regression test `tests/havoc_ffi_panic.rs` confirms that panics are caught and the process survives.

---
*PR created automatically by Jules for task [3371716979600193073](https://jules.google.com/task/3371716979600193073) started by @madmax983*