### PR TITLE
perf(cold-storage): raise zstd sustained_write_10k_versions above target

### DIFF
--- a/benches/cold_storage.rs
+++ b/benches/cold_storage.rs
@@ -34,6 +34,7 @@ use aletheiadb::storage::redb_cold_storage::{CompressionAlgorithm, RedbColdStora
 use aletheiadb::storage::version::NodeVersion;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 use tempfile::TempDir;
 
@@ -283,41 +284,62 @@ fn bench_read_latency_percentiles(c: &mut Criterion) {
 /// Benchmark: Write throughput over time.
 ///
 /// Measures sustained write throughput.
-/// Target: >10k versions/sec
+///
+/// `sustained_write_10k_versions` validates the >10k versions/sec target in
+/// ratio-optimized mode (`CompressionAlgorithm::Zstd`).
+/// `sustained_write_10k_versions_fast_reference` tracks throughput-optimized mode.
 fn bench_sustained_write_throughput(c: &mut Criterion) {
-    let temp_dir =
-        TempDir::new().expect("Failed to create temp directory for sustained write benchmark");
-    let config = RedbConfig::default()
-        .compression(CompressionAlgorithm::Zstd)
-        .enable_checksums(true);
-    let storage = RedbColdStorage::new(temp_dir.path().join("bench.redb"), config)
-        .expect("Failed to create RedbColdStorage for sustained write benchmark");
-
     let batch_size = 10000;
-    let versions = create_test_versions(batch_size);
+    for (bench_name, compression, target_label) in [
+        (
+            "sustained_write_10k_versions",
+            CompressionAlgorithm::Zstd,
+            Some(">10,000 versions/sec"),
+        ),
+        (
+            "sustained_write_10k_versions_fast_reference",
+            CompressionAlgorithm::Fast,
+            None,
+        ),
+    ] {
+        let temp_dir =
+            TempDir::new().expect("Failed to create temp directory for sustained write benchmark");
+        let config = RedbConfig::default()
+            .compression(compression)
+            .enable_checksums(true);
+        let storage = RedbColdStorage::new(temp_dir.path().join("bench.redb"), config)
+            .expect("Failed to create RedbColdStorage for sustained write benchmark");
 
-    c.bench_function("sustained_write_10k_versions", |b| {
-        b.iter_custom(|iters| {
-            let start = Instant::now();
-            for _ in 0..iters {
-                storage
-                    .store_node_versions_batch(black_box(&versions))
-                    .unwrap();
-            }
-            let elapsed = start.elapsed();
+        let versions = create_test_versions(batch_size);
+        let printed = AtomicBool::new(false);
 
-            // Print throughput for manual verification
-            let total_versions = batch_size * iters as usize;
-            let throughput = total_versions as f64 / elapsed.as_secs_f64();
-            if iters == 1 {
-                eprintln!("\nWrite Throughput:");
-                eprintln!("  {:.0} versions/sec", throughput);
-                eprintln!("  Target: >10,000 versions/sec");
-            }
+        c.bench_function(bench_name, |b| {
+            b.iter_custom(|iters| {
+                let start = Instant::now();
+                for _ in 0..iters {
+                    storage
+                        .store_node_versions_batch(black_box(&versions))
+                        .unwrap();
+                }
+                let elapsed = start.elapsed();
 
-            elapsed
+                // Emit a single sample throughput line for manual verification.
+                if !printed.swap(true, Ordering::Relaxed) {
+                    let total_versions = batch_size * iters as usize;
+                    let throughput = total_versions as f64 / elapsed.as_secs_f64();
+                    eprintln!("\nWrite Throughput ({bench_name}):");
+                    eprintln!("  {:.0} versions/sec", throughput);
+                    if let Some(target) = target_label {
+                        eprintln!("  Target: {target}");
+                    } else {
+                        eprintln!("  Mode: throughput-optimized reference (fast)");
+                    }
+                }
+
+                elapsed
+            });
         });
-    });
+    }
 }
 
 /// Benchmark: Compression ratio measurement.

--- a/src/experimental/dissonance.rs
+++ b/src/experimental/dissonance.rs
@@ -120,16 +120,15 @@ impl<'a> DissonanceEngine<'a> {
         let mut valid_neighbors = 0;
 
         for &neighbor_id in &neighbors {
-            if let Ok(neighbor) = self.db.get_node(neighbor_id) {
-                if let Some(n_prop) = neighbor.properties.get(vector_property) {
-                    if let Some(n_vec) = n_prop.as_vector() {
-                        // Compute similarity manually. Defaulting to Cosine for MVP.
-                        // Ideally we'd match the index's metric.
-                        let sim = ops::cosine_similarity(node_vec, n_vec)?;
-                        total_graph_sim += sim;
-                        valid_neighbors += 1;
-                    }
-                }
+            if let Ok(neighbor) = self.db.get_node(neighbor_id)
+                && let Some(n_prop) = neighbor.properties.get(vector_property)
+                && let Some(n_vec) = n_prop.as_vector()
+            {
+                // Compute similarity manually. Defaulting to Cosine for MVP.
+                // Ideally we'd match the index's metric.
+                let sim = ops::cosine_similarity(node_vec, n_vec)?;
+                total_graph_sim += sim;
+                valid_neighbors += 1;
             }
         }
 

--- a/src/experimental/gravity.rs
+++ b/src/experimental/gravity.rs
@@ -149,12 +149,11 @@ impl<'a> GravityWell<'a> {
         if let Ok(history) = self.db.get_node_history(node_id) {
             let mut best_match: Option<Vec<f32>> = None;
             for version in history.versions {
-                if version.temporal.is_valid_at(valid_time) {
-                    if let Some(val) = version.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_match = Some(vec.to_vec());
-                        }
-                    }
+                if version.temporal.is_valid_at(valid_time)
+                    && let Some(val) = version.properties.get(property)
+                    && let Some(vec) = val.as_vector()
+                {
+                    best_match = Some(vec.to_vec());
                 }
             }
             if let Some(vec) = best_match {
@@ -176,10 +175,10 @@ impl<'a> GravityWell<'a> {
     }
 
     fn extract_vector(node: &crate::core::graph::Node, property: &str) -> Result<Option<Vec<f32>>> {
-        if let Some(val) = node.properties.get(property) {
-            if let Some(vec) = val.as_vector() {
-                return Ok(Some(vec.to_vec()));
-            }
+        if let Some(val) = node.properties.get(property)
+            && let Some(vec) = val.as_vector()
+        {
+            return Ok(Some(vec.to_vec()));
         }
         Ok(None)
     }

--- a/src/storage/redb_cold_storage.rs
+++ b/src/storage/redb_cold_storage.rs
@@ -47,6 +47,7 @@ use crate::core::error::{Result, StorageError};
 use crate::core::id::VersionId;
 use crate::core::version::{EdgeVersion, NodeVersion};
 use crate::storage::wal::LSN;
+use rayon::prelude::*;
 use redb::{ReadableDatabase, ReadableTable};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -67,6 +68,16 @@ const METADATA_TABLE: redb::TableDefinition<'static, &'static str, &'static [u8]
 
 /// Metadata keys stored in the metadata table.
 const FLUSHED_LSN_KEY: &str = "flushed_lsn";
+
+/// Batch size threshold where parallel pre-compression becomes worthwhile.
+const PARALLEL_COMPRESSION_THRESHOLD: usize = 1_024;
+
+#[derive(Debug)]
+struct PreparedVersionBatch {
+    entries: Vec<(u64, Vec<u8>)>,
+    raw_size_bytes: u64,
+    compressed_size_bytes: u64,
+}
 
 // ============================================================================
 // Types moved from cold_storage.rs
@@ -407,6 +418,120 @@ impl RedbColdStorage {
     /// Decompress data using the configured algorithm.
     fn decompress(&self, data: &[u8]) -> Result<Vec<u8>> {
         crate::storage::compression::decompress(data, &self.config.to_cold_storage_config())
+    }
+
+    #[inline]
+    fn should_parallel_compress(&self, batch_len: usize) -> bool {
+        matches!(self.config.compression, CompressionAlgorithm::Zstd)
+            && batch_len >= PARALLEL_COMPRESSION_THRESHOLD
+    }
+
+    fn prepare_node_versions_batch(
+        &self,
+        versions: &[NodeVersion],
+    ) -> Result<PreparedVersionBatch> {
+        let cold_config = self.config.to_cold_storage_config();
+
+        let entries_with_sizes: Vec<(u64, Vec<u8>, u64, u64)> = if self
+            .should_parallel_compress(versions.len())
+        {
+            versions
+                .par_iter()
+                .map(|version| {
+                    let encoded = encode_node_version(version);
+                    let raw_size = encoded.len() as u64;
+                    let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
+                    let compressed_size = compressed.len() as u64;
+                    Ok::<_, crate::core::error::Error>((
+                        version.id.as_u64(),
+                        compressed,
+                        raw_size,
+                        compressed_size,
+                    ))
+                })
+                .collect::<Result<_>>()?
+        } else {
+            versions
+                .iter()
+                .map(|version| {
+                    let encoded = encode_node_version(version);
+                    let raw_size = encoded.len() as u64;
+                    let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
+                    let compressed_size = compressed.len() as u64;
+                    Ok((version.id.as_u64(), compressed, raw_size, compressed_size))
+                })
+                .collect::<Result<_>>()?
+        };
+
+        let raw_size_bytes = entries_with_sizes.iter().map(|(_, _, raw, _)| *raw).sum();
+        let compressed_size_bytes = entries_with_sizes
+            .iter()
+            .map(|(_, _, _, compressed)| *compressed)
+            .sum();
+        let entries = entries_with_sizes
+            .into_iter()
+            .map(|(id, payload, _, _)| (id, payload))
+            .collect();
+
+        Ok(PreparedVersionBatch {
+            entries,
+            raw_size_bytes,
+            compressed_size_bytes,
+        })
+    }
+
+    fn prepare_edge_versions_batch(
+        &self,
+        versions: &[EdgeVersion],
+    ) -> Result<PreparedVersionBatch> {
+        let cold_config = self.config.to_cold_storage_config();
+
+        let entries_with_sizes: Vec<(u64, Vec<u8>, u64, u64)> = if self
+            .should_parallel_compress(versions.len())
+        {
+            versions
+                .par_iter()
+                .map(|version| {
+                    let encoded = encode_edge_version(version);
+                    let raw_size = encoded.len() as u64;
+                    let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
+                    let compressed_size = compressed.len() as u64;
+                    Ok::<_, crate::core::error::Error>((
+                        version.id.as_u64(),
+                        compressed,
+                        raw_size,
+                        compressed_size,
+                    ))
+                })
+                .collect::<Result<_>>()?
+        } else {
+            versions
+                .iter()
+                .map(|version| {
+                    let encoded = encode_edge_version(version);
+                    let raw_size = encoded.len() as u64;
+                    let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
+                    let compressed_size = compressed.len() as u64;
+                    Ok((version.id.as_u64(), compressed, raw_size, compressed_size))
+                })
+                .collect::<Result<_>>()?
+        };
+
+        let raw_size_bytes = entries_with_sizes.iter().map(|(_, _, raw, _)| *raw).sum();
+        let compressed_size_bytes = entries_with_sizes
+            .iter()
+            .map(|(_, _, _, compressed)| *compressed)
+            .sum();
+        let entries = entries_with_sizes
+            .into_iter()
+            .map(|(id, payload, _, _)| (id, payload))
+            .collect();
+
+        Ok(PreparedVersionBatch {
+            entries,
+            raw_size_bytes,
+            compressed_size_bytes,
+        })
     }
 
     /// Set fault injection flag for write operations (Test only).
@@ -803,6 +928,9 @@ impl RedbColdStorage {
             return Ok(());
         }
 
+        let prepared = self.prepare_node_versions_batch(versions)?;
+        let version_count = prepared.entries.len() as u64;
+
         let write_txn = self
             .db
             .begin_write()
@@ -816,31 +944,26 @@ impl RedbColdStorage {
                 },
             )?;
 
-            for version in versions {
-                let encoded = encode_node_version(version);
-                let raw_size = encoded.len();
-                let compressed = self.compress(&encoded)?;
-                let compressed_size = compressed.len();
-
+            for (id, compressed) in &prepared.entries {
                 table
-                    .insert(version.id.as_u64(), compressed.as_slice())
+                    .insert(*id, compressed.as_slice())
                     .map_err(map_storage_error("Failed to store node version"))?;
-
-                self.stats
-                    .node_versions_stored
-                    .fetch_add(1, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_raw
-                    .fetch_add(raw_size as u64, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_compressed
-                    .fetch_add(compressed_size as u64, Ordering::Relaxed);
             }
         }
 
         write_txn
             .commit()
             .map_err(map_commit_error("Failed to commit batch"))?;
+
+        self.stats
+            .node_versions_stored
+            .fetch_add(version_count, Ordering::Relaxed);
+        self.stats
+            .bytes_written_raw
+            .fetch_add(prepared.raw_size_bytes, Ordering::Relaxed);
+        self.stats
+            .bytes_written_compressed
+            .fetch_add(prepared.compressed_size_bytes, Ordering::Relaxed);
 
         Ok(())
     }
@@ -852,6 +975,9 @@ impl RedbColdStorage {
         if versions.is_empty() {
             return Ok(());
         }
+
+        let prepared = self.prepare_edge_versions_batch(versions)?;
+        let version_count = prepared.entries.len() as u64;
 
         let write_txn = self
             .db
@@ -866,31 +992,26 @@ impl RedbColdStorage {
                 },
             )?;
 
-            for version in versions {
-                let encoded = encode_edge_version(version);
-                let raw_size = encoded.len();
-                let compressed = self.compress(&encoded)?;
-                let compressed_size = compressed.len();
-
+            for (id, compressed) in &prepared.entries {
                 table
-                    .insert(version.id.as_u64(), compressed.as_slice())
+                    .insert(*id, compressed.as_slice())
                     .map_err(map_storage_error("Failed to store edge version"))?;
-
-                self.stats
-                    .edge_versions_stored
-                    .fetch_add(1, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_raw
-                    .fetch_add(raw_size as u64, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_compressed
-                    .fetch_add(compressed_size as u64, Ordering::Relaxed);
             }
         }
 
         write_txn
             .commit()
             .map_err(map_commit_error("Failed to commit batch"))?;
+
+        self.stats
+            .edge_versions_stored
+            .fetch_add(version_count, Ordering::Relaxed);
+        self.stats
+            .bytes_written_raw
+            .fetch_add(prepared.raw_size_bytes, Ordering::Relaxed);
+        self.stats
+            .bytes_written_compressed
+            .fetch_add(prepared.compressed_size_bytes, Ordering::Relaxed);
 
         Ok(())
     }
@@ -940,6 +1061,11 @@ impl RedbColdStorage {
     ) -> Result<()> {
         self.check_fail_writes()?;
 
+        let prepared_nodes = self.prepare_node_versions_batch(nodes)?;
+        let prepared_edges = self.prepare_edge_versions_batch(edges)?;
+        let node_count = prepared_nodes.entries.len() as u64;
+        let edge_count = prepared_edges.entries.len() as u64;
+
         let write_txn = self
             .db
             .begin_write()
@@ -951,25 +1077,10 @@ impl RedbColdStorage {
                 .open_table(NODE_VERSIONS_TABLE)
                 .map_err(map_table_error("Failed to open node_versions table"))?;
 
-            for version in nodes {
-                let encoded = encode_node_version(version);
-                let raw_size = encoded.len();
-                let compressed = self.compress(&encoded)?;
-                let compressed_size = compressed.len();
-
+            for (id, compressed) in &prepared_nodes.entries {
                 table
-                    .insert(version.id.as_u64(), compressed.as_slice())
+                    .insert(*id, compressed.as_slice())
                     .map_err(map_storage_error("Failed to store node version"))?;
-
-                self.stats
-                    .node_versions_stored
-                    .fetch_add(1, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_raw
-                    .fetch_add(raw_size as u64, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_compressed
-                    .fetch_add(compressed_size as u64, Ordering::Relaxed);
             }
         }
 
@@ -979,25 +1090,10 @@ impl RedbColdStorage {
                 .open_table(EDGE_VERSIONS_TABLE)
                 .map_err(map_table_error("Failed to open edge_versions table"))?;
 
-            for version in edges {
-                let encoded = encode_edge_version(version);
-                let raw_size = encoded.len();
-                let compressed = self.compress(&encoded)?;
-                let compressed_size = compressed.len();
-
+            for (id, compressed) in &prepared_edges.entries {
                 table
-                    .insert(version.id.as_u64(), compressed.as_slice())
+                    .insert(*id, compressed.as_slice())
                     .map_err(map_storage_error("Failed to store edge version"))?;
-
-                self.stats
-                    .edge_versions_stored
-                    .fetch_add(1, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_raw
-                    .fetch_add(raw_size as u64, Ordering::Relaxed);
-                self.stats
-                    .bytes_written_compressed
-                    .fetch_add(compressed_size as u64, Ordering::Relaxed);
             }
         }
 
@@ -1013,6 +1109,21 @@ impl RedbColdStorage {
         write_txn
             .commit()
             .map_err(map_commit_error("Failed to commit batch"))?;
+
+        self.stats
+            .node_versions_stored
+            .fetch_add(node_count, Ordering::Relaxed);
+        self.stats
+            .edge_versions_stored
+            .fetch_add(edge_count, Ordering::Relaxed);
+        self.stats.bytes_written_raw.fetch_add(
+            prepared_nodes.raw_size_bytes + prepared_edges.raw_size_bytes,
+            Ordering::Relaxed,
+        );
+        self.stats.bytes_written_compressed.fetch_add(
+            prepared_nodes.compressed_size_bytes + prepared_edges.compressed_size_bytes,
+            Ordering::Relaxed,
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Optimizes Redb cold-storage batch writes for zstd sustained throughput by pre-encoding/compressing entries before opening the write transaction.
- Adds parallel pre-compression for large zstd batches (`>= 1024`) using Rayon.
- Reduces hot-path atomic contention by aggregating batch stats updates and applying them once per commit.
- Restores the sustained throughput target benchmark to zstd mode and keeps a fast-compression reference benchmark.
- Fixes existing clippy `collapsible_if` warnings in experimental modules touched by strict linting.

## Why
The `sustained_write_10k_versions` benchmark in zstd mode was under target (~4.8k versions/sec vs >10k target).

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib redb_cold_storage`
- `cargo bench --bench cold_storage -- sustained_write_10k_versions`
  - `sustained_write_10k_versions` (zstd target): ~15,281 versions/sec (target >10,000)
  - `sustained_write_10k_versions_fast_reference`: ~20,235 versions/sec