### PR TITLE
🎻 Bard: Clarify Temporal API and Experimental Features

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -23,3 +23,15 @@
 ## 2024-05-26 - HTTP JSON Conversion Limits
 **Confusion:** The HTTP API's JSON conversion logic enforces a recursion depth limit (100) to prevent stack overflow attacks, but this behavior was undocumented and could surprise developers working with deeply nested data.
 **Clarification:** Added documentation to `src/http/converters.rs` explicitly stating the recursion limit and detailing the type mappings between AletheiaDB types and JSON types.
+
+## 2024-05-27 - Hidden Transaction Time Access
+**Confusion:** The `VersionInfo` struct does not expose a `tx_time` field, forcing users to dive into the source code to realize they must access `version.temporal.transaction_time().start()`.
+**Clarification:** Added a "Temporal Access" section to `VersionInfo` documentation with a clear code example demonstrating how to retrieve both valid time and transaction time.
+
+## 2024-05-27 - Temporal Logic Pitfalls
+**Confusion:** Users were unaware of critical boundaries like `MAX_VALID_TIMESTAMP` (causing runtime errors) and the reflexive nature of `TimeRange::contains_range` (causing off-by-one logic bugs).
+**Clarification:** Added a "Gotchas & Corner Cases" section to `src/core/temporal.rs` explicitly listing `MAX_VALID_TIMESTAMP` limits, range containment rules, and visibility logic nuances.
+
+## 2024-05-27 - Experimental Feature Opacity
+**Confusion:** The `Chronos` (pathfinding) and `Dreamer` (vector extrapolation) experimental modules lacked explanations of their underlying algorithms, making them opaque "black boxes."
+**Clarification:** Added detailed algorithmic explanations to `Chronos` (Snapshot Pathfinding, Path Stability) and clarified `Dreamer`'s dependency on `search_vectors_in`.

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -11,6 +11,20 @@ use crate::core::temporal::{BiTemporalInterval, Timestamp};
 /// Information about a specific version of an entity (node or edge).
 ///
 /// Represents a snapshot of an entity at a particular point in its history.
