### PR TITLE
🤖 Sentinel: Strengthen temporal and HLC boundary tests

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1043,6 +1043,50 @@ mod tests {
         // NOT visible at valid_time=Jan 15, tx_time=Jan 15 (before recording)
         assert!(!interval.is_visible_at(jan_15, jan_15));
     }
+
+    #[test]
+    fn test_timerange_rejects_invalid_timestamps_internal() {
+        // Use new_unchecked to bypass HybridTimestamp validation and create an invalid timestamp
+        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+
+        // For start check: make end larger so start < end check passes
+        // TIMESTAMP_MAX is valid and larger than invalid_ts
+        let valid_end = TIMESTAMP_MAX;
+
+        // Should reject invalid start
+        let result = TimeRange::new(invalid_ts, valid_end);
+        assert!(
+            matches!(result, Err(TemporalError::InvalidTimestamp { .. })),
+            "Expected InvalidTimestamp error for start, got {:?}",
+            result
+        );
+
+        // Should reject invalid end
+        let valid_start = HybridTimestamp::new(100, 0).unwrap();
+        let result = TimeRange::new(valid_start, invalid_ts);
+        assert!(
+            matches!(result, Err(TemporalError::InvalidTimestamp { .. })),
+            "Expected InvalidTimestamp error for end, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_contains_range_excludes_partial_overlap_start() {
+        // Outer: [100, 200)
+        let start = HybridTimestamp::new(100, 0).unwrap();
+        let end = HybridTimestamp::new(200, 0).unwrap();
+        let outer = TimeRange::new(start, end).unwrap();
+
+        // Inner: [50, 150) - Starts before outer
+        // This targets the potential missing `self.start <= other.start` check
+        let inner_start = HybridTimestamp::new(50, 0).unwrap();
+        let inner_end = HybridTimestamp::new(150, 0).unwrap();
+        let inner = TimeRange::new(inner_start, inner_end).unwrap();
+
+        // Should return false because inner.start < outer.start
+        assert!(!outer.contains_range(&inner), "Range starting before outer should not be contained");
+    }
 }
 
 #[cfg(test)]

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1085,7 +1085,10 @@ mod tests {
         let inner = TimeRange::new(inner_start, inner_end).unwrap();
 
         // Should return false because inner.start < outer.start
-        assert!(!outer.contains_range(&inner), "Range starting before outer should not be contained");
+        assert!(
+            !outer.contains_range(&inner),
+            "Range starting before outer should not be contained"
+        );
     }
 }
 

--- a/tests/hlc_tests.rs
+++ b/tests/hlc_tests.rs
@@ -5,7 +5,7 @@
 //! - Causality preservation
 //! - Serialization/deserialization
 
-use aletheiadb::core::hlc::{evaluate_clock_skew, MAX_BACKWARD_DRIFT_US, HybridTimestamp};
+use aletheiadb::core::hlc::{HybridTimestamp, MAX_BACKWARD_DRIFT_US, evaluate_clock_skew};
 use aletheiadb::core::temporal::MAX_VALID_TIMESTAMP;
 use aletheiadb::utils::error::{StorageError, TemporalError};
 use proptest::prelude::*;
