### PR TITLE
🤖 Sentinel: Strengthened TimeRange::contains_range boundary tests

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -624,6 +624,46 @@ mod tests {
     }
 
     #[test]
+    fn test_time_range_contains_range_boundaries() {
+        let outer = TimeRange::new(100.into(), 300.into()).unwrap();
+
+        // Same start
+        let inner_same_start = TimeRange::new(100.into(), 200.into()).unwrap();
+        assert!(
+            outer.contains_range(&inner_same_start),
+            "Should contain range with same start"
+        );
+
+        // Same end
+        let inner_same_end = TimeRange::new(200.into(), 300.into()).unwrap();
+        assert!(
+            outer.contains_range(&inner_same_end),
+            "Should contain range with same end"
+        );
+
+        // Same start and end (exact match)
+        let exact_match = TimeRange::new(100.into(), 300.into()).unwrap();
+        assert!(
+            outer.contains_range(&exact_match),
+            "Should contain exact same range"
+        );
+
+        // Just outside start
+        let outside_start = TimeRange::new(99.into(), 200.into()).unwrap();
+        assert!(
+            !outer.contains_range(&outside_start),
+            "Should not contain range starting before"
+        );
+
+        // Just outside end (301)
+        let outside_end = TimeRange::new(200.into(), 301.into()).unwrap();
+        assert!(
+            !outer.contains_range(&outside_end),
+            "Should not contain range ending after"
+        );
+    }
+
+    #[test]
     fn test_time_range_close_at() {
         let open = TimeRange::from(100.into());
         let closed = open.close_at(200.into()).unwrap();


### PR DESCRIPTION
*   **🧬 Mutants Found:** Identified a potential gap where `contains_range` boundary conditions (checking ranges sharing exact start/end timestamps) were not explicitly tested, allowing mutations like `<=` to `<` to theoretically survive.
*   **🎯 Tests Added/Strengthened:** Added `test_time_range_contains_range_boundaries` to `src/core/temporal.rs` to explicitly verify containment of ranges with identical start/end points, and ranges just outside the boundaries.
*   **⚠️ Suspected Bugs:** None. The implementation was correct, but the tests were weak.
*   **📊 Kill Rate:** Improved coverage for `TimeRange` boundary logic.
*   **🔗 Havoc Interaction:** None directly, but this strengthens the core temporal primitives used by Havoc.

---
*PR created automatically by Jules for task [1325033885455886678](https://jules.google.com/task/1325033885455886678) started by @madmax983*