### PR TITLE
🔭 Vantage: Spec for Temporal Hindsight (Time-Travel Simulation)

### DIFF
--- a/src/experimental/hindsight.rs
+++ b/src/experimental/hindsight.rs
@@ -19,6 +19,7 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, MAX_VALID_ID, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyMapBuilder};
+use crate::core::temporal::Timestamp;
 use crate::utils::error::{Result, StorageError};
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -68,10 +69,26 @@ impl Scenario {
     }
 }
 
+/// A report of the differences between the scenario and the base state.
+#[derive(Debug, Clone)]
+pub struct HindsightDiff {
+    /// Nodes added in this scenario.
+    pub added_nodes: HashMap<NodeId, Node>,
+    /// Nodes removed in this scenario.
+    pub removed_nodes: HashSet<NodeId>,
+    /// Nodes modified in this scenario, with their property patches.
+    /// Note: This excludes nodes that were modified and subsequently removed.
+    pub modified_nodes: HashMap<NodeId, PropertyMap>,
+}
+
 /// The Hindsight engine wrapping the database and a scenario.
 pub struct Hindsight<'a> {
     db: &'a AletheiaDB,
     scenario: Scenario,
+    /// Optional base time for temporal simulation.
+    /// If None, simulation runs against current state.
+    /// If Some((valid_time, tx_time)), simulation runs against historical state.
+    base_time: Option<(Timestamp, Timestamp)>,
 }
 
 impl<'a> Hindsight<'a> {
@@ -80,12 +97,35 @@ impl<'a> Hindsight<'a> {
         Self {
             db,
             scenario: Scenario::new(),
+            base_time: None,
         }
+    }
+
+    /// Set the base time for the simulation (Time Travel).
+    ///
+    /// The virtual graph will be based on the state of the database at the specified
+    /// valid_time and transaction_time.
+    pub fn at(mut self, valid_time: Timestamp, tx_time: Timestamp) -> Self {
+        self.base_time = Some((valid_time, tx_time));
+        self
     }
 
     /// Get the current scenario.
     pub fn scenario(&self) -> &Scenario {
         &self.scenario
+    }
+
+    /// Compute the difference between the scenario and the base state.
+    pub fn diff(&self) -> Result<HindsightDiff> {
+        // Filter out modified nodes that are also in removed_nodes
+        let mut modified = self.scenario.modified_nodes.clone();
+        modified.retain(|id, _| !self.scenario.removed_nodes.contains(id));
+
+        Ok(HindsightDiff {
+            added_nodes: self.scenario.added_nodes.clone(),
+            removed_nodes: self.scenario.removed_nodes.clone(),
+            modified_nodes: modified,
+        })
     }
 
     /// Generate a temporary NodeId.
@@ -233,7 +273,11 @@ impl<'a> Hindsight<'a> {
         }
 
         // 3. Fetch from DB
-        let mut node = self.db.get_node(id)?;
+        let mut node = if let Some((vt, tt)) = self.base_time {
+            self.db.get_node_at_time(id, vt, tt)?
+        } else {
+            self.db.get_node(id)?
+        };
 
         // 4. Apply modifications
         if let Some(patch) = self.scenario.modified_nodes.get(&id) {
@@ -273,7 +317,11 @@ impl<'a> Hindsight<'a> {
         }
 
         // 3. Fetch from DB
-        let edge = self.db.get_edge(id)?;
+        let edge = if let Some((vt, tt)) = self.base_time {
+            self.db.get_edge_at_time(id, vt, tt)?
+        } else {
+            self.db.get_edge(id)?
+        };
 
         // Check if endpoints are removed (implicitly removes edge)
         if self.scenario.removed_nodes.contains(&edge.source)
@@ -297,12 +345,29 @@ impl<'a> Hindsight<'a> {
         // 2. Get edges from DB (if node is not purely virtual)
         if !self.scenario.added_nodes.contains_key(&id) {
             // It's a DB node
-            // get_outgoing_edges returns Vec<EdgeId>
-            let db_edges = self.db.current.get_outgoing_edges(id);
+            let db_edges = if let Some((vt, tt)) = self.base_time {
+                self.db.get_outgoing_edges_at_time(id, vt, tt)
+            } else {
+                self.db.current.get_outgoing_edges(id)
+            };
+
             for edge_id in db_edges {
                 // Also check if target is removed.
-                if !self.scenario.removed_edges.contains(&edge_id)
-                    && let Ok(target) = self.db.current.get_edge_target(edge_id)
+                if self.scenario.removed_edges.contains(&edge_id) {
+                    continue;
+                }
+
+                // Resolve target to check if it's removed
+                let target_opt = if let Some((vt, tt)) = self.base_time {
+                    self.db
+                        .get_edge_at_time(edge_id, vt, tt)
+                        .map(|e| e.target)
+                        .ok()
+                } else {
+                    self.db.current.get_edge_target(edge_id).ok()
+                };
+
+                if let Some(target) = target_opt
                     && !self.scenario.removed_nodes.contains(&target)
                 {
                     edges.push(edge_id);
@@ -365,7 +430,14 @@ impl<'a> Hindsight<'a> {
                     Some(edge.target)
                 } else {
                     // DB edge
-                    self.db.current.get_edge_target(edge_id).ok()
+                    if let Some((vt, tt)) = self.base_time {
+                        self.db
+                            .get_edge_at_time(edge_id, vt, tt)
+                            .map(|e| e.target)
+                            .ok()
+                    } else {
+                        self.db.current.get_edge_target(edge_id).ok()
+                    }
                 };
 
                 if let Some(target) = target_opt
@@ -422,12 +494,6 @@ impl<'a> Hindsight<'a> {
         }
 
         // 2. Search DB with predicate
-        // We filter out:
-        // - Removed nodes
-        // - Modified nodes (since we handled them above if they have the vector)
-        //   Note: If a modified node *doesn't* touch the vector, we *should* get it from DB.
-        //   So we only filter modified nodes if the patch *contains* the vector property.
-
         // Build set of IDs to exclude from DB search
         let mut exclude_ids = self.scenario.removed_nodes.clone();
         for (id, patch) in &self.scenario.modified_nodes {
@@ -437,8 +503,24 @@ impl<'a> Hindsight<'a> {
         }
 
         let db_results = if self.db.has_vector_index(property) {
-            self.db
-                .find_similar_with_predicate(property, vector, k, |id| !exclude_ids.contains(id))?
+            if let Some((vt, _)) = self.base_time {
+                // Temporal vector search does not support predicates, so we over-fetch and filter
+                let fetch_k = k + exclude_ids.len();
+                let results = self
+                    .db
+                    .find_similar_as_of_in(property, vector, fetch_k, vt)?;
+
+                results
+                    .into_iter()
+                    .filter(|(id, _)| !exclude_ids.contains(id))
+                    .collect()
+            } else {
+                // Current vector search supports predicates
+                self.db
+                    .find_similar_with_predicate(property, vector, k, |id| {
+                        !exclude_ids.contains(id)
+                    })?
+            }
         } else {
             Vec::new() // Or error? Let's be robust and just return virtual results if no index.
         };
@@ -458,8 +540,143 @@ impl<'a> Hindsight<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::transaction::WriteOps;
     use crate::core::property::PropertyMapBuilder;
+    use crate::core::temporal::time;
+    use crate::index::vector::temporal::TemporalVectorConfig;
     use crate::index::vector::{DistanceMetric, HnswConfig};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_hindsight_temporal_get() {
+        let db = AletheiaDB::new().unwrap();
+
+        // 1. Create Node at T0
+        let props_v1 = PropertyMapBuilder::new().insert("version", 1).build();
+        let id = db.create_node("Node", props_v1).unwrap();
+
+        // Sleep to ensure distinct timestamps
+        thread::sleep(Duration::from_millis(10));
+        let t1 = time::now();
+        thread::sleep(Duration::from_millis(10));
+
+        // 2. Update Node at T2
+        let props_v2 = PropertyMapBuilder::new().insert("version", 2).build();
+        db.write(|tx| tx.update_node(id, props_v2)).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        let t2 = time::now();
+
+        // 3. Test Hindsight at T1 (Should see v1)
+        let hs_t1 = Hindsight::new(&db).at(t1, t1);
+        let node_t1 = hs_t1.get_node(id).unwrap();
+        assert_eq!(
+            node_t1.get_property("version").unwrap().as_int().unwrap(),
+            1
+        );
+
+        // 4. Test Hindsight at T2 (Should see v2)
+        let hs_t2 = Hindsight::new(&db).at(t2, t2);
+        let node_t2 = hs_t2.get_node(id).unwrap();
+        assert_eq!(
+            node_t2.get_property("version").unwrap().as_int().unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_hindsight_diff() {
+        let db = AletheiaDB::new().unwrap();
+
+        // Setup DB state
+        let props = PropertyMapBuilder::new().build();
+        let b = db.create_node("Node", props.clone()).unwrap();
+        let c = db.create_node("Node", props.clone()).unwrap();
+        let d = db.create_node("Node", props.clone()).unwrap();
+
+        let mut hs = Hindsight::new(&db);
+
+        // 1. Add Node A
+        let a = hs.add_node("Node", props.clone()).unwrap();
+
+        // 2. Remove Node B
+        hs.remove_node(b);
+
+        // 3. Modify Node C
+        let props_mod = PropertyMapBuilder::new().insert("mod", true).build();
+        hs.update_node(c, props_mod).unwrap();
+
+        // 4. Modify Node D then Remove D
+        hs.update_node(d, props.clone()).unwrap();
+        hs.remove_node(d);
+
+        // Verify Diff
+        let diff = hs.diff().unwrap();
+
+        // Added
+        assert!(diff.added_nodes.contains_key(&a));
+        assert_eq!(diff.added_nodes.len(), 1);
+
+        // Removed (B and D)
+        assert!(diff.removed_nodes.contains(&b));
+        assert!(diff.removed_nodes.contains(&d));
+        assert_eq!(diff.removed_nodes.len(), 2);
+
+        // Modified (C only, D excluded because removed)
+        assert!(diff.modified_nodes.contains_key(&c));
+        assert!(!diff.modified_nodes.contains_key(&d));
+        assert_eq!(diff.modified_nodes.len(), 1);
+    }
+
+    #[test]
+    fn test_hindsight_temporal_vector_search() {
+        let db = AletheiaDB::new().unwrap();
+
+        // Enable temporal vector index
+        let hnsw_config = HnswConfig::new(2, DistanceMetric::Cosine);
+        let temporal_config = TemporalVectorConfig::default_with_hnsw(hnsw_config.clone());
+        db.enable_temporal_vector_index("vec", temporal_config)
+            .unwrap();
+
+        // 1. Create Node at T0 with vec [1.0, 0.0]
+        let props_v1 = PropertyMapBuilder::new()
+            .insert_vector("vec", &[1.0, 0.0])
+            .build();
+        let id = db.create_node("Node", props_v1).unwrap();
+
+        thread::sleep(Duration::from_millis(50));
+        let t1 = time::now();
+        thread::sleep(Duration::from_millis(50));
+
+        // 2. Update Node at T2 with vec [0.0, 1.0]
+        let props_v2 = PropertyMapBuilder::new()
+            .insert_vector("vec", &[0.0, 1.0])
+            .build();
+        db.write(|tx| tx.update_node(id, props_v2)).unwrap();
+
+        // Force manual snapshot to ensure T2 is indexed (since anchors might not trigger on every update)
+        if let Some(idx) = db.current.get_temporal_vector_index() {
+            idx.create_manual_snapshot().unwrap();
+        }
+
+        thread::sleep(Duration::from_millis(50));
+        let t2 = time::now();
+
+        // 3. Search at T1 for [1.0, 0.0] -> Should find perfect match
+        let hs_t1 = Hindsight::new(&db).at(t1, t1);
+        let results_t1 = hs_t1.find_similar("vec", &[1.0, 0.0], 1).unwrap();
+        assert!(!results_t1.is_empty());
+        assert_eq!(results_t1[0].0, id);
+        assert!((results_t1[0].1 - 1.0).abs() < 0.001); // Cosine(A, A) = 1.0
+
+        // 4. Search at T2 for [1.0, 0.0] -> Should find orthogonal (0.0)
+        let hs_t2 = Hindsight::new(&db).at(t2, t2);
+        let results_t2 = hs_t2.find_similar("vec", &[1.0, 0.0], 1).unwrap();
+        assert!(!results_t2.is_empty());
+        assert_eq!(results_t2[0].0, id);
+        assert!(results_t2[0].1 < 0.001); // Cosine([1,0], [0,1]) = 0.0
+    }
 
     #[test]
     fn test_hindsight_basic_crud() {


### PR DESCRIPTION
# 🔭 Vantage: Spec for Temporal Hindsight

**User Story:** "As a Risk Analyst, I want to simulate adding a relationship between Entity A and Entity B *as if it happened last month*, so that I can backtest if it would have triggered a fraud alert."

## Changes
- **Temporal Context**: `Hindsight` now supports a `base_time` (Valid + Transaction time). All queries (`get_node`, `find_path`, `find_similar`) respect this baseline.
- **Diff Engine**: New `diff()` method returns a structured `HindsightDiff` (added, removed, modified) to visualize the impact of the simulation.
- **Vector Search Integration**: Hybrid query logic now supports temporal vector search by leveraging `find_similar_as_of` and performing client-side filtering for virtual/removed nodes.

## Verification
- Added `test_hindsight_temporal_get` to verify historical property access.
- Added `test_hindsight_diff` to verify clean diff generation.
- Added `test_hindsight_temporal_vector_search` to verify semantic search at different time points (includes manual snapshot forcing for consistency).
- Validated with `cargo test --features nova`.


---
*PR created automatically by Jules for task [1776937705662329036](https://jules.google.com/task/1776937705662329036) started by @madmax983*