### PR TITLE
Fix HNSW deadlock on re-entrant custom metric access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,20 +1638,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -1659,11 +1645,11 @@ dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
@@ -3046,7 +3032,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3071,16 +3057,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3211,16 +3187,6 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sdd"
@@ -3761,7 +3727,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls",
  "tokio",
 ]
 

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -457,6 +457,11 @@ where
     F: Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static + ?Sized,
 {
     Box::new(move |a: *const f32, b: *const f32| {
+        // Prevent re-entrant index access (deadlock prevention)
+        // This sets a thread-local flag that causes add/remove/search/save to fail immediately
+        // rather than deadlocking on the lock held by the outer search.
+        let _guard = FilterCallbackGuard::new();
+
         // Check for null pointers to prevent UB
         if a.is_null() || b.is_null() {
             // This should never happen with a correct usearch implementation.
@@ -794,15 +799,12 @@ impl std::fmt::Debug for HnswIndex {
 
 impl VectorIndex for HnswIndex {
     fn add(&self, id: NodeId, vector: &[f32]) -> Result<()> {
-        // Check for re-entrant modification during filtered search (prevents deadlock)
-        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
-            return Err(Error::Vector(VectorError::IndexError(
-                "Cannot modify index from within a search_with_filter callback. \
-                 This would cause a deadlock due to lock re-entrancy. \
-                 Consider collecting modifications and applying them after the search completes."
-                    .to_string(),
-            )));
-        }
+        // Check for re-entrant modification during search callback (prevents deadlock)
+        self.check_reentrancy(
+            "Cannot modify index from within a search callback (filter or custom metric). \
+             This would cause a deadlock due to lock re-entrancy. \
+             Consider collecting modifications and applying them after the search completes.",
+        )?;
 
         // Check if index is read-only (memory-mapped)
         if self.is_mmap {
@@ -1035,15 +1037,12 @@ impl VectorIndex for HnswIndex {
     }
 
     fn remove(&self, id: NodeId) -> Result<()> {
-        // Check for re-entrant modification during filtered search (prevents deadlock)
-        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
-            return Err(Error::Vector(VectorError::IndexError(
-                "Cannot modify index from within a search_with_filter callback. \
-                 This would cause a deadlock due to lock re-entrancy. \
-                 Consider collecting modifications and applying them after the search completes."
-                    .to_string(),
-            )));
-        }
+        // Check for re-entrant modification during search callback (prevents deadlock)
+        self.check_reentrancy(
+            "Cannot modify index from within a search callback (filter or custom metric). \
+             This would cause a deadlock due to lock re-entrancy. \
+             Consider collecting modifications and applying them after the search completes.",
+        )?;
 
         // Check if index is read-only (memory-mapped)
         if self.is_mmap {
@@ -1074,14 +1073,11 @@ impl VectorIndex for HnswIndex {
     }
 
     fn search(&self, query: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>> {
-        // Check for re-entrant access during filtered search (prevents deadlock)
-        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
-            return Err(Error::Vector(VectorError::IndexError(
-                "Cannot perform search from within a search_with_filter callback. \
-                 This prevents deadlocks when concurrent writers are pending."
-                    .to_string(),
-            )));
-        }
+        // Check for re-entrant access during search callback (prevents deadlock)
+        self.check_reentrancy(
+            "Cannot perform search from within a search callback (filter or custom metric). \
+             This prevents deadlocks when concurrent writers are pending.",
+        )?;
 
         // Validate query vector
         validate_vector(query)?;
@@ -1153,14 +1149,11 @@ impl VectorIndex for HnswIndex {
     where
         F: Fn(&NodeId) -> bool + Send + Sync,
     {
-        // Check for re-entrant access during filtered search (prevents deadlock)
-        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
-            return Err(Error::Vector(VectorError::IndexError(
-                "Cannot perform search_with_filter from within a search_with_filter callback. \
-                 This prevents deadlocks when concurrent writers are pending."
-                    .to_string(),
-            )));
-        }
+        // Check for re-entrant access during search callback (prevents deadlock)
+        self.check_reentrancy(
+            "Cannot perform search_with_filter from within a search callback (filter or custom metric). \
+             This prevents deadlocks when concurrent writers are pending.",
+        )?;
 
         // Validate query vector
         validate_vector(query)?;
@@ -1299,15 +1292,12 @@ impl VectorIndex for HnswIndex {
     /// If executed outside a Tokio runtime, or in a single-threaded runtime (where `block_in_place`
     /// would panic), it falls back to standard synchronous execution.
     fn save(&self, path: &Path) -> Result<()> {
-        // Check for re-entrant modification during filtered search (prevents deadlock)
-        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
-            return Err(Error::Vector(VectorError::IndexError(
-                "Cannot save index from within a search_with_filter callback. \
-                 This would cause a deadlock due to lock re-entrancy. \
-                 Consider saving after the search completes."
-                    .to_string(),
-            )));
-        }
+        // Check for re-entrant modification during search callback (prevents deadlock)
+        self.check_reentrancy(
+            "Cannot save index from within a search callback (filter or custom metric). \
+             This would cause a deadlock due to lock re-entrancy. \
+             Consider saving after the search completes.",
+        )?;
 
         #[cfg(any(feature = "tokio", feature = "embeddings"))]
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -1337,6 +1327,16 @@ impl VectorIndex for HnswIndex {
 
 // Private helper methods for HnswIndex
 impl HnswIndex {
+    /// Check for re-entrant access to prevent deadlocks.
+    fn check_reentrancy(&self, error_message: &str) -> Result<()> {
+        if IN_FILTER_CALLBACK.with(|flag| flag.get()) {
+            return Err(Error::Vector(VectorError::IndexError(
+                error_message.to_string(),
+            )));
+        }
+        Ok(())
+    }
+
     /// Helper to retry usearch operations on transient errors (like thread pool exhaustion).
     fn retry_usearch<F, T, E>(&self, mut op: F, context: &str) -> Result<T>
     where
@@ -3786,3 +3786,6 @@ mod race_recovery_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod havoc;

--- a/src/index/vector/hnsw/havoc.rs
+++ b/src/index/vector/hnsw/havoc.rs
@@ -1,0 +1,115 @@
+use crate::index::vector::{HnswConfig, DistanceMetric, Quantization, HnswIndexBuilder, HnswIndex};
+use crate::core::id::NodeId;
+use crate::index::VectorIndex;
+use proptest::prelude::*;
+use std::io::Cursor;
+use tempfile::tempdir;
+use std::sync::{Arc, Mutex, Weak};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    #[test]
+    fn fuzz_hnsw_config_deserialization(data in prop::collection::vec(any::<u8>(), 0..1024)) {
+        let mut cursor = Cursor::new(data);
+        // We expect errors, but no panics
+        let _ = HnswConfig::deserialize_from(&mut cursor);
+    }
+
+    #[test]
+    fn fuzz_load_mappings_with_integrity(
+        file_content in prop::collection::vec(any::<u8>(), 0..2048),
+    ) {
+        let dir = tempdir().unwrap();
+        let mappings_path = dir.path().join("test.usearch.mappings");
+        std::fs::write(&mappings_path, &file_content).unwrap();
+
+        // This is a private function, so we need to be in the module hierarchy
+        let _ = super::load_mappings_with_integrity(&mappings_path);
+    }
+
+    #[test]
+    fn fuzz_hnsw_index_ops(
+        // Generated vectors must match dimension (e.g., 4)
+        vectors in prop::collection::vec(prop::collection::vec(any::<f32>(), 4), 1..50),
+        ops in prop::collection::vec(prop::bool::ANY, 1..100)
+    ) {
+        // Build an index
+        let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine).build().unwrap();
+
+        // Add vectors
+        for (i, vector) in vectors.iter().enumerate() {
+            let id = NodeId::new((i + 1) as u64).unwrap();
+            // This might fail if vector has NaNs, but shouldn't panic
+            let _ = index.add(id, vector);
+        }
+
+        // Perform random operations
+        for (i, should_remove) in ops.iter().enumerate() {
+             let id_val = (i % vectors.len()) + 1;
+             let id = NodeId::new(id_val as u64).unwrap();
+             if *should_remove {
+                 let _ = index.remove(id);
+             } else {
+                 let _ = index.add(id, &vectors[id_val - 1]);
+             }
+
+             // Verify search doesn't panic
+             let _ = index.search(&[0.1, 0.2, 0.3, 0.4], 5);
+        }
+    }
+}
+
+#[test]
+fn test_deadlock_custom_metric_reentrancy() {
+    // Shared state to give access to index inside metric
+    struct Shared {
+        index: Mutex<Option<Weak<HnswIndex>>>,
+    }
+    let shared = Arc::new(Shared { index: Mutex::new(None) });
+    let shared_clone = shared.clone();
+
+    // Define metric that tries to add to index
+    let metric_fn = move |_a: &[f32], _b: &[f32]| -> f32 {
+        // Try to get index
+        if let Some(weak) = shared_clone.index.lock().unwrap().as_ref() {
+            if let Some(index) = weak.upgrade() {
+                // Try to add - THIS SHOULD DEADLOCK if inner lock is held
+                // We use a different ID to avoid other logic
+                // Using a vector that definitely exists to ensure we don't just exit early
+                let _ = index.add(NodeId::new(999).unwrap(), &[0.1, 0.2, 0.3, 0.4]);
+            }
+        }
+        0.0
+    };
+
+    let mut builder = HnswIndexBuilder::new(4, DistanceMetric::Cosine);
+    // We need F32 for custom metric
+    builder = builder.quantization(Quantization::F32);
+    builder = builder.with_custom_metric("deadlock", metric_fn);
+
+    let index = Arc::new(builder.build().unwrap());
+
+    // Populate shared state
+    *shared.index.lock().unwrap() = Some(Arc::downgrade(&index));
+
+    // Add some data to enable search
+    index.add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    index.add(NodeId::new(2).unwrap(), &[0.0, 1.0, 0.0, 0.0]).unwrap();
+
+    // Trigger search which calls metric
+    // Use a timeout to detect deadlock
+    let (tx, rx) = std::sync::mpsc::channel();
+    let index_clone = index.clone();
+    std::thread::spawn(move || {
+        // Search will call metric_fn, which calls index.add(), which tries to write-lock inner.
+        // search holds read-lock on inner.
+        // Deadlock.
+        let _ = index_clone.search(&[1.0, 0.0, 0.0, 0.0], 1);
+        tx.send(()).unwrap();
+    });
+
+    if rx.recv_timeout(std::time::Duration::from_secs(2)).is_err() {
+        panic!("Deadlock detected! Custom metric re-entrancy caused deadlock.");
+    }
+}

--- a/src/index/vector/hnsw/havoc.rs
+++ b/src/index/vector/hnsw/havoc.rs
@@ -1,10 +1,10 @@
-use crate::index::vector::{HnswConfig, DistanceMetric, Quantization, HnswIndexBuilder, HnswIndex};
 use crate::core::id::NodeId;
 use crate::index::VectorIndex;
+use crate::index::vector::{DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization};
 use proptest::prelude::*;
 use std::io::Cursor;
-use tempfile::tempdir;
 use std::sync::{Arc, Mutex, Weak};
+use tempfile::tempdir;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(1000))]
@@ -66,7 +66,9 @@ fn test_deadlock_custom_metric_reentrancy() {
     struct Shared {
         index: Mutex<Option<Weak<HnswIndex>>>,
     }
-    let shared = Arc::new(Shared { index: Mutex::new(None) });
+    let shared = Arc::new(Shared {
+        index: Mutex::new(None),
+    });
     let shared_clone = shared.clone();
 
     // Define metric that tries to add to index
@@ -94,8 +96,12 @@ fn test_deadlock_custom_metric_reentrancy() {
     *shared.index.lock().unwrap() = Some(Arc::downgrade(&index));
 
     // Add some data to enable search
-    index.add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0]).unwrap();
-    index.add(NodeId::new(2).unwrap(), &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    index
+        .add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0])
+        .unwrap();
+    index
+        .add(NodeId::new(2).unwrap(), &[0.0, 1.0, 0.0, 0.0])
+        .unwrap();
 
     // Trigger search which calls metric
     // Use a timeout to detect deadlock

--- a/tests/havoc/havoc_deadlock_save.rs
+++ b/tests/havoc/havoc_deadlock_save.rs
@@ -53,7 +53,7 @@ fn run_havoc_deadlock_save_vs_add() {
                 if let Err(e) = &result {
                     let err_msg = e.to_string();
                     if !err_msg
-                        .contains("Cannot save index from within a search_with_filter callback")
+                        .contains("Cannot save index from within a search callback")
                     {
                         // Print error but try not to panic inside FFI if possible?
                         // But for test, panic is the way to signal failure.

--- a/tests/havoc/havoc_hnsw_deadlock.rs
+++ b/tests/havoc/havoc_hnsw_deadlock.rs
@@ -39,7 +39,7 @@ fn test_hnsw_reentrant_deadlock_prevented() {
             assert!(add_result.is_err(), "Expected add to fail during filter");
             let err_msg = add_result.unwrap_err().to_string();
             assert!(
-                err_msg.contains("Cannot modify index from within a search_with_filter callback"),
+                err_msg.contains("Cannot modify index from within a search callback"),
                 "Expected re-entrancy error, got: {}",
                 err_msg
             );


### PR DESCRIPTION
Prevents a deadlock where a custom metric function (invoked during search) attempts to modify the index (e.g. via `add`). This would cause the thread to wait for a write lock while holding a read lock.
Added `FilterCallbackGuard` to `create_metric_wrapper` to flag when a metric is running.
Updated `add`, `remove`, `save`, `search` to check this flag and return a specific error instead of blocking.
Added fuzzing tests and a deadlock reproduction test case in `src/index/vector/hnsw/havoc.rs`.

---
*PR created automatically by Jules for task [6286757619373863364](https://jules.google.com/task/6286757619373863364) started by @madmax983*