### PR TITLE
feat(dx): Simplify time imports and fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ println!("Created Alice: {:?}", alice);
 ### Time-Travel Queries
 
 ```rust
-use aletheiadb::core::temporal::time;
+use aletheiadb::time;
 
 // Get current time
 let now = time::now();
@@ -411,8 +411,8 @@ use aletheiadb::query::ir::Predicate;
 
 // Setup query parameters
 let query_embedding = vec![0.1f32; 384];
-let valid_time = aletheiadb::core::temporal::time::now();
-let tx_time = aletheiadb::core::temporal::time::now();
+let valid_time = aletheiadb::time::now();
+let tx_time = aletheiadb::time::now();
 
 // Simple: Graph + Vector hybrid
 let results = db.traverse_and_rank(alice_id, "KNOWS", &query_embedding, 10)?;
@@ -426,7 +426,7 @@ let results = db.query()
     .as_of(valid_time, tx_time)        // Temporal: point-in-time
     .start(alice_id)                   // Graph: start node
     .traverse("KNOWS")                 // Graph: traverse edges
-    .rank_by_similarity(&embedding, 10) // Vector: rank by similarity
+    .rank_by_similarity(&query_embedding, 10) // Vector: rank by similarity
     .with_provenance()                 // Include metadata
     .execute(&db)?;
 
@@ -442,7 +442,7 @@ for row in results {
 
 // Property-specific vector queries
 let results = db.query()
-    .find_similar_builder(&embedding, 10)
+    .find_similar_builder(&query_embedding, 10)
     .property("embedding")  // Query specific property
     .metric(DistanceMetric::Cosine)
     .finish()
@@ -458,8 +458,8 @@ use aletheiadb::index::vector::temporal::DriftMetric;
 use aletheiadb::core::temporal::TimeRange;
 
 // Define time range
-let timestamp_2023 = aletheiadb::core::temporal::time::from_secs(1672531200);
-let timestamp_2024 = aletheiadb::core::temporal::time::from_secs(1704067200);
+let timestamp_2023 = aletheiadb::time::from_secs(1672531200);
+let timestamp_2024 = aletheiadb::time::from_secs(1704067200);
 
 // Find all nodes with significant semantic drift
 let time_range = TimeRange::new(timestamp_2023, timestamp_2024)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub use config::{
     HistoricalConfigBuilder, VectorIndexConfig, VectorIndexConfigBuilder, WalConfig,
     WalConfigBuilder,
 };
+pub use core::temporal::time;
 pub use core::{
     BiTemporalInterval, Edge, EdgeId, EntityId, GLOBAL_INTERNER, InternedString, Node, NodeId,
     PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue, StringInterner, TimeRange,


### PR DESCRIPTION
This PR improves the Developer Experience (DX) based on the "Echo" persona audit.

1.  **Simplifies Imports**: Users can now use `use aletheiadb::time;` instead of the verbose `use aletheiadb::core::temporal::time;`.
2.  **Fixes Documentation**: Corrects a broken code example in `README.md` where a variable name mismatch (`embedding` vs `query_embedding`) caused compilation errors for new users.
3.  **Modernizes Examples**: Updates `README.md` code blocks to use the shorter `time` import path.

Verified by creating and running temporary example files (`examples/echo_*.rs`).

---
*PR created automatically by Jules for task [10171378925425392696](https://jules.google.com/task/10171378925425392696) started by @madmax983*