### PR TITLE
👺 Havoc: Fix FFI Panic & Expose WAL Gaps

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -442,19 +442,21 @@ where
         // Check for null pointers to prevent UB
         if a.is_null() || b.is_null() {
             // This should never happen with a correct usearch implementation.
-            // If it does, we panic to prevent UB from dereferencing null.
+            // If it does, we return f32::MAX to avoid crashing/UB.
             // We cannot return an error here because the signature is fixed by usearch trait.
-            panic!("usearch passed null pointer to metric function");
+            eprintln!("usearch passed null pointer to metric function - returning max distance");
+            return f32::MAX;
         }
 
         // Check for alignment to prevent UB
         // Use bitwise check for power-of-2 alignment (f32 align is 4)
         let align_mask = std::mem::align_of::<f32>() - 1;
         if (a as usize) & align_mask != 0 || (b as usize) & align_mask != 0 {
-            panic!(
-                "usearch passed unaligned pointer to metric function (expected alignment {})",
+            eprintln!(
+                "usearch passed unaligned pointer to metric function (expected alignment {}) - returning max distance",
                 std::mem::align_of::<f32>()
             );
+            return f32::MAX;
         }
 
         // SAFETY: usearch guarantees pointers are valid for `dims` elements.
@@ -1966,8 +1968,7 @@ mod sentry_tests {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "usearch passed unaligned pointer")]
-    fn test_metric_wrapper_panic_on_unaligned() {
+    fn test_metric_wrapper_safe_on_unaligned() {
         let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
 
@@ -1978,7 +1979,8 @@ mod sentry_tests {
         let aligned_vec = [0.0f32; 4];
         let aligned_ptr = aligned_vec.as_ptr();
 
-        wrapper(unaligned_ptr, aligned_ptr);
+        let result = wrapper(unaligned_ptr, aligned_ptr);
+        assert_eq!(result, f32::MAX);
     }
 
     #[test]
@@ -2143,8 +2145,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "usearch passed unaligned pointer")]
-    fn test_metric_wrapper_panic_on_unaligned() {
+    fn test_metric_wrapper_safe_on_unaligned() {
         // This test ensures that the metric wrapper correctly detects unaligned pointers.
         let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
@@ -2161,8 +2162,9 @@ mod tests {
         let unaligned_ptr = unsafe { aligned_ptr.add(1) } as *const f32;
         let valid_ptr = aligned_ptr as *const f32;
 
-        // Pass unaligned pointer - should panic
-        wrapper(valid_ptr, unaligned_ptr);
+        // Pass unaligned pointer - should return f32::MAX
+        let result = wrapper(valid_ptr, unaligned_ptr);
+        assert_eq!(result, f32::MAX);
     }
 
     #[test]
@@ -2579,10 +2581,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "usearch passed null pointer")]
-    fn test_metric_wrapper_panic_on_null() {
+    fn test_metric_wrapper_safe_on_null() {
         // This test ensures that the metric wrapper correctly detects null pointers
-        // and panics to prevent UB. This covers the safety check added for FFI.
+        // and returns MAX distance instead of panicking to prevent UB.
         let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
 
@@ -2591,8 +2592,9 @@ mod tests {
         let valid_ptr = vec.as_ptr();
         let null_ptr = std::ptr::null();
 
-        // Pass null pointer - should panic
-        wrapper(valid_ptr, null_ptr);
+        // Pass null pointer - should return f32::MAX
+        let result = wrapper(valid_ptr, null_ptr);
+        assert_eq!(result, f32::MAX);
     }
 
     #[test]
@@ -3211,7 +3213,6 @@ mod coverage_tests {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "usearch passed null pointer")]
     fn test_metric_wrapper_null_pointer() {
         let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
@@ -3220,12 +3221,12 @@ mod coverage_tests {
         let valid_data = [0.0f32; 4];
         let valid_ptr = valid_data.as_ptr();
 
-        // This should panic
-        wrapper(null_ptr, valid_ptr);
+        // This should return f32::MAX
+        let result = wrapper(null_ptr, valid_ptr);
+        assert_eq!(result, f32::MAX);
     }
 
     #[test]
-    #[should_panic(expected = "usearch passed unaligned pointer")]
     fn test_metric_wrapper_unaligned_pointer() {
         let distance_fn = Arc::new(|_: &[f32], _: &[f32]| 0.0);
         let wrapper = create_metric_wrapper(4, distance_fn);
@@ -3235,8 +3236,9 @@ mod coverage_tests {
         let valid_data = [0.0f32; 4];
         let valid_ptr = valid_data.as_ptr();
 
-        // This should panic
-        wrapper(unaligned_ptr, valid_ptr);
+        // This should return f32::MAX
+        let result = wrapper(unaligned_ptr, valid_ptr);
+        assert_eq!(result, f32::MAX);
     }
 
     #[test]

--- a/tests/havoc_wal_gaps.rs
+++ b/tests/havoc_wal_gaps.rs
@@ -1,0 +1,124 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::core::interning::GLOBAL_INTERNER;
+use aletheiadb::core::property::PropertyMap;
+use aletheiadb::core::temporal::time;
+use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
+use aletheiadb::storage::wal::entry::{MAX_WAL_ENTRY_SIZE, WalOperation};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn test_operation(id: u64) -> WalOperation {
+    WalOperation::CreateNode {
+        node_id: NodeId::new(id).unwrap(),
+        label: GLOBAL_INTERNER.intern("Test").unwrap(),
+        properties: PropertyMap::new(),
+        valid_from: time::now(),
+    }
+}
+
+// Create a huge operation that exceeds MAX_WAL_ENTRY_SIZE
+fn huge_operation(id: u64) -> WalOperation {
+    let mut props = PropertyMap::new();
+    // MAX_WAL_ENTRY_SIZE is 64MB.
+    // Create a property map larger than that.
+    // A vector of f32 is dense. 64MB / 4 = 16M floats.
+    // But MAX_VECTOR_DIMENSIONS is 100,000. So we can't use a single vector.
+    // We can use a large string or bytes.
+    // Bytes limit? PropertyValue::Bytes(Arc<[u8]>)
+    // Is there a limit on Bytes size?
+    // serialized_size checks recursion depth but not explicit byte size limit?
+    // Let's check PropertyValue::Bytes.
+    // Wait, PropertyValue::Bytes stores Arc<[u8]>.
+    // `estimated_entry_capacity` checks size.
+    // `MAX_WAL_ENTRY_SIZE` is enforced in `ConcurrentWal::serialize_entry`.
+
+    // Create a byte array slightly larger than MAX_WAL_ENTRY_SIZE
+    let size = MAX_WAL_ENTRY_SIZE + 1024;
+    let bytes = vec![0u8; size];
+
+    // We need to bypass PropertyMapBuilder if it enforces limits?
+    // PropertyMap::deserialize enforces count limit.
+    // serialize_recursive enforces recursion depth.
+    // But huge bytes are allowed in PropertyValue (just heap alloc).
+
+    // However, serialize_entry will fail if size > MAX_WAL_ENTRY_SIZE.
+
+    let props = aletheiadb::core::property::PropertyMapBuilder::new()
+        .insert("huge", bytes)
+        .build();
+
+    WalOperation::CreateNode {
+        node_id: NodeId::new(id).unwrap(),
+        label: GLOBAL_INTERNER.intern("Huge").unwrap(),
+        properties: props,
+        valid_from: time::now(),
+    }
+}
+
+#[test]
+fn test_havoc_wal_batch_gaps() {
+    let dir = tempdir().unwrap();
+    let config = ConcurrentWalConfig::new(dir.path());
+    let wal = ConcurrentWal::new(config).unwrap();
+
+    // 1. Create a batch: [Valid, Huge (Invalid), Valid]
+    let ops = vec![
+        test_operation(1),
+        huge_operation(2),
+        test_operation(3),
+    ];
+
+    // 2. Append batch - should fail
+    let result = wal.append_batch(ops);
+    assert!(result.is_err(), "Batch append should fail due to size limit");
+
+    let err = result.unwrap_err();
+    println!("Append batch error (expected): {}", err);
+    assert!(err.to_string().contains("CapacityExceeded") || err.to_string().contains("WAL entry size"));
+
+    // 3. Append another valid operation successfully
+    let lsn_after = wal.append_async(test_operation(4)).unwrap();
+    println!("Appended valid op after failure, LSN: {:?}", lsn_after);
+
+    // 4. Drain and inspect LSNs
+    let entries = wal.drain_all();
+    let lsns: Vec<u64> = entries.iter().map(|e| e.lsn.0).collect();
+
+    println!("Drained LSNs: {:?}", lsns);
+
+    // 5. Verify the wreckage: Gaps in LSN sequence
+    // Expected: LSN 1 (from first op in batch) MIGHT be there?
+    // No, `append_batch` loop:
+    // 1. Allocates 3 LSNs (current, current+1, current+2).
+    // 2. Loop idx=0: Serialize (ok), Append (ok). LSN 1 written.
+    // 3. Loop idx=1: Serialize (fail), Return Err.
+    // 4. Loop idx=2: Never executed.
+
+    // So LSN 1 should be written.
+    // LSN 2 was allocated but serialization failed.
+    // LSN 3 was allocated but loop aborted.
+    // Next LSN allocated by `append_async` should be 4.
+
+    // So we expect LSNs: [1, 4]
+    // Gap: 2, 3 are missing.
+
+    assert!(lsns.contains(&1), "LSN 1 should be present (written before failure)");
+    assert!(!lsns.contains(&2), "LSN 2 should be missing (failed serialization)");
+    assert!(!lsns.contains(&3), "LSN 3 should be missing (aborted loop)");
+    assert!(lsns.contains(&lsn_after.0), "LSN after batch should be present");
+
+    // Prove non-contiguity
+    let mut contiguous = true;
+    for i in 0..lsns.len()-1 {
+        if lsns[i+1] != lsns[i] + 1 {
+            contiguous = false;
+            break;
+        }
+    }
+
+    if !contiguous {
+        println!("👺 HAVOC SUCCESS: Found gaps in LSN sequence! System is fragile.");
+    } else {
+        panic!("Boring. LSNs are contiguous. Failed to break it.");
+    }
+}

--- a/tests/havoc_wal_gaps.rs
+++ b/tests/havoc_wal_gaps.rs
@@ -4,7 +4,6 @@ use aletheiadb::core::property::PropertyMap;
 use aletheiadb::core::temporal::time;
 use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
 use aletheiadb::storage::wal::entry::{MAX_WAL_ENTRY_SIZE, WalOperation};
-use std::sync::Arc;
 use tempfile::tempdir;
 
 fn test_operation(id: u64) -> WalOperation {
@@ -18,7 +17,6 @@ fn test_operation(id: u64) -> WalOperation {
 
 // Create a huge operation that exceeds MAX_WAL_ENTRY_SIZE
 fn huge_operation(id: u64) -> WalOperation {
-    let mut props = PropertyMap::new();
     // MAX_WAL_ENTRY_SIZE is 64MB.
     // Create a property map larger than that.
     // A vector of f32 is dense. 64MB / 4 = 16M floats.

--- a/tests/havoc_wal_gaps.rs
+++ b/tests/havoc_wal_gaps.rs
@@ -62,19 +62,20 @@ fn test_havoc_wal_batch_gaps() {
     let wal = ConcurrentWal::new(config).unwrap();
 
     // 1. Create a batch: [Valid, Huge (Invalid), Valid]
-    let ops = vec![
-        test_operation(1),
-        huge_operation(2),
-        test_operation(3),
-    ];
+    let ops = vec![test_operation(1), huge_operation(2), test_operation(3)];
 
     // 2. Append batch - should fail
     let result = wal.append_batch(ops);
-    assert!(result.is_err(), "Batch append should fail due to size limit");
+    assert!(
+        result.is_err(),
+        "Batch append should fail due to size limit"
+    );
 
     let err = result.unwrap_err();
     println!("Append batch error (expected): {}", err);
-    assert!(err.to_string().contains("CapacityExceeded") || err.to_string().contains("WAL entry size"));
+    assert!(
+        err.to_string().contains("CapacityExceeded") || err.to_string().contains("WAL entry size")
+    );
 
     // 3. Append another valid operation successfully
     let lsn_after = wal.append_async(test_operation(4)).unwrap();
@@ -102,15 +103,24 @@ fn test_havoc_wal_batch_gaps() {
     // So we expect LSNs: [1, 4]
     // Gap: 2, 3 are missing.
 
-    assert!(lsns.contains(&1), "LSN 1 should be present (written before failure)");
-    assert!(!lsns.contains(&2), "LSN 2 should be missing (failed serialization)");
+    assert!(
+        lsns.contains(&1),
+        "LSN 1 should be present (written before failure)"
+    );
+    assert!(
+        !lsns.contains(&2),
+        "LSN 2 should be missing (failed serialization)"
+    );
     assert!(!lsns.contains(&3), "LSN 3 should be missing (aborted loop)");
-    assert!(lsns.contains(&lsn_after.0), "LSN after batch should be present");
+    assert!(
+        lsns.contains(&lsn_after.0),
+        "LSN after batch should be present"
+    );
 
     // Prove non-contiguity
     let mut contiguous = true;
-    for i in 0..lsns.len()-1 {
-        if lsns[i+1] != lsns[i] + 1 {
+    for i in 0..lsns.len() - 1 {
+        if lsns[i + 1] != lsns[i] + 1 {
             contiguous = false;
             break;
         }


### PR DESCRIPTION
👺 **Havoc Report:**

1.  **FFI Panic (Fixed):**
    *   **The Trigger:** `usearch` (C++) passing null or unaligned pointers to the Rust metric callback.
    *   **The Fix:** Changed `create_metric_wrapper` to return `f32::MAX` and log an error instead of panicking. Panicking across FFI is UB.
    *   **Verification:** Updated `test_metric_wrapper_safe_on_unaligned` and `test_metric_wrapper_safe_on_null` to assert safe return values.

2.  **WAL LSN Gaps (Identified):**
    *   **The Trigger:** Calling `append_batch` with an operation that fails serialization (e.g., > `MAX_WAL_ENTRY_SIZE`) in the middle of a batch.
    *   **The Wreckage:** `tests/havoc_wal_gaps.rs` proves that LSNs are allocated but not written, leaving gaps (e.g., 1, 4). This confirms system fragility regarding contiguous LSN assumptions.


---
*PR created automatically by Jules for task [3231727643357601703](https://jules.google.com/task/3231727643357601703) started by @madmax983*