### PR TITLE
🤖 Sentinel: Harden float comparison and vector delta logic

### DIFF
--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -2371,6 +2371,35 @@ mod sentry_tests {
         let delta = PropertyDelta::from_diff(&props, &props);
         assert!(delta.is_empty(), "NaN -> NaN should result in empty delta");
     }
+
+    #[test]
+    fn test_sentry_floats_epsilon_boundary() {
+        // 🛡️ Sentry Test: Verify floats_approx_equal handles exact epsilon difference as equal.
+        // This targets mutants that replace `<=` with `<` in (a-b).abs() <= VECTOR_EPSILON.
+
+        let old = vec![0.0f32];
+        let new = vec![VECTOR_EPSILON]; // Exact epsilon difference
+
+        // Should be considered equal, so no delta
+        let delta = VectorDelta::from_diff(&old, &new);
+        assert!(
+            delta.is_none(),
+            "Difference of exactly EPSILON should be treated as equal"
+        );
+    }
+
+    #[test]
+    fn test_sentry_floats_infinite_equality() {
+        // 🛡️ Sentry Test: Verify floats_approx_equal handles infinity equality correctly.
+        // This targets mutants that remove the explicit `is_infinite` check.
+        // (INF - INF) is NaN, and NaN <= EPSILON is false, so without check they would be unequal.
+
+        let old = vec![f32::INFINITY];
+        let new = vec![f32::INFINITY];
+
+        let delta = VectorDelta::from_diff(&old, &new);
+        assert!(delta.is_none(), "Infinity == Infinity should be no change");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**🧬 Mutants Found:** 2 targeted mutants in `src/core/version.rs`:
1. `floats_approx_equal`: Replacing `<=` with `<` in `(a-b).abs() <= VECTOR_EPSILON` (survived because no test checked exact epsilon difference).
2. `floats_approx_equal`: Removing `if a.is_infinite() || b.is_infinite()` (survived because no test checked `INF == INF` behavior which relies on this check).

**🎯 Tests Added:**
- `test_sentry_floats_epsilon_boundary`: Asserts `VectorDelta` treats exact `VECTOR_EPSILON` diff as equal.
- `test_sentry_floats_infinite_equality`: Asserts `VectorDelta` treats `INFINITY == INFINITY` as equal (no delta).

**📊 Kill Rate:** These tests explicitly target the identified gaps, improving the robustness of vector delta compression logic against regression.


---
*PR created automatically by Jules for task [3232076103238403376](https://jules.google.com/task/3232076103238403376) started by @madmax983*