### PR TITLE
Fix single-node forward skew false positive after idle periods

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -31,6 +31,7 @@ use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
 use crate::utils::error::{Result, StorageError, TransactionError};
 use parking_lot::RwLock;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 mod apply;
 mod conflict;
@@ -86,6 +87,7 @@ pub struct WriteTransaction {
     pub(crate) temporal_indexes: Arc<TemporalIndexes>,
     pub(crate) wal: Arc<ConcurrentWalSystem>,
     pub(crate) current_timestamp: Arc<Mutex<Timestamp>>,
+    pub(crate) commit_clock_observed_at: Arc<Mutex<Instant>>,
     pub(crate) visibility_manager: Arc<TxVisibilityManager>,
 
     // ID generators (needed for creating new entities)
@@ -100,6 +102,7 @@ pub struct WriteTransaction {
 
 impl WriteTransaction {
     /// Create a new write transaction with default durability mode (Synchronous).
+    #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         tx_id: TxId,
@@ -130,7 +133,41 @@ impl WriteTransaction {
         )
     }
 
+    /// Create a new write transaction with explicit commit clock observation state.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_clock_observed_at(
+        tx_id: TxId,
+        snapshot: TransactionSnapshot,
+        current: Arc<CurrentStorage>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+        temporal_indexes: Arc<TemporalIndexes>,
+        wal: Arc<ConcurrentWalSystem>,
+        current_timestamp: Arc<Mutex<Timestamp>>,
+        commit_clock_observed_at: Arc<Mutex<Instant>>,
+        visibility_manager: Arc<TxVisibilityManager>,
+        node_id_gen: Arc<IdGenerator>,
+        edge_id_gen: Arc<IdGenerator>,
+        version_id_gen: Arc<IdGenerator>,
+    ) -> Self {
+        Self::new_with_durability_and_clock_observed_at(
+            tx_id,
+            snapshot,
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            commit_clock_observed_at,
+            visibility_manager,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+            DurabilityMode::Synchronous,
+        )
+    }
+
     /// Create a new write transaction with a specific durability mode.
+    #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_with_durability(
         tx_id: TxId,
@@ -140,6 +177,40 @@ impl WriteTransaction {
         temporal_indexes: Arc<TemporalIndexes>,
         wal: Arc<ConcurrentWalSystem>,
         current_timestamp: Arc<Mutex<Timestamp>>,
+        visibility_manager: Arc<TxVisibilityManager>,
+        node_id_gen: Arc<IdGenerator>,
+        edge_id_gen: Arc<IdGenerator>,
+        version_id_gen: Arc<IdGenerator>,
+        durability_mode: DurabilityMode,
+    ) -> Self {
+        Self::new_with_durability_and_clock_observed_at(
+            tx_id,
+            snapshot,
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            Arc::new(Mutex::new(Instant::now())),
+            visibility_manager,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+            durability_mode,
+        )
+    }
+
+    /// Create a new write transaction with specific durability and clock observation state.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_durability_and_clock_observed_at(
+        tx_id: TxId,
+        snapshot: TransactionSnapshot,
+        current: Arc<CurrentStorage>,
+        historical: Arc<RwLock<HistoricalStorage>>,
+        temporal_indexes: Arc<TemporalIndexes>,
+        wal: Arc<ConcurrentWalSystem>,
+        current_timestamp: Arc<Mutex<Timestamp>>,
+        commit_clock_observed_at: Arc<Mutex<Instant>>,
         visibility_manager: Arc<TxVisibilityManager>,
         node_id_gen: Arc<IdGenerator>,
         edge_id_gen: Arc<IdGenerator>,
@@ -157,6 +228,7 @@ impl WriteTransaction {
             temporal_indexes,
             wal,
             current_timestamp,
+            commit_clock_observed_at,
             visibility_manager,
             node_id_gen,
             edge_id_gen,
@@ -179,6 +251,20 @@ impl WriteTransaction {
     /// Get transaction ID.
     pub fn tx_id(&self) -> TxId {
         self.tx_id
+    }
+
+    fn adaptive_forward_jump_limit_us(&self, observed_at: Instant) -> Result<i64> {
+        let mut previous_observed_at =
+            self.commit_clock_observed_at
+                .lock()
+                .map_err(|_| TransactionError::LockPoisoned {
+                    resource: "commit_clock_observed_at".to_string(),
+                })?;
+        let elapsed = observed_at.duration_since(*previous_observed_at);
+        *previous_observed_at = observed_at;
+
+        let elapsed_us = i64::try_from(elapsed.as_micros()).unwrap_or(i64::MAX);
+        Ok(MAX_FORWARD_JUMP_US.saturating_add(elapsed_us))
     }
 
     /// Commit the transaction.
@@ -290,12 +376,14 @@ impl WriteTransaction {
             // Phase 2: Use HLC for distributed temporal consistency
             // Get current physical wallclock
             let current_wallclock = crate::core::temporal::time::now();
+            let observed_at = Instant::now();
+            let adaptive_forward_limit_us = self.adaptive_forward_jump_limit_us(observed_at)?;
 
             let self_heal_clock_skew = is_clock_skew_self_heal_enabled();
             let skew_decision = evaluate_clock_skew(
                 current_wallclock.wallclock(),
                 ts.wallclock(),
-                Some(MAX_FORWARD_JUMP_US),
+                Some(adaptive_forward_limit_us),
                 self_heal_clock_skew,
             )
             .map_err(|violation| TransactionError::ClockSkew {

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -253,18 +253,22 @@ impl WriteTransaction {
         self.tx_id
     }
 
-    fn adaptive_forward_jump_limit_us(&self, observed_at: Instant) -> Result<i64> {
-        let mut previous_observed_at =
+    fn lock_adaptive_forward_jump_limit(
+        &self,
+        observed_at: Instant,
+    ) -> Result<(std::sync::MutexGuard<'_, Instant>, i64)> {
+        let previous_observed_at =
             self.commit_clock_observed_at
                 .lock()
                 .map_err(|_| TransactionError::LockPoisoned {
                     resource: "commit_clock_observed_at".to_string(),
                 })?;
         let elapsed = observed_at.duration_since(*previous_observed_at);
-        *previous_observed_at = observed_at;
-
         let elapsed_us = i64::try_from(elapsed.as_micros()).unwrap_or(i64::MAX);
-        Ok(MAX_FORWARD_JUMP_US.saturating_add(elapsed_us))
+        Ok((
+            previous_observed_at,
+            MAX_FORWARD_JUMP_US.saturating_add(elapsed_us),
+        ))
     }
 
     /// Commit the transaction.
@@ -377,7 +381,8 @@ impl WriteTransaction {
             // Get current physical wallclock
             let current_wallclock = crate::core::temporal::time::now();
             let observed_at = Instant::now();
-            let adaptive_forward_limit_us = self.adaptive_forward_jump_limit_us(observed_at)?;
+            let (mut previous_observed_at, adaptive_forward_limit_us) =
+                self.lock_adaptive_forward_jump_limit(observed_at)?;
 
             let self_heal_clock_skew = is_clock_skew_self_heal_enabled();
             let skew_decision = evaluate_clock_skew(
@@ -459,6 +464,9 @@ impl WriteTransaction {
 
             // Update current_timestamp for next transaction's snapshot
             *ts = commit;
+            // Persist observation only after we successfully advanced the frontier.
+            *previous_observed_at = observed_at;
+            drop(previous_observed_at);
 
             #[cfg(feature = "observability")]
             let wal_start = std::time::Instant::now();

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2394,6 +2394,7 @@ mod clock_skew_tests {
     use crate::api::transaction::TxIdGenerator;
     use crate::core::property::PropertyMapBuilder;
     use crate::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     /// Test harness for clock skew tests.
@@ -2403,6 +2404,7 @@ mod clock_skew_tests {
         temporal_indexes: Arc<TemporalIndexes>,
         wal: Arc<ConcurrentWalSystem>,
         current_timestamp: Arc<Mutex<Timestamp>>,
+        commit_clock_observed_at: Arc<Mutex<Instant>>,
         visibility_manager: Arc<TxVisibilityManager>,
         node_id_gen: Arc<IdGenerator>,
         edge_id_gen: Arc<IdGenerator>,
@@ -2422,6 +2424,7 @@ mod clock_skew_tests {
             let wal = Arc::new(ConcurrentWalSystem::new(wal_config).unwrap());
 
             let current_timestamp = Arc::new(Mutex::new(time::now()));
+            let commit_clock_observed_at = Arc::new(Mutex::new(Instant::now()));
             let node_id_gen = Arc::new(IdGenerator::new());
             let edge_id_gen = Arc::new(IdGenerator::new());
             let version_id_gen = Arc::new(IdGenerator::new());
@@ -2434,6 +2437,7 @@ mod clock_skew_tests {
                 temporal_indexes,
                 wal,
                 current_timestamp,
+                commit_clock_observed_at,
                 visibility_manager,
                 node_id_gen,
                 edge_id_gen,
@@ -2455,6 +2459,26 @@ mod clock_skew_tests {
                 self.temporal_indexes.clone(),
                 self.wal.clone(),
                 self.current_timestamp.clone(),
+                self.visibility_manager.clone(),
+                self.node_id_gen.clone(),
+                self.edge_id_gen.clone(),
+                self.version_id_gen.clone(),
+            )
+        }
+
+        fn create_tx_with_shared_observation_clock(&self) -> WriteTransaction {
+            let snapshot_ts = *self.current_timestamp.lock().unwrap();
+            let snapshot = self.visibility_manager.capture_snapshot(snapshot_ts);
+
+            WriteTransaction::new_with_clock_observed_at(
+                self.tx_id_gen.next(),
+                snapshot,
+                self.current.clone(),
+                self.historical.clone(),
+                self.temporal_indexes.clone(),
+                self.wal.clone(),
+                self.current_timestamp.clone(),
+                self.commit_clock_observed_at.clone(),
                 self.visibility_manager.clone(),
                 self.node_id_gen.clone(),
                 self.edge_id_gen.clone(),
@@ -2524,6 +2548,41 @@ mod clock_skew_tests {
             }
             err => panic!("Expected ClockSkew error, got: {:?}", err),
         }
+    }
+
+    #[test]
+    fn test_clock_skew_allows_idle_forward_drift_with_shared_observation_clock() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx_with_shared_observation_clock();
+
+        let props = PropertyMapBuilder::new().insert("test", true).build();
+        tx.create_node("Test", props).unwrap();
+
+        let idle_gap_us = super::MAX_FORWARD_JUMP_US + 2_000_000;
+        {
+            let mut ts = harness.current_timestamp.lock().unwrap();
+            let past_time = time::now().wallclock() - idle_gap_us;
+            *ts = crate::core::hlc::HybridTimestamp::new(past_time, 0).unwrap();
+        }
+
+        {
+            let mut observed_at = harness.commit_clock_observed_at.lock().unwrap();
+            match Instant::now().checked_sub(Duration::from_micros(idle_gap_us as u64)) {
+                Some(past_instant) => *observed_at = past_instant,
+                None => {
+                    println!(
+                        "Skipping test_clock_skew_allows_idle_forward_drift_with_shared_observation_clock: uptime insufficient for 1h+ idle gap."
+                    );
+                    return;
+                }
+            }
+        }
+
+        let result = tx.commit();
+        assert!(
+            result.is_ok(),
+            "normal idle time should not be treated as forward clock skew"
+        );
     }
 }
 

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2566,9 +2566,8 @@ mod clock_skew_tests {
 
         let old_observed_at = {
             let mut observed_at = harness.commit_clock_observed_at.lock().unwrap();
-            let old_observed = Instant::now()
-                .checked_sub(Duration::from_secs(2 * 60 * 60))
-                .expect("uptime should support two-hour rollback");
+            let now = Instant::now();
+            let old_observed = now.checked_sub(Duration::from_secs(5)).unwrap_or(now);
             *observed_at = old_observed;
             old_observed
         };

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2551,6 +2551,44 @@ mod clock_skew_tests {
     }
 
     #[test]
+    fn test_clock_skew_failure_does_not_advance_observation_timestamp() {
+        let harness = TestHarness::new();
+        let mut tx = harness.create_tx_with_shared_observation_clock();
+
+        let props = PropertyMapBuilder::new().insert("test", true).build();
+        tx.create_node("Test", props).unwrap();
+
+        {
+            let mut ts = harness.current_timestamp.lock().unwrap();
+            let old_frontier = time::now().wallclock() - (6 * 60 * 60 * 1_000_000);
+            *ts = crate::core::hlc::HybridTimestamp::new(old_frontier, 0).unwrap();
+        }
+
+        let old_observed_at = {
+            let mut observed_at = harness.commit_clock_observed_at.lock().unwrap();
+            let old_observed = Instant::now()
+                .checked_sub(Duration::from_secs(2 * 60 * 60))
+                .expect("uptime should support two-hour rollback");
+            *observed_at = old_observed;
+            old_observed
+        };
+
+        let result = tx.commit();
+        assert!(matches!(
+            result,
+            Err(crate::utils::error::Error::Transaction(
+                TransactionError::ClockSkew { .. }
+            ))
+        ));
+
+        let observed_after_failure = *harness.commit_clock_observed_at.lock().unwrap();
+        assert_eq!(
+            observed_after_failure, old_observed_at,
+            "failed skew validation must not consume idle-time budget"
+        );
+    }
+
+    #[test]
     fn test_clock_skew_allows_idle_forward_drift_with_shared_observation_clock() {
         let harness = TestHarness::new();
         let mut tx = harness.create_tx_with_shared_observation_clock();

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -17,6 +17,7 @@ use crate::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalS
 use crate::utils::error::Result;
 use parking_lot::RwLock;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 fn bootstrap_timestamp(
     current: &CurrentStorage,
@@ -201,6 +202,7 @@ impl AletheiaDB {
             temporal_indexes: Arc::new(TemporalIndexes::new()),
             wal,
             current_timestamp: Arc::new(Mutex::new(time::now())),
+            commit_clock_observed_at: Arc::new(Mutex::new(Instant::now())),
             tx_id_gen: Arc::new(TxIdGenerator::new()),
             visibility_manager: Arc::new(TxVisibilityManager::new()),
             node_id_gen: Arc::new(IdGenerator::new()),
@@ -324,6 +326,7 @@ impl AletheiaDB {
             temporal_indexes: Arc::new(TemporalIndexes::new()),
             wal,
             current_timestamp: Arc::new(Mutex::new(time::now())),
+            commit_clock_observed_at: Arc::new(Mutex::new(Instant::now())),
             tx_id_gen: Arc::new(TxIdGenerator::new()),
             visibility_manager: Arc::new(TxVisibilityManager::new()),
             node_id_gen: Arc::new(IdGenerator::new()),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,6 +15,7 @@ use crate::storage::wal::DurabilityMode;
 use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
 use parking_lot::RwLock;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 /// Administrative and maintenance operations.
 pub mod admin;
@@ -108,6 +109,8 @@ pub struct AletheiaDB {
     pub(crate) wal: Arc<ConcurrentWalSystem>,
     /// Current logical timestamp for transaction time - Mutex-protected for thread-safe increment
     pub(crate) current_timestamp: Arc<Mutex<Timestamp>>,
+    /// Monotonic observation time for adaptive forward clock-skew limits.
+    pub(crate) commit_clock_observed_at: Arc<Mutex<Instant>>,
     /// Transaction ID generator for MVCC
     pub(crate) tx_id_gen: Arc<TxIdGenerator>,
     /// Transaction visibility manager for Snapshot Isolation

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -166,7 +166,7 @@ impl AletheiaDB {
         // Capture snapshot
         let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-        Ok(WriteTransaction::new(
+        Ok(WriteTransaction::new_with_clock_observed_at(
             tx_id,
             snapshot,
             Arc::clone(&self.current),
@@ -174,6 +174,7 @@ impl AletheiaDB {
             Arc::clone(&self.temporal_indexes),
             Arc::clone(&self.wal),
             Arc::clone(&self.current_timestamp),
+            Arc::clone(&self.commit_clock_observed_at),
             Arc::clone(&self.visibility_manager),
             Arc::clone(&self.node_id_gen),
             Arc::clone(&self.edge_id_gen),
@@ -399,7 +400,7 @@ impl AletheiaDB {
         // Determine effective durability mode
         let durability = options.effective_durability(self.default_durability);
 
-        Ok(WriteTransaction::new_with_durability(
+        Ok(WriteTransaction::new_with_durability_and_clock_observed_at(
             tx_id,
             snapshot,
             Arc::clone(&self.current),
@@ -407,6 +408,7 @@ impl AletheiaDB {
             Arc::clone(&self.temporal_indexes),
             Arc::clone(&self.wal),
             Arc::clone(&self.current_timestamp),
+            Arc::clone(&self.commit_clock_observed_at),
             Arc::clone(&self.visibility_manager),
             Arc::clone(&self.node_id_gen),
             Arc::clone(&self.edge_id_gen),


### PR DESCRIPTION
## Summary
- add per-database commit observation clock state to track monotonic idle elapsed time
- use adaptive forward skew limits in single-node write commits (max forward = 1h + elapsed since last observation)
- keep backward skew protections unchanged
- add regression test covering >1h idle gap without false-positive ClockSkew rejection

## Verification
- cargo test -p aletheiadb clock_skew_tests --offline -- --nocapture
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --offline