### PR TITLE
🔒 Warden: Fix dangling edge creation validation

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -37,6 +37,8 @@ mod apply;
 mod conflict;
 mod validation;
 mod wal;
+#[cfg(test)]
+mod repro_dangling_edge;
 
 #[cfg(test)]
 pub(crate) const MAX_BACKWARD_DRIFT_US: i64 = crate::core::hlc::MAX_BACKWARD_DRIFT_US;

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -35,10 +35,10 @@ use std::time::Instant;
 
 mod apply;
 mod conflict;
-mod validation;
-mod wal;
 #[cfg(test)]
 mod repro_dangling_edge;
+mod validation;
+mod wal;
 
 #[cfg(test)]
 pub(crate) const MAX_BACKWARD_DRIFT_US: i64 = crate::core::hlc::MAX_BACKWARD_DRIFT_US;

--- a/src/api/transaction/write/repro_dangling_edge.rs
+++ b/src/api/transaction/write/repro_dangling_edge.rs
@@ -1,8 +1,7 @@
-
 #[cfg(test)]
 mod warden_repro {
-    use crate::api::transaction::{TransactionSnapshot, TxVisibilityManager, WriteOps};
     use crate::api::transaction::write::WriteTransaction;
+    use crate::api::transaction::{TransactionSnapshot, TxVisibilityManager, WriteOps};
     use crate::core::id::IdGenerator;
     use crate::core::property::PropertyMapBuilder;
     use crate::index::temporal::TemporalIndexes;
@@ -102,13 +101,19 @@ mod warden_repro {
 
         // Commit should fail
         let result = tx2.commit();
-        assert!(result.is_err(), "Commit should fail when creating edge from deleted node");
+        assert!(
+            result.is_err(),
+            "Commit should fail when creating edge from deleted node"
+        );
 
         // Check error message
         if let Err(e) = result {
-             let err_str = format!("{}", e);
-             assert!(err_str.contains("Edge source node") || err_str.contains("does not exist"),
-                     "Unexpected error: {}", err_str);
+            let err_str = format!("{}", e);
+            assert!(
+                err_str.contains("Edge source node") || err_str.contains("does not exist"),
+                "Unexpected error: {}",
+                err_str
+            );
         }
     }
 }

--- a/src/api/transaction/write/repro_dangling_edge.rs
+++ b/src/api/transaction/write/repro_dangling_edge.rs
@@ -1,0 +1,114 @@
+
+#[cfg(test)]
+mod warden_repro {
+    use crate::api::transaction::{TransactionSnapshot, TxVisibilityManager, WriteOps};
+    use crate::api::transaction::write::WriteTransaction;
+    use crate::core::id::IdGenerator;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::index::temporal::TemporalIndexes;
+    use crate::storage::current::CurrentStorage;
+    use crate::storage::historical::HistoricalStorage;
+    use crate::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
+    use parking_lot::RwLock;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    fn create_test_write_tx() -> (WriteTransaction, TempDir) {
+        let current = Arc::new(CurrentStorage::new());
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        let temporal_indexes = Arc::new(TemporalIndexes::new());
+
+        let temp_dir = TempDir::new().unwrap();
+        let wal_config = ConcurrentWalSystemConfig::new(temp_dir.path());
+        let wal = Arc::new(ConcurrentWalSystem::new(wal_config).unwrap());
+
+        let current_timestamp = Arc::new(Mutex::new(crate::core::temporal::time::now()));
+        let node_id_gen = Arc::new(IdGenerator::new());
+        let edge_id_gen = Arc::new(IdGenerator::new());
+        let version_id_gen = Arc::new(IdGenerator::new());
+        let tx_id_gen = crate::api::transaction::TxIdGenerator::new();
+
+        let visibility_manager = Arc::new(TxVisibilityManager::new());
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: crate::core::temporal::time::now(),
+            active_transactions: Arc::new(std::collections::HashSet::new()),
+        };
+
+        let tx = WriteTransaction::new(
+            tx_id_gen.next(),
+            snapshot,
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            visibility_manager,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+        );
+
+        (tx, temp_dir)
+    }
+
+    #[test]
+    fn test_create_edge_with_deleted_node_same_tx() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+
+        // Capture components for next tx
+        let current = tx.current.clone();
+        let historical = tx.historical.clone();
+        let temporal_indexes = tx.temporal_indexes.clone();
+        let wal = tx.wal.clone();
+        let current_timestamp = tx.current_timestamp.clone();
+        let visibility_manager = tx.visibility_manager.clone();
+        let node_id_gen = tx.node_id_gen.clone();
+        let edge_id_gen = tx.edge_id_gen.clone();
+        let version_id_gen = tx.version_id_gen.clone();
+        let tx_id_gen = crate::api::transaction::TxIdGenerator::new();
+
+        // Create nodes
+        let props = PropertyMapBuilder::new().build();
+        let node1 = tx.create_node("Person", props.clone()).unwrap();
+        let node2 = tx.create_node("Person", props.clone()).unwrap();
+        tx.commit().unwrap();
+
+        // Start new transaction
+        let snapshot = TransactionSnapshot {
+            snapshot_timestamp: crate::core::temporal::time::now(),
+            active_transactions: Arc::new(std::collections::HashSet::new()),
+        };
+
+        let mut tx2 = WriteTransaction::new(
+            tx_id_gen.next(),
+            snapshot,
+            current,
+            historical,
+            temporal_indexes,
+            wal,
+            current_timestamp,
+            visibility_manager,
+            node_id_gen,
+            edge_id_gen,
+            version_id_gen,
+        );
+
+        // Delete node1
+        tx2.delete_node(node1).unwrap();
+
+        // Create edge from node1 (deleted) to node2
+        let edge_props = PropertyMapBuilder::new().build();
+        tx2.create_edge(node1, node2, "KNOWS", edge_props).unwrap();
+
+        // Commit should fail
+        let result = tx2.commit();
+        assert!(result.is_err(), "Commit should fail when creating edge from deleted node");
+
+        // Check error message
+        if let Err(e) = result {
+             let err_str = format!("{}", e);
+             assert!(err_str.contains("Edge source node") || err_str.contains("does not exist"),
+                     "Unexpected error: {}", err_str);
+        }
+    }
+}

