### PR TITLE
fix(temporal-vector): remove incorrect full_snapshot_interval restriction

### DIFF
--- a/src/index/vector/temporal/config.rs
+++ b/src/index/vector/temporal/config.rs
@@ -10,14 +10,13 @@ use std::time::Duration;
 /// Maximum number of retries when creating a snapshot due to races (default: 3)
 pub const MAX_SNAPSHOT_RETRIES: usize = 3;
 
-/// Maximum depth of delta chain traversal before forcing full snapshot.
-/// Increased from 10 to 50 to support business scenarios:
-/// - Frequently updated embeddings (re-training cycles, continuous learning)
-/// - Live document embeddings with frequent updates
-/// - A/B testing with multiple variant updates
+/// Safety limit for delta chain traversal.
 ///
-///   This prevents unbounded delta chains while reducing compaction frequency
-///   for high-update workloads.
+/// **Note**: This value does NOT limit `full_snapshot_interval`. The implementation enforces a
+/// "Star Topology" where all delta snapshots point directly to the last full snapshot (depth=1).
+///
+/// This constant is used only as a safety sentinel during traversal to prevent infinite loops
+/// in case of memory corruption or future implementation changes that might introduce chains.
 pub const MAX_DELTA_CHAIN_DEPTH: usize = 50;
 
 /// Minimum capacity estimate for HashMap pre-allocation (default: 100)
