### PR TITLE
test(core): Strengthen temporal tests against mutations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,13 @@
 **Summary:** The `receive` function's logic for incrementing the logical counter when `new_wallclock == self.wallclock` was susceptible to an off-by-one mutation (`>` vs `>=`) if `physical_wallclock` exactly matched `self.wallclock` while being greater than `msg.wallclock`.
 **Diagnosis:** **Missing Coverage**. Existing tests covered cases where wallclock advanced or was strictly determined by `msg` or `self`, but not the specific collision case where physical clock equals local clock (and prevails over message clock).
 **Kill Shot:** Added `test_receive_when_physical_equals_local_and_ahead_of_msg` which specifically targets this condition, ensuring logical counter increments instead of resetting.
+
+**[Temporal Range Boundary Gaps]**
+**Module:** `src/core/temporal.rs`
+**Summary:**
+1. `BiTemporalInterval::close_both` was susceptible to argument swapping (passing `valid_end` as `tx_end` and vice versa) because the existing test `test_bitemporal_close` only asserted that the range was closed, not the specific end timestamps.
+2. `TimeRange::contains_range` was susceptible to using `<` instead of `<=` for boundary checks because existing tests only covered ranges strictly inside or clearly outside, missing exact boundary matches.
+**Diagnosis:** **Weak Assertion** (close_both) and **Missing Coverage** (contains_range boundaries).
+**Kill Shot:**
+1. Strengthened `test_bitemporal_close` to assert `closed_both.valid_time().end() == valid_end` and `closed_both.transaction_time().end() == tx_end`.
+2. Added `test_time_range_contains_range_boundaries` to specifically test cases where inner range shares exactly the same start or end timestamp as the outer range.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -624,6 +624,42 @@ mod tests {
     }
 
     #[test]
+    fn test_time_range_contains_range_boundaries() {
+        let outer = TimeRange::new(100.into(), 300.into()).unwrap();
+
+        // Match start exactly
+        let start_match = TimeRange::new(100.into(), 200.into()).unwrap();
+        assert!(
+            outer.contains_range(&start_match),
+            "Should contain range with same start"
+        );
+
+        // Match end exactly
+        let end_match = TimeRange::new(200.into(), 300.into()).unwrap();
+        assert!(
+            outer.contains_range(&end_match),
+            "Should contain range with same end"
+        );
+
+        // Match both (reflexive)
+        assert!(outer.contains_range(&outer), "Should contain itself");
+
+        // Slightly outside start
+        let start_out = TimeRange::new(99.into(), 200.into()).unwrap();
+        assert!(
+            !outer.contains_range(&start_out),
+            "Should not contain range starting earlier"
+        );
+
+        // Slightly outside end
+        let end_out = TimeRange::new(200.into(), 301.into()).unwrap();
+        assert!(
+            !outer.contains_range(&end_out),
+            "Should not contain range ending later"
+        );
+    }
+
+    #[test]
     fn test_time_range_close_at() {
         let open = TimeRange::from(100.into());
         let closed = open.close_at(200.into()).unwrap();
@@ -703,6 +739,16 @@ mod tests {
         let closed_both = interval.close_both(1500.into(), 2500.into()).unwrap();
         assert!(!closed_both.is_currently_valid());
         assert!(!closed_both.is_currently_recorded());
+        assert_eq!(
+            closed_both.valid_time().end(),
+            1500.into(),
+            "Valid time end should be correct"
+        );
+        assert_eq!(
+            closed_both.transaction_time().end(),
+            2500.into(),
+            "Transaction time end should be correct"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR strengthens the test suite for `src/core/temporal.rs` by adding targeted assertions for boundary conditions and argument propagation.

**Changes:**
1.  **Strengthened `test_bitemporal_close`**: The existing test verified that `BiTemporalInterval` was closed but did not verify *when* it was closed. This left the code susceptible to mutations where `valid_end` and `tx_end` arguments could be swapped or ignored without failure. The updated test asserts that `valid_time().end()` and `transaction_time().end()` exactly match the input arguments.
2.  **Added `test_time_range_contains_range_boundaries`**: The existing `contains_range` tests only covered cases where the inner range was strictly inside the outer range. This left the code susceptible to mutations where comparison operators (`<=`) could be replaced with `<` (strict inequality). The new test explicitly verifies that ranges sharing exactly the same start or end timestamp are correctly identified as contained.

**Verification:**
- `cargo test core::temporal` passes.
- `cargo fmt` applied.


---
*PR created automatically by Jules for task [3044783002678385747](https://jules.google.com/task/3044783002678385747) started by @madmax983*