### PR TITLE
Fix: Persistence atomicity and collision recovery in HNSW index

### DIFF
--- a/add_test_2.py
+++ b/add_test_2.py
@@ -1,0 +1,40 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+new_test = """
+    #[test]
+    fn test_save_internal_temp_create_error() {
+        let index = HnswIndexBuilder::new(2, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+
+        // Use a path in a non-existent directory
+        // On Linux, /nonexistent/ usually doesn't exist.
+        // Or use a relative path with missing parent.
+        let path = Path::new("nonexistent_dir/test.index");
+
+        let result = index.save(path);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(msg.contains("Failed to save index to temp file"), "Got error: {}", msg);
+            }
+            _ => panic!("Expected save index temp file error, got {:?}", result),
+        }
+    }
+"""
+
+# Insert before the last closing brace (end of mod error_tests)
+# Find the last closing brace
+for i in range(len(lines)-1, -1, -1):
+    if lines[i].strip() == "}":
+        # Check if it's the module closing brace
+        # We assume the last line is the module closing brace
+        lines.insert(i, new_test)
+        break
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/add_tests.py
+++ b/add_tests.py
@@ -1,0 +1,84 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+new_tests = """
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_collision_recovery_limit() {
+        let index = HnswIndexBuilder::new(2, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+
+        // Manually occupy keys 0..1100 in the internal index to force collisions
+        // next_key starts at 0.
+        {
+            let mut inner = index.inner.write();
+            // We need to use usearch API directly to bypass next_key updates
+            // But we can't easily access usearch internals from here if they are not exposed.
+            // HnswIndex wraps `usearch::Index`.
+            // We can use `inner.add(key, vector)` directly?
+            // HnswIndex::inner is Arc<RwLock<Index>>.
+            // We can add vectors directly.
+
+            for i in 0..1100 {
+                inner.add(i, &[1.0, 0.0]).unwrap();
+            }
+        }
+
+        // Now try to add a NEW node via public API.
+        // It will try key=0 (collision), key=1 (collision)... key=1000 (collision).
+        // Should eventually fail with "Too many key collisions"
+        let result = index.add(NodeId::new(1).unwrap(), &[0.0, 1.0]);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(msg.contains("Too many key collisions"), "Got error: {}", msg);
+            }
+            _ => panic!("Expected Too many key collisions error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_save_index_rename_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let index = HnswIndexBuilder::new(2, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+
+        // Setup paths
+        let index_path = dir.path().join("test.index");
+
+        // Create a directory at index_path to force index rename failure
+        fs::create_dir(&index_path).unwrap();
+
+        // mappings_path will be "test.usearch.mappings"
+        // This path is free, so mappings rename should SUCCEED.
+
+        let result = index.save(&index_path);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(msg.contains("Failed to rename index file"), "Got error: {}", msg);
+            }
+            _ => panic!("Expected rename index file error, got {:?}", result),
+        }
+
+        // Verify mappings file exists (it was renamed successfully)
+        let mappings_path = index_path.with_extension("usearch.mappings");
+        assert!(mappings_path.exists());
+    }
+}
+"""
+
+lines.append(new_tests)
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/fix_clippy.py
+++ b/fix_clippy.py
@@ -1,0 +1,66 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+# Fix 1: line 1035 (approx)
+# if let Err(e) = self.retry_usearch(
+#     || index.reserve(new_capacity),
+#     "Failed to expand capacity (race recovery)",
+# ) {
+#     return Err(e);
+# }
+
+for i in range(len(lines)):
+    if "if let Err(e) = self.retry_usearch(" in lines[i]:
+        # Check if next lines match the pattern
+        if "|| index.reserve(new_capacity)," in lines[i+1]:
+            # Replace with ?
+            lines[i] = lines[i].replace("if let Err(e) = ", "")
+            # Remove the { return Err(e); } part
+            # It spans multiple lines.
+            # line i: self.retry_usearch(
+            # line i+1: || ...
+            # line i+2: "..."
+            # line i+3: ) {
+            # line i+4: return Err(e);
+            # line i+5: }
+
+            # Simplified replacement logic:
+            # Join the lines, replace the pattern, split again? No.
+            pass
+
+# Since exact line numbers might shift due to previous edits, I'll use simple search/replace logic based on context.
+
+# Block 1
+block1_start = -1
+for i in range(len(lines)):
+    if "if let Err(e) = self.retry_usearch(" in lines[i] and "index.reserve(new_capacity)" in lines[i+1]:
+        block1_start = i
+        break
+
+if block1_start != -1:
+    lines[block1_start] = lines[block1_start].replace("if let Err(e) = ", "")
+    # line i+3 is `) {`
+    lines[block1_start+3] = lines[block1_start+3].replace(") {", ")?;")
+    # clear lines i+4 and i+5
+    lines[block1_start+4] = ""
+    lines[block1_start+5] = ""
+
+# Block 2
+block2_start = -1
+for i in range(len(lines)):
+    if "if let Err(e) = self.retry_usearch(" in lines[i] and "index.remove(key)" in lines[i+1]:
+        block2_start = i
+        break
+
+if block2_start != -1:
+    lines[block2_start] = lines[block2_start].replace("if let Err(e) = ", "")
+    # line i+3 is `) {`
+    lines[block2_start+3] = lines[block2_start+3].replace(") {", ")?;")
+    # clear lines i+4 and i+5
+    lines[block2_start+4] = ""
+    lines[block2_start+5] = ""
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/fix_syntax.py
+++ b/fix_syntax.py
@@ -1,0 +1,46 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+# Fix block at 1035
+# Line 1035: self.retry_usearch(
+# Line 1036: || index.reserve(new_capacity),
+# Line 1037: "Failed to expand capacity (race recovery)",
+# Line 1038: ) {
+# Line 1039: return Err(e);
+# Line 1040: }
+
+start_1 = 1035 - 1 # 0-indexed
+end_1 = 1040
+
+# Verify content
+if "self.retry_usearch(" in lines[start_1] and "race recovery" in lines[start_1+2]:
+    lines[start_1] = '                        self.retry_usearch(\n'
+    lines[start_1+1] = '                            || index.reserve(new_capacity),\n'
+    lines[start_1+2] = '                            "Failed to expand capacity (race recovery)",\n'
+    lines[start_1+3] = '                        )?;\n'
+    lines[start_1+4] = '' # delete
+    lines[start_1+5] = '' # delete
+
+# Fix block at 1096
+# Line 1096: self.retry_usearch(
+# Line 1097: || index.remove(key),
+# Line 1098: "Failed to rollback vector after concurrent add",
+# Line 1099: ) {
+# Line 1100: return Err(e);
+# Line 1101: }
+
+start_2 = 1096 - 1
+end_2 = 1101
+
+if "self.retry_usearch(" in lines[start_2] and "concurrent add" in lines[start_2+2]:
+    lines[start_2] = '                        self.retry_usearch(\n'
+    lines[start_2+1] = '                            || index.remove(key),\n'
+    lines[start_2+2] = '                            "Failed to rollback vector after concurrent add",\n'
+    lines[start_2+3] = '                        )?;\n'
+    lines[start_2+4] = '' # delete
+    lines[start_2+5] = '' # delete
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/fix_test.py
+++ b/fix_test.py
@@ -1,0 +1,15 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+# Look for assert!(msg.contains("Failed to create mappings file"));
+# Replace with assert!(msg.contains("Failed to create mappings file") || msg.contains("Failed to rename mappings file"));
+
+for i, line in enumerate(lines):
+    if 'assert!(msg.contains("Failed to create mappings file"));' in line:
+        lines[i] = '            assert!(msg.contains("Failed to create mappings file") || msg.contains("Failed to rename mappings file"));\n'
+        break
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/modify_hnsw.py
+++ b/modify_hnsw.py
@@ -1,0 +1,134 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+new_method = """    fn save_internal(&self, path: &Path) -> Result<()> {
+        // Generate unique suffix for atomic save (timestamp + random if needed, but timestamp is usually enough)
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let suffix = format!("{}", timestamp);
+
+        let index_tmp_path = path.with_extension(format!("usearch.{}.tmp", suffix));
+        let mappings_tmp_path = path.with_extension(format!("usearch.mappings.{}.tmp", suffix));
+        let mappings_path = path.with_extension("usearch.mappings");
+
+        // Acquire save_lock (exclusive) to prevent concurrent adds/removes.
+        // This ensures consistency between the index snapshot and the ID mappings.
+        let _save_guard = self.save_lock.write();
+
+        // Acquire inner write lock to serialize  with concurrent searches.
+        let index = self.inner.write();
+
+        // Collect mappings while holding the locks.
+        // Memory cost: O(N) allocation (~16MB for 1M nodes), acceptable for infrequent save operation.
+        let mappings: Vec<(NodeId, u64)> = self
+            .id_mapping
+            .iter()
+            .map(|e| (*e.key(), *e.value()))
+            .collect();
+        let count = mappings.len();
+
+        // Save usearch index to temporary file
+        index
+            .save(index_tmp_path.to_str().ok_or_else(|| {
+                Error::Vector(VectorError::IndexError(
+                    "Path contains invalid UTF-8".to_string(),
+                ))
+            })?)
+            .map_err(|e| {
+                Error::Vector(VectorError::IndexError(format!(
+                    "Failed to save index to temp file: {}",
+                    e
+                )))
+            })?;
+
+        // Explicit drop to release lock before I/O (mappings write)
+        drop(index);
+        // We drop save_lock here to allow concurrency.
+        // Temp files are unique, so no conflict.
+        drop(_save_guard);
+
+        // Calculate expected size for integrity check (logic preserved)
+        let count_size = count
+            .checked_mul(16)
+            .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
+        let _total_size = count_size
+            .checked_add(4 + 1 + 8 + 1 + 1 + 8 + 4)
+            .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
+
+        // Save mappings to temporary companion file
+        let file = File::create(&mappings_tmp_path).map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to create temp mappings file: {}",
+                e
+            )))
+        })?;
+        let mut writer = BufWriter::new(file);
+
+        // Use Vec iterator instead of DashMap iterator
+        Self::write_mappings_to_writer(&mut writer, mappings.into_iter(), count, &self.config)?;
+
+        // Atomic Rename Sequence: Mappings FIRST, then Index
+        // This ensures that if we crash, we might have (New Mappings, Old Index)
+        // which prevents key collision on recovery (next_key will be high).
+        // If we did Index first, we could have (New Index, Old Mappings),
+        // causing next_key to be low, leading to collisions.
+
+        std::fs::rename(&mappings_tmp_path, &mappings_path).map_err(|e| {
+            // Attempt to clean up temp files on error
+            let _ = std::fs::remove_file(&index_tmp_path);
+            let _ = std::fs::remove_file(&mappings_tmp_path);
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to rename mappings file: {}",
+                e
+            )))
+        })?;
+
+        std::fs::rename(&index_tmp_path, path).map_err(|e| {
+            // Attempt to clean up temp files on error
+            let _ = std::fs::remove_file(&index_tmp_path);
+            // Note: mappings file is already renamed, so we can't rollback easily without risk.
+            // But we are in "New Mappings, Old Index" state, which is safe for collision.
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to rename index file: {}",
+                e
+            )))
+        })?;
+
+        Ok(())
+    }
+"""
+
+start_line = 1611 # 0-indexed, so 1612 -> 1611
+end_line = 1667   # Replaces up to write_mappings_to_writer
+
+# Find start of save_internal
+for i, line in enumerate(lines):
+    if "fn save_internal" in line:
+        start_line = i
+        break
+
+# Find start of write_mappings_to_writer
+for i, line in enumerate(lines):
+    if i > start_line and "fn write_mappings_to_writer" in line:
+        end_line = i
+        break
+
+# Find the end of save_internal (just before write_mappings_to_writer helper method comment)
+# The previous lines has "}" closing the function.
+# Look backwards from end_line
+replace_end = end_line
+while replace_end > start_line:
+    if "/// Helper method" in lines[replace_end-1]:
+        replace_end -= 1
+        break
+    replace_end -= 1
+
+# Replace lines
+lines[start_line:replace_end] = [new_method + "\n"]
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -116,6 +116,7 @@ use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
 
 // Thread-local flag to detect re-entrant modification attempts during filtered search.
