### PR TITLE
🛡️ Sentry: Add WAL checksum & round-trip tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,6 @@ dependencies = [
  "memmap2",
  "metrics",
  "metrics-exporter-prometheus",
- "native-tls",
  "num_cpus",
  "ort",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "memmap2",
  "metrics",
  "metrics-exporter-prometheus",
+ "native-tls",
  "num_cpus",
  "ort",
  "parking_lot",

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -184,6 +184,7 @@ impl WalEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::wal::serialization::serialize_entry_into;
 
     #[test]
     fn test_lsn() {
@@ -214,5 +215,76 @@ mod tests {
         };
         let entry = WalEntry::new(lsn, op);
         assert!(!entry.verify_checksum(&[0u8; 10])); // Less than 24 bytes
+    }
+
+    #[test]
+    fn test_verify_checksum_success() {
+        // 🛡️ Sentry Test: Verify that a valid serialized entry passes checksum verification.
+        // This covers the "happy path" which was previously missing.
+        let lsn = LSN(100);
+        let op = WalOperation::Checkpoint {
+            lsn: LSN(50),
+            timestamp: time::now(),
+        };
+        let entry = WalEntry::new(lsn, op);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+
+        assert!(
+            entry.verify_checksum(&buffer),
+            "Checksum verification failed for valid entry"
+        );
+    }
+
+    #[test]
+    fn test_checksum_integrity() {
+        // 🛡️ Sentry Test: Verify that data corruption is detected.
+        let lsn = LSN(100);
+        let op = WalOperation::Checkpoint {
+            lsn: LSN(50),
+            timestamp: time::now(),
+        };
+        let entry = WalEntry::new(lsn, op);
+
+        let mut buffer = Vec::new();
+        serialize_entry_into(&entry, &mut buffer).unwrap();
+
+        // Sanity check: valid initially
+        assert!(entry.verify_checksum(&buffer));
+
+        // Corrupt LSN (byte 0)
+        let mut corrupt_lsn = buffer.clone();
+        corrupt_lsn[0] ^= 0xFF;
+        assert!(
+            !entry.verify_checksum(&corrupt_lsn),
+            "Checksum should fail when LSN is corrupted"
+        );
+
+        // Corrupt Timestamp (byte 8)
+        let mut corrupt_ts = buffer.clone();
+        corrupt_ts[8] ^= 0xFF;
+        assert!(
+            !entry.verify_checksum(&corrupt_ts),
+            "Checksum should fail when Timestamp is corrupted"
+        );
+
+        // Corrupt Operation Data (last byte)
+        let mut corrupt_data = buffer.clone();
+        let last_idx = corrupt_data.len() - 1;
+        corrupt_data[last_idx] ^= 0xFF;
+        assert!(
+            !entry.verify_checksum(&corrupt_data),
+            "Checksum should fail when Operation Data is corrupted"
+        );
+
+        // Corrupt Checksum Field itself (byte 20)
+        // This ensures verify_checksum isn't just ignoring the stored checksum
+        let mut corrupt_sum = buffer.clone();
+        corrupt_sum[20] ^= 0xFF;
+        assert!(
+            !entry.verify_checksum(&corrupt_sum),
+            "Checksum should fail when stored checksum is corrupted"
+        );
     }
 }

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -253,37 +253,39 @@ mod tests {
         // Sanity check: valid initially
         assert!(entry.verify_checksum(&buffer));
 
+        // Clone once for corruption tests
+        let mut corrupt_buffer = buffer.clone();
+
         // Corrupt LSN (byte 0)
-        let mut corrupt_lsn = buffer.clone();
-        corrupt_lsn[0] ^= 0xFF;
+        corrupt_buffer[0] ^= 0xFF;
         assert!(
-            !entry.verify_checksum(&corrupt_lsn),
+            !entry.verify_checksum(&corrupt_buffer),
             "Checksum should fail when LSN is corrupted"
         );
+        corrupt_buffer[0] ^= 0xFF; // Restore
 
         // Corrupt Timestamp (byte 8)
-        let mut corrupt_ts = buffer.clone();
-        corrupt_ts[8] ^= 0xFF;
+        corrupt_buffer[8] ^= 0xFF;
         assert!(
-            !entry.verify_checksum(&corrupt_ts),
+            !entry.verify_checksum(&corrupt_buffer),
             "Checksum should fail when Timestamp is corrupted"
         );
+        corrupt_buffer[8] ^= 0xFF; // Restore
 
         // Corrupt Operation Data (last byte)
-        let mut corrupt_data = buffer.clone();
-        let last_idx = corrupt_data.len() - 1;
-        corrupt_data[last_idx] ^= 0xFF;
+        let last_idx = corrupt_buffer.len() - 1;
+        corrupt_buffer[last_idx] ^= 0xFF;
         assert!(
-            !entry.verify_checksum(&corrupt_data),
+            !entry.verify_checksum(&corrupt_buffer),
             "Checksum should fail when Operation Data is corrupted"
         );
+        corrupt_buffer[last_idx] ^= 0xFF; // Restore
 
         // Corrupt Checksum Field itself (byte 20)
         // This ensures verify_checksum isn't just ignoring the stored checksum
-        let mut corrupt_sum = buffer.clone();
-        corrupt_sum[20] ^= 0xFF;
+        corrupt_buffer[20] ^= 0xFF;
         assert!(
-            !entry.verify_checksum(&corrupt_sum),
+            !entry.verify_checksum(&corrupt_buffer),
             "Checksum should fail when stored checksum is corrupted"
         );
     }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1924,15 +1924,8 @@ mod sentry_tests {
                 assert_eq!(d_label, label, "Label mismatch");
                 assert_eq!(d_valid, valid_from, "valid_from mismatch");
 
-                // Check properties
-                assert_eq!(d_props.len(), properties.len());
-                assert_eq!(d_props.get("name").and_then(|v| v.as_str()), Some("Sentry"));
-                assert_eq!(
-                    d_props.get("purpose").and_then(|v| v.as_str()),
-                    Some("Correctness")
-                );
-                assert_eq!(d_props.get("active").and_then(|v| v.as_bool()), Some(true));
-                assert_eq!(d_props.get("score").and_then(|v| v.as_float()), Some(100.0));
+                // Use direct PropertyMap equality (derived PartialEq)
+                assert_eq!(d_props, properties, "PropertyMap mismatch");
             }
             _ => panic!("Deserialized operation type mismatch"),
         }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1850,11 +1850,11 @@ mod fuzz_tests {
 #[cfg(test)]
 mod sentry_tests {
     use super::*;
-    use crate::storage::wal::serialization::serialize_entry_into;
+    use crate::core::id::NodeId;
+    use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::time;
-    use crate::core::interning::GLOBAL_INTERNER;
-    use crate::core::id::NodeId;
+    use crate::storage::wal::serialization::serialize_entry_into;
 
     #[test]
     fn test_wal_entry_round_trip_correctness() {
@@ -1894,12 +1894,20 @@ mod sentry_tests {
 
         // 3. Deserialize
         // Note: version 1 is hardcoded here matching WAL_VERSION
-        let (deserialized_entry, consumed) = parse_entry_at(&buffer, 0, 1).expect("Deserialization failed");
+        let (deserialized_entry, consumed) =
+            parse_entry_at(&buffer, 0, 1).expect("Deserialization failed");
 
         // 4. Verify Fidelity
-        assert_eq!(consumed, buffer.len(), "Deserialization should consume entire buffer");
+        assert_eq!(
+            consumed,
+            buffer.len(),
+            "Deserialization should consume entire buffer"
+        );
         assert_eq!(deserialized_entry.lsn, lsn, "LSN mismatch");
-        assert_eq!(deserialized_entry.timestamp, original_entry.timestamp, "Timestamp mismatch");
+        assert_eq!(
+            deserialized_entry.timestamp, original_entry.timestamp,
+            "Timestamp mismatch"
+        );
         // Checksum in deserialized entry is the one read from disk/buffer
         // original_entry.checksum is 0 because it wasn't set by new() (it's computed during serialization)
         // So we can't compare checksums directly unless we update original_entry's checksum.
@@ -1919,7 +1927,10 @@ mod sentry_tests {
                 // Check properties
                 assert_eq!(d_props.len(), properties.len());
                 assert_eq!(d_props.get("name").and_then(|v| v.as_str()), Some("Sentry"));
-                assert_eq!(d_props.get("purpose").and_then(|v| v.as_str()), Some("Correctness"));
+                assert_eq!(
+                    d_props.get("purpose").and_then(|v| v.as_str()),
+                    Some("Correctness")
+                );
                 assert_eq!(d_props.get("active").and_then(|v| v.as_bool()), Some(true));
                 assert_eq!(d_props.get("score").and_then(|v| v.as_float()), Some(100.0));
             }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -1846,3 +1846,84 @@ mod fuzz_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::storage::wal::serialization::serialize_entry_into;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::core::temporal::time;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::id::NodeId;
+
+    #[test]
+    fn test_wal_entry_round_trip_correctness() {
+        // 🛡️ Sentry Test: Verify complete round-trip fidelity for a complex WAL entry.
+        // This ensures that serialization -> deserialization preserves all data exactly,
+        // including LSN, Timestamp, Operation type, and payload (properties).
+
+        let node_id = NodeId::new(999).unwrap();
+        let label = GLOBAL_INTERNER.intern("RoundTripNode").unwrap();
+        let properties = PropertyMapBuilder::new()
+            .insert("name", "Sentry")
+            .insert("purpose", "Correctness")
+            .insert("active", true)
+            .insert("score", 100.0)
+            .build();
+        let valid_from = time::now();
+
+        let operation = WalOperation::CreateNode {
+            node_id,
+            label,
+            properties: properties.clone(),
+            valid_from,
+        };
+
+        let lsn = LSN(12345);
+        let original_entry = WalEntry::new(lsn, operation);
+
+        // 1. Serialize
+        let mut buffer = Vec::new();
+        serialize_entry_into(&original_entry, &mut buffer).expect("Serialization failed");
+
+        // 2. Verify Checksum (Self-check)
+        assert!(
+            original_entry.verify_checksum(&buffer),
+            "Serialized buffer failed checksum verification against original entry"
+        );
+
+        // 3. Deserialize
+        // Note: version 1 is hardcoded here matching WAL_VERSION
+        let (deserialized_entry, consumed) = parse_entry_at(&buffer, 0, 1).expect("Deserialization failed");
+
+        // 4. Verify Fidelity
+        assert_eq!(consumed, buffer.len(), "Deserialization should consume entire buffer");
+        assert_eq!(deserialized_entry.lsn, lsn, "LSN mismatch");
+        assert_eq!(deserialized_entry.timestamp, original_entry.timestamp, "Timestamp mismatch");
+        // Checksum in deserialized entry is the one read from disk/buffer
+        // original_entry.checksum is 0 because it wasn't set by new() (it's computed during serialization)
+        // So we can't compare checksums directly unless we update original_entry's checksum.
+        // But verify_checksum passed, so the buffer is valid.
+
+        match deserialized_entry.operation {
+            WalOperation::CreateNode {
+                node_id: d_id,
+                label: d_label,
+                properties: d_props,
+                valid_from: d_valid,
+            } => {
+                assert_eq!(d_id, node_id, "Node ID mismatch");
+                assert_eq!(d_label, label, "Label mismatch");
+                assert_eq!(d_valid, valid_from, "valid_from mismatch");
+
+                // Check properties
+                assert_eq!(d_props.len(), properties.len());
+                assert_eq!(d_props.get("name").and_then(|v| v.as_str()), Some("Sentry"));
+                assert_eq!(d_props.get("purpose").and_then(|v| v.as_str()), Some("Correctness"));
+                assert_eq!(d_props.get("active").and_then(|v| v.as_bool()), Some(true));
+                assert_eq!(d_props.get("score").and_then(|v| v.as_float()), Some(100.0));
+            }
+            _ => panic!("Deserialized operation type mismatch"),
+        }
+    }
+}


### PR DESCRIPTION
Added comprehensive tests for WAL entry integrity, covering checksum validation and full serialization round-trips. This addresses coverage gaps identified in the WAL subsystem.

---
*PR created automatically by Jules for task [15133145839641742868](https://jules.google.com/task/15133145839641742868) started by @madmax983*