### PR TITLE
⚡ Bolt: Use sort_unstable_by in HNSW search

### DIFF
--- a/examples/bench_search.rs
+++ b/examples/bench_search.rs
@@ -1,0 +1,42 @@
+use aletheiadb::index::vector::hnsw::{HnswConfig, HnswIndex};
+use aletheiadb::index::vector::{DistanceMetric, VectorIndex};
+use aletheiadb::core::id::NodeId;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dimensions = 128;
+    let count = 10_000;
+    let k = 100;
+
+    println!("Setting up index with {} vectors (dims={})...", count, dimensions);
+    let config = HnswConfig::new(dimensions, DistanceMetric::Cosine)
+        .with_m(16)
+        .with_ef_construction(100);
+    let index = HnswIndex::new(config)?;
+
+    // Add vectors
+    for i in 0..count {
+        let vec: Vec<f32> = (0..dimensions).map(|x| (x as f32 + i as f32).sin()).collect();
+        index.add(NodeId::new(i as u64 + 1).unwrap(), &vec)?;
+    }
+
+    println!("Warmup...");
+    let query = vec![0.5f32; dimensions];
+    for _ in 0..100 {
+        index.search(&query, k)?;
+    }
+
+    println!("Benchmarking search...");
+    let start = Instant::now();
+    let iterations = 10_000;
+    for _ in 0..iterations {
+        let results = index.search(&query, k)?;
+        assert_eq!(results.len(), k);
+    }
+    let duration = start.elapsed();
+
+    println!("Total time: {:?}", duration);
+    println!("Avg time per search: {:?}", duration / iterations as u32);
+
+    Ok(())
+}

--- a/examples/bench_search.rs
+++ b/examples/bench_search.rs
@@ -1,6 +1,6 @@
+use aletheiadb::core::id::NodeId;
 use aletheiadb::index::vector::hnsw::{HnswConfig, HnswIndex};
 use aletheiadb::index::vector::{DistanceMetric, VectorIndex};
-use aletheiadb::core::id::NodeId;
 use std::time::Instant;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,7 +8,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let count = 10_000;
     let k = 100;
 
-    println!("Setting up index with {} vectors (dims={})...", count, dimensions);
+    println!(
+        "Setting up index with {} vectors (dims={})...",
+        count, dimensions
+    );
     let config = HnswConfig::new(dimensions, DistanceMetric::Cosine)
         .with_m(16)
         .with_ef_construction(100);
@@ -16,7 +19,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Add vectors
     for i in 0..count {
-        let vec: Vec<f32> = (0..dimensions).map(|x| (x as f32 + i as f32).sin()).collect();
+        let vec: Vec<f32> = (0..dimensions)
+            .map(|x| (x as f32 + i as f32).sin())
+            .collect();
         index.add(NodeId::new(i as u64 + 1).unwrap(), &vec)?;
     }
 

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1090,33 +1090,6 @@ mod tests {
     }
 
     #[test]
-    fn test_timerange_rejects_invalid_timestamps_internal() {
-        // Use new_unchecked to bypass HybridTimestamp validation and create an invalid timestamp
-        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
-
-        // For start check: make end larger so start < end check passes
-        // TIMESTAMP_MAX is valid and larger than invalid_ts
-        let valid_end = TIMESTAMP_MAX;
-
-        // Should reject invalid start
-        let result = TimeRange::new(invalid_ts, valid_end);
-        assert!(
-            matches!(result, Err(TemporalError::InvalidTimestamp { .. })),
-            "Expected InvalidTimestamp error for start, got {:?}",
-            result
-        );
-
-        // Should reject invalid end
-        let valid_start = HybridTimestamp::new(100, 0).unwrap();
-        let result = TimeRange::new(valid_start, invalid_ts);
-        assert!(
-            matches!(result, Err(TemporalError::InvalidTimestamp { .. })),
-            "Expected InvalidTimestamp error for end, got {:?}",
-            result
-        );
-    }
-
-    #[test]
     fn test_contains_range_excludes_partial_overlap_start() {
         // Outer: [100, 200)
         let start = HybridTimestamp::new(100, 0).unwrap();

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1626,8 +1626,9 @@ impl HnswIndex {
             }
         }
 
-        // Results should already be sorted by usearch, but ensure descending order by similarity
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        // Results should already be sorted by usearch, but ensure descending order by similarity.
+        // Use sort_unstable_by to avoid auxiliary memory allocation (O(N) vs O(log N) stack).
+        results.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         results
     }


### PR DESCRIPTION
⚡ **Bolt Performance Improvement**

**Optimization:**
Switched from `Vec::sort_by` (stable sort) to `Vec::sort_unstable_by` (unstable sort) in `HnswIndex::convert_and_sort_matches`.

**Why:**
- `sort_by` allocates O(N) auxiliary memory.
- `sort_unstable_by` uses O(log N) stack space and 0 heap allocation.
- The relative order of search results with identical similarity scores is not semantically significant, so stable sort is unnecessary.
- This reduces heap allocations on the hot path of vector search.

**Impact:**
- Eliminates one vector allocation per search request.
- Negligible impact on small K, but significant for large K or high throughput.

**Fix:**
- Fixed a build error (`E0428`) in `src/core/temporal.rs` where `test_timerange_rejects_invalid_timestamps_internal` was defined twice. Removed the duplicate to enable tests to run.


---
*PR created automatically by Jules for task [11829909061637243489](https://jules.google.com/task/11829909061637243489) started by @madmax983*