### PR TITLE
Fix race condition in WAL flush coordinator during segment rotation

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -316,9 +316,7 @@ impl FlushCoordinator {
     }
 
     /// Open or create the current segment file.
-    fn ensure_segment_open(&self) -> Result<()> {
-        let mut writer_guard = self.writer.lock().unwrap_or_else(|e| e.into_inner());
-
+    fn ensure_segment_open(&self, writer_guard: &mut Option<BufWriter<File>>) -> Result<()> {
         if writer_guard.is_some() {
             return Ok(());
         }
@@ -379,31 +377,28 @@ impl FlushCoordinator {
 
     /// Rotate to a new segment if current exceeds size limit.
     ///
-    /// # Safety Invariant
+    /// # Thread Safety
     ///
-    /// This method assumes single-threaded access from the flush coordinator.
-    /// Multiple threads should not call `flush()` concurrently, which is the
-    /// only caller of this method. The FlushCoordinator is designed for use
-    /// with a single background flush thread.
-    fn maybe_rotate_segment(&self) -> Result<bool> {
+    /// This method is called while holding the `writer` lock from `flush()`.
+    /// This ensures that segment rotation is atomic with respect to other
+    /// flush operations.
+    fn maybe_rotate_segment(&self, writer_guard: &mut Option<BufWriter<File>>) -> Result<bool> {
         let current_size = self.current_segment_size.load(Ordering::Relaxed);
 
         if current_size >= self.config.segment_size as u64 {
             let closing_segment_id = self.current_segment_id.load(Ordering::Relaxed);
 
-            // Flush and sync current segment
-            {
-                let mut writer_guard = self.writer.lock().unwrap_or_else(|e| e.into_inner());
-                if let Some(ref mut writer) = *writer_guard {
-                    writer.flush().map_err(|e| {
-                        Error::Storage(StorageError::IoError(format!(
-                            "Failed to flush WAL segment: {}",
-                            e
-                        )))
-                    })?;
-                }
-                *writer_guard = None;
+            // Flush current segment
+            if let Some(writer) = writer_guard {
+                writer.flush().map_err(|e| {
+                    Error::Storage(StorageError::IoError(format!(
+                        "Failed to flush WAL segment: {}",
+                        e
+                    )))
+                })?;
             }
+            // Close writer (drops BufWriter)
+            *writer_guard = None;
 
             // Sync before closing
             if self.config.sync_on_flush {
@@ -602,8 +597,11 @@ impl FlushCoordinator {
         // Inner function to perform I/O operations.
         // This allows us to catch errors and notify pending entries before returning.
         let do_flush = || -> Result<FlushStats> {
+            // Acquire lock once for the entire operation to ensure thread safety
+            let mut writer_guard = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+
             // Ensure segment is open
-            self.ensure_segment_open()?;
+            self.ensure_segment_open(&mut writer_guard)?;
 
             let mut bytes_written = 0usize;
 
@@ -613,7 +611,6 @@ impl FlushCoordinator {
 
             // Write all entries
             {
-                let mut writer_guard = self.writer.lock().unwrap_or_else(|e| e.into_inner());
                 let writer = writer_guard.as_mut().ok_or_else(|| {
                     Error::Storage(StorageError::WalError {
                         reason: "WAL writer not initialized".to_string(),
@@ -667,7 +664,7 @@ impl FlushCoordinator {
                 .fetch_add(bytes_written as u64, Ordering::Relaxed);
 
             // Check for rotation
-            let segment_rotated = self.maybe_rotate_segment()?;
+            let segment_rotated = self.maybe_rotate_segment(&mut writer_guard)?;
 
             // Update metrics
             self.total_entries_flushed
@@ -1416,7 +1413,12 @@ mod tests {
         let coordinator = FlushCoordinator::new(config).unwrap();
 
         // 2. Open segment to get sync handle
-        coordinator.ensure_segment_open().unwrap();
+        {
+            let mut writer_guard = coordinator.writer.lock().unwrap();
+            coordinator
+                .ensure_segment_open(&mut writer_guard)
+                .unwrap();
+        }
 
         // 3. Replace sync_handle with a File opening /dev/null
         // fsync on /dev/null returns EINVAL on Linux, which causes sync_data to fail.

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -1415,9 +1415,7 @@ mod tests {
         // 2. Open segment to get sync handle
         {
             let mut writer_guard = coordinator.writer.lock().unwrap();
-            coordinator
-                .ensure_segment_open(&mut writer_guard)
-                .unwrap();
+            coordinator.ensure_segment_open(&mut writer_guard).unwrap();
         }
 
         // 3. Replace sync_handle with a File opening /dev/null

--- a/tests/havoc_flush_race.rs
+++ b/tests/havoc_flush_race.rs
@@ -1,0 +1,146 @@
+use aletheiadb::storage::wal::entry::LSN;
+use aletheiadb::storage::wal::flush_coordinator::{
+    FlushCoordinator, FlushCoordinatorConfig, SegmentMetadata,
+};
+use aletheiadb::storage::wal::ring_buffer::PendingEntry;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use tempfile::tempdir;
+
+#[test]
+fn test_flush_coordinator_race_condition() {
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path().to_path_buf();
+
+    // Set segment size small enough to trigger rotation frequently
+    // Header is 5 bytes. Data is 8 bytes per entry.
+    // Segment size 100 bytes => ~12 entries per segment.
+    let mut config = FlushCoordinatorConfig::new(dir_path.clone());
+    config.segment_size = 100;
+    // We don't care about sync for this test, just the rotation logic
+    config.sync_on_flush = false;
+
+    let coordinator = Arc::new(FlushCoordinator::new(config).unwrap());
+
+    // Use multiple threads to create contention on segment rotation
+    let num_threads = 50;
+    let entries_per_thread = 100;
+
+    for _ in 0..10 {
+        let barrier = Arc::new(Barrier::new(num_threads));
+        let mut handles = Vec::new();
+
+        for t in 0..num_threads {
+            let coordinator = Arc::clone(&coordinator);
+            let barrier = Arc::clone(&barrier);
+
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                for i in 0..entries_per_thread {
+                    // LSN is unique across threads to allow checking later
+                    // We use a large multiplier to avoid collisions between iterations
+                    let lsn = (t * entries_per_thread + i) as u64 + (coordinator.total_flushes() * 1000);
+                    // Store LSN in data for verification (little endian)
+                    let data = lsn.to_le_bytes().to_vec();
+                    let entry = PendingEntry::new_async(LSN(lsn), data);
+
+                    // Flush individually to increase contention on rotation check
+                    // We ignore errors here as we are testing for data consistency, not I/O errors
+                    let _ = coordinator.flush(vec![entry], false);
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    // Verify consistency
+    // Read all segments and check if metadata matches content
+    let mut segments = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir_path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "log") {
+                if let Some(id) = path
+                    .file_stem()
+                    .and_then(|s| s.to_string_lossy().parse::<u64>().ok())
+                {
+                    segments.push((id, path));
+                }
+            }
+        }
+    }
+    segments.sort_by_key(|(id, _)| *id);
+
+    println!("Found {} segments", segments.len());
+    let mut failures = 0;
+
+    for (id, path) in segments {
+        // Read content
+        let content = match std::fs::read(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Failed to read segment {}: {}", id, e);
+                continue;
+            }
+        };
+
+        // Skip header (5 bytes: 4 magic + 1 version)
+        if content.len() < 5 {
+            continue;
+        }
+        let data_slice = &content[5..];
+
+        // Parse entries (fixed 8 bytes because we wrote u64 LSNs)
+        let mut actual_min = u64::MAX;
+        let mut actual_max = 0;
+        let mut count = 0;
+
+        for chunk in data_slice.chunks_exact(8) {
+            let lsn = u64::from_le_bytes(chunk.try_into().unwrap());
+            actual_min = actual_min.min(lsn);
+            actual_max = actual_max.max(lsn);
+            count += 1;
+        }
+
+        if count == 0 {
+            continue;
+        }
+
+        // Read metadata
+        let metadata = match coordinator.read_segment_metadata(id) {
+            Some(m) => m,
+            None => {
+                // Metadata file might be missing if rotation didn't happen gracefully or test ended
+                // But for intermediate segments it should exist.
+                // Let's just log and continue if missing, but it's suspicious.
+                println!("Missing metadata for segment {}", id);
+                continue;
+            }
+        };
+
+        println!(
+            "Segment {}: Content LSN range [{}-{}], Metadata LSN range [{}-{}]",
+            id, actual_min, actual_max, metadata.min_lsn.0, metadata.max_lsn.0
+        );
+
+        if metadata.min_lsn.0 > actual_min {
+            println!(
+                "FAILURE: Segment {} metadata min LSN {} > actual min LSN {}",
+                id, metadata.min_lsn.0, actual_min
+            );
+            failures += 1;
+        }
+        if metadata.max_lsn.0 < actual_max {
+            println!(
+                "FAILURE: Segment {} metadata max LSN {} < actual max LSN {}",
+                id, metadata.max_lsn.0, actual_max
+            );
+            failures += 1;
+        }
+    }
+
+    assert_eq!(failures, 0, "Found {} segments with inconsistent metadata", failures);
+}

--- a/tests/havoc_flush_race.rs
+++ b/tests/havoc_flush_race.rs
@@ -39,7 +39,8 @@ fn test_flush_coordinator_race_condition() {
                 for i in 0..entries_per_thread {
                     // LSN is unique across threads to allow checking later
                     // We use a large multiplier to avoid collisions between iterations
-                    let lsn = (t * entries_per_thread + i) as u64 + (coordinator.total_flushes() * 1000);
+                    let lsn =
+                        (t * entries_per_thread + i) as u64 + (coordinator.total_flushes() * 1000);
                     // Store LSN in data for verification (little endian)
                     let data = lsn.to_le_bytes().to_vec();
                     let entry = PendingEntry::new_async(LSN(lsn), data);
@@ -142,5 +143,9 @@ fn test_flush_coordinator_race_condition() {
         }
     }
 
-    assert_eq!(failures, 0, "Found {} segments with inconsistent metadata", failures);
+    assert_eq!(
+        failures, 0,
+        "Found {} segments with inconsistent metadata",
+        failures
+    );
 }

--- a/tests/havoc_flush_race.rs
+++ b/tests/havoc_flush_race.rs
@@ -1,8 +1,7 @@
 use aletheiadb::storage::wal::entry::LSN;
-use aletheiadb::storage::wal::flush_coordinator::{
-    FlushCoordinator, FlushCoordinatorConfig, SegmentMetadata,
-};
+use aletheiadb::storage::wal::flush_coordinator::{FlushCoordinator, FlushCoordinatorConfig};
 use aletheiadb::storage::wal::ring_buffer::PendingEntry;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use tempfile::tempdir;
@@ -25,22 +24,22 @@ fn test_flush_coordinator_race_condition() {
     // Use multiple threads to create contention on segment rotation
     let num_threads = 50;
     let entries_per_thread = 100;
+    let lsn_counter = Arc::new(AtomicU64::new(0));
 
     for _ in 0..10 {
         let barrier = Arc::new(Barrier::new(num_threads));
         let mut handles = Vec::new();
 
-        for t in 0..num_threads {
+        for _ in 0..num_threads {
             let coordinator = Arc::clone(&coordinator);
             let barrier = Arc::clone(&barrier);
+            let lsn_counter = Arc::clone(&lsn_counter);
 
             handles.push(thread::spawn(move || {
                 barrier.wait();
-                for i in 0..entries_per_thread {
+                for _ in 0..entries_per_thread {
                     // LSN is unique across threads to allow checking later
-                    // We use a large multiplier to avoid collisions between iterations
-                    let lsn =
-                        (t * entries_per_thread + i) as u64 + (coordinator.total_flushes() * 1000);
+                    let lsn = lsn_counter.fetch_add(1, Ordering::Relaxed);
                     // Store LSN in data for verification (little endian)
                     let data = lsn.to_le_bytes().to_vec();
                     let entry = PendingEntry::new_async(LSN(lsn), data);
@@ -63,13 +62,12 @@ fn test_flush_coordinator_race_condition() {
     if let Ok(entries) = std::fs::read_dir(&dir_path) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "log") {
-                if let Some(id) = path
+            if path.extension().is_some_and(|ext| ext == "log")
+                && let Some(id) = path
                     .file_stem()
                     .and_then(|s| s.to_string_lossy().parse::<u64>().ok())
-                {
-                    segments.push((id, path));
-                }
+            {
+                segments.push((id, path));
             }
         }
     }


### PR DESCRIPTION
This PR fixes a race condition in the `FlushCoordinator` where concurrent calls to `flush` could lead to inconsistent segment metadata (specifically `min_lsn` being reset to `u64::MAX` after a new entry was written).

The race occurred because `maybe_rotate_segment` was called after releasing the writer lock in `flush`. A concurrent thread could then write to the new segment and update `min_lsn`, only for `maybe_rotate_segment` to subsequently reset it.

The fix involves holding the `writer` mutex for the entire duration of the `flush` operation, ensuring that writing and rotation are atomic.

A new regression test `tests/havoc_flush_race.rs` is added, which reproduces the issue by spawning multiple threads that flush concurrently with a small segment size.

---
*PR created automatically by Jules for task [8945728892727440380](https://jules.google.com/task/8945728892727440380) started by @madmax983*