### PR TITLE
🔒 Warden: Fix WAL memory exhaustion and PropertyMap panic DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -18,3 +18,11 @@
 **2026-02-15 - FFI Boundary Panic Resilience**
 **Threat:** A custom distance metric function provided by the user could panic (e.g., due to division by zero or explicit panic). Since this function is called from the C++ `usearch` library via FFI, allowing the panic to unwind across the FFI boundary causes Undefined Behavior (UB), typically aborting the process.
 **Defense:** Wrapped the user-provided metric closure in `std::panic::catch_unwind` within `create_metric_wrapper` in `src/index/vector/hnsw.rs`. If a panic occurs, it is caught, logged to stderr, and `f32::MAX` is returned to indicate infinite distance (no match), preserving process stability.
+
+**2026-02-16 - DoS via Massive WAL Entry**
+**Threat:** A malicious user could submit a database operation (e.g. `CreateNode`) with a `PropertyMap` containing massive values (e.g. 10M element arrays or 100MB byte strings). `ConcurrentWal` would unknowingly serialize this into a huge buffer and attempt to append it to the `WalRingBuffer`. If multiple such requests occurred, the fixed-capacity (by slot) ring buffer would hold gigabytes of data, causing Out-Of-Memory (OOM) crashes.
+**Defense:** Introduced `MAX_WAL_ENTRY_SIZE` (64MB) in `src/storage/wal/entry.rs`. Modified `ConcurrentWal::serialize_entry` to check the estimated size against this limit *before* allocation, returning `StorageError::CapacityExceeded` if violated. Added `tests/warden_wal_dos.rs` to verify rejection.
+
+**2026-02-16 - Panic in PropertyMap::from_iter**
+**Threat:** The `PropertyMap::from_iter` method used `expect()` when calculating serialized size. If a user provided a deeply nested `PropertyValue` (exceeding `MAX_RECURSION_DEPTH` of 100), `serialized_size()` would return an error, causing `from_iter` to panic and crash the process. This crash vector was reachable via standard iterator usage.
+**Defense:** Replaced `expect()` with `unwrap_or(RECURSION_PENALTY_SIZE)` in `src/core/property.rs`. This allows map construction to proceed without crashing. Safety is maintained because the subsequent `serialize()` operation re-checks recursion depth and will fail gracefully (returning `Result::Err`) instead of panicking.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1816,20 +1816,16 @@ impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
             // 10MB penalty discourages abuse.
             const RECURSION_PENALTY_SIZE: usize = 10 * 1024 * 1024;
 
-            let val_size = value
-                .serialized_size()
-                .unwrap_or(RECURSION_PENALTY_SIZE);
+            let val_size = value.serialized_size().unwrap_or(RECURSION_PENALTY_SIZE);
 
             size = size.saturating_add(key_size).saturating_add(val_size);
 
             if let Some(old_val) = map.insert(key, value) {
                 // If replaced, subtract the size of the old entry (key + value)
                 // Key size is the same since it's the same key ID
-                size = size.saturating_sub(key_size).saturating_sub(
-                    old_val
-                        .serialized_size()
-                        .unwrap_or(RECURSION_PENALTY_SIZE),
-                );
+                size = size
+                    .saturating_sub(key_size)
+                    .saturating_sub(old_val.serialized_size().unwrap_or(RECURSION_PENALTY_SIZE));
             }
         }
 
@@ -4153,7 +4149,10 @@ mod sentry_tests {
 
         // But serialization MUST fail because it re-checks depth
         let result = map.serialize();
-        assert!(result.is_err(), "Serialization should fail due to recursion limit");
+        assert!(
+            result.is_err(),
+            "Serialization should fail due to recursion limit"
+        );
 
         // Verify cached_size includes penalty
         assert!(map.serialized_size() > 10 * 1024 * 1024);

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1811,9 +1811,14 @@ impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
                 .resolve_with(key, |s| s.len())
                 .unwrap_or(256);
             let key_size = 4 + key_len;
+            // Use penalty size if recursion limit exceeded to prevent panic.
+            // Incorrect size here is safe because serialize() re-checks limits.
+            // 10MB penalty discourages abuse.
+            const RECURSION_PENALTY_SIZE: usize = 10 * 1024 * 1024;
+
             let val_size = value
                 .serialized_size()
-                .expect("Recursion depth limit exceeded in FromIterator");
+                .unwrap_or(RECURSION_PENALTY_SIZE);
 
             size = size.saturating_add(key_size).saturating_add(val_size);
 
@@ -1823,7 +1828,7 @@ impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
                 size = size.saturating_sub(key_size).saturating_sub(
                     old_val
                         .serialized_size()
-                        .expect("Recursion depth limit exceeded in FromIterator"),
+                        .unwrap_or(RECURSION_PENALTY_SIZE),
                 );
             }
         }