@@ -98,23 +97,8 @@ impl TemporalVectorConfig {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - `full_snapshot_interval` exceeds `MAX_DELTA_CHAIN_DEPTH`
     /// - `max_snapshots` is 0
-    ///
-    /// # Safety
-    /// This validation prevents delta chain depth from exceeding the hard limit,
-    /// which would cause get_vector() and to_hashmap() to return partial/empty results.
     pub fn validate(&self) -> Result<()> {
-        if self.full_snapshot_interval > MAX_DELTA_CHAIN_DEPTH {
-            return Err(VectorError::IndexError(format!(
-                "full_snapshot_interval ({}) exceeds MAX_DELTA_CHAIN_DEPTH ({}). \
-                     This would cause delta chains to exceed traversal depth limits, \
-                     leading to silent data loss. Reduce full_snapshot_interval to at most {}.",
-                self.full_snapshot_interval, MAX_DELTA_CHAIN_DEPTH, MAX_DELTA_CHAIN_DEPTH
-            ))
-            .into());
-        }
-
         if self.max_snapshots == 0 {
             return Err(
                 VectorError::IndexError("max_snapshots must be at least 1".to_string()).into(),

--- a/src/index/vector/temporal/mod.rs
+++ b/src/index/vector/temporal/mod.rs
@@ -3415,28 +3415,23 @@ mod tests {
     // ==================== Config Validation Tests ====================
 
     #[test]
-    fn test_config_validation_full_snapshot_interval_too_large() {
+    fn test_config_validation_full_snapshot_interval_allowed_large() {
+        // This test verifies that we can set full_snapshot_interval > MAX_DELTA_CHAIN_DEPTH
+        // because the implementation uses a Star Topology (depth=1), so large intervals
+        // do not cause deep traversals.
         let config = TemporalVectorConfig {
             snapshot_strategy: SnapshotStrategy::TransactionInterval(10),
             retention_policy: RetentionPolicy::KeepN(100),
             max_snapshots: 100,
-            full_snapshot_interval: 100, // Exceeds MAX_DELTA_CHAIN_DEPTH (10)
+            full_snapshot_interval: 100, // Exceeds MAX_DELTA_CHAIN_DEPTH (50)
             hnsw_config: Some(HnswConfig::new(4, DistanceMetric::Cosine)),
         };
 
         let result = TemporalVectorIndex::new(config);
         assert!(
-            result.is_err(),
-            "Should reject config with full_snapshot_interval > MAX_DELTA_CHAIN_DEPTH"
+            result.is_ok(),
+            "Should accept config with large full_snapshot_interval"
         );
-
-        if let Err(err) = result {
-            let err_msg = err.to_string();
-            assert!(
-                err_msg.contains("exceeds MAX_DELTA_CHAIN_DEPTH"),
-                "Error message should mention MAX_DELTA_CHAIN_DEPTH"
-            );
-        }
     }
 
     #[test]
@@ -3617,25 +3612,17 @@ mod tests {
             snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
             retention_policy: RetentionPolicy::KeepN(50),
             max_snapshots: 50,
-            full_snapshot_interval: 100, // Would normally never create full snapshots
+            full_snapshot_interval: 100, // High interval, should rely on memory fallback
             hnsw_config: Some(HnswConfig::new(4, DistanceMetric::Cosine)),
         };
 
-        // This should fail due to validation (full_snapshot_interval > MAX_DELTA_CHAIN_DEPTH)
-        let result = TemporalVectorIndex::new(config);
-        assert!(result.is_err(), "Should reject invalid config");
-
-        // Use valid config instead
-        let config = TemporalVectorConfig {
-            snapshot_strategy: SnapshotStrategy::TransactionInterval(1),
-            retention_policy: RetentionPolicy::KeepN(50),
-            max_snapshots: 50,
-            full_snapshot_interval: 10, // Valid
-            hnsw_config: Some(HnswConfig::new(4, DistanceMetric::Cosine)),
-        };
         let index = TemporalVectorIndex::new_at(config, 1000.into())?;
 
-        // Add vectors - with full_snapshot_interval=10, we get full snapshots periodically
+        // Add vectors - with full_snapshot_interval=100, we normally wouldn't snapshot fully
+        // until 100 snapshots. But we want to test if memory limits force one earlier.
+        // NOTE: Since MAX_ACCUMULATED_CHANGES is 100,000, we can't easily trigger it
+        // in a unit test without mocking constants or adding huge data.
+        // Instead, we verify that the config is now accepted.
         for i in 0..15 {
             let node_id = NodeId::new(i as u64).unwrap();
             let timestamp = 1000 + (i * 100);

--- a/tests/verify_config_limit.rs
+++ b/tests/verify_config_limit.rs
@@ -1,9 +1,9 @@
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::DistanceMetric;
 use aletheiadb::index::vector::hnsw::HnswConfig;
 use aletheiadb::index::vector::temporal::{
     RetentionPolicy, SnapshotStrategy, TemporalVectorConfig, TemporalVectorIndex,
 };
-use aletheiadb::index::vector::DistanceMetric;
 
 #[test]
 fn test_large_full_snapshot_interval() -> aletheiadb::core::error::Result<()> {
@@ -29,11 +29,7 @@ fn test_large_full_snapshot_interval() -> aletheiadb::core::error::Result<()> {
         let node_id = NodeId::new(i as u64).unwrap();
         let timestamp = (1000 + i * 100) as i64;
 
-        index.add(
-            node_id,
-            &[1.0, 0.0, 0.0, 0.0],
-            timestamp.into(),
-        )?;
+        index.add(node_id, &[1.0, 0.0, 0.0, 0.0], timestamp.into())?;
         index.on_transaction_at(timestamp.into())?;
     }
 

--- a/tests/verify_config_limit.rs
+++ b/tests/verify_config_limit.rs
@@ -1,0 +1,50 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::hnsw::HnswConfig;
+use aletheiadb::index::vector::temporal::{
+    RetentionPolicy, SnapshotStrategy, TemporalVectorConfig, TemporalVectorIndex,
+};
+use aletheiadb::index::vector::DistanceMetric;
+
+#[test]
+fn test_large_full_snapshot_interval() -> aletheiadb::core::error::Result<()> {
+    // This test verifies that we can use a full_snapshot_interval significantly larger than
+    // the safety sentinel MAX_DELTA_CHAIN_DEPTH (50).
+    let interval = 100;
+
+    let config = TemporalVectorConfig {
+        snapshot_strategy: SnapshotStrategy::TransactionInterval(1), // Snapshot every txn
+        retention_policy: RetentionPolicy::KeepAll,
+        max_snapshots: 200,
+        full_snapshot_interval: interval,
+        hnsw_config: Some(HnswConfig::new(4, DistanceMetric::Cosine)),
+    };
+
+    // Should succeed (validation removed)
+    let index = TemporalVectorIndex::new(config)?;
+
+    // Create more snapshots than the safety limit (50) but less than interval (100)
+    // All of these should be Delta snapshots pointing to the same base (Star Topology).
+    // If the implementation incorrectly chained them, we would hit the safety limit around snapshot 50.
+    for i in 0..70 {
+        let node_id = NodeId::new(i as u64).unwrap();
+        let timestamp = (1000 + i * 100) as i64;
+
+        index.add(
+            node_id,
+            &[1.0, 0.0, 0.0, 0.0],
+            timestamp.into(),
+        )?;
+        index.on_transaction_at(timestamp.into())?;
+    }
+
+    assert_eq!(index.snapshot_count(), 70);
+
+    // Verify we can query the latest snapshot (depth should be 1, not 70)
+    let query = vec![1.0, 0.0, 0.0, 0.0];
+    let latest_timestamp = (1000 + 69 * 100) as i64;
+    let results = index.find_similar_as_of(&query, 10, latest_timestamp.into())?;
+
+    assert!(!results.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
Removed the artificial restriction on `full_snapshot_interval` in `TemporalVectorConfig`. The previous limit of 50 (`MAX_DELTA_CHAIN_DEPTH`) was based on an incorrect assumption about delta snapshot chaining. The implementation uses a "Star Topology" (depth=1), so larger intervals are safe and allow for memory optimizations. Added verification tests.

---
*PR created automatically by Jules for task [534281088487944300](https://jules.google.com/task/534281088487944300) started by @madmax983*