@@ -997,99 +998,119 @@ impl VectorIndex for HnswIndex {
                 // This prevents lock ordering inversion (dashmap -> inner is FORBIDDEN)
                 drop(entry);
 
-                // Step 1: Atomically allocate a unique key (no locks held)
-                let key = loop {
-                    let current = self.next_key.load(Ordering::SeqCst);
-                    if current > MAX_VALID_KEY {
+                let mut collisions = 0;
+                loop {
+                    // Step 1: Atomically allocate a unique key (no locks held)
+                    let key = loop {
+                        let current = self.next_key.load(Ordering::SeqCst);
+                        if current > MAX_VALID_KEY {
+                            return Err(Error::Vector(VectorError::IndexError(
+                                "Maximum number of vectors exceeded (key overflow protection)"
+                                    .to_string(),
+                            )));
+                        }
+                        // Try to atomically increment; retry if another thread beat us
+                        match self.next_key.compare_exchange(
+                            current,
+                            current + 1,
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                        ) {
+                            Ok(key) => break key,
+                            Err(_) => continue, // Retry with new current value
+                        }
+                    };
+
+                    // Note: save_lock is already held at start of function.
+
+                    // Step 2: Acquire inner write lock FIRST (follows lock ordering invariant).
+                    // Vacant path updates the index before claiming the map entry (Inner -> Map).
+                    let index = self.inner.write();
+
+                    // Ensure capacity exists. The optimistic check in check_and_expand_capacity
+                    // might have been raced by other threads. Since we hold the write lock now,
+                    // we are the source of truth.
+                    if index.size() >= index.capacity() {
+                        let new_capacity = (index.capacity() * 2).max(1024);
+                        self.retry_usearch(
+                            || index.reserve(new_capacity),
+                            "Failed to expand capacity (race recovery)",
+                        )?;
+                    }
+
+                    // Step 3: Add to inner usearch index while holding write lock
+                    // Handle "Duplicate keys" error by retrying with new key (Robustness fix)
+                    match self.retry_usearch(|| index.add(key, vector), "Failed to add vector") {
+                        Ok(_) => {} // Success, continue
+                        Err(e) => {
+                            if e.to_string().contains("Duplicate keys") {
+                                // Collision detected! (Likely due to persistence mismatch)
+                                // Drop lock, increment retry count, and continue loop to get new key
+                                drop(index);
+                                collisions += 1;
+                                if collisions > 1000 {
+                                    return Err(Error::Vector(VectorError::IndexError(
+                                        "Too many key collisions (index corruption likely)"
+                                            .to_string(),
+                                    )));
+                                }
+                                continue; // Loop again, get new key
+                            }
+                            return Err(e); // Propagate other errors
+                        }
+                    }
+
+                    #[cfg(test)]
+                    {
+                        // Hook to simulate race condition: simulate another thread adding mapping
+                        // after we checked it was vacant but before we inserted our mapping.
+                        if let Some(hook) = TEST_RACE_HOOK.with(|h| h.get()) {
+                            hook(self, id);
+                        }
+                    }
+
+                    // Step 4: Insert to mappings (dashmap) WHILE HOLDING INNER LOCK
+                    // We keep the inner lock held to ensure atomicity with respect to save_internal().
+                    // If we dropped the lock here, save_internal() could run, see the new vector in inner,
+                    // but miss the mapping in id_mapping (Zombie Vector bug).
+                    //
+                    // Lock order check: Inner -> Map (via entry()). This is consistent with other operations.
+                    let race_detected = match self.id_mapping.entry(id) {
+                        dashmap::mapref::entry::Entry::Occupied(_) => true,
+                        dashmap::mapref::entry::Entry::Vacant(e) => {
+                            // Success: we claimed the ID
+                            e.insert(key);
+                            // Drop the entry lock implicitly here when e is consumed/scope ends
+                            false
+                        }
+                    };
+
+                    if race_detected {
+                        // Race detected: Another thread added this NodeId concurrently
+                        // Our vector is in inner with key=key, but someone else claimed the ID.
+                        // We must rollback our addition to avoid phantom vectors.
+
+                        // We already hold the inner write lock, so we can remove directly.
+                        self.retry_usearch(
+                            || index.remove(key),
+                            "Failed to rollback vector after concurrent add",
+                        )?;
                         return Err(Error::Vector(VectorError::IndexError(
-                            "Maximum number of vectors exceeded (key overflow protection)"
+                            "Concurrent add detected for same NodeId, vector already exists"
                                 .to_string(),
                         )));
                     }
-                    // Try to atomically increment; retry if another thread beat us
-                    match self.next_key.compare_exchange(
-                        current,
-                        current + 1,
-                        Ordering::SeqCst,
-                        Ordering::SeqCst,
-                    ) {
-                        Ok(key) => break key,
-                        Err(_) => continue, // Retry with new current value
-                    }
-                };
 
-                // Note: save_lock is already held at start of function.
+                    // If no race, we successfully inserted into id_mapping.
+                    // Now insert reverse mapping.
+                    self.reverse_mapping.insert(key, id);
+                    self.stats.vectors_added.fetch_add(1, Ordering::Relaxed);
 
-                // Step 2: Acquire inner write lock FIRST (follows lock ordering invariant).
-                // Vacant path updates the index before claiming the map entry (Inner -> Map).
-                let index = self.inner.write();
+                    // Explicitly drop index lock (though it would drop at end of scope)
+                    drop(index);
 
-                // Ensure capacity exists. The optimistic check in check_and_expand_capacity
-                // might have been raced by other threads. Since we hold the write lock now,
-                // we are the source of truth.
-                if index.size() >= index.capacity() {
-                    let new_capacity = (index.capacity() * 2).max(1024);
-                    self.retry_usearch(
-                        || index.reserve(new_capacity),
-                        "Failed to expand capacity (race recovery)",
-                    )?;
+                    return Ok(());
                 }
-
-                // Step 3: Add to inner usearch index while holding write lock
-                self.retry_usearch(|| index.add(key, vector), "Failed to add vector")?;
-
-                #[cfg(test)]
-                {
-                    // Hook to simulate race condition: simulate another thread adding mapping
-                    // after we checked it was vacant but before we inserted our mapping.
-                    if let Some(hook) = TEST_RACE_HOOK.with(|h| h.get()) {
-                        hook(self, id);
-                    }
-                }
-
-                // Step 4: Insert to mappings (dashmap) WHILE HOLDING INNER LOCK
-                // We keep the inner lock held to ensure atomicity with respect to save_internal().
-                // If we dropped the lock here, save_internal() could run, see the new vector in inner,
-                // but miss the mapping in id_mapping (Zombie Vector bug).
-                //
-                // Lock order check: Inner -> Map (via entry()). This is consistent with other operations.
-                let race_detected = match self.id_mapping.entry(id) {
-                    dashmap::mapref::entry::Entry::Occupied(_) => true,
-                    dashmap::mapref::entry::Entry::Vacant(e) => {
-                        // Success: we claimed the ID
-                        e.insert(key);
-                        // Drop the entry lock implicitly here when e is consumed/scope ends
-                        false
-                    }
-                };
-
-                if race_detected {
-                    // Race detected: Another thread added this NodeId concurrently
-                    // Our vector is in inner with key=key, but someone else claimed the ID.
-                    // We must rollback our addition to avoid phantom vectors.
-
-                    // We already hold the inner write lock, so we can remove directly.
-                    self.retry_usearch(
-                        || index.remove(key),
-                        "Failed to rollback vector after concurrent add",
-                    )?;
-
-                    // The existing mapping wins; return error to indicate retry needed
-                    return Err(Error::Vector(VectorError::IndexError(
-                        "Concurrent add detected for same NodeId, vector already exists"
-                            .to_string(),
-                    )));
-                }
-
-                // If no race, we successfully inserted into id_mapping.
-                // Now insert reverse mapping.
-                self.reverse_mapping.insert(key, id);
-                self.stats.vectors_added.fetch_add(1, Ordering::Relaxed);
-
-                // Explicitly drop index lock (though it would drop at end of scope)
-                drop(index);
-
-                Ok(())
             }
         }
     }
