### PR TITLE
🔒 Warden: Fix HNSW dimension mismatch vulnerability

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -39,3 +39,7 @@
 **2026-02-16 - Unchecked Dimensions in HNSW Index**
 **Threat:** The `HnswIndexBuilder` allowed creating indexes with arbitrary dimensions (up to `usize::MAX`). The internal `create_metric_wrapper` function used `unsafe { slice::from_raw_parts(ptr, dims) }`. If a malicious user provided a dimension such that `dims * 4 > isize::MAX`, this would invoke Undefined Behavior (UB) in Rust's slice creation. Additionally, huge dimensions could cause OOM Denial of Service during index construction or loading.
 **Defense:** Enforced `MAX_VECTOR_DIMENSIONS` (100,000) in `HnswIndexBuilder::build`, `HnswConfig::deserialize_from`, `HnswIndex::load`, and `HnswIndex::open_mmap`. This limit (400KB per vector) is sufficient for all reasonable embeddings while preventing UB and massive allocations. Added `tests/warden_hnsw_builder.rs` to verify rejection of excessive dimensions.
+
+**2025-05-15 - [HNSW Dimension Mismatch Vulnerability]**
+**Threat:** Inconsistent state between `usearch` index (C++) and `HnswConfig` (Rust) allowed buffer over-read in custom metric wrapper. A malicious user could provide a small index file and a config claiming large dimensions, causing `unsafe` slice construction with out-of-bounds length.
+**Defense:** Added explicit check in `HnswIndex::load` to enforce `index.dimensions() == config.dimensions()`.

--- a/src/experimental/sybil.rs
+++ b/src/experimental/sybil.rs
@@ -240,10 +240,10 @@ impl<'a> Sybil<'a> {
 
                 let mut neighbor_vectors = Vec::new();
                 for edge_id in incoming_edges {
-                    if let Ok(source) = self.db.get_edge_source(edge_id) {
-                        if let Some(vec) = current_state.get(&source) {
-                            neighbor_vectors.push((source, vec.as_slice()));
-                        }
+                    if let Ok(source) = self.db.get_edge_source(edge_id)
+                        && let Some(vec) = current_state.get(&source)
+                    {
+                        neighbor_vectors.push((source, vec.as_slice()));
                     }
                 }
 
@@ -267,12 +267,11 @@ impl<'a> Sybil<'a> {
 
         for row in results {
             let row = row?;
-            if let Some(node) = row.entity.as_node() {
-                if let Some(prop) = node.get_property(property_name) {
-                    if let Some(vec) = prop.as_vector() {
-                        state.insert(node.id, vec.to_vec());
-                    }
-                }
+            if let Some(node) = row.entity.as_node()
+                && let Some(prop) = node.get_property(property_name)
+                && let Some(vec) = prop.as_vector()
+            {
+                state.insert(node.id, vec.to_vec());
             }
         }
         Ok(state)

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1990,6 +1990,17 @@ impl HnswIndex {
                 )))
             })?;
 
