### PR TITLE
🤖 Sentinel: Kill TimeRange::contains_range boundary mutant

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1652,4 +1652,34 @@ mod sentry_tests {
             "Should accept large timestamp close to i64::MAX"
         );
     }
+
+    #[test]
+    fn test_sentry_contains_range_boundary_conditions() {
+        // 🛡️ Sentry Test: Verify contains_range handles identical start/end points.
+        // This targets mutants that replace <= with < in the implementation.
+
+        // Outer: [100, 200)
+        let outer = TimeRange::new(100.into(), 200.into()).unwrap();
+
+        // Same start: [100, 150)
+        let same_start = TimeRange::new(100.into(), 150.into()).unwrap();
+        assert!(
+            outer.contains_range(&same_start),
+            "Should contain range with same start timestamp"
+        );
+
+        // Same end: [150, 200)
+        let same_end = TimeRange::new(150.into(), 200.into()).unwrap();
+        assert!(
+            outer.contains_range(&same_end),
+            "Should contain range with same end timestamp"
+        );
+
+        // Same range: [100, 200)
+        let same_range = TimeRange::new(100.into(), 200.into()).unwrap();
+        assert!(
+            outer.contains_range(&same_range),
+            "Should contain itself (reflexive)"
+        );
+    }
 }

--- a/src/experimental/dissonance.rs
+++ b/src/experimental/dissonance.rs
@@ -120,16 +120,15 @@ impl<'a> DissonanceEngine<'a> {
         let mut valid_neighbors = 0;
 
         for &neighbor_id in &neighbors {
-            if let Ok(neighbor) = self.db.get_node(neighbor_id) {
-                if let Some(n_prop) = neighbor.properties.get(vector_property) {
-                    if let Some(n_vec) = n_prop.as_vector() {
-                        // Compute similarity manually. Defaulting to Cosine for MVP.
-                        // Ideally we'd match the index's metric.
-                        let sim = ops::cosine_similarity(node_vec, n_vec)?;
-                        total_graph_sim += sim;
-                        valid_neighbors += 1;
-                    }
-                }
+            if let Ok(neighbor) = self.db.get_node(neighbor_id)
+                && let Some(n_prop) = neighbor.properties.get(vector_property)
+                && let Some(n_vec) = n_prop.as_vector()
+            {
+                // Compute similarity manually. Defaulting to Cosine for MVP.
+                // Ideally we'd match the index's metric.
+                let sim = ops::cosine_similarity(node_vec, n_vec)?;
+                total_graph_sim += sim;
+                valid_neighbors += 1;
             }
         }
 

--- a/src/experimental/gravity.rs
+++ b/src/experimental/gravity.rs
@@ -149,12 +149,11 @@ impl<'a> GravityWell<'a> {
         if let Ok(history) = self.db.get_node_history(node_id) {
             let mut best_match: Option<Vec<f32>> = None;
             for version in history.versions {
-                if version.temporal.is_valid_at(valid_time) {
-                    if let Some(val) = version.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_match = Some(vec.to_vec());
-                        }
-                    }
+                if version.temporal.is_valid_at(valid_time)
+                    && let Some(val) = version.properties.get(property)
+                    && let Some(vec) = val.as_vector()
+                {
+                    best_match = Some(vec.to_vec());
                 }
             }
             if let Some(vec) = best_match {
@@ -176,10 +175,10 @@ impl<'a> GravityWell<'a> {
     }
 
     fn extract_vector(node: &crate::core::graph::Node, property: &str) -> Result<Option<Vec<f32>>> {
-        if let Some(val) = node.properties.get(property) {
-            if let Some(vec) = val.as_vector() {
-                return Ok(Some(vec.to_vec()));
-            }
+        if let Some(val) = node.properties.get(property)
+            && let Some(vec) = val.as_vector()
+        {
+            return Ok(Some(vec.to_vec()));
         }
         Ok(None)
     }


### PR DESCRIPTION
This PR adds a targeted unit test `test_sentry_contains_range_boundary_conditions` to `src/core/temporal.rs`. 

The test verifies that `TimeRange::contains_range` returns true when the inner range shares the exact start or end timestamp with the outer range. This guards against mutations that might replace the inclusive comparison (`<=`) with a strict one (`<`).

Although a proptest (`prop_time_range_contains_self`) covered the reflexive case, this new test explicitly covers the `same_start` and `same_end` cases with a deterministic unit test, improving the test suite's clarity and speed for this boundary condition.

I also fixed several `clippy::collapsible_if` warnings in `src/experimental/dissonance.rs` and `src/experimental/gravity.rs` to ensure the codebase passes strict pre-commit checks.


---
*PR created automatically by Jules for task [5658865058858639008](https://jules.google.com/task/5658865058858639008) started by @madmax983*