### PR TITLE
Elenchus Audit: Strengthen HLC and Vector Tests

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -162,3 +162,24 @@
 **Finding:** `test_truncate_to_lsn_removes_old_segments` used an assertion `removed > 0 || count_before == count_after`, which allows "doing nothing" to be considered a success.
 **Evidence:** Reproduction test confirmed that a broken implementation (returning 0 removed) would pass.
 **Resolution:** Modified the test to setup a scenario where exactly 1 segment *must* be removed and asserted `removed == 1`.
+
+**[HLC Monotonicity Assertion Weakness]**
+**Module:** `src/core/hlc.rs`
+**Severity:** 🟡 Suspect
+**Finding:** `prop_send_monotonicity` silently swallows errors unless they are explicitly `LogicalCounterOverflow`. If `send` returned an unexpected error (e.g., due to a bug in validation logic), the test would pass silently.
+**Evidence:** Code inspection: `if let Ok(next) = current.send(new_wallclock) { ... }`.
+**Recommendation:** Modify the test to explicitly match `Err` variants and fail on unexpected ones.
+
+**[HLC Collision Tautology]**
+**Module:** `src/core/hlc.rs`
+**Severity:** 🟡 Suspect
+**Finding:** `prop_receive_causality_collision` mirrors the implementation logic (`max(l1, l2) + 1`) to verify the result. This proves only that the implementation matches the test's reimplementation, not that the logic is correct according to spec.
+**Evidence:** `let expected_logical = local_logical.max(msg_logical).checked_add(1);`.
+**Recommendation:** Add an Oracle-style test with hardcoded values to anchor the behavior to specific expected outcomes.
+
+**[Loose SIMD Precision Check]**
+**Module:** `src/core/vector/sentry_tests.rs`
+**Severity:** 🟡 Suspect
+**Finding:** `test_simd_dot_and_magnitudes_large_vector` uses a very loose epsilon (`0.1`) for comparing SIMD vs Scalar results. This could mask significant precision loss or subtle logic errors in remainder handling.
+**Evidence:** `let epsilon = 0.1;` for a sum around 30,000.
+**Recommendation:** Tighten the epsilon to `0.01` or `0.005` to enforce stricter adherence to scalar precision.

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -346,6 +346,30 @@ mod tests {
     }
 
     #[test]
