### PR TITLE
Refactor sparse squared Euclidean distance for numerical stability

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -17,3 +17,7 @@
 ## [Pre-existing Failure in Parser Recursion Test]
 **Learning:** Found a failing test `query::parser::sentry_tests::test_parser_recursion_limit_boundary` while verifying HNSW changes. It seems to fail consistently on the boundary condition (100 nested parens). This indicates an off-by-one error in recursion depth check or test expectation.
 **Action:** Logged for future investigation; proceeded with HNSW coverage improvements as they are isolated.
+
+## [Catastrophic Cancellation in Euclidean Distance]
+**Learning:** The formula `||a||^2 + ||b||^2 - 2<a,b>` for squared Euclidean distance is numerically unstable for vectors that are very close to each other, leading to negative results due to floating-point errors. This causes `sqrt()` to return `NaN`.
+**Action:** Replaced with the stable single-pass algorithm `sum((a_i - b_i)^2)` in `sparse_squared_euclidean_distance`. This is both numerically robust and faster (1 pass vs 3). Added deterministic regression test with seed 34.

--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -98,6 +98,9 @@ mod sentry_tests;
 mod sentry_sparse_consistency_tests;
 
 #[cfg(test)]
+mod sentry_sparse_tests;
+
+#[cfg(test)]
 mod tests;
 
 pub use constants::*;

--- a/src/core/vector/sentry_sparse_tests.rs
+++ b/src/core/vector/sentry_sparse_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+use crate::utils::error::{Error, VectorError};
+
+#[test]
+fn test_negative_distance_regression() {
+    // 🛡️ Sentry Regression Test: Seed 34 triggered negative distance with unstable formula.
+    // This test ensures the stable formula (sum of squared differences) is used.
+
+    let seed = 34;
+    let size = 1000;
+    let indices: Vec<u32> = (0..size).map(|i| i as u32).collect();
+    // Deterministic generation that caused the issue
+    let values: Vec<f32> = (0..size).map(|i| {
+        let mut x = (i as f32 * (seed as f32 + 1.0));
+        x = x % 1000.0 + 0.1;
+        x
+    }).collect();
+
+    let vec = SparseVec::new(indices, values, size as u32).unwrap();
+    let dist = sparse_squared_euclidean_distance(&vec, &vec).unwrap();
+
+    // Should be exactly 0.0 for identical vectors, but definitely non-negative
+    assert!(dist >= 0.0, "Distance should be non-negative, got {:.20}", dist);
+
+    // Ideally it should be very close to 0.0
+    assert!(dist < 1e-6, "Self distance should be close to 0, got {:.20}", dist);
+}
+
+#[test]
+fn test_sparse_euclidean_distance_nan_regression() {
+    // 🛡️ Sentry: Ensure sparse_euclidean_distance handles close vectors without returning NaN
+    // If squared distance is negative, sqrt() returns NaN.
+
+    let seed = 34;
+    let size = 1000;
+    let indices: Vec<u32> = (0..size).map(|i| i as u32).collect();
+    let values: Vec<f32> = (0..size).map(|i| {
+        let mut x = (i as f32 * (seed as f32 + 1.0));
+        x = x % 1000.0 + 0.1;
+        x
+    }).collect();
+
+    let vec = SparseVec::new(indices, values, size as u32).unwrap();
+    let dist = sparse_euclidean_distance(&vec, &vec).unwrap();
+
+    assert!(!dist.is_nan(), "Euclidean distance should not be NaN");
+    assert!(dist >= 0.0);
+}
+
+#[test]
+fn test_sparse_squared_euclidean_distance_correctness() {
+    // Verify correctness against manual calculation for a simple case
+    let a = SparseVec::new(vec![0, 2], vec![1.0, 3.0], 5).unwrap();
+    let b = SparseVec::new(vec![0, 3], vec![2.0, 4.0], 5).unwrap();
+
+    // a = [1, 0, 3, 0, 0]
+    // b = [2, 0, 0, 4, 0]
+    // diff = [-1, 0, 3, -4, 0]
+    // sq_diff = [1, 0, 9, 16, 0]
+    // sum = 1 + 9 + 16 = 26
+
+    let dist = sparse_squared_euclidean_distance(&a, &b).unwrap();
+    assert!((dist - 26.0).abs() < 1e-6, "Expected 26.0, got {}", dist);
+}

--- a/src/core/vector/sentry_sparse_tests.rs
+++ b/src/core/vector/sentry_sparse_tests.rs
@@ -10,20 +10,30 @@ fn test_negative_distance_regression() {
     let size = 1000;
     let indices: Vec<u32> = (0..size).map(|i| i as u32).collect();
     // Deterministic generation that caused the issue
-    let values: Vec<f32> = (0..size).map(|i| {
-        let mut x = (i as f32 * (seed as f32 + 1.0));
-        x = x % 1000.0 + 0.1;
-        x
-    }).collect();
+    let values: Vec<f32> = (0..size)
+        .map(|i| {
+            let mut x = (i as f32 * (seed as f32 + 1.0));
+            x = x % 1000.0 + 0.1;
+            x
+        })
+        .collect();
 
     let vec = SparseVec::new(indices, values, size as u32).unwrap();
     let dist = sparse_squared_euclidean_distance(&vec, &vec).unwrap();
 
     // Should be exactly 0.0 for identical vectors, but definitely non-negative
-    assert!(dist >= 0.0, "Distance should be non-negative, got {:.20}", dist);
+    assert!(
+        dist >= 0.0,
+        "Distance should be non-negative, got {:.20}",
+        dist
+    );
 
     // Ideally it should be very close to 0.0
-    assert!(dist < 1e-6, "Self distance should be close to 0, got {:.20}", dist);
+    assert!(
+        dist < 1e-6,
+        "Self distance should be close to 0, got {:.20}",
+        dist
+    );
 }
 
 #[test]
