### PR TITLE
🤖 Sentinel: Closing gaps in core/temporal coverage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,15 @@
 **Summary:** The `receive` function's logic for incrementing the logical counter when `new_wallclock == self.wallclock` was susceptible to an off-by-one mutation (`>` vs `>=`) if `physical_wallclock` exactly matched `self.wallclock` while being greater than `msg.wallclock`.
 **Diagnosis:** **Missing Coverage**. Existing tests covered cases where wallclock advanced or was strictly determined by `msg` or `self`, but not the specific collision case where physical clock equals local clock (and prevails over message clock).
 **Kill Shot:** Added `test_receive_when_physical_equals_local_and_ahead_of_msg` which specifically targets this condition, ensuring logical counter increments instead of resetting.
+
+**[TimeRange Validation Gap]**
+**Module:** `src/core/temporal.rs`
+**Summary:** `TimeRange::new` checks if timestamps exceed `MAX_VALID_TIMESTAMP`, but no test explicitly verifies that invalid timestamps are rejected.
+**Diagnosis:** **Missing Coverage**. Existing tests check `start > end` rejection and `MAX_VALID_TIMESTAMP` acceptance, but not `MAX_VALID_TIMESTAMP + 1` rejection. A mutant disabling this check would survive.
+**Kill Shot:** Added `test_time_range_rejects_timestamps_exceeding_max_valid` to assert `TimeRange::new` returns `InvalidTimestamp` error for out-of-bounds values.
+
+**[TimeRange Containment Boundaries]**
+**Module:** `src/core/temporal.rs`
+**Summary:** `contains_range` checks strict containment, but existing tests don't explicitly cover cases where start or end timestamps match exactly.
+**Diagnosis:** **Weak Test**. While likely covered by property tests implicitly, explicit boundary tests ensure off-by-one errors (like `<` vs `<=`) in containment logic are deterministically caught.
+**Kill Shot:** Added `test_time_range_contains_range_boundaries` to check `[100, 300)` contains `[100, 200)` and `[200, 300)`.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1075,6 +1075,53 @@ mod tests {
             "Range starting before outer should not be contained"
         );
     }
+
+    #[test]
+    fn test_time_range_rejects_timestamps_exceeding_max_valid() {
+        use crate::core::hlc::HybridTimestamp;
+
+        // Test with MAX_VALID_TIMESTAMP + 1
+        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let valid_ts = HybridTimestamp::new(100, 0).unwrap();
+
+        // Test start timestamp validation
+        // Use invalid_ts for both start and end to avoid InvalidTimeRange (start > end)
+        let result = TimeRange::new(invalid_ts, invalid_ts);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            TemporalError::InvalidTimestamp { .. }
+        ));
+
+        // Test end timestamp validation
+        let result = TimeRange::new(valid_ts, invalid_ts);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            TemporalError::InvalidTimestamp { .. }
+        ));
+    }
+
+    #[test]
+    fn test_time_range_contains_range_boundaries() {
+        use crate::core::hlc::HybridTimestamp;
+        let start = HybridTimestamp::new(100, 0).unwrap();
+        let mid = HybridTimestamp::new(200, 0).unwrap();
+        let end = HybridTimestamp::new(300, 0).unwrap();
+
+        let outer = TimeRange::new(start, end).unwrap(); // [100, 300)
+        let inner_start = TimeRange::new(start, mid).unwrap(); // [100, 200)
+        let inner_end = TimeRange::new(mid, end).unwrap(); // [200, 300)
+
+        // Should contain range starting at same time
+        assert!(outer.contains_range(&inner_start));
+
+        // Should contain range ending at same time
+        assert!(outer.contains_range(&inner_end));
+
+        // Should contain itself
+        assert!(outer.contains_range(&outer));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🧬 Mutants Found:
- Analyzed `src/core/temporal.rs` and identified gaps in validation and boundary testing.
- Suspected that a mutant disabling the `MAX_VALID_TIMESTAMP` check in `TimeRange::new` would survive.
- Suspected that mutants changing `<` to `<=` in `contains_range` boundaries would survive.

🎯 Tests Added:
- `test_time_range_rejects_timestamps_exceeding_max_valid`: Uses `HybridTimestamp::new_unchecked` to bypass early validation and assert that `TimeRange::new` correctly rejects invalid timestamps.
- `test_time_range_contains_range_boundaries`: Explicitly tests exact boundary matching for containment to prevent off-by-one errors.

📊 Kill Rate:
- These tests ensure that the validation logic and containment logic are strictly enforced, eliminating potential mutants.

---
*PR created automatically by Jules for task [3245813707023894271](https://jules.google.com/task/3245813707023894271) started by @madmax983*