### PR TITLE
Fix StringInterner snapshot truncation race condition

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -219,3 +219,10 @@
 **Severity:** 🟢 Acquitted (Conditional)
 **Finding:** The test `test_havoc_wal_batch_gaps` passes when it successfully identifies gaps in the LSN sequence after a failed batch append. This confirms the system's failure mode (atomicity is per-entry, not per-batch for LSN allocation).
 **Evidence:** Test logic explicitly asserts `!contiguous` to pass.
+
+**[StringInterner Snapshot Truncation]**
+**Module:** `src/core/interning.rs`
+**Severity:** 🔴 Critical
+**Finding:** `get_all_strings` relied on `self.len()` to pre-allocate the result vector. Due to lock ordering in `intern` (inserting into `id_to_string` before `string_to_id`), a concurrent insert could produce an ID that exists in `id_to_string` but is not yet reflected in `len()`. The iterator would skip this ID, resulting in a truncated snapshot. If used for checkpointing, this could cause data corruption (dangling references).
+**Evidence:** Manual audit revealed the race condition. `tests/regression_interning_snapshot.rs` was created to stress-test snapshot consistency.
+**Resolution:** Modified `get_all_strings` to dynamically resize the result vector if an encountered ID exceeds the initial capacity, ensuring all visible IDs are captured.

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -357,9 +357,12 @@ impl StringInterner {
         // Collect all (id, string) pairs
         for entry in self.id_to_string.iter() {
             let id = entry.key().as_u32() as usize;
-            if id < count {
-                strings[id] = entry.value().to_string();
+            // If the ID is outside our initial estimate (due to concurrent inserts),
+            // resize the vector to accommodate it.
+            if id >= strings.len() {
+                strings.resize(id + 1, String::new());
             }
+            strings[id] = entry.value().to_string();
         }
 
         strings

--- a/tests/regression_interning_snapshot.rs
+++ b/tests/regression_interning_snapshot.rs
@@ -1,0 +1,75 @@
+#[cfg(test)]
+mod tests {
+    use aletheiadb::core::interning::StringInterner;
+    use aletheiadb::core::interning::InternedString;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn test_get_all_strings_race_condition() {
+        // Run multiple iterations to increase chance of hitting the race
+        for _ in 0..5 {
+            run_race_test();
+        }
+    }
+
+    fn run_race_test() {
+        let interner = Arc::new(StringInterner::new());
+        let barrier = Arc::new(Barrier::new(2));
+
+        // Pre-fill some strings
+        for i in 0..100 {
+            interner.intern(format!("init_{}", i)).unwrap();
+        }
+
+        let interner_clone = interner.clone();
+        let barrier_clone = barrier.clone();
+
+        // Spawn a thread that will insert strings concurrently
+        let handle = thread::spawn(move || {
+            barrier_clone.wait(); // Sync start
+            for i in 0..5000 {
+                interner_clone.intern(format!("race_{}", i)).unwrap();
+                if i % 50 == 0 { thread::yield_now(); }
+            }
+        });
+
+        barrier.wait(); // Sync start
+
+        let mut max_len = 0;
+
+        // Repeatedly call get_all_strings and check for consistency
+        for _ in 0..50 {
+            let snapshot = interner.get_all_strings();
+            max_len = std::cmp::max(max_len, snapshot.len());
+
+            // Check 1: No empty holes in the middle of the vector
+            for (id, s) in snapshot.iter().enumerate() {
+                if s.is_empty() {
+                    let id_handle = InternedString::from_raw(id as u32);
+                    // If the ID exists in the interner, the snapshot MUST have it.
+                    if let Some(actual_str) = interner.resolve_with(id_handle, |s| s.to_string()) {
+                         if !actual_str.is_empty() {
+                             panic!(
+                                 "Snapshot corruption (HOLE) at ID {}: expected '{}', got empty string. Snapshot len: {}",
+                                 id, actual_str, snapshot.len()
+                             );
+                         }
+                    }
+                } else {
+                    // Check 2: Content matches
+                    let id_handle = InternedString::from_raw(id as u32);
+                    if let Some(actual_str) = interner.resolve_with(id_handle, |s| s.to_string()) {
+                        assert_eq!(s, &actual_str, "Snapshot content mismatch at ID {}", id);
+                    }
+                }
+            }
+        }
+
+        handle.join().unwrap();
+
+        // Check 3: Ensure we actually captured new data
+        // This prevents the "Alibi Test" where we always return just the initial 100 items.
+        assert!(max_len > 100, "Snapshot failed to capture any concurrent insertions");
+    }
+}


### PR DESCRIPTION
Fixes a critical race condition in `StringInterner::get_all_strings` where the method could return a truncated list of strings if concurrent insertions occurred. The issue was due to `self.len()` (reading `string_to_id`) lagging behind `id_to_string` inserts. The fix dynamically resizes the result vector if an ID larger than the initial estimate is encountered. This ensures that all strings visible in `id_to_string` are captured, preventing potential data corruption during persistence checkpoints.

Includes a regression test `tests/regression_interning_snapshot.rs` that stress-tests the interner with concurrent inserts and verifies no data loss occurs.

---
*PR created automatically by Jules for task [5425574898807471446](https://jules.google.com/task/5425574898807471446) started by @madmax983*