### PR TITLE
🔒 Warden: Fix TxIdGenerator integer overflow

### DIFF
--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -1484,17 +1484,52 @@ impl TxIdGenerator {
     ///
     /// This operation is atomic and thread-safe.
     pub fn next(&self) -> TxId {
-        TxId(self.counter.fetch_add(1, Ordering::SeqCst))
+        let mut current = self.counter.load(Ordering::SeqCst);
+        loop {
+            if current == u64::MAX {
+                panic!("Transaction ID overflow! Database requires restart/migration.");
+            }
+            match self.counter.compare_exchange(
+                current,
+                current + 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return TxId(current),
+                Err(v) => current = v,
+            }
+        }
     }
 
     /// Get the current transaction ID (last generated)
     pub fn current(&self) -> TxId {
         TxId(self.counter.load(Ordering::SeqCst).saturating_sub(1))
     }
+
+    #[cfg(test)]
+    /// Set the internal counter for testing overflow conditions.
+    pub fn set_counter(&self, val: u64) {
+        self.counter.store(val, Ordering::SeqCst);
+    }
 }
 
 impl Default for TxIdGenerator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod warden_repro {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Transaction ID overflow")]
+    fn test_tx_id_overflow_panic() {
+        let generator = TxIdGenerator::new();
+        // Force counter to max to simulate exhaustion
+        generator.set_counter(u64::MAX);
+        // This should panic to prevent wrapping to 0
+        let _ = generator.next();
     }
 }


### PR DESCRIPTION
**Threat:** `TxIdGenerator` used `fetch_add` which wraps on overflow. If the transaction ID counter reached `u64::MAX`, it would silently wrap to 0, potentially causing ID reuse and data integrity issues.

**Defense:** Switched to a `compare_exchange` loop that explicitly checks for `u64::MAX`. If the limit is reached, the process now panics with a clear message, preserving data integrity over availability.

**Severity:** Critical (Integrity). While `u64` exhaustion is theoretically unlikely, a wrap-around would be catastrophic.

**Verification:** Added `core::id::warden_repro` test module with a reproduction case that forces the counter to max and asserts a panic occurs. Confirmed the test fails (no panic) without the fix and passes with the fix.

---
*PR created automatically by Jules for task [17260524945278180548](https://jules.google.com/task/17260524945278180548) started by @madmax983*