### PR TITLE
doc: Update Elenchus Journal with test audit verdicts

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -183,3 +183,39 @@
 **Finding:** `test_simd_dot_and_magnitudes_large_vector` uses a very loose epsilon (`0.1`) for comparing SIMD vs Scalar results. This could mask significant precision loss or subtle logic errors in remainder handling.
 **Evidence:** `let epsilon = 0.1;` for a sum around 30,000.
 **Recommendation:** Tighten the epsilon to `0.01` or `0.005` to enforce stricter adherence to scalar precision.
+
+**[PropertyMap Heap Size Audit]**
+**Module:** `src/core/property.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** Previous concern about weak assertions (`size >= 5`) was investigated. Current tests use precise `assert_eq!` with calculated expected values (e.g., `expected_delta = embedding.len() * size_of::<f32>()`).
+**Evidence:** `test_property_map_estimated_heap_size_with_vector` uses exact calculation.
+
+**[PropertyMap Round-Trip]**
+**Module:** `src/core/property.rs`, `tests/havoc_property.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** Concern about missing round-trip tests. Found `test_all_property_types_round_trip` in unit tests and `prop_round_trip` with `arb_property_value()` in havoc tests covering nested structures.
+**Evidence:** `tests/havoc_property.rs` exists and contains property-based round-trip tests.
+
+**[Vector Delta Inconsistency]**
+**Module:** `src/core/version.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** The inconsistency between `apply` (fail-open) and `materialize` (fail-closed) for sparse deltas is intentional and documented.
+**Evidence:** Code comments explicitly explain the "fail-open" design choice for views vs "fail-closed" for persistence.
+
+**[HLC Tests Audit]**
+**Module:** `src/core/hlc.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** Previous concerns about weak assertions and tautologies were addressed. `test_receive_collision_oracle` provides an independent verification, and `prop_send_monotonicity` explicitly handles errors.
+**Evidence:** Code inspection of `src/core/hlc.rs`.
+
+**[SIMD Precision]**
+**Module:** `src/core/vector/sentry_tests.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** `test_simd_dot_and_magnitudes_large_vector` uses a tighter epsilon (`0.01`) as recommended.
+**Evidence:** Code inspection.
+
+**[WAL Gaps Havoc Test]**
+**Module:** `tests/havoc_wal_gaps.rs`
+**Severity:** 🟢 Acquitted (Conditional)
+**Finding:** The test `test_havoc_wal_batch_gaps` passes when it successfully identifies gaps in the LSN sequence after a failed batch append. This confirms the system's failure mode (atomicity is per-entry, not per-batch for LSN allocation).
+**Evidence:** Test logic explicitly asserts `!contiguous` to pass.


### PR DESCRIPTION
Audited tests in src/core/property.rs, src/core/version.rs, src/core/hlc.rs, and src/core/vector. Verified fixes for previous findings and acquitted modules where tests are now robust. Confirmed intentional behavior for WAL gaps test.

---
*PR created automatically by Jules for task [435142800162793169](https://jules.google.com/task/435142800162793169) started by @madmax983*