### PR TITLE
Sentinel: Kill mutants in temporal.rs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,15 @@
 **Summary:** `serialize_entry` checks `estimated_capacity > MAX_WAL_ENTRY_SIZE`, but no test verified behavior at exactly `MAX_WAL_ENTRY_SIZE` or just above it.
 **Diagnosis:** **Missing Coverage**. A mutant changing `>` to `>=` (rejecting valid max-size entries) or removing the check entirely (allowing DoS) would survive.
 **Kill Shot:** Added `test_append_entry_exactly_max_size_succeeds` and `test_append_entry_exceeding_max_size_fails` in `sentry_tests` module to enforce strict boundary compliance.
+
+**[Time ISO 8601 Precision Loss]**
+**Module:** `src/core/temporal.rs`
+**Summary:** `time::to_iso8601` calculation of nanoseconds (`(wallclock % 1_000_000) * 1000`) was susceptible to arithmetic mutations (e.g. `*` to `/`).
+**Diagnosis:** **Weak Test**. Existing tests only asserted that the seconds component was present in the output string, allowing incorrect fractional parts to pass unnoticed.
+**Kill Shot:** Added `test_sentry_iso8601_precision` which inputs a timestamp with microseconds and explicitly asserts that the calculated nanoseconds appear in the output.
+
+**[MAX_VALID_TIMESTAMP Value Integrity]**
+**Module:** `src/core/temporal.rs`
+**Summary:** `MAX_VALID_TIMESTAMP` constant definition was susceptible to reduction (e.g. `replace - with /`) because existing boundary tests used the constant itself for assertions (tautological tests).
+**Diagnosis:** **Weak Test**. Tests checked `TimeRange::new(MAX_VALID_TIMESTAMP, ...)` which would pass even if `MAX_VALID_TIMESTAMP` was small, as long as it was self-consistent.
+**Kill Shot:** Added `test_sentry_max_valid_timestamp_value` which asserts that `TimeRange::new` accepts a hardcoded large timestamp (`i64::MAX - 2000`), ensuring the limit isn't drastically reduced.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1595,13 +1595,30 @@ mod sentry_tests {
         let output = time::to_iso8601(ts);
 
         // Expected nanoseconds: 123456000
-        // Debug format for Duration/SystemTime usually includes "tv_nsec: 123456000" or similar.
-        // Or if it prints float-like seconds: ".123456000".
-        assert!(
-            output.contains("123456000"),
-            "Output should contain nanoseconds: {}",
-            output
-        );
+        if cfg!(windows) {
+            // On Windows, SystemTime debug format is "SystemTime { intervals: <count> }"
+            // intervals are 100ns ticks since 1601-01-01.
+            // Base seconds (1601 to 1970) = 11644473600.
+            // Target seconds (1970 to 2021) = 1609459200.
+            // Total seconds = 13253932800.
+            // Total ticks from seconds = 13253932800 * 10_000_000 = 132539328000000000.
+            // Ticks from microseconds = 123456 * 10 = 1234560.
+            // Total ticks = 132539328001234560.
+            // We check for the fractional part contribution or the exact tick count.
+            // Since the output observed is "intervals: 132539328001234560", we check for that suffix.
+            assert!(
+                output.contains("1234560"),
+                "Output should contain the fractional ticks (1234560): {}",
+                output
+            );
+        } else {
+            // On Unix-like systems, Debug format usually contains "tv_nsec: 123456000".
+            assert!(
+                output.contains("123456000"),
+                "Output should contain nanoseconds (123456000): {}",
+                output
+            );
+        }
     }
 
     #[test]

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1583,4 +1583,56 @@ mod sentry_tests {
             "Should contain range ending at exact same time"
         );
     }
