### PR TITLE
Fix WAL benchmark tempdir lifetime race

### DIFF
--- a/benches/durability_modes.rs
+++ b/benches/durability_modes.rs
@@ -29,11 +29,13 @@ use tempfile::TempDir;
 
 /// Helper to create a database with a specific durability mode.
 ///
-/// Returns both the database and the TempDir guard. The guard must be kept
-/// alive for the duration of the benchmark to prevent the directory from
-/// being cleaned up prematurely. When the guard is dropped, the directory
-/// is automatically cleaned up.
-fn create_db_with_mode(mode: DurabilityMode) -> (AletheiaDB, TempDir) {
+/// Returns both the TempDir guard and the database.
+///
+/// The tuple order is intentional: benchmark call sites bind as
+/// `let (_guard, db) = ...`, so `db` drops before `_guard`. This keeps the
+/// WAL directory alive until after the WAL background flush thread has shut
+/// down.
+fn create_db_with_mode(mode: DurabilityMode) -> (TempDir, AletheiaDB) {
     let temp_dir = TempDir::new().expect("failed to create temp dir");
     let config = WalConfigBuilder::new()
         .wal_dir(temp_dir.path().to_path_buf())
@@ -44,7 +46,7 @@ fn create_db_with_mode(mode: DurabilityMode) -> (AletheiaDB, TempDir) {
         .durability_mode(mode)
         .build();
     let db = AletheiaDB::with_wal_config(config).unwrap();
-    (db, temp_dir)
+    (temp_dir, db)
 }
 
 /// Benchmark single transaction latency for each mode
@@ -56,7 +58,7 @@ fn bench_single_transaction_latency(c: &mut Criterion) {
 
     // Synchronous (baseline)
     group.bench_function("synchronous", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Synchronous);
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Synchronous);
         let mut counter = 0u64;
 
         b.iter(|| {
@@ -75,7 +77,7 @@ fn bench_single_transaction_latency(c: &mut Criterion) {
 
     // Async mode
     group.bench_function("async", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Async {
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Async {
             flush_interval_ms: 100,
         });
         let mut counter = 0u64;
@@ -96,7 +98,7 @@ fn bench_single_transaction_latency(c: &mut Criterion) {
 
     // GroupCommit default (2ms, 200 batch)
     group.bench_function("group_commit_default", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::group_commit_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::group_commit_default());
         let mut counter = 0u64;
 
         b.iter(|| {
@@ -115,7 +117,7 @@ fn bench_single_transaction_latency(c: &mut Criterion) {
 
     // GroupCommit fast (1ms, 500 batch) - high throughput
     group.bench_function("group_commit_fast", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::fast());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::fast());
         let mut counter = 0u64;
 
         b.iter(|| {
@@ -134,7 +136,7 @@ fn bench_single_transaction_latency(c: &mut Criterion) {
 
     // AsyncBatched default (10ms, 100 batch) - low latency target
     group.bench_function("async_batched_default", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::async_batched_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::async_batched_default());
         let mut counter = 0u64;
 
         b.iter(|| {
@@ -153,7 +155,7 @@ fn bench_single_transaction_latency(c: &mut Criterion) {
 
     // AsyncBatched aggressive (5ms, 50 batch) - ultra-low latency
     group.bench_function("async_batched_aggressive", |b| {
-        let (db, _guard) =
+        let (_guard, db) =
             create_db_with_mode(DurabilityMode::async_batched_validated(5, 50).unwrap());
         let mut counter = 0u64;
 
@@ -205,7 +207,7 @@ fn bench_batch_throughput(c: &mut Criterion) {
 
     for (name, mode) in modes {
         group.bench_function(name, |b| {
-            let (db, _guard) = create_db_with_mode(mode);
+            let (_guard, db) = create_db_with_mode(mode);
 
             b.iter(|| {
                 for i in 0..1000 {
@@ -257,7 +259,7 @@ fn bench_concurrent_writes(c: &mut Criterion) {
 
     for (name, mode) in modes {
         group.bench_function(name, |b| {
-            let (db, _guard) = create_db_with_mode(mode);
+            let (_guard, db) = create_db_with_mode(mode);
             let db = Arc::new(db);
 
             b.iter(|| {
@@ -300,7 +302,7 @@ fn bench_group_commit_batch_sizes(c: &mut Criterion) {
 
     for batch_size in &[10, 50, 100, 200, 500] {
         group.bench_function(BenchmarkId::from_parameter(batch_size), |b| {
-            let (db, _guard) = create_db_with_mode(DurabilityMode::GroupCommit {
+            let (_guard, db) = create_db_with_mode(DurabilityMode::GroupCommit {
                 max_delay_ms: 50,
                 max_batch_size: *batch_size,
             });
@@ -331,7 +333,7 @@ fn bench_group_commit_delays(c: &mut Criterion) {
 
     for delay_ms in &[1, 5, 10, 20, 50] {
         group.bench_function(BenchmarkId::from_parameter(delay_ms), |b| {
-            let (db, _guard) = create_db_with_mode(DurabilityMode::GroupCommit {
+            let (_guard, db) = create_db_with_mode(DurabilityMode::GroupCommit {
                 max_delay_ms: *delay_ms,
                 max_batch_size: 100,
             });
@@ -361,7 +363,7 @@ fn bench_per_transaction_override(c: &mut Criterion) {
 
     // Async DB with Synchronous override
     group.bench_function("async_db_sync_override", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Async {
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Async {
             flush_interval_ms: 100,
         });
         let options = WriteOptions {
@@ -385,7 +387,7 @@ fn bench_per_transaction_override(c: &mut Criterion) {
 
     // Synchronous DB with Async override
     group.bench_function("sync_db_async_override", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Synchronous);
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Synchronous);
         let options = WriteOptions {
             durability_mode: Some(DurabilityMode::Async {
                 flush_interval_ms: 100,
@@ -409,7 +411,7 @@ fn bench_per_transaction_override(c: &mut Criterion) {
 
     // AsyncBatched DB with Synchronous override
     group.bench_function("async_batched_db_sync_override", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::async_batched_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::async_batched_default());
         let options = WriteOptions {
             durability_mode: Some(DurabilityMode::Synchronous),
         };
@@ -431,7 +433,7 @@ fn bench_per_transaction_override(c: &mut Criterion) {
 
     // Synchronous DB with AsyncBatched override
     group.bench_function("sync_db_async_batched_override", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Synchronous);
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Synchronous);
         let options = WriteOptions {
             durability_mode: Some(DurabilityMode::async_batched_default()),
         };
@@ -460,7 +462,7 @@ fn bench_mixed_workload(c: &mut Criterion) {
     group.throughput(Throughput::Elements(100));
 
     group.bench_function("90_async_10_sync", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Async {
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Async {
             flush_interval_ms: 100,
         });
         let sync_options = WriteOptions {
@@ -497,7 +499,7 @@ fn bench_mixed_workload(c: &mut Criterion) {
     });
 
     group.bench_function("90_async_batched_10_sync", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::async_batched_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::async_batched_default());
         let sync_options = WriteOptions {
             durability_mode: Some(DurabilityMode::Synchronous),
         };
@@ -532,7 +534,7 @@ fn bench_mixed_workload(c: &mut Criterion) {
     });
 
     group.bench_function("90_async_batched_10_group_commit", |b| {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::async_batched_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::async_batched_default());
         let gc_options = WriteOptions {
             durability_mode: Some(DurabilityMode::group_commit_default()),
         };
@@ -576,7 +578,7 @@ fn bench_async_batched_batch_sizes(c: &mut Criterion) {
 
     for batch_size in &[10, 50, 100, 200, 500] {
         group.bench_function(BenchmarkId::from_parameter(batch_size), |b| {
-            let (db, _guard) = create_db_with_mode(DurabilityMode::AsyncBatched {
+            let (_guard, db) = create_db_with_mode(DurabilityMode::AsyncBatched {
                 max_delay_ms: 50,
                 max_batch_size: *batch_size,
             });
@@ -607,7 +609,7 @@ fn bench_async_batched_delays(c: &mut Criterion) {
 
     for delay_ms in &[1, 5, 10, 20, 50] {
         group.bench_function(BenchmarkId::from_parameter(delay_ms), |b| {
-            let (db, _guard) = create_db_with_mode(DurabilityMode::AsyncBatched {
+            let (_guard, db) = create_db_with_mode(DurabilityMode::AsyncBatched {
                 max_delay_ms: *delay_ms,
                 max_batch_size: 100,
             });

--- a/tests/quick_perf_test.rs
+++ b/tests/quick_perf_test.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use std::time::Instant;
 use tempfile::TempDir;
 
-fn create_db_with_mode(mode: DurabilityMode) -> (AletheiaDB, TempDir) {
+fn create_db_with_mode(mode: DurabilityMode) -> (TempDir, AletheiaDB) {
     let temp_dir = TempDir::new().expect("failed to create temp dir");
     let config = WalConfigBuilder::new()
         .wal_dir(temp_dir.path().to_path_buf())
@@ -21,7 +21,7 @@ fn create_db_with_mode(mode: DurabilityMode) -> (AletheiaDB, TempDir) {
         .durability_mode(mode)
         .build();
     let db = AletheiaDB::with_wal_config(config).unwrap();
-    (db, temp_dir)
+    (temp_dir, db)
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn quick_perf_test() {
 
     // Test Synchronous (baseline)
     {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Synchronous);
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Synchronous);
         let start = Instant::now();
 
         for i in 0..test_count {
@@ -60,7 +60,7 @@ fn quick_perf_test() {
 
     // Test Async
     {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::Async {
+        let (_guard, db) = create_db_with_mode(DurabilityMode::Async {
             flush_interval_ms: 100,
         });
         let start = Instant::now();
@@ -88,7 +88,7 @@ fn quick_perf_test() {
 
     // Test GroupCommit
     {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::group_commit_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::group_commit_default());
         let start = Instant::now();
 
         for i in 0..test_count {
@@ -114,7 +114,7 @@ fn quick_perf_test() {
 
     // Test AsyncBatched default
     {
-        let (db, _guard) = create_db_with_mode(DurabilityMode::async_batched_default());
+        let (_guard, db) = create_db_with_mode(DurabilityMode::async_batched_default());
         let start = Instant::now();
 
         for i in 0..test_count {
@@ -140,7 +140,7 @@ fn quick_perf_test() {
 
     // Test AsyncBatched aggressive
     {
-        let (db, _guard) =
+        let (_guard, db) =
             create_db_with_mode(DurabilityMode::async_batched_validated(5, 50).unwrap());
         let start = Instant::now();
 


### PR DESCRIPTION
## Summary
- fix drop-order lifetime bug in durability benchmark helper by returning (TempDir, AletheiaDB) and binding (_guard, db) so WAL threads shut down before temp dir cleanup
- apply same lifetime fix to 	ests/quick_perf_test.rs to avoid the same race in ignored perf test
- document intentional tuple order in benchmark helper to prevent regressions

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo check --bench durability_modes
- cargo bench --bench durability_modes -- single_transaction_latency/async --sample-size 10 --warm-up-time 0.5 --measurement-time 1
- cargo bench --profile dev --bench durability_modes -- single_transaction_latency/async --sample-size 10 --warm-up-time 0.5 --measurement-time 1
- cargo test quick_perf_test -- --nocapture --ignored

## Problem addressed
This removes repeated WAL flush error ... Failed to open WAL segment ... (os error 3) messages caused by temp directories being dropped before async WAL flush threads stopped.