### PR TITLE
🤖 Sentinel: Kill TimeRange::overlaps mutant with symmetric test

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -601,6 +601,18 @@ mod tests {
     }
 
     #[test]
+    fn test_time_range_overlaps_touching_repro() {
+        let r1 = TimeRange::new(100.into(), 200.into()).unwrap();
+        let r2 = TimeRange::new(200.into(), 300.into()).unwrap();
+
+        // Ensure symmetry: neither should overlap the other
+        // This prevents the mutant where "start < end" becomes "start <= end"
+        // which would cause r2.overlaps(r1) to be true (200 <= 200)
+        assert!(!r1.overlaps(&r2));
+        assert!(!r2.overlaps(&r1));
+    }
+
+    #[test]
     fn test_time_range_contains_range() {
         let outer = TimeRange::new(100.into(), 300.into()).unwrap();
         let inner = TimeRange::new(150.into(), 250.into()).unwrap();


### PR DESCRIPTION
**🧬 Mutants Found:**
- `src/core/temporal.rs`: `TimeRange::overlaps` comparison operator replacement (`<` to `<=`).

**🎯 Tests Added/Strengthened:**
- `test_time_range_overlaps_touching_repro`: Explicitly asserts that touching ranges (end == start) do not overlap in both directions. This prevents the mutant from surviving by returning `true` for `r2.overlaps(r1)` where `r2.start == r1.end`.

**⚠️ Suspected Bugs:**
- None found. The code was correct, but the tests were weak regarding symmetry.

**📊 Kill Rate:**
- Improved for `src/core/temporal.rs` by eliminating a survivable mutant.

---
*PR created automatically by Jules for task [7073814921121691345](https://jules.google.com/task/7073814921121691345) started by @madmax983*