### PR TITLE
Perf: remove per-commit adjacency compaction and stabilize create benchmarks

### DIFF
--- a/benches/aletheiadb.rs
+++ b/benches/aletheiadb.rs
@@ -77,45 +77,57 @@ fn create_versioned_graph(
     (db, node_ids)
 }
 
-/// Benchmark node creation (with versioning overhead).
+/// Benchmark node creation on a warm database.
+///
+/// This measures steady-state create latency (transaction + WAL + temporal writes)
+/// and intentionally excludes one-time database startup overhead.
 fn bench_node_creation_with_versioning(c: &mut Criterion) {
+    let db = create_benchmark_db();
+    let mut counter = 0i64;
+
     c.bench_function("aletheiadb_node_creation", |b| {
-        b.iter_batched(
-            create_benchmark_db,
-            |db| {
-                let props = PropertyMapBuilder::new()
-                    .insert("name", "Alice")
-                    .insert("age", 30i64)
-                    .build();
-                let node = db.create_node("Person", props);
-                black_box(node)
-            },
-            criterion::BatchSize::SmallInput,
-        );
+        b.iter(|| {
+            let props = PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .insert("seq", counter)
+                .build();
+            counter = counter.wrapping_add(1);
+
+            let node = db.create_node("Person", props);
+            black_box(node)
+        });
     });
 }
 
