### PR TITLE
👺 Havoc: Prevent DoS via HNSW Config Validation Bypass

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -391,6 +391,71 @@ impl HnswConfig {
             ..Default::default()
         })
     }
+
+    /// Validate the configuration parameters to prevent DoS or safety issues.
+    pub fn validate(&self) -> Result<()> {
+        // Validate dimensions
+        if self.dimensions == 0 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: "dimensions must be > 0".to_string(),
+            }));
+        }
+        if self.dimensions > MAX_VECTOR_DIMENSIONS {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!(
+                    "dimensions {} exceeds maximum allowed {}",
+                    self.dimensions, MAX_VECTOR_DIMENSIONS
+                ),
+            }));
+        }
+
+        // Validate M
+        if self.m == 0 || self.m > 64 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!("M must be in range [1, 64], got {}", self.m),
+            }));
+        }
+
+        // Validate ef_construction
+        // Prevent DoS via excessive memory allocation
+        if self.ef_construction < 10 || self.ef_construction > 4096 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!(
+                    "ef_construction must be in range [10, 4096], got {}",
+                    self.ef_construction
+                ),
+            }));
+        }
+
+        // Validate ef_search
+        // Prevent DoS via excessive CPU/Memory usage
+        if self.ef_search < 1 || self.ef_search > 4096 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!(
+                    "ef_search must be in range [1, 4096], got {}",
+                    self.ef_search
+                ),
+            }));
+        }
+
+        // Security Check: Custom metrics require F32 quantization
+        // This is critical because usearch passes raw pointers to the metric function.
+        // If quantization is not F32 (e.g., I8 or F16), the pointers will point to
+        // compressed data, but our metric wrapper casts them to `*const f32`.
+        // This would cause a buffer over-read (reading 4x or 2x memory), leading to
+        // potential crashes (DoS) or information leakage.
+        if self.custom_metric.is_some() && self.quantization != Quantization::F32 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: format!(
+                    "Custom metrics are only supported with F32 quantization (requested {:?}). \
+                     Using other quantization levels with custom metrics causes memory safety issues.",
+                    self.quantization
+                ),
+            }));
+        }
+
+        Ok(())
+    }
 }
 
 /// Statistics for index operations.
@@ -575,65 +640,8 @@ impl HnswIndexBuilder {
 
     /// Builds the HNSW index with the configured parameters.
     pub fn build(self) -> Result<HnswIndex> {
-        // Validate dimensions
-        if self.config.dimensions == 0 {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: "dimensions must be > 0".to_string(),
-            }));
-        }
-        if self.config.dimensions > MAX_VECTOR_DIMENSIONS {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!(
-                    "dimensions {} exceeds maximum allowed {}",
-                    self.config.dimensions, MAX_VECTOR_DIMENSIONS
-                ),
-            }));
-        }
-
-        // Validate M
-        if self.config.m == 0 || self.config.m > 64 {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!("M must be in range [1, 64], got {}", self.config.m),
-            }));
-        }
-
-        // Validate ef_construction
-        // Prevent DoS via excessive memory allocation
-        if self.config.ef_construction < 10 || self.config.ef_construction > 4096 {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!(
-                    "ef_construction must be in range [10, 4096], got {}",
-                    self.config.ef_construction
-                ),
-            }));
-        }
-
-        // Validate ef_search
-        // Prevent DoS via excessive CPU/Memory usage
-        if self.config.ef_search < 1 || self.config.ef_search > 4096 {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!(
-                    "ef_search must be in range [1, 4096], got {}",
-                    self.config.ef_search
-                ),
-            }));
-        }
-
-        // Security Check: Custom metrics require F32 quantization
-        // This is critical because usearch passes raw pointers to the metric function.
-        // If quantization is not F32 (e.g., I8 or F16), the pointers will point to
-        // compressed data, but our metric wrapper casts them to `*const f32`.
-        // This would cause a buffer over-read (reading 4x or 2x memory), leading to
-        // potential crashes (DoS) or information leakage.
-        if self.config.custom_metric.is_some() && self.config.quantization != Quantization::F32 {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!(
-                    "Custom metrics are only supported with F32 quantization (requested {:?}). \
-                     Using other quantization levels with custom metrics causes memory safety issues.",
-                    self.config.quantization
-                ),
-            }));
-        }
+        // Validate config
+        self.config.validate()?;
 
         // Create usearch index options
         let options = IndexOptions {
@@ -1940,25 +1948,8 @@ impl HnswIndex {
 
     /// Loads an index from a file path.
     pub fn load(path: &Path, config: HnswConfig) -> Result<Self> {
-        if config.dimensions > MAX_VECTOR_DIMENSIONS {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!(
-                    "dimensions {} exceeds maximum allowed {}",
-                    config.dimensions, MAX_VECTOR_DIMENSIONS
-                ),
-            }));
-        }
-
-        // Security Check: Custom metrics require F32 quantization
-        if config.custom_metric.is_some() && config.quantization != Quantization::F32 {
-            return Err(Error::Vector(VectorError::InvalidVector {
-                reason: format!(
-                    "Custom metrics are only supported with F32 quantization (requested {:?}). \
-                     Using other quantization levels with custom metrics causes memory safety issues.",
-                    config.quantization
-                ),
-            }));
-        }
+        // Validate config (prevents DoS with huge M/ef values)
+        config.validate()?;
 
         let options = IndexOptions {
             dimensions: config.dimensions,

--- a/tests/warden_hnsw_exploit.rs
+++ b/tests/warden_hnsw_exploit.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::NodeId;
 use aletheiadb::index::VectorIndex;
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndexBuilder, Quantization};
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization};
 
 #[test]
 fn test_warden_hnsw_dimension_mismatch_exploit() {
@@ -64,4 +64,67 @@ fn test_warden_hnsw_dimension_mismatch_exploit() {
             assert!(msg.contains("config has 100"));
         }
     }
