### PR TITLE
fix(vector): correct DotProduct similarity conversion in HNSW

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -219,3 +219,22 @@
 **Severity:** 🟢 Acquitted (Conditional)
 **Finding:** The test `test_havoc_wal_batch_gaps` passes when it successfully identifies gaps in the LSN sequence after a failed batch append. This confirms the system's failure mode (atomicity is per-entry, not per-batch for LSN allocation).
 **Evidence:** Test logic explicitly asserts `!contiguous` to pass.
+
+**[DotProduct Metric Conversion Regression]**
+**Module:** `src/index/vector/hnsw.rs`
+**Severity:** 🔴 Critical
+**Finding:** The code contained `DistanceMetric::DotProduct => -distance`, contradicting the previous journal resolution which stated it should be `1.0 - distance`. This caused dot product similarity to be `0.0` (or negative) for identical unit vectors instead of `1.0`.
+**Evidence:** `tests/repro_hnsw_dotproduct.rs` failed with `Expected 1.0, got -0`.
+**Resolution:** Re-applied the fix: `DistanceMetric::DotProduct => 1.0 - distance`. Added permanent regression test `test_dot_product_similarity_metric` to prevent future regressions.
+
+**[HLC Tests Audit]**
+**Module:** `src/core/hlc.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** Verified that critical concerns "HLC Causality Blind Spot" and "HLC Assertion Weakness" are addressed. `prop_receive_causality_collision` now explicitly tests the logical counter increment on wallclock collision.
+**Evidence:** Code inspection of `src/core/hlc.rs` and successful test execution.
+
+**[String Interning Audit]**
+**Module:** `src/core/interning.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** Module contains robust concurrency tests including `test_intern_concurrent_capacity_race` and `test_concurrent_interning`.
+**Evidence:** Code inspection.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1616,7 +1616,7 @@ impl HnswIndex {
                 let similarity = match self.config.metric {
                     DistanceMetric::Cosine => 1.0 - distance,
                     DistanceMetric::Euclidean => -distance,
-                    DistanceMetric::DotProduct => -distance,
+                    DistanceMetric::DotProduct => 1.0 - distance,
                     DistanceMetric::Haversine => -distance,
                     DistanceMetric::Hamming => -distance,
                     DistanceMetric::Tanimoto => 1.0 - distance,
@@ -2277,6 +2277,32 @@ mod tests {
 
         let results = index.search(&[1.0, 0.0, 0.0, 0.0], 2)?;
         assert_eq!(results[0].0, node1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_dot_product_similarity_metric() -> Result<()> {
+        // Test DotProduct similarity conversion
+        // Dot Product of (1,0) and (1,0) is 1.0.
+        // usearch IP metric returns 1 - dot_product (or similar).
+        // We verify that our conversion (1.0 - distance) yields the correct dot product (1.0).
+
+        let index = HnswIndexBuilder::new(2, DistanceMetric::DotProduct).build()?;
+        let node = NodeId::new(1).unwrap();
+        index.add(node, &[1.0, 0.0])?;
+
+        let results = index.search(&[1.0, 0.0], 1)?;
+        assert_eq!(results.len(), 1);
+        let similarity = results[0].1;
+
+        // We expect similarity to be exactly 1.0 for normalized dot product of identical unit vectors.
+        // Previously this was returning 0.0 (or -0.0) due to incorrect conversion.
+        assert!(
+            (similarity - 1.0).abs() < 0.001,
+            "Expected 1.0, got {}",
+            similarity
+        );
 
         Ok(())
     }


### PR DESCRIPTION
This PR addresses a critical regression in the HNSW `DotProduct` similarity calculation identified during an Elenchus test audit. 

**Bug Fix:**
- `usearch`'s IP metric returns a distance of `1 - dot_product` (for normalized vectors) or similar zero-based distance for identical vectors.
- The previous conversion `similarity = -distance` yielded `0.0` (or `-0.0`) for identical unit vectors (dot product 1.0), which is incorrect.
- The fixed conversion `similarity = 1.0 - distance` correctly yields `1.0`.

**Audit Findings:**
- **HNSW:** Regressed (now fixed).
- **HLC:** `src/core/hlc.rs` tests were audited and found to robustly cover the "Causality Blind Spot" via `prop_receive_causality_collision`.
- **Interning:** `src/core/interning.rs` concurrency tests were audited and found sufficient.

**Verification:**
- Added `test_dot_product_similarity_metric` to `src/index/vector/hnsw.rs` which explicitly asserts similarity is `1.0` for identical unit vectors.
- Ran all tests in `index::vector::hnsw`.


---
*PR created automatically by Jules for task [6651036929233280510](https://jules.google.com/task/6651036929233280510) started by @madmax983*