### PR TITLE
feat(core): enforce MAX_VALID_ID for TxId

### DIFF
--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -111,7 +111,7 @@ impl ReadTransaction {
                 // NOTE: Historical versions don't track created_by_tx, so we use TxId(0)
                 // The commit_timestamp is extracted from transaction_time.start
                 let metadata = VersionMetadata::new(
-                    super::TxId::new(0), // Historical versions don't track creating tx
+                    super::TxId::new(0).unwrap(), // Historical versions don't track creating tx
                     version.temporal.transaction_time().start(), // Extract commit timestamp
                 );
 
@@ -179,7 +179,7 @@ impl ReadTransaction {
                 // NOTE: Historical versions don't track created_by_tx, so we use TxId(0)
                 // The commit_timestamp is extracted from transaction_time.start
                 let metadata = VersionMetadata::new(
-                    super::TxId::new(0), // Historical versions don't track creating tx
+                    super::TxId::new(0).unwrap(), // Historical versions don't track creating tx
                     version.temporal.transaction_time().start(), // Extract commit timestamp
                 );
 
@@ -325,11 +325,11 @@ mod tests {
     #[test]
     fn test_read_transaction_creation() {
         let current = Arc::new(CurrentStorage::new());
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
 
-        assert_eq!(tx.tx_id(), TxId::new(1));
+        assert_eq!(tx.tx_id(), TxId::new(1).unwrap());
         let metadata = tx.metadata();
-        assert_eq!(metadata.tx_id, TxId::new(1));
+        assert_eq!(metadata.tx_id, TxId::new(1).unwrap());
         assert!(metadata.is_read_only);
         assert_eq!(metadata.state, TxState::Active);
         assert_eq!(metadata.commit_timestamp, None);
@@ -347,7 +347,7 @@ mod tests {
         let node_id = current.create_node("Person", props.clone()).unwrap();
 
         // Read through transaction
-        let tx = create_test_read_tx(TxId::new(1), Arc::clone(&current));
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), Arc::clone(&current));
         let node = tx.get_node(node_id).unwrap();
 
         assert_eq!(node.id, node_id);
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn test_read_transaction_get_node_not_found() {
         let current = Arc::new(CurrentStorage::new());
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
 
         let result = tx.get_node(NodeId::new(999).unwrap());
         assert!(result.is_err());
@@ -377,7 +377,7 @@ mod tests {
         current.create_node("Person", props.clone()).unwrap();
         current.create_node("Person", props).unwrap();
 
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
         assert_eq!(tx.node_count(), 3);
     }
 
@@ -391,7 +391,7 @@ mod tests {
         let node2 = current.create_node("Person", props.clone()).unwrap();
         let edge_id = current.create_edge(node1, node2, "KNOWS", props).unwrap();
 
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
 
         // Get edge
         let edge = tx.get_edge(edge_id).unwrap();
@@ -425,7 +425,7 @@ mod tests {
             .unwrap();
         let _edge2 = current.create_edge(node1, node3, "FOLLOWS", props).unwrap();
 
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
 
         // Get only KNOWS edges
         let knows_edges = tx.get_outgoing_edges_with_label(node1, "KNOWS");
@@ -452,7 +452,7 @@ mod tests {
         for i in 0..10 {
             let current_clone = Arc::clone(&current);
             let handle = thread::spawn(move || {
-                let tx = create_test_read_tx(TxId::new(i), current_clone);
+                let tx = create_test_read_tx(TxId::new(i).unwrap(), current_clone);
                 let node = tx.get_node(node_id).unwrap();
                 assert_eq!(
                     node.get_property("value").and_then(|v| v.as_int()),
@@ -474,7 +474,7 @@ mod tests {
         let current = Arc::new(CurrentStorage::new());
         let visibility_manager = Arc::new(TxVisibilityManager::new());
 
-        let tx_id = TxId::new(42);
+        let tx_id = TxId::new(42).unwrap();
 
         // Register transaction as active
         visibility_manager.register_active(tx_id);
@@ -530,7 +530,7 @@ mod tests {
             )
             .unwrap();
 
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
 
         let results = tx.find_nodes_by_property(
             "Person",
@@ -543,7 +543,7 @@ mod tests {
     #[test]
     fn test_read_transaction_find_nodes_by_property_empty() {
         let current = Arc::new(CurrentStorage::new());
-        let tx = create_test_read_tx(TxId::new(1), current);
+        let tx = create_test_read_tx(TxId::new(1).unwrap(), current);
 
         let results = tx.find_nodes_by_property(
             "Person",

--- a/src/api/transaction/types.rs
+++ b/src/api/transaction/types.rs
@@ -49,21 +49,21 @@ mod tests {
 
     #[test]
     fn test_tx_id_creation() {
-        let tx_id = TxId::new(42);
+        let tx_id = TxId::new(42).unwrap();
         assert_eq!(tx_id.as_u64(), 42u64);
     }
 
     #[test]
     fn test_tx_id_ordering() {
-        let tx1 = TxId::new(1);
-        let tx2 = TxId::new(2);
+        let tx1 = TxId::new(1).unwrap();
+        let tx2 = TxId::new(2).unwrap();
         assert!(tx1 < tx2);
         assert_eq!(tx1, tx1);
     }
 
     #[test]
     fn test_tx_id_display() {
-        let tx_id = TxId::new(123);
+        let tx_id = TxId::new(123).unwrap();
         assert_eq!(format!("{}", tx_id), "TxId(123)");
     }
 
@@ -78,9 +78,9 @@ mod tests {
     #[test]
     fn test_tx_id_generator() {
         let generator = TxIdGenerator::new();
-        let tx1 = generator.next();
-        let tx2 = generator.next();
-        let tx3 = generator.next();
+        let tx1 = generator.next().unwrap();
+        let tx2 = generator.next().unwrap();
+        let tx3 = generator.next().unwrap();
 
         assert_eq!(tx1.as_u64(), 1u64);
         assert_eq!(tx2.as_u64(), 2u64);
@@ -102,7 +102,7 @@ mod tests {
             let handle = thread::spawn(move || {
                 let mut ids = vec![];
                 for _ in 0..100 {
-                    ids.push(generator_clone.next());
+                    ids.push(generator_clone.next().unwrap());
                 }
                 ids
             });
@@ -130,14 +130,14 @@ mod tests {
     #[test]
     fn test_tx_metadata() {
         let metadata = TxMetadata {
-            tx_id: TxId::new(1),
+            tx_id: TxId::new(1).unwrap(),
             start_timestamp: 100.into(),
             commit_timestamp: None,
             state: TxState::Active,
             is_read_only: false,
         };
 
-        assert_eq!(metadata.tx_id, TxId::new(1));
+        assert_eq!(metadata.tx_id, TxId::new(1).unwrap());
         assert_eq!(metadata.start_timestamp, 100.into());
         assert_eq!(metadata.commit_timestamp, None);
         assert_eq!(metadata.state, TxState::Active);

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -849,8 +849,16 @@ mod tests {
 
         assert_eq!(snapshot.snapshot_timestamp, 100.into());
         assert_eq!(snapshot.active_transactions.len(), 2);
-        assert!(snapshot.active_transactions.contains(&TxId::new(1).unwrap()));
-        assert!(snapshot.active_transactions.contains(&TxId::new(2).unwrap()));
+        assert!(
+            snapshot
+                .active_transactions
+                .contains(&TxId::new(1).unwrap())
+        );
+        assert!(
+            snapshot
+                .active_transactions
+                .contains(&TxId::new(2).unwrap())
+        );
     }
 
     #[test]
@@ -944,11 +952,19 @@ mod tests {
         // Snapshot 2 - sees tx2 as active, tx1 committed
         let snapshot2 = manager.capture_snapshot(120.into());
         assert_eq!(snapshot1.active_transactions.len(), 1);
-        assert!(snapshot2.active_transactions.contains(&TxId::new(2).unwrap()));
+        assert!(
+            snapshot2
+                .active_transactions
+                .contains(&TxId::new(2).unwrap())
+        );
 
         // Original snapshot1 unchanged
         assert_eq!(snapshot1.active_transactions.len(), 1);
-        assert!(snapshot1.active_transactions.contains(&TxId::new(1).unwrap()));
+        assert!(
+            snapshot1
+                .active_transactions
+                .contains(&TxId::new(1).unwrap())
+        );
     }
 
     #[test]
@@ -1026,7 +1042,12 @@ mod tests {
     #[test]
     fn test_epoch_range_basic() {
         // Test that EpochRange can represent a range of sequential transactions
-        let epoch = EpochRange::new(TxId::new(1).unwrap(), TxId::new(100).unwrap(), 1000.into(), 1099.into());
+        let epoch = EpochRange::new(
+            TxId::new(1).unwrap(),
+            TxId::new(100).unwrap(),
+            1000.into(),
+            1099.into(),
+        );
 
         // Should contain transactions in the range
         assert!(epoch.contains(TxId::new(1).unwrap()));
@@ -1038,8 +1059,14 @@ mod tests {
         assert!(!epoch.contains(TxId::new(101).unwrap()));
 
         // Should be able to get commit timestamp for transactions in range
-        assert_eq!(epoch.get_commit_timestamp(TxId::new(1).unwrap()), Some(1000.into()));
-        assert_eq!(epoch.get_commit_timestamp(TxId::new(50).unwrap()), Some(1049.into()));
+        assert_eq!(
+            epoch.get_commit_timestamp(TxId::new(1).unwrap()),
+            Some(1000.into())
+        );
+        assert_eq!(
+            epoch.get_commit_timestamp(TxId::new(50).unwrap()),
+            Some(1049.into())
+        );
         assert_eq!(
             epoch.get_commit_timestamp(TxId::new(100).unwrap()),
             Some(1099.into())
@@ -1181,10 +1208,7 @@ mod tests {
         let base_ts = 1000;
         for i in 1..=10000 {
             manager.register_active(TxId::new(i).unwrap());
-            manager.register_commit(
-                TxId::new(i).unwrap(),
-                (base_ts + (i as i64) - 1).into(),
-            );
+            manager.register_commit(TxId::new(i).unwrap(), (base_ts + (i as i64) - 1).into());
         }
 
         // Trigger compression
@@ -1230,10 +1254,7 @@ mod tests {
         let base_ts = 1000;
         for i in 1..=10000 {
             manager.register_active(TxId::new(i).unwrap());
-            manager.register_commit(
-                TxId::new(i).unwrap(),
-                (base_ts + (i as i64) - 1).into(),
-            );
+            manager.register_commit(TxId::new(i).unwrap(), (base_ts + (i as i64) - 1).into());
         }
 
         let uncompressed_count = manager.committed_count();
@@ -1266,10 +1287,7 @@ mod tests {
         let base_ts = 1000;
         for i in 1..=1000 {
             manager.register_active(TxId::new(i).unwrap());
-            manager.register_commit(
-                TxId::new(i).unwrap(),
-                (base_ts + (i as i64) - 1).into(),
-            );
+            manager.register_commit(TxId::new(i).unwrap(), (base_ts + (i as i64) - 1).into());
         }
 
         // Should recommend compression if memory exceeds low threshold

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -302,7 +302,9 @@ impl CompressedCommitLog {
 
                 // Check if both tx_id and timestamp increment by 1
                 // Note: We compare wallclock values since logical component should be 0
-                if next_tx == expected_tx && next_ts.wallclock() == expected_ts_wallclock {
+                if expected_tx.map(|tx| tx == next_tx).unwrap_or(false)
+                    && next_ts.wallclock() == expected_ts_wallclock
+                {
                     end_tx = next_tx;
                     end_ts = next_ts;
                     run_length += 1;
@@ -782,7 +784,7 @@ mod tests {
         };
 
         // Version committed before snapshot - visible
-        assert!(snapshot.is_visible(TxId::new(1), Some(50.into())));
+        assert!(snapshot.is_visible(TxId::new(1).unwrap(), Some(50.into())));
     }
 
     #[test]
@@ -793,7 +795,7 @@ mod tests {
         };
 
         // Version committed after snapshot - not visible
-        assert!(!snapshot.is_visible(TxId::new(1), Some(150.into())));
+        assert!(!snapshot.is_visible(TxId::new(1).unwrap(), Some(150.into())));
     }
 
     #[test]
@@ -804,13 +806,13 @@ mod tests {
         };
 
         // Uncommitted version - not visible
-        assert!(!snapshot.is_visible(TxId::new(1), None));
+        assert!(!snapshot.is_visible(TxId::new(1).unwrap(), None));
     }
 
     #[test]
     fn test_snapshot_visibility_active_transaction() {
         let mut active = HashSet::new();
-        active.insert(TxId::new(1));
+        active.insert(TxId::new(1).unwrap());
 
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: 100.into(),
@@ -818,7 +820,7 @@ mod tests {
         };
 
         // Version from active transaction - not visible even if committed before snapshot
-        assert!(!snapshot.is_visible(TxId::new(1), Some(50.into())));
+        assert!(!snapshot.is_visible(TxId::new(1).unwrap(), Some(50.into())));
     }
 
     #[test]
@@ -831,8 +833,8 @@ mod tests {
     #[test]
     fn test_register_active() {
         let manager = TxVisibilityManager::new();
-        manager.register_active(TxId::new(1));
-        manager.register_active(TxId::new(2));
+        manager.register_active(TxId::new(1).unwrap());
+        manager.register_active(TxId::new(2).unwrap());
 
         assert_eq!(manager.active_count(), 2);
     }
@@ -840,26 +842,26 @@ mod tests {
     #[test]
     fn test_capture_snapshot() {
         let manager = TxVisibilityManager::new();
-        manager.register_active(TxId::new(1));
-        manager.register_active(TxId::new(2));
+        manager.register_active(TxId::new(1).unwrap());
+        manager.register_active(TxId::new(2).unwrap());
 
         let snapshot = manager.capture_snapshot(100.into());
 
         assert_eq!(snapshot.snapshot_timestamp, 100.into());
         assert_eq!(snapshot.active_transactions.len(), 2);
-        assert!(snapshot.active_transactions.contains(&TxId::new(1)));
-        assert!(snapshot.active_transactions.contains(&TxId::new(2)));
+        assert!(snapshot.active_transactions.contains(&TxId::new(1).unwrap()));
+        assert!(snapshot.active_transactions.contains(&TxId::new(2).unwrap()));
     }
 
     #[test]
     fn test_register_commit() {
         let manager = TxVisibilityManager::new();
-        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(1).unwrap());
 
         assert_eq!(manager.active_count(), 1);
         assert_eq!(manager.committed_count(), 0);
 
-        manager.register_commit(TxId::new(1), 100.into());
+        manager.register_commit(TxId::new(1).unwrap(), 100.into());
 
         assert_eq!(manager.active_count(), 0);
         assert_eq!(manager.committed_count(), 1);
@@ -868,11 +870,11 @@ mod tests {
     #[test]
     fn test_register_abort() {
         let manager = TxVisibilityManager::new();
-        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(1).unwrap());
 
         assert_eq!(manager.active_count(), 1);
 
-        manager.register_abort(TxId::new(1));
+        manager.register_abort(TxId::new(1).unwrap());
 
         assert_eq!(manager.active_count(), 0);
         assert_eq!(manager.committed_count(), 0);
@@ -883,14 +885,14 @@ mod tests {
         let manager = TxVisibilityManager::new();
 
         // Start and commit transaction 1
-        manager.register_active(TxId::new(1));
-        manager.register_commit(TxId::new(1), 50.into());
+        manager.register_active(TxId::new(1).unwrap());
+        manager.register_commit(TxId::new(1).unwrap(), 50.into());
 
         // Take snapshot after commit
         let snapshot = manager.capture_snapshot(100.into());
 
         // Version from tx1 should be visible
-        assert!(manager.is_visible(&snapshot, TxId::new(1)));
+        assert!(manager.is_visible(&snapshot, TxId::new(1).unwrap()));
     }
 
     #[test]
@@ -898,12 +900,12 @@ mod tests {
         let manager = TxVisibilityManager::new();
 
         // Start transaction 1 but don't commit
-        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(1).unwrap());
 
         let snapshot = manager.capture_snapshot(100.into());
 
         // Version from uncommitted tx1 should not be visible
-        assert!(!manager.is_visible(&snapshot, TxId::new(1)));
+        assert!(!manager.is_visible(&snapshot, TxId::new(1).unwrap()));
     }
 
     #[test]
@@ -911,17 +913,17 @@ mod tests {
         let manager = TxVisibilityManager::new();
 
         // Start tx1
-        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(1).unwrap());
 
         // Take snapshot (tx1 is active)
         let snapshot = manager.capture_snapshot(100.into());
 
         // Commit tx1 after snapshot
-        manager.register_commit(TxId::new(1), 90.into());
+        manager.register_commit(TxId::new(1).unwrap(), 90.into());
 
         // Even though tx1 committed before snapshot timestamp,
         // it was active at snapshot time, so not visible
-        assert!(!manager.is_visible(&snapshot, TxId::new(1)));
+        assert!(!manager.is_visible(&snapshot, TxId::new(1).unwrap()));
     }
 
     #[test]
@@ -929,24 +931,24 @@ mod tests {
         let manager = TxVisibilityManager::new();
 
         // Start tx1
-        manager.register_active(TxId::new(1));
+        manager.register_active(TxId::new(1).unwrap());
 
         // Snapshot 1 - sees tx1 as active
         let snapshot1 = manager.capture_snapshot(100.into());
         assert_eq!(snapshot1.active_transactions.len(), 1);
 
         // Commit tx1, start tx2
-        manager.register_commit(TxId::new(1), 110.into());
-        manager.register_active(TxId::new(2));
+        manager.register_commit(TxId::new(1).unwrap(), 110.into());
+        manager.register_active(TxId::new(2).unwrap());
 
         // Snapshot 2 - sees tx2 as active, tx1 committed
         let snapshot2 = manager.capture_snapshot(120.into());
         assert_eq!(snapshot1.active_transactions.len(), 1);
-        assert!(snapshot2.active_transactions.contains(&TxId::new(2)));
+        assert!(snapshot2.active_transactions.contains(&TxId::new(2).unwrap()));
 
         // Original snapshot1 unchanged
         assert_eq!(snapshot1.active_transactions.len(), 1);
-        assert!(snapshot1.active_transactions.contains(&TxId::new(1)));
+        assert!(snapshot1.active_transactions.contains(&TxId::new(1).unwrap()));
     }
 
     #[test]
@@ -958,18 +960,18 @@ mod tests {
         assert_eq!(manager.committed_count(), 0);
 
         // Add active transactions
-        manager.register_active(TxId::new(1));
-        manager.register_active(TxId::new(2));
+        manager.register_active(TxId::new(1).unwrap());
+        manager.register_active(TxId::new(2).unwrap());
         assert_eq!(manager.active_count(), 2);
         assert_eq!(manager.committed_count(), 0);
 
         // Commit one
-        manager.register_commit(TxId::new(1), 100.into());
+        manager.register_commit(TxId::new(1).unwrap(), 100.into());
         assert_eq!(manager.active_count(), 1);
         assert_eq!(manager.committed_count(), 1);
 
         // Abort the other
-        manager.register_abort(TxId::new(2));
+        manager.register_abort(TxId::new(2).unwrap());
         assert_eq!(manager.active_count(), 0);
         assert_eq!(manager.committed_count(), 1);
     }
@@ -983,8 +985,8 @@ mod tests {
 
         // Setup: commit several transactions
         for i in 1..=10 {
-            manager.register_active(TxId::new(i));
-            manager.register_commit(TxId::new(i), ((i * 10) as i64).into());
+            manager.register_active(TxId::new(i).unwrap());
+            manager.register_commit(TxId::new(i).unwrap(), ((i * 10) as i64).into());
         }
 
         // Take snapshot after all commits (timestamp 100 is the last commit)
@@ -999,7 +1001,7 @@ mod tests {
                 thread::spawn(move || {
                     // Each thread performs many visibility checks
                     for _ in 0..1000 {
-                        let tx_id = TxId::new((i % 10) + 1);
+                        let tx_id = TxId::new((i % 10) + 1).unwrap();
                         // All these transactions were committed before snapshot time
                         assert!(mgr.is_visible(&snap, tx_id));
                     }
@@ -1024,25 +1026,25 @@ mod tests {
     #[test]
     fn test_epoch_range_basic() {
         // Test that EpochRange can represent a range of sequential transactions
-        let epoch = EpochRange::new(TxId::new(1), TxId::new(100), 1000.into(), 1099.into());
+        let epoch = EpochRange::new(TxId::new(1).unwrap(), TxId::new(100).unwrap(), 1000.into(), 1099.into());
 
         // Should contain transactions in the range
-        assert!(epoch.contains(TxId::new(1)));
-        assert!(epoch.contains(TxId::new(50)));
-        assert!(epoch.contains(TxId::new(100)));
+        assert!(epoch.contains(TxId::new(1).unwrap()));
+        assert!(epoch.contains(TxId::new(50).unwrap()));
+        assert!(epoch.contains(TxId::new(100).unwrap()));
 
         // Should not contain transactions outside the range
-        assert!(!epoch.contains(TxId::new(0)));
-        assert!(!epoch.contains(TxId::new(101)));
+        assert!(!epoch.contains(TxId::new(0).unwrap()));
+        assert!(!epoch.contains(TxId::new(101).unwrap()));
 
         // Should be able to get commit timestamp for transactions in range
-        assert_eq!(epoch.get_commit_timestamp(TxId::new(1)), Some(1000.into()));
-        assert_eq!(epoch.get_commit_timestamp(TxId::new(50)), Some(1049.into()));
+        assert_eq!(epoch.get_commit_timestamp(TxId::new(1).unwrap()), Some(1000.into()));
+        assert_eq!(epoch.get_commit_timestamp(TxId::new(50).unwrap()), Some(1049.into()));
         assert_eq!(
-            epoch.get_commit_timestamp(TxId::new(100)),
+            epoch.get_commit_timestamp(TxId::new(100).unwrap()),
             Some(1099.into())
         );
-        assert_eq!(epoch.get_commit_timestamp(TxId::new(101)), None);
+        assert_eq!(epoch.get_commit_timestamp(TxId::new(101).unwrap()), None);
     }
 
     #[test]
@@ -1052,7 +1054,7 @@ mod tests {
 
         // Add 1000 sequential transactions
         for i in 1..=1000 {
-            log.insert(TxId::new(i), (1000 + (i as i64) - 1).into());
+            log.insert(TxId::new(i).unwrap(), (1000 + (i as i64) - 1).into());
         }
 
         // Trigger compression
@@ -1063,9 +1065,9 @@ mod tests {
         assert_eq!(log.exception_count(), 0);
 
         // All lookups should still work
-        assert_eq!(log.get(TxId::new(1)), Some(1000.into()));
-        assert_eq!(log.get(TxId::new(500)), Some(1499.into()));
-        assert_eq!(log.get(TxId::new(1000)), Some(1999.into()));
+        assert_eq!(log.get(TxId::new(1).unwrap()), Some(1000.into()));
+        assert_eq!(log.get(TxId::new(500).unwrap()), Some(1499.into()));
+        assert_eq!(log.get(TxId::new(1000).unwrap()), Some(1999.into()));
 
         // Memory usage should be much smaller than uncompressed
         let compressed_size = log.memory_usage();
@@ -1087,7 +1089,7 @@ mod tests {
         for i in 1..=1000 {
             if i % 100 != 0 {
                 // Skip every 100th transaction (simulating aborts)
-                log.insert(TxId::new(i), (1000 + (i as i64) - 1).into());
+                log.insert(TxId::new(i).unwrap(), (1000 + (i as i64) - 1).into());
             }
         }
 
@@ -1103,10 +1105,10 @@ mod tests {
         );
 
         // All lookups should still work
-        assert_eq!(log.get(TxId::new(1)), Some(1000.into()));
-        assert_eq!(log.get(TxId::new(50)), Some(1049.into()));
-        assert_eq!(log.get(TxId::new(100)), None); // Was skipped
-        assert_eq!(log.get(TxId::new(101)), Some(1100.into()));
+        assert_eq!(log.get(TxId::new(1).unwrap()), Some(1000.into()));
+        assert_eq!(log.get(TxId::new(50).unwrap()), Some(1049.into()));
+        assert_eq!(log.get(TxId::new(100).unwrap()), None); // Was skipped
+        assert_eq!(log.get(TxId::new(101).unwrap()), Some(1100.into()));
     }
 
     #[test]
@@ -1121,7 +1123,7 @@ mod tests {
             } else {
                 (1000 + (i as i64) - 1).into()
             };
-            log.insert(TxId::new(i), timestamp);
+            log.insert(TxId::new(i).unwrap(), timestamp);
         }
 
         log.compress();
@@ -1133,9 +1135,9 @@ mod tests {
         );
 
         // All lookups should still work correctly
-        assert_eq!(log.get(TxId::new(1)), Some(1000.into()));
-        assert_eq!(log.get(TxId::new(50)), Some(5000.into())); // Outlier
-        assert_eq!(log.get(TxId::new(100)), Some(1099.into()));
+        assert_eq!(log.get(TxId::new(1).unwrap()), Some(1000.into()));
+        assert_eq!(log.get(TxId::new(50).unwrap()), Some(5000.into())); // Outlier
+        assert_eq!(log.get(TxId::new(100).unwrap()), Some(1099.into()));
     }
 
     #[test]
@@ -1145,7 +1147,7 @@ mod tests {
 
         // Add and compress first batch
         for i in 1..=1000 {
-            log.insert(TxId::new(i), (1000 + (i as i64) - 1).into());
+            log.insert(TxId::new(i).unwrap(), (1000 + (i as i64) - 1).into());
         }
         log.compress();
 
@@ -1153,7 +1155,7 @@ mod tests {
 
         // Add more sequential transactions
         for i in 1001..=2000 {
-            log.insert(TxId::new(i), (1000 + (i as i64) - 1).into());
+            log.insert(TxId::new(i).unwrap(), (1000 + (i as i64) - 1).into());
         }
         log.compress();
 
@@ -1164,9 +1166,9 @@ mod tests {
         );
 
         // All lookups should still work
-        assert_eq!(log.get(TxId::new(1)), Some(1000.into()));
-        assert_eq!(log.get(TxId::new(1500)), Some(2499.into()));
-        assert_eq!(log.get(TxId::new(2000)), Some(2999.into()));
+        assert_eq!(log.get(TxId::new(1).unwrap()), Some(1000.into()));
+        assert_eq!(log.get(TxId::new(1500).unwrap()), Some(2499.into()));
+        assert_eq!(log.get(TxId::new(2000).unwrap()), Some(2999.into()));
     }
 
     #[test]
@@ -1178,8 +1180,11 @@ mod tests {
         // This is the typical pattern when transactions commit in order
         let base_ts = 1000;
         for i in 1..=10000 {
-            manager.register_active(TxId::new(i));
-            manager.register_commit(TxId::new(i), (base_ts + (i as i64) - 1).into());
+            manager.register_active(TxId::new(i).unwrap());
+            manager.register_commit(
+                TxId::new(i).unwrap(),
+                (base_ts + (i as i64) - 1).into(),
+            );
         }
 
         // Trigger compression
@@ -1196,14 +1201,14 @@ mod tests {
         let snapshot = manager.capture_snapshot(6000.into());
 
         // Committed transactions strictly before snapshot should be visible
-        assert!(manager.is_visible(&snapshot, TxId::new(1))); // commits at 1000
-        assert!(manager.is_visible(&snapshot, TxId::new(5000))); // commits at 5999
+        assert!(manager.is_visible(&snapshot, TxId::new(1).unwrap())); // commits at 1000
+        assert!(manager.is_visible(&snapshot, TxId::new(5000).unwrap())); // commits at 5999
 
         // Transaction at exactly snapshot time should NOT be visible (strict <)
-        assert!(!manager.is_visible(&snapshot, TxId::new(5001))); // commits at 6000
+        assert!(!manager.is_visible(&snapshot, TxId::new(5001).unwrap())); // commits at 6000
 
         // Transactions after snapshot should not be visible
-        assert!(!manager.is_visible(&snapshot, TxId::new(5002))); // commits at 6001
+        assert!(!manager.is_visible(&snapshot, TxId::new(5002).unwrap())); // commits at 6001
 
         // Memory usage should be significantly reduced
         let memory_usage = manager.commit_log_memory_usage();
@@ -1224,8 +1229,11 @@ mod tests {
         // Add 10000 sequential transactions with sequential timestamps
         let base_ts = 1000;
         for i in 1..=10000 {
-            manager.register_active(TxId::new(i));
-            manager.register_commit(TxId::new(i), (base_ts + (i as i64) - 1).into());
+            manager.register_active(TxId::new(i).unwrap());
+            manager.register_commit(
+                TxId::new(i).unwrap(),
+                (base_ts + (i as i64) - 1).into(),
+            );
         }
 
         let uncompressed_count = manager.committed_count();
@@ -1257,8 +1265,11 @@ mod tests {
         // Add transactions until memory threshold is exceeded
         let base_ts = 1000;
         for i in 1..=1000 {
-            manager.register_active(TxId::new(i));
-            manager.register_commit(TxId::new(i), (base_ts + (i as i64) - 1).into());
+            manager.register_active(TxId::new(i).unwrap());
+            manager.register_commit(
+                TxId::new(i).unwrap(),
+                (base_ts + (i as i64) - 1).into(),
+            );
         }
 
         // Should recommend compression if memory exceeds low threshold

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -28,7 +28,7 @@ mod tombstone_tests {
         };
 
         let tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,
@@ -107,7 +107,7 @@ mod general_tests {
         };
 
         let tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,
@@ -998,7 +998,7 @@ mod general_tests {
             active_transactions: Arc::new(std::collections::HashSet::new()),
         };
         let mut tx1 = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot1,
             current.clone(),
             historical.clone(),
@@ -1030,7 +1030,7 @@ mod general_tests {
             active_transactions: Arc::new(std::collections::HashSet::new()),
         };
         let mut tx2 = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot2,
             current.clone(),
             historical.clone(),
@@ -1457,7 +1457,7 @@ mod general_tests {
         };
 
         let tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,
@@ -1540,7 +1540,7 @@ mod conflict_detection_tests {
             };
 
             WriteTransaction::new(
-                self.tx_id_gen.next(),
+                self.tx_id_gen.next().unwrap(),
                 snapshot,
                 self.current.clone(),
                 self.historical.clone(),
@@ -2452,7 +2452,7 @@ mod clock_skew_tests {
             let snapshot = self.visibility_manager.capture_snapshot(snapshot_ts);
 
             WriteTransaction::new(
-                self.tx_id_gen.next(),
+                self.tx_id_gen.next().unwrap(),
                 snapshot,
                 self.current.clone(),
                 self.historical.clone(),
@@ -2471,7 +2471,7 @@ mod clock_skew_tests {
             let snapshot = self.visibility_manager.capture_snapshot(snapshot_ts);
 
             WriteTransaction::new_with_clock_observed_at(
-                self.tx_id_gen.next(),
+                self.tx_id_gen.next().unwrap(),
                 snapshot,
                 self.current.clone(),
                 self.historical.clone(),
@@ -2685,7 +2685,7 @@ mod timestamp_ordering_tests {
             };
 
             WriteTransaction::new(
-                self.tx_id_gen.next(),
+                self.tx_id_gen.next().unwrap(),
                 snapshot,
                 self.current.clone(),
                 self.historical.clone(),
@@ -2937,7 +2937,7 @@ mod bitemporal_validation_tests {
         }
 
         fn begin_write(&self) -> WriteTransaction {
-            let tx_id = self.tx_id_gen.next();
+            let tx_id = self.tx_id_gen.next().unwrap();
             let snapshot_ts = *self.current_timestamp.lock().unwrap();
             let snapshot = self.visibility_manager.capture_snapshot(snapshot_ts);
 
@@ -3177,7 +3177,7 @@ mod find_nodes_by_property_tests {
         };
 
         let tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,
@@ -3228,7 +3228,7 @@ mod find_nodes_by_property_tests {
         };
 
         let tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,
@@ -3293,7 +3293,7 @@ mod find_nodes_by_property_tests {
         };
 
         let mut tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,
@@ -3344,7 +3344,7 @@ mod find_nodes_by_property_tests {
         };
 
         let mut tx = WriteTransaction::new(
-            tx_id_gen.next(),
+            tx_id_gen.next().unwrap(),
             snapshot,
             current,
             historical,

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -504,17 +504,17 @@ mod sentry_tests {
         // Initial state: starts at 1
         // current() returns counter - 1. So initially 1 - 1 = 0.
         // This means "last generated ID was 0" (reserved).
-        assert_eq!(tx_gen.current(), TxId(0));
+        assert_eq!(tx_gen.current(), TxId::new(0).unwrap());
 
         // First generation
-        let id1 = tx_gen.next();
-        assert_eq!(id1, TxId(1));
-        assert_eq!(tx_gen.current(), TxId(1));
+        let id1 = tx_gen.next().unwrap();
+        assert_eq!(id1, TxId::new(1).unwrap());
+        assert_eq!(tx_gen.current(), TxId::new(1).unwrap());
 
         // Second generation
-        let id2 = tx_gen.next();
-        assert_eq!(id2, TxId(2));
-        assert_eq!(tx_gen.current(), TxId(2));
+        let id2 = tx_gen.next().unwrap();
+        assert_eq!(id2, TxId::new(2).unwrap());
+        assert_eq!(tx_gen.current(), TxId::new(2).unwrap());
 
         // Verify strict ordering
         assert!(id2 > id1);
@@ -522,8 +522,21 @@ mod sentry_tests {
 
     #[test]
     fn test_tx_id_display() {
-        let tx_id = TxId::new(12345);
+        let tx_id = TxId::new(12345).unwrap();
         assert_eq!(format!("{}", tx_id), "TxId(12345)");
+    }
+
+    #[test]
+    fn test_tx_id_validation_rejects_out_of_range() {
+        assert!(TxId::new(MAX_VALID_ID).is_ok());
+        assert!(TxId::new(MAX_VALID_ID + 1).is_err());
+        assert!(TxId::new(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn test_tx_id_new_unchecked() {
+        let tx_id = TxId::new_unchecked(u64::MAX);
+        assert_eq!(tx_id.as_u64(), u64::MAX);
     }
 
     #[test]
@@ -1413,10 +1426,10 @@ mod proptests {
         #[test]
         fn prop_tx_id_generator_monotonic(_dummy in 0..50usize) {
             let tx_gen = TxIdGenerator::new();
-            let mut prev = tx_gen.next();
+            let mut prev = tx_gen.next().unwrap();
 
             for _ in 0..10 {
-                let curr = tx_gen.next();
+                let curr = tx_gen.next().unwrap();
                 prop_assert!(curr > prev,
                     "TxId should be strictly increasing: {:?} vs {:?}", prev, curr);
                 prev = curr;
@@ -1449,11 +1462,27 @@ pub struct TxId(u64);
 
 impl TxId {
     /// Create a new transaction ID
-    pub fn new(id: u64) -> Self {
+    ///
+    /// Returns an error if the ID exceeds MAX_VALID_ID.
+    #[inline]
+    pub fn new(id: u64) -> Result<Self, StorageError> {
+        if id > MAX_VALID_ID {
+            return Err(StorageError::InvalidId {
+                id,
+                id_type: "transaction",
+            });
+        }
+        Ok(TxId(id))
+    }
+
+    /// Create a new transaction ID without validation (for internal use only).
+    #[inline]
+    pub const fn new_unchecked(id: u64) -> Self {
         TxId(id)
     }
 
     /// Get the inner ID value
+    #[inline]
     pub fn as_u64(&self) -> u64 {
         self.0
     }
@@ -1474,7 +1503,7 @@ pub struct TxIdGenerator {
 
 impl TxIdGenerator {
     /// Create a new transaction ID generator starting from 1
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         TxIdGenerator {
             counter: AtomicU64::new(1),
         }
@@ -1483,8 +1512,17 @@ impl TxIdGenerator {
     /// Generate the next transaction ID
     ///
     /// This operation is atomic and thread-safe.
-    pub fn next(&self) -> TxId {
-        TxId(self.counter.fetch_add(1, Ordering::SeqCst))
+    ///
+    /// Returns an error if the generator would exceed `MAX_VALID_ID`.
+    pub fn next(&self) -> Result<TxId, StorageError> {
+        let id = self.counter.fetch_add(1, Ordering::SeqCst);
+        if id > MAX_VALID_ID {
+            return Err(StorageError::InvalidId {
+                id,
+                id_type: "generated_transaction",
+            });
+        }
+        Ok(TxId(id))
     }
 
     /// Get the current transaction ID (last generated)

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -55,7 +55,7 @@ impl VersionMetadata {
     pub fn default_for_existing() -> Self {
         use crate::core::hlc::HybridTimestamp;
         VersionMetadata {
-            created_by_tx: TxId::new(0),
+            created_by_tx: TxId::new(0).unwrap(),
             // Phase 2: Use HybridTimestamp instead of integer literal
             commit_timestamp: Some(HybridTimestamp::new_unchecked(0, 0)),
         }
@@ -1038,7 +1038,7 @@ mod metadata_tests {
 
     #[test]
     fn test_version_metadata_new() {
-        let tx_id = TxId::new(100);
+        let tx_id = TxId::new(100).unwrap();
         let timestamp = Timestamp::from(5000);
         let metadata = VersionMetadata::new(tx_id, timestamp);
 
@@ -1048,7 +1048,7 @@ mod metadata_tests {
 
     #[test]
     fn test_version_metadata_uncommitted() {
-        let tx_id = TxId::new(200);
+        let tx_id = TxId::new(200).unwrap();
         let metadata = VersionMetadata::uncommitted(tx_id);
 
         assert_eq!(metadata.created_by_tx, tx_id);
@@ -1101,13 +1101,13 @@ mod metadata_tests {
 
         assert_eq!(metadata.created_by_tx, default_expected.created_by_tx);
         assert_eq!(metadata.commit_timestamp, default_expected.commit_timestamp);
-        assert_eq!(metadata.created_by_tx, TxId::new(0));
+        assert_eq!(metadata.created_by_tx, TxId::new(0).unwrap());
         assert!(metadata.commit_timestamp.is_some());
     }
 
     #[test]
     fn test_version_metadata_debug() {
-        let tx_id = TxId::new(123);
+        let tx_id = TxId::new(123).unwrap();
         let timestamp = Timestamp::from(456);
         let metadata = VersionMetadata::new(tx_id, timestamp);
         let debug_str = format!("{:?}", metadata);
@@ -1120,7 +1120,7 @@ mod metadata_tests {
 
     #[test]
     fn test_version_metadata_clone_copy() {
-        let tx_id = TxId::new(123);
+        let tx_id = TxId::new(123).unwrap();
         let timestamp = Timestamp::from(456);
         let metadata = VersionMetadata::new(tx_id, timestamp);
 

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -73,7 +73,7 @@ impl AletheiaDB {
     /// // No commit needed - transaction is read-only
     /// ```
     pub fn read_transaction(&self) -> Result<ReadTransaction> {
-        let tx_id = self.tx_id_gen.next();
+        let tx_id = self.tx_id_gen.next()?;
         let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
 
         // Register as active
@@ -157,7 +157,7 @@ impl AletheiaDB {
     /// tx.commit()?;  // or tx.rollback()
     /// ```
     pub fn write_transaction(&self) -> Result<WriteTransaction> {
-        let tx_id = self.tx_id_gen.next();
+        let tx_id = self.tx_id_gen.next()?;
         let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
 
         // Register as active
@@ -388,7 +388,7 @@ impl AletheiaDB {
         &self,
         options: WriteOptions,
     ) -> Result<WriteTransaction> {
-        let tx_id = self.tx_id_gen.next();
+        let tx_id = self.tx_id_gen.next()?;
         let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
 
         // Register as active

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1136,7 +1136,7 @@ impl CheckpointManager {
                     // Transaction time comes from when the WAL entry was logged
                     let commit_timestamp = entry.timestamp;
                     let metadata =
-                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID).unwrap(), commit_timestamp);
                     let version_id = VersionId::new(next_version_id)?;
                     next_version_id += 1;
 
@@ -1182,7 +1182,7 @@ impl CheckpointManager {
 
                     let commit_timestamp = entry.timestamp;
                     let metadata =
-                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID).unwrap(), commit_timestamp);
                     let version_id = VersionId::new(next_version_id)?;
                     next_version_id += 1;
 
@@ -1232,7 +1232,7 @@ impl CheckpointManager {
 
                     let commit_timestamp = entry.timestamp;
                     let metadata =
-                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID).unwrap(), commit_timestamp);
 
                     let node = Node::with_metadata(
                         node_id,
@@ -1281,7 +1281,7 @@ impl CheckpointManager {
 
                     let commit_timestamp = entry.timestamp;
                     let metadata =
-                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID), commit_timestamp);
+                        VersionMetadata::new(TxId::new(RECOVERY_TX_ID).unwrap(), commit_timestamp);
 
                     let edge = Edge::with_metadata(
                         edge_id,

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -676,7 +676,7 @@ pub(crate) fn load_indexes_startup(
                         properties,
                         current_version: version_id,
                         metadata: VersionMetadata {
-                            created_by_tx: TxId::new(0), // Restored from disk
+                            created_by_tx: TxId::new(0).unwrap(), // Restored from disk
                             commit_timestamp: Some(current_time),
                         },
                     };
@@ -737,7 +737,7 @@ pub(crate) fn load_indexes_startup(
                         properties,
                         current_version: version_id,
                         metadata: VersionMetadata {
-                            created_by_tx: TxId::new(0), // Restored from disk
+                            created_by_tx: TxId::new(0).unwrap(), // Restored from disk
                             commit_timestamp: Some(current_time),
                         },
                     };

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -358,14 +358,16 @@ impl ShardCoordinator {
         &self,
         participants: Vec<ShardId>,
     ) -> Result<TxId, DistributedTxError> {
-        let tx_id =
-            TxId::new(
-                self.tx_id_generator
-                    .next()
-                    .map_err(|_| DistributedTxError::Aborted {
-                        reason: "Transaction ID exhausted".to_string(),
-                    })?,
-            );
+        let id = self
+            .tx_id_generator
+            .next()
+            .map_err(|_| DistributedTxError::Aborted {
+                reason: "Transaction ID exhausted".to_string(),
+            })?;
+
+        let tx_id = TxId::new(id).map_err(|_| DistributedTxError::Aborted {
+            reason: "Transaction ID invalid".to_string(),
+        })?;
 
         let transaction =
             DistributedTransaction::new(tx_id, participants, self.transaction_timeout);
@@ -1200,13 +1202,13 @@ mod tests {
         let mut conn = ShardConnection::new(shard_id, "localhost:9000".to_string());
 
         assert!(conn.healthy);
-        assert!(conn.prepare(TxId::new(1), None).is_ok());
-        assert!(conn.commit(TxId::new(1), None).is_ok());
-        assert!(conn.abort(TxId::new(1)).is_ok());
+        assert!(conn.prepare(TxId::new(1).unwrap(), None).is_ok());
+        assert!(conn.commit(TxId::new(1).unwrap(), None).is_ok());
+        assert!(conn.abort(TxId::new(1).unwrap()).is_ok());
 
         conn.mark_unhealthy();
         assert!(!conn.healthy);
-        assert!(conn.prepare(TxId::new(2), None).is_err());
+        assert!(conn.prepare(TxId::new(2).unwrap(), None).is_err());
 
         conn.mark_healthy();
         assert!(conn.healthy);
@@ -1241,16 +1243,16 @@ mod tests {
     #[test]
     fn test_recovery_result_is_complete() {
         let result = RecoveryResult {
-            recovered: vec![TxId::new(1), TxId::new(2)],
+            recovered: vec![TxId::new(1).unwrap(), TxId::new(2).unwrap()],
             dead_lettered: vec![],
         };
         assert!(result.is_complete());
         assert_eq!(result.dead_letter_count(), 0);
 
         let result_with_dead = RecoveryResult {
-            recovered: vec![TxId::new(1)],
+            recovered: vec![TxId::new(1).unwrap()],
             dead_lettered: vec![DeadLetteredTransaction {
-                tx_id: TxId::new(2),
+                tx_id: TxId::new(2).unwrap(),
                 reason: "Test failure".to_string(),
                 last_attempt: Instant::now(),
                 attempt_count: 3,
@@ -1282,9 +1284,9 @@ mod tests {
         conn.mark_unhealthy();
 
         // All operations should fail when unhealthy
-        assert!(conn.prepare(TxId::new(1), None).is_err());
-        assert!(conn.commit(TxId::new(1), None).is_err());
-        assert!(conn.abort(TxId::new(1)).is_err());
+        assert!(conn.prepare(TxId::new(1).unwrap(), None).is_err());
+        assert!(conn.commit(TxId::new(1).unwrap(), None).is_err());
+        assert!(conn.abort(TxId::new(1).unwrap()).is_err());
     }
 
     // ==================== Extended Coordinator Tests ====================
@@ -1327,7 +1329,7 @@ mod tests {
     fn test_coordinator_get_nonexistent_transaction() {
         let coordinator = ShardCoordinator::new(test_config());
 
-        let tx = coordinator.get_transaction(TxId::new(99999));
+        let tx = coordinator.get_transaction(TxId::new(99999).unwrap());
         assert!(tx.is_none());
     }
 
@@ -1335,7 +1337,7 @@ mod tests {
     fn test_coordinator_prepare_nonexistent_transaction() {
         let coordinator = ShardCoordinator::new(test_config());
 
-        let result = coordinator.prepare_distributed_transaction(TxId::new(99999));
+        let result = coordinator.prepare_distributed_transaction(TxId::new(99999).unwrap());
         assert!(result.is_err());
     }
 
@@ -1343,7 +1345,7 @@ mod tests {
     fn test_coordinator_commit_nonexistent_transaction() {
         let coordinator = ShardCoordinator::new(test_config());
 
-        let result = coordinator.commit_distributed_transaction(TxId::new(99999));
+        let result = coordinator.commit_distributed_transaction(TxId::new(99999).unwrap());
         assert!(result.is_err());
     }
 
@@ -1351,7 +1353,7 @@ mod tests {
     fn test_coordinator_abort_nonexistent_transaction() {
         let coordinator = ShardCoordinator::new(test_config());
 
-        let result = coordinator.abort_distributed_transaction(TxId::new(99999), "test");
+        let result = coordinator.abort_distributed_transaction(TxId::new(99999).unwrap(), "test");
         assert!(result.is_err());
     }
 
@@ -1384,14 +1386,14 @@ mod tests {
     fn test_coordinator_retry_nonexistent_dead_letter() {
         let coordinator = ShardCoordinator::new(test_config());
 
-        let result = coordinator.retry_dead_lettered_transaction(TxId::new(99999));
+        let result = coordinator.retry_dead_lettered_transaction(TxId::new(99999).unwrap());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_dead_lettered_transaction_debug() {
         let tx = DeadLetteredTransaction {
-            tx_id: TxId::new(1),
+            tx_id: TxId::new(1).unwrap(),
             reason: "Test failure".to_string(),
             last_attempt: Instant::now(),
             attempt_count: 3,
@@ -1406,7 +1408,7 @@ mod tests {
     #[test]
     fn test_recovery_result_debug() {
         let result = RecoveryResult {
-            recovered: vec![TxId::new(1)],
+            recovered: vec![TxId::new(1).unwrap()],
             dead_lettered: vec![],
         };
 

--- a/src/storage/sharding/network.rs
+++ b/src/storage/sharding/network.rs
@@ -1156,7 +1156,7 @@ mod tests {
     fn test_mock_client_prepare() {
         let client = MockShardClient::new(make_shard_id(0));
 
-        let response = client.prepare(TxId::new(1), &[], None).unwrap();
+        let response = client.prepare(TxId::new(1).unwrap(), &[], None).unwrap();
         assert!(response.ready);
         assert_eq!(client.call_count("prepare"), 1);
     }
@@ -1165,7 +1165,7 @@ mod tests {
     fn test_mock_client_commit() {
         let client = MockShardClient::new(make_shard_id(0));
 
-        let response = client.commit(TxId::new(1), None).unwrap();
+        let response = client.commit(TxId::new(1).unwrap(), None).unwrap();
         assert!(response.success);
         assert_eq!(client.call_count("commit"), 1);
     }
@@ -1174,7 +1174,7 @@ mod tests {
     fn test_mock_client_abort() {
         let client = MockShardClient::new(make_shard_id(0));
 
-        let response = client.abort(TxId::new(1)).unwrap();
+        let response = client.abort(TxId::new(1).unwrap()).unwrap();
         assert!(response.acknowledged);
         assert_eq!(client.call_count("abort"), 1);
     }
@@ -1184,7 +1184,7 @@ mod tests {
         let client = MockShardClient::new(make_shard_id(0));
         client.set_healthy(false);
 
-        let result = client.prepare(TxId::new(1), &[], None);
+        let result = client.prepare(TxId::new(1).unwrap(), &[], None);
         assert!(matches!(result, Err(NetworkError::ShardUnavailable(_))));
     }
 
@@ -1198,11 +1198,11 @@ mod tests {
             duration: Duration::from_secs(30),
         });
 
-        let result = client.prepare(TxId::new(1), &[], None);
+        let result = client.prepare(TxId::new(1).unwrap(), &[], None);
         assert!(matches!(result, Err(NetworkError::Timeout { .. })));
 
         // Next call should succeed
-        let result = client.prepare(TxId::new(2), &[], None);
+        let result = client.prepare(TxId::new(2).unwrap(), &[], None);
         assert!(result.is_ok());
     }
 
@@ -1215,7 +1215,7 @@ mod tests {
             reason: Some("test".to_string()),
         });
 
-        let response = client.prepare(TxId::new(1), &[], None).unwrap();
+        let response = client.prepare(TxId::new(1).unwrap(), &[], None).unwrap();
         assert!(!response.ready);
         assert_eq!(response.reason, Some("test".to_string()));
     }

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -278,7 +278,12 @@ impl CommitLogEntry {
             entry_data[offset + 6],
             entry_data[offset + 7],
         ]);
-        let tx_id = TxId::new(tx_id_val);
+        let tx_id = TxId::new(tx_id_val).map_err(|_| {
+            CommitLogError::InvalidEntry(format!(
+                "Invalid transaction ID {} exceeds maximum allowed value",
+                tx_id_val
+            ))
+        })?;
         offset += 8;
 
         // Timestamp
@@ -775,33 +780,36 @@ mod tests {
 
     #[test]
     fn test_entry_serialize_deserialize_commit() {
-        let entry =
-            CommitLogEntry::commit(1, TxId::new(100), vec![make_shard_id(0), make_shard_id(1)]);
+        let entry = CommitLogEntry::commit(
+            1,
+            TxId::new(100).unwrap(),
+            vec![make_shard_id(0), make_shard_id(1)],
+        );
 
         let serialized = entry.serialize();
         let deserialized = CommitLogEntry::deserialize(&serialized).unwrap();
 
         assert_eq!(deserialized.lsn, 1);
         assert_eq!(deserialized.entry_type, EntryType::Commit);
-        assert_eq!(deserialized.tx_id, TxId::new(100));
+        assert_eq!(deserialized.tx_id, TxId::new(100).unwrap());
         assert_eq!(deserialized.participants.len(), 2);
     }
 
     #[test]
     fn test_entry_serialize_deserialize_abort() {
-        let entry = CommitLogEntry::abort(2, TxId::new(200), vec![make_shard_id(3)]);
+        let entry = CommitLogEntry::abort(2, TxId::new(200).unwrap(), vec![make_shard_id(3)]);
 
         let serialized = entry.serialize();
         let deserialized = CommitLogEntry::deserialize(&serialized).unwrap();
 
         assert_eq!(deserialized.lsn, 2);
         assert_eq!(deserialized.entry_type, EntryType::Abort);
-        assert_eq!(deserialized.tx_id, TxId::new(200));
+        assert_eq!(deserialized.tx_id, TxId::new(200).unwrap());
     }
 
     #[test]
     fn test_entry_serialize_deserialize_complete() {
-        let entry = CommitLogEntry::complete(3, TxId::new(300));
+        let entry = CommitLogEntry::complete(3, TxId::new(300).unwrap());
 
         let serialized = entry.serialize();
         let deserialized = CommitLogEntry::deserialize(&serialized).unwrap();
@@ -813,7 +821,7 @@ mod tests {
 
     #[test]
     fn test_entry_checksum_validation() {
-        let entry = CommitLogEntry::commit(1, TxId::new(100), vec![make_shard_id(0)]);
+        let entry = CommitLogEntry::commit(1, TxId::new(100).unwrap(), vec![make_shard_id(0)]);
         let mut serialized = entry.serialize();
 
         // Corrupt the data
@@ -859,37 +867,41 @@ mod tests {
         let log = PersistentCommitLog::in_memory();
 
         let lsn = log
-            .log_commit(TxId::new(1), vec![make_shard_id(0), make_shard_id(1)])
+            .log_commit(
+                TxId::new(1).unwrap(),
+                vec![make_shard_id(0), make_shard_id(1)],
+            )
             .unwrap();
         assert_eq!(lsn, 1);
 
-        assert!(log.has_pending_decision(TxId::new(1)));
-        assert!(!log.has_pending_decision(TxId::new(2)));
+        assert!(log.has_pending_decision(TxId::new(1).unwrap()));
+        assert!(!log.has_pending_decision(TxId::new(2).unwrap()));
 
         let pending = log.pending_commits();
         assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].tx_id, TxId::new(1));
+        assert_eq!(pending[0].tx_id, TxId::new(1).unwrap());
     }
 
     #[test]
     fn test_in_memory_log_complete() {
         let log = PersistentCommitLog::in_memory();
 
-        log.log_commit(TxId::new(1), vec![make_shard_id(0)])
+        log.log_commit(TxId::new(1).unwrap(), vec![make_shard_id(0)])
             .unwrap();
-        assert!(log.has_pending_decision(TxId::new(1)));
+        assert!(log.has_pending_decision(TxId::new(1).unwrap()));
 
-        log.log_complete(TxId::new(1)).unwrap();
-        assert!(!log.has_pending_decision(TxId::new(1)));
+        log.log_complete(TxId::new(1).unwrap()).unwrap();
+        assert!(!log.has_pending_decision(TxId::new(1).unwrap()));
     }
 
     #[test]
     fn test_in_memory_log_stats() {
         let log = PersistentCommitLog::in_memory();
 
-        log.log_commit(TxId::new(1), vec![make_shard_id(0)])
+        log.log_commit(TxId::new(1).unwrap(), vec![make_shard_id(0)])
             .unwrap();
-        log.log_abort(TxId::new(2), vec![make_shard_id(1)]).unwrap();
+        log.log_abort(TxId::new(2).unwrap(), vec![make_shard_id(1)])
+            .unwrap();
 
         let stats = log.stats();
         assert_eq!(stats.entries_written, 2);
@@ -918,9 +930,13 @@ mod tests {
         // Write some entries
         {
             let log = PersistentCommitLog::new(&path, CommitLogConfig::default()).unwrap();
-            log.log_commit(TxId::new(1), vec![make_shard_id(0), make_shard_id(1)])
+            log.log_commit(
+                TxId::new(1).unwrap(),
+                vec![make_shard_id(0), make_shard_id(1)],
+            )
+            .unwrap();
+            log.log_abort(TxId::new(2).unwrap(), vec![make_shard_id(2)])
                 .unwrap();
-            log.log_abort(TxId::new(2), vec![make_shard_id(2)]).unwrap();
             log.close().unwrap();
         }
 
@@ -932,11 +948,11 @@ mod tests {
 
             let commits = log.pending_commits();
             assert_eq!(commits.len(), 1);
-            assert_eq!(commits[0].tx_id, TxId::new(1));
+            assert_eq!(commits[0].tx_id, TxId::new(1).unwrap());
 
             let aborts = log.pending_aborts();
             assert_eq!(aborts.len(), 1);
-            assert_eq!(aborts[0].tx_id, TxId::new(2));
+            assert_eq!(aborts[0].tx_id, TxId::new(2).unwrap());
         }
     }
 
@@ -948,11 +964,11 @@ mod tests {
         // Write entries including completion
         {
             let log = PersistentCommitLog::new(&path, CommitLogConfig::default()).unwrap();
-            log.log_commit(TxId::new(1), vec![make_shard_id(0)])
+            log.log_commit(TxId::new(1).unwrap(), vec![make_shard_id(0)])
                 .unwrap();
-            log.log_commit(TxId::new(2), vec![make_shard_id(1)])
+            log.log_commit(TxId::new(2).unwrap(), vec![make_shard_id(1)])
                 .unwrap();
-            log.log_complete(TxId::new(1)).unwrap();
+            log.log_complete(TxId::new(1).unwrap()).unwrap();
             log.close().unwrap();
         }
 
@@ -961,7 +977,7 @@ mod tests {
             let log = PersistentCommitLog::new(&path, CommitLogConfig::default()).unwrap();
             let pending = log.pending_decisions();
             assert_eq!(pending.len(), 1);
-            assert_eq!(pending[0].tx_id, TxId::new(2));
+            assert_eq!(pending[0].tx_id, TxId::new(2).unwrap());
         }
     }
 
@@ -973,9 +989,9 @@ mod tests {
         // Write some entries
         let max_lsn = {
             let log = PersistentCommitLog::new(&path, CommitLogConfig::default()).unwrap();
-            log.log_commit(TxId::new(1), vec![make_shard_id(0)])
+            log.log_commit(TxId::new(1).unwrap(), vec![make_shard_id(0)])
                 .unwrap();
-            log.log_commit(TxId::new(2), vec![make_shard_id(1)])
+            log.log_commit(TxId::new(2).unwrap(), vec![make_shard_id(1)])
                 .unwrap();
             let lsn = log.current_lsn();
             log.close().unwrap();
@@ -986,7 +1002,7 @@ mod tests {
         {
             let log = PersistentCommitLog::new(&path, CommitLogConfig::default()).unwrap();
             let new_lsn = log
-                .log_commit(TxId::new(3), vec![make_shard_id(2)])
+                .log_commit(TxId::new(3).unwrap(), vec![make_shard_id(2)])
                 .unwrap();
             assert!(new_lsn >= max_lsn);
         }
@@ -996,16 +1012,19 @@ mod tests {
     fn test_persistent_log_get_decision() {
         let log = PersistentCommitLog::in_memory();
 
-        log.log_commit(TxId::new(1), vec![make_shard_id(0), make_shard_id(1)])
-            .unwrap();
+        log.log_commit(
+            TxId::new(1).unwrap(),
+            vec![make_shard_id(0), make_shard_id(1)],
+        )
+        .unwrap();
 
-        let decision = log.get_decision(TxId::new(1));
+        let decision = log.get_decision(TxId::new(1).unwrap());
         assert!(decision.is_some());
         let decision = decision.unwrap();
         assert_eq!(decision.entry_type, EntryType::Commit);
         assert_eq!(decision.participants.len(), 2);
 
-        assert!(log.get_decision(TxId::new(999)).is_none());
+        assert!(log.get_decision(TxId::new(999).unwrap()).is_none());
     }
 
     // ==================== Error Tests ====================
@@ -1018,7 +1037,7 @@ mod tests {
         let err = CommitLogError::CorruptedLog("bad data".to_string());
         assert!(format!("{}", err).contains("Corrupted"));
 
-        let err = CommitLogError::TransactionNotFound(TxId::new(42));
+        let err = CommitLogError::TransactionNotFound(TxId::new(42).unwrap());
         assert!(format!("{}", err).contains("42"));
 
         let err = CommitLogError::ChecksumMismatch {

--- a/src/storage/sharding/rpc_client.rs
+++ b/src/storage/sharding/rpc_client.rs
@@ -797,9 +797,9 @@ mod tests {
         let client = HttpShardClient::new(shard_id, config).unwrap();
 
         // All operations should return errors when feature is disabled
-        assert!(client.prepare(TxId::new(1), &[], None).is_err());
-        assert!(client.commit(TxId::new(1), None).is_err());
-        assert!(client.abort(TxId::new(1)).is_err());
+        assert!(client.prepare(TxId::new(1).unwrap(), &[], None).is_err());
+        assert!(client.commit(TxId::new(1).unwrap(), None).is_err());
+        assert!(client.abort(TxId::new(1).unwrap()).is_err());
         assert!(client.query(1, &[]).is_err());
         assert!(client.get_state().is_err());
         assert!(client.health_check().is_err());

--- a/src/storage/sharding/transaction.rs
+++ b/src/storage/sharding/transaction.rs
@@ -524,7 +524,7 @@ mod tests {
     use super::*;
 
     fn make_tx_id(id: u64) -> TxId {
-        TxId::new(id)
+        TxId::new(id).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `TxId` and `TxIdGenerator` in `src/core/id.rs`.
💣 Risk: `TxId` could be created with values > `MAX_VALID_ID` or wrap around `u64::MAX`, potentially causing issues in storage or logic relying on valid ID ranges.
🧪 Strategy: Updated `TxId::new` to enforce `MAX_VALID_ID` and return `Result`. Updated `TxIdGenerator::next` to return `Result` and prevent overflow. Updated all call sites to handle the new return type. Added unit tests for validation and overflow protection.
🔬 Verification: Ran `cargo test` and `repro_tx_id_overflow` (which now passes by asserting error). All existing tests passed after refactoring.

---
*PR created automatically by Jules for task [663706941381345602](https://jules.google.com/task/663706941381345602) started by @madmax983*