+    fn test_receive_collision_oracle() {
+        // Oracle Test: Hardcoded scenario to verify collision logic without reconstructing the formula
+        // Scenario: Local(1000, 10) receives Msg(1000, 20) with physical clock 1000.
+        // Rule: max(1000, 1000, 1000) -> 1000.
+        // Logical: max(10, 20) + 1 = 21.
+        let local = HybridTimestamp::new(1000, 10).unwrap();
+        let msg = HybridTimestamp::new(1000, 20).unwrap();
+        let next = local.receive(msg, 1000).unwrap();
+
+        assert_eq!(next.wallclock(), 1000);
+        assert_eq!(next.logical(), 21);
+
+        // Scenario: Local(1000, 20) receives Msg(1000, 10) with physical clock 1000.
+        // Rule: max(1000, 1000, 1000) -> 1000.
+        // Logical: max(20, 10) + 1 = 21.
+        let local = HybridTimestamp::new(1000, 20).unwrap();
+        let msg = HybridTimestamp::new(1000, 10).unwrap();
+        let next = local.receive(msg, 1000).unwrap();
+
+        assert_eq!(next.wallclock(), 1000);
+        assert_eq!(next.logical(), 21);
+    }
+
+    #[test]
     fn test_send_logic() {
         let ts = HybridTimestamp::new(1000, 5).unwrap();
 
@@ -514,11 +538,21 @@ mod proptests {
             new_wallclock in valid_wallclock()
         ) {
             // send() might fail if logical overflows, but for random inputs probability is low.
-            // However, we should handle the Result.
-            if let Ok(next) = current.send(new_wallclock) {
-                prop_assert!(next > current);
-                prop_assert!(next.wallclock() >= new_wallclock);
-                prop_assert!(next.wallclock() >= current.wallclock());
+            // However, we should handle the Result explicitly.
+            match current.send(new_wallclock) {
+                Ok(next) => {
+                    prop_assert!(next > current);
+                    prop_assert!(next.wallclock() >= new_wallclock);
+                    prop_assert!(next.wallclock() >= current.wallclock());
+                }
+                Err(e) => {
+                    // Only overflow errors are expected for valid inputs
+                    prop_assert!(
+                        matches!(e, TemporalError::LogicalCounterOverflow { .. }),
+                        "Unexpected error: {:?}",
+                        e
+                    );
+                }
             }
         }
 

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -332,8 +332,8 @@ fn test_simd_dot_and_magnitudes_large_vector() {
     let expected_mag_b: f32 = b.iter().map(|x| x * x).sum();
 
     // Allow small epsilon for floating point accumulation differences
-    // 0.1 is safe for sum around 30,000 (machine epsilon approx 0.0036 at this magnitude)
-    let epsilon = 0.1;
+    // 0.01 is stricter but should still pass if SIMD implementation is reasonably precise
+    let epsilon = 0.01;
     assert!(
         (dot - expected_dot).abs() < epsilon,
         "Dot product mismatch: {} vs {}",
@@ -351,6 +351,41 @@ fn test_simd_dot_and_magnitudes_large_vector() {
         "Mag B mismatch: {} vs {}",
         mag_b,
         expected_mag_b
+    );
+}
+
+#[test]
+fn test_simd_dot_product_associativity() {
+    // 🧪 Strategy: Check if SIMD (chunked sum) produces significantly different results
+    // from Scalar (sequential sum) for a sensitive dataset.
+    // Floating point addition is non-associative.
+
+    let len = 1000;
+    // Use values with alternating magnitudes to exacerbate rounding errors
+    let a: Vec<f32> = (0..len).map(|i| if i % 2 == 0 { 1.0e5 } else { 1.0 }).collect();
+    let b: Vec<f32> = (0..len).map(|i| if i % 2 == 0 { 1.0 } else { -1.0e5 }).collect();
+
+    // Scalar sum: (1e5 * 1) + (1 * -1e5) + ... = 1e5 - 1e5 = 0
+    // But sequential sum might drift.
+    let scalar_dot = super::simd::dot_product_scalar(&a, &b);
+
+    // SIMD sum: sums 8 lanes independently.
+    // Lane 0: 1e5, 1e5, ... -> Sum(1e5)
+    // Lane 1: -1e5, -1e5, ... -> Sum(-1e5)
+    // Then horizontal sum.
+    let simd_dot = super::simd::dot_product_sum(&a, &b);
+
+    // We expect them to be close, but maybe not identical.
+    // This test documents the behavior.
+    let diff = (scalar_dot - simd_dot).abs();
+
+    // They should be reasonably close for this balanced dataset
+    assert!(
+        diff < 1.0,
+        "SIMD vs Scalar divergence: scalar {}, simd {}, diff {}",
+        scalar_dot,
+        simd_dot,
+        diff
     );
 }
 

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -362,8 +362,12 @@ fn test_simd_dot_product_associativity() {
 
     let len = 1000;
     // Use values with alternating magnitudes to exacerbate rounding errors
-    let a: Vec<f32> = (0..len).map(|i| if i % 2 == 0 { 1.0e5 } else { 1.0 }).collect();
-    let b: Vec<f32> = (0..len).map(|i| if i % 2 == 0 { 1.0 } else { -1.0e5 }).collect();
+    let a: Vec<f32> = (0..len)
+        .map(|i| if i % 2 == 0 { 1.0e5 } else { 1.0 })
+        .collect();
+    let b: Vec<f32> = (0..len)
+        .map(|i| if i % 2 == 0 { 1.0 } else { -1.0e5 })
+        .collect();
 
     // Scalar sum: (1e5 * 1) + (1 * -1e5) + ... = 1e5 - 1e5 = 0
     // But sequential sum might drift.


### PR DESCRIPTION
Adopted Elenchus persona to audit and strengthen tests in src/core/hlc.rs and src/core/vector/sentry_tests.rs.
- Added test_receive_collision_oracle to HLC tests to verify causality logic without tautology.
- Strengthened prop_send_monotonicity in HLC proptests to assert on specific error types.
- Tightened epsilon in SIMD large vector tests to 0.01 to better detect precision loss.
- Added test_simd_dot_product_associativity to document SIMD vs Scalar divergence.
- Updated .jules/elenchus.md with findings.

---
*PR created automatically by Jules for task [12272668703796128830](https://jules.google.com/task/12272668703796128830) started by @madmax983*