@@ -54,11 +54,13 @@ fn test_evaluate_clock_skew_exact_boundaries() {
 
     // Test strictly greater forward drift (violation)
     let frontier_forward_violation = current - max_forward - 1;
-    let result = evaluate_clock_skew(current, frontier_forward_violation, Some(max_forward), false);
-    assert!(
-        result.is_err(),
-        "Exceeding forward jump limit should fail"
+    let result = evaluate_clock_skew(
+        current,
+        frontier_forward_violation,
+        Some(max_forward),
+        false,
     );
+    assert!(result.is_err(), "Exceeding forward jump limit should fail");
 }
 
 #[test]

--- a/tests/hlc_tests.rs
+++ b/tests/hlc_tests.rs
@@ -5,10 +5,61 @@
 //! - Causality preservation
 //! - Serialization/deserialization
 
-use aletheiadb::core::hlc::HybridTimestamp;
+use aletheiadb::core::hlc::{evaluate_clock_skew, MAX_BACKWARD_DRIFT_US, HybridTimestamp};
 use aletheiadb::core::temporal::MAX_VALID_TIMESTAMP;
 use aletheiadb::utils::error::{StorageError, TemporalError};
 use proptest::prelude::*;
+
+#[test]
+fn test_evaluate_clock_skew_exact_boundaries() {
+    let current = 1_000_000;
+
+    // Test Backward Drift Boundary
+    // Drift = current - frontier
+    // We want drift = -MAX_BACKWARD_DRIFT_US
+    // So 1_000_000 - frontier = -MAX_BACKWARD_DRIFT_US
+    // frontier = 1_000_000 + MAX_BACKWARD_DRIFT_US
+    let frontier_exact = current + MAX_BACKWARD_DRIFT_US;
+
+    // Should be OK (exact boundary allowed)
+    let result = evaluate_clock_skew(current, frontier_exact, None, false);
+    assert!(
+        result.is_ok(),
+        "Exact backward drift limit should be allowed, got {:?}",
+        result
+    );
+
+    // Test strictly greater backward drift (violation)
+    let frontier_violation = current + MAX_BACKWARD_DRIFT_US + 1;
+    let result = evaluate_clock_skew(current, frontier_violation, None, false);
+    assert!(
+        result.is_err(),
+        "Exceeding backward drift limit should fail"
+    );
+
+    // Test Forward Jump Boundary
+    let max_forward = 100_000;
+    // Drift = current - frontier
+    // We want drift = max_forward
+    // current - frontier = max_forward
+    // frontier = current - max_forward
+    let frontier_forward_exact = current - max_forward;
+
+    let result = evaluate_clock_skew(current, frontier_forward_exact, Some(max_forward), false);
+    assert!(
+        result.is_ok(),
+        "Exact forward jump limit should be allowed, got {:?}",
+        result
+    );
+
+    // Test strictly greater forward drift (violation)
+    let frontier_forward_violation = current - max_forward - 1;
+    let result = evaluate_clock_skew(current, frontier_forward_violation, Some(max_forward), false);
+    assert!(
+        result.is_err(),
+        "Exceeding forward jump limit should fail"
+    );
+}
 
 #[test]
 fn test_new_validates_wallclock() {


### PR DESCRIPTION
**🤖 Sentinel Report**

**🧬 Mutants Found & Eliminated:**
- **`src/core/temporal.rs`**: `TimeRange::contains_range` missed verifying the start boundary condition (partial overlap starting before).
  - *Kill Shot:* Added `test_contains_range_excludes_partial_overlap_start`.
- **`src/core/hlc.rs`**: `evaluate_clock_skew` boundaries were susceptible to off-by-one errors (strict inequality vs inclusive).
  - *Kill Shot:* Added `test_evaluate_clock_skew_exact_boundaries`.
- **`src/core/temporal.rs`**: `TimeRange::new` validation check was not explicitly tested against internally constructed invalid timestamps.
  - *Kill Shot:* Added `test_timerange_rejects_invalid_timestamps_internal`.

**🎯 Changes:**
- Modified `src/core/temporal.rs` to include new unit tests.
- Modified `tests/hlc_tests.rs` to include clock skew boundary tests.

**⚠️ Suspected Bugs:**
- None. The implementation was correct; only the test suite coverage was insufficient to prove it against mutation.

**📊 Verification:**
- Manually simulated mutants (by modifying code to remove checks or change operators) and verified that the new tests fail, confirming they effectively "kill" the mutants.
- All tests passed on clean code.

---
*PR created automatically by Jules for task [12800031977403705364](https://jules.google.com/task/12800031977403705364) started by @madmax983*