### PR TITLE
[Security] Fix silent data loss in PropertyMapBuilder when interner is full

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -43,3 +43,7 @@
 **2025-05-15 - [HNSW Dimension Mismatch Vulnerability]**
 **Threat:** Inconsistent state between `usearch` index (C++) and `HnswConfig` (Rust) allowed buffer over-read in custom metric wrapper. A malicious user could provide a small index file and a config claiming large dimensions, causing `unsafe` slice construction with out-of-bounds length.
 **Defense:** Added explicit check in `HnswIndex::load` to enforce `index.dimensions() == config.dimensions()`.
+
+**2026-02-18 - Silent Data Loss in Property Interning**
+**Threat:** `PropertyMapBuilder::try_insert` silently swallowed errors when the string interner was full (e.g. DoS attack filling capacity). This resulted in properties being silently dropped during node/edge creation or updates, potentially leading to security bypasses (e.g. missing "role: admin" or "acl" properties) or data integrity issues.
+**Defense:** Modified `try_insert` to propagate the `CapacityExceeded` error instead of returning `Ok(self)`. Added regression test `tests/security_interner_dos.rs` which verifies that insertion fails when the interner is full.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1475,9 +1475,9 @@ impl PropertyMapBuilder {
 
     /// Insert a property (fallible).
     pub fn try_insert<V: Into<PropertyValue>>(mut self, key: &str, value: V) -> Result<Self> {
-        let Ok(interned_key) = GLOBAL_INTERNER.intern(key) else {
-            return Ok(self);
-        };
+        // Warden: Propagate interning errors (e.g. CapacityExceeded) to prevent silent data loss.
+        // Previously, failure to intern would silently drop the property, which is a security risk.
+        let interned_key = GLOBAL_INTERNER.intern(key)?;
         let val = value.into();
         let val_size = val.serialized_size()?;
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -448,14 +448,19 @@ impl AletheiaMcpServer {
         }
     }
 
-    fn json_to_property_map(&self, json: &HashMap<String, serde_json::Value>) -> PropertyMap {
+    fn json_to_property_map(
+        &self,
+        json: &HashMap<String, serde_json::Value>,
+    ) -> Result<PropertyMap, String> {
         let mut builder = PropertyMapBuilder::new();
         for (key, value) in json {
             if let Some(pv) = self.json_to_property_value(value) {
-                builder = builder.insert(key.as_str(), pv);
+                builder = builder
+                    .try_insert(key.as_str(), pv)
+                    .map_err(|e| e.to_string())?;
             }
         }
-        builder.build()
+        Ok(builder.build())
     }
 
     fn json_to_property_value(&self, value: &serde_json::Value) -> Option<PropertyValue> {
@@ -605,10 +610,13 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
         };
 
-        let properties = req
-            .properties
-            .map(|p| self.json_to_property_map(&p))
-            .unwrap_or_default();
+        let properties = match req.properties {
+            Some(p) => match self.json_to_property_map(&p) {
+                Ok(map) => map,
+                Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+            },
+            None => PropertyMap::default(),
+        };
 
         match self.db.create_node(&req.label, properties) {
             Ok(node_id) => match self.db.get_node(node_id) {
@@ -636,7 +644,10 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&e.to_string()),
         };
 
-        let properties = self.json_to_property_map(&req.properties);
+        let properties = match self.json_to_property_map(&req.properties) {
+            Ok(map) => map,
+            Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+        };
 
         match self.db.write(|tx| tx.update_node(node_id, properties)) {
             Ok(()) => match self.db.get_node(node_id) {
@@ -869,10 +880,13 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&format!("Invalid target_id: {}", e)),
         };
 
-        let properties = req
-            .properties
-            .map(|p| self.json_to_property_map(&p))
-            .unwrap_or_default();
+        let properties = match req.properties {
+            Some(p) => match self.json_to_property_map(&p) {
+                Ok(map) => map,
+                Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+            },
+            None => PropertyMap::default(),
+        };
 
         match self
             .db
@@ -903,7 +917,10 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&e.to_string()),
         };
 
