### PR TITLE
🤖 Sentinel: Fix oversized vector delta bug and strengthen version tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,15 @@
 **Summary:** `serialize_entry` checks `estimated_capacity > MAX_WAL_ENTRY_SIZE`, but no test verified behavior at exactly `MAX_WAL_ENTRY_SIZE` or just above it.
 **Diagnosis:** **Missing Coverage**. A mutant changing `>` to `>=` (rejecting valid max-size entries) or removing the check entirely (allowing DoS) would survive.
 **Kill Shot:** Added `test_append_entry_exactly_max_size_succeeds` and `test_append_entry_exceeding_max_size_fails` in `sentry_tests` module to enforce strict boundary compliance.
+
+**[PropertyDelta Oversized Vector Ignored]**
+**Module:** `src/core/version.rs`
+**Summary:** `PropertyDelta::from_diff` silently ignored changes to vectors exceeding `MAX_VECTOR_DIMENSIONS` because `VectorDelta::from_diff` returned `None` (correctly), but the fallback logic assumed `None` meant "no change" without checking sizes or content.
+**Diagnosis:** **Suspected Code Bug**. The implementation failed to handle the edge case where `VectorDelta` refuses to process a vector due to size limits, leading to silent data loss/inconsistency.
+**Kill Shot:** Added `test_property_delta_handles_oversized_vectors` to verify that oversized vector changes trigger a full replacement. Fixed implementation to fallback to full replacement when `len > MAX` and content differs.
+
+**[VectorDelta Equality Order Sensitivity]**
+**Module:** `src/core/version.rs`
+**Summary:** `VectorDelta::eq` compares sparse changes position-wise, making it sensitive to index order.
+**Diagnosis:** **Weakness/Implementation Detail**. While `from_diff` guarantees sorted order, manual construction does not. Documented this behavior to prevent future regression or assumptions.
+**Kill Shot:** Added `test_vector_delta_partial_eq_order_sensitivity` to enforce/document this constraint.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "memmap2",
  "metrics",
  "metrics-exporter-prometheus",
