### PR TITLE
fix(query): prevent unsafe limit pushdown through filters

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -187,7 +187,7 @@ impl TimeRange {
     /// Note: Phase 2 - removed const due to HybridTimestamp comparison.
     #[inline]
     pub fn contains_range(&self, other: &TimeRange) -> bool {
-        self.start <= other.start && other.end <= self.end
+        self.start < other.start && other.end < self.end
     }
 
     /// Close this range at the given timestamp.
@@ -380,7 +380,7 @@ impl BiTemporalInterval {
     /// Note: Phase 2 - removed const due to HybridTimestamp comparison.
     #[inline]
     pub fn is_current(&self) -> bool {
-        self.is_currently_valid() && self.is_currently_recorded()
+        self.is_currently_valid() || self.is_currently_recorded()
     }
 
     /// Check if this interval is visible at the given valid time.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -187,7 +187,7 @@ impl TimeRange {
     /// Note: Phase 2 - removed const due to HybridTimestamp comparison.
     #[inline]
     pub fn contains_range(&self, other: &TimeRange) -> bool {
-        self.start < other.start && other.end < self.end
+        self.start <= other.start && other.end <= self.end
     }
 
     /// Close this range at the given timestamp.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -380,7 +380,7 @@ impl BiTemporalInterval {
     /// Note: Phase 2 - removed const due to HybridTimestamp comparison.
     #[inline]
     pub fn is_current(&self) -> bool {
-        self.is_currently_valid() || self.is_currently_recorded()
+        self.is_currently_valid() && self.is_currently_recorded()
     }
 
     /// Check if this interval is visible at the given valid time.

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -145,7 +145,9 @@ impl LimitPushdown {
                 op: UnaryOp::Filter(predicate),
                 input,
             } => {
-                let (optimized_input, changed) = self.push_down(input, limit)?;
+                // Cannot safely push limit through filter because filtering reduces cardinality.
+                // We might need to scan many more items than 'limit' to find 'limit' matches.
+                let (optimized_input, changed) = self.push_down(input, None)?;
                 Ok((
                     LogicalOp::unary(UnaryOp::Filter(predicate.clone()), optimized_input),
                     changed,
@@ -280,5 +282,75 @@ mod tests {
 
         let result = rule.apply(&plan, &stats).unwrap();
         assert!(result.is_none()); // No change needed
+    }
+
+    #[test]
+    fn test_limit_pushdown_blocked_by_filter() {
+        use crate::query::ir::{Predicate, PredicateValue};
+
+        let rule = LimitPushdown;
+        let stats = test_stats();
+
+        // Limit(1, Filter(id > 5, Limit(10, Scan)))
+        // The inner Limit(10) MUST NOT be reduced to 1 because Filter reduces cardinality.
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(1),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::Gt {
+                    key: "id".to_string(),
+                    value: PredicateValue::Int(5),
+                }),
+                LogicalOp::unary(
+                    UnaryOp::Limit(10),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        // If optimization returns None, it means no changes were made, which implies
+        // the inner limit was preserved (safe).
+        // If it returns Some, we must verify the inner limit wasn't reduced.
+        if let Some(optimized) = result {
+            let mut current = &optimized.root;
+
+            // Root: Limit(1)
+            if let LogicalOp::Unary {
+                op: UnaryOp::Limit(n),
+                input,
+            } = current
+            {
+                assert_eq!(*n, 1);
+                current = input;
+            } else {
+                panic!("Expected Limit(1) at root");
+            }
+
+            // Next: Filter
+            if let LogicalOp::Unary {
+                op: UnaryOp::Filter(_),
+                input,
+            } = current
+            {
+                current = input;
+            } else {
+                panic!("Expected Filter");
+            }
+
+            // Next: Inner Limit
+            if let LogicalOp::Unary {
+                op: UnaryOp::Limit(n),
+                ..
+            } = current
+            {
+                assert_eq!(
+                    *n, 10,
+                    "Inner limit should not be reduced below Filter (must remain 10)"
+                );
+            } else {
+                panic!("Expected inner Limit");
+            }
+        }
     }
 }


### PR DESCRIPTION
**🤖 Sentinel: Fixed Unsafe Limit Pushdown in Query Planner**

## 🧬 Diagnosis
Mutation analysis revealed a critical flaw in the `LimitPushdown` optimization rule. The optimizer was aggressively pushing `Limit` operators down through `Filter` operators. 

**The Bug:**
If a query had a structure like `Limit(N) -> Filter -> Source`, the optimizer would rewrite it as `Filter -> Limit(N) -> Source`.
This is **incorrect** because `Filter` reduces the number of rows. If the source produces `N` rows but only `K` pass the filter (where `K < N`), the query returns `K` rows, even if the source had more matching rows available beyond the first `N`.

## 🎯 The Fix
I modified `src/query/planner/rules/limit_pushdown.rs` to stop propagating the limit value when traversing through a `Filter` operation. The `push_down` method now passes `None` (no limit) to the input of a `Filter`, effectively blocking the pushdown.

```rust
// Before
let (optimized_input, changed) = self.push_down(input, limit)?;

// After
let (optimized_input, changed) = self.push_down(input, None)?;
```

## 🛡️ Verification
I added a regression test `test_limit_pushdown_blocked_by_filter` to `src/query/planner/rules/limit_pushdown.rs`.
This test constructs a logical plan: `Limit(1) -> Filter(id > 5) -> Limit(10) -> Scan`.
- **Before Fix:** The optimizer reduced the inner `Limit(10)` to `Limit(1)`, causing the test to fail.
- **After Fix:** The optimizer preserves the inner `Limit(10)`, ensuring the scan produces enough rows to satisfy the filter.

## 🔗 Context
This bug was identified by analyzing potential mutants where `Limit` behavior might be overly aggressive. While `cargo-mutants` timed out on the full run, targeted analysis of optimization rules revealed this logical gap.


---
*PR created automatically by Jules for task [987403552246156679](https://jules.google.com/task/987403552246156679) started by @madmax983*