### PR TITLE
Refactor index persistence serialization

### DIFF
--- a/src/storage/index_persistence/common.rs
+++ b/src/storage/index_persistence/common.rs
@@ -1,0 +1,113 @@
+//! Common utilities for index persistence.
+//!
+//! Provides generic helpers for saving and loading data with CRC32 checksums.
+
+use bitcode::{Decode, Encode};
+use crc32fast::Hasher;
+use std::fs;
+use std::path::Path;
+
+use super::atomic_write;
+use super::error::{IndexPersistenceError, Result};
+
+/// Save encoded data with CRC32 checksum using atomic write.
+///
+/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
+///
+/// Uses write-temp-then-rename to prevent corruption on crash.
+///
+/// # Arguments
+///
+/// * `data` - The data to serialize and save
+/// * `path` - The file path to write to
+///
+/// # Errors
+///
+/// Returns an error if serialization or file I/O fails.
+pub fn save_encoded_with_crc<T: Encode>(data: &T, path: &Path) -> Result<()> {
+    let encoded = bitcode::encode(data);
+
+    // Calculate CRC32 of the encoded data
+    let mut hasher = Hasher::new();
+    hasher.update(&encoded);
+    let checksum = hasher.finalize();
+
+    // Write data + checksum
+    let mut data_with_checksum = encoded;
+    data_with_checksum.extend_from_slice(&checksum.to_le_bytes());
+
+    atomic_write(path, &data_with_checksum)
+}
+
+/// Load encoded data from disk and validate CRC32 checksum.
+///
+/// # Arguments
+///
+/// * `path` - The file path to read from
+/// * `max_size` - Maximum allowed file size (DoS protection)
+/// * `context` - Context name for error messages (e.g., "Vector index")
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - File size exceeds `max_size`
+/// - File is too small (missing checksum)
+/// - CRC32 checksum mismatch
+/// - Deserialization fails
+pub fn load_encoded_with_crc<T: for<'a> Decode<'a>>(
+    path: &Path,
+    max_size: u64,
+    context: &str,
+) -> Result<T> {
+    // Check file size before reading to prevent OOM/DoS
+    let metadata = fs::metadata(path)?;
+    if metadata.len() > max_size {
+        return Err(IndexPersistenceError::SizeLimitExceeded {
+            message: format!(
+                "{} file size {} exceeds limit {}",
+                context,
+                metadata.len(),
+                max_size
+            ),
+        });
+    }
+
+    let bytes = fs::read(path)?;
+
+    // Check minimum size (must have at least 4 bytes for CRC)
+    if bytes.len() < 4 {
+        return Err(IndexPersistenceError::Corrupted {
+            path: path.to_path_buf(),
+            source: "File too small to contain CRC32 checksum".into(),
+        });
+    }
+
+    // Split data and checksum
+    let (data, checksum_bytes) = bytes.split_at(bytes.len() - 4);
+    let stored_checksum = u32::from_le_bytes(checksum_bytes.try_into().map_err(|_| {
+        IndexPersistenceError::Corrupted {
+            path: path.to_path_buf(),
+            source: "Invalid CRC32 checksum format".into(),
+        }
+    })?);
+
+    // Verify checksum
+    let mut hasher = Hasher::new();
+    hasher.update(data);
+    let computed_checksum = hasher.finalize();
+
+    if computed_checksum != stored_checksum {
+        return Err(IndexPersistenceError::Corrupted {
+            path: path.to_path_buf(),
+            source: format!(
+                "CRC32 checksum mismatch: expected {}, got {}",
+                stored_checksum, computed_checksum
+            )
+            .into(),
+        });
+    }
+
+    // Decode
+    let decoded: T = bitcode::decode(data)?;
+    Ok(decoded)
+}

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -75,6 +75,7 @@
 //! - **Versioning**: All files include a version byte to support future schema evolution.
 
 pub mod api;
+pub(crate) mod common;
 mod error;
 pub mod formats;
 pub mod graph;

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -1,20 +1,13 @@
 //! String interner persistence.
 
 use crate::core::GLOBAL_INTERNER;
-use std::fs;
 use std::path::Path;
-
-use crc32fast::Hasher;
 
 use super::error::{IndexPersistenceError, Result};
 use super::formats::StringInternerData;
 use super::{INTERNER_MAGIC, MANIFEST_VERSION};
 
 /// Save the global string interner to disk with CRC32 checksum using atomic write.
