### PR TITLE
test: kill 6 surviving mutants in src/core/history.rs

### DIFF
--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -432,6 +432,98 @@ mod tests {
         assert_eq!(summary.change_count(), 6); // 2 + 1 + 3
     }
 
+    #[test]
+    fn test_version_diff_has_changes_added_only() {
+        let from_props = PropertyMapBuilder::new().build();
+        let to_props = PropertyMapBuilder::new().insert("name", "Alice").build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            test_version_id(10),
+            test_version_id(11),
+        );
+
+        assert_eq!(diff.added.len(), 1);
+        assert!(diff.removed.is_empty());
+        assert!(diff.modified.is_empty());
+        assert!(diff.has_changes());
+    }
+
+    #[test]
+    fn test_version_diff_has_changes_removed_only() {
+        let from_props = PropertyMapBuilder::new().insert("status", "active").build();
+        let to_props = PropertyMapBuilder::new().build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            test_version_id(12),
+            test_version_id(13),
+        );
+
+        assert!(diff.added.is_empty());
+        assert_eq!(diff.removed.len(), 1);
+        assert!(diff.modified.is_empty());
+        assert!(diff.has_changes());
+    }
+
+    #[test]
+    fn test_version_diff_change_count_sums_all_categories() {
+        let from_props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .insert("status", "active")
+            .build();
+        let to_props = PropertyMapBuilder::new()
+            .insert("name", "Bob")
+            .insert("city", "NYC")
+            .build();
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            test_version_id(14),
+            test_version_id(15),
+        );
+
+        assert_eq!(diff.added.len(), 1);
+        assert_eq!(diff.removed.len(), 2);
+        assert_eq!(diff.modified.len(), 1);
+        assert_eq!(diff.change_count(), 4);
+    }
+
+    #[test]
+    fn test_version_summary_has_changes_removed_only() {
+        let summary = VersionSummary {
+            version_id: test_version_id(3),
+            version_number: 3,
+            valid_from: test_timestamp(3000),
+            transaction_time: test_timestamp(4000),
+            properties_added: 0,
+            properties_removed: 1,
+            properties_modified: 0,
+        };
+
+        assert!(summary.has_changes());
+        assert_eq!(summary.change_count(), 1);
+    }
+
+    #[test]
+    fn test_version_summary_has_changes_modified_only() {
+        let summary = VersionSummary {
+            version_id: test_version_id(4),
+            version_number: 4,
+            valid_from: test_timestamp(4000),
+            transaction_time: test_timestamp(5000),
+            properties_added: 0,
+            properties_removed: 0,
+            properties_modified: 1,
+        };
+
+        assert!(summary.has_changes());
+        assert_eq!(summary.change_count(), 1);
+    }
     // ==================== Helper Functions ====================
 
     fn create_test_version_info(version_num: u64, wallclock: i64) -> VersionInfo {


### PR DESCRIPTION
Mutation-kill pass for `src/core/history.rs`.

## Baseline
- File: `src/core/history.rs`
- Initial survivor set: 6 missed mutants in `VersionDiff`/`VersionSummary`
- Total mutants under file scope: 44 (inferred from `6` active + `38` previously caught/unviable during iterate)

## Survivors Addressed
- `src/core/history.rs:132` `VersionDiff::has_changes` (`||` -> `&&`)
- `src/core/history.rs:138` `VersionDiff::change_count` (`+` -> `-`, `+` -> `*`)
- `src/core/history.rs:165` `VersionSummary::has_changes` (`||` -> `&&`, `>` -> `<` variants)

## Tests Added
- `test_version_diff_has_changes_added_only`
- `test_version_diff_has_changes_removed_only`
- `test_version_diff_change_count_sums_all_categories`
- `test_version_summary_has_changes_removed_only`
- `test_version_summary_has_changes_modified_only`

## Verification
- `cargo test --offline --lib core::history -- --test-threads=2` ?
- `cargo mutants -f src/core/history.rs --iterate -- --lib core::history -- --test-threads=2` ? (`6 caught`)
- Re-run iterate: `Found 0 mutants to test` ?
- `cargo test --offline -- --test-threads=2` ?

## Before / After Mutation Score (file scope)
- Before: `38/44` caught or unviable (86.36%), `6/44` missed
- After: `44/44` caught or unviable (100%), `0/44` missed

## Commit
- `456a376d5` `test: kill 6 surviving mutants in src/core/history.rs`
