### PR TITLE
test(hlc): add coverage for receive boundary condition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+# Sentinel's Journal
+
+**[HLC Receive Logic Gap]**
+**Module:** `src/core/hlc.rs`
+**Summary:** The `receive` function's logic for incrementing the logical counter when `new_wallclock == self.wallclock` was susceptible to an off-by-one mutation (`>` vs `>=`) if `physical_wallclock` exactly matched `self.wallclock` while being greater than `msg.wallclock`.
+**Diagnosis:** **Missing Coverage**. Existing tests covered cases where wallclock advanced or was strictly determined by `msg` or `self`, but not the specific collision case where physical clock equals local clock (and prevails over message clock).
+**Kill Shot:** Added `test_receive_when_physical_equals_local_and_ahead_of_msg` which specifically targets this condition, ensuring logical counter increments instead of resetting.

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -743,6 +743,34 @@ mod tests {
         assert_eq!(ts.as_secs(), micros / 1_000_000);
         assert_eq!(ts.as_millis(), micros / 1000);
     }
+
+    #[test]
+    fn test_receive_when_physical_equals_local_and_ahead_of_msg() {
+        // Scenario: Physical clock catches up to local clock, and both are ahead of message.
+        // HLC should increment logical counter, not reset it.
+        // This targets the specific gap where `new_wallclock == self.wallclock` but strict `>` was mutated to `>=`.
+
+        let local = HybridTimestamp::new(1000, 5).unwrap();
+        let msg = HybridTimestamp::new(900, 0).unwrap();
+        let physical = 1000; // Equals local.wallclock
+
+        // Expected: new_wallclock = 1000.
+        // Logic should fall through to "new_wallclock == self.wallclock" branch.
+        // Result logical should be local.logical + 1 = 6.
+
+        let result = local.receive(msg, physical).unwrap();
+
+        assert_eq!(result.wallclock(), 1000);
+        assert_eq!(
+            result.logical(),
+            6,
+            "Logical counter should increment, not reset"
+        );
+        assert!(
+            result > local,
+            "Result should be strictly greater than local"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added a targeted test `test_receive_when_physical_equals_local_and_ahead_of_msg` to `src/core/hlc.rs` to cover a specific boundary condition in `HybridTimestamp::receive` where the physical clock exactly matches the local clock. This protects against off-by-one mutations that would reset the logical counter instead of incrementing it. Verified via manual reproduction as cargo-mutants timed out.

---
*PR created automatically by Jules for task [5182413190510791700](https://jules.google.com/task/5182413190510791700) started by @madmax983*