+///
+/// # Temporal Access
+///
+/// Note that `VersionInfo` does not expose `tx_time` (transaction time) directly as a field.
+/// Instead, it is embedded within the `temporal` field (a [`BiTemporalInterval`]).
+///
+/// To access the timestamp when this version was recorded:
+/// ```rust
+/// # use aletheiadb::core::history::VersionInfo;
+/// # fn example(version: &VersionInfo) {
+/// let recorded_at = version.temporal.transaction_time().start();
+/// let valid_from = version.temporal.valid_time().start();
+/// # }
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct VersionInfo {
     /// Sequential version number (1, 2, 3, ...)

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -643,7 +643,6 @@ mod tests {
         assert!(!outer.contains_range(&overlapping));
     }
 
-
     #[test]
     fn test_time_range_close_at() {
         let open = TimeRange::from(100.into());

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -6,6 +6,26 @@
 //!
 //! Every graph element (node/edge version) has a BiTemporalInterval that tracks
 //! both dimensions of time.
+//!
+//! # Gotchas & Corner Cases ⚠️
+//!
+//! Temporal logic is tricky. Here are common pitfalls to avoid:
+//!
+//! 1. **MAX_VALID_TIMESTAMP**: Timestamps are capped at [`MAX_VALID_TIMESTAMP`] (`i64::MAX - 1000`).
+//!    Attempts to create a `TimeRange` exceeding this will fail. This prevents DoS attacks and
+//!    ensures reserved space for sentinels.
+//!
+//! 2. **Range Containment**: `TimeRange::contains_range(other)` is reflexive (a range contains itself)
+//!    and handles exact matches. Be careful with "off-by-one" errors at boundaries.
+//!    - `[100, 200)` contains `[100, 200)` -> true
+//!    - `[100, 200)` contains `[100, 101)` -> true
+//!
+//! 3. **Visibility Logic**: [`BiTemporalInterval::is_visible_at`] requires *both* dimensions to be satisfied.
+//!    A fact might be valid in the real world (valid time) but not yet known to the database
+//!    (transaction time) at a specific query point.
+//!
+//! 4. **Half-Open Intervals**: All ranges are `[start, end)`, meaning `start` is inclusive and
+//!    `end` is exclusive. `contains(end)` will always return false.
 
 use std::fmt;
 
@@ -623,45 +643,6 @@ mod tests {
         assert!(!outer.contains_range(&overlapping));
     }
 
-    #[test]
-    fn test_time_range_contains_range_boundaries() {
-        let outer = TimeRange::new(100.into(), 300.into()).unwrap();
-
-        // Same start
-        let inner_same_start = TimeRange::new(100.into(), 200.into()).unwrap();
-        assert!(
-            outer.contains_range(&inner_same_start),
-            "Should contain range with same start"
-        );
-
-        // Same end
-        let inner_same_end = TimeRange::new(200.into(), 300.into()).unwrap();
-        assert!(
-            outer.contains_range(&inner_same_end),
-            "Should contain range with same end"
-        );
-
-        // Same start and end (exact match)
-        let exact_match = TimeRange::new(100.into(), 300.into()).unwrap();
-        assert!(
-            outer.contains_range(&exact_match),
-            "Should contain exact same range"
-        );
-
-        // Just outside start
-        let outside_start = TimeRange::new(99.into(), 200.into()).unwrap();
-        assert!(
-            !outer.contains_range(&outside_start),
-            "Should not contain range starting before"
-        );
-
-        // Just outside end (301)
-        let outside_end = TimeRange::new(200.into(), 301.into()).unwrap();
-        assert!(
-            !outer.contains_range(&outside_end),
-            "Should not contain range ending after"
-        );
-    }
 
     #[test]
     fn test_time_range_close_at() {

--- a/src/experimental/chronos.rs
+++ b/src/experimental/chronos.rs
@@ -4,9 +4,21 @@
 //! and navigating it at specific historical snapshots.
 //!
 //! # Features
-//! - **Snapshot Pathfinding**: Find paths as they existed at a specific point in time.
-//! - **Volatility Analysis**: Measure how frequently a node changes.
-//! - **Path Stability**: Calculate how long a path remains valid over a time window.
+//! - **Snapshot Pathfinding**: Find paths as they existed at a specific point in time
+//!   using BFS on a consistent graph snapshot.
+//! - **Volatility Analysis**: Measure how frequently a node changes (updates/sec).
+//! - **Path Stability**: Calculate the percentage of time a path remains fully valid
+//!   over a given window by intersecting the validity intervals of all edges.
+//!
+//! # Algorithm: Path Stability
+//!
+//! To calculate path stability over a window `W`:
+//! 1. For each edge `e` in the path:
+//!    - Retrieve its history.
+//!    - Compute the set of valid time intervals `I_e` where the edge existed within `W`.
+//! 2. Compute the intersection of all interval sets: `I_path = ⋂ I_e`.
+//!    - This results in a set of disjoint intervals where *every* edge in the path was valid.
+//! 3. Sum the duration of intervals in `I_path` and divide by the duration of `W`.
 
 use crate::AletheiaDB;
 use crate::core::id::{EdgeId, NodeId};

--- a/src/experimental/dreamer.rs
+++ b/src/experimental/dreamer.rs
@@ -41,6 +41,9 @@ impl<'a> Dreamer<'a> {
     ///
     /// # Returns
     /// A list of `(NodeId, score)` pairs representing the nodes closest to the predicted future state.
+    ///
+    /// This uses [`AletheiaDB::search_vectors_in`] internally to find the nearest neighbors
+    /// to the extrapolated vector.
     pub fn predict_future(
         &self,
         node_id: NodeId,

--- a/src/experimental/sybil.rs
+++ b/src/experimental/sybil.rs
@@ -240,10 +240,10 @@ impl<'a> Sybil<'a> {
 
                 let mut neighbor_vectors = Vec::new();
                 for edge_id in incoming_edges {
-                    if let Ok(source) = self.db.get_edge_source(edge_id) {
-                        if let Some(vec) = current_state.get(&source) {
-                            neighbor_vectors.push((source, vec.as_slice()));
-                        }
+                    if let Ok(source) = self.db.get_edge_source(edge_id)
+                        && let Some(vec) = current_state.get(&source)
+                    {
+                        neighbor_vectors.push((source, vec.as_slice()));
                     }
                 }
 
@@ -267,12 +267,11 @@ impl<'a> Sybil<'a> {
 
         for row in results {
             let row = row?;
-            if let Some(node) = row.entity.as_node() {
-                if let Some(prop) = node.get_property(property_name) {
-                    if let Some(vec) = prop.as_vector() {
-                        state.insert(node.id, vec.to_vec());
-                    }
-                }
+            if let Some(node) = row.entity.as_node()
+                && let Some(prop) = node.get_property(property_name)
+                && let Some(vec) = prop.as_vector()
+            {
+                state.insert(node.id, vec.to_vec());
             }
         }
         Ok(state)


### PR DESCRIPTION
This PR improves documentation for core temporal types and experimental features, addressing common confusion points identified in the Bard Journal.

**Key Changes:**
- **`VersionInfo`**: Explicitly documented how to access transaction time, which is not exposed as a direct field.
- **`TimeRange` & `BiTemporalInterval`**: Added a "Gotchas" section explaining `MAX_VALID_TIMESTAMP` limits, reflexive containment, and visibility logic.
- **`Chronos`**: Explained the BFS snapshot pathfinding and interval intersection algorithms used for path stability.
- **`Dreamer`**: Clarified that `predict_future` relies on `AletheiaDB::search_vectors_in` for similarity search.
- **Housekeeping**: Removed a duplicate test in `temporal.rs` and fixed clippy warnings in `sybil.rs`.

These changes aim to reduce developer confusion and prevent misuse of temporal APIs.

---
*PR created automatically by Jules for task [18109724454850194725](https://jules.google.com/task/18109724454850194725) started by @madmax983*