@@ -34,11 +44,13 @@ fn test_sparse_euclidean_distance_nan_regression() {
     let seed = 34;
     let size = 1000;
     let indices: Vec<u32> = (0..size).map(|i| i as u32).collect();
-    let values: Vec<f32> = (0..size).map(|i| {
-        let mut x = (i as f32 * (seed as f32 + 1.0));
-        x = x % 1000.0 + 0.1;
-        x
-    }).collect();
+    let values: Vec<f32> = (0..size)
+        .map(|i| {
+            let mut x = (i as f32 * (seed as f32 + 1.0));
+            x = x % 1000.0 + 0.1;
+            x
+        })
+        .collect();
 
     let vec = SparseVec::new(indices, values, size as u32).unwrap();
     let dist = sparse_euclidean_distance(&vec, &vec).unwrap();

--- a/src/core/vector/sentry_sparse_tests.rs
+++ b/src/core/vector/sentry_sparse_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::utils::error::{Error, VectorError};
 
 #[test]
 fn test_negative_distance_regression() {
@@ -12,7 +11,7 @@ fn test_negative_distance_regression() {
     // Deterministic generation that caused the issue
     let values: Vec<f32> = (0..size)
         .map(|i| {
-            let mut x = (i as f32 * (seed as f32 + 1.0));
+            let mut x = i as f32 * (seed as f32 + 1.0);
             x = x % 1000.0 + 0.1;
             x
         })
@@ -46,7 +45,7 @@ fn test_sparse_euclidean_distance_nan_regression() {
     let indices: Vec<u32> = (0..size).map(|i| i as u32).collect();
     let values: Vec<f32> = (0..size)
         .map(|i| {
-            let mut x = (i as f32 * (seed as f32 + 1.0));
+            let mut x = i as f32 * (seed as f32 + 1.0);
             x = x % 1000.0 + 0.1;
             x
         })

--- a/src/core/vector/sparse.rs
+++ b/src/core/vector/sparse.rs
@@ -557,12 +557,47 @@ pub fn sparse_squared_euclidean_distance(a: &SparseVec, b: &SparseVec) -> Result
         .into());
     }
 
-    // ||a - b||² = ||a||² + ||b||² - 2*dot(a,b)
-    let dot = sparse_dot_product(a, b)?;
-    let mag_a_sq = a.squared_magnitude();
-    let mag_b_sq = b.squared_magnitude();
+    // Stable algorithm: sum((a_i - b_i)^2)
+    // Avoids catastrophic cancellation from ||a||^2 + ||b||^2 - 2<a,b>
+    // when a and b are very close.
+    // Also faster (O(N) single pass vs O(N) triple pass).
 
-    Ok(mag_a_sq + mag_b_sq - 2.0 * dot)
+    let mut sum_sq_diff = 0.0f32;
+    let mut i = 0;
+    let mut j = 0;
+
+    let a_indices = a.indices();
+    let a_values = a.values();
+    let b_indices = b.indices();
+    let b_values = b.values();
+
+    while i < a_indices.len() && j < b_indices.len() {
+        if a_indices[i] == b_indices[j] {
+            let diff = a_values[i] - b_values[j];
+            sum_sq_diff += diff * diff;
+            i += 1;
+            j += 1;
+        } else if a_indices[i] < b_indices[j] {
+            sum_sq_diff += a_values[i] * a_values[i];
+            i += 1;
+        } else {
+            sum_sq_diff += b_values[j] * b_values[j];
+            j += 1;
+        }
+    }
+
+    // Process remaining elements
+    while i < a_indices.len() {
+        sum_sq_diff += a_values[i] * a_values[i];
+        i += 1;
+    }
+
+    while j < b_indices.len() {
+        sum_sq_diff += b_values[j] * b_values[j];
+        j += 1;
+    }
+
+    Ok(sum_sq_diff)
 }
 
 /// Computes Euclidean distance between two sparse vectors.


### PR DESCRIPTION
The original implementation of `sparse_squared_euclidean_distance` used the expanded formula `||a||^2 + ||b||^2 - 2<a,b>`. While mathematically correct, this formula is known to be numerically unstable for vectors that are very close to each other (relative to their distance from the origin) due to catastrophic cancellation.

This instability could cause the function to return a small negative number (e.g., `-1e-16`) for identical or nearly identical vectors. When `sparse_euclidean_distance` subsequently took the square root of this negative value, it resulted in `NaN`.

This change replaces the implementation with a direct summation of squared differences: `sum((a_i - b_i)^2)`. This approach:
1.  Is numerically stable (always non-negative).
2.  Is more efficient (requires a single pass over the data instead of three).
3.  Avoids the `NaN` issue entirely.

Verified with a new regression test suite `src/core/vector/sentry_sparse_tests.rs` that specifically targets the conditions that caused the instability (using deterministic random seed 34).

---
*PR created automatically by Jules for task [18074031306805621924](https://jules.google.com/task/18074031306805621924) started by @madmax983*