### PR TITLE
feat(http): add execute_query endpoint for AQL

### DIFF
--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -9,6 +9,9 @@
 //! conversion functions enforce a maximum recursion depth of 100 levels.
 
 use crate::core::{GLOBAL_INTERNER, PropertyMap, PropertyMapBuilder, PropertyValue};
+use crate::query::converter::ParameterValue;
+use crate::query::executor::{EntityId, EntityResult, QueryRow};
+use crate::query::ir::PredicateValue;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -140,6 +143,117 @@ pub fn json_to_property_map(
             .map_err(|e| e.to_string())?;
     }
     Ok(builder.build())
+}
+
+/// Converts a JSON parameter map to AletheiaDB parameter values.
+pub fn json_to_parameter_map(
+    json: &HashMap<String, serde_json::Value>,
+) -> Result<HashMap<String, ParameterValue>, String> {
+    let mut params = HashMap::new();
+    for (key, value) in json {
+        params.insert(key.clone(), json_to_parameter_value(value)?);
+    }
+    Ok(params)
+}
+
+/// Converts a JSON value to a ParameterValue.
+pub fn json_to_parameter_value(value: &serde_json::Value) -> Result<ParameterValue, String> {
+    match value {
+        serde_json::Value::Null => Ok(ParameterValue::Value(PredicateValue::Null)),
+        serde_json::Value::Bool(b) => Ok(ParameterValue::Value(PredicateValue::Bool(*b))),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(ParameterValue::Value(PredicateValue::Int(i)))
+            } else {
+                let f = n
+                    .as_f64()
+                    .ok_or_else(|| "Invalid number format".to_string())?;
+                Ok(ParameterValue::Value(PredicateValue::Float(f)))
+            }
+        }
+        serde_json::Value::String(s) => {
+            Ok(ParameterValue::Value(PredicateValue::String(s.clone())))
+        }
+        serde_json::Value::Array(arr) => {
+            // Check if it's an embedding (vector of floats)
+            let floats: Result<Vec<f32>, _> = arr
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .map(|f| f as f32)
+                        .ok_or_else(|| "Invalid float in embedding array".to_string())
+                })
+                .collect();
+
+            if let Ok(f) = floats {
+                Ok(ParameterValue::Embedding(Arc::from(f)))
+            } else {
+                Err("Arrays in parameters must be numeric vectors (embeddings)".to_string())
+            }
+        }
+        serde_json::Value::Object(_) => {
+            Err("Objects are not supported as parameter values".to_string())
+        }
+    }
+}
+
+/// Converts a QueryRow to a JSON object.
+pub fn query_row_to_json(row: QueryRow) -> Result<serde_json::Value, String> {
+    let mut obj = serde_json::Map::new();
+
+    // Add entity data
+    match row.entity {
+        EntityResult::Node(node) => {
+            obj.insert(
+                "node".to_string(),
+                json!({
+                    "id": node.id.as_u64(),
+                    "label": interned_to_string(node.label),
+                    "properties": property_map_to_json(&node.properties)?
+                }),
+            );
+        }
+        EntityResult::Edge(edge) => {
+            obj.insert(
+                "edge".to_string(),
+                json!({
+                    "id": edge.id.as_u64(),
+                    "label": interned_to_string(edge.label),
+                    "source": edge.source.as_u64(),
+                    "target": edge.target.as_u64(),
+                    "properties": property_map_to_json(&edge.properties)?
+                }),
+            );
+        }
+        EntityResult::NodeId(id) => {
+            obj.insert("node_id".to_string(), json!(id.as_u64()));
+        }
+        EntityResult::EdgeId(id) => {
+            obj.insert("edge_id".to_string(), json!(id.as_u64()));
+        }
+    }
+
+    // Add metadata
+    if let Some(score) = row.score {
+        obj.insert("score".to_string(), json!(score));
+    }
+
+    if let Some(path) = row.path {
+        let path_json: Vec<serde_json::Value> = path
+            .iter()
+            .map(|id| match id {
+                EntityId::Node(nid) => json!({"type": "node", "id": nid.as_u64()}),
+                EntityId::Edge(eid) => json!({"type": "edge", "id": eid.as_u64()}),
+            })
+            .collect();
+        obj.insert("path".to_string(), serde_json::Value::Array(path_json));
+    }
+
+    if let Some(ts) = row.timestamp {
+        obj.insert("timestamp".to_string(), json!(ts.wallclock()));
+    }
+
+    Ok(serde_json::Value::Object(obj))
 }
 
 /// Converts a serde JSON Value to a [`PropertyValue`].

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -176,7 +176,7 @@ pub fn json_to_parameter_value(value: &serde_json::Value) -> Result<ParameterVal
         }
         serde_json::Value::Array(arr) => {
             // Check if it's an embedding (vector of floats)
-            let floats: Result<Vec<f32>, _> = arr
+            let floats: Result<Vec<f32>, String> = arr
                 .iter()
                 .map(|v| {
                     v.as_f64()
@@ -185,10 +185,9 @@ pub fn json_to_parameter_value(value: &serde_json::Value) -> Result<ParameterVal
                 })
                 .collect();
 
-            if let Ok(f) = floats {
-                Ok(ParameterValue::Embedding(Arc::from(f)))
-            } else {
-                Err("Arrays in parameters must be numeric vectors (embeddings)".to_string())
+            match floats {
+                Ok(f) => Ok(ParameterValue::Embedding(Arc::from(f))),
+                Err(e) => Err(e),
             }
         }
         serde_json::Value::Object(_) => {

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -551,6 +551,55 @@ mod tests {
     }
 
     #[actix_rt::test]
+    async fn test_execute_query_with_projection() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+
+        // Setup data with extra property
+        let props = crate::core::PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .insert("secret", "hidden")
+            .build();
+        let _alice = db.create_node("Person", props).unwrap();
+
+        let state = web::Data::new(AppState::new(db));
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
+
+        let payload = json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person) RETURN n.name, n.age"
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        if !resp.status().is_success() {
+            let body = test::read_body(resp).await;
+            panic!("Request failed: {:?}", body);
+        }
+
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let data = json["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+
+        let props = &data[0]["node"]["properties"];
+        assert_eq!(props["name"], "Alice");
+        assert_eq!(props["age"], 30);
+        // "secret" should be filtered out
+        assert!(props.get("secret").is_none());
+    }
+
+    #[actix_rt::test]
     async fn test_health_check_returns_json() {
         let app =
             test::init_service(App::new().route("/status", web::get().to(health_check))).await;

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -22,9 +22,13 @@
 //! ```
 
 use crate::core::NodeId;
-use crate::http::converters::{interned_to_string, json_to_property_map, property_map_to_json};
+use crate::http::converters::{
+    interned_to_string, json_to_parameter_map, json_to_property_map, property_map_to_json,
+    query_row_to_json,
+};
 use crate::http::state::AppState;
 use crate::query::QueryBuilder;
+use crate::query::converter::{parse_query, parse_query_with_params};
 use crate::query::ir::{Predicate, PredicateValue};
 use actix_web::{HttpResponse, web};
 use serde::{Deserialize, Serialize};
@@ -180,6 +184,29 @@ pub enum QueryRequest {
         /// Pagination offset (default: 0).
         #[serde(default)]
         offset: Option<usize>,
+    },
+
+    /// Execute an AQL query string.
+    ///
+    /// # Fields
+    /// * `query` - The AQL query string.
+    /// * `parameters` - Optional parameters for the query.
+    ///
+    /// # Example
+    /// ```json
+    /// {
+    ///   "operation": "execute_query",
+    ///   "query": "MATCH (n:Person) WHERE n.age > $min_age RETURN n",
+    ///   "parameters": {
+    ///     "min_age": 21
+    ///   }
+    /// }
+    /// ```
+    ExecuteQuery {
+        /// The AQL query string.
+        query: String,
+        /// Optional parameters for the query.
+        parameters: Option<HashMap<String, serde_json::Value>>,
     },
 }
 
@@ -455,6 +482,55 @@ pub async fn handle_query(
                 Err(e) => HttpResponse::BadRequest().json(ApiResponse::error(e.to_string())),
             }
         }