-        let properties = self.json_to_property_map(&req.properties);
+        let properties = match self.json_to_property_map(&req.properties) {
+            Ok(map) => map,
+            Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+        };
 
         match self.db.write(|tx| tx.update_edge(edge_id, properties)) {
             Ok(()) => match self.db.get_edge(edge_id) {

--- a/tests/security_interner_dos.rs
+++ b/tests/security_interner_dos.rs
@@ -1,0 +1,72 @@
+use std::process::Command;
+use std::env;
+
+#[test]
+fn test_property_map_silent_loss_when_interner_full() {
+    // Check if we are the subprocess
+    if env::var("WARDEN_SUBPROCESS").is_ok() {
+        run_subprocess_test();
+        return;
+    }
+
+    let exe = env::current_exe().expect("failed to get current exe");
+    let output = Command::new(exe)
+        .arg("test_property_map_silent_loss_when_interner_full") // Run specific test
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("WARDEN_SUBPROCESS", "1")
+        .env("GALLIFREYDB_MAX_INTERNED_STRINGS", "5") // Limit < COMMON_STRINGS.len() (10)
+        .output()
+        .expect("failed to spawn subprocess");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        println!("Subprocess stdout:\n{}", stdout);
+        println!("Subprocess stderr:\n{}", stderr);
+
+        if stdout.contains("VULNERABILITY CONFIRMED") {
+             // We reproduced it!
+             // To make the test "pass" in the sense of "we confirmed the bug exists",
+             // we could assert(true). But normally we want tests to pass when code is correct.
+             // So initially this test will FAIL.
+             panic!("Vulnerability reproduced: Property silently dropped!");
+        }
+        panic!("Subprocess failed unexpectedly");
+    }
+
+    // If we reach here, subprocess succeeded (meaning it got an Error or Key was present)
+    println!("Subprocess passed. Vulnerability fixed or not reproducible.");
+}
+
+fn run_subprocess_test() {
+    use aletheiadb::core::property::PropertyMapBuilder;
+    use aletheiadb::core::GLOBAL_INTERNER;
+
+    println!("Interner len: {}", GLOBAL_INTERNER.len());
+
+    // Try to insert a new property key
+    // Since limit is 5 and we have 10 common strings pre-interned, next_id is 10.
+    // 10 >= 5, so intern() should fail.
+    let result = PropertyMapBuilder::new().try_insert("new_key_1", 1);
+
+    match result {
+        Ok(builder) => {
+            let map = builder.build();
+            if !map.contains_key("new_key_1") {
+                println!("VULNERABILITY CONFIRMED: Property silently dropped!");
+                // Panic to signal failure to parent
+                panic!("VULNERABILITY CONFIRMED");
+            } else {
+                // If we reach here, it means the key WAS inserted, which implies the
+                // interner limit was NOT enforced. This is a test setup failure.
+                panic!("TEST SETUP FAILURE: Key was inserted successfully. Interner limit was not enforced?");
+            }
+        }
+        Err(e) => {
+            println!("Got expected error: {}", e);
+            // This is the desired behavior!
+        }
+    }
+}

--- a/tests/security_interner_dos.rs
+++ b/tests/security_interner_dos.rs
@@ -1,5 +1,5 @@
-use std::process::Command;
 use std::env;
+use std::process::Command;
 
 #[test]
 fn test_property_map_silent_loss_when_interner_full() {
@@ -27,11 +27,11 @@ fn test_property_map_silent_loss_when_interner_full() {
         println!("Subprocess stderr:\n{}", stderr);
 
         if stdout.contains("VULNERABILITY CONFIRMED") {
-             // We reproduced it!
-             // To make the test "pass" in the sense of "we confirmed the bug exists",
-             // we could assert(true). But normally we want tests to pass when code is correct.
-             // So initially this test will FAIL.
-             panic!("Vulnerability reproduced: Property silently dropped!");
+            // We reproduced it!
+            // To make the test "pass" in the sense of "we confirmed the bug exists",
+            // we could assert(true). But normally we want tests to pass when code is correct.
+            // So initially this test will FAIL.
+            panic!("Vulnerability reproduced: Property silently dropped!");
         }
         panic!("Subprocess failed unexpectedly");
     }
@@ -41,8 +41,8 @@ fn test_property_map_silent_loss_when_interner_full() {
 }
 
 fn run_subprocess_test() {
-    use aletheiadb::core::property::PropertyMapBuilder;
     use aletheiadb::core::GLOBAL_INTERNER;
+    use aletheiadb::core::property::PropertyMapBuilder;
 
     println!("Interner len: {}", GLOBAL_INTERNER.len());
 
@@ -61,7 +61,9 @@ fn run_subprocess_test() {
             } else {
                 // If we reach here, it means the key WAS inserted, which implies the
                 // interner limit was NOT enforced. This is a test setup failure.
-                panic!("TEST SETUP FAILURE: Key was inserted successfully. Interner limit was not enforced?");
+                panic!(
+                    "TEST SETUP FAILURE: Key was inserted successfully. Interner limit was not enforced?"
+                );
             }
         }
         Err(e) => {


### PR DESCRIPTION
This PR fixes a security vulnerability where properties could be silently dropped during node/edge creation if the string interner capacity was exceeded. This could lead to security bypasses if critical properties (like ACLs or roles) were dropped while the operation appeared to succeed.

The fix ensures that interning errors are propagated, causing the operation to fail explicitly rather than silently omitting data.

Testing:
- Added `tests/security_interner_dos.rs` which uses a subprocess to test `GLOBAL_INTERNER` with a constrained capacity limit, verifying that insertion correctly fails.

---
*PR created automatically by Jules for task [789164235560560223](https://jules.google.com/task/789164235560560223) started by @madmax983*