### PR TITLE
🛡️ Sentry: Fix dangling edge creation on deleted nodes

### DIFF
--- a/src/api/transaction/write/validation.rs
+++ b/src/api/transaction/write/validation.rs
@@ -59,7 +59,9 @@ pub(crate) fn validate(tx: &WriteTransaction) -> Result<()> {
                     if tx.buffer.has_modified_node(*node_id) {
                         // Check buffered operation - fail if deleted
                         match tx.buffer.get_node_write(*node_id) {
-                            Some(crate::api::transaction::BufferedWrite::DeleteNode { .. }) => false,
+                            Some(crate::api::transaction::BufferedWrite::DeleteNode { .. }) => {
+                                false
+                            }
                             _ => true, // Created or Updated means it exists
                         }
                     } else {

--- a/src/api/transaction/write/validation.rs
+++ b/src/api/transaction/write/validation.rs
@@ -55,13 +55,27 @@ pub(crate) fn validate(tx: &WriteTransaction) -> Result<()> {
             | crate::api::transaction::BufferedWrite::UpdateEdge { source, target, .. } => {
                 // Check that source and target nodes exist
                 // They might exist in current storage or be created in this transaction
-                if !tx.buffer.has_modified_node(*source) && tx.current.get_node(*source).is_err() {
+                let node_exists = |node_id: &crate::core::NodeId| -> bool {
+                    if tx.buffer.has_modified_node(*node_id) {
+                        // Check buffered operation - fail if deleted
+                        match tx.buffer.get_node_write(*node_id) {
+                            Some(crate::api::transaction::BufferedWrite::DeleteNode { .. }) => false,
+                            _ => true, // Created or Updated means it exists
+                        }
+                    } else {
+                        // Check storage
+                        tx.current.get_node(*node_id).is_ok()
+                    }
+                };
+
+                if !node_exists(source) {
                     return Err(TransactionError::ValidationFailed {
                         reason: format!("Edge source node {:?} does not exist", source),
                     }
                     .into());
                 }
-                if !tx.buffer.has_modified_node(*target) && tx.current.get_node(*target).is_err() {
+
+                if !node_exists(target) {
                     return Err(TransactionError::ValidationFailed {
                         reason: format!("Edge target node {:?} does not exist", target),
                     }

--- a/tests/sentry_dangling_edge_repro.rs
+++ b/tests/sentry_dangling_edge_repro.rs
@@ -1,20 +1,21 @@
-
 #[cfg(test)]
 mod tests {
-    use aletheiadb::{AletheiaDB, Error, NodeId};
     use aletheiadb::api::transaction::WriteOps;
     use aletheiadb::core::property::PropertyMap;
+    use aletheiadb::{AletheiaDB, Error, NodeId};
 
     #[test]
     fn test_create_edge_on_deleted_node_in_same_tx() {
         let db = AletheiaDB::new().unwrap();
 
         // 1. Create two nodes
-        let (node1, node2) = db.write(|tx| -> Result<(NodeId, NodeId), Error> {
-            let n1 = tx.create_node("Person", PropertyMap::new())?;
-            let n2 = tx.create_node("Person", PropertyMap::new())?;
-            Ok((n1, n2))
-        }).unwrap();
+        let (node1, node2) = db
+            .write(|tx| -> Result<(NodeId, NodeId), Error> {
+                let n1 = tx.create_node("Person", PropertyMap::new())?;
+                let n2 = tx.create_node("Person", PropertyMap::new())?;
+                Ok((n1, n2))
+            })
+            .unwrap();
 
         // 2. In a new transaction: delete node1, then try to create an edge from node1 to node2
         let result: Result<(), Error> = db.write(|tx| {
@@ -29,7 +30,10 @@ mod tests {
         });
 
         // 3. Verify the result
-        assert!(result.is_err(), "Should not be able to create edge on deleted node");
+        assert!(
+            result.is_err(),
+            "Should not be able to create edge on deleted node"
+        );
 
         // 4. If it succeeded (bug exists), verify state
         if result.is_ok() {

--- a/tests/sentry_dangling_edge_repro.rs
+++ b/tests/sentry_dangling_edge_repro.rs
@@ -1,0 +1,46 @@
+
+#[cfg(test)]
+mod tests {
+    use aletheiadb::{AletheiaDB, Error, NodeId};
+    use aletheiadb::api::transaction::WriteOps;
+    use aletheiadb::core::property::PropertyMap;
+
+    #[test]
+    fn test_create_edge_on_deleted_node_in_same_tx() {
+        let db = AletheiaDB::new().unwrap();
+
+        // 1. Create two nodes
+        let (node1, node2) = db.write(|tx| -> Result<(NodeId, NodeId), Error> {
+            let n1 = tx.create_node("Person", PropertyMap::new())?;
+            let n2 = tx.create_node("Person", PropertyMap::new())?;
+            Ok((n1, n2))
+        }).unwrap();
+
+        // 2. In a new transaction: delete node1, then try to create an edge from node1 to node2
+        let result: Result<(), Error> = db.write(|tx| {
+            // Delete the source node
+            tx.delete_node(node1)?;
+
+            // Try to create an edge from the deleted node
+            // This SHOULD fail validation
+            tx.create_edge(node1, node2, "GHOST_EDGE", PropertyMap::new())?;
+
+            Ok(())
+        });
+
+        // 3. Verify the result
+        assert!(result.is_err(), "Should not be able to create edge on deleted node");
+
+        // 4. If it succeeded (bug exists), verify state
+        if result.is_ok() {
+            println!("Bug confirmed: Transaction committed successfully");
+
+            // Verify edge count via statistics
+            let stats = db.statistics();
+            println!("Edge count: {}", stats.edge_count());
+
+            // If edge_count > 0, we have a dangling edge
+            assert_eq!(stats.edge_count(), 0, "Should have 0 edges");
+        }
+    }
+}


### PR DESCRIPTION
**Problem:**
A transaction could delete a node and then create an edge connecting to it within the same transaction. The `validate` function checked `has_modified_node`, which returns true for deleted nodes, and mistakenly skipped the existence check, assuming "modified" meant "exists".

**Solution:**
Refined the validation logic in `src/api/transaction/write/validation.rs`. If a node is found in the write buffer, we now inspect the specific `BufferedWrite` operation. If it is a `DeleteNode` operation, we treat the node as non-existent and fail validation.

**Verification:**
Added `tests/sentry_dangling_edge_repro.rs` which reproduces the bug (asserting failure). The test now passes (validation correctly fails). Existing transaction tests passed.


---
*PR created automatically by Jules for task [14472886602008767062](https://jules.google.com/task/14472886602008767062) started by @madmax983*