### PR TITLE
🤖 Sentinel: Kill mutant in Edge::connects source verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,13 @@
 **Summary:** `MAX_VALID_TIMESTAMP` constant definition was susceptible to reduction (e.g. `replace - with /`) because existing boundary tests used the constant itself for assertions (tautological tests).
 **Diagnosis:** **Weak Test**. Tests checked `TimeRange::new(MAX_VALID_TIMESTAMP, ...)` which would pass even if `MAX_VALID_TIMESTAMP` was small, as long as it was self-consistent.
 **Kill Shot:** Added `test_sentry_max_valid_timestamp_value` which asserts that `TimeRange::new` accepts a hardcoded large timestamp (`i64::MAX - 2000`), ensuring the limit isn't drastically reduced.
+
+**[Weakness in Edge::connects Verification]**
+**Module:** `src/core/graph.rs`
+**Summary:** The `Edge::connects(source, target)` method was vulnerable to a mutation where the `source` check could be ignored (e.g., `self.target == target` instead of `self.source == source && self.target == target`). Existing tests only checked:
+1. `(Correct, Correct) -> True`
+2. `(Wrong, Wrong) -> False`
+3. `(Correct, Wrong) -> False`
+They missed the case `(Wrong, Correct) -> False`.
+**Diagnosis:** **Weak Test**. The test suite lacked a specific assertion for source mismatch when the target matches.
+**Kill Shot:** Added `test_sentry_edge_connects_source_check` which explicitly verifies `!edge.connects(wrong_source, correct_target)`.

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -554,4 +554,28 @@ mod sentry_tests {
             "has_label_str should return false for invalid label ID"
         );
     }
+
+    #[test]
+    fn test_sentry_edge_connects_source_check() {
+        // 🛡️ Sentry Test: Verify Edge::connects checks both source and target.
+        // This targets mutants that might ignore one of the checks (e.g. `source == s || target == t`).
+
+        let edge = Edge::new(
+            EdgeId::new(1).unwrap(),
+            crate::core::interning::GLOBAL_INTERNER
+                .intern("KNOWS")
+                .unwrap(),
+            NodeId::new(10).unwrap(), // Source
+            NodeId::new(20).unwrap(), // Target
+            PropertyMapBuilder::new().build(),
+            VersionId::new(100).unwrap(),
+        );
+
+        // Case 1: Wrong Source, Correct Target
+        // If implementation ignores source (e.g. just checks target), this returns True.
+        assert!(
+            !edge.connects(NodeId::new(99).unwrap(), NodeId::new(20).unwrap()),
+            "Should return false when source mismatch (even if target matches)"
+        );
+    }
 }


### PR DESCRIPTION
Improved test coverage for `src/core/graph.rs` to eliminate a surviving mutant in `Edge::connects`. The new test ensures that both source and target IDs are validated.

---
*PR created automatically by Jules for task [16834797047937069411](https://jules.google.com/task/16834797047937069411) started by @madmax983*