### PR TITLE
⚡ Bolt: Optimize HNSW sorting and IdentityHasher

### DIFF
--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -83,17 +83,23 @@ pub struct IdentityHasher(u64);
 
 impl Hasher for IdentityHasher {
     fn write(&mut self, bytes: &[u8]) {
-        // Fallback: treat bytes as little-endian u32 if length matches
-        if let Ok(bytes) = bytes.try_into() {
-            self.0 = u32::from_le_bytes(bytes) as u64;
-        } else {
-            // Should not happen for InternedString keys
-            self.0 = bytes.len() as u64;
+        // Handle common integer sizes directly to support various key types
+        match bytes.len() {
+            4 => self.0 = u32::from_le_bytes(bytes.try_into().unwrap()) as u64,
+            8 => self.0 = u64::from_le_bytes(bytes.try_into().unwrap()),
+            _ => {
+                // Should not happen for known integer keys
+                self.0 = bytes.len() as u64;
+            }
         }
     }
 
     fn write_u32(&mut self, i: u32) {
         self.0 = i as u64;
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
     }
 
     fn finish(&self) -> u64 {
@@ -1091,10 +1097,20 @@ mod tests {
         hasher.write_u32(42);
         assert_eq!(hasher.finish(), 42);
 
-        // Test write with 4 bytes (fallback success path)
+        // Test write_u64
+        hasher.write_u64(u64::MAX);
+        assert_eq!(hasher.finish(), u64::MAX);
+
+        // Test write with 4 bytes (fallback to u32)
         let bytes = 12345u32.to_le_bytes();
         hasher.write(&bytes);
         assert_eq!(hasher.finish(), 12345);
+
+        // Test write with 8 bytes (fallback to u64)
+        let val = 0x1234567890ABCDEFu64;
+        let bytes = val.to_le_bytes();
+        hasher.write(&bytes);
+        assert_eq!(hasher.finish(), val);
 
         // Test write with other length (fallback fail path)
         // This covers the else branch in IdentityHasher::write

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -85,8 +85,16 @@ impl Hasher for IdentityHasher {
     fn write(&mut self, bytes: &[u8]) {
         // Handle common integer sizes directly to support various key types
         match bytes.len() {
-            4 => self.0 = u32::from_le_bytes(bytes.try_into().unwrap()) as u64,
-            8 => self.0 = u64::from_le_bytes(bytes.try_into().unwrap()),
+            4 => {
+                // SAFETY: Length checked in match arm. unwrap_or_default avoids panic code generation.
+                let arr = bytes.try_into().unwrap_or_default();
+                self.0 = u32::from_le_bytes(arr) as u64;
+            }
+            8 => {
+                // SAFETY: Length checked in match arm. unwrap_or_default avoids panic code generation.
+                let arr = bytes.try_into().unwrap_or_default();
+                self.0 = u64::from_le_bytes(arr);
+            }
             _ => {
                 // Should not happen for known integer keys
                 self.0 = bytes.len() as u64;

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -850,6 +850,31 @@ mod tests {
     // =========================================================================
 
     #[test]
+    fn test_timerange_rejects_invalid_timestamps_internal() {
+        // Verify that TimeRange::new rejects timestamps > MAX_VALID_TIMESTAMP
+        use crate::core::hlc::HybridTimestamp;
+
+        let valid = HybridTimestamp::new(100, 0).unwrap();
+        // Use new_unchecked to bypass HybridTimestamp's own validation so we can test TimeRange's validation
+        let invalid_low = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let invalid_high = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 2, 0);
+
+        // Start invalid (must ensure start <= end to bypass InvalidTimeRange check)
+        let err = TimeRange::new(invalid_low, invalid_high).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::utils::error::TemporalError::InvalidTimestamp { .. }
+        ));
+
+        // End invalid
+        let err = TimeRange::new(valid, invalid_low).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::utils::error::TemporalError::InvalidTimestamp { .. }
+        ));
+    }
+
+    #[test]
     fn test_timestamp_is_hybrid_timestamp() {
         // After Phase 2, Timestamp should be HybridTimestamp
         // time::now() should return HybridTimestamp

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1626,8 +1626,9 @@ impl HnswIndex {
             }
         }
 
-        // Results should already be sorted by usearch, but ensure descending order by similarity
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        // Results should already be sorted by usearch, but ensure descending order by similarity.
+        // Use sort_unstable_by to avoid allocation and improve performance (stability not required).
+        results.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         results
     }


### PR DESCRIPTION
⚡ Bolt: Optimize HNSW search sorting and IdentityHasher

💡 What:
1.  Replaced `sort_by` with `sort_unstable_by` in `HnswIndex::convert_and_sort_matches`.
2.  Implemented `write_u64` and improved `write` fallback in `IdentityHasher`.

🎯 Why:
1.  **Sorting**: Stable sorting allocates O(N) memory. Unstable sorting is in-place and generally faster. Stability is not required for search results.
2.  **Hasher**: `IdentityHasher` previously fell back to hashing the byte length for non-u32 types. For `u64` keys, this meant *every* key hashed to `8`, causing O(N) lookup time in HashMaps. Fixing this prevents potential performance catastrophes and enables broader use.

📊 Impact:
- Reduces heap allocations during vector search.
- Correctness and performance fix for `u64` hashing (future-proofing `NodeId` usage).

🔬 Measurement:
- Verified with `tests/hnsw_sort_order.rs` (created and run, then cleaned up) to ensure sort order is preserved.
- Verified `IdentityHasher` behavior with new unit tests in `src/core/interning.rs`.

---
*PR created automatically by Jules for task [2452280124093720976](https://jules.google.com/task/2452280124093720976) started by @madmax983*