### PR TITLE
👺 Havoc: Harden Edge Cases (TxId Overflow, HNSW Zero-Dims, Concurrency)

### DIFF
--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -1480,11 +1480,38 @@ impl TxIdGenerator {
         }
     }
 
+    /// Create a new transaction ID generator starting from a specific value.
+    /// Useful for testing overflow behavior.
+    pub fn with_start(start: u64) -> Self {
+        TxIdGenerator {
+            counter: AtomicU64::new(start),
+        }
+    }
+
     /// Generate the next transaction ID
     ///
     /// This operation is atomic and thread-safe.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transaction ID counter overflows (reaches u64::MAX).
+    /// This is a catastrophic event requiring a database restart/migration.
     pub fn next(&self) -> TxId {
-        TxId(self.counter.fetch_add(1, Ordering::SeqCst))
+        let mut current = self.counter.load(Ordering::SeqCst);
+        loop {
+            if current == u64::MAX {
+                panic!("Transaction ID overflow: exhausted all 2^64 IDs");
+            }
+            match self.counter.compare_exchange(
+                current,
+                current + 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return TxId(current),
+                Err(v) => current = v,
+            }
+        }
     }
 
     /// Get the current transaction ID (last generated)

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -364,6 +364,12 @@ impl HnswConfig {
         reader.read_exact(&mut buf_u64)?;
         let dimensions = u64::from_le_bytes(buf_u64) as usize;
 
+        if dimensions == 0 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: "dimensions must be > 0".to_string(),
+            }));
+        }
+
         if dimensions > MAX_VECTOR_DIMENSIONS {
             return Err(Error::Vector(VectorError::InvalidVector {
                 reason: format!(
@@ -476,6 +482,9 @@ fn create_metric_wrapper<F>(
 where
     F: Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static + ?Sized,
 {
+    // Warden: Ensure positive dimensions to prevent invalid slice creation
+    assert!(dims > 0, "Metric wrapper created with 0 dimensions");
+
     Box::new(move |a: *const f32, b: *const f32| {
         // Check for null pointers to prevent UB
         if a.is_null() || b.is_null() {
@@ -2159,6 +2168,12 @@ impl HnswIndex {
     /// - The mappings file is corrupted (CRC mismatch).
     /// - Custom metric is used with non-F32 quantization (safety violation).
     pub fn load(path: &Path, config: HnswConfig) -> Result<Self> {
+        if config.dimensions == 0 {
+            return Err(Error::Vector(VectorError::InvalidVector {
+                reason: "dimensions must be > 0".to_string(),
+            }));
+        }
+
         if config.dimensions > MAX_VECTOR_DIMENSIONS {
             return Err(Error::Vector(VectorError::InvalidVector {
                 reason: format!(

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -2493,7 +2493,7 @@ mod sentry_tests {
     #[test]
     fn test_hnsw_config_deserialize_invalid_quantization() {
         // Construct a buffer that is valid until quantization byte
-        let config = HnswConfig::default();
+        let config = HnswConfig::new(128, DistanceMetric::Cosine); // Use valid dimensions
         let mut buffer = Vec::new();
         // Write valid parts manually to ensure we reach quantization read
         buffer.extend_from_slice(&(config.dimensions as u64).to_le_bytes());
@@ -4222,7 +4222,7 @@ mod coverage_misc_tests {
     #[test]
     fn test_deserialize_quantization_error() {
         // Construct valid data up to quantization
-        let config = HnswConfig::default();
+        let config = HnswConfig::new(128, DistanceMetric::Cosine); // Use valid dimensions
         let mut buffer = Vec::new();
         buffer.extend_from_slice(&(config.dimensions as u64).to_le_bytes());
         buffer.push(config.metric.to_u8());

--- a/tests/havoc_concurrency.rs
+++ b/tests/havoc_concurrency.rs
@@ -1,0 +1,42 @@
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, VectorIndex};
+use aletheiadb::core::id::NodeId;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+#[test]
+fn test_concurrency_stress() {
+    let index = Arc::new(HnswIndexBuilder::new(4, DistanceMetric::Cosine).build().unwrap());
+
+    let num_threads = 10;
+    let iterations = 100;
+    let barrier = Arc::new(Barrier::new(num_threads));
+
+    let mut handles = vec![];
+
+    for i in 0..num_threads {
+        let index = index.clone();
+        let barrier = barrier.clone();
+
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+
+            for j in 0..iterations {
+                let id = NodeId::new(((i * iterations + j) % 100) as u64 + 1).unwrap();
+                let vec = vec![0.1 * (j as f32), 0.2, 0.3, 0.4];
+
+                // Randomly choose operation
+                if j % 3 == 0 {
+                    let _ = index.add(id, &vec);
+                } else if j % 3 == 1 {
+                    let _ = index.search(&vec, 5);
+                } else {
+                    let _ = index.remove(id);
+                }
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}

--- a/tests/havoc_concurrency.rs
+++ b/tests/havoc_concurrency.rs
@@ -1,11 +1,15 @@
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, VectorIndex};
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndexBuilder, VectorIndex};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
 #[test]
 fn test_concurrency_stress() {
-    let index = Arc::new(HnswIndexBuilder::new(4, DistanceMetric::Cosine).build().unwrap());
+    let index = Arc::new(
+        HnswIndexBuilder::new(4, DistanceMetric::Cosine)
+            .build()
+            .unwrap(),
+    );
 
     let num_threads = 10;
     let iterations = 100;

--- a/tests/havoc_hnsw_config.rs
+++ b/tests/havoc_hnsw_config.rs
@@ -1,0 +1,27 @@
+use aletheiadb::index::vector::{HnswConfig, DistanceMetric, Quantization};
+use std::io::Cursor;
+
+#[test]
+fn test_hnsw_zero_dimensions_rejected() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // dimensions: 0
+    bytes.push(DistanceMetric::Cosine.to_u8());
+    bytes.extend_from_slice(&16u64.to_le_bytes()); // m
+    bytes.extend_from_slice(&128u64.to_le_bytes()); // ef_construction
+    bytes.extend_from_slice(&64u64.to_le_bytes()); // ef_search
+    bytes.extend_from_slice(&1000u64.to_le_bytes()); // capacity
+    bytes.push(Quantization::F32.to_u8());
+
+    let mut cursor = Cursor::new(bytes);
+
+    let config_result = HnswConfig::deserialize_from(&mut cursor);
+
+    if let Err(e) = config_result {
+        if e.to_string().contains("dimensions must be > 0") {
+             return; // Passed
+        }
+        panic!("Deserialization failed but with unexpected error: {:?}", e);
+    }
+
+    panic!("Deserialization SUCCEEDED with 0 dimensions! Security regression.");
+}

--- a/tests/havoc_hnsw_config.rs
+++ b/tests/havoc_hnsw_config.rs
@@ -1,4 +1,4 @@
-use aletheiadb::index::vector::{HnswConfig, DistanceMetric, Quantization};
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, Quantization};
 use std::io::Cursor;
 
 #[test]
@@ -18,7 +18,7 @@ fn test_hnsw_zero_dimensions_rejected() {
 
     if let Err(e) = config_result {
         if e.to_string().contains("dimensions must be > 0") {
-             return; // Passed
+            return; // Passed
         }
         panic!("Deserialization failed but with unexpected error: {:?}", e);
     }

--- a/tests/havoc_tx_overflow.rs
+++ b/tests/havoc_tx_overflow.rs
@@ -1,0 +1,20 @@
+use aletheiadb::core::id::TxIdGenerator;
+
+#[test]
+#[should_panic(expected = "Transaction ID overflow")]
+fn test_tx_id_overflow_panic() {
+    // Start at MAX-1.
+    // next() -> MAX-1
+    // next() -> MAX
+    // next() -> Should panic
+    let generator = TxIdGenerator::with_start(u64::MAX - 1);
+
+    let id1 = generator.next();
+    assert_eq!(id1.as_u64(), u64::MAX - 1);
+
+    let id2 = generator.next();
+    assert_eq!(id2.as_u64(), u64::MAX);
+
+    // This should panic
+    let _id3 = generator.next();
+}


### PR DESCRIPTION
This PR hardens the system against several edge cases identified during chaos engineering:

1.  **Transaction ID Overflow**: `TxIdGenerator` was using `fetch_add`, which wraps on overflow. While highly unlikely (taking centuries), wrapping to 0 could violate uniqueness guarantees. I replaced this with a CAS loop that panics if `u64::MAX` is reached, ensuring fail-stop safety.
2.  **HNSW Zero Dimensions**: `HnswConfig` deserialization allowed `dimensions = 0`. This could lead to undefined behavior in `usearch` or when creating unsafe slices in `create_metric_wrapper`. I added explicit checks in `deserialize_from` and `load` to reject 0 dimensions, and a defensive assertion in `create_metric_wrapper`.
3.  **Concurrency**: A new stress test `havoc_concurrency.rs` verifies the thread safety of `HnswIndex` under heavy concurrent load (add, remove, search).

These changes ensure the system is robust against invalid configurations and extreme usage scenarios.


---
*PR created automatically by Jules for task [17946727265227954345](https://jules.google.com/task/17946727265227954345) started by @madmax983*