### PR TITLE
DX: Add convenience methods and fix docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,29 +326,23 @@ See **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for complete architecture d
 ### Basic Graph Operations
 
 ```rust
-use aletheiadb::{AletheiaDB, properties, WriteOps};
+use aletheiadb::{AletheiaDB, properties};
 
 // Create a new database
 let db = AletheiaDB::new().unwrap();
 
-// Create nodes using write transactions
-let alice_id = db.write(|tx| {
-    tx.create_node("Person", properties! {
-        "name" => "Alice",
-        "age" => 30,
-    })
+// Create nodes
+let alice_id = db.create_node("Person", properties! {
+    "name" => "Alice",
+    "age" => 30,
 })?;
 
-let bob_id = db.write(|tx| {
-    tx.create_node("Person", properties! {
-        "name" => "Bob",
-    })
+let bob_id = db.create_node("Person", properties! {
+    "name" => "Bob",
 })?;
 
 // Create relationships
-db.write(|tx| {
-    tx.create_edge(alice_id, bob_id, "KNOWS", properties! {})
-})?;
+db.create_edge(alice_id, bob_id, "KNOWS", properties! {})?;
 
 // Read current state
 let alice = db.get_node(alice_id)?;
@@ -407,7 +401,16 @@ let similar = db.find_similar(doc_id, 10)?;
 ### Hybrid Queries (Graph + Vector + Temporal)
 
 ```rust
-use aletheiadb::query::ir::Predicate;
+use aletheiadb::{AletheiaDB, properties, HnswConfig, DistanceMetric};
+
+// Setup database context (if starting fresh)
+let db = AletheiaDB::new().unwrap();
+let alice_id = db.create_node("Person", properties! { "name" => "Alice" })?;
+
+// Ensure vector index is enabled (required for vector operations)
+db.vector_index("embedding")
+    .hnsw(HnswConfig::new(384, DistanceMetric::Cosine))
+    .enable()?;
 
 // Setup query parameters
 let query_embedding = vec![0.1f32; 384];
