### PR TITLE
fix: resolve interner snapshot race and vector precision issues

### DIFF
--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -351,12 +351,17 @@ impl StringInterner {
     /// This is useful for persistence where we need to save and restore
     /// the interner state.
     pub fn get_all_strings(&self) -> Vec<String> {
-        let count = self.len();
+        // Use next_id to ensure we capture all allocated IDs, even if string_to_id
+        // (used by len()) hasn't been updated yet. This prevents snapshot truncation
+        // where valid, resolvable IDs are missed because len() lags behind.
+        let count = self.next_id.load(Ordering::Relaxed) as usize;
         let mut strings = vec![String::new(); count];
 
         // Collect all (id, string) pairs
         for entry in self.id_to_string.iter() {
             let id = entry.key().as_u32() as usize;
+            // Note: id < count should always be true since next_id is incremented before insertion,
+            // but we keep the check for safety.
             if id < count {
                 strings[id] = entry.value().to_string();
             }

--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -102,9 +102,16 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Result<f32> {
     // Use SIMD-accelerated computation when available
     let (dot, mag_a_sq, mag_b_sq) = dot_and_magnitudes(a, b);
 
+    // Treat vectors with negligible magnitude as zero
+    // This prevents numerical instability from denormal numbers and avoids
+    // assertion failures when dot product slightly exceeds magnitude product
+    if mag_a_sq < SQUARED_MAGNITUDE_THRESHOLD || mag_b_sq < SQUARED_MAGNITUDE_THRESHOLD {
+        return Ok(0.0);
+    }
+
     let magnitude = (mag_a_sq * mag_b_sq).sqrt();
 
-    // Handle zero vectors
+    // Handle zero vectors (redundant but safe)
     if magnitude == 0.0 {
         return Ok(0.0);
     }

--- a/tests/havoc_proptest_vector_ops.proptest-regressions
+++ b/tests/havoc_proptest_vector_ops.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 02cac0759345741291c1f58896845494276cdc6c32950b1bc59a2df4d8385898 # shrinks to (vec1, vec2) = ([5.649016e-23], [535028.8])


### PR DESCRIPTION
This PR addresses two issues identified during chaos engineering:

1.  **Interner Snapshot Truncation:**
    *   **Issue:** The `StringInterner::get_all_strings` method used `self.len()` (count of inserted keys in `string_to_id`) to size the result vector. However, insertion into `string_to_id` happens *after* insertion into `id_to_string`. A race condition existed where a snapshot taken between these two events would use a stale length, truncating valid, resolvable IDs from the snapshot.
    *   **Fix:** Updated `get_all_strings` to use `self.next_id` (AtomicU32) for sizing. This is the source of truth for allocated IDs and ensures the snapshot covers all potential in-flight or committed IDs. Gaps (allocated but not yet inserted) are safely handled as empty strings (which `String::new()` initializes).

2.  **Vector Ops Numerical Instability:**
    *   **Issue:** Fuzz testing (`havoc_proptest_vector_ops`) revealed that subnormal input vectors (e.g., `5e-23`) caused `cosine_similarity` to calculate a result slightly > 1.0 (e.g., 1.06) due to precision loss in magnitude calculation vs dot product, triggering a debug assertion.
    *   **Fix:** Added a check to treat vectors with squared magnitude below `SQUARED_MAGNITUDE_THRESHOLD` (1e-14) as zero vectors, returning 0.0 similarity. This matches the behavior of `normalize` and ensures numerical stability.

---
*PR created automatically by Jules for task [11659224167265767354](https://jules.google.com/task/11659224167265767354) started by @madmax983*