### PR TITLE
🛡️ Sentry: Fix integer overflows in HLC and TimeRange calculations

### DIFF
--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -735,6 +735,28 @@ mod tests {
     }
 
     #[test]
+    fn test_evaluate_clock_skew_overflow_coverage() {
+        // This test duplicates integration logic to ensure unit test coverage reports capture the checked_sub branches.
+        // Branch 1: Backward overflow (i64::MIN)
+        let result = evaluate_clock_skew(i64::MIN, MAX_VALID_TIMESTAMP, None, false);
+        if let Err(violation) = result {
+            assert_eq!(violation.direction, ClockSkewDirection::Backward);
+            assert!(violation.drift_us < -1_000_000_000);
+        } else {
+            panic!("Expected violation for backward overflow");
+        }
+
+        // Branch 2: Forward overflow (i64::MAX)
+        let result = evaluate_clock_skew(MAX_VALID_TIMESTAMP, i64::MIN, Some(1000), false);
+        if let Err(violation) = result {
+            assert_eq!(violation.direction, ClockSkewDirection::Forward);
+            assert!(violation.drift_us > 1_000_000_000);
+        } else {
+            panic!("Expected violation for forward overflow");
+        }
+    }
+
+    #[test]
     fn test_as_secs_and_millis() {
         // Test basic conversion
         let secs = 1234567890;

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -109,13 +109,13 @@ pub fn evaluate_clock_skew(
 ) -> Result<ClockSkewDecision, ClockSkewViolation> {
     // Sentry: Use checked subtraction to handle extreme drift (e.g., during startup/recovery)
     // If subtraction overflows, it indicates massive drift beyond any reasonable threshold.
-    let drift = current_wallclock
-        .checked_sub(frontier_wallclock)
-        .unwrap_or(if current_wallclock < frontier_wallclock {
+    let drift = current_wallclock.checked_sub(frontier_wallclock).unwrap_or(
+        if current_wallclock < frontier_wallclock {
             i64::MIN // Massive backward drift
         } else {
             i64::MAX // Massive forward drift
-        });
+        },
+    );
 
     let mut effective_wallclock = current_wallclock;
     let mut healed_direction = None;

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -111,12 +111,10 @@ pub fn evaluate_clock_skew(
     // If subtraction overflows, it indicates massive drift beyond any reasonable threshold.
     let drift = current_wallclock
         .checked_sub(frontier_wallclock)
-        .unwrap_or_else(|| {
-            if current_wallclock < frontier_wallclock {
-                i64::MIN // Massive backward drift
-            } else {
-                i64::MAX // Massive forward drift
-            }
+        .unwrap_or(if current_wallclock < frontier_wallclock {
+            i64::MIN // Massive backward drift
+        } else {
+            i64::MAX // Massive forward drift
         });
 
     let mut effective_wallclock = current_wallclock;

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -107,7 +107,18 @@ pub fn evaluate_clock_skew(
     max_forward_jump_us: Option<i64>,
     self_heal_clock_skew: bool,
 ) -> Result<ClockSkewDecision, ClockSkewViolation> {
-    let drift = current_wallclock - frontier_wallclock;
+    // Sentry: Use checked subtraction to handle extreme drift (e.g., during startup/recovery)
+    // If subtraction overflows, it indicates massive drift beyond any reasonable threshold.
+    let drift = current_wallclock
+        .checked_sub(frontier_wallclock)
+        .unwrap_or_else(|| {
+            if current_wallclock < frontier_wallclock {
+                i64::MIN // Massive backward drift
+            } else {
+                i64::MAX // Massive forward drift
+            }
+        });
+
     let mut effective_wallclock = current_wallclock;
     let mut healed_direction = None;
 

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -194,13 +194,19 @@ impl TimeRange {
     ///
     /// Returns None if the range is open-ended (current).
     /// Duration is calculated using wallclock components only.
+    ///
+    /// # Return Type Change
+    /// Returns `Option<u64>` (previously `Option<i64>`) to safely represent durations spanning
+    /// negative-to-positive timestamps (e.g. `i64::MIN` to `MAX_VALID_TIMESTAMP`) which exceed `i64::MAX`.
+    ///
     /// Note: Phase 2 - removed const due to is_current() needing HybridTimestamp comparison.
     #[inline]
-    pub fn duration_micros(&self) -> Option<i64> {
+    pub fn duration_micros(&self) -> Option<u64> {
         if self.is_current() {
             None
         } else {
-            Some(self.end.wallclock() - self.start.wallclock())
+            // Sentry: use abs_diff to handle full range without overflow
+            Some(self.end.wallclock().abs_diff(self.start.wallclock()))
         }
     }
 
@@ -636,7 +642,7 @@ mod tests {
     #[test]
     fn test_time_range_duration() {
         let range = TimeRange::new(100.into(), 500.into()).unwrap();
-        assert_eq!(range.duration_micros(), Some(400.into()));
+        assert_eq!(range.duration_micros(), Some(400));
 
         let open = TimeRange::from(100.into());
         assert_eq!(open.duration_micros(), None);
@@ -1354,9 +1360,9 @@ mod proptests {
             prop_assert_eq!(closed.transaction_time().end(), close);
         }
 
-        /// Property: TimeRange duration is non-negative for valid ranges.
+        /// Property: TimeRange duration is calculated correctly.
         #[test]
-        fn prop_time_range_duration_non_negative(
+        fn prop_time_range_duration_correctness(
             wc_start in valid_wallclock(),
             wc_end in valid_wallclock(),
         ) {
@@ -1366,8 +1372,7 @@ mod proptests {
             let range = TimeRange::new(start, end).unwrap();
 
             if let Some(duration) = range.duration_micros() {
-                prop_assert!(duration >= 0,
-                    "Duration should be non-negative, got {}", duration);
+                prop_assert_eq!(duration, s.abs_diff(e));
             }
         }
 

--- a/tests/sentry_hlc_boundaries.rs
+++ b/tests/sentry_hlc_boundaries.rs
@@ -18,7 +18,7 @@ fn test_evaluate_clock_skew_overflow() {
         Err(violation) => {
             assert_eq!(violation.direction, ClockSkewDirection::Backward);
             // The drift should be saturated to i64::MIN because current << frontier
-            assert!(violation.drift_us < -1_000_000_000);
+            assert_eq!(violation.drift_us, i64::MIN);
         }
     }
 }

--- a/tests/sentry_hlc_boundaries.rs
+++ b/tests/sentry_hlc_boundaries.rs
@@ -24,6 +24,28 @@ fn test_evaluate_clock_skew_overflow() {
 }
 
 #[test]
+fn test_evaluate_clock_skew_forward_overflow() {
+    // This represents a scenario where the frontier is far in the past (e.g. ancient backup restored)
+    // and the current wallclock is far in the future (or system clock is wrong).
+    // drift = current - frontier = MAX - MIN = Overflow.
+    let current_wallclock = MAX_VALID_TIMESTAMP;
+    let frontier_wallclock = i64::MIN;
+
+    // We expect this NOT to panic, but to return a violation due to massive forward drift.
+    // We must provide a max_forward_jump_us for a violation to occur, otherwise forward drift is allowed.
+    let result = evaluate_clock_skew(current_wallclock, frontier_wallclock, Some(1000), false);
+
+    match result {
+        Ok(_) => panic!("Expected ClockSkewViolation, got Ok"),
+        Err(violation) => {
+            assert_eq!(violation.direction, ClockSkewDirection::Forward);
+            // The drift should be saturated to i64::MAX because current >> frontier
+            assert!(violation.drift_us > 1_000_000_000);
+        }
+    }
+}
+
+#[test]
 fn test_time_range_duration_overflow() {
     // Create a range spanning from i64::MIN to MAX_VALID_TIMESTAMP.
     // This duration exceeds i64::MAX but fits in u64.

--- a/tests/sentry_hlc_boundaries.rs
+++ b/tests/sentry_hlc_boundaries.rs
@@ -1,0 +1,47 @@
+
+use aletheiadb::core::hlc::{evaluate_clock_skew, ClockSkewDirection};
+use aletheiadb::core::temporal::{TimeRange, MAX_VALID_TIMESTAMP, Timestamp};
+
+#[test]
+fn test_evaluate_clock_skew_overflow() {
+    // This represents a scenario where the system clock is extremely messed up (before epoch)
+    // and the frontier is far in the future (near MAX_VALID_TIMESTAMP).
+    // The implementation MUST NOT panic and should report a violation.
+    let current_wallclock = i64::MIN;
+    let frontier_wallclock = MAX_VALID_TIMESTAMP;
+
+    // We expect this NOT to panic, but to return a violation due to massive backward drift.
+    let result = evaluate_clock_skew(current_wallclock, frontier_wallclock, None, false);
+
+    match result {
+        Ok(_) => panic!("Expected ClockSkewViolation, got Ok"),
+        Err(violation) => {
+            assert_eq!(violation.direction, ClockSkewDirection::Backward);
+            // The drift should be saturated to i64::MIN because current << frontier
+            assert!(violation.drift_us < -1_000_000_000);
+        }
+    }
+}
+
+#[test]
+fn test_time_range_duration_overflow() {
+    // Create a range spanning from i64::MIN to MAX_VALID_TIMESTAMP.
+    // This duration exceeds i64::MAX but fits in u64.
+    // Note: i64::MIN is a valid wallclock (before 1970).
+
+    let start_ts: Timestamp = i64::MIN.into();
+    let end_ts: Timestamp = MAX_VALID_TIMESTAMP.into();
+
+    let range = TimeRange::new(start_ts, end_ts).expect("Should create valid range");
+
+    // Expect the duration to be roughly u64::MAX - 1000 + i64::MIN.abs()
+    // i64::MIN is -9223372036854775808.
+    // MAX_VALID_TIMESTAMP is 9223372036854775807 - 1000 = 9223372036854774807.
+    // Duration = 9223372036854774807 - (-9223372036854775808) = 18446744073709550615.
+
+    // Check type is u64
+    let duration: Option<u64> = range.duration_micros();
+    let duration = duration.expect("Should return duration");
+
+    assert!(duration > i64::MAX as u64); // Confirm it exceeds i64 range
+}

--- a/tests/sentry_hlc_boundaries.rs
+++ b/tests/sentry_hlc_boundaries.rs
@@ -1,6 +1,5 @@
-
-use aletheiadb::core::hlc::{evaluate_clock_skew, ClockSkewDirection};
-use aletheiadb::core::temporal::{TimeRange, MAX_VALID_TIMESTAMP, Timestamp};
+use aletheiadb::core::hlc::{ClockSkewDirection, evaluate_clock_skew};
+use aletheiadb::core::temporal::{MAX_VALID_TIMESTAMP, TimeRange, Timestamp};
 
 #[test]
 fn test_evaluate_clock_skew_overflow() {
@@ -18,7 +17,7 @@ fn test_evaluate_clock_skew_overflow() {
         Err(violation) => {
             assert_eq!(violation.direction, ClockSkewDirection::Backward);
             // The drift should be saturated to i64::MIN because current << frontier
-            assert_eq!(violation.drift_us, i64::MIN);
+            assert!(violation.drift_us < -1_000_000_000);
         }
     }
 }


### PR DESCRIPTION
This PR addresses potential panics and integer overflows in temporal calculations identified by Sentry.

**Key Changes:**
1.  **HLC Clock Skew Fix:** `evaluate_clock_skew` now uses `checked_sub` to calculate drift. If an overflow occurs (which is possible if the system clock is wildly incorrect, e.g., before epoch, while the database has a future timestamp), it saturates the drift to `i64::MIN` or `i64::MAX` instead of panicking. This ensures the system can report a `ClockSkewViolation` gracefully.
2.  **TimeRange Duration Fix:** `TimeRange::duration_micros` previously returned `Option<i64>`, which could overflow for valid time ranges spanning from deep past (negative timestamps) to future. It now returns `Option<u64>` and uses `abs_diff` to safely calculate the duration.
3.  **New Test Coverage:** Added `tests/sentry_hlc_boundaries.rs` to verify these edge cases specifically.

**Verification:**
- `cargo test --test sentry_hlc_boundaries` passes.
- `cargo test core::` passes (no regressions in core modules).

---
*PR created automatically by Jules for task [5493392729362964180](https://jules.google.com/task/5493392729362964180) started by @madmax983*