@@ -507,7 +510,9 @@ for (node_id, drift_score) in drifted_nodes {
 
 ### Narrative Generation (Experimental)
 
-> **Requires `nova` feature**
+> ⚠️ **REQUIRES FEATURE `nova`**
+>
+> This example requires the `nova` feature flag. If you see "could not find `experimental`", you forgot to enable it!
 >
 > Run the demo:
 > ```bash
@@ -515,7 +520,7 @@ for (node_id, drift_score) in drifted_nodes {
 > ```
 
 ```rust
-use aletheiadb::{AletheiaDB, properties, WriteOps};
+use aletheiadb::{AletheiaDB, properties};
 // ⚠️ REQUIRES FEATURE 'NOVA'
 // Enable in Cargo.toml: features = ["nova"]
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;

--- a/examples/doctor_who_demo.rs
+++ b/examples/doctor_who_demo.rs
@@ -11,7 +11,6 @@
 
 use aletheiadb::{
     AletheiaDB, GLOBAL_INTERNER, InternedString, NodeId, PropertyMapBuilder, Result, Timestamp,
-    WriteOps,
 };
 use std::collections::HashMap;
 use std::io::{self, Write};
@@ -542,16 +541,14 @@ fn populate_database(demo: &mut DemoData) -> Result<()> {
         let incarnation_owned = incarnation.to_string();
         let regen = *regen_num;
 
-        demo.db.write(|tx| {
-            tx.update_node(
-                doctor,
-                props! {
-                    "actor" => actor_owned.as_str(),
-                    "current_incarnation" => incarnation_owned.as_str(),
-                    "regeneration_count" => regen,
-                },
-            )
-        })?;
+        demo.db.update_node(
+            doctor,
+            props! {
+                "actor" => actor_owned.as_str(),
+                "current_incarnation" => incarnation_owned.as_str(),
+                "regeneration_count" => regen,
+            },
+        )?;
 
         // Record the regeneration event
         demo.regenerations.push(RegenerationEvent {
@@ -798,16 +795,14 @@ fn update_doctor_incarnation(
         let new_actor_owned = new_actor.to_string();
         let incarnation_owned = incarnation_final.clone();
 
-        demo.db.write(|tx| {
-            tx.update_node(
-                doctor_id,
-                props! {
-                    "actor" => new_actor_owned.as_str(),
-                    "current_incarnation" => incarnation_owned.as_str(),
-                    "regeneration_count" => regen_count + 1,
-                },
-            )
-        })?;
+        demo.db.update_node(
+            doctor_id,
+            props! {
+                "actor" => new_actor_owned.as_str(),
+                "current_incarnation" => incarnation_owned.as_str(),
+                "regeneration_count" => regen_count + 1,
+            },
+        )?;
 
         // Record the regeneration event
         demo.record_regeneration(

--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -23,7 +23,6 @@
 //! ```
 
 use aletheiadb::AletheiaDB;
-use aletheiadb::WriteOps;
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
 use aletheiadb::properties;
 
@@ -40,16 +39,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // 2. Update Node
-    db.write(|tx| {
-        tx.update_node(
-            node_id,
-            properties! {
-                "name" => "Alice",
-                "age" => 31,
-                "city" => "London",
-            },
-        )
-    })?;
+    db.update_node(
+        node_id,
+        properties! {
+            "name" => "Alice",
+            "age" => 31,
+            "city" => "London",
+        },
+    )?;
 
     // 3. Generate Narrative
     let generator = NarrativeGenerator::new(&db);

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -63,6 +63,65 @@ impl AletheiaDB {
         self.write(|tx| tx.create_edge(source, target, label, properties))
     }
 
+    /// Update a node's properties.
+    ///
+    /// This is a convenience method that internally uses a write transaction.
+    /// For multiple operations, prefer using `write()` or `write_transaction()`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, properties, core::NodeId};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// # let node_id = NodeId::new(1)?;
+    /// db.update_node(
+    ///     node_id,
+    ///     properties! { "age" => 31 }
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update_node(&self, node_id: NodeId, properties: PropertyMap) -> Result<()> {
+        self.write(|tx| tx.update_node(node_id, properties))
+    }
+
+    /// Update an edge's properties.
+    ///
+    /// This is a convenience method that internally uses a write transaction.
+    /// For multiple operations, prefer using `write()` or `write_transaction()`.
+    pub fn update_edge(&self, edge_id: EdgeId, properties: PropertyMap) -> Result<()> {
+        self.write(|tx| tx.update_edge(edge_id, properties))
+    }
+
+    /// Delete a node (leaves connected edges).
+    ///
+    /// **Warning**: This leaves orphaned edges. Use [`delete_node_cascade`](Self::delete_node_cascade)
+    /// for safe deletion.
+    ///
+    /// This is a convenience method that internally uses a write transaction.
+    pub fn delete_node(&self, node_id: NodeId) -> Result<()> {
+        self.write(|tx| tx.delete_node(node_id))
+    }
+
+    /// Delete a node and all connected edges (cascade delete).
+    ///
+    /// This method deletes both the node and all edges where the node
+    /// appears as either the source or target. This prevents orphaned edges
+    /// and maintains referential integrity in the graph.
+    ///
+    /// This is a convenience method that internally uses a write transaction.
+    pub fn delete_node_cascade(&self, node_id: NodeId) -> Result<()> {
+        self.write(|tx| tx.delete_node_cascade(node_id))
+    }
+
+    /// Delete an edge.
+    ///
+    /// This is a convenience method that internally uses a write transaction.
+    pub fn delete_edge(&self, edge_id: EdgeId) -> Result<()> {
+        self.write(|tx| tx.delete_edge(edge_id))
+    }
+
     /// Get the current state of a node.
     ///
     /// This uses the fast path (current storage) for O(1) lookup.

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2241,3 +2241,100 @@ fn test_multiple_edges_same_nodes() {
     assert_eq!(db.out_degree(bob), 1);
     assert_eq!(db.in_degree(bob), 2);
 }
+
+// ========================================================================
+// Convenience Methods Tests
+// ========================================================================
+
+#[test]
+fn test_convenience_update_node() {
+    let db = AletheiaDB::new().unwrap();
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("age", 30i64).build(),
+        )
+        .unwrap();
+
+    db.update_node(
+        node_id,
+        PropertyMapBuilder::new().insert("age", 31i64).build(),
+    )
+    .unwrap();
+
+    let node = db.get_node(node_id).unwrap();
+    assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(31));
+}
+
+#[test]
+fn test_convenience_update_edge() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let edge_id = db
+        .create_edge(
+            n1,
+            n2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("w", 1i64).build(),
+        )
+        .unwrap();
+
+    db.update_edge(edge_id, PropertyMapBuilder::new().insert("w", 2i64).build())
+        .unwrap();
+
+    let edge = db.get_edge(edge_id).unwrap();
+    assert_eq!(edge.properties.get("w").and_then(|v| v.as_int()), Some(2));
+}
+
+#[test]
+fn test_convenience_delete_node() {
+    let db = AletheiaDB::new().unwrap();
+    let node_id = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.delete_node(node_id).unwrap();
+
+    assert!(db.get_node(node_id).is_err());
+}
+
+#[test]
+fn test_convenience_delete_node_cascade() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(n1, n2, "K", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.delete_node_cascade(n1).unwrap();
+
+    assert!(db.get_node(n1).is_err());
+    assert_eq!(db.edge_count(), 0);
+}
+
+#[test]
+fn test_convenience_delete_edge() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let edge_id = db
+        .create_edge(n1, n2, "K", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.delete_edge(edge_id).unwrap();
+
+    assert!(db.get_edge(edge_id).is_err());
+}