+ "native-tls",
  "num_cpus",
  "ort",
  "parking_lot",

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -2431,13 +2431,20 @@ mod sentry_tests {
 
         let delta = PropertyDelta::from_diff(&old_props, &new_props);
 
-        assert!(!delta.is_empty(), "Oversized vector change should be detected");
-        assert!(delta
-            .changed
-            .contains_key(&GLOBAL_INTERNER.intern("embedding").unwrap()));
-        assert!(!delta
-            .vector_deltas
-            .contains_key(&GLOBAL_INTERNER.intern("embedding").unwrap()));
+        assert!(
+            !delta.is_empty(),
+            "Oversized vector change should be detected"
+        );
+        assert!(
+            delta
+                .changed
+                .contains_key(&GLOBAL_INTERNER.intern("embedding").unwrap())
+        );
+        assert!(
+            !delta
+                .vector_deltas
+                .contains_key(&GLOBAL_INTERNER.intern("embedding").unwrap())
+        );
     }
 
     #[test]

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -402,8 +402,14 @@ impl PropertyDelta {
                             // Both are vectors - use sparse delta if beneficial
                             if let Some(vec_delta) = VectorDelta::from_diff(old_vec, new_vec) {
                                 delta.vector_deltas.insert(*key, vec_delta);
-                            } else if old_vec.len() != new_vec.len() {
-                                // If dimensions differ, treat as full replacement
+                            } else if old_vec.len() != new_vec.len()
+                                || (old_vec.len() > crate::core::property::MAX_VECTOR_DIMENSIONS
+                                    && old_vec != new_vec)
+                            {
+                                // If dimensions differ or exceed the limit for sparse/approximate delta,
+                                // treat as full replacement to ensure correctness.
+                                // We check for exact equality here because from_diff returns None for
+                                // oversized vectors even if they changed.
                                 delta.changed.insert(*key, new_value.clone());
                             }
                             // Else: Dimensions match but no changes > epsilon. Treated as no change.
@@ -2399,6 +2405,61 @@ mod sentry_tests {
 
         let delta = VectorDelta::from_diff(&old, &new);
         assert!(delta.is_none(), "Infinity == Infinity should be no change");
+    }
+
+    #[test]
+    fn test_property_delta_handles_oversized_vectors() {
+        // 🛡️ Sentry Test: Verify that PropertyDelta handles oversized vectors by performing a full replacement
+        // instead of silently ignoring changes (Bug Fix).
+
+        let len = MAX_VECTOR_DIMENSIONS + 1;
+        let old_vec = vec![0.0f32; len];
+        let mut new_vec = old_vec.clone();
+        new_vec[0] = 1.0;
+
+        // Manually construct PropertyValues to bypass creation checks
+        let old_val = PropertyValue::Vector(Arc::from(old_vec.into_boxed_slice()));
+        let new_val = PropertyValue::Vector(Arc::from(new_vec.into_boxed_slice()));
+
+        let old_props = PropertyMapBuilder::new()
+            .insert("embedding", old_val)
+            .build();
+
+        let new_props = PropertyMapBuilder::new()
+            .insert("embedding", new_val)
+            .build();
+
+        let delta = PropertyDelta::from_diff(&old_props, &new_props);
+
+        assert!(!delta.is_empty(), "Oversized vector change should be detected");
+        assert!(delta
+            .changed
+            .contains_key(&GLOBAL_INTERNER.intern("embedding").unwrap()));
+        assert!(!delta
+            .vector_deltas
+            .contains_key(&GLOBAL_INTERNER.intern("embedding").unwrap()));
+    }
+
+    #[test]
+    fn test_vector_delta_partial_eq_order_sensitivity() {
+        // 🛡️ Sentry Test: Document that VectorDelta::eq implies sorted indices.
+        // If indices are unsorted (e.g. from manual construction), equivalent deltas are not equal.
+        // This is an implementation detail that we lock in with a test.
+
+        let changes1 = vec![(1u32, 1.0f32), (2u32, 2.0f32)];
+        let changes2 = vec![(2u32, 2.0f32), (1u32, 1.0f32)]; // Same changes, different order
+
+        let delta1 = VectorDelta::Sparse {
+            dimension: 10,
+            changes: Arc::new(changes1),
+        };
+
+        let delta2 = VectorDelta::Sparse {
+            dimension: 10,
+            changes: Arc::new(changes2),
+        };
+
+        assert_ne!(delta1, delta2, "VectorDelta equality relies on index order");
     }
 }
 


### PR DESCRIPTION
**🤖 Sentinel Report**

**🧬 Mutants Found:** 
- **Suspected Bug:** `PropertyDelta::from_diff` relied on `VectorDelta::from_diff` returning `Some` to detect vector changes. However, `VectorDelta::from_diff` returns `None` if the vector exceeds `MAX_VECTOR_DIMENSIONS` (to avoid expensive sparse calculation). The fallback logic assumed `None` + `same length` meant "no change", causing silent data loss for changes in oversized vectors.

**🎯 Tests Added/Strengthened:**
- `test_property_delta_handles_oversized_vectors`: Verifies that modifying a vector larger than `MAX_VECTOR_DIMENSIONS` correctly results in a full replacement in the delta.
- `test_vector_delta_partial_eq_order_sensitivity`: Documents that `VectorDelta` equality is sensitive to index order (implementation detail relevant for manual construction).

**⚠️ Suspected Bugs Fixed:**
- Fixed the silent data loss for oversized vectors by adding an explicit check: if `len > MAX` and `old != new`, treat as full replacement.

**🔗 Havoc Interaction:**
- This bug might have been caught by Havoc if it generated oversized vectors, but `MAX_VECTOR_DIMENSIONS` is large (100,000), making it unlikely for random fuzzing to hit without targeted guidance. Sentinel's analysis of the source code boundary checks was key.


---
*PR created automatically by Jules for task [13367715247396760183](https://jules.google.com/task/13367715247396760183) started by @madmax983*