+        // Security Check: Verify loaded index dimensions match configuration
+        // This prevents buffer over-reads in custom metric wrappers if a malicious actor
+        // provides a mismatched index (e.g. index has 4 dims, config has 100).
+        if index.dimensions() != config.dimensions {
+            return Err(Error::Vector(VectorError::IndexError(format!(
+                "Index dimension mismatch: usearch index has {}, config has {}",
+                index.dimensions(),
+                config.dimensions
+            ))));
+        }
+
         // Apply custom metric if configured (must happen after load, before use)
         // This ensures custom metrics are preserved across save/load cycles
         if let Some(ref custom) = config.custom_metric {

--- a/tests/warden_hnsw_exploit.rs
+++ b/tests/warden_hnsw_exploit.rs
@@ -1,0 +1,70 @@
+
+use aletheiadb::index::vector::{HnswConfig, HnswIndexBuilder, DistanceMetric, Quantization};
+use aletheiadb::index::VectorIndex;
+use aletheiadb::core::id::NodeId;
+
+#[test]
+fn test_warden_hnsw_dimension_mismatch_exploit() {
+    let dir = tempfile::tempdir().unwrap();
+    let index_path = dir.path().join("exploit.usearch");
+
+    // 1. Create a REAL index with small dimensions (e.g., 4)
+    let small_dim = 4;
+    {
+        let index = HnswIndexBuilder::new(small_dim, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+        // Add some data to make it real
+        index.add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        index.save(&index_path).unwrap();
+    }
+
+    // 2. Manipulate the mappings file to claim LARGE dimensions (e.g., 100)
+    let large_dim = 100;
+
+    let mappings_path = index_path.with_extension("usearch.mappings");
+    let mut data = std::fs::read(&mappings_path).unwrap();
+
+    // HNSW mappings format V2:
+    // [MAGIC:4][VERSION:1][DIMS:8]...
+    // Offset 5 is dimensions (u64 little endian).
+    let dims_offset = 5;
+    let new_dims_bytes = (large_dim as u64).to_le_bytes();
+    for i in 0..8 {
+        data[dims_offset + i] = new_dims_bytes[i];
+    }
+
+    // Fix CRC
+    let crc_offset = data.len() - 4;
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&data[..crc_offset]);
+    let new_crc = hasher.finalize();
+    let crc_bytes = new_crc.to_le_bytes();
+    for i in 0..4 {
+        data[crc_offset + i] = crc_bytes[i];
+    }
+
+    std::fs::write(&mappings_path, &data).unwrap();
+
+    // 3. Try to load with large_dim config and custom metric
+    let config = HnswConfig::new(large_dim, DistanceMetric::Cosine)
+        .with_quantization(Quantization::F32)
+        .with_custom_metric("exploit", |_a, _b| {
+            0.0
+        });
+
+    // 4. Load MUST FAIL with the new security check
+    let index_result = aletheiadb::index::vector::HnswIndex::load(&index_path, config);
+
+    match index_result {
+        Ok(_) => panic!("VULNERABILITY: Successfully loaded index with dimension mismatch! Fix failed."),
+        Err(e) => {
+            println!("Load failed as expected: {}", e);
+            let msg = e.to_string();
+            assert!(msg.contains("Index dimension mismatch"));
+            // Verify detail: usearch index has 4, config has 100
+            assert!(msg.contains("usearch index has 4"));
+            assert!(msg.contains("config has 100"));
+        }
+    }
+}

--- a/tests/warden_hnsw_exploit.rs
+++ b/tests/warden_hnsw_exploit.rs
@@ -1,7 +1,6 @@
-
-use aletheiadb::index::vector::{HnswConfig, HnswIndexBuilder, DistanceMetric, Quantization};
-use aletheiadb::index::VectorIndex;
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndexBuilder, Quantization};
 
 #[test]
 fn test_warden_hnsw_dimension_mismatch_exploit() {
@@ -15,7 +14,9 @@ fn test_warden_hnsw_dimension_mismatch_exploit() {
             .build()
             .unwrap();
         // Add some data to make it real
-        index.add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        index
+            .add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0])
+            .unwrap();
         index.save(&index_path).unwrap();
     }
 
@@ -30,9 +31,7 @@ fn test_warden_hnsw_dimension_mismatch_exploit() {
     // Offset 5 is dimensions (u64 little endian).
     let dims_offset = 5;
     let new_dims_bytes = (large_dim as u64).to_le_bytes();
-    for i in 0..8 {
-        data[dims_offset + i] = new_dims_bytes[i];
-    }
+    data[dims_offset..dims_offset + 8].copy_from_slice(&new_dims_bytes);
 
     // Fix CRC
     let crc_offset = data.len() - 4;
@@ -40,24 +39,22 @@ fn test_warden_hnsw_dimension_mismatch_exploit() {
     hasher.update(&data[..crc_offset]);
     let new_crc = hasher.finalize();
     let crc_bytes = new_crc.to_le_bytes();
-    for i in 0..4 {
-        data[crc_offset + i] = crc_bytes[i];
-    }
+    data[crc_offset..crc_offset + 4].copy_from_slice(&crc_bytes);
 
     std::fs::write(&mappings_path, &data).unwrap();
 
     // 3. Try to load with large_dim config and custom metric
     let config = HnswConfig::new(large_dim, DistanceMetric::Cosine)
         .with_quantization(Quantization::F32)
-        .with_custom_metric("exploit", |_a, _b| {
-            0.0
-        });
+        .with_custom_metric("exploit", |_a, _b| 0.0);
 
     // 4. Load MUST FAIL with the new security check
     let index_result = aletheiadb::index::vector::HnswIndex::load(&index_path, config);
 
     match index_result {
-        Ok(_) => panic!("VULNERABILITY: Successfully loaded index with dimension mismatch! Fix failed."),
+        Ok(_) => {
+            panic!("VULNERABILITY: Successfully loaded index with dimension mismatch! Fix failed.")
+        }
         Err(e) => {
             println!("Load failed as expected: {}", e);
             let msg = e.to_string();


### PR DESCRIPTION
🔒 Warden: [security fix]

🦠 Threat: Inconsistent state between `usearch` index (C++) and `HnswConfig` (Rust) allowed buffer over-read in custom metric wrapper. A malicious user could provide a small index file and a config claiming large dimensions, causing `unsafe` slice construction with out-of-bounds length.

🛡️ Defense: Added explicit check in `HnswIndex::load` to enforce `index.dimensions() == config.dimensions()`. If they mismatch, the load operation fails with a specific error.

💥 Severity: High - could allow DoS (crash) or potential information leakage via out-of-bounds reads in custom metric functions.

🧪 Verification: Added `tests/warden_hnsw_exploit.rs` which simulates the attack vector by creating a mismatched index/mappings pair and asserting that `load` rejects it.

---
*PR created automatically by Jules for task [17005056188826439771](https://jules.google.com/task/17005056188826439771) started by @madmax983*