### PR TITLE
docs: improve documentation for HTTP API and Query Planner

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1,4 +1,25 @@
 //! HTTP request handlers.
+//!
+//! This module defines the JSON API contract for the AletheiaDB HTTP server.
+//! It includes the request structures, response formats, and handler functions.
+//!
+//! # API Structure
+//!
+//! All query operations are handled via a single POST endpoint (`/query`) that accepts
+//! a JSON payload. The payload is polymorphic, using the `operation` field to distinguish
+//! between different request types.
+//!
+//! # Example Request
+//!
+//! ```json
+//! {
+//!   "operation": "find_node",
+//!   "label": "Person",
+//!   "properties": {
+//!     "name": "Alice"
+//!   }
+//! }
+//! ```
 
 use crate::core::NodeId;
 use crate::http::converters::{interned_to_string, json_to_property_map, property_map_to_json};
@@ -35,41 +56,156 @@ pub fn configure_health_routes(cfg: &mut web::ServiceConfig) {
 // Query Endpoint
 // ============================================================================
 
+/// Polymorphic request structure for the `/query` endpoint.
+///
+/// The structure deserializes based on the `operation` field tag.
+///
+/// # Examples
+///
+/// ## Create a Node
+/// ```json
+/// {
+///   "operation": "create_node",
+///   "label": "Person",
+///   "properties": {
+///     "name": "Alice",
+///     "age": 30
+///   }
+/// }
+/// ```
+///
+/// ## Find Nodes
+/// ```json
+/// {
+///   "operation": "find_node",
+///   "label": "Person",
+///   "limit": 10
+/// }
+/// ```
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum QueryRequest {
+    /// Find nodes matching specific criteria.
+    ///
+    /// # Fields
+    /// * `label` - Optional label to filter by (e.g., "Person").
+    /// * `properties` - Optional map of property key-value pairs to match (exact match).
+    /// * `limit` - Maximum number of results to return (default: 100, max: 1000).
+    /// * `offset` - Number of results to skip (default: 0).
+    ///
+    /// # Example
+    /// ```json
+    /// {
+    ///   "operation": "find_node",
+    ///   "label": "Person",
+    ///   "properties": { "active": true },
+    ///   "limit": 50
+    /// }
+    /// ```
     FindNode {
+        /// Optional label to filter by (e.g., "Person").
         label: Option<String>,
+        /// Optional map of property key-value pairs to match (exact match).
         properties: Option<HashMap<String, serde_json::Value>>,
+        /// Maximum number of results to return (default: 100, max: 1000).
         limit: Option<usize>,
+        /// Number of results to skip (default: 0).
         offset: Option<usize>,
     },
+
+    /// Get a single node by its internal ID.
+    ///
+    /// # Fields
+    /// * `node_id` - The 64-bit unsigned integer ID of the node.
+    ///
+    /// # Example
+    /// ```json
+    /// {
+    ///   "operation": "get_node",
+    ///   "node_id": 12345
+    /// }
+    /// ```
     GetNode {
+        /// The 64-bit unsigned integer ID of the node.
         node_id: u64,
     },
+
+    /// Create a new node.
+    ///
+    /// # Fields
+    /// * `label` - The label/type of the node (e.g., "User").
+    /// * `properties` - Optional initial properties for the node.
+    ///
+    /// # Example
+    /// ```json
+    /// {
+    ///   "operation": "create_node",
+    ///   "label": "User",
+    ///   "properties": {
+    ///     "username": "jdoe",
+    ///     "email": "jdoe@example.com"
+    ///   }
+    /// }
+    /// ```
     CreateNode {
+        /// The label/type of the node (e.g., "User").
         label: String,
+        /// Optional initial properties for the node.
         properties: Option<HashMap<String, serde_json::Value>>,
     },
+
+    /// Find all neighbors connected to a specific node.
+    ///
+    /// Returns nodes connected by *any* edge direction (incoming or outgoing).
+    ///
+    /// # Fields
+    /// * `node_id` - The ID of the central node.
+    /// * `limit` - Maximum number of neighbors to return (default: 100).
+    /// * `offset` - Pagination offset (default: 0).
+    ///
+    /// # Example
+    /// ```json
+    /// {
+    ///   "operation": "find_neighbors",
+    ///   "node_id": 12345,
+    ///   "limit": 20
+    /// }
+    /// ```
     FindNeighbors {
+        /// The ID of the central node.
         node_id: u64,
+        /// Maximum number of neighbors to return (default: 100).
         #[serde(default)]
         limit: Option<usize>,
+        /// Pagination offset (default: 0).
         #[serde(default)]
         offset: Option<usize>,
     },
 }
 
+/// Standardized API response structure.
+///
+/// All API responses follow this wrapper format.
+///
+/// # Structure
+///
+/// * `success`: Boolean indicating if the operation succeeded.
+/// * `data`: The result payload (only present if `success` is true).
+/// * `error`: Error message string (only present if `success` is false).
 #[derive(Debug, Serialize)]
 pub struct ApiResponse {
+    /// Indicates whether the request was successful.
     success: bool,
+    /// The successful response payload.
     #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<serde_json::Value>,
+    /// The error message if the request failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
 
 impl ApiResponse {
+    /// Create a success response.
     fn success(data: serde_json::Value) -> Self {
         Self {
             success: true,
@@ -78,6 +214,7 @@ impl ApiResponse {
         }
     }
 
+    /// Create an error response.
     fn error(msg: impl Into<String>) -> Self {
         Self {
             success: false,
@@ -105,6 +242,14 @@ fn json_to_predicate_value(v: &serde_json::Value) -> Option<PredicateValue> {
 }
 
 /// Query endpoint handler.
+///
+/// Accepts a JSON `QueryRequest` and executes the corresponding operation against the database.
+/// Returns an `ApiResponse` wrapped in an `HttpResponse`.
+///
+/// # Resource Limits
+///
+/// * **Pagination**: `limit + offset` must not exceed 10,000 to prevent CPU exhaustion.
+/// * **Result Size**: `limit` is capped at 1000 for neighbor queries.
 pub async fn handle_query(
     state: web::Data<AppState>,
     req: web::Json<QueryRequest>,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -29,11 +29,11 @@
 
 mod config;
 pub(crate) mod converters;
-mod handlers;
+pub mod handlers;
 mod server;
 mod state;
 
 pub use config::{CorsConfig, ServerConfig, ServerConfigBuilder};
-pub use handlers::health_check;
+pub use handlers::{ApiResponse, QueryRequest, handle_query, health_check};
 pub use server::{ShutdownHandle, configure_app, create_app, create_server, run_server};
 pub use state::AppState;

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -3,6 +3,23 @@
 //! Transforms logical plans into optimized physical plans for execution.
 //! The planner applies optimization rules and uses a cost model to choose
 //! the best execution strategy.
+//!
+//! # Life of a Query
+//!
+//! 1. **Logical Planning**: The `Query` struct (IR) is converted into a `LogicalPlan`.
+//!    This represents *what* to compute without specifying *how*.
+//!    - Example: `Scan(Person) -> Filter(age > 30)`
+//!
+//! 2. **Optimization**: The planner applies a series of `OptimizationRule`s to the logical plan.
+//!    - **Filter Pushdown**: Moves filters closer to the data source.
+//!    - **Join Reordering**: Reorders joins to minimize intermediate result sizes.
+//!    - **Cost-Based Decisions**: Uses `Statistics` and a `CostModel` to estimate the cost of different plans.
+//!
+//! 3. **Physical Planning**: The optimized logical plan is converted into a `PhysicalPlan`.
+//!    This represents the actual execution strategy (e.g., "Index Scan" vs "Full Scan").
+//!    - Example: `IndexScan(Person, age > 30)`
+//!
+//! 4. **Execution**: The `PhysicalPlan` is handed off to the `Executor` (not part of this module).
 
 pub mod cost;
 pub mod physical;


### PR DESCRIPTION
This PR significantly improves the documentation for the HTTP API and the Query Planner.

### HTTP API
The `QueryRequest` and `ApiResponse` types were previously undocumented and hidden from the public API docs. I have:
1. Exported them in `src/http/mod.rs`.
2. Added detailed doc comments with JSON examples for every request variant (`FindNode`, `GetNode`, `CreateNode`, `FindNeighbors`).
3. Documented the fields of `QueryRequest` to satisfy `missing_docs` lint.

### Query Planner
The query planner was a bit of a black box. I added a module-level doc section "Life of a Query" in `src/query/planner/mod.rs` that explains the high-level flow:
`Query (IR) -> LogicalPlan -> Optimization -> PhysicalPlan -> Execution`.

This makes the codebase much more approachable for new contributors and users of the API.


---
*PR created automatically by Jules for task [12389468279473094824](https://jules.google.com/task/12389468279473094824) started by @madmax983*