--- a/src/db/tests_convenience.rs
+++ b/src/db/tests_convenience.rs
@@ -1,0 +1,100 @@
+
+// ========================================================================
+// Convenience Methods Tests
+// ========================================================================
+
+#[test]
+fn test_convenience_update_node() {
+    let db = AletheiaDB::new().unwrap();
+    let node_id = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("age", 30i64).build(),
+        )
+        .unwrap();
+
+    db.update_node(
+        node_id,
+        PropertyMapBuilder::new().insert("age", 31i64).build(),
+    )
+    .unwrap();
+
+    let node = db.get_node(node_id).unwrap();
+    assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(31));
+}
+
+#[test]
+fn test_convenience_update_edge() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let edge_id = db
+        .create_edge(
+            n1,
+            n2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("w", 1i64).build(),
+        )
+        .unwrap();
+
+    db.update_edge(
+        edge_id,
+        PropertyMapBuilder::new().insert("w", 2i64).build(),
+    )
+    .unwrap();
+
+    let edge = db.get_edge(edge_id).unwrap();
+    assert_eq!(edge.properties.get("w").and_then(|v| v.as_int()), Some(2));
+}
+
+#[test]
+fn test_convenience_delete_node() {
+    let db = AletheiaDB::new().unwrap();
+    let node_id = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.delete_node(node_id).unwrap();
+
+    assert!(db.get_node(node_id).is_err());
+}
+
+#[test]
+fn test_convenience_delete_node_cascade() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(n1, n2, "K", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.delete_node_cascade(n1).unwrap();
+
+    assert!(db.get_node(n1).is_err());
+    assert_eq!(db.edge_count(), 0);
+}
+
+#[test]
+fn test_convenience_delete_edge() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let n2 = db
+        .create_node("P", PropertyMapBuilder::new().build())
+        .unwrap();
+    let edge_id = db
+        .create_edge(n1, n2, "K", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    db.delete_edge(edge_id).unwrap();
+
+    assert!(db.get_edge(edge_id).is_err());
+}


### PR DESCRIPTION
Improved Developer Experience (DX) by implementing missing convenience methods (`update_node`, `delete_node`, etc.) on `AletheiaDB` struct to match `create_node`. Updated examples and README to use these methods and clarified feature flag requirements. Fixed broken README examples.

---
*PR created automatically by Jules for task [15650637261789036247](https://jules.google.com/task/15650637261789036247) started by @madmax983*