### PR TITLE
test(core): add test for PropertyDelta::materialize_vector_deltas

### DIFF
--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -2412,6 +2412,56 @@ mod sentry_tests {
         let delta = VectorDelta::from_diff(&old, &new);
         assert!(delta.is_none(), "Infinity == Infinity should be no change");
     }
+
+    #[test]
+    fn test_materialize_vector_deltas_success() {
+        // 🛡️ Sentry Test: Verify success path of materialize_vector_deltas.
+        // This targets mutants that might empty the function body or loop, causing data loss.
+        // If materialization fails silently, sparse deltas are not persisted!
+
+        let mut delta = PropertyDelta::new();
+        let key = GLOBAL_INTERNER.intern("embedding").unwrap();
+
+        // Create a sparse delta: change index 0 to 1.0
+        // Base vector size: 10
+        let changes = std::sync::Arc::new(vec![(0, 1.0f32)]);
+        let vec_delta = VectorDelta::Sparse {
+            dimension: 10,
+            changes,
+        };
+
+        delta.vector_deltas.insert(key, vec_delta);
+
+        // Base property map with valid vector
+        let base_vec = vec![0.0f32; 10];
+        let base = PropertyMapBuilder::new()
+            .insert_vector("embedding", &base_vec)
+            .build();
+
+        // Perform materialization
+        let result = delta.materialize_vector_deltas(&base);
+        assert!(result.is_ok(), "Materialization should succeed");
+
+        // Verify side effects
+        assert!(
+            delta.vector_deltas.is_empty(),
+            "vector_deltas should be empty after materialization"
+        );
+        assert!(
+            delta.changed.contains_key(&key),
+            "changed should contain the materialized vector"
+        );
+
+        // Verify the value in changed is correct (should be full vector)
+        let materialized = delta.changed.get(&key).unwrap();
+        if let PropertyValue::Vector(v) = materialized {
+            assert_eq!(v.len(), 10);
+            assert_eq!(v[0], 1.0f32); // Applied change
+            assert_eq!(v[1], 0.0f32); // Unchanged
+        } else {
+            panic!("Materialized value should be a Vector");
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🤖 **Sentinel Report**

**Module:** `src/core/version.rs`

**Summary:** Added a missing test case for `PropertyDelta::materialize_vector_deltas`. This function is critical for converting sparse vector deltas (an optimization) into full vectors before persistence. Without this test, a mutation that disabled the function body would pass, leading to silent data loss (sparse deltas being dropped instead of stored).

**Tests Added:**
- `test_materialize_vector_deltas_success`: Verifies that:
    1. A `PropertyDelta` with a sparse vector delta is correctly processed.
    2. The sparse delta is removed from `vector_deltas`.
    3. The materialized full vector is added to `changed`.
    4. The resulting vector contains the correct values (base + delta).

**Verification:**
- `cargo test --lib core::version` passes.
- Manual analysis confirms this kills potential mutants that would empty the function body.

---
*PR created automatically by Jules for task [12934310127854334971](https://jules.google.com/task/12934310127854334971) started by @madmax983*