### PR TITLE
🤖 Sentinel: Killed off-by-one mutant in LsnAllocator batch allocation

### DIFF
--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -230,7 +230,12 @@ mod sentry_tests {
             lsn: LSN(456),
             timestamp: fixed_timestamp,
         };
-        let entry = WalEntry { lsn, timestamp: fixed_timestamp, operation: op, checksum: 0 };
+        let entry = WalEntry {
+            lsn,
+            timestamp: fixed_timestamp,
+            operation: op,
+            checksum: 0,
+        };
 
         // Serialize
         let mut buffer = Vec::new();

--- a/src/storage/wal/lsn_allocator.rs
+++ b/src/storage/wal/lsn_allocator.rs
@@ -378,4 +378,17 @@ mod sentry_tests {
         // Next allocation should fail as next_lsn is now MAX
         let _ = alloc.allocate();
     }
+
+    #[test]
+    fn test_batch_allocation_exact_fit_succeeds() {
+        // Start 10 steps before limit
+        let alloc = LsnAllocator::starting_at(LSN(u64::MAX - 10));
+
+        // Allocate exactly 10 items [MAX-10, ..., MAX-1]
+        // This MUST succeed (not panic) for the code to be correct.
+        // A mutant changing `>` to `>=` in the check would panic here.
+        let (start, end) = alloc.allocate_batch(10);
+        assert_eq!(start, LSN(u64::MAX - 10));
+        assert_eq!(end, LSN(u64::MAX - 1));
+    }
 }


### PR DESCRIPTION
**🧬 Mutants Found:**
- Identified a surviving mutant in `src/storage/wal/lsn_allocator.rs` where `>` was replaced with `>=` in the `allocate_batch` overflow check.
- This mutant survived because `test_batch_allocation_boundary` used `#[should_panic]` which masked the fact that the mutant caused a panic *too early* (rejecting valid input at the boundary) rather than correctly rejecting invalid input.

**🎯 Tests Added:**
- Added `test_batch_allocation_exact_fit_succeeds` to `src/storage/wal/lsn_allocator.rs`.
- This test explicitly asserts that a batch allocation that exactly fills the remaining `u64` space succeeds without panicking.
- This ensures the mutant (which would panic in this scenario) is killed.

**⚠️ Suspected Bugs:**
- None. The code was correct, but the test coverage was weak at the exact boundary.

**📊 Kill Rate:**
- Improved detection of off-by-one errors in WAL LSN allocation.

---
*PR created automatically by Jules for task [1875512299202136042](https://jules.google.com/task/1875512299202136042) started by @madmax983*