@@ -1609,6 +1630,17 @@ impl HnswIndex {
     /// - **Binary Index**: Saved directly by usearch C++ library.
     /// - **Mappings File**: Saved by Rust with CRC32 checksum.
     fn save_internal(&self, path: &Path) -> Result<()> {
+        // Generate unique suffix for atomic save
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let suffix = format!("{}", timestamp);
+
+        let index_tmp_path = path.with_extension(format!("usearch.{}.tmp", suffix));
+        let mappings_tmp_path = path.with_extension(format!("usearch.mappings.{}.tmp", suffix));
+        let mappings_path = path.with_extension("usearch.mappings");
+
         // Acquire save_lock (exclusive) to prevent concurrent adds/removes.
         // This ensures consistency between the index snapshot and the ID mappings.
         let _save_guard = self.save_lock.write();
@@ -1625,28 +1657,27 @@ impl HnswIndex {
             .collect();
         let count = mappings.len();
 
+        // Save usearch index to temporary file
         index
-            .save(path.to_str().ok_or_else(|| {
+            .save(index_tmp_path.to_str().ok_or_else(|| {
                 Error::Vector(VectorError::IndexError(
                     "Path contains invalid UTF-8".to_string(),
                 ))
             })?)
             .map_err(|e| {
                 Error::Vector(VectorError::IndexError(format!(
-                    "Failed to save index: {}",
+                    "Failed to save index to temp file: {}",
                     e
                 )))
             })?;
-        // Explicit drop to release lock before I/O
+
+        // Explicit drop to release lock before I/O (mappings write)
         drop(index);
+        // We drop save_lock here to allow concurrency.
+        // Temp files are unique, so no conflict.
         drop(_save_guard);
 
-        // Save mappings to companion file with integrity checks
-        // Format: [MAGIC:4][VERSION:2][DIMS:8][QUANT:1][METRIC:1][COUNT:8][DATA:16*count][CRC32:4]
-        let mappings_path = path.with_extension("usearch.mappings");
-
-        // Calculate total size: Magic(4) + Version(1) + Dims(8) + Quant(1) + Metric(1) + Count(8) + Data(count * 16) + CRC(4)
-        // Use checked arithmetic to prevent overflow
+        // Calculate expected size for integrity check (logic preserved)
         let count_size = count
             .checked_mul(16)
             .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
@@ -1654,17 +1685,46 @@ impl HnswIndex {
             .checked_add(4 + 1 + 8 + 1 + 1 + 8 + 4)
             .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
 
-        // Open file with streaming writer
-        let file = File::create(&mappings_path).map_err(|e| {
+        // Save mappings to temporary companion file
+        let file = File::create(&mappings_tmp_path).map_err(|e| {
             Error::Vector(VectorError::IndexError(format!(
-                "Failed to create mappings file: {}",
+                "Failed to create temp mappings file: {}",
                 e
             )))
         })?;
         let mut writer = BufWriter::new(file);
 
         // Use Vec iterator instead of DashMap iterator
-        Self::write_mappings_to_writer(&mut writer, mappings.into_iter(), count, &self.config)
+        Self::write_mappings_to_writer(&mut writer, mappings.into_iter(), count, &self.config)?;
+
+        // Atomic Rename Sequence: Mappings FIRST, then Index
+        // This ensures that if we crash, we might have (New Mappings, Old Index)
+        // which prevents key collision on recovery (next_key will be high).
+        // If we did Index first, we could have (New Index, Old Mappings),
+        // causing next_key to be low, leading to collisions.
+
+        std::fs::rename(&mappings_tmp_path, &mappings_path).map_err(|e| {
+            // Attempt to clean up temp files on error
+            let _ = std::fs::remove_file(&index_tmp_path);
+            let _ = std::fs::remove_file(&mappings_tmp_path);
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to rename mappings file: {}",
+                e
+            )))
+        })?;
+
+        std::fs::rename(&index_tmp_path, path).map_err(|e| {
+            // Attempt to clean up temp files on error
+            let _ = std::fs::remove_file(&index_tmp_path);
+            // Note: mappings file is already renamed, so we can't rollback easily without risk.
+            // But we are in "New Mappings, Old Index" state, which is safe for collision.
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to rename index file: {}",
+                e
+            )))
+        })?;
+
+        Ok(())
     }
 
     /// Helper method to stream mappings to a writer with CRC calculation.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -3559,7 +3559,7 @@ mod tests {
 
         assert!(result.is_err());
         if let Err(Error::Vector(VectorError::IndexError(msg))) = result {
-            assert!(msg.contains("Failed to create mappings file"));
+            assert!(msg.contains("Failed to create mappings file") || msg.contains("Failed to rename mappings file"));
         } else {
             // Note: Depending on OS, saving the index itself might fail first if index_path is valid but related calls fail.
             // But here index_path is valid (does not exist). usearch index save should succeed.

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -3559,7 +3559,10 @@ mod tests {
 
         assert!(result.is_err());
         if let Err(Error::Vector(VectorError::IndexError(msg))) = result {
-            assert!(msg.contains("Failed to create mappings file") || msg.contains("Failed to rename mappings file"));
+            assert!(
+                msg.contains("Failed to create mappings file")
+                    || msg.contains("Failed to rename mappings file")
+            );
         } else {
             // Note: Depending on OS, saving the index itself might fail first if index_path is valid but related calls fail.
             // But here index_path is valid (does not exist). usearch index save should succeed.
@@ -4385,5 +4388,112 @@ mod coverage_additions {
 
         assert!(path.exists());
         assert!(path.with_extension("usearch.mappings").exists());
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_collision_recovery_limit() {
+        let index = HnswIndexBuilder::new(2, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+
+        // Manually occupy keys 0..1100 in the internal index to force collisions
+        // next_key starts at 0.
+        {
+            let inner = index.inner.write();
+            // We need to use usearch API directly to bypass next_key updates
+            // But we can't easily access usearch internals from here if they are not exposed.
+            // HnswIndex wraps `usearch::Index`.
+            // We can use `inner.add(key, vector)` directly?
+            // HnswIndex::inner is Arc<RwLock<Index>>.
+            // We can add vectors directly.
+
+            for i in 0..1100 {
+                inner.add(i, &[1.0, 0.0]).unwrap();
+            }
+        }
+
+        // Now try to add a NEW node via public API.
+        // It will try key=0 (collision), key=1 (collision)... key=1000 (collision).
+        // Should eventually fail with "Too many key collisions"
+        let result = index.add(NodeId::new(1).unwrap(), &[0.0, 1.0]);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(
+                    msg.contains("Too many key collisions"),
+                    "Got error: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Too many key collisions error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_save_index_rename_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let index = HnswIndexBuilder::new(2, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+
+        // Setup paths
+        let index_path = dir.path().join("test.index");
+
+        // Create a directory at index_path to force index rename failure
+        fs::create_dir(&index_path).unwrap();
+
+        // mappings_path will be "test.usearch.mappings"
+        // This path is free, so mappings rename should SUCCEED.
+
+        let result = index.save(&index_path);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(
+                    msg.contains("Failed to rename index file"),
+                    "Got error: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected rename index file error, got {:?}", result),
+        }
+
+        // Verify mappings file exists (it was renamed successfully)
+        let mappings_path = index_path.with_extension("usearch.mappings");
+        assert!(mappings_path.exists());
+    }
+
+    #[test]
+    fn test_save_internal_temp_create_error() {
+        let index = HnswIndexBuilder::new(2, DistanceMetric::Cosine)
+            .build()
+            .unwrap();
+
+        // Use a path in a non-existent directory
+        // On Linux, /nonexistent/ usually doesn't exist.
+        // Or use a relative path with missing parent.
+        let path = Path::new("nonexistent_dir/test.index");
+
+        let result = index.save(path);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::Vector(VectorError::IndexError(msg))) => {
+                assert!(
+                    msg.contains("Failed to save index to temp file"),
+                    "Got error: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected save index temp file error, got {:?}", result),
+        }
     }
 }

--- a/update_hnsw.py
+++ b/update_hnsw.py
@@ -1,0 +1,129 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+start_idx = 1611  # line 1612 (0-indexed)
+end_idx = 1711    # line 1712
+
+# Find the start of write_mappings_to_writer
+for i in range(start_idx, len(lines)):
+    if "fn write_mappings_to_writer" in lines[i]:
+        end_idx = i
+        break
+
+# Back up to the comment above it
+# /// Helper method ...
+while end_idx > start_idx:
+    if "/// Helper method" in lines[end_idx-1]:
+        end_idx -= 1
+        break
+    end_idx -= 1
+
+# Verify we are removing the right function
+print(f"Replacing lines {start_idx+1} to {end_idx}")
+
+new_code = """    fn save_internal(&self, path: &Path) -> Result<()> {
+        // Generate unique suffix for atomic save
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let suffix = format!("{}", timestamp);
+
+        let index_tmp_path = path.with_extension(format!("usearch.{}.tmp", suffix));
+        let mappings_tmp_path = path.with_extension(format!("usearch.mappings.{}.tmp", suffix));
+        let mappings_path = path.with_extension("usearch.mappings");
+
+        // Acquire save_lock (exclusive) to prevent concurrent adds/removes.
+        // This ensures consistency between the index snapshot and the ID mappings.
+        let _save_guard = self.save_lock.write();
+
+        // Acquire inner write lock to serialize `save` with concurrent searches.
+        let index = self.inner.write();
+
+        // Collect mappings while holding the locks.
+        // Memory cost: O(N) allocation (~16MB for 1M nodes), acceptable for infrequent save operation.
+        let mappings: Vec<(NodeId, u64)> = self
+            .id_mapping
+            .iter()
+            .map(|e| (*e.key(), *e.value()))
+            .collect();
+        let count = mappings.len();
+
+        // Save usearch index to temporary file
+        index
+            .save(index_tmp_path.to_str().ok_or_else(|| {
+                Error::Vector(VectorError::IndexError(
+                    "Path contains invalid UTF-8".to_string(),
+                ))
+            })?)
+            .map_err(|e| {
+                Error::Vector(VectorError::IndexError(format!(
+                    "Failed to save index to temp file: {}",
+                    e
+                )))
+            })?;
+
+        // Explicit drop to release lock before I/O (mappings write)
+        drop(index);
+        // We drop save_lock here to allow concurrency.
+        // Temp files are unique, so no conflict.
+        drop(_save_guard);
+
+        // Calculate expected size for integrity check (logic preserved)
+        let count_size = count
+            .checked_mul(16)
+            .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
+        let _total_size = count_size
+            .checked_add(4 + 1 + 8 + 1 + 1 + 8 + 4)
+            .ok_or_else(|| Error::Vector(VectorError::IndexError("Index too large".to_string())))?;
+
+        // Save mappings to temporary companion file
+        let file = File::create(&mappings_tmp_path).map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to create temp mappings file: {}",
+                e
+            )))
+        })?;
+        let mut writer = BufWriter::new(file);
+
+        // Use Vec iterator instead of DashMap iterator
+        Self::write_mappings_to_writer(&mut writer, mappings.into_iter(), count, &self.config)?;
+
+        // Atomic Rename Sequence: Mappings FIRST, then Index
+        // This ensures that if we crash, we might have (New Mappings, Old Index)
+        // which prevents key collision on recovery (next_key will be high).
+        // If we did Index first, we could have (New Index, Old Mappings),
+        // causing next_key to be low, leading to collisions.
+
+        std::fs::rename(&mappings_tmp_path, &mappings_path).map_err(|e| {
+            // Attempt to clean up temp files on error
+            let _ = std::fs::remove_file(&index_tmp_path);
+            let _ = std::fs::remove_file(&mappings_tmp_path);
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to rename mappings file: {}",
+                e
+            )))
+        })?;
+
+        std::fs::rename(&index_tmp_path, path).map_err(|e| {
+            // Attempt to clean up temp files on error
+            let _ = std::fs::remove_file(&index_tmp_path);
+            // Note: mappings file is already renamed, so we can't rollback easily without risk.
+            // But we are in "New Mappings, Old Index" state, which is safe for collision.
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to rename index file: {}",
+                e
+            )))
+        })?;
+
+        Ok(())
+    }
+
+"""
+
+lines[start_idx:end_idx] = [new_code]
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)

--- a/update_hnsw_add.py
+++ b/update_hnsw_add.py
@@ -1,0 +1,159 @@
+import sys
+
+with open("src/index/vector/hnsw.rs", "r") as f:
+    lines = f.readlines()
+
+start_idx = 991  # line 992 (0-indexed)
+end_idx = 1089   # line 1090 (approx)
+
+# Find the start of Vacant branch
+for i, line in enumerate(lines):
+    if "dashmap::mapref::entry::Entry::Vacant(entry) => {" in line:
+        start_idx = i
+        break
+
+# Find the end of Vacant branch
+# It should end with `            }` before `        }` before `    }` before `}`
+# We look for the closing brace that matches the indentation of `Vacant`.
+# Indentation of `Vacant` line is 12 spaces.
+for i in range(start_idx + 1, len(lines)):
+    if lines[i].startswith("            }"):
+        end_idx = i + 1
+        break
+
+print(f"Replacing lines {start_idx+1} to {end_idx}")
+
+new_code = """            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                // New node: allocate key with overflow protection
+                // Check BEFORE incrementing to avoid leaving next_key in invalid state
+                const MAX_VALID_KEY: u64 = u64::MAX - 1000;
+
+                // CRITICAL: Drop the entry to release DashMap lock BEFORE acquiring inner lock
+                // This prevents lock ordering inversion (dashmap -> inner is FORBIDDEN)
+                drop(entry);
+
+                let mut collisions = 0;
+                loop {
+                    // Step 1: Atomically allocate a unique key (no locks held)
+                    let key = loop {
+                        let current = self.next_key.load(Ordering::SeqCst);
+                        if current > MAX_VALID_KEY {
+                            return Err(Error::Vector(VectorError::IndexError(
+                                "Maximum number of vectors exceeded (key overflow protection)"
+                                    .to_string(),
+                            )));
+                        }
+                        // Try to atomically increment; retry if another thread beat us
+                        match self.next_key.compare_exchange(
+                            current,
+                            current + 1,
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                        ) {
+                            Ok(key) => break key,
+                            Err(_) => continue, // Retry with new current value
+                        }
+                    };
+
+                    // Note: save_lock is already held at start of function.
+
+                    // Step 2: Acquire inner write lock FIRST (follows lock ordering invariant).
+                    // Vacant path updates the index before claiming the map entry (Inner -> Map).
+                    let index = self.inner.write();
+
+                    // Ensure capacity exists. The optimistic check in check_and_expand_capacity
+                    // might have been raced by other threads. Since we hold the write lock now,
+                    // we are the source of truth.
+                    if index.size() >= index.capacity() {
+                        let new_capacity = (index.capacity() * 2).max(1024);
+                        if let Err(e) = self.retry_usearch(
+                            || index.reserve(new_capacity),
+                            "Failed to expand capacity (race recovery)",
+                        ) {
+                            return Err(e);
+                        }
+                    }
+
+                    // Step 3: Add to inner usearch index while holding write lock
+                    // Handle "Duplicate keys" error by retrying with new key (Robustness fix)
+                    match self.retry_usearch(|| index.add(key, vector), "Failed to add vector") {
+                        Ok(_) => {}, // Success, continue
+                        Err(e) => {
+                            if e.to_string().contains("Duplicate keys") {
+                                // Collision detected! (Likely due to persistence mismatch)
+                                // Drop lock, increment retry count, and continue loop to get new key
+                                drop(index);
+                                collisions += 1;
+                                if collisions > 1000 {
+                                    return Err(Error::Vector(VectorError::IndexError(
+                                        "Too many key collisions (index corruption likely)".to_string()
+                                    )));
+                                }
+                                continue; // Loop again, get new key
+                            }
+                            return Err(e); // Propagate other errors
+                        }
+                    }
+
+                    #[cfg(test)]
+                    {
+                        // Hook to simulate race condition: simulate another thread adding mapping
+                        // after we checked it was vacant but before we inserted our mapping.
+                        if let Some(hook) = TEST_RACE_HOOK.with(|h| h.get()) {
+                            hook(self, id);
+                        }
+                    }
+
+                    // Step 4: Insert to mappings (dashmap) WHILE HOLDING INNER LOCK
+                    // We keep the inner lock held to ensure atomicity with respect to save_internal().
+                    // If we dropped the lock here, save_internal() could run, see the new vector in inner,
+                    // but miss the mapping in id_mapping (Zombie Vector bug).
+                    //
+                    // Lock order check: Inner -> Map (via entry()). This is consistent with other operations.
+                    let race_detected = match self.id_mapping.entry(id) {
+                        dashmap::mapref::entry::Entry::Occupied(_) => true,
+                        dashmap::mapref::entry::Entry::Vacant(e) => {
+                            // Success: we claimed the ID
+                            e.insert(key);
+                            // Drop the entry lock implicitly here when e is consumed/scope ends
+                            false
+                        }
+                    };
+
+                    if race_detected {
+                        // Race detected: Another thread added this NodeId concurrently
+                        // Our vector is in inner with key=key, but someone else claimed the ID.
+                        // We must rollback our addition to avoid phantom vectors.
+
+                        // We already hold the inner write lock, so we can remove directly.
+                        if let Err(e) = self.retry_usearch(
+                            || index.remove(key),
+                            "Failed to rollback vector after concurrent add",
+                        ) {
+                            return Err(e);
+                        }
+
+                        // The existing mapping wins; return error to indicate retry needed
+                        return Err(Error::Vector(VectorError::IndexError(
+                            "Concurrent add detected for same NodeId, vector already exists"
+                                .to_string(),
+                        )));
+                    }
+
+                    // If no race, we successfully inserted into id_mapping.
+                    // Now insert reverse mapping.
+                    self.reverse_mapping.insert(key, id);
+                    self.stats.vectors_added.fetch_add(1, Ordering::Relaxed);
+
+                    // Explicitly drop index lock (though it would drop at end of scope)
+                    drop(index);
+
+                    return Ok(());
+                }
+            }
+"""
+
+lines[start_idx:end_idx] = [new_code + "\n"]
+
+with open("src/index/vector/hnsw.rs", "w") as f:
+    f.writelines(lines)


### PR DESCRIPTION
Implemented atomic save for HNSW index using temporary files and rename to prevent index corruption on crash.
Added collision recovery logic in `add()` to handle "Duplicate keys" error by retrying with a new key, robustifying against stale mappings.
Verified with reproduction test case and existing regression tests.

---
*PR created automatically by Jules for task [8053657899299848668](https://jules.google.com/task/8053657899299848668) started by @madmax983*