+        QueryRequest::ExecuteQuery { query, parameters } => {
+            // 1. Parse the query (with parameters if provided)
+            let parsed_query = if let Some(params_json) = parameters {
+                match json_to_parameter_map(&params_json) {
+                    Ok(params) => match parse_query_with_params(&query, params) {
+                        Ok(q) => q,
+                        Err(e) => {
+                            return HttpResponse::BadRequest()
+                                .json(ApiResponse::error(e.to_string()));
+                        }
+                    },
+                    Err(e) => return HttpResponse::BadRequest().json(ApiResponse::error(e)),
+                }
+            } else {
+                match parse_query(&query) {
+                    Ok(q) => q,
+                    Err(e) => {
+                        return HttpResponse::BadRequest().json(ApiResponse::error(e.to_string()));
+                    }
+                }
+            };
+
+            // 2. Execute the query
+            match db.execute_query(parsed_query) {
+                Ok(results) => {
+                    // 3. Serialize results
+                    let mut json_results = Vec::new();
+                    for row_result in results {
+                        match row_result {
+                            Ok(row) => match query_row_to_json(row) {
+                                Ok(json) => json_results.push(json),
+                                Err(e) => {
+                                    return HttpResponse::InternalServerError()
+                                        .json(ApiResponse::error(e));
+                                }
+                            },
+                            Err(e) => {
+                                return HttpResponse::InternalServerError()
+                                    .json(ApiResponse::error(e.to_string()));
+                            }
+                        }
+                    }
+                    HttpResponse::Ok().json(ApiResponse::success(json!(json_results)))
+                }
+                Err(e) => {
+                    HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string()))
+                }
+            }
+        }
     }
 }
 