@@ -4130,10 +4135,9 @@ mod sentry_tests {
     /// 🎯 Target: PropertyMap::from_iter
     /// 💣 Risk: Panics when recursion depth limit is exceeded.
     /// 🧪 Strategy: Construct a deeply nested structure and try to create a PropertyMap from it using collect().
-    /// 🔬 Verification: Expect panic with specific message.
+    /// 🔬 Verification: Expect NO panic (Warden fix), but subsequent serialize() should fail.
     #[test]
-    #[should_panic(expected = "Recursion depth limit exceeded in FromIterator")]
-    fn test_property_map_from_iter_panics_on_deep_recursion() {
+    fn test_property_map_from_iter_no_panic_on_deep_recursion() {
         // Construct a deeply nested value: Array(Array(...Array(Int(42))...))
         // Depth: MAX_RECURSION_DEPTH + 1
         let mut value = PropertyValue::Int(42);
@@ -4142,10 +4146,17 @@ mod sentry_tests {
             value = PropertyValue::Array(Arc::new(vec![value]));
         }
 
-        // This should panic because FromIterator uses expect() on serialized_size()
-        let _map: PropertyMap = vec![(GLOBAL_INTERNER.intern("deep").unwrap(), value)]
+        // This should NOT panic (Warden fix)
+        let map: PropertyMap = vec![(GLOBAL_INTERNER.intern("deep").unwrap(), value)]
             .into_iter()
             .collect();
+
+        // But serialization MUST fail because it re-checks depth
+        let result = map.serialize();
+        assert!(result.is_err(), "Serialization should fail due to recursion limit");
+
+        // Verify cached_size includes penalty
+        assert!(map.serialized_size() > 10 * 1024 * 1024);
     }
 
     /// 🎯 Target: PropertyMapBuilder::try_insert

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -406,6 +406,16 @@ impl ConcurrentWal {
     /// need for a temporary buffer copy, reducing both CPU and memory overhead.
     fn serialize_entry(&self, lsn: LSN, operation: &WalOperation) -> Result<Vec<u8>> {
         let estimated_capacity = super::estimate_entry_capacity(operation);
+
+        // Security Check: Enforce maximum entry size to prevent DoS
+        if estimated_capacity > super::entry::MAX_WAL_ENTRY_SIZE {
+            return Err(Error::Storage(StorageError::CapacityExceeded {
+                resource: "WAL entry size".to_string(),
+                current: estimated_capacity,
+                limit: super::entry::MAX_WAL_ENTRY_SIZE,
+            }));
+        }
+
         let mut buffer = Vec::with_capacity(estimated_capacity);
 
         // Generate timestamp

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -7,6 +7,17 @@ use crate::core::{
     temporal::{Timestamp, time},
 };
 
+/// Maximum size of a single WAL entry in bytes (64 MB).
+///
+/// This limit prevents DoS attacks where a malicious user constructs a huge
+/// entry (e.g., 1GB PropertyMap) to exhaust memory in the WAL ring buffer.
+/// Since the ring buffer has fixed slot count (default 1024), unbounded entry
+/// size would allow unbounded memory usage (1024 * 1GB = 1TB).
+///
+/// The limit is set to 64MB to match the default segment size. Entries larger
+/// than this would force immediate segment rotation anyway.
+pub const MAX_WAL_ENTRY_SIZE: usize = 64 * 1024 * 1024;
+
 /// Log Sequence Number - monotonically increasing identifier for WAL entries
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LSN(pub u64);

--- a/tests/warden_wal_dos.rs
+++ b/tests/warden_wal_dos.rs
@@ -1,0 +1,40 @@
+use aletheiadb::core::interning::GLOBAL_INTERNER;
+use aletheiadb::core::property::{PropertyMapBuilder, PropertyValue};
+use aletheiadb::core::temporal::time;
+use aletheiadb::core::id::NodeId;
+use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
+use aletheiadb::storage::wal::WalOperation;
+use tempfile::tempdir;
+
+#[test]
+fn test_wal_entry_size_limit() {
+    let dir = tempdir().unwrap();
+    let config = ConcurrentWalConfig::new(dir.path());
+    let wal = ConcurrentWal::new(config).unwrap();
+
+    // Create a huge property value
+    // MAX_WAL_ENTRY_SIZE is 64MB.
+    // We create a value slightly larger than that.
+    let size = 65 * 1024 * 1024; // 65 MB
+    let huge_bytes = vec![0u8; size];
+    let huge_prop = PropertyValue::bytes(huge_bytes);
+
+    let properties = PropertyMapBuilder::new()
+        .insert("huge", huge_prop)
+        .build();
+
+    let op = WalOperation::CreateNode {
+        node_id: NodeId::new(1).unwrap(),
+        label: GLOBAL_INTERNER.intern("DoS").unwrap(),
+        properties,
+        valid_from: time::now(),
+    };
+
+    // Attempt to append
+    let result = wal.append_async(op);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("Capacity exceeded for WAL entry size"));
+    assert!(err.contains("DoS protection"));
+}

--- a/tests/warden_wal_dos.rs
+++ b/tests/warden_wal_dos.rs
@@ -1,9 +1,9 @@
+use aletheiadb::core::id::NodeId;
 use aletheiadb::core::interning::GLOBAL_INTERNER;
 use aletheiadb::core::property::{PropertyMapBuilder, PropertyValue};
 use aletheiadb::core::temporal::time;
-use aletheiadb::core::id::NodeId;
-use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
 use aletheiadb::storage::wal::WalOperation;
+use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
 use tempfile::tempdir;
 
 #[test]
@@ -19,9 +19,7 @@ fn test_wal_entry_size_limit() {
     let huge_bytes = vec![0u8; size];
     let huge_prop = PropertyValue::bytes(huge_bytes);
 
-    let properties = PropertyMapBuilder::new()
-        .insert("huge", huge_prop)
-        .build();
+    let properties = PropertyMapBuilder::new().insert("huge", huge_prop).build();
 
     let op = WalOperation::CreateNode {
         node_id: NodeId::new(1).unwrap(),


### PR DESCRIPTION
**Threats Mitigated:**
1.  **DoS via Massive WAL Entry:** A malicious user could construct a huge entry (e.g., 1GB `PropertyMap`), filling the `WalRingBuffer` (1024 slots) and consuming massive amounts of RAM (1TB+), leading to OOM crash.
2.  **Panic in `PropertyMap::from_iter`:** `PropertyMap::from_iter` used `expect()` when calculating serialized size. If a deeply nested `PropertyValue` (exceeding `MAX_RECURSION_DEPTH`) was passed, the process panicked (crashed).

**Defenses:**
1.  **WAL Entry Size Limit:** Introduced `MAX_WAL_ENTRY_SIZE` (64MB) in `src/storage/wal/entry.rs` and enforced it in `ConcurrentWal::serialize_entry`. Entries exceeding this limit are now rejected with `StorageError::CapacityExceeded`.
2.  **Robust PropertyMap Construction:** Replaced `expect()` in `PropertyMap::from_iter` with `unwrap_or(RECURSION_PENALTY_SIZE)` (10MB). This prevents the panic. Invalid deeply nested structures will still fail safely during `serialize()` (returning `Result::Err`) due to recursion checks, but the application will not crash.

**Verification:**
-   Added `tests/warden_wal_dos.rs` to verify that appending an entry > 64MB returns the correct error.
-   Updated `test_property_map_from_iter_no_panic_on_deep_recursion` in `src/core/property.rs` to verify that deep recursion no longer panics but fails serialization later.
-   Ran all tests including existing regression tests.

---
*PR created automatically by Jules for task [5021199971706152373](https://jules.google.com/task/5021199971706152373) started by @madmax983*