-///
-/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
-///
-/// Uses write-temp-then-rename to prevent corruption on crash.
 pub fn save_string_interner(path: &Path) -> Result<()> {
     let strings = GLOBAL_INTERNER.get_all_strings();
 
@@ -25,72 +18,16 @@ pub fn save_string_interner(path: &Path) -> Result<()> {
         strings,
     };
 
-    let encoded = bitcode::encode(&data);
-
-    // Calculate CRC32 of the encoded data
-    let mut hasher = Hasher::new();
-    hasher.update(&encoded);
-    let checksum = hasher.finalize();
-
-    // Write data + checksum
-    let mut data_with_checksum = encoded;
-    data_with_checksum.extend_from_slice(&checksum.to_le_bytes());
-
-    super::atomic_write(path, &data_with_checksum)?;
-
-    Ok(())
+    super::common::save_encoded_with_crc(&data, path)
 }
 
 /// Load the string interner from disk and validate CRC32 checksum.
 pub fn load_string_interner(path: &Path) -> Result<StringInternerData> {
-    let metadata = fs::metadata(path)?;
-    if metadata.len() > super::MAX_STRING_INTERNER_FILE_SIZE {
-        return Err(IndexPersistenceError::SizeLimitExceeded {
-            message: format!(
-                "String interner file size {} exceeds limit {}",
-                metadata.len(),
-                super::MAX_STRING_INTERNER_FILE_SIZE
-            ),
-        });
-    }
-
-    let bytes = fs::read(path)?;
-
-    // Check minimum size (must have at least 4 bytes for CRC)
-    if bytes.len() < 4 {
-        return Err(IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: "File too small to contain CRC32 checksum".into(),
-        });
-    }
-
-    // Split data and checksum
-    let (data, checksum_bytes) = bytes.split_at(bytes.len() - 4);
-    let stored_checksum = u32::from_le_bytes(checksum_bytes.try_into().map_err(|_| {
-        IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: "Invalid CRC32 checksum format".into(),
-        }
-    })?);
-
-    // Verify checksum
-    let mut hasher = Hasher::new();
-    hasher.update(data);
-    let computed_checksum = hasher.finalize();
-
-    if computed_checksum != stored_checksum {
-        return Err(IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: format!(
-                "CRC32 checksum mismatch: expected {}, got {}",
-                stored_checksum, computed_checksum
-            )
-            .into(),
-        });
-    }
-
-    // Decode and validate
-    let data: StringInternerData = bitcode::decode(data)?;
+    let data: StringInternerData = super::common::load_encoded_with_crc(
+        path,
+        super::MAX_STRING_INTERNER_FILE_SIZE,
+        "String interner",
+    )?;
 
     // Validate magic bytes
     if data.magic != INTERNER_MAGIC {
@@ -160,6 +97,8 @@ pub fn restore_string_interner(data: &StringInternerData) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crc32fast::Hasher;
+    use std::fs;
     use tempfile::tempdir;
 
     #[test]

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -32,10 +32,7 @@
 //! - `VectorDelta::Sparse` **CANNOT** be persisted directly to prevent data loss. It must be
 //!   materialized into a full vector before persistence using `PropertyDelta::materialize_vector_deltas()`.
 
-use std::fs;
 use std::path::Path;
-
-use crc32fast::Hasher;
 
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
@@ -484,29 +481,8 @@ pub fn restore_into_historical_storage(
 }
 
 /// Save temporal index data to disk with CRC32 checksum using atomic write.
-///
-/// Format: `[bitcode_data][crc32_checksum_4_bytes]`
-///
-/// Uses `atomic_write` (write-temp-then-rename) to prevent corruption if the
-/// process crashes during write.
-///
-/// # Errors
-///
-/// Returns an error if serialization or file I/O fails.
 pub fn save_temporal_index(data: &TemporalIndexData, path: &Path) -> Result<()> {
-    let encoded = bitcode::encode(data);
-
-    // Calculate CRC32 of the encoded data
-    let mut hasher = Hasher::new();
-    hasher.update(&encoded);
-    let checksum = hasher.finalize();
-
-    // Write data + checksum
-    let mut data_with_checksum = encoded;
-    data_with_checksum.extend_from_slice(&checksum.to_le_bytes());
-
-    super::atomic_write(path, &data_with_checksum)?;
-    Ok(())
+    super::common::save_encoded_with_crc(data, path)
 }
 
 /// Load temporal index data from disk and validate CRC32 checksum.
@@ -523,54 +499,11 @@ pub fn save_temporal_index(data: &TemporalIndexData, path: &Path) -> Result<()> 
 ///
 /// Returns an error if the file is missing, corrupted, or incompatible.
 pub fn load_temporal_index(path: &Path) -> Result<TemporalIndexData> {
-    let metadata = fs::metadata(path)?;
-    if metadata.len() > super::MAX_TEMPORAL_INDEX_FILE_SIZE {
-        return Err(IndexPersistenceError::SizeLimitExceeded {
-            message: format!(
-                "Temporal index file size {} exceeds limit {}",
-                metadata.len(),
-                super::MAX_TEMPORAL_INDEX_FILE_SIZE
-            ),
-        });
-    }
-
-    let bytes = fs::read(path)?;
-
-    // Check minimum size (must have at least 4 bytes for CRC)
-    if bytes.len() < 4 {
-        return Err(IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: "File too small to contain CRC32 checksum".into(),
-        });
-    }
-
-    // Split data and checksum
-    let (data, checksum_bytes) = bytes.split_at(bytes.len() - 4);
-    let stored_checksum = u32::from_le_bytes(checksum_bytes.try_into().map_err(|_| {
-        IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: "Invalid CRC32 checksum format".into(),
-        }
-    })?);
-
-    // Verify checksum
-    let mut hasher = Hasher::new();
-    hasher.update(data);
-    let computed_checksum = hasher.finalize();
-
-    if computed_checksum != stored_checksum {
-        return Err(IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: format!(
-                "CRC32 checksum mismatch: expected {}, got {}",
-                stored_checksum, computed_checksum
-            )
-            .into(),
-        });
-    }
-
-    // Decode and validate
-    let data: TemporalIndexData = bitcode::decode(data)?;
+    let data: TemporalIndexData = super::common::load_encoded_with_crc(
+        path,
+        super::MAX_TEMPORAL_INDEX_FILE_SIZE,
+        "Temporal index",
+    )?;
 
     if data.magic != TEMPORAL_MAGIC {
         return Err(IndexPersistenceError::InvalidMagic {

--- a/src/storage/index_persistence/vector.rs
+++ b/src/storage/index_persistence/vector.rs
@@ -4,11 +4,8 @@
 //! - usearch native format for the HNSW index itself
 //! - bitcode for metadata and ID mappings
 
-use std::fs;
 use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use crc32fast::Hasher;
 
 use super::error::{IndexPersistenceError, Result};
 use super::formats::{
@@ -16,85 +13,19 @@ use super::formats::{
 };
 use super::{MANIFEST_VERSION, VECTOR_META_MAGIC};
 
-/// Helper function to save data with CRC32 checksum using atomic write.
-///
-/// Uses write-temp-then-rename to prevent corruption on crash.
-fn save_with_crc(data: &[u8], path: &Path) -> Result<()> {
-    let mut hasher = Hasher::new();
-    hasher.update(data);
-    let checksum = hasher.finalize();
-
-    let mut data_with_checksum = data.to_vec();
-    data_with_checksum.extend_from_slice(&checksum.to_le_bytes());
-
-    super::atomic_write(path, &data_with_checksum)?;
-    Ok(())
-}
-
-/// Helper function to load data and validate CRC32 checksum.
-///
-/// # Arguments
-///
-/// * `path` - The file path to read from
-/// * `max_size` - Maximum allowed file size (DoS protection)
-fn load_with_crc(path: &Path, max_size: u64) -> Result<Vec<u8>> {
-    let metadata = fs::metadata(path)?;
-    if metadata.len() > max_size {
-        return Err(IndexPersistenceError::SizeLimitExceeded {
-            message: format!(
-                "Vector index file size {} exceeds limit {}",
-                metadata.len(),
-                max_size
-            ),
-        });
-    }
-
-    let bytes = fs::read(path)?;
-
-    if bytes.len() < 4 {
-        return Err(IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: "File too small to contain CRC32 checksum".into(),
-        });
-    }
-
-    let (data, checksum_bytes) = bytes.split_at(bytes.len() - 4);
-    let stored_checksum = u32::from_le_bytes(checksum_bytes.try_into().map_err(|_| {
-        IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: "Invalid CRC32 checksum format".into(),
-        }
-    })?);
-
-    let mut hasher = Hasher::new();
-    hasher.update(data);
-    let computed_checksum = hasher.finalize();
-
-    if computed_checksum != stored_checksum {
-        return Err(IndexPersistenceError::Corrupted {
-            path: path.to_path_buf(),
-            source: format!(
-                "CRC32 checksum mismatch: expected {}, got {}",
-                stored_checksum, computed_checksum
-            )
-            .into(),
-        });
-    }
-
-    Ok(data.to_vec())
-}
-
 /// Save vector index metadata with CRC32 checksum.
 pub fn save_vector_meta(meta: &VectorIndexMeta, path: &Path) -> Result<()> {
-    let encoded = bitcode::encode(meta);
-    save_with_crc(&encoded, path)
+    super::common::save_encoded_with_crc(meta, path)
 }
 
 /// Load vector index metadata and validate CRC32 checksum.
 pub fn load_vector_meta(path: &Path) -> Result<VectorIndexMeta> {
     // Metadata should be small, but use standard limit for consistency
-    let data = load_with_crc(path, super::MAX_VECTOR_INDEX_FILE_SIZE)?;
-    let meta: VectorIndexMeta = bitcode::decode(&data)?;
+    let meta: VectorIndexMeta = super::common::load_encoded_with_crc(
+        path,
+        super::MAX_VECTOR_INDEX_FILE_SIZE,
+        "Vector index",
+    )?;
 
     if meta.magic != VECTOR_META_MAGIC {
         return Err(IndexPersistenceError::InvalidMagic {
@@ -116,28 +47,22 @@ pub fn load_vector_meta(path: &Path) -> Result<VectorIndexMeta> {
 
 /// Save vector ID mappings with CRC32 checksum.
 pub fn save_vector_mappings(mappings: &VectorMappingsData, path: &Path) -> Result<()> {
-    let encoded = bitcode::encode(mappings);
-    save_with_crc(&encoded, path)
+    super::common::save_encoded_with_crc(mappings, path)
 }
 
 /// Load vector ID mappings and validate CRC32 checksum.
 pub fn load_vector_mappings(path: &Path) -> Result<VectorMappingsData> {
-    let data = load_with_crc(path, super::MAX_VECTOR_INDEX_FILE_SIZE)?;
-    let mappings: VectorMappingsData = bitcode::decode(&data)?;
-    Ok(mappings)
+    super::common::load_encoded_with_crc(path, super::MAX_VECTOR_INDEX_FILE_SIZE, "Vector index")
 }
 
 /// Save vector snapshot metadata with CRC32 checksum.
 pub fn save_snapshot_meta(meta: &VectorSnapshotMeta, path: &Path) -> Result<()> {
-    let encoded = bitcode::encode(meta);
-    save_with_crc(&encoded, path)
+    super::common::save_encoded_with_crc(meta, path)
 }
 
 /// Load vector snapshot metadata and validate CRC32 checksum.
 pub fn load_snapshot_meta(path: &Path) -> Result<VectorSnapshotMeta> {
-    let data = load_with_crc(path, super::MAX_VECTOR_INDEX_FILE_SIZE)?;
-    let meta: VectorSnapshotMeta = bitcode::decode(&data)?;
-    Ok(meta)
+    super::common::load_encoded_with_crc(path, super::MAX_VECTOR_INDEX_FILE_SIZE, "Vector index")
 }
 
 /// Load a complete vector index (meta + mappings + index path) from a directory.

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -230,7 +230,12 @@ mod sentry_tests {
             lsn: LSN(456),
             timestamp: fixed_timestamp,
         };
-        let entry = WalEntry { lsn, timestamp: fixed_timestamp, operation: op, checksum: 0 };
+        let entry = WalEntry {
+            lsn,
+            timestamp: fixed_timestamp,
+            operation: op,
+            checksum: 0,
+        };
 
         // Serialize
         let mut buffer = Vec::new();


### PR DESCRIPTION
Extracted common serialization pattern (bitcode + CRC32 + atomic write) into a shared module.
Refactored `vector.rs`, `temporal.rs`, and `strings.rs` to remove duplicated code.
Ensured no behavioral changes and full test coverage.

---
*PR created automatically by Jules for task [3969780743673541549](https://jules.google.com/task/3969780743673541549) started by @madmax983*