### PR TITLE
🛡️ Sentry: Fix deadlock on dropped PendingEntry

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -25,3 +25,7 @@
 ## 2026-03-01 - Thread-Local Stripe Affinity Bug
 **Learning:** `ConcurrentWal` cached stripe indices in a global `thread_local!` variable. This index was tied to the `num_stripes` of the *first* WAL instance accessed by the thread. When the same thread accessed a second WAL instance with fewer stripes (common in test suites or multi-tenant setups), the cached index could exceed the bounds of the new `stripes` vector, causing a panic.
 **Action:** Changed `THREAD_STRIPE_ID` to cache the `thread_id.hash()` (u64) instead of the calculated stripe index. The stripe index is now re-calculated on every access (`hash & stripe_mask`), which is cheap and always correct for the current WAL instance's configuration.
+
+## 2026-03-02 - Deadlock in Synchronous WAL Append
+**Learning:** `PendingEntry` was intended to implement `Drop` to notify waiters of errors if the entry was discarded (e.g., buffer full or panic), but the implementation was missing. This caused `CompletionHandle::wait()` to hang indefinitely if the entry was dropped before completion.
+**Action:** Implemented `Drop` for `PendingEntry` to check `!notifier.is_complete()` and notify an error. Also updated tests to access `PendingEntry` fields by reference since `Drop` prevents moving fields out.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "memmap2",
  "metrics",
  "metrics-exporter-prometheus",
+ "native-tls",
  "num_cpus",
  "ort",
  "parking_lot",

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -204,6 +204,7 @@ impl Drop for PendingEntry {
         // If the entry is dropped and hasn't been completed yet, notify an error.
         // This prevents deadlocks where a waiter hangs forever if the entry is discarded
         // (e.g. buffer full, panic, or explicit drop) without being flushed.
+        #[allow(clippy::collapsible_if)]
         if let Some(ref notifier) = self.completion {
             if !notifier.is_complete() {
                 notifier.notify_error("PendingEntry dropped before flush");

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -199,6 +199,19 @@ impl PendingEntry {
     }
 }
 
+impl Drop for PendingEntry {
+    fn drop(&mut self) {
+        // If the entry is dropped and hasn't been completed yet, notify an error.
+        // This prevents deadlocks where a waiter hangs forever if the entry is discarded
+        // (e.g. buffer full, panic, or explicit drop) without being flushed.
+        if let Some(ref notifier) = self.completion {
+            if !notifier.is_complete() {
+                notifier.notify_error("PendingEntry dropped before flush");
+            }
+        }
+    }
+}
+
 /// Completion notification state.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1151,7 +1164,8 @@ mod tests {
                 for entry in entries {
                     drained_count += 1;
                     // Verify data integrity
-                    let val = u64::from_le_bytes(entry.data.try_into().unwrap());
+                    // Access data by reference since Drop implementation prevents moving fields
+                    let val = u64::from_le_bytes(entry.data.as_slice().try_into().unwrap());
                     checksum = checksum.wrapping_add(val);
                 }
             }
@@ -1398,5 +1412,34 @@ mod tests {
             max_sleep_us: 10,
         };
         let _ = WalRingBuffer::with_config(1024, config);
+    }
+}
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+
+    #[test]
+    fn test_sentry_dropped_entry_notifies_error() {
+        // 🛡️ Sentry: Verify that dropping a PendingEntry notifies the waiter with an error.
+        // This prevents deadlocks if an entry is dropped (e.g. on full buffer or panic)
+        // while a thread is waiting for sync persistence.
+
+        let (entry, handle) = PendingEntry::new_sync(LSN(100), vec![]);
+
+        // Ensure initially pending
+        assert!(!handle.is_complete(), "Handle should be pending initially");
+
+        // Drop the entry immediately without flushing
+        drop(entry);
+
+        // The handle should report an error because the entry was dropped before completion
+        // If this fails (handle remains pending), it means we have a deadlock risk
+        assert!(handle.is_complete(), "Handle should be complete (error) after entry drop");
+
+        let result = handle.wait();
+        assert!(result.is_err(), "Handle should return error");
+        let err = result.unwrap_err();
+        assert!(err.contains("PendingEntry dropped"), "Error should mention dropped entry");
     }
 }

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1435,11 +1435,17 @@ mod sentry_tests {
 
         // The handle should report an error because the entry was dropped before completion
         // If this fails (handle remains pending), it means we have a deadlock risk
-        assert!(handle.is_complete(), "Handle should be complete (error) after entry drop");
+        assert!(
+            handle.is_complete(),
+            "Handle should be complete (error) after entry drop"
+        );
 
         let result = handle.wait();
         assert!(result.is_err(), "Handle should return error");
         let err = result.unwrap_err();
-        assert!(err.contains("PendingEntry dropped"), "Error should mention dropped entry");
+        assert!(
+            err.contains("PendingEntry dropped"),
+            "Error should mention dropped entry"
+        );
     }
 }

--- a/tests/havoc/havoc_ring_buffer_torture.rs
+++ b/tests/havoc/havoc_ring_buffer_torture.rs
@@ -86,7 +86,7 @@ fn test_ring_buffer_torture() {
 
             for entry in entries {
                 total_received += 1;
-                let val = u64::from_le_bytes(entry.data.try_into().unwrap());
+                let val = u64::from_le_bytes(entry.data.as_slice().try_into().unwrap());
                 let p_id = (val >> 32) as usize;
                 let seq = val & 0xFFFFFFFF;
 


### PR DESCRIPTION
Implemented `Drop` for `PendingEntry` to ensure that waiters are notified with an error if the entry is dropped before being flushed. This prevents potential deadlocks where a thread waits indefinitely for a completion signal that will never come.

Verified with a new test case `test_sentry_dropped_entry_notifies_error` and ran existing tests to ensure no regressions. Also updated `havoc_ring_buffer_torture` test to accommodate the new `Drop` implementation (cannot move fields out of struct).

---
*PR created automatically by Jules for task [7015409862389187599](https://jules.google.com/task/7015409862389187599) started by @madmax983*