+}
+
+#[test]
+fn test_warden_hnsw_config_bypass_m() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("warden_bypass_m.index");
+
+    // 1. Create a valid index and save it.
+    {
+        let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+        index.add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        index.save(&path).unwrap();
+    }
+
+    // 2. Try to load it with a malicious config (M is huge)
+    // HnswIndexBuilder enforces M <= 64.
+    // HnswIndex::load takes raw HnswConfig.
+    let malicious_config = HnswConfig {
+        dimensions: 4,
+        metric: DistanceMetric::Cosine,
+        m: 100_000, // Massive M
+        ef_construction: 100,
+        ef_search: 100,
+        ..Default::default()
+    };
+
+    // This should fail due to HnswConfig::validate() being called in load()
+    let result = HnswIndex::load(&path, malicious_config);
+
+    assert!(result.is_err(), "Load should fail with invalid config (M too large)");
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("M must be in range"), "Unexpected error: {}", err);
+}
+
+#[test]
+fn test_warden_hnsw_config_bypass_ef() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("warden_bypass_ef.index");
+
+    // 1. Create a valid index and save it.
+    {
+        let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+        index.save(&path).unwrap();
+    }
+
+    // 2. Load with invalid ef_construction (too large)
+    let malicious_config = HnswConfig {
+        dimensions: 4,
+        metric: DistanceMetric::Cosine,
+        m: 16,
+        ef_construction: 1_000_000, // Massive ef_construction
+        ef_search: 100,
+        ..Default::default()
+    };
+
+    let result = HnswIndex::load(&path, malicious_config);
+    assert!(result.is_err(), "Load should fail with invalid ef_construction");
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("ef_construction must be in range"), "Unexpected error: {}", err);
 }

--- a/tests/warden_hnsw_exploit.rs
+++ b/tests/warden_hnsw_exploit.rs
@@ -1,6 +1,8 @@
 use aletheiadb::core::id::NodeId;
 use aletheiadb::index::VectorIndex;
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization};
+use aletheiadb::index::vector::{
+    DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization,
+};
 
 #[test]
 fn test_warden_hnsw_dimension_mismatch_exploit() {
@@ -76,7 +78,9 @@ fn test_warden_hnsw_config_bypass_m() {
         let index = HnswIndexBuilder::new(4, DistanceMetric::Cosine)
             .build()
             .unwrap();
-        index.add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        index
+            .add(NodeId::new(1).unwrap(), &[1.0, 0.0, 0.0, 0.0])
+            .unwrap();
         index.save(&path).unwrap();
     }
 
@@ -95,9 +99,16 @@ fn test_warden_hnsw_config_bypass_m() {
     // This should fail due to HnswConfig::validate() being called in load()
     let result = HnswIndex::load(&path, malicious_config);
 
-    assert!(result.is_err(), "Load should fail with invalid config (M too large)");
+    assert!(
+        result.is_err(),
+        "Load should fail with invalid config (M too large)"
+    );
     let err = result.unwrap_err();
-    assert!(err.to_string().contains("M must be in range"), "Unexpected error: {}", err);
+    assert!(
+        err.to_string().contains("M must be in range"),
+        "Unexpected error: {}",
+        err
+    );
 }
 
 #[test]
@@ -124,7 +135,14 @@ fn test_warden_hnsw_config_bypass_ef() {
     };
 
     let result = HnswIndex::load(&path, malicious_config);
-    assert!(result.is_err(), "Load should fail with invalid ef_construction");
+    assert!(
+        result.is_err(),
+        "Load should fail with invalid ef_construction"
+    );
     let err = result.unwrap_err();
-    assert!(err.to_string().contains("ef_construction must be in range"), "Unexpected error: {}", err);
+    assert!(
+        err.to_string().contains("ef_construction must be in range"),
+        "Unexpected error: {}",
+        err
+    );
 }


### PR DESCRIPTION
* 🧨 **The Trigger:** `HnswIndex::load` accepted raw `HnswConfig` structs without validation, allowing attackers to inject `M=100_000` or `ef_construction=1_000_000`.
* 📉 **The Impact:** Excessive memory allocation and CPU usage inside `usearch`, leading to Denial of Service or crashes.
* 🧪 **The Fix:** Centralized validation logic into `HnswConfig::validate` and enforced it in both `HnswIndexBuilder::build` and `HnswIndex::load`.
* 😈 **Comment:** "You thought checking dimensions was enough? I brought a config with `M=MAX_USIZE` to the party."

---
*PR created automatically by Jules for task [15840483058493712790](https://jules.google.com/task/15840483058493712790) started by @madmax983*