### PR TITLE
🤖 Sentinel: Kill mutant in core::history and fix duplicate test

### DIFF
--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -637,4 +637,25 @@ mod tests {
         );
         assert!(!diff.has_changes());
     }
+
+    #[test]
+    fn test_version_diff_compute_verifies_ids() {
+        let from_props = PropertyMapBuilder::new().build();
+        let to_props = PropertyMapBuilder::new().build();
+        let from_id = test_version_id(1);
+        let to_id = test_version_id(2);
+
+        let diff = VersionDiff::compute(
+            &from_props,
+            &to_props,
+            from_id,
+            to_id,
+        );
+
+        // Verify that ID fields are correctly assigned
+        // This kills mutants that swap or default-initialize these fields
+        assert_eq!(diff.from_version, from_id, "from_version must match input");
+        assert_eq!(diff.to_version, to_id, "to_version must match input");
+        assert_ne!(from_id, to_id, "Test requires distinct IDs");
+    }
 }

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -645,12 +645,7 @@ mod tests {
         let from_id = test_version_id(1);
         let to_id = test_version_id(2);
 
-        let diff = VersionDiff::compute(
-            &from_props,
-            &to_props,
-            from_id,
-            to_id,
-        );
+        let diff = VersionDiff::compute(&from_props, &to_props, from_id, to_id);
 
         // Verify that ID fields are correctly assigned
         // This kills mutants that swap or default-initialize these fields

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1142,26 +1142,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_time_range_contains_range_boundaries() {
-        use crate::core::hlc::HybridTimestamp;
-        let start = HybridTimestamp::new(100, 0).unwrap();
-        let mid = HybridTimestamp::new(200, 0).unwrap();
-        let end = HybridTimestamp::new(300, 0).unwrap();
-
-        let outer = TimeRange::new(start, end).unwrap(); // [100, 300)
-        let inner_start = TimeRange::new(start, mid).unwrap(); // [100, 200)
-        let inner_end = TimeRange::new(mid, end).unwrap(); // [200, 300)
-
-        // Should contain range starting at same time
-        assert!(outer.contains_range(&inner_start));
-
-        // Should contain range ending at same time
-        assert!(outer.contains_range(&inner_end));
-
-        // Should contain itself
-        assert!(outer.contains_range(&outer));
-    }
 }
 
 #[cfg(test)]

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1141,7 +1141,6 @@ mod tests {
             TemporalError::InvalidTimestamp { .. }
         ));
     }
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Sentinel run targeting `src/core/history.rs`. 
Found that `VersionDiff::compute` did not have tests verifying that `from_version` and `to_version` fields were correctly assigned (not swapped). Added a targeted test to kill this mutant.
Also fixed a compilation error in `src/core/temporal.rs` where a test function was defined twice.

---
*PR created automatically by Jules for task [17532123470333942677](https://jules.google.com/task/17532123470333942677) started by @madmax983*