### PR TITLE
🛡️ Sentry: Add recursion limit tests to AQL parser

### DIFF
--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2091,15 +2091,11 @@ mod sentry_tests {
         // 🧪 Strategy: Verify that exactly MAX_RECURSION_DEPTH is allowed
 
         let depth = MAX_RECURSION_DEPTH;
-        let mut query = "MATCH (n) WHERE ".to_string();
-        for _ in 0..depth {
-            query.push('(');
-        }
-        query.push_str("n.age > 10");
-        for _ in 0..depth {
-            query.push(')');
-        }
-        query.push_str(" RETURN n");
+        let query = format!(
+            "MATCH (n) WHERE {}(n.age > 10){} RETURN n",
+            "(".repeat(depth),
+            ")".repeat(depth)
+        );
 
         let result = Parser::parse(&query);
         assert!(result.is_ok(), "Should accept recursion up to the limit");

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2049,15 +2049,11 @@ mod sentry_tests {
         // 🧪 Strategy: Construct a query exceeding MAX_RECURSION_DEPTH
 
         let depth = MAX_RECURSION_DEPTH + 1;
-        let mut query = "MATCH (n) WHERE ".to_string();
-        for _ in 0..depth {
-            query.push('(');
-        }
-        query.push_str("n.age > 10");
-        for _ in 0..depth {
-            query.push(')');
-        }
-        query.push_str(" RETURN n");
+        let query = format!(
+            "MATCH (n) WHERE {}(n.age > 10){} RETURN n",
+            "(".repeat(depth),
+            ")".repeat(depth)
+        );
 
         let result = Parser::parse(&query);
         assert!(result.is_err());

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2071,11 +2071,10 @@ mod sentry_tests {
         // 💣 Risk: Stack overflow from deeply nested NOT operators
 
         let depth = MAX_RECURSION_DEPTH + 1;
-        let mut query = "MATCH (n) WHERE ".to_string();
-        for _ in 0..depth {
-            query.push_str("NOT ");
-        }
-        query.push_str("n.active = true RETURN n");
+        let query = format!(
+            "MATCH (n) WHERE {}n.active = true RETURN n",
+            "NOT ".repeat(depth)
+        );
 
         let result = Parser::parse(&query);
         assert!(result.is_err());

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2037,3 +2037,76 @@ mod tests {
         // This implicitly tests From<LexerError> for ParseError
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+
+    #[test]
+    fn test_parser_recursion_limit_nested_parens() {
+        // 🎯 Target: Parser recursion depth limit (DoS protection)
+        // 💣 Risk: Stack overflow from deeply nested queries
+        // 🧪 Strategy: Construct a query exceeding MAX_RECURSION_DEPTH
+
+        let depth = MAX_RECURSION_DEPTH + 1;
+        let mut query = "MATCH (n) WHERE ".to_string();
+        for _ in 0..depth {
+            query.push('(');
+        }
+        query.push_str("n.age > 10");
+        for _ in 0..depth {
+            query.push(')');
+        }
+        query.push_str(" RETURN n");
+
+        let result = Parser::parse(&query);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("Recursion limit exceeded"),
+            "Expected recursion limit error, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_parser_recursion_limit_nested_not() {
+        // 🎯 Target: Parser recursion depth limit for unary operators
+        // 💣 Risk: Stack overflow from deeply nested NOT operators
+
+        let depth = MAX_RECURSION_DEPTH + 1;
+        let mut query = "MATCH (n) WHERE ".to_string();
+        for _ in 0..depth {
+            query.push_str("NOT ");
+        }
+        query.push_str("n.active = true RETURN n");
+
+        let result = Parser::parse(&query);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("Recursion limit exceeded"),
+            "Expected recursion limit error, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_parser_recursion_limit_boundary() {
+        // 🧪 Strategy: Verify that exactly MAX_RECURSION_DEPTH is allowed
+
+        let depth = MAX_RECURSION_DEPTH;
+        let mut query = "MATCH (n) WHERE ".to_string();
+        for _ in 0..depth {
+            query.push('(');
+        }
+        query.push_str("n.age > 10");
+        for _ in 0..depth {
+            query.push(')');
+        }
+        query.push_str(" RETURN n");
+
+        let result = Parser::parse(&query);
+        assert!(result.is_ok(), "Should accept recursion up to the limit");
+    }
+}


### PR DESCRIPTION
**🎯 Target:** `src/query/parser.rs` - `Parser::parse` recursion depth limit.
**💣 Risk:** Stack overflow DoS from deeply nested queries.
**🧪 Strategy:** Added `sentry_tests` module with unit tests constructing queries with depth `MAX_RECURSION_DEPTH + 1` (expect error) and `MAX_RECURSION_DEPTH` (expect success).
**🔬 Verification:** `cargo test query::parser::sentry_tests` passes.

---
*PR created automatically by Jules for task [13188470103439999121](https://jules.google.com/task/13188470103439999121) started by @madmax983*