### PR TITLE
docs: improve Sherlock example documentation with feature flag warning

### DIFF
--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -43,8 +43,15 @@
 //!
 //! # Example: Detecting Suspicious Patterns with Sherlock
 //!
+//! > ⚠️ **REQUIRES FEATURE 'NOVA'**
+//! >
+//! > This feature is experimental and requires the `nova` feature flag.
+//! > Add `features = ["nova"]` to your `Cargo.toml`.
+//!
 //! ```rust,ignore
-//! // Requires features = ["nova"]
+//! // [dependencies]
+//! // aletheiadb = { version = "0.1", features = ["nova"] }
+//!
 //! use aletheiadb::AletheiaDB;
 //! use aletheiadb::experimental::sherlock::{Sherlock, Mystery, Clue};
 //! use aletheiadb::core::property::PropertyValue;


### PR DESCRIPTION
Improved the Developer Experience (DX) for the experimental `Sherlock` feature by explicitly documenting the requirement for the `nova` feature flag in the module-level documentation example. This prevents users from encountering confusing "symbol not found" errors when trying to run the example without the correct configuration.


---
*PR created automatically by Jules for task [6467009417258286804](https://jules.google.com/task/6467009417258286804) started by @madmax983*