### PR TITLE
test: Add Sentinel tests for query operation ordering

### DIFF
--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -2030,4 +2030,48 @@ mod sentry_tests {
         assert!(has_start_node, "Should use StartNode");
         assert!(has_label_filter, "Should preserve 'Secret' label check");
     }
+
+    #[test]
+    fn test_pagination_order() {
+        // 🎯 Target: convert_pagination order (Skip before Limit)
+        // 💣 Risk: Semantic change (Skip 5 then Take 10 vs Take 10 then Skip 5)
+        // 🧪 Strategy: Parse query with both and check IR order
+
+        let ast = Parser::parse("MATCH (n) RETURN n SKIP 5 LIMIT 10").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let skip_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Skip(_)));
+        let limit_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Limit(_)));
+
+        assert!(skip_idx.is_some(), "Skip op missing");
+        assert!(limit_idx.is_some(), "Limit op missing");
+
+        assert!(
+            skip_idx.unwrap() < limit_idx.unwrap(),
+            "Skip operation must precede Limit operation"
+        );
+    }
+
+    #[test]
+    fn test_filter_before_project() {
+        // 🎯 Target: Pipeline order (Filter before Project)
+        // 💣 Risk: Filtering on projected-away columns
+        // 🧪 Strategy: Parse query with WHERE and RETURN specific property
+
+        let ast = Parser::parse("MATCH (n) WHERE n.age > 10 RETURN n.name").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let filter_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Filter(_)));
+        let project_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Project(_)));
+
+        assert!(filter_idx.is_some(), "Filter op missing");
+        assert!(project_idx.is_some(), "Project op missing");
+
+        assert!(
+            filter_idx.unwrap() < project_idx.unwrap(),
+            "Filter operation must precede Project operation"
+        );
+    }
 }

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -2041,8 +2041,14 @@ mod sentry_tests {
         let converter = AstConverter::new();
         let query = converter.convert(&ast).unwrap();
 
-        let skip_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Skip(_)));
-        let limit_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Limit(_)));
+        let skip_idx = query
+            .ops
+            .iter()
+            .position(|op| matches!(op, QueryOp::Skip(_)));
+        let limit_idx = query
+            .ops
+            .iter()
+            .position(|op| matches!(op, QueryOp::Limit(_)));
 
         assert!(skip_idx.is_some(), "Skip op missing");
         assert!(limit_idx.is_some(), "Limit op missing");
@@ -2063,8 +2069,14 @@ mod sentry_tests {
         let converter = AstConverter::new();
         let query = converter.convert(&ast).unwrap();
 
-        let filter_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Filter(_)));
-        let project_idx = query.ops.iter().position(|op| matches!(op, QueryOp::Project(_)));
+        let filter_idx = query
+            .ops
+            .iter()
+            .position(|op| matches!(op, QueryOp::Filter(_)));
+        let project_idx = query
+            .ops
+            .iter()
+            .position(|op| matches!(op, QueryOp::Project(_)));
 
         assert!(filter_idx.is_some(), "Filter op missing");
         assert!(project_idx.is_some(), "Project op missing");


### PR DESCRIPTION
🤖 **Sentinel Report**

I have analyzed the `src/query/converter.rs` module and identified a potential weakness in the test suite: the order of query operations in the generated IR is not explicitly verified by existing tests.

**The Gap:**
A mutation that swaps `SKIP` and `LIMIT` (or `FILTER` and `PROJECT`) would change query semantics but might pass existing tests that only check for the *presence* of these operations or rely on simple end-to-end results.

**The Kill Shot:**
I added two targeted "Sentinel" tests to `src/query/converter.rs` (`mod sentry_tests`):
1.  `test_pagination_order`: Verifies that `QueryOp::Skip` appears before `QueryOp::Limit` in the operator list.
2.  `test_filter_before_project`: Verifies that `QueryOp::Filter` appears before `QueryOp::Project`.

These tests lock in the correct execution order at the IR level, ensuring correctness even if implementation details change.

**Verification:**
Ran `cargo test query::converter::sentry_tests` and verified all tests pass.
Ran `cargo test query::converter::tests` to ensure no regressions.

**Note:** `cargo mutants` scans were attempted but timed out in this environment. I proceeded with manual mutant analysis and targeted test creation based on Sentinel principles.

---
*PR created automatically by Jules for task [1112681782746923064](https://jules.google.com/task/1112681782746923064) started by @madmax983*