### PR TITLE
🤖 Sentinel: [WAL Entry Size] Add boundary tests for MAX_WAL_ENTRY_SIZE

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,9 @@
 **Summary:** `contains_range` checks strict containment, but existing tests don't explicitly cover cases where start or end timestamps match exactly.
 **Diagnosis:** **Weak Test**. While likely covered by property tests implicitly, explicit boundary tests ensure off-by-one errors (like `<` vs `<=`) in containment logic are deterministically caught.
 **Kill Shot:** Added `test_time_range_contains_range_boundaries` to check `[100, 300)` contains `[100, 200)` and `[200, 300)`.
+
+**[WAL Entry Size Boundary Check]**
+**Module:** `src/storage/wal/concurrent.rs`
+**Summary:** `serialize_entry` checks `estimated_capacity > MAX_WAL_ENTRY_SIZE`, but no test verified behavior at exactly `MAX_WAL_ENTRY_SIZE` or just above it.
+**Diagnosis:** **Missing Coverage**. A mutant changing `>` to `>=` (rejecting valid max-size entries) or removing the check entirely (allowing DoS) would survive.
+**Kill Shot:** Added `test_append_entry_exactly_max_size_succeeds` and `test_append_entry_exceeding_max_size_fails` in `sentry_tests` module to enforce strict boundary compliance.

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -896,8 +896,7 @@ mod sentry_tests {
     fn test_append_entry_exactly_max_size_succeeds() {
         let dir = tempdir().unwrap();
         // Increase segment size to accommodate large entry
-        let config = ConcurrentWalConfig::new(dir.path())
-            .with_segment_size(MAX_WAL_ENTRY_SIZE * 2);
+        let config = ConcurrentWalConfig::new(dir.path()).with_segment_size(MAX_WAL_ENTRY_SIZE * 2);
         let wal = ConcurrentWal::new(config).unwrap();
 
         // Calculate size needed for payload
@@ -920,9 +919,7 @@ mod sentry_tests {
         // We use repeat to create it efficiently
         let big_string = "x".repeat(target_val_len);
 
-        let properties = PropertyMapBuilder::new()
-            .insert("k", big_string)
-            .build();
+        let properties = PropertyMapBuilder::new().insert("k", big_string).build();
 
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
@@ -933,11 +930,18 @@ mod sentry_tests {
 
         // Verify our math was correct
         let estimated = crate::storage::wal::estimate_entry_capacity(&op);
-        assert_eq!(estimated, MAX_WAL_ENTRY_SIZE, "Entry size calculation incorrect");
+        assert_eq!(
+            estimated, MAX_WAL_ENTRY_SIZE,
+            "Entry size calculation incorrect"
+        );
 
         // Attempt append - should succeed
         let result = wal.append_async(op);
-        assert!(result.is_ok(), "Failed to append entry of exactly MAX_WAL_ENTRY_SIZE: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Failed to append entry of exactly MAX_WAL_ENTRY_SIZE: {:?}",
+            result.err()
+        );
     }
 
     /// 🎯 Target: MAX_WAL_ENTRY_SIZE boundary check
@@ -947,8 +951,7 @@ mod sentry_tests {
     #[test]
     fn test_append_entry_exceeding_max_size_fails() {
         let dir = tempdir().unwrap();
-        let config = ConcurrentWalConfig::new(dir.path())
-            .with_segment_size(MAX_WAL_ENTRY_SIZE * 2);
+        let config = ConcurrentWalConfig::new(dir.path()).with_segment_size(MAX_WAL_ENTRY_SIZE * 2);
         let wal = ConcurrentWal::new(config).unwrap();
 
         // Use same calculation as above but +1 byte
@@ -957,9 +960,7 @@ mod sentry_tests {
 
         let big_string = "x".repeat(target_val_len);
 
-        let properties = PropertyMapBuilder::new()
-            .insert("k", big_string)
-            .build();
+        let properties = PropertyMapBuilder::new().insert("k", big_string).build();
 
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
@@ -970,7 +971,11 @@ mod sentry_tests {
 
         // Verify size
         let estimated = crate::storage::wal::estimate_entry_capacity(&op);
-        assert_eq!(estimated, MAX_WAL_ENTRY_SIZE + 1, "Entry size calculation incorrect");
+        assert_eq!(
+            estimated,
+            MAX_WAL_ENTRY_SIZE + 1,
+            "Entry size calculation incorrect"
+        );
 
         // Attempt append - should fail
         let result = wal.append_async(op);

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -877,3 +877,111 @@ mod tests {
         assert!(wal.stripe(1000).is_none());
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::GLOBAL_INTERNER;
+    use crate::core::id::NodeId;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::core::temporal::time;
+    use crate::storage::wal::entry::MAX_WAL_ENTRY_SIZE;
+    use tempfile::tempdir;
+
+    /// 🎯 Target: MAX_WAL_ENTRY_SIZE boundary check
+    /// 💣 Risk: Off-by-one errors (e.g. `>` becoming `>=`) could reject valid max-size entries.
+    /// 🧪 Strategy: Construct an entry exactly at the size limit.
+    /// 🔬 Verification: Ensure append succeeds.
+    #[test]
+    fn test_append_entry_exactly_max_size_succeeds() {
+        let dir = tempdir().unwrap();
+        // Increase segment size to accommodate large entry
+        let config = ConcurrentWalConfig::new(dir.path())
+            .with_segment_size(MAX_WAL_ENTRY_SIZE * 2);
+        let wal = ConcurrentWal::new(config).unwrap();
+
+        // Calculate size needed for payload
+        // CreateNode overhead:
+        // Fixed: 24 bytes (LSN + Time + Checksum)
+        // Variable: 1 (op) + 8 (node_id) + 4 (label) + 12 (time) = 25 bytes
+        // PropertyMap overhead:
+        // 4 (count) + 4 (key_len) + key_bytes + 1 (tag_string) + 4 (val_len) + val_bytes
+
+        // Let's use a key "k" (1 byte)
+        // Overhead = 24 + 25 + 4 + 4 + 1 + 1 + 4 = 63 bytes
+        // Total = 63 + val_bytes
+        // Target = MAX_WAL_ENTRY_SIZE
+        // val_bytes = MAX_WAL_ENTRY_SIZE - 63
+
+        let overhead = 63;
+        let target_val_len = MAX_WAL_ENTRY_SIZE - overhead;
+
+        // Create a string of target length
+        // We use repeat to create it efficiently
+        let big_string = "x".repeat(target_val_len);
+
+        let properties = PropertyMapBuilder::new()
+            .insert("k", big_string)
+            .build();
+
+        let op = WalOperation::CreateNode {
+            node_id: NodeId::new(1).unwrap(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
+            properties,
+            valid_from: time::now(),
+        };
+
+        // Verify our math was correct
+        let estimated = crate::storage::wal::estimate_entry_capacity(&op);
+        assert_eq!(estimated, MAX_WAL_ENTRY_SIZE, "Entry size calculation incorrect");
+
+        // Attempt append - should succeed
+        let result = wal.append_async(op);
+        assert!(result.is_ok(), "Failed to append entry of exactly MAX_WAL_ENTRY_SIZE: {:?}", result.err());
+    }
+
+    /// 🎯 Target: MAX_WAL_ENTRY_SIZE boundary check
+    /// 💣 Risk: Missing check or loose check (e.g. removing check entirely) allows DoS.
+    /// 🧪 Strategy: Construct an entry 1 byte over the limit.
+    /// 🔬 Verification: Ensure append fails with CapacityExceeded.
+    #[test]
+    fn test_append_entry_exceeding_max_size_fails() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalConfig::new(dir.path())
+            .with_segment_size(MAX_WAL_ENTRY_SIZE * 2);
+        let wal = ConcurrentWal::new(config).unwrap();
+
+        // Use same calculation as above but +1 byte
+        let overhead = 63;
+        let target_val_len = MAX_WAL_ENTRY_SIZE - overhead + 1;
+
+        let big_string = "x".repeat(target_val_len);
+
+        let properties = PropertyMapBuilder::new()
+            .insert("k", big_string)
+            .build();
+
+        let op = WalOperation::CreateNode {
+            node_id: NodeId::new(1).unwrap(),
+            label: GLOBAL_INTERNER.intern("Test").unwrap(),
+            properties,
+            valid_from: time::now(),
+        };
+
+        // Verify size
+        let estimated = crate::storage::wal::estimate_entry_capacity(&op);
+        assert_eq!(estimated, MAX_WAL_ENTRY_SIZE + 1, "Entry size calculation incorrect");
+
+        // Attempt append - should fail
+        let result = wal.append_async(op);
+        assert!(result.is_err(), "Should have rejected oversized entry");
+
+        match result {
+            Err(Error::Storage(StorageError::CapacityExceeded { current, limit, .. })) => {
+                assert_eq!(current, MAX_WAL_ENTRY_SIZE + 1);
+                assert_eq!(limit, MAX_WAL_ENTRY_SIZE);
+            }
+            _ => panic!("Expected CapacityExceeded error, got {:?}", result),
+        }
+    }
+}


### PR DESCRIPTION
**🧬 Mutants Found:** 2 targeted mutants killed (potential invalid entry rejection and DoS vulnerability).
**🎯 Tests Added/Strengthened:**
- `test_append_entry_exactly_max_size_succeeds`: Ensures valid max-size entries are accepted (prevents `>` -> `>=` mutation).
- `test_append_entry_exceeding_max_size_fails`: Ensures oversized entries are rejected (prevents check removal).
**⚠️ Suspected Bugs:** None. The code was correct, but untested at the boundary.
**📊 Kill Rate:** Improved coverage for `src/storage/wal/concurrent.rs`.
**🔗 Havoc Interaction:** None specific.

---
*PR created automatically by Jules for task [38703184251126184](https://jules.google.com/task/38703184251126184) started by @madmax983*