-/// Benchmark edge creation (with versioning overhead).
+/// Benchmark edge creation on a warm database.
+///
+/// Uses a pre-built node pool and rotates source/target pairs so benchmarked
+/// time reflects edge create cost (not DB startup or per-iteration node setup).
 fn bench_edge_creation_with_versioning(c: &mut Criterion) {
-    c.bench_function("aletheiadb_edge_creation", |b| {
-        b.iter_batched(
-            || {
-                let db = create_benchmark_db();
-                let n1 = db
-                    .create_node("Person", PropertyMapBuilder::new().build())
-                    .unwrap();
-                let n2 = db
-                    .create_node("Person", PropertyMapBuilder::new().build())
-                    .unwrap();
-                (db, n1, n2)
-            },
-            |(db, n1, n2)| {
-                let props = PropertyMapBuilder::new().insert("since", 2020i64).build();
-                let edge = db.create_edge(n1, n2, "KNOWS", props);
-                black_box(edge)
-            },
-            criterion::BatchSize::SmallInput,
+    const NODE_POOL_SIZE: usize = 4_096;
+
+    let db = create_benchmark_db();
+    let mut node_pool = Vec::with_capacity(NODE_POOL_SIZE);
+    for _ in 0..NODE_POOL_SIZE {
+        node_pool.push(
+            db.create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap(),
         );
+    }
+
+    let mut edge_counter = 0usize;
+
+    c.bench_function("aletheiadb_edge_creation", |b| {
+        b.iter(|| {
+            let source_idx = edge_counter % NODE_POOL_SIZE;
+            let target_idx = (edge_counter + 1) % NODE_POOL_SIZE;
+            edge_counter = edge_counter.wrapping_add(1);
+
+            let props = PropertyMapBuilder::new().insert("since", 2020i64).build();
+            let edge = db.create_edge(node_pool[source_idx], node_pool[target_idx], "KNOWS", props);
+            black_box(edge)
+        });
     });
 }
 

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -483,10 +483,8 @@ pub(crate) fn apply_changes(tx: &WriteTransaction, commit_timestamp: Timestamp) 
 
     drop(historical);
 
-    // Rebuild adjacency indexes
-    if tx.buffer.has_edge_operations() {
-        tx.current.compact_adjacency();
-    }
+    // With incremental adjacency indexes, edge updates are immediately visible
+    // via merged reads. Background compaction handles delta->frozen promotion.
 
     Ok(())
 }

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -955,10 +955,10 @@ mod general_tests {
         let edge_props = PropertyMapBuilder::new().insert("since", 2020i64).build();
         let edge_id = tx.create_edge(alice, bob, "KNOWS", edge_props).unwrap();
 
-        // Commit - should call rebuild_adjacency() since edge was created
+        // Commit and verify edge adjacency is immediately visible.
         tx.commit().unwrap();
 
-        // Verify adjacency was rebuilt correctly
+        // Verify adjacency is readable without explicit compaction
         assert_eq!(current.node_count(), 2);
         assert_eq!(current.edge_count(), 1);
 
@@ -970,6 +970,32 @@ mod general_tests {
         let incoming = current.get_incoming_edges(bob);
         assert_eq!(incoming.len(), 1);
         assert_eq!(incoming[0], edge_id);
+    }
+
+    #[test]
+    fn test_edge_commit_does_not_force_adjacency_compaction() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let current = Arc::clone(&tx.current);
+
+        let props = PropertyMapBuilder::new().build();
+        let source = tx.create_node("Person", props.clone()).unwrap();
+        let target = tx.create_node("Person", props).unwrap();
+
+        tx.create_edge(
+            source,
+            target,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020i64).build(),
+        )
+        .unwrap();
+
+        tx.commit().unwrap();
+
+        // Edges are immediately readable from merged adjacency without forcing
+        // commit-time compaction; compaction is handled asynchronously.
+        assert_eq!(current.edge_count(), 1);
+        assert_eq!(current.out_degree(source), 1);
+        assert_eq!(current.delta_edge_count(), 1);
     }
 
     #[test]
@@ -1150,7 +1176,7 @@ mod general_tests {
     }
 
     #[test]
-    fn test_batch_edge_operations_rebuild_once() {
+    fn test_batch_edge_operations_visible_without_manual_compaction() {
         let (mut tx, _temp_dir) = create_test_write_tx();
         let current = Arc::clone(&tx.current);
 
@@ -1177,7 +1203,7 @@ mod general_tests {
             .unwrap();
         }
 
-        // Commit should rebuild adjacency only once
+        // Commit should make edges visible immediately (compaction is asynchronous)
         tx.commit().unwrap();
 
         // Verify all edges are in adjacency index

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -709,6 +709,14 @@ impl CurrentStorage {
         self.indexes.compact_adjacency();
     }
 
+    /// Get the current number of delta edges (test-only).
+    ///
+    /// Delta edges are insertions not yet compacted into frozen CSR.
+    #[cfg(test)]
+    pub(crate) fn delta_edge_count(&self) -> usize {
+        self.indexes.delta_edge_count()
+    }
+
     /// Rebuild adjacency indexes (deprecated - use `compact_adjacency` instead).
     ///
     /// This method is kept for backward compatibility and simply calls `compact_adjacency`.

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -230,7 +230,12 @@ mod sentry_tests {
             lsn: LSN(456),
             timestamp: fixed_timestamp,
         };
-        let entry = WalEntry { lsn, timestamp: fixed_timestamp, operation: op, checksum: 0 };
+        let entry = WalEntry {
+            lsn,
+            timestamp: fixed_timestamp,
+            operation: op,
+            checksum: 0,
+        };
 
         // Serialize
         let mut buffer = Vec::new();


### PR DESCRIPTION
## Summary
- remove synchronous `compact_adjacency()` from write-transaction commit apply path
- keep adjacency visibility immediate via incremental adjacency merged reads
- add a regression test proving edge commits do not force compaction
- expose delta-edge count from current storage under `#[cfg(test)]` for assertions
- fix `aletheiadb` create benchmarks to measure warm steady-state latency instead of per-iteration DB setup

## Why
Node/edge create benchmarks were dominated by setup/commit artifacts and edge commits still paid an avoidable compaction tax.

## Benchmarks
Ran:
- `cargo bench --bench aletheiadb -- aletheiadb_node_creation`
- `cargo bench --bench aletheiadb -- aletheiadb_edge_creation`

Results:
- `aletheiadb_node_creation`: `[94.430 µs 104.72 µs 114.54 µs]`
- `aletheiadb_edge_creation`: `[95.128 µs 106.13 µs 116.41 µs]`

(Previous reported range in this area was ~0.3-0.5 ms/op with sampling warnings.)

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- `cargo test` (with `ALETHEIADB_AUTO_HEAL_CLOCK_SKEW=0` in this shell to keep clock-skew tests deterministic)
- targeted tests:
  - `test_edge_commit_does_not_force_adjacency_compaction`
  - `test_batch_edge_operations_visible_without_manual_compaction`
  - `test_transaction_with_edge_operations`