### PR TITLE
fix: Prevent silent data corruption in cold storage serialization

### DIFF
--- a/src/storage/redb_cold_storage.rs
+++ b/src/storage/redb_cold_storage.rs
@@ -438,7 +438,7 @@ impl RedbColdStorage {
             versions
                 .par_iter()
                 .map(|version| {
-                    let encoded = encode_node_version(version);
+                    let encoded = encode_node_version(version)?;
                     let raw_size = encoded.len() as u64;
                     let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
                     let compressed_size = compressed.len() as u64;
@@ -454,7 +454,7 @@ impl RedbColdStorage {
             versions
                 .iter()
                 .map(|version| {
-                    let encoded = encode_node_version(version);
+                    let encoded = encode_node_version(version)?;
                     let raw_size = encoded.len() as u64;
                     let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
                     let compressed_size = compressed.len() as u64;
@@ -492,7 +492,7 @@ impl RedbColdStorage {
             versions
                 .par_iter()
                 .map(|version| {
-                    let encoded = encode_edge_version(version);
+                    let encoded = encode_edge_version(version)?;
                     let raw_size = encoded.len() as u64;
                     let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
                     let compressed_size = compressed.len() as u64;
@@ -508,7 +508,7 @@ impl RedbColdStorage {
             versions
                 .iter()
                 .map(|version| {
-                    let encoded = encode_edge_version(version);
+                    let encoded = encode_edge_version(version)?;
                     let raw_size = encoded.len() as u64;
                     let compressed = crate::storage::compression::compress(&encoded, &cold_config)?;
                     let compressed_size = compressed.len() as u64;
@@ -634,7 +634,7 @@ impl RedbColdStorage {
     pub fn store_node_version(&self, version: &NodeVersion) -> Result<()> {
         self.check_fail_writes()?;
 
-        let encoded = encode_node_version(version);
+        let encoded = encode_node_version(version)?;
         let raw_size = encoded.len();
         let compressed = self.compress(&encoded)?;
         let compressed_size = compressed.len();
@@ -724,7 +724,7 @@ impl RedbColdStorage {
     pub fn store_edge_version(&self, version: &EdgeVersion) -> Result<()> {
         self.check_fail_writes()?;
 
-        let encoded = encode_edge_version(version);
+        let encoded = encode_edge_version(version)?;
         let raw_size = encoded.len();
         let compressed = self.compress(&encoded)?;
         let compressed_size = compressed.len();
@@ -1212,8 +1212,17 @@ enum SerializablePropertyValue {
 /// Encode a NodeVersion to bytes for storage.
 ///
 /// This function is public for use by all cold storage implementations.
-pub fn encode_node_version(version: &NodeVersion) -> Vec<u8> {
+pub fn encode_node_version(version: &NodeVersion) -> Result<Vec<u8>> {
     use crate::core::interning::GLOBAL_INTERNER;
+
+    let label = GLOBAL_INTERNER
+        .resolve_with(version.label, |s| s.to_string())
+        .ok_or_else(|| {
+            StorageError::corruption(format!(
+                "Failed to resolve interned label ID {:?} for NodeVersion {:?}",
+                version.label, version.id
+            ))
+        })?;
 
     let serializable = SerializableNodeVersion {
         id: version.id.as_u64(),
@@ -1222,15 +1231,13 @@ pub fn encode_node_version(version: &NodeVersion) -> Vec<u8> {
         temporal_valid_end: version.temporal.valid_time().end().wallclock(),
         temporal_tx_start: version.temporal.transaction_time().start().wallclock(),
         temporal_tx_end: version.temporal.transaction_time().end().wallclock(),
-        label: GLOBAL_INTERNER
-            .resolve_with(version.label, |s| s.to_string())
-            .unwrap_or_default(),
-        data: encode_version_data(&version.data),
+        label,
+        data: encode_version_data(&version.data)?,
         next_version: version.next_version.map(|v| v.as_u64()),
         prev_version: version.prev_version.map(|v| v.as_u64()),
     };
 
-    bitcode::encode(&serializable)
+    Ok(bitcode::encode(&serializable))
 }
 
 /// Decode a NodeVersion from bytes.
@@ -1282,8 +1289,17 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
 /// Encode an EdgeVersion to bytes for storage.
 ///
 /// This function is public for use by all cold storage implementations.
-pub fn encode_edge_version(version: &EdgeVersion) -> Vec<u8> {
+pub fn encode_edge_version(version: &EdgeVersion) -> Result<Vec<u8>> {
     use crate::core::interning::GLOBAL_INTERNER;
+
+    let label = GLOBAL_INTERNER
+        .resolve_with(version.label, |s| s.to_string())
+        .ok_or_else(|| {
+            StorageError::corruption(format!(
+                "Failed to resolve interned label ID {:?} for EdgeVersion {:?}",
+                version.label, version.id
+            ))
+        })?;
 
     let serializable = SerializableEdgeVersion {
         id: version.id.as_u64(),
@@ -1292,17 +1308,15 @@ pub fn encode_edge_version(version: &EdgeVersion) -> Vec<u8> {
         temporal_valid_end: version.temporal.valid_time().end().wallclock(),
         temporal_tx_start: version.temporal.transaction_time().start().wallclock(),
         temporal_tx_end: version.temporal.transaction_time().end().wallclock(),
-        label: GLOBAL_INTERNER
-            .resolve_with(version.label, |s| s.to_string())
-            .unwrap_or_default(),
+        label,
         source: version.source.as_u64(),
         target: version.target.as_u64(),
-        data: encode_version_data(&version.data),
+        data: encode_version_data(&version.data)?,
         next_version: version.next_version.map(|v| v.as_u64()),
         prev_version: version.prev_version.map(|v| v.as_u64()),
     };
 
-    bitcode::encode(&serializable)
+    Ok(bitcode::encode(&serializable))
 }
 
 /// Decode an EdgeVersion from bytes.
@@ -1355,7 +1369,9 @@ pub fn decode_edge_version(data: &[u8]) -> Result<EdgeVersion> {
     })
 }
 
-fn encode_version_data(data: &crate::storage::version::VersionData) -> SerializableVersionData {
+fn encode_version_data(
+    data: &crate::storage::version::VersionData,
+) -> Result<SerializableVersionData> {
     use crate::core::interning::GLOBAL_INTERNER;
     use crate::storage::version::VersionData;
 
@@ -1363,43 +1379,57 @@ fn encode_version_data(data: &crate::storage::version::VersionData) -> Serializa
         VersionData::Anchor {
             properties,
             vector_snapshot_id,
-        } => SerializableVersionData::Anchor {
-            properties: properties
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        GLOBAL_INTERNER
-                            .resolve_with(*k, |s| s.to_string())
-                            .unwrap_or_default(),
-                        encode_property_value(v),
-                    )
-                })
-                .collect(),
-            vector_snapshot_id: vector_snapshot_id.map(|id| id as u64),
-        },
-        VersionData::Delta { delta } => SerializableVersionData::Delta {
-            changed: delta
-                .changed
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        GLOBAL_INTERNER
-                            .resolve_with(*k, |s| s.to_string())
-                            .unwrap_or_default(),
-                        encode_property_value(v),
-                    )
-                })
-                .collect(),
-            removed: delta
-                .removed
-                .iter()
-                .map(|k| {
-                    GLOBAL_INTERNER
-                        .resolve_with(*k, |s| s.to_string())
-                        .unwrap_or_default()
-                })
-                .collect(),
-        },
+        } => {
+            let mut encoded_properties = Vec::with_capacity(properties.len());
+            for (k, v) in properties.iter() {
+                let key_str = GLOBAL_INTERNER
+                    .resolve_with(*k, |s| s.to_string())
+                    .ok_or_else(|| {
+                        StorageError::corruption(format!(
+                            "Failed to resolve interned property key ID {:?}",
+                            k
+                        ))
+                    })?;
+                encoded_properties.push((key_str, encode_property_value(v)));
+            }
+
+            Ok(SerializableVersionData::Anchor {
+                properties: encoded_properties,
+                vector_snapshot_id: vector_snapshot_id.map(|id| id as u64),
+            })
+        }
+        VersionData::Delta { delta } => {
+            let mut encoded_changed = Vec::with_capacity(delta.changed.len());
+            for (k, v) in delta.changed.iter() {
+                let key_str = GLOBAL_INTERNER
+                    .resolve_with(*k, |s| s.to_string())
+                    .ok_or_else(|| {
+                        StorageError::corruption(format!(
+                            "Failed to resolve interned property key ID {:?} in delta",
+                            k
+                        ))
+                    })?;
+                encoded_changed.push((key_str, encode_property_value(v)));
+            }
+
+            let mut encoded_removed = Vec::with_capacity(delta.removed.len());
+            for k in delta.removed.iter() {
+                let key_str = GLOBAL_INTERNER
+                    .resolve_with(*k, |s| s.to_string())
+                    .ok_or_else(|| {
+                        StorageError::corruption(format!(
+                            "Failed to resolve interned property key ID {:?} in removed set",
+                            k
+                        ))
+                    })?;
+                encoded_removed.push(key_str);
+            }
+
+            Ok(SerializableVersionData::Delta {
+                changed: encoded_changed,
+                removed: encoded_removed,
+            })
+        }
     }
 }
 

--- a/src/storage/redb_cold_storage.rs
+++ b/src/storage/redb_cold_storage.rs
@@ -1380,18 +1380,20 @@ fn encode_version_data(
             properties,
             vector_snapshot_id,
         } => {
-            let mut encoded_properties = Vec::with_capacity(properties.len());
-            for (k, v) in properties.iter() {
-                let key_str = GLOBAL_INTERNER
-                    .resolve_with(*k, |s| s.to_string())
-                    .ok_or_else(|| {
-                        StorageError::corruption(format!(
-                            "Failed to resolve interned property key ID {:?}",
-                            k
-                        ))
-                    })?;
-                encoded_properties.push((key_str, encode_property_value(v)));
-            }
+            let encoded_properties = properties
+                .iter()
+                .map(|(k, v)| {
+                    let key_str = GLOBAL_INTERNER
+                        .resolve_with(*k, |s| s.to_string())
+                        .ok_or_else(|| {
+                            StorageError::corruption(format!(
+                                "Failed to resolve interned property key ID {:?}",
+                                k
+                            ))
+                        })?;
+                    Ok((key_str, encode_property_value(v)))
+                })
+                .collect::<std::result::Result<Vec<_>, StorageError>>()?;
 
             Ok(SerializableVersionData::Anchor {
                 properties: encoded_properties,
@@ -1399,31 +1401,36 @@ fn encode_version_data(
             })
         }
         VersionData::Delta { delta } => {
-            let mut encoded_changed = Vec::with_capacity(delta.changed.len());
-            for (k, v) in delta.changed.iter() {
-                let key_str = GLOBAL_INTERNER
-                    .resolve_with(*k, |s| s.to_string())
-                    .ok_or_else(|| {
-                        StorageError::corruption(format!(
-                            "Failed to resolve interned property key ID {:?} in delta",
-                            k
-                        ))
-                    })?;
-                encoded_changed.push((key_str, encode_property_value(v)));
-            }
+            let encoded_changed = delta
+                .changed
+                .iter()
+                .map(|(k, v)| {
+                    let key_str = GLOBAL_INTERNER
+                        .resolve_with(*k, |s| s.to_string())
+                        .ok_or_else(|| {
+                            StorageError::corruption(format!(
+                                "Failed to resolve interned property key ID {:?} in delta",
+                                k
+                            ))
+                        })?;
+                    Ok((key_str, encode_property_value(v)))
+                })
+                .collect::<std::result::Result<Vec<_>, StorageError>>()?;
 
-            let mut encoded_removed = Vec::with_capacity(delta.removed.len());
-            for k in delta.removed.iter() {
-                let key_str = GLOBAL_INTERNER
-                    .resolve_with(*k, |s| s.to_string())
-                    .ok_or_else(|| {
-                        StorageError::corruption(format!(
-                            "Failed to resolve interned property key ID {:?} in removed set",
-                            k
-                        ))
-                    })?;
-                encoded_removed.push(key_str);
-            }
+            let encoded_removed = delta
+                .removed
+                .iter()
+                .map(|k| {
+                    GLOBAL_INTERNER
+                        .resolve_with(*k, |s| s.to_string())
+                        .ok_or_else(|| {
+                            StorageError::corruption(format!(
+                                "Failed to resolve interned property key ID {:?} in removed set",
+                                k
+                            ))
+                        })
+                })
+                .collect::<std::result::Result<Vec<_>, StorageError>>()?;
 
             Ok(SerializableVersionData::Delta {
                 changed: encoded_changed,

--- a/tests/repro_corruption.rs
+++ b/tests/repro_corruption.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+mod tests {
+    use aletheiadb::storage::redb_cold_storage::{encode_node_version};
+    use aletheiadb::core::version::NodeVersion;
+    use aletheiadb::core::id::{VersionId, NodeId};
+    use aletheiadb::core::temporal::BiTemporalInterval;
+    use aletheiadb::core::property::PropertyMapBuilder;
+    use aletheiadb::core::interning::{InternedString};
+
+    #[test]
+    fn test_encode_node_version_fails_on_invalid_id() {
+        // create a forged ID that definitely doesn't exist
+        // We assume 1 billion is safe and unused
+        let invalid_id = InternedString::from_raw(1_000_000_000);
+
+        let props = PropertyMapBuilder::new().build();
+        let version = NodeVersion::new_anchor(
+            VersionId::new(1).unwrap(),
+            NodeId::new(1).unwrap(),
+            BiTemporalInterval::current(1000.into()),
+            invalid_id, // This ID does not exist in GLOBAL_INTERNER
+            props,
+        );
+
+        // Now this should fail with an error
+        let result = encode_node_version(&version);
+
+        assert!(result.is_err(), "encode_node_version should fail for invalid ID");
+        let err = result.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Failed to resolve interned label ID"), "Error message should mention resolution failure: {}", msg);
+
+        println!("Confirmed: Invalid ID caused explicit error as expected.");
+    }
+}

--- a/tests/repro_corruption.rs
+++ b/tests/repro_corruption.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use aletheiadb::storage::redb_cold_storage::{encode_node_version};
-    use aletheiadb::core::version::NodeVersion;
-    use aletheiadb::core::id::{VersionId, NodeId};
-    use aletheiadb::core::temporal::BiTemporalInterval;
+    use aletheiadb::core::id::{NodeId, VersionId};
+    use aletheiadb::core::interning::InternedString;
     use aletheiadb::core::property::PropertyMapBuilder;
-    use aletheiadb::core::interning::{InternedString};
+    use aletheiadb::core::temporal::BiTemporalInterval;
+    use aletheiadb::core::version::NodeVersion;
+    use aletheiadb::storage::redb_cold_storage::encode_node_version;
 
     #[test]
     fn test_encode_node_version_fails_on_invalid_id() {
@@ -25,10 +25,17 @@ mod tests {
         // Now this should fail with an error
         let result = encode_node_version(&version);
 
-        assert!(result.is_err(), "encode_node_version should fail for invalid ID");
+        assert!(
+            result.is_err(),
+            "encode_node_version should fail for invalid ID"
+        );
         let err = result.unwrap_err();
         let msg = format!("{}", err);
-        assert!(msg.contains("Failed to resolve interned label ID"), "Error message should mention resolution failure: {}", msg);
+        assert!(
+            msg.contains("Failed to resolve interned label ID"),
+            "Error message should mention resolution failure: {}",
+            msg
+        );
 
         println!("Confirmed: Invalid ID caused explicit error as expected.");
     }


### PR DESCRIPTION
This PR addresses a critical data integrity issue in the Redb cold storage backend. Previously, when serializing node or edge versions for cold storage, `encode_node_version` and `encode_edge_version` used `unwrap_or_default()` when resolving `InternedString` IDs (for labels and property keys). If an ID was invalid (e.g., due to interner inconsistency or reset), it would silently be replaced by an empty string `""`, leading to data corruption without any error.

Changes:
- Refactored `encode_node_version` and `encode_edge_version` in `src/storage/redb_cold_storage.rs` to return `Result<Vec<u8>>` instead of `Vec<u8>`.
- Refactored `encode_version_data` to return `Result<SerializableVersionData>`.
- Replaced `unwrap_or_default()` with explicit error propagation using `ok_or_else(|| StorageError::corruption(...))` when resolving interned strings.
- Updated all call sites (including parallel iterators in `prepare_*_batch` methods) to handle and propagate the new `Result`.
- Added a regression test `tests/repro_corruption.rs` that explicitly attempts to encode a version with an invalid ID and verifies that it now returns an error instead of succeeding with corrupted data.

This ensures that any inconsistency between the version data and the string interner fails fast with a descriptive error, preventing corrupted data from being written to disk.

---
*PR created automatically by Jules for task [2339342497721883291](https://jules.google.com/task/2339342497721883291) started by @madmax983*