### PR TITLE
📜 Codex: ADR 027 Update & Architecture Diagram

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,8 +103,9 @@ classDiagram
 
     MCPServer --> QueryEngine : Uses
     QueryEngine --> AletheiaDB : Uses
-    AletheiaDB --> CurrentStorage : Composes
-    AletheiaDB --> HistoricalStorage : Composes
+    AletheiaDB ..> CurrentStorage : Uses (Trait Bound)
+    AletheiaDB ..> HistoricalStorage : Uses (Trait Bound)
+    %% Removed the circular dependency arrow
     HistoricalStorage --> TieredStorage : Uses
     TieredStorage --> RedbColdStorage : Uses
 ```

--- a/docs/adr/0027-decouple-storage-from-core.md
+++ b/docs/adr/0027-decouple-storage-from-core.md
@@ -22,6 +22,14 @@ We will **decouple the storage logic from the core domain** by moving all persis
 
 The architectural boundary will be defined by a set of **Storage Traits** located in the `core` module:
 
+```mermaid
+classDiagram
+    class Core
+    class Storage
+    Core --> Storage : Uses (Trait Bound)
+    %% Removed the circular dependency arrow
+```
+
 ```rust
 // In Core
 pub trait StorageEngine: Send + Sync {


### PR DESCRIPTION
This PR updates the architectural documentation to reflect the decision to decouple the storage module from the core domain.

Changes:
1.  **ADR-0027**: Added a Mermaid class diagram visualizing the dependency inversion (Core defines traits, Storage implements them).
2.  **Architecture Map**: Updated the Class Diagram in `docs/ARCHITECTURE.md` to show `Uses (Trait Bound)` relationships instead of direct composition, removing circular dependency implications.


---
*PR created automatically by Jules for task [12067677120123260136](https://jules.google.com/task/12067677120123260136) started by @madmax983*