+
+    #[test]
+    fn test_sentry_iso8601_precision() {
+        // 🛡️ Sentry Test: Verify sub-second precision in ISO 8601 output.
+        // This targets mutants that break nanosecond calculation.
+
+        let secs = 1609459200;
+        let micros = 123456;
+        let ts = HybridTimestamp::new_unchecked(secs * 1_000_000 + micros, 0);
+        let output = time::to_iso8601(ts);
+
+        // Expected nanoseconds: 123456000
+        // Debug format for Duration/SystemTime usually includes "tv_nsec: 123456000" or similar.
+        // Or if it prints float-like seconds: ".123456000".
+        assert!(
+            output.contains("123456000"),
+            "Output should contain nanoseconds: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_sentry_max_valid_timestamp_value() {
+        // 🛡️ Sentry Test: Verify MAX_VALID_TIMESTAMP allows reasonably large values.
+        // This targets mutants that drastically reduce MAX_VALID_TIMESTAMP (e.g. replace - with /).
+
+        // i64::MAX is ~9e18. i64::MAX / 1000 is ~9e15.
+        // We want to ensure we can store something larger than 9e15.
+        // 9e15 micros is ~285 years.
+        // Wait, i64::MAX micros is ~292,000 years.
+        // If we mutate to i64::MAX / 1000, we limit to ~292 years.
+        // Current time is ~1.7e15 micros (2024).
+        // So i64::MAX / 1000 (9e15) is still future (year ~2250).
+        // But we want to support timestamps far in the future (e.g. year 3000).
+
+        // Let's just pick a value close to i64::MAX, e.g. i64::MAX - 2000.
+        // If MAX_VALID_TIMESTAMP is i64::MAX / 1000, this will fail.
+
+        let large_val = i64::MAX - 2000;
+        let ts = HybridTimestamp::new_unchecked(large_val, 0);
+
+        // This should be accepted by TimeRange::new if MAX_VALID_TIMESTAMP is correct.
+        // But wait, TimeRange::new checks against MAX_VALID_TIMESTAMP.
+        // If MAX_VALID_TIMESTAMP is correct (i64::MAX - 1000), then i64::MAX - 2000 < MAX_VALID_TIMESTAMP. OK.
+        // If MAX_VALID_TIMESTAMP is mutated to (i64::MAX / 1000), then i64::MAX - 2000 > MAX_VALID_TIMESTAMP. Error.
+
+        let result = TimeRange::new(ts, ts);
+        assert!(
+            result.is_ok(),
+            "Should accept large timestamp close to i64::MAX"
+        );
+    }
 }


### PR DESCRIPTION
🤖 **Sentinel Report**

I have strengthened the test suite for `src/core/temporal.rs` by identifying and eliminating surviving mutants.

**🧬 Mutants Targeted:**
1.  **Arithmetic Mutation in `to_iso8601`**: Existing tests only checked for seconds, allowing broken nanosecond calculations (e.g., `*` vs `/`) to survive.
2.  **Constant Reduction in `MAX_VALID_TIMESTAMP`**: Existing tests used the constant itself for assertions, creating tautologies that allowed the constant to be drastically reduced without failure.

**🎯 Tests Added:**
*   `test_sentry_iso8601_precision`: Inputs a timestamp with microseconds and asserts the output string contains the correct nanosecond fraction.
*   `test_sentry_max_valid_timestamp_value`: Asserts that `TimeRange::new` accepts a hardcoded large timestamp (`i64::MAX - 2000`), ensuring the validity limit remains high.

**📊 Verification:**
*   `cargo test core::temporal` passes.
*   Analytical verification confirms these tests kill the identified mutants where previous tests failed to do so.
*   `cargo mutants` execution was attempted but timed out due to environment constraints; however, the logic of the new tests is strictly targeted at the mutation operators.

**🔗 Havoc Interaction:**
No direct overlap with Havoc's concurrency/fuzzing domain, but `MAX_VALID_TIMESTAMP` integrity is critical for Havoc's property tests involving time ranges.


---
*PR created automatically by Jules for task [8498179322882472386](https://jules.google.com/task/8498179322882472386) started by @madmax983*