### PR TITLE
Fix race condition in WAL flush coordinator segment rotation

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -216,6 +216,8 @@ pub struct FlushCoordinator {
     current_segment_max_lsn: AtomicU64,
     /// Entry count in the current segment.
     current_segment_entry_count: AtomicU64,
+    /// Lock for serializing flush operations.
+    flush_lock: Mutex<()>,
 }
 
 impl FlushCoordinator {
@@ -241,6 +243,7 @@ impl FlushCoordinator {
             current_segment_min_lsn: AtomicU64::new(u64::MAX),
             current_segment_max_lsn: AtomicU64::new(0),
             current_segment_entry_count: AtomicU64::new(0),
+            flush_lock: Mutex::new(()),
         };
 
         // Find the latest segment ID
@@ -596,6 +599,12 @@ impl FlushCoordinator {
         if entries.is_empty() {
             return Ok(FlushStats::default());
         }
+
+        // Acquire flush lock to serialize operations
+        // This prevents race conditions during segment rotation where metadata
+        // tracking could be reset while another thread is writing to the new segment.
+        // See tests/havoc_flush_race.rs for reproduction.
+        let _flush_guard = self.flush_lock.lock().unwrap_or_else(|e| e.into_inner());
 
         let start = Instant::now();
 

--- a/tests/havoc_flush_race.rs
+++ b/tests/havoc_flush_race.rs
@@ -1,6 +1,6 @@
+use aletheiadb::storage::wal::LSN;
 use aletheiadb::storage::wal::flush_coordinator::{FlushCoordinator, FlushCoordinatorConfig};
 use aletheiadb::storage::wal::ring_buffer::PendingEntry;
-use aletheiadb::storage::wal::LSN;
 use std::sync::Arc;
 use std::thread;
 
@@ -83,15 +83,25 @@ fn test_flush_race_condition() {
         );
 
         if meta.min_lsn.0 > actual_min {
-            println!("VIOLATION: Meta min {} > Actual min {}", meta.min_lsn.0, actual_min);
+            println!(
+                "VIOLATION: Meta min {} > Actual min {}",
+                meta.min_lsn.0, actual_min
+            );
             violations += 1;
         }
 
         if meta.max_lsn.0 < actual_max {
-             println!("VIOLATION: Meta max {} < Actual max {}", meta.max_lsn.0, actual_max);
-             violations += 1;
+            println!(
+                "VIOLATION: Meta max {} < Actual max {}",
+                meta.max_lsn.0, actual_max
+            );
+            violations += 1;
         }
     }
 
-    assert_eq!(violations, 0, "Found {} metadata consistency violations due to race condition", violations);
+    assert_eq!(
+        violations, 0,
+        "Found {} metadata consistency violations due to race condition",
+        violations
+    );
 }

--- a/tests/havoc_flush_race.rs
+++ b/tests/havoc_flush_race.rs
@@ -1,0 +1,97 @@
+use aletheiadb::storage::wal::flush_coordinator::{FlushCoordinator, FlushCoordinatorConfig};
+use aletheiadb::storage::wal::ring_buffer::PendingEntry;
+use aletheiadb::storage::wal::LSN;
+use std::sync::Arc;
+use std::thread;
+
+fn create_entry(lsn: u64) -> PendingEntry {
+    // 8 bytes payload containing LSN
+    PendingEntry::new_async(LSN(lsn), lsn.to_le_bytes().to_vec())
+}
+
+#[test]
+fn test_flush_race_condition() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = FlushCoordinatorConfig::new(dir.path());
+    // Set segment size small to force frequent rotations
+    // Header (5) + 2 entries (16) = 21 bytes.
+    // If we set limit to 20, it should rotate every 2 entries roughly.
+    config.segment_size = 20;
+    config.segments_to_retain = 1000; // Keep everything
+
+    let coordinator = Arc::new(FlushCoordinator::new(config).unwrap());
+
+    let num_threads = 4;
+    let entries_per_thread = 100;
+
+    let mut handles = Vec::new();
+
+    for t in 0..num_threads {
+        let coordinator = Arc::clone(&coordinator);
+        handles.push(thread::spawn(move || {
+            for i in 0..entries_per_thread {
+                let lsn = (t * entries_per_thread + i) as u64;
+                let entry = create_entry(lsn);
+                // We ignore errors here as we are stress testing
+                let _ = coordinator.flush(vec![entry], false);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Now verify consistency
+    let mut violations = 0;
+
+    // Iterate over all segment files
+    let segments = coordinator.list_segments_with_metadata();
+
+    // Also check for segments that might be missing metadata (though list_segments_with_metadata filters them)
+    // We want to be sure we check everything.
+    // But let's trust list_segments_with_metadata for now as it gives us the metadata to check against.
+
+    for (id, meta) in segments {
+        let path = dir.path().join(format!("{:06}.log", id));
+        let content = std::fs::read(&path).unwrap();
+
+        // Skip header
+        if content.len() < 5 {
+            continue;
+        }
+        let data = &content[5..];
+
+        let mut actual_min = u64::MAX;
+        let mut actual_max = 0;
+        let mut count = 0;
+
+        for chunk in data.chunks_exact(8) {
+            let lsn = u64::from_le_bytes(chunk.try_into().unwrap());
+            actual_min = actual_min.min(lsn);
+            actual_max = actual_max.max(lsn);
+            count += 1;
+        }
+
+        if count == 0 {
+            continue;
+        }
+
+        println!(
+            "Segment {}: Meta[{}, {}] Actual[{}, {}]",
+            id, meta.min_lsn.0, meta.max_lsn.0, actual_min, actual_max
+        );
+
+        if meta.min_lsn.0 > actual_min {
+            println!("VIOLATION: Meta min {} > Actual min {}", meta.min_lsn.0, actual_min);
+            violations += 1;
+        }
+
+        if meta.max_lsn.0 < actual_max {
+             println!("VIOLATION: Meta max {} < Actual max {}", meta.max_lsn.0, actual_max);
+             violations += 1;
+        }
+    }
+
+    assert_eq!(violations, 0, "Found {} metadata consistency violations due to race condition", violations);
+}


### PR DESCRIPTION
Fixes a race condition in `FlushCoordinator` where concurrent flush operations could cause metadata corruption during segment rotation. 

Prior to this fix, if one thread triggered a segment rotation (resetting `min_lsn` to `MAX`) while another thread was writing to the new segment, the metadata could incorrectly report `min_lsn` as `MAX`, hiding actual entries from truncation and recovery logic.

The fix introduces a `flush_lock` mutex to ensure `flush` operations are serialized, making segment rotation and writing atomic with respect to each other.

Also adds `tests/havoc_flush_race.rs`, a stress test that reproduces the issue and verifies the fix.

---
*PR created automatically by Jules for task [735316802183520121](https://jules.google.com/task/735316802183520121) started by @madmax983*