### PR TITLE
🛡️ Sentry: Fix panic in ConcurrentWal with mixed stripe counts

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -21,3 +21,7 @@
 ## [Catastrophic Cancellation in Euclidean Distance]
 **Learning:** The formula `||a||^2 + ||b||^2 - 2<a,b>` for squared Euclidean distance is numerically unstable for vectors that are very close to each other, leading to negative results due to floating-point errors. This causes `sqrt()` to return `NaN`.
 **Action:** Replaced with the stable single-pass algorithm `sum((a_i - b_i)^2)` in `sparse_squared_euclidean_distance`. This is both numerically robust and faster (1 pass vs 3). Added deterministic regression test with seed 34.
+
+## 2026-03-01 - Thread-Local Stripe Affinity Bug
+**Learning:** `ConcurrentWal` cached stripe indices in a global `thread_local!` variable. This index was tied to the `num_stripes` of the *first* WAL instance accessed by the thread. When the same thread accessed a second WAL instance with fewer stripes (common in test suites or multi-tenant setups), the cached index could exceed the bounds of the new `stripes` vector, causing a panic.
+**Action:** Changed `THREAD_STRIPE_ID` to cache the `thread_id.hash()` (u64) instead of the calculated stripe index. The stripe index is now re-calculated on every access (`hash & stripe_mask`), which is cheap and always correct for the current WAL instance's configuration.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ thiserror = "2.0"
 smallvec = "1.13"
 chrono = "0.4"
 
+# Force native-tls to 0.2.16 to avoid build breakage in 0.2.17
+native-tls = "=0.2.16"
+
 # Configuration support (optional TOML config files)
 serde = { version = "1.0", features = ["derive"], optional = true }
 toml = { version = "0.8", optional = true }
@@ -88,7 +91,7 @@ lazy_static = "1.4"
 # Readline with auto-complete for examples
 rustyline = "17.0"
 # Loom for concurrency testing
-loom = { version = "0.7", features = ["checkpoint"] }
+loom = { version = "0.7.2", features = ["checkpoint"] }
 
 [features]
 # Nova experimental features

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -1006,7 +1006,8 @@ mod sentry_tests {
                 thread::spawn(|| {
                     // 1. Large WAL (32 stripes)
                     let dir_large = tempdir().unwrap();
-                    let config_large = ConcurrentWalConfig::new(dir_large.path()).with_num_stripes(32);
+                    let config_large =
+                        ConcurrentWalConfig::new(dir_large.path()).with_num_stripes(32);
                     let wal_large = ConcurrentWal::new(config_large).unwrap();
 
                     let op = WalOperation::CreateNode {
@@ -1021,7 +1022,8 @@ mod sentry_tests {
 
                     // 2. Small WAL (4 stripes)
                     let dir_small = tempdir().unwrap();
-                    let config_small = ConcurrentWalConfig::new(dir_small.path()).with_num_stripes(4);
+                    let config_small =
+                        ConcurrentWalConfig::new(dir_small.path()).with_num_stripes(4);
                     let wal_small = ConcurrentWal::new(config_small).unwrap();
 
                     // This should reuse the cached index. If index > 3, it will panic

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -140,7 +140,7 @@ impl ConcurrentWalConfig {
 
 // Thread-local stripe ID for affinity-based stripe selection.
 thread_local! {
-    static THREAD_STRIPE_ID: Cell<Option<usize>> = const { Cell::new(None) };
+    static THREAD_ID_HASH: Cell<Option<u64>> = const { Cell::new(None) };
 }
 
 /// Concurrent Write-Ahead Log with striped architecture.
@@ -212,24 +212,25 @@ impl ConcurrentWal {
     /// on first access and sticks with it for cache efficiency.
     #[inline]
     fn get_stripe(&self) -> &WalStripe {
-        let stripe_id = THREAD_STRIPE_ID.with(|id| {
+        let hash = THREAD_ID_HASH.with(|id| {
             if let Some(existing) = id.get() {
                 existing
             } else {
                 // Assign based on thread ID hash
                 let thread_id = std::thread::current().id();
-                let hash = {
+                let h = {
                     use std::hash::{Hash, Hasher};
                     let mut hasher = std::collections::hash_map::DefaultHasher::new();
                     thread_id.hash(&mut hasher);
-                    hasher.finish() as usize
+                    hasher.finish()
                 };
-                let assigned = hash & self.stripe_mask;
-                id.set(Some(assigned));
-                assigned
+                id.set(Some(h));
+                h
             }
         });
 
+        // Use hash to determine stripe
+        let stripe_id = (hash as usize) & self.stripe_mask;
         &self.stripes[stripe_id]
     }
 
@@ -987,6 +988,51 @@ mod sentry_tests {
                 assert_eq!(limit, MAX_WAL_ENTRY_SIZE);
             }
             _ => panic!("Expected CapacityExceeded error, got {:?}", result),
+        }
+    }
+
+    /// 🎯 Target: Thread-local stripe affinity caching.
+    /// 💣 Risk: Cached stripe indices from a large WAL (e.g. 32 stripes) can be out of bounds
+    ///          when reused by a thread accessing a small WAL (e.g. 4 stripes).
+    /// 🧪 Strategy: Spawn threads, force access to large WAL, then small WAL.
+    /// 🔬 Verification: Ensure no panic.
+    #[test]
+    fn test_thread_local_switching_between_sizes() {
+        use std::thread;
+
+        // Run multiple threads to ensure we hit a case where hash % 32 > 3
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                thread::spawn(|| {
+                    // 1. Large WAL (32 stripes)
+                    let dir_large = tempdir().unwrap();
+                    let config_large = ConcurrentWalConfig::new(dir_large.path()).with_num_stripes(32);
+                    let wal_large = ConcurrentWal::new(config_large).unwrap();
+
+                    let op = WalOperation::CreateNode {
+                        node_id: NodeId::new(1).unwrap(),
+                        label: GLOBAL_INTERNER.intern("Test").unwrap(),
+                        properties: PropertyMapBuilder::new().build(),
+                        valid_from: time::now(),
+                    };
+
+                    // This populates the thread-local cache with an index in [0, 31]
+                    wal_large.append_async(op.clone()).unwrap();
+
+                    // 2. Small WAL (4 stripes)
+                    let dir_small = tempdir().unwrap();
+                    let config_small = ConcurrentWalConfig::new(dir_small.path()).with_num_stripes(4);
+                    let wal_small = ConcurrentWal::new(config_small).unwrap();
+
+                    // This should reuse the cached index. If index > 3, it will panic
+                    // unless the implementation correctly re-checks or uses a hash.
+                    wal_small.append_async(op).unwrap();
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
         }
     }
 }


### PR DESCRIPTION
This PR fixes a critical bug where `ConcurrentWal` used a thread-local cached stripe index that could become invalid when a thread switched between WAL instances with different stripe counts (e.g., in tests or multi-tenant scenarios).

The fix changes the caching strategy to cache the thread ID hash (which is stable) and calculate the stripe index dynamically (`hash & mask`), ensuring it is always valid for the current WAL instance.

Includes a regression test that reliably reproduces the panic by forcing threads to access a large WAL then a small WAL.

---
*PR created automatically by Jules for task [16563825926708497458](https://jules.google.com/task/16563825926708497458) started by @madmax983*