--- a/src/api/transaction/write/validation.rs
+++ b/src/api/transaction/write/validation.rs
@@ -1,4 +1,5 @@
 use super::{MAX_VALID_TIME_FUTURE_OFFSET_US, WriteTransaction};
+use crate::api::transaction::BufferedWrite;
 use crate::core::error::{Result, TransactionError};
 use crate::core::temporal::{Timestamp, time};
 
@@ -51,17 +52,35 @@ pub(crate) fn validate_valid_from_not_before_creation(
 pub(crate) fn validate(tx: &WriteTransaction) -> Result<()> {
     for write in tx.buffer.operations() {
         match write {
-            crate::api::transaction::BufferedWrite::CreateEdge { source, target, .. }
-            | crate::api::transaction::BufferedWrite::UpdateEdge { source, target, .. } => {
+            BufferedWrite::CreateEdge { source, target, .. }
+            | BufferedWrite::UpdateEdge { source, target, .. } => {
                 // Check that source and target nodes exist
-                // They might exist in current storage or be created in this transaction
-                if !tx.buffer.has_modified_node(*source) && tx.current.get_node(*source).is_err() {
+                // They might exist in current storage or be created in this transaction.
+                //
+                // CRITICAL SECURITY FIX: We must check get_node_write() to ensure the
+                // latest operation is not a DeleteNode. has_modified_node() returns
+                // true for deleted nodes, which allowed creating dangling edges.
+
+                let source_exists = if let Some(write) = tx.buffer.get_node_write(*source) {
+                    !matches!(write, BufferedWrite::DeleteNode { .. })
+                } else {
+                    tx.current.get_node(*source).is_ok()
+                };
+
+                if !source_exists {
                     return Err(TransactionError::ValidationFailed {
                         reason: format!("Edge source node {:?} does not exist", source),
                     }
                     .into());
                 }
-                if !tx.buffer.has_modified_node(*target) && tx.current.get_node(*target).is_err() {
+
+                let target_exists = if let Some(write) = tx.buffer.get_node_write(*target) {
+                    !matches!(write, BufferedWrite::DeleteNode { .. })
+                } else {
+                    tx.current.get_node(*target).is_ok()
+                };
+
+                if !target_exists {
                     return Err(TransactionError::ValidationFailed {
                         reason: format!("Edge target node {:?} does not exist", target),
                     }


### PR DESCRIPTION
🦠 Threat: A transaction could create an edge connecting to a node that was deleted in the same transaction. The validation logic `!tx.buffer.has_modified_node(*source)` incorrectly assumed that if a node was modified (even if deleted), it was valid for edge creation.

🛡️ Defense: Modified `src/api/transaction/write/validation.rs` to explicitly check the type of buffered write. If `get_node_write` returns `DeleteNode`, the edge creation is rejected.

💥 Severity: High - Data Integrity. This allowed creating edges pointing to non-existent (deleted) nodes, violating referential integrity.

🧪 Verification: Added `src/api/transaction/write/repro_dangling_edge.rs` which reproduces the issue (creates node, commits, deletes node, creates edge -> expects commit error). Confirmed that the test failed before the fix and passes after.

---
*PR created automatically by Jules for task [9898823094505551133](https://jules.google.com/task/9898823094505551133) started by @madmax983*