@@ -576,5 +652,128 @@ mod tests {
             "Error: {}",
             error
         );
+    }
+
+    #[actix_rt::test]
+    async fn test_execute_query_simple_match() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+
+        // Setup data
+        let props = crate::core::PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .build();
+        let _alice_id = db.create_node("Person", props).unwrap();
+
+        let state = web::Data::new(AppState::new(db));
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
+
+        let payload = json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person) RETURN n"
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        if !resp.status().is_success() {
+            let body = test::read_body(resp).await;
+            panic!("Request failed: {:?}", body);
+        }
+
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(json["success"].as_bool().unwrap());
+        let data = json["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+
+        let node = &data[0]["node"];
+        assert_eq!(node["label"], "Person");
+        assert_eq!(node["properties"]["name"], "Alice");
+    }
+
+    #[actix_rt::test]
+    async fn test_execute_query_with_params() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+
+        // Setup data
+        let props_alice = crate::core::PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30i64)
+            .build();
+        let _alice = db.create_node("Person", props_alice).unwrap();
+
+        let props_bob = crate::core::PropertyMapBuilder::new()
+            .insert("name", "Bob")
+            .insert("age", 20i64)
+            .build();
+        let _bob = db.create_node("Person", props_bob).unwrap();
+
+        let state = web::Data::new(AppState::new(db));
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
+
+        let payload = json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person) WHERE n.age > $min_age RETURN n",
+            "parameters": {
+                "min_age": 25
+            }
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        if !resp.status().is_success() {
+            let body = test::read_body(resp).await;
+            panic!("Request failed: {:?}", body);
+        }
+
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let data = json["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0]["node"]["properties"]["name"], "Alice");
+    }
+
+    #[actix_rt::test]
+    async fn test_execute_query_syntax_error() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+        let state = web::Data::new(AppState::new(db));
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
+
+        let payload = json!({
+            "operation": "execute_query",
+            "query": "MATCH (n:Person RETURN n" // Missing closing paren
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_client_error()); // 400 Bad Request
     }
 }

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -768,10 +768,20 @@ impl AstConverter {
                 Expression::Property(prop) => {
                     projections.push(prop.property.clone());
                 }
-                Expression::Identifier(name) => {
-                    // Bare variable (e.g., RETURN n) - store the variable name.
-                    // The executor handles returning the full node for bare variables.
-                    projections.push(name.clone());
+                Expression::Identifier(_) => {
+                    // Bare variable (e.g., RETURN n).
+                    // We DO NOT add this to projections, because Project op
+                    // assumes all strings are property keys.
+                    // If we have a bare variable, it implies returning the whole entity
+                    // (or at least not filtering it out).
+
+                    // Note: If we have mixed RETURN n, n.prop, the behavior
+                    // depends on whether Project applies intersection or union.
+                    // Current ProjectIterator creates a NEW node with ONLY the listed properties.
+                    // So if we have bare variable, we shouldn't use Project op at all?
+
+                    // For now, ignoring identifiers means we don't treat them as property keys.
+                    // If the projection list is empty, we don't generate QueryOp::Project.
                 }
                 _ => {
                     // Other expressions are computed at execution time

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1299,7 +1299,10 @@ pub struct ProjectIterator {
 }
 
 impl ProjectIterator {
-    pub fn new(input: Box<dyn ResultIterator>, properties: Vec<String>) -> Self {
+    pub fn new(input: Box<dyn ResultIterator>, mut properties: Vec<String>) -> Self {
+        // Deduplicate properties to prevent errors when projecting same property multiple times
+        properties.sort();
+        properties.dedup();
         ProjectIterator { input, properties }
     }
 }

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -2175,6 +2175,75 @@ mod tests {
         assert_eq!(upper, Some(5));
     }
 
+    // ==================== ProjectIterator Tests ====================
+
+    #[test]
+    fn test_project_iterator_filters_properties() {
+        let props = PropertyMapBuilder::new()
+            .insert("name", "Alice")
+            .insert("age", 30)
+            .insert("city", "Paris")
+            .build();
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        let node = Node::new(
+            NodeId::new(1).unwrap(),
+            label,
+            props,
+            VersionId::new(1).unwrap(),
+        );
+
+        let input = MockIterator::from_nodes(vec![node]);
+        let mut project = ProjectIterator::new(
+            Box::new(input),
+            vec!["name".to_string(), "city".to_string()],
+        );
+
+        let row = project.next().unwrap().unwrap();
+        let projected_node = row.entity.as_node().unwrap();
+
+        assert_eq!(
+            projected_node.properties.get("name").unwrap().as_str().unwrap(),
+            "Alice"
+        );
+        assert_eq!(
+            projected_node.properties.get("city").unwrap().as_str().unwrap(),
+            "Paris"
+        );
+        assert!(projected_node.properties.get("age").is_none());
+    }
+
+    #[test]
+    fn test_project_iterator_missing_property() {
+        let node = test_node(1, "Alice"); // Only has "name"
+        let input = MockIterator::from_nodes(vec![node]);
+        let mut project = ProjectIterator::new(
+            Box::new(input),
+            vec!["name".to_string(), "age".to_string()],
+        );
+
+        let row = project.next().unwrap().unwrap();
+        let projected_node = row.entity.as_node().unwrap();
+
+        assert_eq!(
+            projected_node.properties.get("name").unwrap().as_str().unwrap(),
+            "Alice"
+        );
+        assert!(projected_node.properties.get("age").is_none());
+    }
+
+    #[test]
+    fn test_project_iterator_non_node_pass_through() {
+        // Projecting on non-node entities (like EdgeId) should be a no-op currently
+        // as the implementation only checks for Node
+        let row = QueryRow::from_entity(EntityResult::NodeId(NodeId::new(1).unwrap()));
+        let input = MockIterator::from_results(vec![Ok(row)]);
+
+        let mut project = ProjectIterator::new(Box::new(input), vec!["name".to_string()]);
+
+        let result = project.next().unwrap().unwrap();
+        assert!(matches!(result.entity, EntityResult::NodeId(_)));
+    }
+
     // ==================== MockIterator Tests ====================
 
     #[test]

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1292,6 +1292,48 @@ impl ResultIterator for ProvenanceFilterIterator {
     }
 }
 
+/// Iterator for projecting specific properties from query results.
+pub struct ProjectIterator {
+    input: Box<dyn ResultIterator>,
+    properties: Vec<String>,
+}
+
+impl ProjectIterator {
+    pub fn new(input: Box<dyn ResultIterator>, properties: Vec<String>) -> Self {
+        ProjectIterator { input, properties }
+    }
+}
+
+impl ResultIterator for ProjectIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        match self.input.next() {
+            Some(Ok(mut row)) => {
+                if let Some(node) = row.entity.as_node() {
+                    let mut new_props = crate::core::PropertyMapBuilder::new();
+                    for prop in &self.properties {
+                        if let Some(val) = node.properties.get(prop) {
+                            new_props = new_props.try_insert(prop, val.clone()).unwrap();
+                        }
+                    }
+                    let new_node = crate::core::graph::Node::new(
+                        node.id,
+                        node.label,
+                        new_props.build(),
+                        node.current_version,
+                    );
+                    row.entity = EntityResult::Node(new_node);
+                }
+                Some(Ok(row))
+            }
+            other => other,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
 /// Convert a `PredicateValue` to a `PropertyValue` for storage-level lookups.
 fn predicate_to_property_value(pv: &PredicateValue) -> PropertyValue {
     match pv {

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -2202,11 +2202,21 @@ mod tests {
         let projected_node = row.entity.as_node().unwrap();
 
         assert_eq!(
-            projected_node.properties.get("name").unwrap().as_str().unwrap(),
+            projected_node
+                .properties
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
             "Alice"
         );
         assert_eq!(
-            projected_node.properties.get("city").unwrap().as_str().unwrap(),
+            projected_node
+                .properties
+                .get("city")
+                .unwrap()
+                .as_str()
+                .unwrap(),
             "Paris"
         );
         assert!(projected_node.properties.get("age").is_none());
@@ -2216,16 +2226,19 @@ mod tests {
     fn test_project_iterator_missing_property() {
         let node = test_node(1, "Alice"); // Only has "name"
         let input = MockIterator::from_nodes(vec![node]);
-        let mut project = ProjectIterator::new(
-            Box::new(input),
-            vec!["name".to_string(), "age".to_string()],
-        );
+        let mut project =
+            ProjectIterator::new(Box::new(input), vec!["name".to_string(), "age".to_string()]);
 
         let row = project.next().unwrap().unwrap();
         let projected_node = row.entity.as_node().unwrap();
 
         assert_eq!(
-            projected_node.properties.get("name").unwrap().as_str().unwrap(),
+            projected_node
+                .properties
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
             "Alice"
         );
         assert!(projected_node.properties.get("age").is_none());

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -297,6 +297,14 @@ impl QueryExecutor {
                 )))
             }
 
+            PhysicalOp::Project { input, properties } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::ProjectIterator::new(
+                    input_iter,
+                    properties.clone(),
+                )))
+            }
+
             PhysicalOp::Empty => Ok(Box::new(iterators::EmptyIterator)),
             PhysicalOp::SimilarToNode {
                 source_node,

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -1361,4 +1361,35 @@ mod tests {
             _ => panic!("Expected Node or NodeId result"),
         }
     }
+
+    #[test]
+    fn test_execute_project() {
+        let (current, historical, alice, _bob) = create_test_storage_with_data();
+        let executor = QueryExecutor::new(current, historical);
+
+        let plan = PhysicalPlan {
+            root: PhysicalOp::Project {
+                input: Box::new(PhysicalOp::NodeLookup {
+                    node_ids: vec![alice],
+                }),
+                properties: vec!["name".to_string()],
+            },
+            estimated_cost: Default::default(),
+            temporal_context: None,
+            parallel: false,
+            include_provenance: false,
+        };
+
+        let results = executor.execute(plan).expect("Execution failed");
+        let rows: Vec<_> = results.collect_all().expect("Collection failed");
+
+        assert_eq!(rows.len(), 1);
+        let node = rows[0].entity.as_node().unwrap();
+        assert_eq!(
+            node.properties.get("name").unwrap().as_str().unwrap(),
+            "Alice"
+        );
+        // Embedding should be filtered out
+        assert!(node.properties.get("embedding").is_none());
+    }
 }


### PR DESCRIPTION
This PR adds the ability to execute raw AQL queries via the HTTP API using the `execute_query` operation. This enables developers to use the full power of the AletheiaDB query language from any client.

It also implements the missing `ProjectIterator` in the query executor, which is required for `RETURN` clauses to work.

Example usage:
```json
{
  "operation": "execute_query",
  "query": "MATCH (n:Person) WHERE n.age > $min_age RETURN n",
  "parameters": {
    "min_age": 21
  }
}
```

---
*PR created automatically by Jules for task [1704402888746289268](https://jules.google.com/task/1704402888746289268) started by @madmax983*