### PR TITLE
🎻 Bard: Document graph_context module

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -35,3 +35,7 @@
 ## 2024-05-27 - Experimental Feature Opacity
 **Confusion:** The `Chronos` (pathfinding) and `Dreamer` (vector extrapolation) experimental modules lacked explanations of their underlying algorithms, making them opaque "black boxes."
 **Clarification:** Added detailed algorithmic explanations to `Chronos` (Snapshot Pathfinding, Path Stability) and clarified `Dreamer`'s dependency on `search_vectors_in`.
+
+## 2024-05-28 - Broken Links in Feature-Gated Modules
+**Confusion:** Running `cargo doc` without features enabled resulted in broken intra-doc links to experimental modules (like `sherlock` or `hindsight`), causing warnings and confusion about missing items.
+**Clarification:** Documentation generation for experimental features requires enabling the `nova` feature flag (e.g., `cargo doc --features nova`).

--- a/src/experimental/graph_context.rs
+++ b/src/experimental/graph_context.rs
@@ -1,3 +1,59 @@
+//! Graph Context Exporter ("The Scribe")
+//!
+//! This module provides tools to generate rich, human-readable context descriptions
+//! for nodes in the graph. It is designed specifically for **Retrieval-Augmented Generation (RAG)**
+//! scenarios where an LLM needs to understand a node's state, history, and relationships.
+//!
+//! # Purpose
+//!
+//! When feeding graph data to an LLM, raw JSON or triples can be token-inefficient and hard
+//! for models to reason about. The `GraphContextBuilder` converts a node's "ego network"
+//! into a structured Markdown format that highlights:
+//!
+//! 1.  **Identity**: Who/what is this node? (Label, ID)
+//! 2.  **State**: What are its properties?
+//! 3.  **Evolution**: How has it changed over time? (Narrative history)
+//! 4.  **Context**: Who is it connected to? (Immediate neighborhood)
+//!
+//! # Usage
+//!
+//! ```rust
+//! use aletheiadb::AletheiaDB;
+//! use aletheiadb::experimental::graph_context::GraphContextBuilder;
+//! use aletheiadb::core::id::NodeId;
+//!
+//! # fn example(db: &AletheiaDB, node_id: NodeId) -> aletheiadb::core::error::Result<()> {
+//! // Create a builder for a specific node
+//! let context = GraphContextBuilder::new(db, node_id)
+//!     .with_history_limit(3)   // Limit history to last 3 events
+//!     .with_neighbor_limit(5)  // Limit neighbors to 5
+//!     .build()?;
+//!
+//! println!("{}", context);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Output Format
+//!
+//! The output is a Markdown string structured as follows:
+//!
+//! ```markdown
+//! # Node Context: 42 (Person)
+//!
+//! ## Properties
+//! - name: "Alice"
+//! - role: "Engineer"
+//!
+//! ## Evolution
+//! - 2023-10-27T10:00:00Z (v2): updated properties
+//!   - Modified property 'role' from '"Intern"' to '"Engineer"'
+//!
+//! ## Neighborhood
+//! - WORKS_AT -> Company (101)
+//!   - Properties: { since: 2020 }
+//! ```
+
 use crate::AletheiaDB;
 use crate::core::error::Result;
 use crate::core::id::NodeId;
@@ -10,6 +66,20 @@ use std::fmt::Write;
 /// This generates a Markdown-formatted string containing the node's current state,
 /// recent history (evolution), and immediate neighborhood. It is designed for
 /// injecting context into LLM prompts.
+///
+/// # Example
+///
+/// ```rust
+/// # use aletheiadb::AletheiaDB;
+/// # use aletheiadb::experimental::graph_context::GraphContextBuilder;
+/// # fn example(db: &AletheiaDB, node_id: aletheiadb::core::id::NodeId) -> aletheiadb::core::error::Result<()> {
+/// let context = GraphContextBuilder::new(db, node_id)
+///     .with_history_limit(5)
+///     .with_neighbor_limit(10)
+///     .build()?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct GraphContextBuilder<'a> {
     db: &'a AletheiaDB,
     center_node: NodeId,
@@ -19,6 +89,11 @@ pub struct GraphContextBuilder<'a> {
 
 impl<'a> GraphContextBuilder<'a> {
     /// Create a new builder for the given node.
+    ///
+    /// # Arguments
+    ///
+    /// * `db` - Reference to the database instance.
+    /// * `center_node` - The ID of the node to generate context for.
     pub fn new(db: &'a AletheiaDB, center_node: NodeId) -> Self {
         Self {
             db,
@@ -29,12 +104,26 @@ impl<'a> GraphContextBuilder<'a> {
     }
 
     /// Set the maximum number of history events to include.
+    ///
+    /// # Trade-offs
+    ///
+    /// *   **Higher limit**: Provides more context on how the node evolved, useful for understanding causality.
+    /// *   **Lower limit**: Saves tokens in the LLM prompt window.
+    ///
+    /// Defaults to 5.
     pub fn with_history_limit(mut self, limit: usize) -> Self {
         self.history_limit = limit;
         self
     }
 
     /// Set the maximum number of neighbors to include.
+    ///
+    /// # Trade-offs
+    ///
+    /// *   **Higher limit**: Provides a broader view of the node's connections.
+    /// *   **Lower limit**: Saves tokens and prevents "context pollution" from irrelevant neighbors.
+    ///
+    /// Defaults to 10.
     pub fn with_neighbor_limit(mut self, limit: usize) -> Self {
         self.neighbor_limit = limit;
         self
@@ -47,6 +136,14 @@ impl<'a> GraphContextBuilder<'a> {
     }
 
     /// Build the context string (Markdown).
+    ///
+    /// # Returns
+    ///
+    /// A formatted Markdown string containing the node's context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `center_node` does not exist in the database.
     pub fn build(&self) -> Result<String> {
         let mut output = String::new();
         let node = self.db.get_node(self.center_node)?;


### PR DESCRIPTION
This PR enhances the documentation for the `graph_context` experimental module, transforming it from a bare implementation into a well-documented component with a clear story and usage guide, following the Bard persona guidelines. It explains how to use the builder to generate Markdown context for LLMs.

---
*PR created automatically by Jules for task [4533591985942325929](https://jules.google.com/task/4533591985942325929) started by @madmax983*