### PR TITLE
chronos: benchmark report for 198c57d

### DIFF
--- a/benchmarks/history.json
+++ b/benchmarks/history.json
@@ -330,5 +330,1404 @@
         "std_dev_ns": 27171.71107871942
       }
     }
+  },
+  {
+    "timestamp": "2026-02-21T20:43:41.849269+00:00",
+    "commit": "198c57d",
+    "branch": "jules-3069904928789557752-7bfd23b2",
+    "benchmarks": {
+      "aletheiadb_node_creation": {
+        "point_estimate_ns": 105587.98688853759,
+        "ci_lower_ns": 95514.70531319677,
+        "ci_upper_ns": 116848.53890799564,
+        "std_dev_ns": 297899.615617021
+      },
+      "node_lookup": {
+        "point_estimate_ns": 64.59939206492983,
+        "ci_lower_ns": 64.31960598586475,
+        "ci_upper_ns": 64.78000830642684,
+        "std_dev_ns": 0.6200861374209033
+      },
+      "aletheiadb_3_hop_traversal": {
+        "point_estimate_ns": 483.03326182978645,
+        "ci_lower_ns": 481.80184349359325,
+        "ci_upper_ns": 484.84096805610665,
+        "std_dev_ns": 6.6300598861301525
+      },
+      "mixed_read_write_80_20": {
+        "point_estimate_ns": 16590656.9,
+        "ci_lower_ns": 16207655.196500001,
+        "ci_upper_ns": 16980903.3395,
+        "std_dev_ns": 1415377.3600942031
+      },
+      "out_degree": {
+        "point_estimate_ns": 406.190262954019,
+        "ci_lower_ns": 404.293682319799,
+        "ci_upper_ns": 407.7133926523594,
+        "std_dev_ns": 4.541576157545607
+      },
+      "labeled_traversal": {
+        "point_estimate_ns": 465.9282119825052,
+        "ci_lower_ns": 465.36575554437513,
+        "ci_upper_ns": 466.53109839958495,
+        "std_dev_ns": 2.354312474418055
+      },
+      "aletheiadb_labeled_traversal": {
+        "point_estimate_ns": 159.868221653519,
+        "ci_lower_ns": 159.70189521578737,
+        "ci_upper_ns": 160.06935757679213,
+        "std_dev_ns": 0.38902356521474263
+      },
+      "write_transaction_creation": {
+        "point_estimate_ns": 462.437451192751,
+        "ci_lower_ns": 461.99519122365655,
+        "ci_upper_ns": 462.94956434670564,
+        "std_dev_ns": 1.8428791358821337
+      },
+      "aletheiadb_historical_stats": {
+        "point_estimate_ns": 1059.2181286545674,
+        "ci_lower_ns": 1057.0127237653435,
+        "ci_upper_ns": 1061.7960082805034,
+        "std_dev_ns": 4.316067987400935
+      },
+      "aletheiadb_edge_creation": {
+        "point_estimate_ns": 97345.81847350029,
+        "ci_lower_ns": 87540.2698041836,
+        "ci_upper_ns": 106690.73199747702,
+        "std_dev_ns": 322980.4204883581
+      },
+      "edge_lookup": {
+        "point_estimate_ns": 62.379754055443655,
+        "ci_lower_ns": 62.31319748551088,
+        "ci_upper_ns": 62.43332704863329,
+        "std_dev_ns": 0.1907702482557801
+      },
+      "cosine_similarity_openai_1536d": {
+        "point_estimate_ns": 301.5357890223981,
+        "ci_lower_ns": 299.436828174268,
+        "ci_upper_ns": 304.2497533911666,
+        "std_dev_ns": 6.190632927568682
+      },
+      "3_hop_traversal": {
+        "point_estimate_ns": 56709.40060537482,
+        "ci_lower_ns": 56625.45557799764,
+        "ci_upper_ns": 56814.57330336405,
+        "std_dev_ns": 319.55667834177916
+      },
+      "sustained_write_10k_versions_fast_reference": {
+        "point_estimate_ns": 455090030.52,
+        "ci_lower_ns": 454130011.388,
+        "ci_upper_ns": 456073534.51449996,
+        "std_dev_ns": 3565380.523849086
+      },
+      "find_neighbors": {
+        "point_estimate_ns": 1240.9175305026301,
+        "ci_lower_ns": 1239.2111025292563,
+        "ci_upper_ns": 1243.020194052436,
+        "std_dev_ns": 7.3909887971046215
+      },
+      "read_transaction_creation": {
+        "point_estimate_ns": 339.2398020202676,
+        "ci_lower_ns": 335.7963868551652,
+        "ci_upper_ns": 343.7172284630253,
+        "std_dev_ns": 18.818965872716934
+      },
+      "in_degree": {
+        "point_estimate_ns": 398.58432612085096,
+        "ci_lower_ns": 398.22563133232137,
+        "ci_upper_ns": 399.0398903730286,
+        "std_dev_ns": 1.759143199386583
+      },
+      "sustained_write_10k_versions": {
+        "point_estimate_ns": 181743777.5,
+        "ci_lower_ns": 180886862.2425,
+        "ci_upper_ns": 182694409.9835,
+        "std_dev_ns": 3304803.1740842476
+      },
+      "read_latency_p50_p99": {
+        "point_estimate_ns": 8.775181449430733,
+        "ci_lower_ns": 8.024850170733629,
+        "ci_upper_ns": 9.860906759496226,
+        "std_dev_ns": 46.621558845681925
+      },
+      "closure_write_single_node": {
+        "point_estimate_ns": 2805759.5909726266,
+        "ci_lower_ns": 2796347.4384530853,
+        "ci_upper_ns": 2816012.120000868,
+        "std_dev_ns": 34097.21087582842
+      },
+      "aletheiadb_out_degree": {
+        "point_estimate_ns": 100.39473233264385,
+        "ci_lower_ns": 100.3461474740387,
+        "ci_upper_ns": 100.45337807251627,
+        "std_dev_ns": 0.20210721265146966
+      },
+      "node_creation": {
+        "point_estimate_ns": 4433.240196900578,
+        "ci_lower_ns": 4241.021954438019,
+        "ci_upper_ns": 4580.727389059392,
+        "std_dev_ns": 3145.673287505665
+      },
+      "aletheiadb_in_degree": {
+        "point_estimate_ns": 104.89167571884613,
+        "ci_lower_ns": 104.80995331613747,
+        "ci_upper_ns": 104.97736687520474,
+        "std_dev_ns": 0.3996576690269795
+      },
+      "edge_creation": {
+        "point_estimate_ns": 4461.170580124679,
+        "ci_lower_ns": 4220.316615507933,
+        "ci_upper_ns": 4642.308576440936,
+        "std_dev_ns": 895.9354625716146
+      },
+      "traverse_and_rank_basic/100_power_law/100": {
+        "point_estimate_ns": 40645.37641606975,
+        "ci_lower_ns": 40575.570950488844,
+        "ci_upper_ns": 40756.949997928285,
+        "std_dev_ns": 336.8497633314371
+      },
+      "traverse_and_rank_basic/1K_power_law/1000": {
+        "point_estimate_ns": 47543.057259595385,
+        "ci_lower_ns": 46021.64734128316,
+        "ci_upper_ns": 48908.16197054701,
+        "std_dev_ns": 4763.408049445584
+      },
+      "traverse_and_rank_basic/1K_uniform/1000": {
+        "point_estimate_ns": 8124.010274408515,
+        "ci_lower_ns": 8111.796362768051,
+        "ci_upper_ns": 8140.633225059812,
+        "std_dev_ns": 40.44531174462546
+      },
+      "traverse_and_rank_basic/1K_sparse/1000": {
+        "point_estimate_ns": 1276.267736055206,
+        "ci_lower_ns": 1275.238050728605,
+        "ci_upper_ns": 1277.5031410824251,
+        "std_dev_ns": 4.52527124574391
+      },
+      "traverse_and_rank_basic/100_uniform/100": {
+        "point_estimate_ns": 7893.298112167472,
+        "ci_lower_ns": 7888.653271164987,
+        "ci_upper_ns": 7898.511851004496,
+        "std_dev_ns": 17.626978977413632
+      },
+      "traverse_and_rank_basic/100_sparse/100": {
+        "point_estimate_ns": 1286.6027493511683,
+        "ci_lower_ns": 1285.0983382172292,
+        "ci_upper_ns": 1288.1828752014662,
+        "std_dev_ns": 5.089050680837771
+      },
+      "cosine_similarity/optimized/384": {
+        "point_estimate_ns": 77.19818195555419,
+        "ci_lower_ns": 77.0254227262645,
+        "ci_upper_ns": 77.35644672994619,
+        "std_dev_ns": 0.6351143353771208
+      },
+      "cosine_similarity/optimized/1536": {
+        "point_estimate_ns": 299.6658910971508,
+        "ci_lower_ns": 299.28030145854456,
+        "ci_upper_ns": 300.01812927935566,
+        "std_dev_ns": 0.9796408552665271
+      },
+      "cosine_similarity/optimized/768": {
+        "point_estimate_ns": 151.7529320616881,
+        "ci_lower_ns": 151.66339332681332,
+        "ci_upper_ns": 151.8528047146588,
+        "std_dev_ns": 0.42975604256628436
+      },
+      "cosine_similarity/optimized/3072": {
+        "point_estimate_ns": 592.05438700011,
+        "ci_lower_ns": 591.7843089564706,
+        "ci_upper_ns": 592.3524809415526,
+        "std_dev_ns": 3.140527182797275
+      },
+      "cosine_similarity/optimized/1024": {
+        "point_estimate_ns": 201.4877458513007,
+        "ci_lower_ns": 200.85042107432656,
+        "ci_upper_ns": 202.30991997683532,
+        "std_dev_ns": 2.286718757092517
+      },
+      "cosine_similarity/naive_3pass/384": {
+        "point_estimate_ns": 1652.069934743413,
+        "ci_lower_ns": 1650.8755199815955,
+        "ci_upper_ns": 1653.63424223979,
+        "std_dev_ns": 3.902929057670135
+      },
+      "cosine_similarity/naive_3pass/1536": {
+        "point_estimate_ns": 6951.807962931847,
+        "ci_lower_ns": 6948.693184144439,
+        "ci_upper_ns": 6955.301184913111,
+        "std_dev_ns": 26.557028069060614
+      },
+      "cosine_similarity/naive_3pass/768": {
+        "point_estimate_ns": 3435.1943197863548,
+        "ci_lower_ns": 3415.0074432186134,
+        "ci_upper_ns": 3460.2340041209404,
+        "std_dev_ns": 33.745485433033565
+      },
+      "cosine_similarity/naive_3pass/3072": {
+        "point_estimate_ns": 14033.896443987927,
+        "ci_lower_ns": 14017.637288965314,
+        "ci_upper_ns": 14055.332691369887,
+        "std_dev_ns": 68.56629049836619
+      },
+      "cosine_similarity/naive_3pass/1024": {
+        "point_estimate_ns": 4599.753067310874,
+        "ci_lower_ns": 4596.423134574021,
+        "ci_upper_ns": 4603.320594678359,
+        "std_dev_ns": 11.839112254157909
+      },
+      "cosine_similarity/scalar_1pass/384": {
+        "point_estimate_ns": 636.193272589146,
+        "ci_lower_ns": 603.1786000088678,
+        "ci_upper_ns": 671.3907328636794,
+        "std_dev_ns": 54.35142076677396
+      },
+      "cosine_similarity/scalar_1pass/1536": {
+        "point_estimate_ns": 2360.199107123709,
+        "ci_lower_ns": 2353.509533143971,
+        "ci_upper_ns": 2371.9777121865504,
+        "std_dev_ns": 27.06475924935487
+      },
+      "cosine_similarity/scalar_1pass/768": {
+        "point_estimate_ns": 1181.9781014168025,
+        "ci_lower_ns": 1181.4734150690697,
+        "ci_upper_ns": 1182.503293651828,
+        "std_dev_ns": 2.447470776519013
+      },
+      "cosine_similarity/scalar_1pass/3072": {
+        "point_estimate_ns": 4728.166806747599,
+        "ci_lower_ns": 4714.062297505582,
+        "ci_upper_ns": 4744.313450360317,
+        "std_dev_ns": 31.848888397850683
+      },
+      "cosine_similarity/scalar_1pass/1024": {
+        "point_estimate_ns": 1581.0847224462116,
+        "ci_lower_ns": 1575.386218516162,
+        "ci_upper_ns": 1590.0045152937837,
+        "std_dev_ns": 333.81839431270055
+      },
+      "aletheiadb_batch/batch_node_creation/100": {
+        "point_estimate_ns": 289829222.94,
+        "ci_lower_ns": 288086841.681,
+        "ci_upper_ns": 291591735.663,
+        "std_dev_ns": 6371752.922878724
+      },
+      "aletheiadb_batch/batch_node_creation/1000": {
+        "point_estimate_ns": 2831177141.04,
+        "ci_lower_ns": 2815906625.1605,
+        "ci_upper_ns": 2849516226.441,
+        "std_dev_ns": 61540296.89892609
+      },
+      "aletheiadb_batch/batch_node_creation/10": {
+        "point_estimate_ns": 27807499.68,
+        "ci_lower_ns": 27674955.065375,
+        "ci_upper_ns": 27937406.647625,
+        "std_dev_ns": 478086.70359114587
+      },
+      "cold_batch_write_throughput/zstd/100": {
+        "point_estimate_ns": 7446457.8212696565,
+        "ci_lower_ns": 7420127.676199213,
+        "ci_upper_ns": 7471651.742407324,
+        "std_dev_ns": 72697.98103978255
+      },
+      "cold_batch_write_throughput/zstd/1000": {
+        "point_estimate_ns": 66782380.72,
+        "ci_lower_ns": 66576414.6425,
+        "ci_upper_ns": 67011409.79025,
+        "std_dev_ns": 790677.2192639813
+      },
+      "cold_batch_write_throughput/zstd/10000": {
+        "point_estimate_ns": 189514991.74,
+        "ci_lower_ns": 187487924.0425,
+        "ci_upper_ns": 191762558.41050002,
+        "std_dev_ns": 7782845.710291847
+      },
+      "cold_batch_write_throughput/fast/100": {
+        "point_estimate_ns": 4929242.764985439,
+        "ci_lower_ns": 4907642.7816374935,
+        "ci_upper_ns": 4953927.579909837,
+        "std_dev_ns": 69123.27007270302
+      },
+      "cold_batch_write_throughput/fast/1000": {
+        "point_estimate_ns": 45813563.21999999,
+        "ci_lower_ns": 45746108.88133332,
+        "ci_upper_ns": 45887614.86299998,
+        "std_dev_ns": 257616.34052136034
+      },
+      "cold_batch_write_throughput/fast/10000": {
+        "point_estimate_ns": 454829735.4,
+        "ci_lower_ns": 454227247.375,
+        "ci_upper_ns": 455468619.39250004,
+        "std_dev_ns": 2252619.1835775143
+      },
+      "cosine_similarity_normalized/specialized/384": {
+        "point_estimate_ns": 56.59762000366868,
+        "ci_lower_ns": 56.5607990597491,
+        "ci_upper_ns": 56.63747457203557,
+        "std_dev_ns": 0.11204400005862736
+      },
+      "cosine_similarity_normalized/specialized/1536": {
+        "point_estimate_ns": 284.76728742221144,
+        "ci_lower_ns": 280.13208389175924,
+        "ci_upper_ns": 290.0487059848769,
+        "std_dev_ns": 10.327696695751309
+      },
+      "cosine_similarity_normalized/general/384": {
+        "point_estimate_ns": 78.06332090156614,
+        "ci_lower_ns": 77.98414692436332,
+        "ci_upper_ns": 78.14823327687195,
+        "std_dev_ns": 0.19590303752736146
+      },
+      "cosine_similarity_normalized/general/1536": {
+        "point_estimate_ns": 300.4556351290062,
+        "ci_lower_ns": 299.919767288446,
+        "ci_upper_ns": 301.2823096721473,
+        "std_dev_ns": 3.0957363966422045
+      },
+      "vector_batch_serialize/rag_workload/100x1536": {
+        "point_estimate_ns": 22986.302710144148,
+        "ci_lower_ns": 22883.256720141966,
+        "ci_upper_ns": 23114.737578911776,
+        "std_dev_ns": 370.808906808476
+      },
+      "id_generation_current/read_current_approximate": {
+        "point_estimate_ns": 0.38298145410761325,
+        "ci_lower_ns": 0.3827446624742064,
+        "ci_upper_ns": 0.3832859438077964,
+        "std_dev_ns": 0.0014634778046948562
+      },
+      "id_generation_current/read_current": {
+        "point_estimate_ns": 0.38403609330145705,
+        "ci_lower_ns": 0.38353250613535567,
+        "ci_upper_ns": 0.38477552592734005,
+        "std_dev_ns": 0.001193710479478649
+      },
+      "single_transaction_latency/async": {
+        "point_estimate_ns": 65064.95586410406,
+        "ci_lower_ns": 57281.11139309532,
+        "ci_upper_ns": 72113.96764436083,
+        "std_dev_ns": 36257.02388392231
+      },
+      "single_transaction_latency/synchronous": {
+        "point_estimate_ns": 571976.8932190698,
+        "ci_lower_ns": 563852.8705069101,
+        "ci_upper_ns": 579816.9539870191,
+        "std_dev_ns": 27015.07526741548
+      },
+      "single_transaction_latency/group_commit_fast": {
+        "point_estimate_ns": 1799045.5265463018,
+        "ci_lower_ns": 1776809.670913189,
+        "ci_upper_ns": 1822518.8644070849,
+        "std_dev_ns": 80513.5807297254
+      },
+      "single_transaction_latency/group_commit_default": {
+        "point_estimate_ns": 2755248.5911706463,
+        "ci_lower_ns": 2743608.3875506874,
+        "ci_upper_ns": 2767805.857782784,
+        "std_dev_ns": 149327.2377911224
+      },
+      "single_transaction_latency/async_batched_default": {
+        "point_estimate_ns": 9188520.870000003,
+        "ci_lower_ns": 9183672.443199998,
+        "ci_upper_ns": 9193712.409999998,
+        "std_dev_ns": 18332.469964266
+      },
+      "single_transaction_latency/async_batched_aggressive": {
+        "point_estimate_ns": 5017230.003587653,
+        "ci_lower_ns": 4994946.330417144,
+        "ci_upper_ns": 5033474.251226593,
+        "std_dev_ns": 781014.4978530124
+      },
+      "target_time_travel/with_5_deltas": {
+        "point_estimate_ns": 279.26660591422876,
+        "ci_lower_ns": 270.62639508449615,
+        "ci_upper_ns": 290.0937413466504,
+        "std_dev_ns": 20.37210012896134
+      },
+      "target_time_travel/at_anchor": {
+        "point_estimate_ns": 272.30035568291356,
+        "ci_lower_ns": 272.12185278998066,
+        "ci_upper_ns": 272.49278264771937,
+        "std_dev_ns": 0.9667052441516802
+      },
+      "target_time_travel/worst_case_9_deltas": {
+        "point_estimate_ns": 274.46354850831545,
+        "ci_lower_ns": 274.26264211138334,
+        "ci_upper_ns": 274.6611589693988,
+        "std_dev_ns": 1.8974563556307482
+      },
+      "euclidean_distance/scalar/384": {
+        "point_estimate_ns": 566.6878257899341,
+        "ci_lower_ns": 566.0426552274762,
+        "ci_upper_ns": 567.3179776987806,
+        "std_dev_ns": 2.5250879216221414
+      },
+      "euclidean_distance/scalar/1536": {
+        "point_estimate_ns": 2332.189815352802,
+        "ci_lower_ns": 2330.847686373473,
+        "ci_upper_ns": 2334.0001891804973,
+        "std_dev_ns": 9.378124805684932
+      },
+      "euclidean_distance/scalar/768": {
+        "point_estimate_ns": 1155.2432735799714,
+        "ci_lower_ns": 1154.6503997718094,
+        "ci_upper_ns": 1155.8921738443653,
+        "std_dev_ns": 2.4107406294676887
+      },
+      "euclidean_distance/scalar/1024": {
+        "point_estimate_ns": 1548.5691262270595,
+        "ci_lower_ns": 1547.4469941751292,
+        "ci_upper_ns": 1549.9194334032748,
+        "std_dev_ns": 4.068111450057118
+      },
+      "euclidean_distance/squared_optimized/384": {
+        "point_estimate_ns": 56.54935943610618,
+        "ci_lower_ns": 56.49328139894014,
+        "ci_upper_ns": 56.60575220652723,
+        "std_dev_ns": 0.41466772652803724
+      },
+      "euclidean_distance/squared_optimized/1536": {
+        "point_estimate_ns": 269.6691770580903,
+        "ci_lower_ns": 269.2291547012724,
+        "ci_upper_ns": 270.15127651894113,
+        "std_dev_ns": 0.9017312909151741
+      },
+      "euclidean_distance/squared_optimized/768": {
+        "point_estimate_ns": 121.20137541414549,
+        "ci_lower_ns": 121.06846434986943,
+        "ci_upper_ns": 121.35750949907654,
+        "std_dev_ns": 2.133007006943603
+      },
+      "euclidean_distance/squared_optimized/1024": {
+        "point_estimate_ns": 173.00439571343534,
+        "ci_lower_ns": 172.87465717697717,
+        "ci_upper_ns": 173.15795926277556,
+        "std_dev_ns": 0.7656656467220114
+      },
+      "euclidean_distance/optimized/384": {
+        "point_estimate_ns": 65.57527435939502,
+        "ci_lower_ns": 60.83333640760525,
+        "ci_upper_ns": 69.99990814531309,
+        "std_dev_ns": 7.800896216176965
+      },
+      "euclidean_distance/optimized/1536": {
+        "point_estimate_ns": 272.6012258228882,
+        "ci_lower_ns": 272.4163630482749,
+        "ci_upper_ns": 272.8048343492003,
+        "std_dev_ns": 1.2809147242660688
+      },
+      "euclidean_distance/optimized/768": {
+        "point_estimate_ns": 123.78840471954702,
+        "ci_lower_ns": 123.67942151394844,
+        "ci_upper_ns": 123.91545195200639,
+        "std_dev_ns": 0.3390450102255318
+      },
+      "euclidean_distance/optimized/1024": {
+        "point_estimate_ns": 174.9884045355915,
+        "ci_lower_ns": 174.56833126494863,
+        "ci_upper_ns": 175.5089974607085,
+        "std_dev_ns": 1.2316625335398383
+      },
+      "read_under_write_contention/concurrent_writers/0": {
+        "point_estimate_ns": 4455.426772706844,
+        "ci_lower_ns": 4228.904255243324,
+        "ci_upper_ns": 4747.023021532846,
+        "std_dev_ns": 593.7576979858123
+      },
+      "read_under_write_contention/concurrent_writers/2": {
+        "point_estimate_ns": 56660316.7,
+        "ci_lower_ns": 56342906.459,
+        "ci_upper_ns": 57013083.076,
+        "std_dev_ns": 1234746.7595733292
+      },
+      "read_under_write_contention/concurrent_writers/4": {
+        "point_estimate_ns": 114751007.08,
+        "ci_lower_ns": 114185925.59750001,
+        "ci_upper_ns": 115377109.3205,
+        "std_dev_ns": 2190986.5817636866
+      },
+      "id_generation_concurrent/threads/16": {
+        "point_estimate_ns": 674798.7572626674,
+        "ci_lower_ns": 668288.2926207652,
+        "ci_upper_ns": 681783.3986652055,
+        "std_dev_ns": 23923.610665976543
+      },
+      "id_generation_concurrent/threads/8": {
+        "point_estimate_ns": 375165.36757558107,
+        "ci_lower_ns": 364372.68182923587,
+        "ci_upper_ns": 389890.68533766165,
+        "std_dev_ns": 20331.940368507767
+      },
+      "id_generation_concurrent/threads/2": {
+        "point_estimate_ns": 120894.25543802958,
+        "ci_lower_ns": 119813.18037511063,
+        "ci_upper_ns": 122226.33233414432,
+        "std_dev_ns": 3215.281715497198
+      },
+      "id_generation_concurrent/threads/4": {
+        "point_estimate_ns": 198106.50377518928,
+        "ci_lower_ns": 195265.73151800624,
+        "ci_upper_ns": 201011.87742324016,
+        "std_dev_ns": 7944.915683285184
+      },
+      "get_outgoing_allocation/degree_100": {
+        "point_estimate_ns": 35.37007753341642,
+        "ci_lower_ns": 35.32957017978826,
+        "ci_upper_ns": 35.41783828205542,
+        "std_dev_ns": 0.31983952106436037
+      },
+      "get_outgoing_allocation/degree_1": {
+        "point_estimate_ns": 35.64383561653385,
+        "ci_lower_ns": 35.61734796572943,
+        "ci_upper_ns": 35.66919243545134,
+        "std_dev_ns": 0.06884481015157937
+      },
+      "get_outgoing_allocation/degree_10": {
+        "point_estimate_ns": 35.29625517503524,
+        "ci_lower_ns": 35.26888529547903,
+        "ci_upper_ns": 35.32687675869668,
+        "std_dev_ns": 0.08881434916073606
+      },
+      "knn_search/k/50": {
+        "point_estimate_ns": 122093.90440761723,
+        "ci_lower_ns": 121492.29242675022,
+        "ci_upper_ns": 122907.09339724136,
+        "std_dev_ns": 2652.666291309944
+      },
+      "knn_search/k/1": {
+        "point_estimate_ns": 126509.63519457828,
+        "ci_lower_ns": 122083.13383962188,
+        "ci_upper_ns": 132789.85542901038,
+        "std_dev_ns": 19356.090456311176
+      },
+      "knn_search/k/20": {
+        "point_estimate_ns": 123289.13095568381,
+        "ci_lower_ns": 122098.07132619909,
+        "ci_upper_ns": 124403.67722678144,
+        "std_dev_ns": 3430.693861973091
+      },
+      "knn_search/k/5": {
+        "point_estimate_ns": 119250.1898455728,
+        "ci_lower_ns": 118895.43223975068,
+        "ci_upper_ns": 119590.96809472723,
+        "std_dev_ns": 866.5413190063905
+      },
+      "knn_search/k/10": {
+        "point_estimate_ns": 121112.20972699476,
+        "ci_lower_ns": 119567.8092913403,
+        "ci_upper_ns": 123386.16247473622,
+        "std_dev_ns": 4584.707344926931
+      },
+      "time_travel/with_deltas_v15": {
+        "point_estimate_ns": 123.94108617344811,
+        "ci_lower_ns": 123.87726856500903,
+        "ci_upper_ns": 124.00331126580733,
+        "std_dev_ns": 0.20129852895614195
+      },
+      "time_travel/worst_case_v19": {
+        "point_estimate_ns": 124.38143219103625,
+        "ci_lower_ns": 124.31759565286475,
+        "ci_upper_ns": 124.43933881412619,
+        "std_dev_ns": 0.22737834678792196
+      },
+      "time_travel/deep_history_v5": {
+        "point_estimate_ns": 124.32220953215895,
+        "ci_lower_ns": 124.25382761521922,
+        "ci_upper_ns": 124.40117725691292,
+        "std_dev_ns": 0.30269301475505767
+      },
+      "time_travel/at_anchor_v20": {
+        "point_estimate_ns": 123.9871966988356,
+        "ci_lower_ns": 123.88165028073607,
+        "ci_upper_ns": 124.10902247919365,
+        "std_dev_ns": 0.3018724578665994
+      },
+      "cold_read_latency/single_read/fast_compression": {
+        "point_estimate_ns": 34538.98897418321,
+        "ci_lower_ns": 34483.416819465136,
+        "ci_upper_ns": 34597.04178980134,
+        "std_dev_ns": 186.98530354473306
+      },
+      "cold_read_latency/single_read/no_compression": {
+        "point_estimate_ns": 3305.515133139873,
+        "ci_lower_ns": 3297.8645851267975,
+        "ci_upper_ns": 3314.7192684643405,
+        "std_dev_ns": 25.440653302298184
+      },
+      "cold_read_latency/single_read/zstd_compression": {
+        "point_estimate_ns": 34408.70690512883,
+        "ci_lower_ns": 34361.242517227394,
+        "ci_upper_ns": 34464.71293006415,
+        "std_dev_ns": 246.06774057610986
+      },
+      "compression_ratio/compress/zstd": {
+        "point_estimate_ns": 36219494.286666654,
+        "ci_lower_ns": 35560019.79233333,
+        "ci_upper_ns": 36921965.50316668,
+        "std_dev_ns": 2477152.691846728
+      },
+      "compression_ratio/compress/fast": {
+        "point_estimate_ns": 34868527.833333336,
+        "ci_lower_ns": 33563202.329333335,
+        "ci_upper_ns": 36400317.15733333,
+        "std_dev_ns": 5177346.382327758
+      },
+      "compression_ratio/compress/no_compression": {
+        "point_estimate_ns": 31258891.685,
+        "ci_lower_ns": 31049722.01375,
+        "ci_upper_ns": 31475848.00925,
+        "std_dev_ns": 775448.9110164539
+      },
+      "target_3_hop/traverse_three_hops": {
+        "point_estimate_ns": 269.43765503624775,
+        "ci_lower_ns": 268.0298722529492,
+        "ci_upper_ns": 271.0012557019393,
+        "std_dev_ns": 9.606920176901632
+      },
+      "vector_round_trip/round_trip/384": {
+        "point_estimate_ns": 384.86400918963216,
+        "ci_lower_ns": 382.49770453437765,
+        "ci_upper_ns": 386.9566262476498,
+        "std_dev_ns": 6.5658071524244015
+      },
+      "vector_round_trip/round_trip/1536": {
+        "point_estimate_ns": 613.6658263654791,
+        "ci_lower_ns": 611.8239384984795,
+        "ci_upper_ns": 615.3107056889797,
+        "std_dev_ns": 9.509857572562321
+      },
+      "vector_round_trip/round_trip/768": {
+        "point_estimate_ns": 427.7806563706588,
+        "ci_lower_ns": 425.9115196077719,
+        "ci_upper_ns": 429.451104453239,
+        "std_dev_ns": 5.004024432548947
+      },
+      "vector_round_trip/round_trip/3072": {
+        "point_estimate_ns": 1433.3591347985741,
+        "ci_lower_ns": 1421.3147234438861,
+        "ci_upper_ns": 1444.9015894425463,
+        "std_dev_ns": 49.42993508636259
+      },
+      "id_generation_lifecycle/create_and_generate_1000": {
+        "point_estimate_ns": 8802.392448704384,
+        "ci_lower_ns": 8363.484540151285,
+        "ci_upper_ns": 9120.957342294862,
+        "std_dev_ns": 1305.891940216402
+      },
+      "checkpoint_load/100": {
+        "point_estimate_ns": 323505.1117225931,
+        "ci_lower_ns": 317370.35659891285,
+        "ci_upper_ns": 329802.39480044524,
+        "std_dev_ns": 21738.10163697689
+      },
+      "checkpoint_load/1000": {
+        "point_estimate_ns": 1627957.6991962725,
+        "ci_lower_ns": 1614000.2404127382,
+        "ci_upper_ns": 1643690.7458574725,
+        "std_dev_ns": 32446.955283003063
+      },
+      "checkpoint_load/10000": {
+        "point_estimate_ns": 15179930.231428571,
+        "ci_lower_ns": 15079806.457857143,
+        "ci_upper_ns": 15286784.626642859,
+        "std_dev_ns": 375447.7020221171
+      },
+      "vector_batch_deserialize/retrieval_workload/100x1536": {
+        "point_estimate_ns": 36637.56808260677,
+        "ci_lower_ns": 36539.587069966845,
+        "ci_upper_ns": 36728.99519577845,
+        "std_dev_ns": 324.3594376831502
+      },
+      "recovery/100": {
+        "point_estimate_ns": 457033.1928759464,
+        "ci_lower_ns": 438482.2344092627,
+        "ci_upper_ns": 494306.82851205405,
+        "std_dev_ns": 51075.2476465431
+      },
+      "recovery/1000": {
+        "point_estimate_ns": 647916.7172199573,
+        "ci_lower_ns": 646497.8814303161,
+        "ci_upper_ns": 649590.2856508717,
+        "std_dev_ns": 7889.834617825697
+      },
+      "recovery/10": {
+        "point_estimate_ns": 500064.19062317995,
+        "ci_lower_ns": 459829.14466473385,
+        "ci_upper_ns": 536521.8430519077,
+        "std_dev_ns": 77402.31048346696
+      },
+      "multiple_accesses/resolve_100": {
+        "point_estimate_ns": 3567.367055038908,
+        "ci_lower_ns": 3556.587835497716,
+        "ci_upper_ns": 3579.9293147177,
+        "std_dev_ns": 41.49185115037814
+      },
+      "cold_write_latency/single_write/fast_compression": {
+        "point_estimate_ns": 340425.96731120173,
+        "ci_lower_ns": 338745.0933302751,
+        "ci_upper_ns": 342087.8231430796,
+        "std_dev_ns": 5000.708550567791
+      },
+      "cold_write_latency/single_write/no_compression": {
+        "point_estimate_ns": 343791.2879351284,
+        "ci_lower_ns": 317659.6437920853,
+        "ci_upper_ns": 379626.5056915552,
+        "std_dev_ns": 133108.06611400665
+      },
+      "cold_write_latency/single_write/zstd_compression": {
+        "point_estimate_ns": 373867.1990378567,
+        "ci_lower_ns": 370440.4175870634,
+        "ci_upper_ns": 377869.54543988156,
+        "std_dev_ns": 9877.743493399437
+      },
+      "aletheiadb_single_hop/10000_nodes": {
+        "point_estimate_ns": 116.49985044180652,
+        "ci_lower_ns": 116.39087063564696,
+        "ci_upper_ns": 116.60856510997525,
+        "std_dev_ns": 0.3353768363985375
+      },
+      "aletheiadb_single_hop/100_nodes": {
+        "point_estimate_ns": 116.13474008164467,
+        "ci_lower_ns": 116.05774719758405,
+        "ci_upper_ns": 116.21934076123657,
+        "std_dev_ns": 0.2799466457600994
+      },
+      "aletheiadb_single_hop/1000_nodes": {
+        "point_estimate_ns": 116.55173956114795,
+        "ci_lower_ns": 116.46367818388474,
+        "ci_upper_ns": 116.65163854417558,
+        "std_dev_ns": 0.30627926284570367
+      },
+      "valid_at_query/1000_versions": {
+        "point_estimate_ns": 3901.2447142025126,
+        "ci_lower_ns": 3697.8750605947957,
+        "ci_upper_ns": 4082.71623580502,
+        "std_dev_ns": 1058.362185703034
+      },
+      "valid_at_query/100_versions": {
+        "point_estimate_ns": 1529.9313631966777,
+        "ci_lower_ns": 1373.0330513962904,
+        "ci_upper_ns": 1654.4851320116004,
+        "std_dev_ns": 426.82645254257915
+      },
+      "valid_at_query/10000_versions": {
+        "point_estimate_ns": 22355.149504950496,
+        "ci_lower_ns": 21471.26207518374,
+        "ci_upper_ns": 23090.904627556694,
+        "std_dev_ns": 4686.36815458784
+      },
+      "vector_serialize/serialize/1": {
+        "point_estimate_ns": 27.673608053749902,
+        "ci_lower_ns": 27.632286608855228,
+        "ci_upper_ns": 27.724743699562758,
+        "std_dev_ns": 0.2224885253941403
+      },
+      "vector_serialize/serialize/384": {
+        "point_estimate_ns": 134.55908824435917,
+        "ci_lower_ns": 134.43078608145635,
+        "ci_upper_ns": 134.7104438960172,
+        "std_dev_ns": 0.6051064936589614
+      },
+      "vector_serialize/serialize/1536": {
+        "point_estimate_ns": 173.47123845365698,
+        "ci_lower_ns": 173.3445689234157,
+        "ci_upper_ns": 173.60173461784822,
+        "std_dev_ns": 0.7298685288771316
+      },
+      "vector_serialize/serialize/768": {
+        "point_estimate_ns": 133.5553335405855,
+        "ci_lower_ns": 128.5746139526206,
+        "ci_upper_ns": 139.6480356515268,
+        "std_dev_ns": 11.184025489207169
+      },
+      "vector_serialize/serialize/10": {
+        "point_estimate_ns": 27.10969151013782,
+        "ci_lower_ns": 27.088070657580058,
+        "ci_upper_ns": 27.13204086819459,
+        "std_dev_ns": 0.16193194965444008
+      },
+      "vector_serialize/serialize/3072": {
+        "point_estimate_ns": 219.166398555573,
+        "ci_lower_ns": 218.12404349449477,
+        "ci_upper_ns": 220.38295068654887,
+        "std_dev_ns": 3.1593014081284116
+      },
+      "vector_serialize/serialize/128": {
+        "point_estimate_ns": 34.78008298128952,
+        "ci_lower_ns": 34.22327454879736,
+        "ci_upper_ns": 35.39301498867917,
+        "std_dev_ns": 1.5387129620804807
+      },
+      "target_single_hop/traverse_one_hop": {
+        "point_estimate_ns": 39.50975043293543,
+        "ci_lower_ns": 39.45794272543594,
+        "ci_upper_ns": 39.578817026046,
+        "std_dev_ns": 0.2627589623244283
+      },
+      "incremental_read_no_delta/10000edges": {
+        "point_estimate_ns": 32.615126384579405,
+        "ci_lower_ns": 32.59835503228489,
+        "ci_upper_ns": 32.63338056705859,
+        "std_dev_ns": 0.1764509219117716
+      },
+      "incremental_read_no_delta/100edges": {
+        "point_estimate_ns": 32.64998275602441,
+        "ci_lower_ns": 32.62826765842757,
+        "ci_upper_ns": 32.67534077142335,
+        "std_dev_ns": 0.15722805440079446
+      },
+      "incremental_read_no_delta/1000edges": {
+        "point_estimate_ns": 32.638326994677385,
+        "ci_lower_ns": 32.617206185571135,
+        "ci_upper_ns": 32.662425750135775,
+        "std_dev_ns": 0.1365022661685344
+      },
+      "incremental_read_with_delta/5pct_delta": {
+        "point_estimate_ns": 64.20539590577019,
+        "ci_lower_ns": 63.866149530468796,
+        "ci_upper_ns": 64.70296495795208,
+        "std_dev_ns": 1.2042861636660909
+      },
+      "incremental_read_with_delta/10pct_delta": {
+        "point_estimate_ns": 67.85716221005087,
+        "ci_lower_ns": 66.55099368354807,
+        "ci_upper_ns": 69.56345063435435,
+        "std_dev_ns": 11.4710049240047
+      },
+      "incremental_read_with_delta/1pct_delta": {
+        "point_estimate_ns": 63.97808794457741,
+        "ci_lower_ns": 63.803338059925444,
+        "ci_upper_ns": 64.25243762149866,
+        "std_dev_ns": 1.466938559028812
+      },
+      "checkpoint_creation/100": {
+        "point_estimate_ns": 4892958.511683168,
+        "ci_lower_ns": 4453138.641514439,
+        "ci_upper_ns": 5316047.953912391,
+        "std_dev_ns": 957471.1519417716
+      },
+      "checkpoint_creation/1000": {
+        "point_estimate_ns": 4029267.210052417,
+        "ci_lower_ns": 3874044.9090519454,
+        "ci_upper_ns": 4261108.064843288,
+        "std_dev_ns": 441504.3756389884
+      },
+      "checkpoint_creation/10000": {
+        "point_estimate_ns": 7663184.584298194,
+        "ci_lower_ns": 7567967.6947611775,
+        "ci_upper_ns": 7757402.296487848,
+        "std_dev_ns": 293783.8391089341
+      },
+      "aletheiadb_fast_path/node_lookup/100": {
+        "point_estimate_ns": 62.73373899236301,
+        "ci_lower_ns": 62.66483647522679,
+        "ci_upper_ns": 62.809710208718144,
+        "std_dev_ns": 0.39135934967286307
+      },
+      "aletheiadb_fast_path/node_lookup/1000": {
+        "point_estimate_ns": 62.00297879878713,
+        "ci_lower_ns": 61.95085532214455,
+        "ci_upper_ns": 62.069171614739744,
+        "std_dev_ns": 0.24226979413802682
+      },
+      "aletheiadb_fast_path/node_lookup/10000": {
+        "point_estimate_ns": 61.157717975312195,
+        "ci_lower_ns": 61.10321012686252,
+        "ci_upper_ns": 61.22658676833341,
+        "std_dev_ns": 0.20416172669622049
+      },
+      "incremental_insert_latency/10000existing": {
+        "point_estimate_ns": 183.16392077464496,
+        "ci_lower_ns": 173.8104281130073,
+        "ci_upper_ns": 191.40702226917637,
+        "std_dev_ns": 40.58353570472353
+      },
+      "incremental_insert_latency/100000existing": {
+        "point_estimate_ns": 289.18018009986974,
+        "ci_lower_ns": 239.88875383036736,
+        "ci_upper_ns": 340.0765867034958,
+        "std_dev_ns": 118.53591673866855
+      },
+      "incremental_insert_latency/0existing": {
+        "point_estimate_ns": 288.59472195046067,
+        "ci_lower_ns": 238.6229966026389,
+        "ci_upper_ns": 340.8245076954626,
+        "std_dev_ns": 120.28775664838388
+      },
+      "incremental_insert_latency/1000existing": {
+        "point_estimate_ns": 226.3477089455863,
+        "ci_lower_ns": 217.26571311526763,
+        "ci_upper_ns": 238.19503646269692,
+        "std_dev_ns": 54.10091786776028
+      },
+      "string_length/resolve_with": {
+        "point_estimate_ns": 22.016764653074066,
+        "ci_lower_ns": 21.95214356124502,
+        "ci_upper_ns": 22.09002385525802,
+        "std_dev_ns": 0.24871001219589173
+      },
+      "string_length/resolve": {
+        "point_estimate_ns": 36.50580691123255,
+        "ci_lower_ns": 36.20757405196972,
+        "ci_upper_ns": 36.8016939750044,
+        "std_dev_ns": 0.7501905735274245
+      },
+      "temporal_insert/append_only/100": {
+        "point_estimate_ns": 20522.29958305742,
+        "ci_lower_ns": 20385.267113086968,
+        "ci_upper_ns": 20631.394888370593,
+        "std_dev_ns": 684.2967464825315
+      },
+      "temporal_insert/append_only/1000": {
+        "point_estimate_ns": 210751.62610075713,
+        "ci_lower_ns": 209314.34380635383,
+        "ci_upper_ns": 211873.80906999423,
+        "std_dev_ns": 5680.652576793
+      },
+      "temporal_insert/append_only/10000": {
+        "point_estimate_ns": 2170104.954571928,
+        "ci_lower_ns": 2162071.2235821434,
+        "ci_upper_ns": 2177642.346841939,
+        "std_dev_ns": 99951.82828220678
+      },
+      "temporal_insert/retroactive/100": {
+        "point_estimate_ns": 147472.24641996325,
+        "ci_lower_ns": 146592.02753194023,
+        "ci_upper_ns": 149223.88182725324,
+        "std_dev_ns": 9805.6702862456
+      },
+      "temporal_insert/retroactive/1000": {
+        "point_estimate_ns": 12548726.1525,
+        "ci_lower_ns": 12526667.3475625,
+        "ci_upper_ns": 12577634.3285,
+        "std_dev_ns": 93777.24757700117
+      },
+      "temporal_insert/retroactive/10000": {
+        "point_estimate_ns": 1286764102.48,
+        "ci_lower_ns": 1269283391.64,
+        "ci_upper_ns": 1309601746.974,
+        "std_dev_ns": 74452411.39648002
+      },
+      "string_access_single/resolve_with": {
+        "point_estimate_ns": 21.820499640233535,
+        "ci_lower_ns": 21.806117477221118,
+        "ci_upper_ns": 21.836261417227917,
+        "std_dev_ns": 0.039902043410477255
+      },
+      "string_access_single/resolve": {
+        "point_estimate_ns": 35.573416414968506,
+        "ci_lower_ns": 35.559164666582994,
+        "ci_upper_ns": 35.5900314885661,
+        "std_dev_ns": 0.2708011837692615
+      },
+      "comparison_csr/full_rebuild_insert_query": {
+        "point_estimate_ns": 140052.95014629822,
+        "ci_lower_ns": 138986.04724080354,
+        "ci_upper_ns": 141174.3368847318,
+        "std_dev_ns": 3578.8835747506027
+      },
+      "comparison_csr/incremental_csr_insert_query": {
+        "point_estimate_ns": 16596.11120437417,
+        "ci_lower_ns": 16442.978831018278,
+        "ci_upper_ns": 16737.220337734212,
+        "std_dev_ns": 1377.0705344329174
+      },
+      "find_nodes_by_property/10000_nodes": {
+        "point_estimate_ns": 757093.3238672103,
+        "ci_lower_ns": 746168.3758693849,
+        "ci_upper_ns": 766515.1394017288,
+        "std_dev_ns": 29835.045035738345
+      },
+      "find_nodes_by_property/100_nodes": {
+        "point_estimate_ns": 4674.447981458158,
+        "ci_lower_ns": 4670.523795762465,
+        "ci_upper_ns": 4678.918047100781,
+        "std_dev_ns": 14.617992774181248
+      },
+      "find_nodes_by_property/1000_nodes": {
+        "point_estimate_ns": 50790.10942825674,
+        "ci_lower_ns": 47402.70506254149,
+        "ci_upper_ns": 53722.90827884785,
+        "std_dev_ns": 9094.726036926444
+      },
+      "concurrent_reads_same_entity/1000_versions/4_readers": {
+        "point_estimate_ns": 220643.6706594189,
+        "ci_lower_ns": 218651.07300263204,
+        "ci_upper_ns": 222611.5618024858,
+        "std_dev_ns": 4865.43768344186
+      },
+      "concurrent_reads_same_entity/1000_versions/2_readers": {
+        "point_estimate_ns": 130103.11400194137,
+        "ci_lower_ns": 129418.02343327574,
+        "ci_upper_ns": 130803.55000659086,
+        "std_dev_ns": 3216.3649522275277
+      },
+      "concurrent_reads_same_entity/1000_versions/16_readers": {
+        "point_estimate_ns": 767645.7277732479,
+        "ci_lower_ns": 764525.121111043,
+        "ci_upper_ns": 770778.2599352465,
+        "std_dev_ns": 15584.005291488184
+      },
+      "concurrent_reads_same_entity/1000_versions/8_readers": {
+        "point_estimate_ns": 422905.2037297612,
+        "ci_lower_ns": 420854.7629823159,
+        "ci_upper_ns": 424934.40866369667,
+        "std_dev_ns": 11425.593512367848
+      },
+      "concurrent_reads_same_entity/100_versions/4_readers": {
+        "point_estimate_ns": 203703.20611648224,
+        "ci_lower_ns": 202440.93124589915,
+        "ci_upper_ns": 205194.36245293386,
+        "std_dev_ns": 5225.996708479067
+      },
+      "concurrent_reads_same_entity/100_versions/2_readers": {
+        "point_estimate_ns": 130264.34551336728,
+        "ci_lower_ns": 129534.23520270771,
+        "ci_upper_ns": 131028.28359908394,
+        "std_dev_ns": 4798.764901425062
+      },
+      "concurrent_reads_same_entity/100_versions/16_readers": {
+        "point_estimate_ns": 696718.4900718307,
+        "ci_lower_ns": 693914.9793091253,
+        "ci_upper_ns": 699715.2173716048,
+        "std_dev_ns": 15491.27050133308
+      },
+      "concurrent_reads_same_entity/100_versions/8_readers": {
+        "point_estimate_ns": 383867.5403632128,
+        "ci_lower_ns": 382497.37839177676,
+        "ci_upper_ns": 385170.55045344535,
+        "std_dev_ns": 7710.20248888855
+      },
+      "concurrent_reads_same_entity/10000_versions/4_readers": {
+        "point_estimate_ns": 474740.6933333331,
+        "ci_lower_ns": 421344.7715,
+        "ci_upper_ns": 528949.2962499999,
+        "std_dev_ns": 196782.40339912684
+      },
+      "concurrent_reads_same_entity/10000_versions/2_readers": {
+        "point_estimate_ns": 133878.10658767296,
+        "ci_lower_ns": 133460.23790329424,
+        "ci_upper_ns": 134345.93190582373,
+        "std_dev_ns": 2175.063729742513
+      },
+      "incremental_concurrent/threads/8": {
+        "point_estimate_ns": 410131.9005428304,
+        "ci_lower_ns": 408373.5202702741,
+        "ci_upper_ns": 411841.8930391688,
+        "std_dev_ns": 13058.990535438406
+      },
+      "incremental_concurrent/threads/2": {
+        "point_estimate_ns": 141575.1914281492,
+        "ci_lower_ns": 140155.98381994627,
+        "ci_upper_ns": 143494.56347257362,
+        "std_dev_ns": 6603.834932604687
+      },
+      "incremental_concurrent/threads/4": {
+        "point_estimate_ns": 211622.76810935422,
+        "ci_lower_ns": 210643.15045712664,
+        "ci_upper_ns": 212666.46160767143,
+        "std_dev_ns": 4921.443297055306
+      },
+      "batch_throughput/async": {
+        "point_estimate_ns": 52792620.31,
+        "ci_lower_ns": 52741715.938,
+        "ci_upper_ns": 52842522.594000004,
+        "std_dev_ns": 184682.41502608263
+      },
+      "batch_throughput/synchronous": {
+        "point_estimate_ns": 635748426.36,
+        "ci_lower_ns": 625995236.8475,
+        "ci_upper_ns": 645221511.522,
+        "std_dev_ns": 35302616.52595306
+      },
+      "vector_deserialize/deserialize/1": {
+        "point_estimate_ns": 54.634844338887056,
+        "ci_lower_ns": 54.562327144304966,
+        "ci_upper_ns": 54.7180284042944,
+        "std_dev_ns": 0.4692962144789647
+      },
+      "vector_deserialize/deserialize/384": {
+        "point_estimate_ns": 240.66191243823593,
+        "ci_lower_ns": 239.07238836894214,
+        "ci_upper_ns": 242.3761405864826,
+        "std_dev_ns": 6.282165687456844
+      },
+      "vector_deserialize/deserialize/1536": {
+        "point_estimate_ns": 376.7175371779577,
+        "ci_lower_ns": 373.53806652837216,
+        "ci_upper_ns": 380.21145368476397,
+        "std_dev_ns": 10.593303839886085
+      },
+      "vector_deserialize/deserialize/768": {
+        "point_estimate_ns": 281.79972963268517,
+        "ci_lower_ns": 280.3144358714689,
+        "ci_upper_ns": 283.4020330083632,
+        "std_dev_ns": 5.4114215871080855
+      },
+      "vector_deserialize/deserialize/10": {
+        "point_estimate_ns": 55.427536643270656,
+        "ci_lower_ns": 55.35863352615305,
+        "ci_upper_ns": 55.50540540573598,
+        "std_dev_ns": 0.4179189168767644
+      },
+      "vector_deserialize/deserialize/3072": {
+        "point_estimate_ns": 751.7690523500676,
+        "ci_lower_ns": 745.1251654616283,
+        "ci_upper_ns": 758.7798937152565,
+        "std_dev_ns": 32.56934522833825
+      },
+      "vector_deserialize/deserialize/128": {
+        "point_estimate_ns": 67.05146047776178,
+        "ci_lower_ns": 66.95504185671022,
+        "ci_upper_ns": 67.15417781035717,
+        "std_dev_ns": 0.46090468043793825
+      },
+      "point_in_time_queries/100vectors": {
+        "point_estimate_ns": 27.389063786854848,
+        "ci_lower_ns": 27.345163835210737,
+        "ci_upper_ns": 27.440472446259175,
+        "std_dev_ns": 0.14731101925340268
+      },
+      "point_in_time_queries/1000vectors": {
+        "point_estimate_ns": 30.179779021960126,
+        "ci_lower_ns": 30.078579618566604,
+        "ci_upper_ns": 30.289949941880494,
+        "std_dev_ns": 0.26437715703196063
+      },
+      "frozen_view_hot_path/merged_guard/10000edges": {
+        "point_estimate_ns": 32.67519883195999,
+        "ci_lower_ns": 32.649108182513416,
+        "ci_upper_ns": 32.706271673362586,
+        "std_dev_ns": 0.14482066879288646
+      },
+      "frozen_view_hot_path/merged_guard/100000edges": {
+        "point_estimate_ns": 32.76054260158381,
+        "ci_lower_ns": 32.73806757132794,
+        "ci_upper_ns": 32.786727461779705,
+        "std_dev_ns": 0.17373225593993583
+      },
+      "frozen_view_hot_path/merged_guard/1000edges": {
+        "point_estimate_ns": 32.62919008770308,
+        "ci_lower_ns": 32.605461651218995,
+        "ci_upper_ns": 32.65514848763087,
+        "std_dev_ns": 0.21476070759175245
+      },
+      "frozen_view_hot_path/frozen_view/10000edges": {
+        "point_estimate_ns": 33.896657755440856,
+        "ci_lower_ns": 33.482295353838865,
+        "ci_upper_ns": 34.348690334063875,
+        "std_dev_ns": 1.4311210377550325
+      },
+      "frozen_view_hot_path/frozen_view/100000edges": {
+        "point_estimate_ns": 39.969587399460416,
+        "ci_lower_ns": 39.94481871185667,
+        "ci_upper_ns": 39.99974429706756,
+        "std_dev_ns": 0.14857647091883155
+      },
+      "frozen_view_hot_path/frozen_view/1000edges": {
+        "point_estimate_ns": 20.747840792120062,
+        "ci_lower_ns": 20.734209310323433,
+        "ci_upper_ns": 20.762883691754624,
+        "std_dev_ns": 0.17888170415587473
+      },
+      "snapshot_creation/time_interval_1s": {
+        "point_estimate_ns": 77.07483680377175,
+        "ci_lower_ns": 77.01920620750329,
+        "ci_upper_ns": 77.13983057918867,
+        "std_dev_ns": 0.2883066914177555
+      },
+      "snapshot_creation/transaction_interval_10": {
+        "point_estimate_ns": 24160.601549213745,
+        "ci_lower_ns": 24070.95496700248,
+        "ci_upper_ns": 24242.851609687445,
+        "std_dev_ns": 952.9031033834278
+      },
+      "snapshot_creation/transaction_interval_100": {
+        "point_estimate_ns": 2503.7850904370607,
+        "ci_lower_ns": 2490.085509540908,
+        "ci_upper_ns": 2517.3349735616202,
+        "std_dev_ns": 126.61764600049827
+      },
+      "vector_serialize_into/serialize_into/384": {
+        "point_estimate_ns": 119.69433782414332,
+        "ci_lower_ns": 119.42625567786244,
+        "ci_upper_ns": 120.01074892728904,
+        "std_dev_ns": 1.4166882738202475
+      },
+      "vector_serialize_into/serialize_into/1536": {
+        "point_estimate_ns": 181.31700014885956,
+        "ci_lower_ns": 181.2098463237283,
+        "ci_upper_ns": 181.44543224129666,
+        "std_dev_ns": 0.6017509010163365
+      },
+      "vector_serialize_into/serialize_into/768": {
+        "point_estimate_ns": 141.5379075588664,
+        "ci_lower_ns": 141.4070386977251,
+        "ci_upper_ns": 141.68053300576926,
+        "std_dev_ns": 0.6513876337328833
+      },
+      "property_lookup_vs_scan/manual_label_scan_filter": {
+        "point_estimate_ns": 138292.4284031892,
+        "ci_lower_ns": 137987.3106202215,
+        "ci_upper_ns": 138632.84856732658,
+        "std_dev_ns": 791.5883306187459
+      },
+      "property_lookup_vs_scan/find_nodes_by_property": {
+        "point_estimate_ns": 39030.58003540599,
+        "ci_lower_ns": 38955.93113527668,
+        "ci_upper_ns": 39098.61222806409,
+        "std_dev_ns": 239.7993862709776
+      },
+      "cosine_similarity_batch/find_most_similar/100": {
+        "point_estimate_ns": 8280.609838079861,
+        "ci_lower_ns": 8265.691245368853,
+        "ci_upper_ns": 8298.343185238891,
+        "std_dev_ns": 41.256241498551134
+      },
+      "cosine_similarity_batch/find_most_similar/1000": {
+        "point_estimate_ns": 90458.83444632955,
+        "ci_lower_ns": 88304.6182155683,
+        "ci_upper_ns": 92978.87079841267,
+        "std_dev_ns": 4348.194252478644
+      },
+      "cosine_similarity_batch/find_most_similar/10": {
+        "point_estimate_ns": 811.346767454623,
+        "ci_lower_ns": 810.3818058083525,
+        "ci_upper_ns": 812.3507548979015,
+        "std_dev_ns": 3.5231342212289287
+      },
+      "concurrent_writes/same_entity_contention/8": {
+        "point_estimate_ns": 9476390.287272723,
+        "ci_lower_ns": 9148257.177181816,
+        "ci_upper_ns": 9844934.79586364,
+        "std_dev_ns": 1278310.3311533588
+      },
+      "concurrent_writes/same_entity_contention/2": {
+        "point_estimate_ns": 214574.15811153175,
+        "ci_lower_ns": 181185.43486848514,
+        "ci_upper_ns": 248623.72722661766,
+        "std_dev_ns": 52568.23054200384
+      },
+      "concurrent_writes/same_entity_contention/4": {
+        "point_estimate_ns": 1225713.092424772,
+        "ci_lower_ns": 1166934.228398231,
+        "ci_upper_ns": 1295075.5195692186,
+        "std_dev_ns": 191882.99420482724
+      },
+      "concurrent_writes/different_entities/8": {
+        "point_estimate_ns": 417359.9350203844,
+        "ci_lower_ns": 408207.3261324403,
+        "ci_upper_ns": 426214.2611504691,
+        "std_dev_ns": 21102.406923544866
+      },
+      "concurrent_writes/different_entities/2": {
+        "point_estimate_ns": 139706.9219879635,
+        "ci_lower_ns": 138856.87105457723,
+        "ci_upper_ns": 140629.48944885316,
+        "std_dev_ns": 3793.6545388626446
+      },
+      "concurrent_writes/different_entities/4": {
+        "point_estimate_ns": 220014.88403028538,
+        "ci_lower_ns": 218937.17862020747,
+        "ci_upper_ns": 220928.03934378288,
+        "std_dev_ns": 6023.820497545809
+      },
+      "id_generation_single_thread/sequential_10000": {
+        "point_estimate_ns": 69016.45399421676,
+        "ci_lower_ns": 68968.24171414861,
+        "ci_upper_ns": 69070.52474002307,
+        "std_dev_ns": 154.21533071252975
+      },
+      "id_generation_single_thread/sequential_1000": {
+        "point_estimate_ns": 6901.385823250511,
+        "ci_lower_ns": 6897.198130665531,
+        "ci_upper_ns": 6906.045779369853,
+        "std_dev_ns": 18.129633948975492
+      },
+      "single_hop_traversal/10000_nodes": {
+        "point_estimate_ns": 431.90010998472775,
+        "ci_lower_ns": 430.16176804663496,
+        "ci_upper_ns": 435.22520005399963,
+        "std_dev_ns": 3.910805512643241
+      },
+      "single_hop_traversal/100_nodes": {
+        "point_estimate_ns": 431.13578048684417,
+        "ci_lower_ns": 430.5470938155083,
+        "ci_upper_ns": 431.82511293445754,
+        "std_dev_ns": 1.900789041985434
+      },
+      "single_hop_traversal/1000_nodes": {
+        "point_estimate_ns": 431.9392073634425,
+        "ci_lower_ns": 430.5472852379227,
+        "ci_upper_ns": 434.3478903337882,
+        "std_dev_ns": 5.008426399981345
+      },
+      "incremental_compaction/edges/10000+1000": {
+        "point_estimate_ns": 955604.505621398,
+        "ci_lower_ns": 949457.5815469574,
+        "ci_upper_ns": 961351.8567861561,
+        "std_dev_ns": 31094.33736716666
+      },
+      "incremental_compaction/edges/1000+100": {
+        "point_estimate_ns": 60279.243483966304,
+        "ci_lower_ns": 60017.43469354896,
+        "ci_upper_ns": 60514.541520152045,
+        "std_dev_ns": 1169.4178671929315
+      },
+      "incremental_compaction/edges/100000+10000": {
+        "point_estimate_ns": 8192206.006666664,
+        "ci_lower_ns": 8161752.750833332,
+        "ci_upper_ns": 8222796.052333336,
+        "std_dev_ns": 154965.52568273258
+      },
+      "string_comparison/resolve_with": {
+        "point_estimate_ns": 22.172138656238662,
+        "ci_lower_ns": 22.027956189501555,
+        "ci_upper_ns": 22.381519712122486,
+        "std_dev_ns": 0.9543828051736296
+      },
+      "string_comparison/resolve": {
+        "point_estimate_ns": 36.166875268357224,
+        "ci_lower_ns": 35.74626295357047,
+        "ci_upper_ns": 36.63060848650528,
+        "std_dev_ns": 1.5154170521481247
+      },
+      "target_batch_insertion/insert_1000_edges": {
+        "point_estimate_ns": 630488.7643259179,
+        "ci_lower_ns": 627712.4823942354,
+        "ci_upper_ns": 633429.481267599,
+        "std_dev_ns": 6529.230313258534
+      },
+      "knn_search_index_size/index_size/500": {
+        "point_estimate_ns": 68084.75761452413,
+        "ci_lower_ns": 67886.98221119061,
+        "ci_upper_ns": 68321.7698030196,
+        "std_dev_ns": 461.9275418261912
+      },
+      "knn_search_index_size/index_size/100": {
+        "point_estimate_ns": 21022.150894363203,
+        "ci_lower_ns": 20982.212180073308,
+        "ci_upper_ns": 21064.357180164658,
+        "std_dev_ns": 111.01539429908154
+      },
+      "knn_search_index_size/index_size/5000": {
+        "point_estimate_ns": 242319.20836616535,
+        "ci_lower_ns": 241147.3793878223,
+        "ci_upper_ns": 243454.87890109434,
+        "std_dev_ns": 3766.520173643887
+      },
+      "knn_search_index_size/index_size/1000": {
+        "point_estimate_ns": 120521.5449432149,
+        "ci_lower_ns": 120146.73582292297,
+        "ci_upper_ns": 120989.84363510176,
+        "std_dev_ns": 2840.1279841366995
+      },
+      "knn_search_index_size/index_size/10000": {
+        "point_estimate_ns": 313174.4962286636,
+        "ci_lower_ns": 310656.7263447485,
+        "ci_upper_ns": 316856.41957542504,
+        "std_dev_ns": 27171.71107871942
+      }
+    }
   }
 ]

--- a/benchmarks/history.json
+++ b/benchmarks/history.json
@@ -41,5 +41,294 @@
         "std_dev_ns": 114686.11563005627
       }
     }
+  },
+  {
+    "timestamp": "2026-02-21T18:56:59.315967+00:00",
+    "commit": "198c57d",
+    "branch": "jules-3069904928789557752-7bfd23b2",
+    "benchmarks": {
+      "write_transaction_creation": {
+        "point_estimate_ns": 462.437451192751,
+        "ci_lower_ns": 461.99519122365655,
+        "ci_upper_ns": 462.94956434670564,
+        "std_dev_ns": 1.8428791358821337
+      },
+      "read_transaction_creation": {
+        "point_estimate_ns": 339.2398020202676,
+        "ci_lower_ns": 335.7963868551652,
+        "ci_upper_ns": 343.7172284630253,
+        "std_dev_ns": 18.818965872716934
+      },
+      "closure_write_single_node": {
+        "point_estimate_ns": 2805759.5909726266,
+        "ci_lower_ns": 2796347.4384530853,
+        "ci_upper_ns": 2816012.120000868,
+        "std_dev_ns": 34097.21087582842
+      },
+      "target_time_travel/with_5_deltas": {
+        "point_estimate_ns": 275.12280051091363,
+        "ci_lower_ns": 273.3902260088697,
+        "ci_upper_ns": 276.6861536595373,
+        "std_dev_ns": 6.1668907832569655
+      },
+      "target_time_travel/at_anchor": {
+        "point_estimate_ns": 282.59198327344984,
+        "ci_lower_ns": 281.1666674124893,
+        "ci_upper_ns": 284.00000178026704,
+        "std_dev_ns": 5.874914585597326
+      },
+      "target_time_travel/worst_case_9_deltas": {
+        "point_estimate_ns": 286.22596070579993,
+        "ci_lower_ns": 285.2287895292346,
+        "ci_upper_ns": 287.1850984284939,
+        "std_dev_ns": 5.5773781190774185
+      },
+      "read_under_write_contention/concurrent_writers/0": {
+        "point_estimate_ns": 4455.426772706844,
+        "ci_lower_ns": 4228.904255243324,
+        "ci_upper_ns": 4747.023021532846,
+        "std_dev_ns": 593.7576979858123
+      },
+      "read_under_write_contention/concurrent_writers/2": {
+        "point_estimate_ns": 56660316.7,
+        "ci_lower_ns": 56342906.459,
+        "ci_upper_ns": 57013083.076,
+        "std_dev_ns": 1234746.7595733292
+      },
+      "read_under_write_contention/concurrent_writers/4": {
+        "point_estimate_ns": 114751007.08,
+        "ci_lower_ns": 114185925.59750001,
+        "ci_upper_ns": 115377109.3205,
+        "std_dev_ns": 2190986.5817636866
+      },
+      "knn_search/k/50": {
+        "point_estimate_ns": 122093.90440761723,
+        "ci_lower_ns": 121492.29242675022,
+        "ci_upper_ns": 122907.09339724136,
+        "std_dev_ns": 2652.666291309944
+      },
+      "knn_search/k/1": {
+        "point_estimate_ns": 126509.63519457828,
+        "ci_lower_ns": 122083.13383962188,
+        "ci_upper_ns": 132789.85542901038,
+        "std_dev_ns": 19356.090456311176
+      },
+      "knn_search/k/20": {
+        "point_estimate_ns": 123289.13095568381,
+        "ci_lower_ns": 122098.07132619909,
+        "ci_upper_ns": 124403.67722678144,
+        "std_dev_ns": 3430.693861973091
+      },
+      "knn_search/k/5": {
+        "point_estimate_ns": 119250.1898455728,
+        "ci_lower_ns": 118895.43223975068,
+        "ci_upper_ns": 119590.96809472723,
+        "std_dev_ns": 866.5413190063905
+      },
+      "knn_search/k/10": {
+        "point_estimate_ns": 121112.20972699476,
+        "ci_lower_ns": 119567.8092913403,
+        "ci_upper_ns": 123386.16247473622,
+        "std_dev_ns": 4584.707344926931
+      },
+      "target_3_hop/traverse_three_hops": {
+        "point_estimate_ns": 282.15733606030585,
+        "ci_lower_ns": 279.7025671955745,
+        "ci_upper_ns": 285.15103732210275,
+        "std_dev_ns": 13.343540038507856
+      },
+      "valid_at_query/1000_versions": {
+        "point_estimate_ns": 3901.2447142025126,
+        "ci_lower_ns": 3697.8750605947957,
+        "ci_upper_ns": 4082.71623580502,
+        "std_dev_ns": 1058.362185703034
+      },
+      "valid_at_query/100_versions": {
+        "point_estimate_ns": 1529.9313631966777,
+        "ci_lower_ns": 1373.0330513962904,
+        "ci_upper_ns": 1654.4851320116004,
+        "std_dev_ns": 426.82645254257915
+      },
+      "valid_at_query/10000_versions": {
+        "point_estimate_ns": 22355.149504950496,
+        "ci_lower_ns": 21471.26207518374,
+        "ci_upper_ns": 23090.904627556694,
+        "std_dev_ns": 4686.36815458784
+      },
+      "target_single_hop/traverse_one_hop": {
+        "point_estimate_ns": 42.60678833115437,
+        "ci_lower_ns": 42.38483333115782,
+        "ci_upper_ns": 42.83175020908999,
+        "std_dev_ns": 0.9908401654190784
+      },
+      "temporal_insert/append_only/100": {
+        "point_estimate_ns": 20522.29958305742,
+        "ci_lower_ns": 20385.267113086968,
+        "ci_upper_ns": 20631.394888370593,
+        "std_dev_ns": 684.2967464825315
+      },
+      "temporal_insert/append_only/1000": {
+        "point_estimate_ns": 210751.62610075713,
+        "ci_lower_ns": 209314.34380635383,
+        "ci_upper_ns": 211873.80906999423,
+        "std_dev_ns": 5680.652576793
+      },
+      "temporal_insert/append_only/10000": {
+        "point_estimate_ns": 2170104.954571928,
+        "ci_lower_ns": 2162071.2235821434,
+        "ci_upper_ns": 2177642.346841939,
+        "std_dev_ns": 99951.82828220678
+      },
+      "temporal_insert/retroactive/100": {
+        "point_estimate_ns": 147472.24641996325,
+        "ci_lower_ns": 146592.02753194023,
+        "ci_upper_ns": 149223.88182725324,
+        "std_dev_ns": 9805.6702862456
+      },
+      "temporal_insert/retroactive/1000": {
+        "point_estimate_ns": 12548726.1525,
+        "ci_lower_ns": 12526667.3475625,
+        "ci_upper_ns": 12577634.3285,
+        "std_dev_ns": 93777.24757700117
+      },
+      "temporal_insert/retroactive/10000": {
+        "point_estimate_ns": 1286764102.48,
+        "ci_lower_ns": 1269283391.64,
+        "ci_upper_ns": 1309601746.974,
+        "std_dev_ns": 74452411.39648002
+      },
+      "concurrent_reads_same_entity/1000_versions/4_readers": {
+        "point_estimate_ns": 220643.6706594189,
+        "ci_lower_ns": 218651.07300263204,
+        "ci_upper_ns": 222611.5618024858,
+        "std_dev_ns": 4865.43768344186
+      },
+      "concurrent_reads_same_entity/1000_versions/2_readers": {
+        "point_estimate_ns": 130103.11400194137,
+        "ci_lower_ns": 129418.02343327574,
+        "ci_upper_ns": 130803.55000659086,
+        "std_dev_ns": 3216.3649522275277
+      },
+      "concurrent_reads_same_entity/1000_versions/16_readers": {
+        "point_estimate_ns": 767645.7277732479,
+        "ci_lower_ns": 764525.121111043,
+        "ci_upper_ns": 770778.2599352465,
+        "std_dev_ns": 15584.005291488184
+      },
+      "concurrent_reads_same_entity/1000_versions/8_readers": {
+        "point_estimate_ns": 422905.2037297612,
+        "ci_lower_ns": 420854.7629823159,
+        "ci_upper_ns": 424934.40866369667,
+        "std_dev_ns": 11425.593512367848
+      },
+      "concurrent_reads_same_entity/100_versions/4_readers": {
+        "point_estimate_ns": 203703.20611648224,
+        "ci_lower_ns": 202440.93124589915,
+        "ci_upper_ns": 205194.36245293386,
+        "std_dev_ns": 5225.996708479067
+      },
+      "concurrent_reads_same_entity/100_versions/2_readers": {
+        "point_estimate_ns": 130264.34551336728,
+        "ci_lower_ns": 129534.23520270771,
+        "ci_upper_ns": 131028.28359908394,
+        "std_dev_ns": 4798.764901425062
+      },
+      "concurrent_reads_same_entity/100_versions/16_readers": {
+        "point_estimate_ns": 696718.4900718307,
+        "ci_lower_ns": 693914.9793091253,
+        "ci_upper_ns": 699715.2173716048,
+        "std_dev_ns": 15491.27050133308
+      },
+      "concurrent_reads_same_entity/100_versions/8_readers": {
+        "point_estimate_ns": 383867.5403632128,
+        "ci_lower_ns": 382497.37839177676,
+        "ci_upper_ns": 385170.55045344535,
+        "std_dev_ns": 7710.20248888855
+      },
+      "concurrent_reads_same_entity/10000_versions/4_readers": {
+        "point_estimate_ns": 474740.6933333331,
+        "ci_lower_ns": 421344.7715,
+        "ci_upper_ns": 528949.2962499999,
+        "std_dev_ns": 196782.40339912684
+      },
+      "concurrent_reads_same_entity/10000_versions/2_readers": {
+        "point_estimate_ns": 133878.10658767296,
+        "ci_lower_ns": 133460.23790329424,
+        "ci_upper_ns": 134345.93190582373,
+        "std_dev_ns": 2175.063729742513
+      },
+      "concurrent_writes/same_entity_contention/8": {
+        "point_estimate_ns": 9476390.287272723,
+        "ci_lower_ns": 9148257.177181816,
+        "ci_upper_ns": 9844934.79586364,
+        "std_dev_ns": 1278310.3311533588
+      },
+      "concurrent_writes/same_entity_contention/2": {
+        "point_estimate_ns": 214574.15811153175,
+        "ci_lower_ns": 181185.43486848514,
+        "ci_upper_ns": 248623.72722661766,
+        "std_dev_ns": 52568.23054200384
+      },
+      "concurrent_writes/same_entity_contention/4": {
+        "point_estimate_ns": 1225713.092424772,
+        "ci_lower_ns": 1166934.228398231,
+        "ci_upper_ns": 1295075.5195692186,
+        "std_dev_ns": 191882.99420482724
+      },
+      "concurrent_writes/different_entities/8": {
+        "point_estimate_ns": 417359.9350203844,
+        "ci_lower_ns": 408207.3261324403,
+        "ci_upper_ns": 426214.2611504691,
+        "std_dev_ns": 21102.406923544866
+      },
+      "concurrent_writes/different_entities/2": {
+        "point_estimate_ns": 139706.9219879635,
+        "ci_lower_ns": 138856.87105457723,
+        "ci_upper_ns": 140629.48944885316,
+        "std_dev_ns": 3793.6545388626446
+      },
+      "concurrent_writes/different_entities/4": {
+        "point_estimate_ns": 220014.88403028538,
+        "ci_lower_ns": 218937.17862020747,
+        "ci_upper_ns": 220928.03934378288,
+        "std_dev_ns": 6023.820497545809
+      },
+      "target_batch_insertion/insert_1000_edges": {
+        "point_estimate_ns": 781381.9847088103,
+        "ci_lower_ns": 676902.9034657464,
+        "ci_upper_ns": 878073.2895045202,
+        "std_dev_ns": 114686.11563005627
+      },
+      "knn_search_index_size/index_size/500": {
+        "point_estimate_ns": 68084.75761452413,
+        "ci_lower_ns": 67886.98221119061,
+        "ci_upper_ns": 68321.7698030196,
+        "std_dev_ns": 461.9275418261912
+      },
+      "knn_search_index_size/index_size/100": {
+        "point_estimate_ns": 21022.150894363203,
+        "ci_lower_ns": 20982.212180073308,
+        "ci_upper_ns": 21064.357180164658,
+        "std_dev_ns": 111.01539429908154
+      },
+      "knn_search_index_size/index_size/5000": {
+        "point_estimate_ns": 242319.20836616535,
+        "ci_lower_ns": 241147.3793878223,
+        "ci_upper_ns": 243454.87890109434,
+        "std_dev_ns": 3766.520173643887
+      },
+      "knn_search_index_size/index_size/1000": {
+        "point_estimate_ns": 120521.5449432149,
+        "ci_lower_ns": 120146.73582292297,
+        "ci_upper_ns": 120989.84363510176,
+        "std_dev_ns": 2840.1279841366995
+      },
+      "knn_search_index_size/index_size/10000": {
+        "point_estimate_ns": 313174.4962286636,
+        "ci_lower_ns": 310656.7263447485,
+        "ci_upper_ns": 316856.41957542504,
+        "std_dev_ns": 27171.71107871942
+      }
+    }
   }
 ]

--- a/benchmarks/history.json
+++ b/benchmarks/history.json
@@ -1,0 +1,45 @@
+[
+  {
+    "timestamp": "2026-02-21T18:07:48.283497+00:00",
+    "commit": "198c57d",
+    "branch": "jules-3069904928789557752-7bfd23b2",
+    "benchmarks": {
+      "target_time_travel/with_5_deltas": {
+        "point_estimate_ns": 275.12280051091363,
+        "ci_lower_ns": 273.3902260088697,
+        "ci_upper_ns": 276.6861536595373,
+        "std_dev_ns": 6.1668907832569655
+      },
+      "target_time_travel/at_anchor": {
+        "point_estimate_ns": 282.59198327344984,
+        "ci_lower_ns": 281.1666674124893,
+        "ci_upper_ns": 284.00000178026704,
+        "std_dev_ns": 5.874914585597326
+      },
+      "target_time_travel/worst_case_9_deltas": {
+        "point_estimate_ns": 286.22596070579993,
+        "ci_lower_ns": 285.2287895292346,
+        "ci_upper_ns": 287.1850984284939,
+        "std_dev_ns": 5.5773781190774185
+      },
+      "target_3_hop/traverse_three_hops": {
+        "point_estimate_ns": 282.15733606030585,
+        "ci_lower_ns": 279.7025671955745,
+        "ci_upper_ns": 285.15103732210275,
+        "std_dev_ns": 13.343540038507856
+      },
+      "target_single_hop/traverse_one_hop": {
+        "point_estimate_ns": 42.60678833115437,
+        "ci_lower_ns": 42.38483333115782,
+        "ci_upper_ns": 42.83175020908999,
+        "std_dev_ns": 0.9908401654190784
+      },
+      "target_batch_insertion/insert_1000_edges": {
+        "point_estimate_ns": 781381.9847088103,
+        "ci_lower_ns": 676902.9034657464,
+        "ci_upper_ns": 878073.2895045202,
+        "std_dev_ns": 114686.11563005627
+      }
+    }
+  }
+]

--- a/benchmarks/report.html
+++ b/benchmarks/report.html
@@ -1,0 +1,500 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chronos — Benchmark Report</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-adapter-date-fns/3.0.0/chartjs-adapter-date-fns.bundle.min.js"></script>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;600;700&display=swap');
+
+  :root {
+    --bg-primary: #0a0e17;
+    --bg-secondary: #111827;
+    --bg-tertiary: #1a2235;
+    --bg-card: #151d2e;
+    --border: #1e293b;
+    --border-bright: #334155;
+    --text-primary: #e2e8f0;
+    --text-secondary: #94a3b8;
+    --text-muted: #64748b;
+    --accent-cyan: #22d3ee;
+    --accent-green: #34d399;
+    --accent-red: #f87171;
+    --accent-yellow: #fbbf24;
+    --accent-purple: #a78bfa;
+    --accent-orange: #fb923c;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'DM Sans', sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    min-height: 100vh;
+    line-height: 1.6;
+  }
+
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+
+  /* ─── Header ─── */
+  header {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .header-top {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  h1 {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--accent-cyan);
+    letter-spacing: -0.02em;
+  }
+
+  .header-icon {
+    font-size: 1.5rem;
+  }
+
+  .meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+  }
+
+  .meta span {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .meta-label {
+    color: var(--text-secondary);
+  }
+
+  /* ─── Verdict Banner ─── */
+  .verdict {
+    border-radius: 8px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 2rem;
+    border: 1px solid;
+  }
+
+  .verdict-critical {
+    background: rgba(248, 113, 113, 0.08);
+    border-color: rgba(248, 113, 113, 0.3);
+  }
+  .verdict-warn {
+    background: rgba(251, 191, 36, 0.08);
+    border-color: rgba(251, 191, 36, 0.3);
+  }
+  .verdict-good {
+    background: rgba(52, 211, 153, 0.08);
+    border-color: rgba(52, 211, 153, 0.3);
+  }
+  .verdict-neutral {
+    background: rgba(148, 163, 184, 0.06);
+    border-color: rgba(148, 163, 184, 0.2);
+  }
+
+  .verdict h2 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  .verdict p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  /* ─── Stats Row ─── */
+  .stats-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .stat-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+  }
+
+  .stat-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.75rem;
+    font-weight: 700;
+  }
+
+  .stat-label {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-top: 0.25rem;
+  }
+
+  .stat-improved .stat-value { color: var(--accent-green); }
+  .stat-regressed .stat-value { color: var(--accent-red); }
+  .stat-stable .stat-value { color: var(--accent-yellow); }
+  .stat-new .stat-value { color: var(--accent-purple); }
+  .stat-total .stat-value { color: var(--accent-cyan); }
+
+  /* ─── Section Headers ─── */
+  .section-header {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* ─── Table ─── */
+  .table-wrapper {
+    overflow-x: auto;
+    margin-bottom: 3rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+  }
+
+  thead th {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    padding: 0.75rem 1rem;
+    text-align: left;
+    background: var(--bg-tertiary);
+    border-bottom: 1px solid var(--border-bright);
+    position: sticky;
+    top: 0;
+  }
+
+  thead th.numeric,
+  thead th.change,
+  thead th.status-cell {
+    text-align: right;
+  }
+
+  td {
+    padding: 0.65rem 1rem;
+    border-bottom: 1px solid var(--border);
+    transition: background 0.15s;
+  }
+
+  tr:hover td {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .bench-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 500;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+  }
+
+  .numeric {
+    font-family: 'JetBrains Mono', monospace;
+    text-align: right;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+
+  .change {
+    font-family: 'JetBrains Mono', monospace;
+    text-align: right;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .status-cell {
+    text-align: right;
+    font-size: 1rem;
+  }
+
+  .row-improved .change { color: var(--accent-green); }
+  .row-regressed .change { color: var(--accent-red); }
+  .row-critical .change { color: var(--accent-red); font-weight: 700; }
+  .row-stable .change { color: var(--text-muted); }
+  .row-new .change { color: var(--accent-purple); }
+
+  .row-critical {
+    background: rgba(248, 113, 113, 0.05);
+  }
+  .row-improved {
+    background: rgba(52, 211, 153, 0.03);
+  }
+
+  /* ─── Chart ─── */
+  .chart-container {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .chart-canvas-wrap {
+    position: relative;
+    height: 400px;
+  }
+
+  /* ─── Footer ─── */
+  footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  footer a {
+    color: var(--accent-cyan);
+    text-decoration: none;
+  }
+
+  /* ─── Responsive ─── */
+  @media (max-width: 640px) {
+    .container { padding: 1rem; }
+    h1 { font-size: 1.25rem; }
+    .meta { flex-direction: column; gap: 0.5rem; }
+    .chart-canvas-wrap { height: 280px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="container">
+  <header>
+    <div class="header-top">
+      <span class="header-icon">⏱</span>
+      <h1>CHRONOS</h1>
+    </div>
+    <div class="meta">
+      <span><span class="meta-label">commit</span> 198c57d</span>
+      <span><span class="meta-label">branch</span> jules-3069904928789557752-7bfd23b2</span>
+      <span><span class="meta-label">generated</span> 2026-02-21 18:07 UTC</span>
+      <span><span class="meta-label">history</span> 1 runs</span>
+    </div>
+  </header>
+
+  <div class="verdict verdict-neutral">
+    <h2>➖ No Significant Changes</h2>
+    <p>All benchmarks within noise threshold.</p>
+  </div>
+
+  <div class="stats-row">
+    <div class="stat-card stat-total">
+      <div class="stat-value">6</div>
+      <div class="stat-label">Total</div>
+    </div>
+    <div class="stat-card stat-improved">
+      <div class="stat-value">0</div>
+      <div class="stat-label">Improved</div>
+    </div>
+    <div class="stat-card stat-stable">
+      <div class="stat-value">0</div>
+      <div class="stat-label">Stable</div>
+    </div>
+    <div class="stat-card stat-regressed">
+      <div class="stat-value">0</div>
+      <div class="stat-label">Regressed</div>
+    </div>
+    <div class="stat-card stat-new">
+      <div class="stat-value">6</div>
+      <div class="stat-label">New</div>
+    </div>
+  </div>
+
+  <div class="section-header">Benchmark Results</div>
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>Benchmark</th>
+          <th class="numeric">Previous</th>
+          <th class="numeric">Current</th>
+          <th class="change">Change</th>
+          <th class="status-cell">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        <tr class="row-new">
+            <td class="bench-name">target_3_hop/traverse_three_hops</td>
+            <td class="numeric">—</td>
+            <td class="numeric">282.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">target_batch_insertion/insert_1000_edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">781.38 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">target_single_hop/traverse_one_hop</td>
+            <td class="numeric">—</td>
+            <td class="numeric">42.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">target_time_travel/at_anchor</td>
+            <td class="numeric">—</td>
+            <td class="numeric">282.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">target_time_travel/with_5_deltas</td>
+            <td class="numeric">—</td>
+            <td class="numeric">275.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">target_time_travel/worst_case_9_deltas</td>
+            <td class="numeric">—</td>
+            <td class="numeric">286.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="section-header">Performance Over Time (µs)</div>
+  <div class="chart-container">
+    <div class="chart-canvas-wrap">
+      <canvas id="timeseriesChart"></canvas>
+    </div>
+  </div>
+
+  <footer>
+    Generated by <strong>Chronos</strong> — The Temporal Benchkeeper &nbsp;|&nbsp; Powered by Criterion
+  </footer>
+</div>
+
+<script>
+  const datasets = [{"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
+
+  const ctx = document.getElementById('timeseriesChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: { datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: 'index',
+        intersect: false,
+      },
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: {
+            color: '#94a3b8',
+            font: { family: "'JetBrains Mono', monospace", size: 11 },
+            boxWidth: 12,
+            padding: 16,
+          },
+        },
+        tooltip: {
+          backgroundColor: '#1a2235',
+          titleColor: '#e2e8f0',
+          bodyColor: '#94a3b8',
+          borderColor: '#334155',
+          borderWidth: 1,
+          titleFont: { family: "'JetBrains Mono', monospace" },
+          bodyFont: { family: "'JetBrains Mono', monospace", size: 12 },
+          callbacks: {
+            afterTitle: function(items) {
+              const pt = items[0];
+              const ds = datasets[pt.datasetIndex];
+              if (ds && ds.data[pt.dataIndex]) {
+                return 'commit: ' + ds.data[pt.dataIndex].commit;
+              }
+              return '';
+            },
+            label: function(ctx) {
+              return ctx.dataset.label + ': ' + ctx.parsed.y.toFixed(2) + ' µs';
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          type: 'time',
+          time: {
+            tooltipFormat: 'yyyy-MM-dd HH:mm',
+            displayFormats: {
+              hour: 'MMM d HH:mm',
+              day: 'MMM d',
+              week: 'MMM d',
+              month: 'MMM yyyy',
+            },
+          },
+          ticks: {
+            color: '#64748b',
+            font: { family: "'JetBrains Mono', monospace", size: 10 },
+            maxRotation: 45,
+          },
+          grid: {
+            color: 'rgba(30, 41, 59, 0.5)',
+          },
+        },
+        y: {
+          beginAtZero: false,
+          ticks: {
+            color: '#64748b',
+            font: { family: "'JetBrains Mono', monospace", size: 10 },
+            callback: function(val) { return val.toFixed(1) + ' µs'; },
+          },
+          grid: {
+            color: 'rgba(30, 41, 59, 0.5)',
+          },
+        },
+      },
+    },
+  });
+</script>
+
+</body>
+</html>

--- a/benchmarks/report.html
+++ b/benchmarks/report.html
@@ -307,8 +307,8 @@
     <div class="meta">
       <span><span class="meta-label">commit</span> 198c57d</span>
       <span><span class="meta-label">branch</span> jules-3069904928789557752-7bfd23b2</span>
-      <span><span class="meta-label">generated</span> 2026-02-21 18:07 UTC</span>
-      <span><span class="meta-label">history</span> 1 runs</span>
+      <span><span class="meta-label">generated</span> 2026-02-21 18:56 UTC</span>
+      <span><span class="meta-label">history</span> 2 runs</span>
     </div>
   </header>
 
@@ -319,7 +319,7 @@
 
   <div class="stats-row">
     <div class="stat-card stat-total">
-      <div class="stat-value">6</div>
+      <div class="stat-value">47</div>
       <div class="stat-label">Total</div>
     </div>
     <div class="stat-card stat-improved">
@@ -327,7 +327,7 @@
       <div class="stat-label">Improved</div>
     </div>
     <div class="stat-card stat-stable">
-      <div class="stat-value">0</div>
+      <div class="stat-value">6</div>
       <div class="stat-label">Stable</div>
     </div>
     <div class="stat-card stat-regressed">
@@ -335,7 +335,7 @@
       <div class="stat-label">Regressed</div>
     </div>
     <div class="stat-card stat-new">
-      <div class="stat-value">6</div>
+      <div class="stat-value">41</div>
       <div class="stat-label">New</div>
     </div>
   </div>
@@ -355,44 +355,331 @@
       <tbody>
 
         <tr class="row-new">
+            <td class="bench-name">closure_write_single_node</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.81 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/10000_versions/2_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">133.88 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/10000_versions/4_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">474.74 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/1000_versions/16_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">767.65 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/1000_versions/2_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">130.10 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/1000_versions/4_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">220.64 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/1000_versions/8_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">422.91 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/100_versions/16_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">696.72 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/100_versions/2_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">130.26 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/100_versions/4_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">203.70 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_reads_same_entity/100_versions/8_readers</td>
+            <td class="numeric">—</td>
+            <td class="numeric">383.87 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_writes/different_entities/2</td>
+            <td class="numeric">—</td>
+            <td class="numeric">139.71 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_writes/different_entities/4</td>
+            <td class="numeric">—</td>
+            <td class="numeric">220.01 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_writes/different_entities/8</td>
+            <td class="numeric">—</td>
+            <td class="numeric">417.36 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_writes/same_entity_contention/2</td>
+            <td class="numeric">—</td>
+            <td class="numeric">214.57 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_writes/same_entity_contention/4</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.23 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">concurrent_writes/same_entity_contention/8</td>
+            <td class="numeric">—</td>
+            <td class="numeric">9.48 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search/k/1</td>
+            <td class="numeric">—</td>
+            <td class="numeric">126.51 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search/k/10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">121.11 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search/k/20</td>
+            <td class="numeric">—</td>
+            <td class="numeric">123.29 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search/k/5</td>
+            <td class="numeric">—</td>
+            <td class="numeric">119.25 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search/k/50</td>
+            <td class="numeric">—</td>
+            <td class="numeric">122.09 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search_index_size/index_size/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">21.02 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search_index_size/index_size/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">120.52 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search_index_size/index_size/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">313.17 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search_index_size/index_size/500</td>
+            <td class="numeric">—</td>
+            <td class="numeric">68.08 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">knn_search_index_size/index_size/5000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">242.32 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">read_transaction_creation</td>
+            <td class="numeric">—</td>
+            <td class="numeric">339.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">read_under_write_contention/concurrent_writers/0</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.46 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">read_under_write_contention/concurrent_writers/2</td>
+            <td class="numeric">—</td>
+            <td class="numeric">56.66 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">read_under_write_contention/concurrent_writers/4</td>
+            <td class="numeric">—</td>
+            <td class="numeric">114.75 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">target_3_hop/traverse_three_hops</td>
-            <td class="numeric">—</td>
             <td class="numeric">282.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">282.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">target_batch_insertion/insert_1000_edges</td>
-            <td class="numeric">—</td>
             <td class="numeric">781.38 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">781.38 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">target_single_hop/traverse_one_hop</td>
-            <td class="numeric">—</td>
             <td class="numeric">42.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">42.6 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">target_time_travel/at_anchor</td>
-            <td class="numeric">—</td>
             <td class="numeric">282.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">282.6 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">target_time_travel/with_5_deltas</td>
-            <td class="numeric">—</td>
             <td class="numeric">275.1 ns</td>
+            <td class="numeric">275.1 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">target_time_travel/worst_case_9_deltas</td>
+            <td class="numeric">286.2 ns</td>
+            <td class="numeric">286.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">temporal_insert/append_only/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">20.52 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">target_time_travel/worst_case_9_deltas</td>
+            <td class="bench-name">temporal_insert/append_only/1000</td>
             <td class="numeric">—</td>
-            <td class="numeric">286.2 ns</td>
+            <td class="numeric">210.75 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">temporal_insert/append_only/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.17 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">temporal_insert/retroactive/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">147.47 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">temporal_insert/retroactive/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">12.55 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">temporal_insert/retroactive/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.287 s</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">valid_at_query/10000_versions</td>
+            <td class="numeric">—</td>
+            <td class="numeric">22.36 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">valid_at_query/1000_versions</td>
+            <td class="numeric">—</td>
+            <td class="numeric">3.90 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">valid_at_query/100_versions</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.53 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">write_transaction_creation</td>
+            <td class="numeric">—</td>
+            <td class="numeric">462.4 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
@@ -413,7 +700,7 @@
 </div>
 
 <script>
-  const datasets = [{"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
+  const datasets = [{"label": "closure_write_single_node", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2805.76, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.878, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.741, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.646, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.103, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.644, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.905, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.718, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.264, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.703, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.868, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.707, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.015, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.36, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.574, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1225.713, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9476.39, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/1", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.51, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/10", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.112, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/20", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.289, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/5", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.25, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/50", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.094, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.022, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.522, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.174, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/500", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.085, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/5000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.319, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.339, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/0", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.455, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56660.317, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114751.007, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.043, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.283, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.275, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.286, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.522, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.752, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2170.105, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.472, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12548.726, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1286764.102, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/10000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.355, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/1000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.901, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/100_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.53, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "write_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.462, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
 
   const ctx = document.getElementById('timeseriesChart').getContext('2d');
   new Chart(ctx, {

--- a/benchmarks/report.html
+++ b/benchmarks/report.html
@@ -307,27 +307,27 @@
     <div class="meta">
       <span><span class="meta-label">commit</span> 198c57d</span>
       <span><span class="meta-label">branch</span> jules-3069904928789557752-7bfd23b2</span>
-      <span><span class="meta-label">generated</span> 2026-02-21 18:56 UTC</span>
-      <span><span class="meta-label">history</span> 2 runs</span>
+      <span><span class="meta-label">generated</span> 2026-02-21 20:43 UTC</span>
+      <span><span class="meta-label">history</span> 3 runs</span>
     </div>
   </header>
 
-  <div class="verdict verdict-neutral">
-    <h2>➖ No Significant Changes</h2>
-    <p>All benchmarks within noise threshold.</p>
+  <div class="verdict verdict-good">
+    <h2>✅ Performance Improved</h2>
+    <p>5 benchmarks got faster.</p>
   </div>
 
   <div class="stats-row">
     <div class="stat-card stat-total">
-      <div class="stat-value">47</div>
+      <div class="stat-value">232</div>
       <div class="stat-label">Total</div>
     </div>
     <div class="stat-card stat-improved">
-      <div class="stat-value">0</div>
+      <div class="stat-value">5</div>
       <div class="stat-label">Improved</div>
     </div>
     <div class="stat-card stat-stable">
-      <div class="stat-value">6</div>
+      <div class="stat-value">42</div>
       <div class="stat-label">Stable</div>
     </div>
     <div class="stat-card stat-regressed">
@@ -335,7 +335,7 @@
       <div class="stat-label">Regressed</div>
     </div>
     <div class="stat-card stat-new">
-      <div class="stat-value">41</div>
+      <div class="stat-value">185</div>
       <div class="stat-label">New</div>
     </div>
   </div>
@@ -355,333 +355,1628 @@
       <tbody>
 
         <tr class="row-new">
+            <td class="bench-name">3_hop_traversal</td>
+            <td class="numeric">—</td>
+            <td class="numeric">56.71 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_3_hop_traversal</td>
+            <td class="numeric">—</td>
+            <td class="numeric">483.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_batch/batch_node_creation/10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">27.81 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_batch/batch_node_creation/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">289.83 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_batch/batch_node_creation/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.831 s</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_edge_creation</td>
+            <td class="numeric">—</td>
+            <td class="numeric">97.35 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_fast_path/node_lookup/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">62.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_fast_path/node_lookup/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">62.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_fast_path/node_lookup/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">61.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_historical_stats</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.06 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_in_degree</td>
+            <td class="numeric">—</td>
+            <td class="numeric">104.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_labeled_traversal</td>
+            <td class="numeric">—</td>
+            <td class="numeric">159.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_node_creation</td>
+            <td class="numeric">—</td>
+            <td class="numeric">105.59 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_out_degree</td>
+            <td class="numeric">—</td>
+            <td class="numeric">100.4 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_single_hop/10000_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">116.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_single_hop/1000_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">116.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">aletheiadb_single_hop/100_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">116.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">batch_throughput/async</td>
+            <td class="numeric">—</td>
+            <td class="numeric">52.79 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">batch_throughput/synchronous</td>
+            <td class="numeric">—</td>
+            <td class="numeric">635.75 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">checkpoint_creation/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.89 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">checkpoint_creation/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.03 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">checkpoint_creation/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">7.66 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">checkpoint_load/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">323.51 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">checkpoint_load/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.63 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">checkpoint_load/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">15.18 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">closure_write_single_node</td>
-            <td class="numeric">—</td>
             <td class="numeric">2.81 ms</td>
+            <td class="numeric">2.81 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_batch_write_throughput/fast/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.93 ms</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
+            <td class="bench-name">cold_batch_write_throughput/fast/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">45.81 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_batch_write_throughput/fast/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">454.83 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_batch_write_throughput/zstd/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">7.45 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_batch_write_throughput/zstd/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">66.78 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_batch_write_throughput/zstd/10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">189.51 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_read_latency/single_read/fast_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">34.54 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_read_latency/single_read/no_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">3.31 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_read_latency/single_read/zstd_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">34.41 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_write_latency/single_write/fast_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">340.43 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_write_latency/single_write/no_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">343.79 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cold_write_latency/single_write/zstd_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">373.87 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">comparison_csr/full_rebuild_insert_query</td>
+            <td class="numeric">—</td>
+            <td class="numeric">140.05 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">comparison_csr/incremental_csr_insert_query</td>
+            <td class="numeric">—</td>
+            <td class="numeric">16.60 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">compression_ratio/compress/fast</td>
+            <td class="numeric">—</td>
+            <td class="numeric">34.87 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">compression_ratio/compress/no_compression</td>
+            <td class="numeric">—</td>
+            <td class="numeric">31.26 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">compression_ratio/compress/zstd</td>
+            <td class="numeric">—</td>
+            <td class="numeric">36.22 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/10000_versions/2_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">133.88 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">133.88 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/10000_versions/4_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">474.74 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">474.74 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/1000_versions/16_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">767.65 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">767.65 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/1000_versions/2_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">130.10 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">130.10 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/1000_versions/4_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">220.64 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">220.64 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/1000_versions/8_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">422.91 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">422.91 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/100_versions/16_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">696.72 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">696.72 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/100_versions/2_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">130.26 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">130.26 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/100_versions/4_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">203.70 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">203.70 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_reads_same_entity/100_versions/8_readers</td>
-            <td class="numeric">—</td>
             <td class="numeric">383.87 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">383.87 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_writes/different_entities/2</td>
-            <td class="numeric">—</td>
             <td class="numeric">139.71 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">139.71 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_writes/different_entities/4</td>
-            <td class="numeric">—</td>
             <td class="numeric">220.01 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">220.01 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_writes/different_entities/8</td>
-            <td class="numeric">—</td>
             <td class="numeric">417.36 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">417.36 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_writes/same_entity_contention/2</td>
-            <td class="numeric">—</td>
             <td class="numeric">214.57 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">214.57 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_writes/same_entity_contention/4</td>
-            <td class="numeric">—</td>
             <td class="numeric">1.23 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">1.23 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">concurrent_writes/same_entity_contention/8</td>
-            <td class="numeric">—</td>
             <td class="numeric">9.48 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">9.48 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search/k/1</td>
+            <td class="bench-name">cosine_similarity/naive_3pass/1024</td>
             <td class="numeric">—</td>
-            <td class="numeric">126.51 µs</td>
+            <td class="numeric">4.60 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search/k/10</td>
+            <td class="bench-name">cosine_similarity/naive_3pass/1536</td>
             <td class="numeric">—</td>
-            <td class="numeric">121.11 µs</td>
+            <td class="numeric">6.95 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search/k/20</td>
+            <td class="bench-name">cosine_similarity/naive_3pass/3072</td>
             <td class="numeric">—</td>
-            <td class="numeric">123.29 µs</td>
+            <td class="numeric">14.03 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search/k/5</td>
+            <td class="bench-name">cosine_similarity/naive_3pass/384</td>
             <td class="numeric">—</td>
-            <td class="numeric">119.25 µs</td>
+            <td class="numeric">1.65 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search/k/50</td>
+            <td class="bench-name">cosine_similarity/naive_3pass/768</td>
             <td class="numeric">—</td>
-            <td class="numeric">122.09 µs</td>
+            <td class="numeric">3.44 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search_index_size/index_size/100</td>
+            <td class="bench-name">cosine_similarity/optimized/1024</td>
             <td class="numeric">—</td>
-            <td class="numeric">21.02 µs</td>
+            <td class="numeric">201.5 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search_index_size/index_size/1000</td>
+            <td class="bench-name">cosine_similarity/optimized/1536</td>
             <td class="numeric">—</td>
-            <td class="numeric">120.52 µs</td>
+            <td class="numeric">299.7 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search_index_size/index_size/10000</td>
+            <td class="bench-name">cosine_similarity/optimized/3072</td>
             <td class="numeric">—</td>
-            <td class="numeric">313.17 µs</td>
+            <td class="numeric">592.1 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search_index_size/index_size/500</td>
+            <td class="bench-name">cosine_similarity/optimized/384</td>
             <td class="numeric">—</td>
-            <td class="numeric">68.08 µs</td>
+            <td class="numeric">77.2 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">knn_search_index_size/index_size/5000</td>
+            <td class="bench-name">cosine_similarity/optimized/768</td>
             <td class="numeric">—</td>
-            <td class="numeric">242.32 µs</td>
+            <td class="numeric">151.8 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">read_transaction_creation</td>
+            <td class="bench-name">cosine_similarity/scalar_1pass/1024</td>
             <td class="numeric">—</td>
-            <td class="numeric">339.2 ns</td>
+            <td class="numeric">1.58 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">read_under_write_contention/concurrent_writers/0</td>
+            <td class="bench-name">cosine_similarity/scalar_1pass/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.36 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity/scalar_1pass/3072</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.73 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity/scalar_1pass/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">636.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity/scalar_1pass/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.18 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_batch/find_most_similar/10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">811.3 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_batch/find_most_similar/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">8.28 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_batch/find_most_similar/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">90.46 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_normalized/general/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">300.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_normalized/general/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">78.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_normalized/specialized/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">284.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_normalized/specialized/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">56.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">cosine_similarity_openai_1536d</td>
+            <td class="numeric">—</td>
+            <td class="numeric">301.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">edge_creation</td>
             <td class="numeric">—</td>
             <td class="numeric">4.46 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">read_under_write_contention/concurrent_writers/2</td>
+            <td class="bench-name">edge_lookup</td>
             <td class="numeric">—</td>
-            <td class="numeric">56.66 ms</td>
+            <td class="numeric">62.4 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">read_under_write_contention/concurrent_writers/4</td>
+            <td class="bench-name">euclidean_distance/optimized/1024</td>
             <td class="numeric">—</td>
-            <td class="numeric">114.75 ms</td>
+            <td class="numeric">175.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/optimized/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">272.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/optimized/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">65.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/optimized/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">123.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/scalar/1024</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.55 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/scalar/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.33 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/scalar/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">566.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/scalar/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.16 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/squared_optimized/1024</td>
+            <td class="numeric">—</td>
+            <td class="numeric">173.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/squared_optimized/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">269.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/squared_optimized/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">56.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">euclidean_distance/squared_optimized/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">121.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">find_neighbors</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.24 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">find_nodes_by_property/10000_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">757.09 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">find_nodes_by_property/1000_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">50.79 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">find_nodes_by_property/100_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.67 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">frozen_view_hot_path/frozen_view/100000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">40.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">frozen_view_hot_path/frozen_view/10000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">33.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">frozen_view_hot_path/frozen_view/1000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">20.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">frozen_view_hot_path/merged_guard/100000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">32.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">frozen_view_hot_path/merged_guard/10000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">32.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">frozen_view_hot_path/merged_guard/1000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">32.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">get_outgoing_allocation/degree_1</td>
+            <td class="numeric">—</td>
+            <td class="numeric">35.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">get_outgoing_allocation/degree_10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">35.3 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">get_outgoing_allocation/degree_100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">35.4 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_concurrent/threads/16</td>
+            <td class="numeric">—</td>
+            <td class="numeric">674.80 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_concurrent/threads/2</td>
+            <td class="numeric">—</td>
+            <td class="numeric">120.89 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_concurrent/threads/4</td>
+            <td class="numeric">—</td>
+            <td class="numeric">198.11 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_concurrent/threads/8</td>
+            <td class="numeric">—</td>
+            <td class="numeric">375.17 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_current/read_current</td>
+            <td class="numeric">—</td>
+            <td class="numeric">0.4 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_current/read_current_approximate</td>
+            <td class="numeric">—</td>
+            <td class="numeric">0.4 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_lifecycle/create_and_generate_1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">8.80 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_single_thread/sequential_1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">6.90 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">id_generation_single_thread/sequential_10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">69.02 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">in_degree</td>
+            <td class="numeric">—</td>
+            <td class="numeric">398.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_compaction/edges/1000+100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">60.28 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_compaction/edges/10000+1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">955.60 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_compaction/edges/100000+10000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">8.19 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_concurrent/threads/2</td>
+            <td class="numeric">—</td>
+            <td class="numeric">141.58 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_concurrent/threads/4</td>
+            <td class="numeric">—</td>
+            <td class="numeric">211.62 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_concurrent/threads/8</td>
+            <td class="numeric">—</td>
+            <td class="numeric">410.13 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_insert_latency/0existing</td>
+            <td class="numeric">—</td>
+            <td class="numeric">288.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_insert_latency/100000existing</td>
+            <td class="numeric">—</td>
+            <td class="numeric">289.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_insert_latency/10000existing</td>
+            <td class="numeric">—</td>
+            <td class="numeric">183.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_insert_latency/1000existing</td>
+            <td class="numeric">—</td>
+            <td class="numeric">226.3 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_read_no_delta/10000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">32.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_read_no_delta/1000edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">32.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_read_no_delta/100edges</td>
+            <td class="numeric">—</td>
+            <td class="numeric">32.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_read_with_delta/10pct_delta</td>
+            <td class="numeric">—</td>
+            <td class="numeric">67.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_read_with_delta/1pct_delta</td>
+            <td class="numeric">—</td>
+            <td class="numeric">64.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">incremental_read_with_delta/5pct_delta</td>
+            <td class="numeric">—</td>
+            <td class="numeric">64.2 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-stable">
+            <td class="bench-name">knn_search/k/1</td>
+            <td class="numeric">126.51 µs</td>
+            <td class="numeric">126.51 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search/k/10</td>
+            <td class="numeric">121.11 µs</td>
+            <td class="numeric">121.11 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search/k/20</td>
+            <td class="numeric">123.29 µs</td>
+            <td class="numeric">123.29 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search/k/5</td>
+            <td class="numeric">119.25 µs</td>
+            <td class="numeric">119.25 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search/k/50</td>
+            <td class="numeric">122.09 µs</td>
+            <td class="numeric">122.09 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search_index_size/index_size/100</td>
+            <td class="numeric">21.02 µs</td>
+            <td class="numeric">21.02 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search_index_size/index_size/1000</td>
+            <td class="numeric">120.52 µs</td>
+            <td class="numeric">120.52 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search_index_size/index_size/10000</td>
+            <td class="numeric">313.17 µs</td>
+            <td class="numeric">313.17 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search_index_size/index_size/500</td>
+            <td class="numeric">68.08 µs</td>
+            <td class="numeric">68.08 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">knn_search_index_size/index_size/5000</td>
+            <td class="numeric">242.32 µs</td>
+            <td class="numeric">242.32 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">labeled_traversal</td>
+            <td class="numeric">—</td>
+            <td class="numeric">465.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">mixed_read_write_80_20</td>
+            <td class="numeric">—</td>
+            <td class="numeric">16.59 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">multiple_accesses/resolve_100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">3.57 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">node_creation</td>
+            <td class="numeric">—</td>
+            <td class="numeric">4.43 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">node_lookup</td>
+            <td class="numeric">—</td>
+            <td class="numeric">64.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">out_degree</td>
+            <td class="numeric">—</td>
+            <td class="numeric">406.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">point_in_time_queries/1000vectors</td>
+            <td class="numeric">—</td>
+            <td class="numeric">30.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">point_in_time_queries/100vectors</td>
+            <td class="numeric">—</td>
+            <td class="numeric">27.4 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">property_lookup_vs_scan/find_nodes_by_property</td>
+            <td class="numeric">—</td>
+            <td class="numeric">39.03 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">property_lookup_vs_scan/manual_label_scan_filter</td>
+            <td class="numeric">—</td>
+            <td class="numeric">138.29 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">read_latency_p50_p99</td>
+            <td class="numeric">—</td>
+            <td class="numeric">8.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">read_transaction_creation</td>
+            <td class="numeric">339.2 ns</td>
+            <td class="numeric">339.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">read_under_write_contention/concurrent_writers/0</td>
+            <td class="numeric">4.46 µs</td>
+            <td class="numeric">4.46 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">read_under_write_contention/concurrent_writers/2</td>
+            <td class="numeric">56.66 ms</td>
+            <td class="numeric">56.66 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">read_under_write_contention/concurrent_writers/4</td>
+            <td class="numeric">114.75 ms</td>
+            <td class="numeric">114.75 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">recovery/10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">500.06 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">recovery/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">457.03 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">recovery/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">647.92 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_hop_traversal/10000_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">431.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_hop_traversal/1000_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">431.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_hop_traversal/100_nodes</td>
+            <td class="numeric">—</td>
+            <td class="numeric">431.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_transaction_latency/async</td>
+            <td class="numeric">—</td>
+            <td class="numeric">65.06 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_transaction_latency/async_batched_aggressive</td>
+            <td class="numeric">—</td>
+            <td class="numeric">5.02 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_transaction_latency/async_batched_default</td>
+            <td class="numeric">—</td>
+            <td class="numeric">9.19 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_transaction_latency/group_commit_default</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.76 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_transaction_latency/group_commit_fast</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.80 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">single_transaction_latency/synchronous</td>
+            <td class="numeric">—</td>
+            <td class="numeric">571.98 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">snapshot_creation/time_interval_1s</td>
+            <td class="numeric">—</td>
+            <td class="numeric">77.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">snapshot_creation/transaction_interval_10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">24.16 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">snapshot_creation/transaction_interval_100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">2.50 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">string_access_single/resolve</td>
+            <td class="numeric">—</td>
+            <td class="numeric">35.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">string_access_single/resolve_with</td>
+            <td class="numeric">—</td>
+            <td class="numeric">21.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">string_comparison/resolve</td>
+            <td class="numeric">—</td>
+            <td class="numeric">36.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">string_comparison/resolve_with</td>
+            <td class="numeric">—</td>
+            <td class="numeric">22.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">string_length/resolve</td>
+            <td class="numeric">—</td>
+            <td class="numeric">36.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">string_length/resolve_with</td>
+            <td class="numeric">—</td>
+            <td class="numeric">22.0 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">sustained_write_10k_versions</td>
+            <td class="numeric">—</td>
+            <td class="numeric">181.74 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">sustained_write_10k_versions_fast_reference</td>
+            <td class="numeric">—</td>
+            <td class="numeric">455.09 ms</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-improved">
             <td class="bench-name">target_3_hop/traverse_three_hops</td>
             <td class="numeric">282.2 ns</td>
-            <td class="numeric">282.2 ns</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
+            <td class="numeric">269.4 ns</td>
+            <td class="change">-4.5%</td>
+            <td class="status-cell">🟢</td>
         </tr>
-        <tr class="row-stable">
+        <tr class="row-improved">
             <td class="bench-name">target_batch_insertion/insert_1000_edges</td>
             <td class="numeric">781.38 µs</td>
-            <td class="numeric">781.38 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
+            <td class="numeric">630.49 µs</td>
+            <td class="change">-19.3%</td>
+            <td class="status-cell">🟢</td>
         </tr>
-        <tr class="row-stable">
+        <tr class="row-improved">
             <td class="bench-name">target_single_hop/traverse_one_hop</td>
             <td class="numeric">42.6 ns</td>
-            <td class="numeric">42.6 ns</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
+            <td class="numeric">39.5 ns</td>
+            <td class="change">-7.3%</td>
+            <td class="status-cell">🟢</td>
         </tr>
-        <tr class="row-stable">
+        <tr class="row-improved">
             <td class="bench-name">target_time_travel/at_anchor</td>
             <td class="numeric">282.6 ns</td>
-            <td class="numeric">282.6 ns</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
+            <td class="numeric">272.3 ns</td>
+            <td class="change">-3.6%</td>
+            <td class="status-cell">🟢</td>
         </tr>
         <tr class="row-stable">
             <td class="bench-name">target_time_travel/with_5_deltas</td>
             <td class="numeric">275.1 ns</td>
-            <td class="numeric">275.1 ns</td>
+            <td class="numeric">279.3 ns</td>
+            <td class="change">+1.5%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-improved">
+            <td class="bench-name">target_time_travel/worst_case_9_deltas</td>
+            <td class="numeric">286.2 ns</td>
+            <td class="numeric">274.5 ns</td>
+            <td class="change">-4.1%</td>
+            <td class="status-cell">🟢</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">temporal_insert/append_only/100</td>
+            <td class="numeric">20.52 µs</td>
+            <td class="numeric">20.52 µs</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">target_time_travel/worst_case_9_deltas</td>
-            <td class="numeric">286.2 ns</td>
-            <td class="numeric">286.2 ns</td>
+            <td class="bench-name">temporal_insert/append_only/1000</td>
+            <td class="numeric">210.75 µs</td>
+            <td class="numeric">210.75 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">temporal_insert/append_only/10000</td>
+            <td class="numeric">2.17 ms</td>
+            <td class="numeric">2.17 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">temporal_insert/retroactive/100</td>
+            <td class="numeric">147.47 µs</td>
+            <td class="numeric">147.47 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">temporal_insert/retroactive/1000</td>
+            <td class="numeric">12.55 ms</td>
+            <td class="numeric">12.55 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">temporal_insert/retroactive/10000</td>
+            <td class="numeric">1.287 s</td>
+            <td class="numeric">1.287 s</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">temporal_insert/append_only/100</td>
+            <td class="bench-name">time_travel/at_anchor_v20</td>
             <td class="numeric">—</td>
-            <td class="numeric">20.52 µs</td>
+            <td class="numeric">124.0 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">temporal_insert/append_only/1000</td>
+            <td class="bench-name">time_travel/deep_history_v5</td>
             <td class="numeric">—</td>
-            <td class="numeric">210.75 µs</td>
+            <td class="numeric">124.3 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">temporal_insert/append_only/10000</td>
+            <td class="bench-name">time_travel/with_deltas_v15</td>
             <td class="numeric">—</td>
-            <td class="numeric">2.17 ms</td>
+            <td class="numeric">123.9 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">temporal_insert/retroactive/100</td>
+            <td class="bench-name">time_travel/worst_case_v19</td>
             <td class="numeric">—</td>
-            <td class="numeric">147.47 µs</td>
+            <td class="numeric">124.4 ns</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">temporal_insert/retroactive/1000</td>
+            <td class="bench-name">traverse_and_rank_basic/100_power_law/100</td>
             <td class="numeric">—</td>
-            <td class="numeric">12.55 ms</td>
+            <td class="numeric">40.65 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">temporal_insert/retroactive/10000</td>
+            <td class="bench-name">traverse_and_rank_basic/100_sparse/100</td>
             <td class="numeric">—</td>
-            <td class="numeric">1.287 s</td>
+            <td class="numeric">1.29 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
+            <td class="bench-name">traverse_and_rank_basic/100_uniform/100</td>
+            <td class="numeric">—</td>
+            <td class="numeric">7.89 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">traverse_and_rank_basic/1K_power_law/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">47.54 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">traverse_and_rank_basic/1K_sparse/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.28 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">traverse_and_rank_basic/1K_uniform/1000</td>
+            <td class="numeric">—</td>
+            <td class="numeric">8.12 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">valid_at_query/10000_versions</td>
-            <td class="numeric">—</td>
             <td class="numeric">22.36 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">22.36 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">valid_at_query/1000_versions</td>
-            <td class="numeric">—</td>
             <td class="numeric">3.90 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.90 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">valid_at_query/100_versions</td>
-            <td class="numeric">—</td>
             <td class="numeric">1.53 µs</td>
+            <td class="numeric">1.53 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_batch_deserialize/retrieval_workload/100x1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">36.64 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
         </tr>
         <tr class="row-new">
-            <td class="bench-name">write_transaction_creation</td>
+            <td class="bench-name">vector_batch_serialize/rag_workload/100x1536</td>
             <td class="numeric">—</td>
-            <td class="numeric">462.4 ns</td>
+            <td class="numeric">22.99 µs</td>
             <td class="change">NEW</td>
             <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/1</td>
+            <td class="numeric">—</td>
+            <td class="numeric">54.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">55.4 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/128</td>
+            <td class="numeric">—</td>
+            <td class="numeric">67.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">376.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/3072</td>
+            <td class="numeric">—</td>
+            <td class="numeric">751.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">240.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_deserialize/deserialize/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">281.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_round_trip/round_trip/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">613.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_round_trip/round_trip/3072</td>
+            <td class="numeric">—</td>
+            <td class="numeric">1.43 µs</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_round_trip/round_trip/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">384.9 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_round_trip/round_trip/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">427.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/1</td>
+            <td class="numeric">—</td>
+            <td class="numeric">27.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/10</td>
+            <td class="numeric">—</td>
+            <td class="numeric">27.1 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/128</td>
+            <td class="numeric">—</td>
+            <td class="numeric">34.8 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">173.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/3072</td>
+            <td class="numeric">—</td>
+            <td class="numeric">219.2 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">134.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize/serialize/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">133.6 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize_into/serialize_into/1536</td>
+            <td class="numeric">—</td>
+            <td class="numeric">181.3 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize_into/serialize_into/384</td>
+            <td class="numeric">—</td>
+            <td class="numeric">119.7 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-new">
+            <td class="bench-name">vector_serialize_into/serialize_into/768</td>
+            <td class="numeric">—</td>
+            <td class="numeric">141.5 ns</td>
+            <td class="change">NEW</td>
+            <td class="status-cell">🆕</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">write_transaction_creation</td>
+            <td class="numeric">462.4 ns</td>
+            <td class="numeric">462.4 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
       </tbody>
     </table>
@@ -700,7 +1995,7 @@
 </div>
 
 <script>
-  const datasets = [{"label": "closure_write_single_node", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2805.76, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.878, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.741, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.646, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.103, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.644, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.905, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.718, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.264, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.703, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.868, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.707, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.015, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.36, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.574, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1225.713, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9476.39, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/1", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.51, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/10", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.112, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/20", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.289, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/5", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.25, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/50", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.094, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.022, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.522, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.174, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/500", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.085, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/5000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.319, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.339, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/0", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.455, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56660.317, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114751.007, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.043, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.283, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.275, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.286, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.522, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.752, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2170.105, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.472, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12548.726, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1286764.102, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/10000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.355, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/1000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.901, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/100_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.53, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "write_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.462, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
+  const datasets = [{"label": "3_hop_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.709, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_3_hop_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.483, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27807.5, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289829.223, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2831177.141, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_edge_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.346, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.063, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.062, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.061, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_historical_stats", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.059, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_in_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.105, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_labeled_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.16, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_node_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.588, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_out_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.1, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.116, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.117, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.116, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "batch_throughput/async", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52792.62, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "batch_throughput/synchronous", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635748.426, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4892.959, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4029.267, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7663.185, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.505, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1627.958, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15179.93, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "closure_write_single_node", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2805.76, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2805.76, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4929.243, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45813.563, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454829.735, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7446.458, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66782.381, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189514.992, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/fast_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.306, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/zstd_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.409, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/fast_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.791, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/zstd_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.867, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "comparison_csr/full_rebuild_insert_query", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 140.053, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "comparison_csr/incremental_csr_insert_query", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.596, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/fast", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34868.528, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31258.892, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/zstd", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36219.494, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.878, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.878, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.741, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.741, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.646, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.646, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.103, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.103, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.644, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.644, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.905, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.905, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.718, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.718, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.264, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.264, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.703, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.703, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.868, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.868, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.707, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.707, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.015, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.015, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.36, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.36, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.574, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.574, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1225.713, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1225.713, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9476.39, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9476.39, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.952, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 14.034, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.652, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.435, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.201, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.3, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.592, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.077, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.152, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.581, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.36, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.728, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.636, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.182, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.811, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.281, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 90.459, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/general/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.3, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/general/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.078, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/specialized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.285, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/specialized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.057, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_openai_1536d", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.302, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "edge_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.461, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "edge_lookup", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.062, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.175, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.273, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.066, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.549, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.332, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.567, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.155, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.173, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.27, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.057, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.121, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_neighbors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.241, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.093, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.79, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.674, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/100000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.04, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.034, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.021, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/100000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/16", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.799, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/2", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.894, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/4", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.107, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/8", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.165, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_current/read_current", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.0, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_current/read_current_approximate", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.0, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_lifecycle/create_and_generate_1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.802, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_single_thread/sequential_1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.901, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_single_thread/sequential_10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.016, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "in_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.399, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/1000+100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 60.279, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/10000+1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 955.605, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/100000+10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8192.206, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/2", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.575, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/4", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 211.623, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/8", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 410.132, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/0existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.289, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/100000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.289, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/10000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.183, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/1000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.226, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/100edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/10pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.068, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/1pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.064, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/5pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.064, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/1", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.51, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.51, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/10", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.112, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.112, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/20", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.289, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.289, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/5", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.25, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.25, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/50", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.094, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.094, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.022, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.022, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.522, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.522, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.174, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.174, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/500", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.085, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.085, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/5000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.319, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.319, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "labeled_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.466, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "mixed_read_write_80_20", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16590.657, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "multiple_accesses/resolve_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.567, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "node_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.433, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "node_lookup", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.065, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "out_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.406, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "point_in_time_queries/1000vectors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.03, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "point_in_time_queries/100vectors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.027, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "property_lookup_vs_scan/find_nodes_by_property", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.031, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "property_lookup_vs_scan/manual_label_scan_filter", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.292, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_latency_p50_p99", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.009, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.339, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.339, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/0", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.455, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.455, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56660.317, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56660.317, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114751.007, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114751.007, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.064, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.033, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.917, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.432, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.432, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.431, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async_batched_aggressive", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5017.23, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async_batched_default", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9188.521, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/group_commit_default", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2755.249, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/group_commit_fast", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1799.046, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/synchronous", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.977, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/time_interval_1s", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.077, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/transaction_interval_10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 24.161, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/transaction_interval_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.504, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_access_single/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_access_single/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_comparison/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_comparison/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_length/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.037, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_length/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_10k_versions", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181743.777, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_10k_versions_fast_reference", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 455090.031, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.269, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 630.489, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.04, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.272, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.279, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.274, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.522, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.522, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.752, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.752, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2170.105, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2170.105, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.472, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.472, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12548.726, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12548.726, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1286764.102, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1286764.102, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/at_anchor_v20", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/deep_history_v5", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/with_deltas_v15", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/worst_case_v19", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_power_law/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.645, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_sparse/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.287, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_uniform/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.893, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_power_law/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 47.543, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_sparse/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.276, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_uniform/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.124, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/10000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.355, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.355, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/1000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.901, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.901, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/100_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.53, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.53, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_batch_deserialize/retrieval_workload/100x1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.638, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_batch_serialize/rag_workload/100x1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.986, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.055, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.055, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/128", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.067, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.377, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.752, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.241, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.614, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.433, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.385, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.428, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.028, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.027, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/128", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.173, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.219, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.135, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.134, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.181, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.12, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.142, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "write_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.462, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.462, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
 
   const ctx = document.getElementById('timeseriesChart').getContext('2d');
   new Chart(ctx, {

--- a/benchmarks/timeseries.html
+++ b/benchmarks/timeseries.html
@@ -1,0 +1,906 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chronos — Timeseries Dashboard</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-adapter-date-fns/3.0.0/chartjs-adapter-date-fns.bundle.min.js"></script>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap');
+
+  :root {
+    --bg-void:      #06080d;
+    --bg-primary:   #0b0f19;
+    --bg-secondary: #111827;
+    --bg-card:      #141c2b;
+    --bg-elevated:  #1a2336;
+    --bg-hover:     #1e293b;
+    --border:       #1e293b;
+    --border-dim:   #162032;
+    --border-focus: #334155;
+    --text-primary: #e2e8f0;
+    --text-secondary: #94a3b8;
+    --text-muted:   #64748b;
+    --text-dim:     #475569;
+    --cyan:         #22d3ee;
+    --cyan-dim:     rgba(34, 211, 238, 0.15);
+    --green:        #34d399;
+    --green-dim:    rgba(52, 211, 153, 0.1);
+    --red:          #f87171;
+    --red-dim:      rgba(248, 113, 113, 0.1);
+    --yellow:       #fbbf24;
+    --purple:       #a78bfa;
+    --orange:       #fb923c;
+    --sidebar-w:    260px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    font-family: 'DM Sans', sans-serif;
+    background: var(--bg-void);
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+  }
+
+  /* ─── Sidebar ─── */
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: var(--sidebar-w);
+    height: 100vh;
+    background: var(--bg-primary);
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sidebar-header {
+    padding: 1.25rem 1rem;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .sidebar-logo {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--cyan);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .sidebar-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  .sidebar-nav {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.75rem 0;
+  }
+
+  .nav-group-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-dim);
+    padding: 0.75rem 1rem 0.3rem;
+  }
+
+  .nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.45rem 1rem;
+    text-decoration: none;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    border-left: 2px solid transparent;
+    transition: all 0.15s;
+  }
+
+  .nav-item:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    border-left-color: var(--cyan);
+  }
+
+  .nav-item.active {
+    background: var(--cyan-dim);
+    color: var(--cyan);
+    border-left-color: var(--cyan);
+  }
+
+  .nav-bench-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .nav-trend {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    font-weight: 600;
+    flex-shrink: 0;
+    margin-left: 0.5rem;
+  }
+
+  .trend-down { color: var(--green); }
+  .trend-up { color: var(--red); }
+  .trend-flat { color: var(--text-muted); }
+
+  /* ─── Main Content ─── */
+  .main {
+    margin-left: var(--sidebar-w);
+    flex: 1;
+    padding: 2rem 2.5rem;
+    max-width: calc(100vw - var(--sidebar-w));
+  }
+
+  /* ─── Top Header ─── */
+  .page-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .page-header h1 {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+  }
+
+  .page-meta {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .page-meta span { display: flex; align-items: center; gap: 0.35rem; }
+  .page-meta .label { color: var(--text-dim); }
+
+  /* ─── Overview Cards ─── */
+  .overview-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .overview-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+  }
+
+  .overview-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--cyan);
+  }
+
+  .overview-label {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-top: 0.2rem;
+  }
+
+  /* ─── Movers ─── */
+  .movers {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .movers-col {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+  }
+
+  .movers-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.75rem;
+  }
+
+  .improved-label { color: var(--green); }
+  .regressed-label { color: var(--red); }
+
+  .mover-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4rem 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-dim);
+  }
+
+  .mover-item:last-child { border-bottom: none; }
+
+  .mover-item span {
+    font-weight: 600;
+    font-size: 0.75rem;
+  }
+
+  .mover-item.improved span { color: var(--green); }
+  .mover-item.regressed span { color: var(--red); }
+
+  /* ─── Toggle Controls ─── */
+  .controls-bar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .toggle-btn {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .toggle-btn:hover { border-color: var(--border-focus); color: var(--text-secondary); }
+  .toggle-btn.active { background: var(--cyan-dim); border-color: var(--cyan); color: var(--cyan); }
+
+  .controls-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.65rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  /* ─── Benchmark Sections ─── */
+  .bench-section {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    transition: border-color 0.2s;
+  }
+
+  .bench-section:target {
+    border-color: var(--cyan);
+    box-shadow: 0 0 20px rgba(34, 211, 238, 0.05);
+  }
+
+  .bench-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 1rem;
+  }
+
+  .bench-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .bench-latest {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--cyan);
+  }
+
+  .bench-stats-bar {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-dim);
+  }
+
+  .bench-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .bench-stat-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+  }
+
+  .bench-stat-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .bench-stat-value small {
+    color: var(--text-muted);
+    font-size: 0.7rem;
+  }
+
+  .bench-stat-value.best { color: var(--green); }
+  .bench-stat-value.worst { color: var(--red); }
+
+  .chart-wrap {
+    position: relative;
+    height: 260px;
+  }
+
+  /* ─── Footer ─── */
+  footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    text-align: center;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.7rem;
+    color: var(--text-dim);
+  }
+
+  /* ─── Responsive ─── */
+  @media (max-width: 900px) {
+    .sidebar { display: none; }
+    .main { margin-left: 0; padding: 1rem; }
+    .movers { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<!-- Sidebar Navigation -->
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <div class="sidebar-logo">⏱ CHRONOS</div>
+    <div class="sidebar-sub">timeseries dashboard</div>
+  </div>
+  <div class="sidebar-nav">
+    <div class="nav-group-label">target_3_hop</div>
+<a class="nav-item" href="#bench-target_3_hop--traverse_three_hops" data-bench="target_3_hop--traverse_three_hops">
+  <span class="nav-bench-name">traverse_three_hops</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">target_batch_insertion</div>
+<a class="nav-item" href="#bench-target_batch_insertion--insert_1000_edges" data-bench="target_batch_insertion--insert_1000_edges">
+  <span class="nav-bench-name">insert_1000_edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">target_single_hop</div>
+<a class="nav-item" href="#bench-target_single_hop--traverse_one_hop" data-bench="target_single_hop--traverse_one_hop">
+  <span class="nav-bench-name">traverse_one_hop</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">target_time_travel</div>
+<a class="nav-item" href="#bench-target_time_travel--at_anchor" data-bench="target_time_travel--at_anchor">
+  <span class="nav-bench-name">at_anchor</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-target_time_travel--with_5_deltas" data-bench="target_time_travel--with_5_deltas">
+  <span class="nav-bench-name">with_5_deltas</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-target_time_travel--worst_case_9_deltas" data-bench="target_time_travel--worst_case_9_deltas">
+  <span class="nav-bench-name">worst_case_9_deltas</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+
+  </div>
+</nav>
+
+<!-- Main Content -->
+<main class="main">
+  <div class="page-header">
+    <h1>Performance Timeseries</h1>
+    <div class="page-meta">
+      <span><span class="label">runs</span> 1</span>
+      <span><span class="label">benchmarks</span> 6</span>
+      <span><span class="label">generated</span> 2026-02-21 18:08 UTC</span>
+    </div>
+  </div>
+
+  <div class="overview-row">
+    <div class="overview-card">
+      <div class="overview-value">1</div>
+      <div class="overview-label">Total Runs</div>
+    </div>
+    <div class="overview-card">
+      <div class="overview-value">6</div>
+      <div class="overview-label">Benchmarks</div>
+    </div>
+    <div class="overview-card">
+      <div class="overview-value">0</div>
+      <div class="overview-label">Trending Faster</div>
+    </div>
+    <div class="overview-card">
+      <div class="overview-value">0</div>
+      <div class="overview-label">Trending Slower</div>
+    </div>
+  </div>
+
+  <div class="movers">
+
+  </div>
+
+  <div class="controls-bar">
+    <span class="controls-label">Overlays:</span>
+    <button class="toggle-btn active" id="toggle-trend" onclick="toggleOverlay('trend')">Trend Line</button>
+    <button class="toggle-btn active" id="toggle-mean" onclick="toggleOverlay('mean')">Mean</button>
+    <button class="toggle-btn" id="toggle-ci" onclick="toggleOverlay('ci')">Confidence Interval</button>
+  </div>
+
+
+<section class="bench-section" id="bench-target_3_hop--traverse_three_hops" data-bench-name="target_3_hop/traverse_three_hops">
+  <div class="bench-header">
+    <h2 class="bench-title">target_3_hop/traverse_three_hops</h2>
+    <div class="bench-latest">282.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">282.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">282.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">282.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-target_3_hop--traverse_three_hops" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-target_batch_insertion--insert_1000_edges" data-bench-name="target_batch_insertion/insert_1000_edges">
+  <div class="bench-header">
+    <h2 class="bench-title">target_batch_insertion/insert_1000_edges</h2>
+    <div class="bench-latest">781.38 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">781.38 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">781.38 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">781.38 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-target_batch_insertion--insert_1000_edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-target_single_hop--traverse_one_hop" data-bench-name="target_single_hop/traverse_one_hop">
+  <div class="bench-header">
+    <h2 class="bench-title">target_single_hop/traverse_one_hop</h2>
+    <div class="bench-latest">42.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">42.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">42.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">42.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-target_single_hop--traverse_one_hop" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-target_time_travel--at_anchor" data-bench-name="target_time_travel/at_anchor">
+  <div class="bench-header">
+    <h2 class="bench-title">target_time_travel/at_anchor</h2>
+    <div class="bench-latest">282.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">282.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">282.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">282.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-target_time_travel--at_anchor" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-target_time_travel--with_5_deltas" data-bench-name="target_time_travel/with_5_deltas">
+  <div class="bench-header">
+    <h2 class="bench-title">target_time_travel/with_5_deltas</h2>
+    <div class="bench-latest">275.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">275.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">275.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">275.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-target_time_travel--with_5_deltas" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-target_time_travel--worst_case_9_deltas" data-bench-name="target_time_travel/worst_case_9_deltas">
+  <div class="bench-header">
+    <h2 class="bench-title">target_time_travel/worst_case_9_deltas</h2>
+    <div class="bench-latest">286.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">286.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">286.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">286.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-target_time_travel--worst_case_9_deltas" height="260"></canvas>
+  </div>
+</section>
+
+  <footer>
+    Chronos — The Temporal Benchkeeper &nbsp;·&nbsp; Timeseries Dashboard
+  </footer>
+</main>
+
+<script>
+const CONFIGS = {"target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}], "trend": [], "mean": 282.1573, "unit": "ns", "stats": {"mean": "282.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.2 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}], "trend": [], "mean": 781.382, "unit": "\u00b5s", "stats": {"mean": "781.38 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "781.38 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "781.38 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}], "trend": [], "mean": 42.6068, "unit": "ns", "stats": {"mean": "42.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "42.6 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "42.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}], "trend": [], "mean": 282.592, "unit": "ns", "stats": {"mean": "282.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.6 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}], "trend": [], "mean": 275.1228, "unit": "ns", "stats": {"mean": "275.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "275.1 ns", "max": "275.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "275.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}], "trend": [], "mean": 286.226, "unit": "ns", "stats": {"mean": "286.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "286.2 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "286.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}};
+
+const overlays = { trend: true, mean: true, ci: false };
+const charts = {};
+
+const COLORS = {
+  main: '#22d3ee',
+  mainFill: 'rgba(34, 211, 238, 0.08)',
+  trend: '#a78bfa',
+  mean: 'rgba(251, 191, 36, 0.5)',
+  ci: 'rgba(52, 211, 153, 0.12)',
+  ciBorder: 'rgba(52, 211, 153, 0.3)',
+};
+
+function buildChart(benchName, canvasId) {
+  const cfg = CONFIGS[benchName];
+  if (!cfg) return;
+
+  const ctx = document.getElementById(canvasId);
+  if (!ctx) return;
+
+  const datasets = [
+    {
+      label: benchName,
+      data: cfg.data,
+      borderColor: COLORS.main,
+      backgroundColor: COLORS.mainFill,
+      fill: true,
+      tension: 0.3,
+      pointRadius: 5,
+      pointHoverRadius: 8,
+      pointBackgroundColor: COLORS.main,
+      pointBorderColor: '#0b0f19',
+      pointBorderWidth: 2,
+      borderWidth: 2,
+      order: 1,
+    },
+  ];
+
+  // Trend line
+  if (cfg.trend.length >= 2) {
+    datasets.push({
+      label: 'Trend',
+      data: cfg.trend,
+      borderColor: COLORS.trend,
+      borderDash: [6, 4],
+      borderWidth: 1.5,
+      pointRadius: 0,
+      fill: false,
+      hidden: !overlays.trend,
+      order: 2,
+    });
+  }
+
+  // Mean line (annotation via dataset)
+  if (cfg.data.length >= 2) {
+    datasets.push({
+      label: 'Mean',
+      data: [
+        { x: cfg.data[0].x, y: cfg.mean },
+        { x: cfg.data[cfg.data.length - 1].x, y: cfg.mean },
+      ],
+      borderColor: COLORS.mean,
+      borderDash: [3, 3],
+      borderWidth: 1,
+      pointRadius: 0,
+      fill: false,
+      hidden: !overlays.mean,
+      order: 3,
+    });
+  }
+
+  // Confidence interval bands
+  if (cfg.data.some(d => d.ci_upper !== null)) {
+    datasets.push({
+      label: 'CI Upper',
+      data: cfg.data.map(d => ({ x: d.x, y: d.ci_upper || d.y })),
+      borderColor: COLORS.ciBorder,
+      backgroundColor: COLORS.ci,
+      borderWidth: 0.5,
+      pointRadius: 0,
+      fill: '+1',
+      hidden: !overlays.ci,
+      order: 4,
+    });
+    datasets.push({
+      label: 'CI Lower',
+      data: cfg.data.map(d => ({ x: d.x, y: d.ci_lower || d.y })),
+      borderColor: COLORS.ciBorder,
+      borderWidth: 0.5,
+      pointRadius: 0,
+      fill: false,
+      hidden: !overlays.ci,
+      order: 5,
+    });
+  }
+
+  const chart = new Chart(ctx, {
+    type: 'line',
+    data: { datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'bottom',
+          labels: {
+            color: '#64748b',
+            font: { family: "'JetBrains Mono', monospace", size: 10 },
+            boxWidth: 10,
+            padding: 12,
+            filter: (item) => !item.text.startsWith('CI'),
+          },
+        },
+        tooltip: {
+          backgroundColor: '#1a2336',
+          titleColor: '#e2e8f0',
+          bodyColor: '#94a3b8',
+          borderColor: '#334155',
+          borderWidth: 1,
+          titleFont: { family: "'JetBrains Mono', monospace", size: 12 },
+          bodyFont: { family: "'JetBrains Mono', monospace", size: 11 },
+          filter: (item) => item.datasetIndex === 0,
+          callbacks: {
+            afterTitle: function(items) {
+              const pt = cfg.data[items[0].dataIndex];
+              return pt ? 'commit: ' + pt.commit + ' (' + pt.branch + ')' : '';
+            },
+            label: function(ctx) {
+              const pt = cfg.data[ctx.dataIndex];
+              let s = ctx.parsed.y.toFixed(2) + ' ' + cfg.unit;
+              if (pt && pt.ci_lower !== null) {
+                s += '  [' + pt.ci_lower.toFixed(2) + ' – ' + pt.ci_upper.toFixed(2) + ']';
+              }
+              return s;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          type: 'time',
+          time: {
+            tooltipFormat: 'yyyy-MM-dd HH:mm',
+            displayFormats: { hour: 'MMM d HH:mm', day: 'MMM d', week: 'MMM d' },
+          },
+          ticks: { color: '#475569', font: { family: "'JetBrains Mono', monospace", size: 10 }, maxRotation: 45 },
+          grid: { color: 'rgba(30, 41, 59, 0.3)' },
+        },
+        y: {
+          beginAtZero: false,
+          ticks: {
+            color: '#475569',
+            font: { family: "'JetBrains Mono', monospace", size: 10 },
+            callback: (v) => v.toFixed(1) + ' ' + cfg.unit,
+          },
+          grid: { color: 'rgba(30, 41, 59, 0.3)' },
+        },
+      },
+    },
+  });
+
+  charts[benchName] = chart;
+}
+
+function toggleOverlay(name) {
+  overlays[name] = !overlays[name];
+  const btn = document.getElementById('toggle-' + name);
+  btn.classList.toggle('active', overlays[name]);
+
+  // Map overlay name to dataset label patterns
+  const labelMap = {
+    trend: ['Trend'],
+    mean: ['Mean'],
+    ci: ['CI Upper', 'CI Lower'],
+  };
+
+  const labels = labelMap[name] || [];
+
+  Object.values(charts).forEach(chart => {
+    chart.data.datasets.forEach((ds, i) => {
+      if (labels.includes(ds.label)) {
+        chart.setDatasetVisibility(i, overlays[name]);
+      }
+    });
+    chart.update('none');
+  });
+}
+
+// Initialize all charts
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.bench-section').forEach(section => {
+    const name = section.dataset.benchName;
+    const canvasId = section.querySelector('canvas').id;
+    buildChart(name, canvasId);
+  });
+
+  // Sidebar scroll-spy
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      const id = entry.target.id;
+      const link = document.querySelector(`.nav-item[href="#${id}"]`);
+      if (link) {
+        link.classList.toggle('active', entry.isIntersecting);
+      }
+    });
+  }, { rootMargin: '-20% 0px -60% 0px' });
+
+  document.querySelectorAll('.bench-section').forEach(s => observer.observe(s));
+});
+</script>
+
+</body>
+</html>

--- a/benchmarks/timeseries.html
+++ b/benchmarks/timeseries.html
@@ -398,16 +398,247 @@
   </div>
   <div class="sidebar-nav">
     <div class="nav-group-label">ungrouped</div>
+<a class="nav-item" href="#bench-3_hop_traversal" data-bench="3_hop_traversal">
+  <span class="nav-bench-name">3_hop_traversal</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_3_hop_traversal" data-bench="aletheiadb_3_hop_traversal">
+  <span class="nav-bench-name">aletheiadb_3_hop_traversal</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_edge_creation" data-bench="aletheiadb_edge_creation">
+  <span class="nav-bench-name">aletheiadb_edge_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_historical_stats" data-bench="aletheiadb_historical_stats">
+  <span class="nav-bench-name">aletheiadb_historical_stats</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_in_degree" data-bench="aletheiadb_in_degree">
+  <span class="nav-bench-name">aletheiadb_in_degree</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_labeled_traversal" data-bench="aletheiadb_labeled_traversal">
+  <span class="nav-bench-name">aletheiadb_labeled_traversal</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_node_creation" data-bench="aletheiadb_node_creation">
+  <span class="nav-bench-name">aletheiadb_node_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_out_degree" data-bench="aletheiadb_out_degree">
+  <span class="nav-bench-name">aletheiadb_out_degree</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 <a class="nav-item" href="#bench-closure_write_single_node" data-bench="closure_write_single_node">
   <span class="nav-bench-name">closure_write_single_node</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity_openai_1536d" data-bench="cosine_similarity_openai_1536d">
+  <span class="nav-bench-name">cosine_similarity_openai_1536d</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-edge_creation" data-bench="edge_creation">
+  <span class="nav-bench-name">edge_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-edge_lookup" data-bench="edge_lookup">
+  <span class="nav-bench-name">edge_lookup</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-find_neighbors" data-bench="find_neighbors">
+  <span class="nav-bench-name">find_neighbors</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-in_degree" data-bench="in_degree">
+  <span class="nav-bench-name">in_degree</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-labeled_traversal" data-bench="labeled_traversal">
+  <span class="nav-bench-name">labeled_traversal</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-mixed_read_write_80_20" data-bench="mixed_read_write_80_20">
+  <span class="nav-bench-name">mixed_read_write_80_20</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-node_creation" data-bench="node_creation">
+  <span class="nav-bench-name">node_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-node_lookup" data-bench="node_lookup">
+  <span class="nav-bench-name">node_lookup</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-out_degree" data-bench="out_degree">
+  <span class="nav-bench-name">out_degree</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-read_latency_p50_p99" data-bench="read_latency_p50_p99">
+  <span class="nav-bench-name">read_latency_p50_p99</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <a class="nav-item" href="#bench-read_transaction_creation" data-bench="read_transaction_creation">
   <span class="nav-bench-name">read_transaction_creation</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<a class="nav-item" href="#bench-sustained_write_10k_versions" data-bench="sustained_write_10k_versions">
+  <span class="nav-bench-name">sustained_write_10k_versions</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-sustained_write_10k_versions_fast_reference" data-bench="sustained_write_10k_versions_fast_reference">
+  <span class="nav-bench-name">sustained_write_10k_versions_fast_reference</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 <a class="nav-item" href="#bench-write_transaction_creation" data-bench="write_transaction_creation">
   <span class="nav-bench-name">write_transaction_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">aletheiadb_batch</div>
+<a class="nav-item" href="#bench-aletheiadb_batch--batch_node_creation--10" data-bench="aletheiadb_batch--batch_node_creation--10">
+  <span class="nav-bench-name">10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_batch--batch_node_creation--100" data-bench="aletheiadb_batch--batch_node_creation--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_batch--batch_node_creation--1000" data-bench="aletheiadb_batch--batch_node_creation--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">aletheiadb_fast_path</div>
+<a class="nav-item" href="#bench-aletheiadb_fast_path--node_lookup--100" data-bench="aletheiadb_fast_path--node_lookup--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_fast_path--node_lookup--1000" data-bench="aletheiadb_fast_path--node_lookup--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_fast_path--node_lookup--10000" data-bench="aletheiadb_fast_path--node_lookup--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">aletheiadb_single_hop</div>
+<a class="nav-item" href="#bench-aletheiadb_single_hop--10000_nodes" data-bench="aletheiadb_single_hop--10000_nodes">
+  <span class="nav-bench-name">10000_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_single_hop--1000_nodes" data-bench="aletheiadb_single_hop--1000_nodes">
+  <span class="nav-bench-name">1000_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-aletheiadb_single_hop--100_nodes" data-bench="aletheiadb_single_hop--100_nodes">
+  <span class="nav-bench-name">100_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">batch_throughput</div>
+<a class="nav-item" href="#bench-batch_throughput--async" data-bench="batch_throughput--async">
+  <span class="nav-bench-name">async</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-batch_throughput--synchronous" data-bench="batch_throughput--synchronous">
+  <span class="nav-bench-name">synchronous</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">checkpoint_creation</div>
+<a class="nav-item" href="#bench-checkpoint_creation--100" data-bench="checkpoint_creation--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-checkpoint_creation--1000" data-bench="checkpoint_creation--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-checkpoint_creation--10000" data-bench="checkpoint_creation--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">checkpoint_load</div>
+<a class="nav-item" href="#bench-checkpoint_load--100" data-bench="checkpoint_load--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-checkpoint_load--1000" data-bench="checkpoint_load--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-checkpoint_load--10000" data-bench="checkpoint_load--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">cold_batch_write_throughput</div>
+<a class="nav-item" href="#bench-cold_batch_write_throughput--fast--100" data-bench="cold_batch_write_throughput--fast--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_batch_write_throughput--fast--1000" data-bench="cold_batch_write_throughput--fast--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_batch_write_throughput--fast--10000" data-bench="cold_batch_write_throughput--fast--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_batch_write_throughput--zstd--100" data-bench="cold_batch_write_throughput--zstd--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_batch_write_throughput--zstd--1000" data-bench="cold_batch_write_throughput--zstd--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_batch_write_throughput--zstd--10000" data-bench="cold_batch_write_throughput--zstd--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">cold_read_latency</div>
+<a class="nav-item" href="#bench-cold_read_latency--single_read--fast_compression" data-bench="cold_read_latency--single_read--fast_compression">
+  <span class="nav-bench-name">fast_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_read_latency--single_read--no_compression" data-bench="cold_read_latency--single_read--no_compression">
+  <span class="nav-bench-name">no_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_read_latency--single_read--zstd_compression" data-bench="cold_read_latency--single_read--zstd_compression">
+  <span class="nav-bench-name">zstd_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">cold_write_latency</div>
+<a class="nav-item" href="#bench-cold_write_latency--single_write--fast_compression" data-bench="cold_write_latency--single_write--fast_compression">
+  <span class="nav-bench-name">fast_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_write_latency--single_write--no_compression" data-bench="cold_write_latency--single_write--no_compression">
+  <span class="nav-bench-name">no_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cold_write_latency--single_write--zstd_compression" data-bench="cold_write_latency--single_write--zstd_compression">
+  <span class="nav-bench-name">zstd_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">comparison_csr</div>
+<a class="nav-item" href="#bench-comparison_csr--full_rebuild_insert_query" data-bench="comparison_csr--full_rebuild_insert_query">
+  <span class="nav-bench-name">full_rebuild_insert_query</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-comparison_csr--incremental_csr_insert_query" data-bench="comparison_csr--incremental_csr_insert_query">
+  <span class="nav-bench-name">incremental_csr_insert_query</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">compression_ratio</div>
+<a class="nav-item" href="#bench-compression_ratio--compress--fast" data-bench="compression_ratio--compress--fast">
+  <span class="nav-bench-name">fast</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-compression_ratio--compress--no_compression" data-bench="compression_ratio--compress--no_compression">
+  <span class="nav-bench-name">no_compression</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-compression_ratio--compress--zstd" data-bench="compression_ratio--compress--zstd">
+  <span class="nav-bench-name">zstd</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <div class="nav-group-label">concurrent_reads_same_entity</div>
@@ -476,6 +707,306 @@
   <span class="nav-bench-name">8</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<div class="nav-group-label">cosine_similarity</div>
+<a class="nav-item" href="#bench-cosine_similarity--naive_3pass--1024" data-bench="cosine_similarity--naive_3pass--1024">
+  <span class="nav-bench-name">1024</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--naive_3pass--1536" data-bench="cosine_similarity--naive_3pass--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--naive_3pass--3072" data-bench="cosine_similarity--naive_3pass--3072">
+  <span class="nav-bench-name">3072</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--naive_3pass--384" data-bench="cosine_similarity--naive_3pass--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--naive_3pass--768" data-bench="cosine_similarity--naive_3pass--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--optimized--1024" data-bench="cosine_similarity--optimized--1024">
+  <span class="nav-bench-name">1024</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--optimized--1536" data-bench="cosine_similarity--optimized--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--optimized--3072" data-bench="cosine_similarity--optimized--3072">
+  <span class="nav-bench-name">3072</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--optimized--384" data-bench="cosine_similarity--optimized--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--optimized--768" data-bench="cosine_similarity--optimized--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--scalar_1pass--1024" data-bench="cosine_similarity--scalar_1pass--1024">
+  <span class="nav-bench-name">1024</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--scalar_1pass--1536" data-bench="cosine_similarity--scalar_1pass--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--scalar_1pass--3072" data-bench="cosine_similarity--scalar_1pass--3072">
+  <span class="nav-bench-name">3072</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--scalar_1pass--384" data-bench="cosine_similarity--scalar_1pass--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity--scalar_1pass--768" data-bench="cosine_similarity--scalar_1pass--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">cosine_similarity_batch</div>
+<a class="nav-item" href="#bench-cosine_similarity_batch--find_most_similar--10" data-bench="cosine_similarity_batch--find_most_similar--10">
+  <span class="nav-bench-name">10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity_batch--find_most_similar--100" data-bench="cosine_similarity_batch--find_most_similar--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity_batch--find_most_similar--1000" data-bench="cosine_similarity_batch--find_most_similar--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">cosine_similarity_normalized</div>
+<a class="nav-item" href="#bench-cosine_similarity_normalized--general--1536" data-bench="cosine_similarity_normalized--general--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity_normalized--general--384" data-bench="cosine_similarity_normalized--general--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity_normalized--specialized--1536" data-bench="cosine_similarity_normalized--specialized--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-cosine_similarity_normalized--specialized--384" data-bench="cosine_similarity_normalized--specialized--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">euclidean_distance</div>
+<a class="nav-item" href="#bench-euclidean_distance--optimized--1024" data-bench="euclidean_distance--optimized--1024">
+  <span class="nav-bench-name">1024</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--optimized--1536" data-bench="euclidean_distance--optimized--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--optimized--384" data-bench="euclidean_distance--optimized--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--optimized--768" data-bench="euclidean_distance--optimized--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--scalar--1024" data-bench="euclidean_distance--scalar--1024">
+  <span class="nav-bench-name">1024</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--scalar--1536" data-bench="euclidean_distance--scalar--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--scalar--384" data-bench="euclidean_distance--scalar--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--scalar--768" data-bench="euclidean_distance--scalar--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--squared_optimized--1024" data-bench="euclidean_distance--squared_optimized--1024">
+  <span class="nav-bench-name">1024</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--squared_optimized--1536" data-bench="euclidean_distance--squared_optimized--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--squared_optimized--384" data-bench="euclidean_distance--squared_optimized--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-euclidean_distance--squared_optimized--768" data-bench="euclidean_distance--squared_optimized--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">find_nodes_by_property</div>
+<a class="nav-item" href="#bench-find_nodes_by_property--10000_nodes" data-bench="find_nodes_by_property--10000_nodes">
+  <span class="nav-bench-name">10000_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-find_nodes_by_property--1000_nodes" data-bench="find_nodes_by_property--1000_nodes">
+  <span class="nav-bench-name">1000_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-find_nodes_by_property--100_nodes" data-bench="find_nodes_by_property--100_nodes">
+  <span class="nav-bench-name">100_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">frozen_view_hot_path</div>
+<a class="nav-item" href="#bench-frozen_view_hot_path--frozen_view--100000edges" data-bench="frozen_view_hot_path--frozen_view--100000edges">
+  <span class="nav-bench-name">100000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-frozen_view_hot_path--frozen_view--10000edges" data-bench="frozen_view_hot_path--frozen_view--10000edges">
+  <span class="nav-bench-name">10000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-frozen_view_hot_path--frozen_view--1000edges" data-bench="frozen_view_hot_path--frozen_view--1000edges">
+  <span class="nav-bench-name">1000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-frozen_view_hot_path--merged_guard--100000edges" data-bench="frozen_view_hot_path--merged_guard--100000edges">
+  <span class="nav-bench-name">100000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-frozen_view_hot_path--merged_guard--10000edges" data-bench="frozen_view_hot_path--merged_guard--10000edges">
+  <span class="nav-bench-name">10000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-frozen_view_hot_path--merged_guard--1000edges" data-bench="frozen_view_hot_path--merged_guard--1000edges">
+  <span class="nav-bench-name">1000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">get_outgoing_allocation</div>
+<a class="nav-item" href="#bench-get_outgoing_allocation--degree_1" data-bench="get_outgoing_allocation--degree_1">
+  <span class="nav-bench-name">degree_1</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-get_outgoing_allocation--degree_10" data-bench="get_outgoing_allocation--degree_10">
+  <span class="nav-bench-name">degree_10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-get_outgoing_allocation--degree_100" data-bench="get_outgoing_allocation--degree_100">
+  <span class="nav-bench-name">degree_100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">id_generation_concurrent</div>
+<a class="nav-item" href="#bench-id_generation_concurrent--threads--16" data-bench="id_generation_concurrent--threads--16">
+  <span class="nav-bench-name">16</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-id_generation_concurrent--threads--2" data-bench="id_generation_concurrent--threads--2">
+  <span class="nav-bench-name">2</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-id_generation_concurrent--threads--4" data-bench="id_generation_concurrent--threads--4">
+  <span class="nav-bench-name">4</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-id_generation_concurrent--threads--8" data-bench="id_generation_concurrent--threads--8">
+  <span class="nav-bench-name">8</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">id_generation_current</div>
+<a class="nav-item" href="#bench-id_generation_current--read_current" data-bench="id_generation_current--read_current">
+  <span class="nav-bench-name">read_current</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-id_generation_current--read_current_approximate" data-bench="id_generation_current--read_current_approximate">
+  <span class="nav-bench-name">read_current_approximate</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">id_generation_lifecycle</div>
+<a class="nav-item" href="#bench-id_generation_lifecycle--create_and_generate_1000" data-bench="id_generation_lifecycle--create_and_generate_1000">
+  <span class="nav-bench-name">create_and_generate_1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">id_generation_single_thread</div>
+<a class="nav-item" href="#bench-id_generation_single_thread--sequential_1000" data-bench="id_generation_single_thread--sequential_1000">
+  <span class="nav-bench-name">sequential_1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-id_generation_single_thread--sequential_10000" data-bench="id_generation_single_thread--sequential_10000">
+  <span class="nav-bench-name">sequential_10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">incremental_compaction</div>
+<a class="nav-item" href="#bench-incremental_compaction--edges--1000+100" data-bench="incremental_compaction--edges--1000+100">
+  <span class="nav-bench-name">1000+100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_compaction--edges--10000+1000" data-bench="incremental_compaction--edges--10000+1000">
+  <span class="nav-bench-name">10000+1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_compaction--edges--100000+10000" data-bench="incremental_compaction--edges--100000+10000">
+  <span class="nav-bench-name">100000+10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">incremental_concurrent</div>
+<a class="nav-item" href="#bench-incremental_concurrent--threads--2" data-bench="incremental_concurrent--threads--2">
+  <span class="nav-bench-name">2</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_concurrent--threads--4" data-bench="incremental_concurrent--threads--4">
+  <span class="nav-bench-name">4</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_concurrent--threads--8" data-bench="incremental_concurrent--threads--8">
+  <span class="nav-bench-name">8</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">incremental_insert_latency</div>
+<a class="nav-item" href="#bench-incremental_insert_latency--0existing" data-bench="incremental_insert_latency--0existing">
+  <span class="nav-bench-name">0existing</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_insert_latency--100000existing" data-bench="incremental_insert_latency--100000existing">
+  <span class="nav-bench-name">100000existing</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_insert_latency--10000existing" data-bench="incremental_insert_latency--10000existing">
+  <span class="nav-bench-name">10000existing</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_insert_latency--1000existing" data-bench="incremental_insert_latency--1000existing">
+  <span class="nav-bench-name">1000existing</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">incremental_read_no_delta</div>
+<a class="nav-item" href="#bench-incremental_read_no_delta--10000edges" data-bench="incremental_read_no_delta--10000edges">
+  <span class="nav-bench-name">10000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_read_no_delta--1000edges" data-bench="incremental_read_no_delta--1000edges">
+  <span class="nav-bench-name">1000edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_read_no_delta--100edges" data-bench="incremental_read_no_delta--100edges">
+  <span class="nav-bench-name">100edges</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">incremental_read_with_delta</div>
+<a class="nav-item" href="#bench-incremental_read_with_delta--10pct_delta" data-bench="incremental_read_with_delta--10pct_delta">
+  <span class="nav-bench-name">10pct_delta</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_read_with_delta--1pct_delta" data-bench="incremental_read_with_delta--1pct_delta">
+  <span class="nav-bench-name">1pct_delta</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-incremental_read_with_delta--5pct_delta" data-bench="incremental_read_with_delta--5pct_delta">
+  <span class="nav-bench-name">5pct_delta</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 <div class="nav-group-label">knn_search</div>
 <a class="nav-item" href="#bench-knn_search--k--1" data-bench="knn_search--k--1">
   <span class="nav-bench-name">1</span>
@@ -518,6 +1049,29 @@
   <span class="nav-bench-name">5000</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<div class="nav-group-label">multiple_accesses</div>
+<a class="nav-item" href="#bench-multiple_accesses--resolve_100" data-bench="multiple_accesses--resolve_100">
+  <span class="nav-bench-name">resolve_100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">point_in_time_queries</div>
+<a class="nav-item" href="#bench-point_in_time_queries--1000vectors" data-bench="point_in_time_queries--1000vectors">
+  <span class="nav-bench-name">1000vectors</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-point_in_time_queries--100vectors" data-bench="point_in_time_queries--100vectors">
+  <span class="nav-bench-name">100vectors</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">property_lookup_vs_scan</div>
+<a class="nav-item" href="#bench-property_lookup_vs_scan--find_nodes_by_property" data-bench="property_lookup_vs_scan--find_nodes_by_property">
+  <span class="nav-bench-name">find_nodes_by_property</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-property_lookup_vs_scan--manual_label_scan_filter" data-bench="property_lookup_vs_scan--manual_label_scan_filter">
+  <span class="nav-bench-name">manual_label_scan_filter</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 <div class="nav-group-label">read_under_write_contention</div>
 <a class="nav-item" href="#bench-read_under_write_contention--concurrent_writers--0" data-bench="read_under_write_contention--concurrent_writers--0">
   <span class="nav-bench-name">0</span>
@@ -531,33 +1085,124 @@
   <span class="nav-bench-name">4</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<div class="nav-group-label">recovery</div>
+<a class="nav-item" href="#bench-recovery--10" data-bench="recovery--10">
+  <span class="nav-bench-name">10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-recovery--100" data-bench="recovery--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-recovery--1000" data-bench="recovery--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">single_hop_traversal</div>
+<a class="nav-item" href="#bench-single_hop_traversal--10000_nodes" data-bench="single_hop_traversal--10000_nodes">
+  <span class="nav-bench-name">10000_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_hop_traversal--1000_nodes" data-bench="single_hop_traversal--1000_nodes">
+  <span class="nav-bench-name">1000_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_hop_traversal--100_nodes" data-bench="single_hop_traversal--100_nodes">
+  <span class="nav-bench-name">100_nodes</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">single_transaction_latency</div>
+<a class="nav-item" href="#bench-single_transaction_latency--async" data-bench="single_transaction_latency--async">
+  <span class="nav-bench-name">async</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_transaction_latency--async_batched_aggressive" data-bench="single_transaction_latency--async_batched_aggressive">
+  <span class="nav-bench-name">async_batched_aggressive</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_transaction_latency--async_batched_default" data-bench="single_transaction_latency--async_batched_default">
+  <span class="nav-bench-name">async_batched_default</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_transaction_latency--group_commit_default" data-bench="single_transaction_latency--group_commit_default">
+  <span class="nav-bench-name">group_commit_default</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_transaction_latency--group_commit_fast" data-bench="single_transaction_latency--group_commit_fast">
+  <span class="nav-bench-name">group_commit_fast</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-single_transaction_latency--synchronous" data-bench="single_transaction_latency--synchronous">
+  <span class="nav-bench-name">synchronous</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">snapshot_creation</div>
+<a class="nav-item" href="#bench-snapshot_creation--time_interval_1s" data-bench="snapshot_creation--time_interval_1s">
+  <span class="nav-bench-name">time_interval_1s</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-snapshot_creation--transaction_interval_10" data-bench="snapshot_creation--transaction_interval_10">
+  <span class="nav-bench-name">transaction_interval_10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-snapshot_creation--transaction_interval_100" data-bench="snapshot_creation--transaction_interval_100">
+  <span class="nav-bench-name">transaction_interval_100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">string_access_single</div>
+<a class="nav-item" href="#bench-string_access_single--resolve" data-bench="string_access_single--resolve">
+  <span class="nav-bench-name">resolve</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-string_access_single--resolve_with" data-bench="string_access_single--resolve_with">
+  <span class="nav-bench-name">resolve_with</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">string_comparison</div>
+<a class="nav-item" href="#bench-string_comparison--resolve" data-bench="string_comparison--resolve">
+  <span class="nav-bench-name">resolve</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-string_comparison--resolve_with" data-bench="string_comparison--resolve_with">
+  <span class="nav-bench-name">resolve_with</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">string_length</div>
+<a class="nav-item" href="#bench-string_length--resolve" data-bench="string_length--resolve">
+  <span class="nav-bench-name">resolve</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-string_length--resolve_with" data-bench="string_length--resolve_with">
+  <span class="nav-bench-name">resolve_with</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 <div class="nav-group-label">target_3_hop</div>
 <a class="nav-item" href="#bench-target_3_hop--traverse_three_hops" data-bench="target_3_hop--traverse_three_hops">
   <span class="nav-bench-name">traverse_three_hops</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -4.5%</span>
 </a>
 <div class="nav-group-label">target_batch_insertion</div>
 <a class="nav-item" href="#bench-target_batch_insertion--insert_1000_edges" data-bench="target_batch_insertion--insert_1000_edges">
   <span class="nav-bench-name">insert_1000_edges</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -19.3%</span>
 </a>
 <div class="nav-group-label">target_single_hop</div>
 <a class="nav-item" href="#bench-target_single_hop--traverse_one_hop" data-bench="target_single_hop--traverse_one_hop">
   <span class="nav-bench-name">traverse_one_hop</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -7.3%</span>
 </a>
 <div class="nav-group-label">target_time_travel</div>
 <a class="nav-item" href="#bench-target_time_travel--at_anchor" data-bench="target_time_travel--at_anchor">
   <span class="nav-bench-name">at_anchor</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -3.6%</span>
 </a>
 <a class="nav-item" href="#bench-target_time_travel--with_5_deltas" data-bench="target_time_travel--with_5_deltas">
   <span class="nav-bench-name">with_5_deltas</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +1.5%</span>
 </a>
 <a class="nav-item" href="#bench-target_time_travel--worst_case_9_deltas" data-bench="target_time_travel--worst_case_9_deltas">
   <span class="nav-bench-name">worst_case_9_deltas</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -4.1%</span>
 </a>
 <div class="nav-group-label">temporal_insert</div>
 <a class="nav-item" href="#bench-temporal_insert--append_only--100" data-bench="temporal_insert--append_only--100">
@@ -584,6 +1229,48 @@
   <span class="nav-bench-name">10000</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<div class="nav-group-label">time_travel</div>
+<a class="nav-item" href="#bench-time_travel--at_anchor_v20" data-bench="time_travel--at_anchor_v20">
+  <span class="nav-bench-name">at_anchor_v20</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-time_travel--deep_history_v5" data-bench="time_travel--deep_history_v5">
+  <span class="nav-bench-name">deep_history_v5</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-time_travel--with_deltas_v15" data-bench="time_travel--with_deltas_v15">
+  <span class="nav-bench-name">with_deltas_v15</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-time_travel--worst_case_v19" data-bench="time_travel--worst_case_v19">
+  <span class="nav-bench-name">worst_case_v19</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">traverse_and_rank_basic</div>
+<a class="nav-item" href="#bench-traverse_and_rank_basic--100_power_law--100" data-bench="traverse_and_rank_basic--100_power_law--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-traverse_and_rank_basic--100_sparse--100" data-bench="traverse_and_rank_basic--100_sparse--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-traverse_and_rank_basic--100_uniform--100" data-bench="traverse_and_rank_basic--100_uniform--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-traverse_and_rank_basic--1K_power_law--1000" data-bench="traverse_and_rank_basic--1K_power_law--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-traverse_and_rank_basic--1K_sparse--1000" data-bench="traverse_and_rank_basic--1K_sparse--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-traverse_and_rank_basic--1K_uniform--1000" data-bench="traverse_and_rank_basic--1K_uniform--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 <div class="nav-group-label">valid_at_query</div>
 <a class="nav-item" href="#bench-valid_at_query--10000_versions" data-bench="valid_at_query--10000_versions">
   <span class="nav-bench-name">10000_versions</span>
@@ -597,6 +1284,104 @@
   <span class="nav-bench-name">100_versions</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<div class="nav-group-label">vector_batch_deserialize</div>
+<a class="nav-item" href="#bench-vector_batch_deserialize--retrieval_workload--100x1536" data-bench="vector_batch_deserialize--retrieval_workload--100x1536">
+  <span class="nav-bench-name">100x1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">vector_batch_serialize</div>
+<a class="nav-item" href="#bench-vector_batch_serialize--rag_workload--100x1536" data-bench="vector_batch_serialize--rag_workload--100x1536">
+  <span class="nav-bench-name">100x1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">vector_deserialize</div>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--1" data-bench="vector_deserialize--deserialize--1">
+  <span class="nav-bench-name">1</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--10" data-bench="vector_deserialize--deserialize--10">
+  <span class="nav-bench-name">10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--128" data-bench="vector_deserialize--deserialize--128">
+  <span class="nav-bench-name">128</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--1536" data-bench="vector_deserialize--deserialize--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--3072" data-bench="vector_deserialize--deserialize--3072">
+  <span class="nav-bench-name">3072</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--384" data-bench="vector_deserialize--deserialize--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_deserialize--deserialize--768" data-bench="vector_deserialize--deserialize--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">vector_round_trip</div>
+<a class="nav-item" href="#bench-vector_round_trip--round_trip--1536" data-bench="vector_round_trip--round_trip--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_round_trip--round_trip--3072" data-bench="vector_round_trip--round_trip--3072">
+  <span class="nav-bench-name">3072</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_round_trip--round_trip--384" data-bench="vector_round_trip--round_trip--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_round_trip--round_trip--768" data-bench="vector_round_trip--round_trip--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">vector_serialize</div>
+<a class="nav-item" href="#bench-vector_serialize--serialize--1" data-bench="vector_serialize--serialize--1">
+  <span class="nav-bench-name">1</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize--serialize--10" data-bench="vector_serialize--serialize--10">
+  <span class="nav-bench-name">10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize--serialize--128" data-bench="vector_serialize--serialize--128">
+  <span class="nav-bench-name">128</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize--serialize--1536" data-bench="vector_serialize--serialize--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize--serialize--3072" data-bench="vector_serialize--serialize--3072">
+  <span class="nav-bench-name">3072</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize--serialize--384" data-bench="vector_serialize--serialize--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize--serialize--768" data-bench="vector_serialize--serialize--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">vector_serialize_into</div>
+<a class="nav-item" href="#bench-vector_serialize_into--serialize_into--1536" data-bench="vector_serialize_into--serialize_into--1536">
+  <span class="nav-bench-name">1536</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize_into--serialize_into--384" data-bench="vector_serialize_into--serialize_into--384">
+  <span class="nav-bench-name">384</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-vector_serialize_into--serialize_into--768" data-bench="vector_serialize_into--serialize_into--768">
+  <span class="nav-bench-name">768</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 
   </div>
 </nav>
@@ -606,23 +1391,23 @@
   <div class="page-header">
     <h1>Performance Timeseries</h1>
     <div class="page-meta">
-      <span><span class="label">runs</span> 2</span>
-      <span><span class="label">benchmarks</span> 47</span>
-      <span><span class="label">generated</span> 2026-02-21 18:57 UTC</span>
+      <span><span class="label">runs</span> 3</span>
+      <span><span class="label">benchmarks</span> 232</span>
+      <span><span class="label">generated</span> 2026-02-21 20:44 UTC</span>
     </div>
   </div>
 
   <div class="overview-row">
     <div class="overview-card">
-      <div class="overview-value">2</div>
+      <div class="overview-value">3</div>
       <div class="overview-label">Total Runs</div>
     </div>
     <div class="overview-card">
-      <div class="overview-value">47</div>
+      <div class="overview-value">232</div>
       <div class="overview-label">Benchmarks</div>
     </div>
     <div class="overview-card">
-      <div class="overview-value">0</div>
+      <div class="overview-value">5</div>
       <div class="overview-label">Trending Faster</div>
     </div>
     <div class="overview-card">
@@ -632,7 +1417,7 @@
   </div>
 
   <div class="movers">
-
+    <div class="movers-col"><h3 class="movers-label improved-label">⬇ Biggest Improvements</h3><div class="mover-item improved">target_batch_insertion/insert_1000_edges <span>-19.3%</span></div><div class="mover-item improved">target_single_hop/traverse_one_hop <span>-7.3%</span></div><div class="mover-item improved">target_3_hop/traverse_three_hops <span>-4.5%</span></div><div class="mover-item improved">target_time_travel/worst_case_9_deltas <span>-4.1%</span></div><div class="mover-item improved">target_time_travel/at_anchor <span>-3.6%</span></div></div>
   </div>
 
   <div class="controls-bar">
@@ -643,6 +1428,286 @@
   </div>
 
 
+<section class="bench-section" id="bench-3_hop_traversal" data-bench-name="3_hop_traversal">
+  <div class="bench-header">
+    <h2 class="bench-title">3_hop_traversal</h2>
+    <div class="bench-latest">56.71 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">56.71 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">56.71 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">56.71 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-3_hop_traversal" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_3_hop_traversal" data-bench-name="aletheiadb_3_hop_traversal">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_3_hop_traversal</h2>
+    <div class="bench-latest">483.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">483.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">483.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">483.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_3_hop_traversal" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_edge_creation" data-bench-name="aletheiadb_edge_creation">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_edge_creation</h2>
+    <div class="bench-latest">97.35 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">97.35 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">97.35 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">97.35 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_edge_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_historical_stats" data-bench-name="aletheiadb_historical_stats">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_historical_stats</h2>
+    <div class="bench-latest">1.06 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.06 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.06 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.06 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_historical_stats" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_in_degree" data-bench-name="aletheiadb_in_degree">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_in_degree</h2>
+    <div class="bench-latest">104.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">104.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">104.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">104.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_in_degree" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_labeled_traversal" data-bench-name="aletheiadb_labeled_traversal">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_labeled_traversal</h2>
+    <div class="bench-latest">159.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">159.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">159.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">159.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_labeled_traversal" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_node_creation" data-bench-name="aletheiadb_node_creation">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_node_creation</h2>
+    <div class="bench-latest">105.59 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">105.59 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">105.59 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">105.59 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_node_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_out_degree" data-bench-name="aletheiadb_out_degree">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_out_degree</h2>
+    <div class="bench-latest">100.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">100.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">100.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">100.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_out_degree" height="260"></canvas>
+  </div>
+</section>
 <section class="bench-section" id="bench-closure_write_single_node" data-bench-name="closure_write_single_node">
   <div class="bench-header">
     <h2 class="bench-title">closure_write_single_node</h2>
@@ -676,6 +1741,391 @@
   </div>
   <div class="chart-wrap">
     <canvas id="chart-closure_write_single_node" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_openai_1536d" data-bench-name="cosine_similarity_openai_1536d">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_openai_1536d</h2>
+    <div class="bench-latest">301.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">301.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">301.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">301.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_openai_1536d" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-edge_creation" data-bench-name="edge_creation">
+  <div class="bench-header">
+    <h2 class="bench-title">edge_creation</h2>
+    <div class="bench-latest">4.46 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.46 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.46 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.46 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-edge_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-edge_lookup" data-bench-name="edge_lookup">
+  <div class="bench-header">
+    <h2 class="bench-title">edge_lookup</h2>
+    <div class="bench-latest">62.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">62.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">62.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">62.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-edge_lookup" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-find_neighbors" data-bench-name="find_neighbors">
+  <div class="bench-header">
+    <h2 class="bench-title">find_neighbors</h2>
+    <div class="bench-latest">1.24 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.24 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.24 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.24 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-find_neighbors" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-in_degree" data-bench-name="in_degree">
+  <div class="bench-header">
+    <h2 class="bench-title">in_degree</h2>
+    <div class="bench-latest">398.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">398.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">398.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">398.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-in_degree" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-labeled_traversal" data-bench-name="labeled_traversal">
+  <div class="bench-header">
+    <h2 class="bench-title">labeled_traversal</h2>
+    <div class="bench-latest">465.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">465.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">465.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">465.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-labeled_traversal" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-mixed_read_write_80_20" data-bench-name="mixed_read_write_80_20">
+  <div class="bench-header">
+    <h2 class="bench-title">mixed_read_write_80_20</h2>
+    <div class="bench-latest">16.59 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">16.59 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">16.59 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">16.59 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-mixed_read_write_80_20" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-node_creation" data-bench-name="node_creation">
+  <div class="bench-header">
+    <h2 class="bench-title">node_creation</h2>
+    <div class="bench-latest">4.43 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.43 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.43 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.43 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-node_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-node_lookup" data-bench-name="node_lookup">
+  <div class="bench-header">
+    <h2 class="bench-title">node_lookup</h2>
+    <div class="bench-latest">64.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">64.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">64.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">64.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-node_lookup" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-out_degree" data-bench-name="out_degree">
+  <div class="bench-header">
+    <h2 class="bench-title">out_degree</h2>
+    <div class="bench-latest">406.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">406.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">406.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">406.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-out_degree" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-read_latency_p50_p99" data-bench-name="read_latency_p50_p99">
+  <div class="bench-header">
+    <h2 class="bench-title">read_latency_p50_p99</h2>
+    <div class="bench-latest">8.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">8.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">8.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">8.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-read_latency_p50_p99" height="260"></canvas>
   </div>
 </section>
 <section class="bench-section" id="bench-read_transaction_creation" data-bench-name="read_transaction_creation">
@@ -713,6 +2163,76 @@
     <canvas id="chart-read_transaction_creation" height="260"></canvas>
   </div>
 </section>
+<section class="bench-section" id="bench-sustained_write_10k_versions" data-bench-name="sustained_write_10k_versions">
+  <div class="bench-header">
+    <h2 class="bench-title">sustained_write_10k_versions</h2>
+    <div class="bench-latest">181.74 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">181.74 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">181.74 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">181.74 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-sustained_write_10k_versions" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-sustained_write_10k_versions_fast_reference" data-bench-name="sustained_write_10k_versions_fast_reference">
+  <div class="bench-header">
+    <h2 class="bench-title">sustained_write_10k_versions_fast_reference</h2>
+    <div class="bench-latest">455.09 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">455.09 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">455.09 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">455.09 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-sustained_write_10k_versions_fast_reference" height="260"></canvas>
+  </div>
+</section>
 <section class="bench-section" id="bench-write_transaction_creation" data-bench-name="write_transaction_creation">
   <div class="bench-header">
     <h2 class="bench-title">write_transaction_creation</h2>
@@ -746,6 +2266,1196 @@
   </div>
   <div class="chart-wrap">
     <canvas id="chart-write_transaction_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_batch--batch_node_creation--10" data-bench-name="aletheiadb_batch/batch_node_creation/10">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_batch/batch_node_creation/10</h2>
+    <div class="bench-latest">27.81 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">27.81 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">27.81 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">27.81 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_batch--batch_node_creation--10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_batch--batch_node_creation--100" data-bench-name="aletheiadb_batch/batch_node_creation/100">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_batch/batch_node_creation/100</h2>
+    <div class="bench-latest">289.83 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">289.83 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">289.83 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">289.83 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_batch--batch_node_creation--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_batch--batch_node_creation--1000" data-bench-name="aletheiadb_batch/batch_node_creation/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_batch/batch_node_creation/1000</h2>
+    <div class="bench-latest">2.831 s</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.831 s</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.831 s <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.831 s <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_batch--batch_node_creation--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_fast_path--node_lookup--100" data-bench-name="aletheiadb_fast_path/node_lookup/100">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_fast_path/node_lookup/100</h2>
+    <div class="bench-latest">62.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">62.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">62.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">62.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_fast_path--node_lookup--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_fast_path--node_lookup--1000" data-bench-name="aletheiadb_fast_path/node_lookup/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_fast_path/node_lookup/1000</h2>
+    <div class="bench-latest">62.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">62.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">62.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">62.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_fast_path--node_lookup--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_fast_path--node_lookup--10000" data-bench-name="aletheiadb_fast_path/node_lookup/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_fast_path/node_lookup/10000</h2>
+    <div class="bench-latest">61.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">61.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">61.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">61.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_fast_path--node_lookup--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_single_hop--10000_nodes" data-bench-name="aletheiadb_single_hop/10000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_single_hop/10000_nodes</h2>
+    <div class="bench-latest">116.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">116.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">116.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">116.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_single_hop--10000_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_single_hop--1000_nodes" data-bench-name="aletheiadb_single_hop/1000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_single_hop/1000_nodes</h2>
+    <div class="bench-latest">116.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">116.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">116.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">116.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_single_hop--1000_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-aletheiadb_single_hop--100_nodes" data-bench-name="aletheiadb_single_hop/100_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">aletheiadb_single_hop/100_nodes</h2>
+    <div class="bench-latest">116.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">116.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">116.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">116.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-aletheiadb_single_hop--100_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-batch_throughput--async" data-bench-name="batch_throughput/async">
+  <div class="bench-header">
+    <h2 class="bench-title">batch_throughput/async</h2>
+    <div class="bench-latest">52.79 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">52.79 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">52.79 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">52.79 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-batch_throughput--async" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-batch_throughput--synchronous" data-bench-name="batch_throughput/synchronous">
+  <div class="bench-header">
+    <h2 class="bench-title">batch_throughput/synchronous</h2>
+    <div class="bench-latest">635.75 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">635.75 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">635.75 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">635.75 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-batch_throughput--synchronous" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-checkpoint_creation--100" data-bench-name="checkpoint_creation/100">
+  <div class="bench-header">
+    <h2 class="bench-title">checkpoint_creation/100</h2>
+    <div class="bench-latest">4.89 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.89 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.89 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.89 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-checkpoint_creation--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-checkpoint_creation--1000" data-bench-name="checkpoint_creation/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">checkpoint_creation/1000</h2>
+    <div class="bench-latest">4.03 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.03 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.03 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.03 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-checkpoint_creation--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-checkpoint_creation--10000" data-bench-name="checkpoint_creation/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">checkpoint_creation/10000</h2>
+    <div class="bench-latest">7.66 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">7.66 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">7.66 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">7.66 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-checkpoint_creation--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-checkpoint_load--100" data-bench-name="checkpoint_load/100">
+  <div class="bench-header">
+    <h2 class="bench-title">checkpoint_load/100</h2>
+    <div class="bench-latest">323.51 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">323.51 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">323.51 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">323.51 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-checkpoint_load--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-checkpoint_load--1000" data-bench-name="checkpoint_load/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">checkpoint_load/1000</h2>
+    <div class="bench-latest">1.63 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.63 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.63 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.63 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-checkpoint_load--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-checkpoint_load--10000" data-bench-name="checkpoint_load/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">checkpoint_load/10000</h2>
+    <div class="bench-latest">15.18 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">15.18 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">15.18 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">15.18 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-checkpoint_load--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_batch_write_throughput--fast--100" data-bench-name="cold_batch_write_throughput/fast/100">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_batch_write_throughput/fast/100</h2>
+    <div class="bench-latest">4.93 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.93 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.93 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.93 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_batch_write_throughput--fast--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_batch_write_throughput--fast--1000" data-bench-name="cold_batch_write_throughput/fast/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_batch_write_throughput/fast/1000</h2>
+    <div class="bench-latest">45.81 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">45.81 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">45.81 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">45.81 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_batch_write_throughput--fast--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_batch_write_throughput--fast--10000" data-bench-name="cold_batch_write_throughput/fast/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_batch_write_throughput/fast/10000</h2>
+    <div class="bench-latest">454.83 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">454.83 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">454.83 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">454.83 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_batch_write_throughput--fast--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_batch_write_throughput--zstd--100" data-bench-name="cold_batch_write_throughput/zstd/100">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_batch_write_throughput/zstd/100</h2>
+    <div class="bench-latest">7.45 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">7.45 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">7.45 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">7.45 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_batch_write_throughput--zstd--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_batch_write_throughput--zstd--1000" data-bench-name="cold_batch_write_throughput/zstd/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_batch_write_throughput/zstd/1000</h2>
+    <div class="bench-latest">66.78 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">66.78 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">66.78 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">66.78 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_batch_write_throughput--zstd--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_batch_write_throughput--zstd--10000" data-bench-name="cold_batch_write_throughput/zstd/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_batch_write_throughput/zstd/10000</h2>
+    <div class="bench-latest">189.51 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">189.51 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">189.51 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">189.51 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_batch_write_throughput--zstd--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_read_latency--single_read--fast_compression" data-bench-name="cold_read_latency/single_read/fast_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_read_latency/single_read/fast_compression</h2>
+    <div class="bench-latest">34.54 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">34.54 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">34.54 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">34.54 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_read_latency--single_read--fast_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_read_latency--single_read--no_compression" data-bench-name="cold_read_latency/single_read/no_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_read_latency/single_read/no_compression</h2>
+    <div class="bench-latest">3.31 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">3.31 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">3.31 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">3.31 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_read_latency--single_read--no_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_read_latency--single_read--zstd_compression" data-bench-name="cold_read_latency/single_read/zstd_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_read_latency/single_read/zstd_compression</h2>
+    <div class="bench-latest">34.41 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">34.41 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">34.41 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">34.41 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_read_latency--single_read--zstd_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_write_latency--single_write--fast_compression" data-bench-name="cold_write_latency/single_write/fast_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_write_latency/single_write/fast_compression</h2>
+    <div class="bench-latest">340.43 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">340.43 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">340.43 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">340.43 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_write_latency--single_write--fast_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_write_latency--single_write--no_compression" data-bench-name="cold_write_latency/single_write/no_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_write_latency/single_write/no_compression</h2>
+    <div class="bench-latest">343.79 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">343.79 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">343.79 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">343.79 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_write_latency--single_write--no_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cold_write_latency--single_write--zstd_compression" data-bench-name="cold_write_latency/single_write/zstd_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">cold_write_latency/single_write/zstd_compression</h2>
+    <div class="bench-latest">373.87 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">373.87 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">373.87 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">373.87 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cold_write_latency--single_write--zstd_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-comparison_csr--full_rebuild_insert_query" data-bench-name="comparison_csr/full_rebuild_insert_query">
+  <div class="bench-header">
+    <h2 class="bench-title">comparison_csr/full_rebuild_insert_query</h2>
+    <div class="bench-latest">140.05 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">140.05 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">140.05 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">140.05 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-comparison_csr--full_rebuild_insert_query" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-comparison_csr--incremental_csr_insert_query" data-bench-name="comparison_csr/incremental_csr_insert_query">
+  <div class="bench-header">
+    <h2 class="bench-title">comparison_csr/incremental_csr_insert_query</h2>
+    <div class="bench-latest">16.60 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">16.60 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">16.60 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">16.60 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-comparison_csr--incremental_csr_insert_query" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-compression_ratio--compress--fast" data-bench-name="compression_ratio/compress/fast">
+  <div class="bench-header">
+    <h2 class="bench-title">compression_ratio/compress/fast</h2>
+    <div class="bench-latest">34.87 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">34.87 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">34.87 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">34.87 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-compression_ratio--compress--fast" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-compression_ratio--compress--no_compression" data-bench-name="compression_ratio/compress/no_compression">
+  <div class="bench-header">
+    <h2 class="bench-title">compression_ratio/compress/no_compression</h2>
+    <div class="bench-latest">31.26 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">31.26 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">31.26 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">31.26 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-compression_ratio--compress--no_compression" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-compression_ratio--compress--zstd" data-bench-name="compression_ratio/compress/zstd">
+  <div class="bench-header">
+    <h2 class="bench-title">compression_ratio/compress/zstd</h2>
+    <div class="bench-latest">36.22 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">36.22 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">36.22 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">36.22 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-compression_ratio--compress--zstd" height="260"></canvas>
   </div>
 </section>
 <section class="bench-section" id="bench-concurrent_reads_same_entity--10000_versions--2_readers" data-bench-name="concurrent_reads_same_entity/10000_versions/2_readers">
@@ -1308,6 +4018,2491 @@
     <canvas id="chart-concurrent_writes--same_entity_contention--8" height="260"></canvas>
   </div>
 </section>
+<section class="bench-section" id="bench-cosine_similarity--naive_3pass--1024" data-bench-name="cosine_similarity/naive_3pass/1024">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/naive_3pass/1024</h2>
+    <div class="bench-latest">4.60 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.60 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.60 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.60 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--naive_3pass--1024" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--naive_3pass--1536" data-bench-name="cosine_similarity/naive_3pass/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/naive_3pass/1536</h2>
+    <div class="bench-latest">6.95 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">6.95 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">6.95 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">6.95 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--naive_3pass--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--naive_3pass--3072" data-bench-name="cosine_similarity/naive_3pass/3072">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/naive_3pass/3072</h2>
+    <div class="bench-latest">14.03 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">14.03 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">14.03 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">14.03 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--naive_3pass--3072" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--naive_3pass--384" data-bench-name="cosine_similarity/naive_3pass/384">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/naive_3pass/384</h2>
+    <div class="bench-latest">1.65 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.65 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.65 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.65 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--naive_3pass--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--naive_3pass--768" data-bench-name="cosine_similarity/naive_3pass/768">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/naive_3pass/768</h2>
+    <div class="bench-latest">3.44 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">3.44 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">3.44 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">3.44 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--naive_3pass--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--optimized--1024" data-bench-name="cosine_similarity/optimized/1024">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/optimized/1024</h2>
+    <div class="bench-latest">201.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">201.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">201.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">201.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--optimized--1024" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--optimized--1536" data-bench-name="cosine_similarity/optimized/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/optimized/1536</h2>
+    <div class="bench-latest">299.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">299.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">299.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">299.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--optimized--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--optimized--3072" data-bench-name="cosine_similarity/optimized/3072">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/optimized/3072</h2>
+    <div class="bench-latest">592.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">592.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">592.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">592.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--optimized--3072" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--optimized--384" data-bench-name="cosine_similarity/optimized/384">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/optimized/384</h2>
+    <div class="bench-latest">77.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">77.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">77.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">77.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--optimized--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--optimized--768" data-bench-name="cosine_similarity/optimized/768">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/optimized/768</h2>
+    <div class="bench-latest">151.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">151.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">151.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">151.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--optimized--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--scalar_1pass--1024" data-bench-name="cosine_similarity/scalar_1pass/1024">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/scalar_1pass/1024</h2>
+    <div class="bench-latest">1.58 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.58 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.58 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.58 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--scalar_1pass--1024" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--scalar_1pass--1536" data-bench-name="cosine_similarity/scalar_1pass/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/scalar_1pass/1536</h2>
+    <div class="bench-latest">2.36 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.36 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.36 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.36 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--scalar_1pass--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--scalar_1pass--3072" data-bench-name="cosine_similarity/scalar_1pass/3072">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/scalar_1pass/3072</h2>
+    <div class="bench-latest">4.73 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.73 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.73 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.73 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--scalar_1pass--3072" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--scalar_1pass--384" data-bench-name="cosine_similarity/scalar_1pass/384">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/scalar_1pass/384</h2>
+    <div class="bench-latest">636.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">636.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">636.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">636.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--scalar_1pass--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity--scalar_1pass--768" data-bench-name="cosine_similarity/scalar_1pass/768">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity/scalar_1pass/768</h2>
+    <div class="bench-latest">1.18 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.18 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.18 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.18 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity--scalar_1pass--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_batch--find_most_similar--10" data-bench-name="cosine_similarity_batch/find_most_similar/10">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_batch/find_most_similar/10</h2>
+    <div class="bench-latest">811.3 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">811.3 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">811.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">811.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_batch--find_most_similar--10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_batch--find_most_similar--100" data-bench-name="cosine_similarity_batch/find_most_similar/100">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_batch/find_most_similar/100</h2>
+    <div class="bench-latest">8.28 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">8.28 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">8.28 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">8.28 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_batch--find_most_similar--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_batch--find_most_similar--1000" data-bench-name="cosine_similarity_batch/find_most_similar/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_batch/find_most_similar/1000</h2>
+    <div class="bench-latest">90.46 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">90.46 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">90.46 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">90.46 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_batch--find_most_similar--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_normalized--general--1536" data-bench-name="cosine_similarity_normalized/general/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_normalized/general/1536</h2>
+    <div class="bench-latest">300.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">300.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">300.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">300.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_normalized--general--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_normalized--general--384" data-bench-name="cosine_similarity_normalized/general/384">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_normalized/general/384</h2>
+    <div class="bench-latest">78.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">78.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">78.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">78.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_normalized--general--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_normalized--specialized--1536" data-bench-name="cosine_similarity_normalized/specialized/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_normalized/specialized/1536</h2>
+    <div class="bench-latest">284.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">284.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">284.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">284.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_normalized--specialized--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-cosine_similarity_normalized--specialized--384" data-bench-name="cosine_similarity_normalized/specialized/384">
+  <div class="bench-header">
+    <h2 class="bench-title">cosine_similarity_normalized/specialized/384</h2>
+    <div class="bench-latest">56.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">56.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">56.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">56.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-cosine_similarity_normalized--specialized--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--optimized--1024" data-bench-name="euclidean_distance/optimized/1024">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/optimized/1024</h2>
+    <div class="bench-latest">175.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">175.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">175.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">175.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--optimized--1024" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--optimized--1536" data-bench-name="euclidean_distance/optimized/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/optimized/1536</h2>
+    <div class="bench-latest">272.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">272.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">272.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">272.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--optimized--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--optimized--384" data-bench-name="euclidean_distance/optimized/384">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/optimized/384</h2>
+    <div class="bench-latest">65.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">65.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">65.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">65.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--optimized--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--optimized--768" data-bench-name="euclidean_distance/optimized/768">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/optimized/768</h2>
+    <div class="bench-latest">123.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">123.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">123.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">123.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--optimized--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--scalar--1024" data-bench-name="euclidean_distance/scalar/1024">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/scalar/1024</h2>
+    <div class="bench-latest">1.55 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.55 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.55 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.55 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--scalar--1024" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--scalar--1536" data-bench-name="euclidean_distance/scalar/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/scalar/1536</h2>
+    <div class="bench-latest">2.33 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.33 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.33 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.33 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--scalar--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--scalar--384" data-bench-name="euclidean_distance/scalar/384">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/scalar/384</h2>
+    <div class="bench-latest">566.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">566.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">566.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">566.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--scalar--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--scalar--768" data-bench-name="euclidean_distance/scalar/768">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/scalar/768</h2>
+    <div class="bench-latest">1.16 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.16 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.16 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.16 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--scalar--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--squared_optimized--1024" data-bench-name="euclidean_distance/squared_optimized/1024">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/squared_optimized/1024</h2>
+    <div class="bench-latest">173.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">173.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">173.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">173.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--squared_optimized--1024" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--squared_optimized--1536" data-bench-name="euclidean_distance/squared_optimized/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/squared_optimized/1536</h2>
+    <div class="bench-latest">269.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">269.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">269.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">269.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--squared_optimized--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--squared_optimized--384" data-bench-name="euclidean_distance/squared_optimized/384">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/squared_optimized/384</h2>
+    <div class="bench-latest">56.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">56.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">56.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">56.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--squared_optimized--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-euclidean_distance--squared_optimized--768" data-bench-name="euclidean_distance/squared_optimized/768">
+  <div class="bench-header">
+    <h2 class="bench-title">euclidean_distance/squared_optimized/768</h2>
+    <div class="bench-latest">121.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">121.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">121.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">121.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-euclidean_distance--squared_optimized--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-find_nodes_by_property--10000_nodes" data-bench-name="find_nodes_by_property/10000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">find_nodes_by_property/10000_nodes</h2>
+    <div class="bench-latest">757.09 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">757.09 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">757.09 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">757.09 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-find_nodes_by_property--10000_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-find_nodes_by_property--1000_nodes" data-bench-name="find_nodes_by_property/1000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">find_nodes_by_property/1000_nodes</h2>
+    <div class="bench-latest">50.79 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">50.79 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">50.79 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">50.79 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-find_nodes_by_property--1000_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-find_nodes_by_property--100_nodes" data-bench-name="find_nodes_by_property/100_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">find_nodes_by_property/100_nodes</h2>
+    <div class="bench-latest">4.67 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.67 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.67 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.67 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-find_nodes_by_property--100_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-frozen_view_hot_path--frozen_view--100000edges" data-bench-name="frozen_view_hot_path/frozen_view/100000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">frozen_view_hot_path/frozen_view/100000edges</h2>
+    <div class="bench-latest">40.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">40.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">40.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">40.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-frozen_view_hot_path--frozen_view--100000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-frozen_view_hot_path--frozen_view--10000edges" data-bench-name="frozen_view_hot_path/frozen_view/10000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">frozen_view_hot_path/frozen_view/10000edges</h2>
+    <div class="bench-latest">33.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">33.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">33.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">33.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-frozen_view_hot_path--frozen_view--10000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-frozen_view_hot_path--frozen_view--1000edges" data-bench-name="frozen_view_hot_path/frozen_view/1000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">frozen_view_hot_path/frozen_view/1000edges</h2>
+    <div class="bench-latest">20.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">20.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">20.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">20.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-frozen_view_hot_path--frozen_view--1000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-frozen_view_hot_path--merged_guard--100000edges" data-bench-name="frozen_view_hot_path/merged_guard/100000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">frozen_view_hot_path/merged_guard/100000edges</h2>
+    <div class="bench-latest">32.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-frozen_view_hot_path--merged_guard--100000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-frozen_view_hot_path--merged_guard--10000edges" data-bench-name="frozen_view_hot_path/merged_guard/10000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">frozen_view_hot_path/merged_guard/10000edges</h2>
+    <div class="bench-latest">32.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-frozen_view_hot_path--merged_guard--10000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-frozen_view_hot_path--merged_guard--1000edges" data-bench-name="frozen_view_hot_path/merged_guard/1000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">frozen_view_hot_path/merged_guard/1000edges</h2>
+    <div class="bench-latest">32.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-frozen_view_hot_path--merged_guard--1000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-get_outgoing_allocation--degree_1" data-bench-name="get_outgoing_allocation/degree_1">
+  <div class="bench-header">
+    <h2 class="bench-title">get_outgoing_allocation/degree_1</h2>
+    <div class="bench-latest">35.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">35.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">35.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">35.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-get_outgoing_allocation--degree_1" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-get_outgoing_allocation--degree_10" data-bench-name="get_outgoing_allocation/degree_10">
+  <div class="bench-header">
+    <h2 class="bench-title">get_outgoing_allocation/degree_10</h2>
+    <div class="bench-latest">35.3 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">35.3 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">35.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">35.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-get_outgoing_allocation--degree_10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-get_outgoing_allocation--degree_100" data-bench-name="get_outgoing_allocation/degree_100">
+  <div class="bench-header">
+    <h2 class="bench-title">get_outgoing_allocation/degree_100</h2>
+    <div class="bench-latest">35.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">35.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">35.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">35.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-get_outgoing_allocation--degree_100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_concurrent--threads--16" data-bench-name="id_generation_concurrent/threads/16">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_concurrent/threads/16</h2>
+    <div class="bench-latest">674.80 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">674.80 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">674.80 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">674.80 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_concurrent--threads--16" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_concurrent--threads--2" data-bench-name="id_generation_concurrent/threads/2">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_concurrent/threads/2</h2>
+    <div class="bench-latest">120.89 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">120.89 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">120.89 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">120.89 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_concurrent--threads--2" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_concurrent--threads--4" data-bench-name="id_generation_concurrent/threads/4">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_concurrent/threads/4</h2>
+    <div class="bench-latest">198.11 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">198.11 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">198.11 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">198.11 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_concurrent--threads--4" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_concurrent--threads--8" data-bench-name="id_generation_concurrent/threads/8">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_concurrent/threads/8</h2>
+    <div class="bench-latest">375.17 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">375.17 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">375.17 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">375.17 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_concurrent--threads--8" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_current--read_current" data-bench-name="id_generation_current/read_current">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_current/read_current</h2>
+    <div class="bench-latest">0.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">0.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">0.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">0.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_current--read_current" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_current--read_current_approximate" data-bench-name="id_generation_current/read_current_approximate">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_current/read_current_approximate</h2>
+    <div class="bench-latest">0.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">0.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">0.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">0.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_current--read_current_approximate" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_lifecycle--create_and_generate_1000" data-bench-name="id_generation_lifecycle/create_and_generate_1000">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_lifecycle/create_and_generate_1000</h2>
+    <div class="bench-latest">8.80 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">8.80 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">8.80 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">8.80 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_lifecycle--create_and_generate_1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_single_thread--sequential_1000" data-bench-name="id_generation_single_thread/sequential_1000">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_single_thread/sequential_1000</h2>
+    <div class="bench-latest">6.90 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">6.90 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">6.90 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">6.90 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_single_thread--sequential_1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_single_thread--sequential_10000" data-bench-name="id_generation_single_thread/sequential_10000">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_single_thread/sequential_10000</h2>
+    <div class="bench-latest">69.02 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">69.02 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">69.02 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">69.02 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-id_generation_single_thread--sequential_10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_compaction--edges--1000+100" data-bench-name="incremental_compaction/edges/1000+100">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_compaction/edges/1000+100</h2>
+    <div class="bench-latest">60.28 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">60.28 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">60.28 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">60.28 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_compaction--edges--1000+100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_compaction--edges--10000+1000" data-bench-name="incremental_compaction/edges/10000+1000">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_compaction/edges/10000+1000</h2>
+    <div class="bench-latest">955.60 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">955.60 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">955.60 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">955.60 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_compaction--edges--10000+1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_compaction--edges--100000+10000" data-bench-name="incremental_compaction/edges/100000+10000">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_compaction/edges/100000+10000</h2>
+    <div class="bench-latest">8.19 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">8.19 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">8.19 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">8.19 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_compaction--edges--100000+10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_concurrent--threads--2" data-bench-name="incremental_concurrent/threads/2">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_concurrent/threads/2</h2>
+    <div class="bench-latest">141.58 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">141.58 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">141.58 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">141.58 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_concurrent--threads--2" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_concurrent--threads--4" data-bench-name="incremental_concurrent/threads/4">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_concurrent/threads/4</h2>
+    <div class="bench-latest">211.62 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">211.62 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">211.62 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">211.62 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_concurrent--threads--4" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_concurrent--threads--8" data-bench-name="incremental_concurrent/threads/8">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_concurrent/threads/8</h2>
+    <div class="bench-latest">410.13 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">410.13 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">410.13 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">410.13 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_concurrent--threads--8" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_insert_latency--0existing" data-bench-name="incremental_insert_latency/0existing">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_insert_latency/0existing</h2>
+    <div class="bench-latest">288.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">288.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">288.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">288.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_insert_latency--0existing" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_insert_latency--100000existing" data-bench-name="incremental_insert_latency/100000existing">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_insert_latency/100000existing</h2>
+    <div class="bench-latest">289.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">289.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">289.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">289.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_insert_latency--100000existing" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_insert_latency--10000existing" data-bench-name="incremental_insert_latency/10000existing">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_insert_latency/10000existing</h2>
+    <div class="bench-latest">183.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">183.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">183.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">183.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_insert_latency--10000existing" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_insert_latency--1000existing" data-bench-name="incremental_insert_latency/1000existing">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_insert_latency/1000existing</h2>
+    <div class="bench-latest">226.3 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">226.3 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">226.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">226.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_insert_latency--1000existing" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_read_no_delta--10000edges" data-bench-name="incremental_read_no_delta/10000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_read_no_delta/10000edges</h2>
+    <div class="bench-latest">32.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_read_no_delta--10000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_read_no_delta--1000edges" data-bench-name="incremental_read_no_delta/1000edges">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_read_no_delta/1000edges</h2>
+    <div class="bench-latest">32.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_read_no_delta--1000edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_read_no_delta--100edges" data-bench-name="incremental_read_no_delta/100edges">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_read_no_delta/100edges</h2>
+    <div class="bench-latest">32.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_read_no_delta--100edges" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_read_with_delta--10pct_delta" data-bench-name="incremental_read_with_delta/10pct_delta">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_read_with_delta/10pct_delta</h2>
+    <div class="bench-latest">67.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">67.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">67.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">67.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_read_with_delta--10pct_delta" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_read_with_delta--1pct_delta" data-bench-name="incremental_read_with_delta/1pct_delta">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_read_with_delta/1pct_delta</h2>
+    <div class="bench-latest">64.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">64.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">64.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">64.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_read_with_delta--1pct_delta" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-incremental_read_with_delta--5pct_delta" data-bench-name="incremental_read_with_delta/5pct_delta">
+  <div class="bench-header">
+    <h2 class="bench-title">incremental_read_with_delta/5pct_delta</h2>
+    <div class="bench-latest">64.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">64.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">64.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">64.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-incremental_read_with_delta--5pct_delta" height="260"></canvas>
+  </div>
+</section>
 <section class="bench-section" id="bench-knn_search--k--1" data-bench-name="knn_search/k/1">
   <div class="bench-header">
     <h2 class="bench-title">knn_search/k/1</h2>
@@ -1658,6 +6853,181 @@
     <canvas id="chart-knn_search_index_size--index_size--5000" height="260"></canvas>
   </div>
 </section>
+<section class="bench-section" id="bench-multiple_accesses--resolve_100" data-bench-name="multiple_accesses/resolve_100">
+  <div class="bench-header">
+    <h2 class="bench-title">multiple_accesses/resolve_100</h2>
+    <div class="bench-latest">3.57 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">3.57 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">3.57 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">3.57 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-multiple_accesses--resolve_100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-point_in_time_queries--1000vectors" data-bench-name="point_in_time_queries/1000vectors">
+  <div class="bench-header">
+    <h2 class="bench-title">point_in_time_queries/1000vectors</h2>
+    <div class="bench-latest">30.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">30.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">30.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">30.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-point_in_time_queries--1000vectors" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-point_in_time_queries--100vectors" data-bench-name="point_in_time_queries/100vectors">
+  <div class="bench-header">
+    <h2 class="bench-title">point_in_time_queries/100vectors</h2>
+    <div class="bench-latest">27.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">27.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">27.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">27.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-point_in_time_queries--100vectors" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-property_lookup_vs_scan--find_nodes_by_property" data-bench-name="property_lookup_vs_scan/find_nodes_by_property">
+  <div class="bench-header">
+    <h2 class="bench-title">property_lookup_vs_scan/find_nodes_by_property</h2>
+    <div class="bench-latest">39.03 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">39.03 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">39.03 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">39.03 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-property_lookup_vs_scan--find_nodes_by_property" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-property_lookup_vs_scan--manual_label_scan_filter" data-bench-name="property_lookup_vs_scan/manual_label_scan_filter">
+  <div class="bench-header">
+    <h2 class="bench-title">property_lookup_vs_scan/manual_label_scan_filter</h2>
+    <div class="bench-latest">138.29 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">138.29 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">138.29 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">138.29 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-property_lookup_vs_scan--manual_label_scan_filter" height="260"></canvas>
+  </div>
+</section>
 <section class="bench-section" id="bench-read_under_write_contention--concurrent_writers--0" data-bench-name="read_under_write_contention/concurrent_writers/0">
   <div class="bench-header">
     <h2 class="bench-title">read_under_write_contention/concurrent_writers/0</h2>
@@ -1763,15 +7133,15 @@
     <canvas id="chart-read_under_write_contention--concurrent_writers--4" height="260"></canvas>
   </div>
 </section>
-<section class="bench-section" id="bench-target_3_hop--traverse_three_hops" data-bench-name="target_3_hop/traverse_three_hops">
+<section class="bench-section" id="bench-recovery--10" data-bench-name="recovery/10">
   <div class="bench-header">
-    <h2 class="bench-title">target_3_hop/traverse_three_hops</h2>
-    <div class="bench-latest">282.2 ns</div>
+    <h2 class="bench-title">recovery/10</h2>
+    <div class="bench-latest">500.06 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">282.2 ns</span>
+      <span class="bench-stat-value">500.06 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
@@ -1783,7 +7153,742 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">282.2 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">500.06 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">500.06 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-recovery--10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-recovery--100" data-bench-name="recovery/100">
+  <div class="bench-header">
+    <h2 class="bench-title">recovery/100</h2>
+    <div class="bench-latest">457.03 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">457.03 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">457.03 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">457.03 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-recovery--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-recovery--1000" data-bench-name="recovery/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">recovery/1000</h2>
+    <div class="bench-latest">647.92 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">647.92 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">647.92 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">647.92 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-recovery--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_hop_traversal--10000_nodes" data-bench-name="single_hop_traversal/10000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">single_hop_traversal/10000_nodes</h2>
+    <div class="bench-latest">431.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">431.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">431.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">431.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_hop_traversal--10000_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_hop_traversal--1000_nodes" data-bench-name="single_hop_traversal/1000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">single_hop_traversal/1000_nodes</h2>
+    <div class="bench-latest">431.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">431.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">431.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">431.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_hop_traversal--1000_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_hop_traversal--100_nodes" data-bench-name="single_hop_traversal/100_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">single_hop_traversal/100_nodes</h2>
+    <div class="bench-latest">431.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">431.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">431.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">431.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_hop_traversal--100_nodes" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_transaction_latency--async" data-bench-name="single_transaction_latency/async">
+  <div class="bench-header">
+    <h2 class="bench-title">single_transaction_latency/async</h2>
+    <div class="bench-latest">65.06 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">65.06 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">65.06 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">65.06 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_transaction_latency--async" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_transaction_latency--async_batched_aggressive" data-bench-name="single_transaction_latency/async_batched_aggressive">
+  <div class="bench-header">
+    <h2 class="bench-title">single_transaction_latency/async_batched_aggressive</h2>
+    <div class="bench-latest">5.02 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">5.02 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">5.02 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">5.02 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_transaction_latency--async_batched_aggressive" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_transaction_latency--async_batched_default" data-bench-name="single_transaction_latency/async_batched_default">
+  <div class="bench-header">
+    <h2 class="bench-title">single_transaction_latency/async_batched_default</h2>
+    <div class="bench-latest">9.19 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">9.19 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">9.19 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">9.19 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_transaction_latency--async_batched_default" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_transaction_latency--group_commit_default" data-bench-name="single_transaction_latency/group_commit_default">
+  <div class="bench-header">
+    <h2 class="bench-title">single_transaction_latency/group_commit_default</h2>
+    <div class="bench-latest">2.76 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.76 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.76 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.76 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_transaction_latency--group_commit_default" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_transaction_latency--group_commit_fast" data-bench-name="single_transaction_latency/group_commit_fast">
+  <div class="bench-header">
+    <h2 class="bench-title">single_transaction_latency/group_commit_fast</h2>
+    <div class="bench-latest">1.80 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.80 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.80 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.80 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_transaction_latency--group_commit_fast" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_transaction_latency--synchronous" data-bench-name="single_transaction_latency/synchronous">
+  <div class="bench-header">
+    <h2 class="bench-title">single_transaction_latency/synchronous</h2>
+    <div class="bench-latest">571.98 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">571.98 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">571.98 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">571.98 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-single_transaction_latency--synchronous" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-snapshot_creation--time_interval_1s" data-bench-name="snapshot_creation/time_interval_1s">
+  <div class="bench-header">
+    <h2 class="bench-title">snapshot_creation/time_interval_1s</h2>
+    <div class="bench-latest">77.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">77.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">77.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">77.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-snapshot_creation--time_interval_1s" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-snapshot_creation--transaction_interval_10" data-bench-name="snapshot_creation/transaction_interval_10">
+  <div class="bench-header">
+    <h2 class="bench-title">snapshot_creation/transaction_interval_10</h2>
+    <div class="bench-latest">24.16 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">24.16 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">24.16 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">24.16 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-snapshot_creation--transaction_interval_10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-snapshot_creation--transaction_interval_100" data-bench-name="snapshot_creation/transaction_interval_100">
+  <div class="bench-header">
+    <h2 class="bench-title">snapshot_creation/transaction_interval_100</h2>
+    <div class="bench-latest">2.50 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.50 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.50 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.50 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-snapshot_creation--transaction_interval_100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-string_access_single--resolve" data-bench-name="string_access_single/resolve">
+  <div class="bench-header">
+    <h2 class="bench-title">string_access_single/resolve</h2>
+    <div class="bench-latest">35.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">35.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">35.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">35.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_access_single--resolve" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-string_access_single--resolve_with" data-bench-name="string_access_single/resolve_with">
+  <div class="bench-header">
+    <h2 class="bench-title">string_access_single/resolve_with</h2>
+    <div class="bench-latest">21.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">21.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">21.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">21.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_access_single--resolve_with" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-string_comparison--resolve" data-bench-name="string_comparison/resolve">
+  <div class="bench-header">
+    <h2 class="bench-title">string_comparison/resolve</h2>
+    <div class="bench-latest">36.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">36.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">36.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">36.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_comparison--resolve" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-string_comparison--resolve_with" data-bench-name="string_comparison/resolve_with">
+  <div class="bench-header">
+    <h2 class="bench-title">string_comparison/resolve_with</h2>
+    <div class="bench-latest">22.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">22.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">22.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">22.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_comparison--resolve_with" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-string_length--resolve" data-bench-name="string_length/resolve">
+  <div class="bench-header">
+    <h2 class="bench-title">string_length/resolve</h2>
+    <div class="bench-latest">36.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">36.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">36.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">36.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_length--resolve" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-string_length--resolve_with" data-bench-name="string_length/resolve_with">
+  <div class="bench-header">
+    <h2 class="bench-title">string_length/resolve_with</h2>
+    <div class="bench-latest">22.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">22.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">22.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">22.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_length--resolve_with" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-target_3_hop--traverse_three_hops" data-bench-name="target_3_hop/traverse_three_hops">
+  <div class="bench-header">
+    <h2 class="bench-title">target_3_hop/traverse_three_hops</h2>
+    <div class="bench-latest">269.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">277.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">6.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">2.2%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">269.4 ns <small>(198c57d)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1791,7 +7896,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-4.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1801,24 +7906,24 @@
 <section class="bench-section" id="bench-target_batch_insertion--insert_1000_edges" data-bench-name="target_batch_insertion/insert_1000_edges">
   <div class="bench-header">
     <h2 class="bench-title">target_batch_insertion/insert_1000_edges</h2>
-    <div class="bench-latest">781.38 µs</div>
+    <div class="bench-latest">630.49 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">781.38 µs</span>
+      <span class="bench-stat-value">731.08 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">71.13 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">9.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">781.38 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">630.49 µs <small>(198c57d)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1826,7 +7931,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-19.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1836,24 +7941,24 @@
 <section class="bench-section" id="bench-target_single_hop--traverse_one_hop" data-bench-name="target_single_hop/traverse_one_hop">
   <div class="bench-header">
     <h2 class="bench-title">target_single_hop/traverse_one_hop</h2>
-    <div class="bench-latest">42.6 ns</div>
+    <div class="bench-latest">39.5 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">42.6 ns</span>
+      <span class="bench-stat-value">41.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.5%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">42.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">39.5 ns <small>(198c57d)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1861,7 +7966,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-7.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1871,24 +7976,24 @@
 <section class="bench-section" id="bench-target_time_travel--at_anchor" data-bench-name="target_time_travel/at_anchor">
   <div class="bench-header">
     <h2 class="bench-title">target_time_travel/at_anchor</h2>
-    <div class="bench-latest">282.6 ns</div>
+    <div class="bench-latest">272.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">282.6 ns</span>
+      <span class="bench-stat-value">279.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">4.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">1.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">282.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">272.3 ns <small>(198c57d)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1896,7 +8001,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-3.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1906,20 +8011,20 @@
 <section class="bench-section" id="bench-target_time_travel--with_5_deltas" data-bench-name="target_time_travel/with_5_deltas">
   <div class="bench-header">
     <h2 class="bench-title">target_time_travel/with_5_deltas</h2>
-    <div class="bench-latest">275.1 ns</div>
+    <div class="bench-latest">279.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">275.1 ns</span>
+      <span class="bench-stat-value">276.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -1927,11 +8032,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">275.1 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">279.3 ns <small>(198c57d)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+1.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1941,24 +8046,24 @@
 <section class="bench-section" id="bench-target_time_travel--worst_case_9_deltas" data-bench-name="target_time_travel/worst_case_9_deltas">
   <div class="bench-header">
     <h2 class="bench-title">target_time_travel/worst_case_9_deltas</h2>
-    <div class="bench-latest">286.2 ns</div>
+    <div class="bench-latest">274.5 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">286.2 ns</span>
+      <span class="bench-stat-value">282.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">5.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">2.0%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">286.2 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">274.5 ns <small>(198c57d)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1966,7 +8071,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-4.1%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2183,6 +8288,356 @@
     <canvas id="chart-temporal_insert--retroactive--10000" height="260"></canvas>
   </div>
 </section>
+<section class="bench-section" id="bench-time_travel--at_anchor_v20" data-bench-name="time_travel/at_anchor_v20">
+  <div class="bench-header">
+    <h2 class="bench-title">time_travel/at_anchor_v20</h2>
+    <div class="bench-latest">124.0 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">124.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">124.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">124.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-time_travel--at_anchor_v20" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-time_travel--deep_history_v5" data-bench-name="time_travel/deep_history_v5">
+  <div class="bench-header">
+    <h2 class="bench-title">time_travel/deep_history_v5</h2>
+    <div class="bench-latest">124.3 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">124.3 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">124.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">124.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-time_travel--deep_history_v5" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-time_travel--with_deltas_v15" data-bench-name="time_travel/with_deltas_v15">
+  <div class="bench-header">
+    <h2 class="bench-title">time_travel/with_deltas_v15</h2>
+    <div class="bench-latest">123.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">123.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">123.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">123.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-time_travel--with_deltas_v15" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-time_travel--worst_case_v19" data-bench-name="time_travel/worst_case_v19">
+  <div class="bench-header">
+    <h2 class="bench-title">time_travel/worst_case_v19</h2>
+    <div class="bench-latest">124.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">124.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">124.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">124.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-time_travel--worst_case_v19" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-traverse_and_rank_basic--100_power_law--100" data-bench-name="traverse_and_rank_basic/100_power_law/100">
+  <div class="bench-header">
+    <h2 class="bench-title">traverse_and_rank_basic/100_power_law/100</h2>
+    <div class="bench-latest">40.65 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">40.65 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">40.65 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">40.65 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-traverse_and_rank_basic--100_power_law--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-traverse_and_rank_basic--100_sparse--100" data-bench-name="traverse_and_rank_basic/100_sparse/100">
+  <div class="bench-header">
+    <h2 class="bench-title">traverse_and_rank_basic/100_sparse/100</h2>
+    <div class="bench-latest">1.29 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.29 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.29 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.29 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-traverse_and_rank_basic--100_sparse--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-traverse_and_rank_basic--100_uniform--100" data-bench-name="traverse_and_rank_basic/100_uniform/100">
+  <div class="bench-header">
+    <h2 class="bench-title">traverse_and_rank_basic/100_uniform/100</h2>
+    <div class="bench-latest">7.89 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">7.89 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">7.89 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">7.89 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-traverse_and_rank_basic--100_uniform--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-traverse_and_rank_basic--1K_power_law--1000" data-bench-name="traverse_and_rank_basic/1K_power_law/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">traverse_and_rank_basic/1K_power_law/1000</h2>
+    <div class="bench-latest">47.54 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">47.54 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">47.54 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">47.54 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-traverse_and_rank_basic--1K_power_law--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-traverse_and_rank_basic--1K_sparse--1000" data-bench-name="traverse_and_rank_basic/1K_sparse/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">traverse_and_rank_basic/1K_sparse/1000</h2>
+    <div class="bench-latest">1.28 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.28 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.28 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.28 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-traverse_and_rank_basic--1K_sparse--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-traverse_and_rank_basic--1K_uniform--1000" data-bench-name="traverse_and_rank_basic/1K_uniform/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">traverse_and_rank_basic/1K_uniform/1000</h2>
+    <div class="bench-latest">8.12 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">8.12 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">8.12 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">8.12 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-traverse_and_rank_basic--1K_uniform--1000" height="260"></canvas>
+  </div>
+</section>
 <section class="bench-section" id="bench-valid_at_query--10000_versions" data-bench-name="valid_at_query/10000_versions">
   <div class="bench-header">
     <h2 class="bench-title">valid_at_query/10000_versions</h2>
@@ -2288,6 +8743,811 @@
     <canvas id="chart-valid_at_query--100_versions" height="260"></canvas>
   </div>
 </section>
+<section class="bench-section" id="bench-vector_batch_deserialize--retrieval_workload--100x1536" data-bench-name="vector_batch_deserialize/retrieval_workload/100x1536">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_batch_deserialize/retrieval_workload/100x1536</h2>
+    <div class="bench-latest">36.64 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">36.64 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">36.64 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">36.64 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_batch_deserialize--retrieval_workload--100x1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_batch_serialize--rag_workload--100x1536" data-bench-name="vector_batch_serialize/rag_workload/100x1536">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_batch_serialize/rag_workload/100x1536</h2>
+    <div class="bench-latest">22.99 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">22.99 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">22.99 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">22.99 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_batch_serialize--rag_workload--100x1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--1" data-bench-name="vector_deserialize/deserialize/1">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/1</h2>
+    <div class="bench-latest">54.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">54.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">54.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">54.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--1" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--10" data-bench-name="vector_deserialize/deserialize/10">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/10</h2>
+    <div class="bench-latest">55.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">55.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">55.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">55.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--128" data-bench-name="vector_deserialize/deserialize/128">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/128</h2>
+    <div class="bench-latest">67.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">67.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">67.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">67.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--128" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--1536" data-bench-name="vector_deserialize/deserialize/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/1536</h2>
+    <div class="bench-latest">376.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">376.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">376.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">376.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--3072" data-bench-name="vector_deserialize/deserialize/3072">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/3072</h2>
+    <div class="bench-latest">751.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">751.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">751.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">751.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--3072" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--384" data-bench-name="vector_deserialize/deserialize/384">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/384</h2>
+    <div class="bench-latest">240.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">240.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">240.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">240.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_deserialize--deserialize--768" data-bench-name="vector_deserialize/deserialize/768">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_deserialize/deserialize/768</h2>
+    <div class="bench-latest">281.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">281.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">281.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">281.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_deserialize--deserialize--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_round_trip--round_trip--1536" data-bench-name="vector_round_trip/round_trip/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_round_trip/round_trip/1536</h2>
+    <div class="bench-latest">613.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">613.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">613.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">613.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_round_trip--round_trip--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_round_trip--round_trip--3072" data-bench-name="vector_round_trip/round_trip/3072">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_round_trip/round_trip/3072</h2>
+    <div class="bench-latest">1.43 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.43 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.43 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.43 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_round_trip--round_trip--3072" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_round_trip--round_trip--384" data-bench-name="vector_round_trip/round_trip/384">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_round_trip/round_trip/384</h2>
+    <div class="bench-latest">384.9 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">384.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">384.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">384.9 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_round_trip--round_trip--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_round_trip--round_trip--768" data-bench-name="vector_round_trip/round_trip/768">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_round_trip/round_trip/768</h2>
+    <div class="bench-latest">427.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">427.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">427.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">427.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_round_trip--round_trip--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--1" data-bench-name="vector_serialize/serialize/1">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/1</h2>
+    <div class="bench-latest">27.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">27.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">27.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">27.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--1" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--10" data-bench-name="vector_serialize/serialize/10">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/10</h2>
+    <div class="bench-latest">27.1 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">27.1 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">27.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">27.1 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--128" data-bench-name="vector_serialize/serialize/128">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/128</h2>
+    <div class="bench-latest">34.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">34.8 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">34.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">34.8 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--128" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--1536" data-bench-name="vector_serialize/serialize/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/1536</h2>
+    <div class="bench-latest">173.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">173.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">173.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">173.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--3072" data-bench-name="vector_serialize/serialize/3072">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/3072</h2>
+    <div class="bench-latest">219.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">219.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">219.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">219.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--3072" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--384" data-bench-name="vector_serialize/serialize/384">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/384</h2>
+    <div class="bench-latest">134.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">134.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">134.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">134.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize--serialize--768" data-bench-name="vector_serialize/serialize/768">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize/serialize/768</h2>
+    <div class="bench-latest">133.6 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">133.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">133.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">133.6 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize--serialize--768" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize_into--serialize_into--1536" data-bench-name="vector_serialize_into/serialize_into/1536">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize_into/serialize_into/1536</h2>
+    <div class="bench-latest">181.3 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">181.3 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">181.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">181.3 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize_into--serialize_into--1536" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize_into--serialize_into--384" data-bench-name="vector_serialize_into/serialize_into/384">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize_into/serialize_into/384</h2>
+    <div class="bench-latest">119.7 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">119.7 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">119.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">119.7 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize_into--serialize_into--384" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-vector_serialize_into--serialize_into--768" data-bench-name="vector_serialize_into/serialize_into/768">
+  <div class="bench-header">
+    <h2 class="bench-title">vector_serialize_into/serialize_into/768</h2>
+    <div class="bench-latest">141.5 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">141.5 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">141.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">141.5 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-vector_serialize_into--serialize_into--768" height="260"></canvas>
+  </div>
+</section>
 
   <footer>
     Chronos — The Temporal Benchkeeper &nbsp;·&nbsp; Timeseries Dashboard
@@ -2295,7 +9555,7 @@
 </main>
 
 <script>
-const CONFIGS = {"closure_write_single_node": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}], "trend": [], "mean": 2.8058, "unit": "ms", "stats": {"mean": "2.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.81 ms", "max": "2.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/10000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}], "trend": [], "mean": 133.8781, "unit": "\u00b5s", "stats": {"mean": "133.88 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.88 \u00b5s", "max": "133.88 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.88 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/10000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}], "trend": [], "mean": 474.7407, "unit": "\u00b5s", "stats": {"mean": "474.74 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "474.74 \u00b5s", "max": "474.74 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "474.74 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}], "trend": [], "mean": 767.6457, "unit": "\u00b5s", "stats": {"mean": "767.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "767.65 \u00b5s", "max": "767.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "767.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}], "trend": [], "mean": 130.1031, "unit": "\u00b5s", "stats": {"mean": "130.10 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.10 \u00b5s", "max": "130.10 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.10 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}], "trend": [], "mean": 220.6437, "unit": "\u00b5s", "stats": {"mean": "220.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.64 \u00b5s", "max": "220.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}], "trend": [], "mean": 422.9052, "unit": "\u00b5s", "stats": {"mean": "422.91 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "422.91 \u00b5s", "max": "422.91 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "422.91 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}], "trend": [], "mean": 696.7185, "unit": "\u00b5s", "stats": {"mean": "696.72 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "696.72 \u00b5s", "max": "696.72 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "696.72 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}], "trend": [], "mean": 130.2643, "unit": "\u00b5s", "stats": {"mean": "130.26 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.26 \u00b5s", "max": "130.26 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.26 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}], "trend": [], "mean": 203.7032, "unit": "\u00b5s", "stats": {"mean": "203.70 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "203.70 \u00b5s", "max": "203.70 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "203.70 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}], "trend": [], "mean": 383.8675, "unit": "\u00b5s", "stats": {"mean": "383.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "383.87 \u00b5s", "max": "383.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "383.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/different_entities/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}], "trend": [], "mean": 139.7069, "unit": "\u00b5s", "stats": {"mean": "139.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "139.71 \u00b5s", "max": "139.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "139.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/different_entities/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}], "trend": [], "mean": 220.0149, "unit": "\u00b5s", "stats": {"mean": "220.01 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.01 \u00b5s", "max": "220.01 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.01 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/different_entities/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}], "trend": [], "mean": 417.3599, "unit": "\u00b5s", "stats": {"mean": "417.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "417.36 \u00b5s", "max": "417.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "417.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/same_entity_contention/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}], "trend": [], "mean": 214.5742, "unit": "\u00b5s", "stats": {"mean": "214.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "214.57 \u00b5s", "max": "214.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "214.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/same_entity_contention/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}], "trend": [], "mean": 1.2257, "unit": "ms", "stats": {"mean": "1.23 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.23 ms", "max": "1.23 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.23 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/same_entity_contention/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}], "trend": [], "mean": 9.4764, "unit": "ms", "stats": {"mean": "9.48 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.48 ms", "max": "9.48 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.48 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/1": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}], "trend": [], "mean": 126.5096, "unit": "\u00b5s", "stats": {"mean": "126.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "126.51 \u00b5s", "max": "126.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "126.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/10": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}], "trend": [], "mean": 121.1122, "unit": "\u00b5s", "stats": {"mean": "121.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.11 \u00b5s", "max": "121.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/20": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}], "trend": [], "mean": 123.2891, "unit": "\u00b5s", "stats": {"mean": "123.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.29 \u00b5s", "max": "123.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/5": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}], "trend": [], "mean": 119.2502, "unit": "\u00b5s", "stats": {"mean": "119.25 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.25 \u00b5s", "max": "119.25 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.25 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/50": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}], "trend": [], "mean": 122.0939, "unit": "\u00b5s", "stats": {"mean": "122.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "122.09 \u00b5s", "max": "122.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "122.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}], "trend": [], "mean": 21.0222, "unit": "\u00b5s", "stats": {"mean": "21.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.02 \u00b5s", "max": "21.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}], "trend": [], "mean": 120.5215, "unit": "\u00b5s", "stats": {"mean": "120.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.52 \u00b5s", "max": "120.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}], "trend": [], "mean": 313.1745, "unit": "\u00b5s", "stats": {"mean": "313.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "313.17 \u00b5s", "max": "313.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "313.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/500": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}], "trend": [], "mean": 68.0848, "unit": "\u00b5s", "stats": {"mean": "68.08 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "68.08 \u00b5s", "max": "68.08 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "68.08 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/5000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}], "trend": [], "mean": 242.3192, "unit": "\u00b5s", "stats": {"mean": "242.32 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "242.32 \u00b5s", "max": "242.32 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "242.32 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}], "trend": [], "mean": 339.2398, "unit": "ns", "stats": {"mean": "339.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "339.2 ns", "max": "339.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "339.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_under_write_contention/concurrent_writers/0": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}], "trend": [], "mean": 4.4554, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_under_write_contention/concurrent_writers/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}], "trend": [], "mean": 56.6603, "unit": "ms", "stats": {"mean": "56.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.66 ms", "max": "56.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_under_write_contention/concurrent_writers/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}], "trend": [], "mean": 114.751, "unit": "ms", "stats": {"mean": "114.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "114.75 ms", "max": "114.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "114.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573}], "mean": 282.1573, "unit": "ns", "stats": {"mean": "282.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.2 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382}], "mean": 781.382, "unit": "\u00b5s", "stats": {"mean": "781.38 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "781.38 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "781.38 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068}], "mean": 42.6068, "unit": "ns", "stats": {"mean": "42.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "42.6 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "42.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592}], "mean": 282.592, "unit": "ns", "stats": {"mean": "282.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.6 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228}], "mean": 275.1228, "unit": "ns", "stats": {"mean": "275.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "275.1 ns", "max": "275.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "275.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226}], "mean": 286.226, "unit": "ns", "stats": {"mean": "286.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "286.2 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "286.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}], "trend": [], "mean": 20.5223, "unit": "\u00b5s", "stats": {"mean": "20.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.52 \u00b5s", "max": "20.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/append_only/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}], "trend": [], "mean": 210.7516, "unit": "\u00b5s", "stats": {"mean": "210.75 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "210.75 \u00b5s", "max": "210.75 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "210.75 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/append_only/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}], "trend": [], "mean": 2.1701, "unit": "ms", "stats": {"mean": "2.17 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.17 ms", "max": "2.17 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.17 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/retroactive/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}], "trend": [], "mean": 147.4722, "unit": "\u00b5s", "stats": {"mean": "147.47 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "147.47 \u00b5s", "max": "147.47 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "147.47 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/retroactive/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}], "trend": [], "mean": 12.5487, "unit": "ms", "stats": {"mean": "12.55 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "12.55 ms", "max": "12.55 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "12.55 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/retroactive/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}], "trend": [], "mean": 1.2868, "unit": "s", "stats": {"mean": "1.287 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.287 s", "max": "1.287 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.287 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/10000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}], "trend": [], "mean": 22.3551, "unit": "\u00b5s", "stats": {"mean": "22.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.36 \u00b5s", "max": "22.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/1000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}], "trend": [], "mean": 3.9012, "unit": "\u00b5s", "stats": {"mean": "3.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.90 \u00b5s", "max": "3.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/100_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}], "trend": [], "mean": 1.5299, "unit": "\u00b5s", "stats": {"mean": "1.53 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.53 \u00b5s", "max": "1.53 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.53 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "write_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}], "trend": [], "mean": 462.4375, "unit": "ns", "stats": {"mean": "462.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "462.4 ns", "max": "462.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "462.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}};
+const CONFIGS = {"3_hop_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.7094, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.6255, "ci_upper": 56.8146}], "trend": [], "mean": 56.7094, "unit": "\u00b5s", "stats": {"mean": "56.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.71 \u00b5s", "max": "56.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_3_hop_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 483.0333, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 481.8018, "ci_upper": 484.841}], "trend": [], "mean": 483.0333, "unit": "ns", "stats": {"mean": "483.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "483.0 ns", "max": "483.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "483.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_batch/batch_node_creation/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.8075, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.675, "ci_upper": 27.9374}], "trend": [], "mean": 27.8075, "unit": "ms", "stats": {"mean": "27.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.81 ms", "max": "27.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_batch/batch_node_creation/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289.8292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 288.0868, "ci_upper": 291.5917}], "trend": [], "mean": 289.8292, "unit": "ms", "stats": {"mean": "289.83 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "289.83 ms", "max": "289.83 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "289.83 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_batch/batch_node_creation/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8312, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.8159, "ci_upper": 2.8495}], "trend": [], "mean": 2.8312, "unit": "s", "stats": {"mean": "2.831 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.831 s", "max": "2.831 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.831 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_edge_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.3458, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 87.5403, "ci_upper": 106.6907}], "trend": [], "mean": 97.3458, "unit": "\u00b5s", "stats": {"mean": "97.35 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "97.35 \u00b5s", "max": "97.35 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "97.35 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_fast_path/node_lookup/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.7337, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 62.6648, "ci_upper": 62.8097}], "trend": [], "mean": 62.7337, "unit": "ns", "stats": {"mean": "62.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "62.7 ns", "max": "62.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "62.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_fast_path/node_lookup/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.003, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 61.9509, "ci_upper": 62.0692}], "trend": [], "mean": 62.003, "unit": "ns", "stats": {"mean": "62.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "62.0 ns", "max": "62.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "62.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_fast_path/node_lookup/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 61.1577, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 61.1032, "ci_upper": 61.2266}], "trend": [], "mean": 61.1577, "unit": "ns", "stats": {"mean": "61.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "61.2 ns", "max": "61.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "61.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_historical_stats": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.0592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.057, "ci_upper": 1.0618}], "trend": [], "mean": 1.0592, "unit": "\u00b5s", "stats": {"mean": "1.06 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.06 \u00b5s", "max": "1.06 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.06 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_in_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 104.8917, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 104.81, "ci_upper": 104.9774}], "trend": [], "mean": 104.8917, "unit": "ns", "stats": {"mean": "104.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "104.9 ns", "max": "104.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "104.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_labeled_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 159.8682, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 159.7019, "ci_upper": 160.0694}], "trend": [], "mean": 159.8682, "unit": "ns", "stats": {"mean": "159.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "159.9 ns", "max": "159.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "159.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_node_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.588, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 95.5147, "ci_upper": 116.8485}], "trend": [], "mean": 105.588, "unit": "\u00b5s", "stats": {"mean": "105.59 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "105.59 \u00b5s", "max": "105.59 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "105.59 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_out_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 100.3947, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 100.3461, "ci_upper": 100.4534}], "trend": [], "mean": 100.3947, "unit": "ns", "stats": {"mean": "100.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "100.4 ns", "max": "100.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "100.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_single_hop/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.4999, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.3909, "ci_upper": 116.6086}], "trend": [], "mean": 116.4999, "unit": "ns", "stats": {"mean": "116.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "116.5 ns", "max": "116.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "116.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_single_hop/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.5517, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.4637, "ci_upper": 116.6516}], "trend": [], "mean": 116.5517, "unit": "ns", "stats": {"mean": "116.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "116.6 ns", "max": "116.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "116.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_single_hop/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.1347, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.0577, "ci_upper": 116.2193}], "trend": [], "mean": 116.1347, "unit": "ns", "stats": {"mean": "116.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "116.1 ns", "max": "116.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "116.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "batch_throughput/async": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52.7926, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 52.7417, "ci_upper": 52.8425}], "trend": [], "mean": 52.7926, "unit": "ms", "stats": {"mean": "52.79 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "52.79 ms", "max": "52.79 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "52.79 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "batch_throughput/synchronous": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635.7484, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 625.9952, "ci_upper": 645.2215}], "trend": [], "mean": 635.7484, "unit": "ms", "stats": {"mean": "635.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "635.75 ms", "max": "635.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "635.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_creation/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.893, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.4531, "ci_upper": 5.316}], "trend": [], "mean": 4.893, "unit": "ms", "stats": {"mean": "4.89 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.89 ms", "max": "4.89 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.89 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_creation/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.0293, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.874, "ci_upper": 4.2611}], "trend": [], "mean": 4.0293, "unit": "ms", "stats": {"mean": "4.03 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.03 ms", "max": "4.03 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.03 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_creation/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.6632, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.568, "ci_upper": 7.7574}], "trend": [], "mean": 7.6632, "unit": "ms", "stats": {"mean": "7.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.66 ms", "max": "7.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_load/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.5051, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 317.3704, "ci_upper": 329.8024}], "trend": [], "mean": 323.5051, "unit": "\u00b5s", "stats": {"mean": "323.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "323.51 \u00b5s", "max": "323.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "323.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_load/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.628, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.614, "ci_upper": 1.6437}], "trend": [], "mean": 1.628, "unit": "ms", "stats": {"mean": "1.63 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.63 ms", "max": "1.63 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.63 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_load/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15.1799, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 15.0798, "ci_upper": 15.2868}], "trend": [], "mean": 15.1799, "unit": "ms", "stats": {"mean": "15.18 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "15.18 ms", "max": "15.18 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "15.18 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "closure_write_single_node": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8058}], "mean": 2.8058, "unit": "ms", "stats": {"mean": "2.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.81 ms", "max": "2.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "cold_batch_write_throughput/fast/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.9292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.9076, "ci_upper": 4.9539}], "trend": [], "mean": 4.9292, "unit": "ms", "stats": {"mean": "4.93 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.93 ms", "max": "4.93 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.93 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/fast/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45.8136, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 45.7461, "ci_upper": 45.8876}], "trend": [], "mean": 45.8136, "unit": "ms", "stats": {"mean": "45.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "45.81 ms", "max": "45.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "45.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/fast/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454.8297, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 454.2272, "ci_upper": 455.4686}], "trend": [], "mean": 454.8297, "unit": "ms", "stats": {"mean": "454.83 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "454.83 ms", "max": "454.83 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "454.83 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/zstd/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.4465, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.4201, "ci_upper": 7.4717}], "trend": [], "mean": 7.4465, "unit": "ms", "stats": {"mean": "7.45 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.45 ms", "max": "7.45 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.45 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/zstd/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66.7824, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.5764, "ci_upper": 67.0114}], "trend": [], "mean": 66.7824, "unit": "ms", "stats": {"mean": "66.78 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "66.78 ms", "max": "66.78 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "66.78 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/zstd/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189.515, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 187.4879, "ci_upper": 191.7626}], "trend": [], "mean": 189.515, "unit": "ms", "stats": {"mean": "189.51 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "189.51 ms", "max": "189.51 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "189.51 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_read_latency/single_read/fast_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.4834, "ci_upper": 34.597}], "trend": [], "mean": 34.539, "unit": "\u00b5s", "stats": {"mean": "34.54 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.54 \u00b5s", "max": "34.54 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.54 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_read_latency/single_read/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.3055, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.2979, "ci_upper": 3.3147}], "trend": [], "mean": 3.3055, "unit": "\u00b5s", "stats": {"mean": "3.31 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.31 \u00b5s", "max": "3.31 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.31 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_read_latency/single_read/zstd_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.4087, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.3612, "ci_upper": 34.4647}], "trend": [], "mean": 34.4087, "unit": "\u00b5s", "stats": {"mean": "34.41 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.41 \u00b5s", "max": "34.41 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.41 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_write_latency/single_write/fast_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 338.7451, "ci_upper": 342.0878}], "trend": [], "mean": 340.426, "unit": "\u00b5s", "stats": {"mean": "340.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "340.43 \u00b5s", "max": "340.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "340.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_write_latency/single_write/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.7913, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 317.6596, "ci_upper": 379.6265}], "trend": [], "mean": 343.7913, "unit": "\u00b5s", "stats": {"mean": "343.79 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "343.79 \u00b5s", "max": "343.79 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "343.79 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_write_latency/single_write/zstd_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.8672, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 370.4404, "ci_upper": 377.8695}], "trend": [], "mean": 373.8672, "unit": "\u00b5s", "stats": {"mean": "373.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "373.87 \u00b5s", "max": "373.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "373.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "comparison_csr/full_rebuild_insert_query": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 140.053, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.986, "ci_upper": 141.1743}], "trend": [], "mean": 140.053, "unit": "\u00b5s", "stats": {"mean": "140.05 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "140.05 \u00b5s", "max": "140.05 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "140.05 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "comparison_csr/incremental_csr_insert_query": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5961, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 16.443, "ci_upper": 16.7372}], "trend": [], "mean": 16.5961, "unit": "\u00b5s", "stats": {"mean": "16.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "16.60 \u00b5s", "max": "16.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "16.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/fast": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.8685, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 33.5632, "ci_upper": 36.4003}], "trend": [], "mean": 34.8685, "unit": "ms", "stats": {"mean": "34.87 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.87 ms", "max": "34.87 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.87 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31.2589, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 31.0497, "ci_upper": 31.4758}], "trend": [], "mean": 31.2589, "unit": "ms", "stats": {"mean": "31.26 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "31.26 ms", "max": "31.26 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "31.26 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/zstd": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.2195, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.56, "ci_upper": 36.922}], "trend": [], "mean": 36.2195, "unit": "ms", "stats": {"mean": "36.22 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.22 ms", "max": "36.22 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.22 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/10000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.8781}], "mean": 133.8781, "unit": "\u00b5s", "stats": {"mean": "133.88 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.88 \u00b5s", "max": "133.88 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.88 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/10000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.7407}], "mean": 474.7407, "unit": "\u00b5s", "stats": {"mean": "474.74 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "474.74 \u00b5s", "max": "474.74 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "474.74 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.6457}], "mean": 767.6457, "unit": "\u00b5s", "stats": {"mean": "767.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "767.65 \u00b5s", "max": "767.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "767.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.1031}], "mean": 130.1031, "unit": "\u00b5s", "stats": {"mean": "130.10 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.10 \u00b5s", "max": "130.10 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.10 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.6437}], "mean": 220.6437, "unit": "\u00b5s", "stats": {"mean": "220.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.64 \u00b5s", "max": "220.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.9052}], "mean": 422.9052, "unit": "\u00b5s", "stats": {"mean": "422.91 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "422.91 \u00b5s", "max": "422.91 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "422.91 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.7185}], "mean": 696.7185, "unit": "\u00b5s", "stats": {"mean": "696.72 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "696.72 \u00b5s", "max": "696.72 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "696.72 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.2643}], "mean": 130.2643, "unit": "\u00b5s", "stats": {"mean": "130.26 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.26 \u00b5s", "max": "130.26 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.26 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.7032}], "mean": 203.7032, "unit": "\u00b5s", "stats": {"mean": "203.70 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "203.70 \u00b5s", "max": "203.70 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "203.70 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.8675}], "mean": 383.8675, "unit": "\u00b5s", "stats": {"mean": "383.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "383.87 \u00b5s", "max": "383.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "383.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.7069}], "mean": 139.7069, "unit": "\u00b5s", "stats": {"mean": "139.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "139.71 \u00b5s", "max": "139.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "139.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.0149}], "mean": 220.0149, "unit": "\u00b5s", "stats": {"mean": "220.01 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.01 \u00b5s", "max": "220.01 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.01 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.3599}], "mean": 417.3599, "unit": "\u00b5s", "stats": {"mean": "417.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "417.36 \u00b5s", "max": "417.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "417.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.5742}], "mean": 214.5742, "unit": "\u00b5s", "stats": {"mean": "214.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "214.57 \u00b5s", "max": "214.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "214.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2257}], "mean": 1.2257, "unit": "ms", "stats": {"mean": "1.23 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.23 ms", "max": "1.23 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.23 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.4764}], "mean": 9.4764, "unit": "ms", "stats": {"mean": "9.48 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.48 ms", "max": "9.48 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.48 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "cosine_similarity/naive_3pass/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.5998, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.5964, "ci_upper": 4.6033}], "trend": [], "mean": 4.5998, "unit": "\u00b5s", "stats": {"mean": "4.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.60 \u00b5s", "max": "4.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9518, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 6.9487, "ci_upper": 6.9553}], "trend": [], "mean": 6.9518, "unit": "\u00b5s", "stats": {"mean": "6.95 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "6.95 \u00b5s", "max": "6.95 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "6.95 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 14.0339, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 14.0176, "ci_upper": 14.0553}], "trend": [], "mean": 14.0339, "unit": "\u00b5s", "stats": {"mean": "14.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "14.03 \u00b5s", "max": "14.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "14.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.6521, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.6509, "ci_upper": 1.6536}], "trend": [], "mean": 1.6521, "unit": "\u00b5s", "stats": {"mean": "1.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.65 \u00b5s", "max": "1.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.4352, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.415, "ci_upper": 3.4602}], "trend": [], "mean": 3.4352, "unit": "\u00b5s", "stats": {"mean": "3.44 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.44 \u00b5s", "max": "3.44 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.44 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 201.4877, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 200.8504, "ci_upper": 202.3099}], "trend": [], "mean": 201.4877, "unit": "ns", "stats": {"mean": "201.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "201.5 ns", "max": "201.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "201.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 299.6659, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.2803, "ci_upper": 300.0181}], "trend": [], "mean": 299.6659, "unit": "ns", "stats": {"mean": "299.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "299.7 ns", "max": "299.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "299.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 592.0544, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 591.7843, "ci_upper": 592.3525}], "trend": [], "mean": 592.0544, "unit": "ns", "stats": {"mean": "592.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "592.1 ns", "max": "592.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "592.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 77.1982, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.0254, "ci_upper": 77.3564}], "trend": [], "mean": 77.1982, "unit": "ns", "stats": {"mean": "77.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "77.2 ns", "max": "77.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "77.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 151.7529, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 151.6634, "ci_upper": 151.8528}], "trend": [], "mean": 151.7529, "unit": "ns", "stats": {"mean": "151.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "151.8 ns", "max": "151.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "151.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5811, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.5754, "ci_upper": 1.59}], "trend": [], "mean": 1.5811, "unit": "\u00b5s", "stats": {"mean": "1.58 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.58 \u00b5s", "max": "1.58 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.58 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.3602, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.3535, "ci_upper": 2.372}], "trend": [], "mean": 2.3602, "unit": "\u00b5s", "stats": {"mean": "2.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.36 \u00b5s", "max": "2.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.7282, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.7141, "ci_upper": 4.7443}], "trend": [], "mean": 4.7282, "unit": "\u00b5s", "stats": {"mean": "4.73 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.73 \u00b5s", "max": "4.73 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.73 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 636.1933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 603.1786, "ci_upper": 671.3907}], "trend": [], "mean": 636.1933, "unit": "ns", "stats": {"mean": "636.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "636.2 ns", "max": "636.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "636.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.182, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1815, "ci_upper": 1.1825}], "trend": [], "mean": 1.182, "unit": "\u00b5s", "stats": {"mean": "1.18 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.18 \u00b5s", "max": "1.18 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.18 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 811.3468, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 810.3818, "ci_upper": 812.3508}], "trend": [], "mean": 811.3468, "unit": "ns", "stats": {"mean": "811.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "811.3 ns", "max": "811.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "811.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.2806, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.2657, "ci_upper": 8.2983}], "trend": [], "mean": 8.2806, "unit": "\u00b5s", "stats": {"mean": "8.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.28 \u00b5s", "max": "8.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 90.4588, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 88.3046, "ci_upper": 92.9789}], "trend": [], "mean": 90.4588, "unit": "\u00b5s", "stats": {"mean": "90.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "90.46 \u00b5s", "max": "90.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "90.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/general/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 300.4556, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.9198, "ci_upper": 301.2823}], "trend": [], "mean": 300.4556, "unit": "ns", "stats": {"mean": "300.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "300.5 ns", "max": "300.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "300.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/general/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 78.0633, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.9841, "ci_upper": 78.1482}], "trend": [], "mean": 78.0633, "unit": "ns", "stats": {"mean": "78.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "78.1 ns", "max": "78.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "78.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/specialized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 284.7673, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 280.1321, "ci_upper": 290.0487}], "trend": [], "mean": 284.7673, "unit": "ns", "stats": {"mean": "284.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "284.8 ns", "max": "284.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "284.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/specialized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.5976, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.5608, "ci_upper": 56.6375}], "trend": [], "mean": 56.5976, "unit": "ns", "stats": {"mean": "56.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.6 ns", "max": "56.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_openai_1536d": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 301.5358, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.4368, "ci_upper": 304.2498}], "trend": [], "mean": 301.5358, "unit": "ns", "stats": {"mean": "301.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "301.5 ns", "max": "301.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "301.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "edge_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4612, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2203, "ci_upper": 4.6423}], "trend": [], "mean": 4.4612, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "edge_lookup": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.3798, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 62.3132, "ci_upper": 62.4333}], "trend": [], "mean": 62.3798, "unit": "ns", "stats": {"mean": "62.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "62.4 ns", "max": "62.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "62.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 174.9884, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 174.5683, "ci_upper": 175.509}], "trend": [], "mean": 174.9884, "unit": "ns", "stats": {"mean": "175.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "175.0 ns", "max": "175.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "175.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 272.6012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 272.4164, "ci_upper": 272.8048}], "trend": [], "mean": 272.6012, "unit": "ns", "stats": {"mean": "272.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "272.6 ns", "max": "272.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "272.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.5753, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 60.8333, "ci_upper": 69.9999}], "trend": [], "mean": 65.5753, "unit": "ns", "stats": {"mean": "65.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "65.6 ns", "max": "65.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "65.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.7884, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.6794, "ci_upper": 123.9155}], "trend": [], "mean": 123.7884, "unit": "ns", "stats": {"mean": "123.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.8 ns", "max": "123.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5486, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.5474, "ci_upper": 1.5499}], "trend": [], "mean": 1.5486, "unit": "\u00b5s", "stats": {"mean": "1.55 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.55 \u00b5s", "max": "1.55 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.55 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.3322, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.3308, "ci_upper": 2.334}], "trend": [], "mean": 2.3322, "unit": "\u00b5s", "stats": {"mean": "2.33 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.33 \u00b5s", "max": "2.33 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.33 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 566.6878, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 566.0427, "ci_upper": 567.318}], "trend": [], "mean": 566.6878, "unit": "ns", "stats": {"mean": "566.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "566.7 ns", "max": "566.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "566.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.1552, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1547, "ci_upper": 1.1559}], "trend": [], "mean": 1.1552, "unit": "\u00b5s", "stats": {"mean": "1.16 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.16 \u00b5s", "max": "1.16 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.16 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 173.0044, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 172.8747, "ci_upper": 173.158}], "trend": [], "mean": 173.0044, "unit": "ns", "stats": {"mean": "173.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "173.0 ns", "max": "173.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "173.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 269.6692, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 269.2292, "ci_upper": 270.1513}], "trend": [], "mean": 269.6692, "unit": "ns", "stats": {"mean": "269.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "269.7 ns", "max": "269.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "269.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.5494, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.4933, "ci_upper": 56.6058}], "trend": [], "mean": 56.5494, "unit": "ns", "stats": {"mean": "56.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.5 ns", "max": "56.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.2014, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.0685, "ci_upper": 121.3575}], "trend": [], "mean": 121.2014, "unit": "ns", "stats": {"mean": "121.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.2 ns", "max": "121.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_neighbors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2409, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2392, "ci_upper": 1.243}], "trend": [], "mean": 1.2409, "unit": "\u00b5s", "stats": {"mean": "1.24 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.24 \u00b5s", "max": "1.24 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.24 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_nodes_by_property/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.0933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 746.1684, "ci_upper": 766.5151}], "trend": [], "mean": 757.0933, "unit": "\u00b5s", "stats": {"mean": "757.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "757.09 \u00b5s", "max": "757.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "757.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_nodes_by_property/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.7901, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 47.4027, "ci_upper": 53.7229}], "trend": [], "mean": 50.7901, "unit": "\u00b5s", "stats": {"mean": "50.79 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "50.79 \u00b5s", "max": "50.79 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "50.79 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_nodes_by_property/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6744, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.6705, "ci_upper": 4.6789}], "trend": [], "mean": 4.6744, "unit": "\u00b5s", "stats": {"mean": "4.67 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.67 \u00b5s", "max": "4.67 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.67 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/100000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.9696, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 39.9448, "ci_upper": 39.9997}], "trend": [], "mean": 39.9696, "unit": "ns", "stats": {"mean": "40.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "40.0 ns", "max": "40.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "40.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 33.8967, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 33.4823, "ci_upper": 34.3487}], "trend": [], "mean": 33.8967, "unit": "ns", "stats": {"mean": "33.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "33.9 ns", "max": "33.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "33.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.7478, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.7342, "ci_upper": 20.7629}], "trend": [], "mean": 20.7478, "unit": "ns", "stats": {"mean": "20.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.7 ns", "max": "20.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/100000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.7605, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.7381, "ci_upper": 32.7867}], "trend": [], "mean": 32.7605, "unit": "ns", "stats": {"mean": "32.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.8 ns", "max": "32.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6491, "ci_upper": 32.7063}], "trend": [], "mean": 32.6752, "unit": "ns", "stats": {"mean": "32.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.7 ns", "max": "32.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6055, "ci_upper": 32.6551}], "trend": [], "mean": 32.6292, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.6438, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.6173, "ci_upper": 35.6692}], "trend": [], "mean": 35.6438, "unit": "ns", "stats": {"mean": "35.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.6 ns", "max": "35.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.2963, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.2689, "ci_upper": 35.3269}], "trend": [], "mean": 35.2963, "unit": "ns", "stats": {"mean": "35.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.3 ns", "max": "35.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.3701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.3296, "ci_upper": 35.4178}], "trend": [], "mean": 35.3701, "unit": "ns", "stats": {"mean": "35.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.4 ns", "max": "35.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/16": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.7988, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 668.2883, "ci_upper": 681.7834}], "trend": [], "mean": 674.7988, "unit": "\u00b5s", "stats": {"mean": "674.80 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "674.80 \u00b5s", "max": "674.80 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "674.80 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/2": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.8943, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.8132, "ci_upper": 122.2263}], "trend": [], "mean": 120.8943, "unit": "\u00b5s", "stats": {"mean": "120.89 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.89 \u00b5s", "max": "120.89 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.89 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/4": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.1065, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 195.2657, "ci_upper": 201.0119}], "trend": [], "mean": 198.1065, "unit": "\u00b5s", "stats": {"mean": "198.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "198.11 \u00b5s", "max": "198.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "198.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/8": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.1654, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 364.3727, "ci_upper": 389.8907}], "trend": [], "mean": 375.1654, "unit": "\u00b5s", "stats": {"mean": "375.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "375.17 \u00b5s", "max": "375.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "375.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_current/read_current": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.384, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 0.3835, "ci_upper": 0.3848}], "trend": [], "mean": 0.384, "unit": "ns", "stats": {"mean": "0.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "0.4 ns", "max": "0.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "0.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_current/read_current_approximate": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.383, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 0.3827, "ci_upper": 0.3833}], "trend": [], "mean": 0.383, "unit": "ns", "stats": {"mean": "0.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "0.4 ns", "max": "0.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "0.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_lifecycle/create_and_generate_1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.8024, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.3635, "ci_upper": 9.121}], "trend": [], "mean": 8.8024, "unit": "\u00b5s", "stats": {"mean": "8.80 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.80 \u00b5s", "max": "8.80 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.80 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_single_thread/sequential_1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9014, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 6.8972, "ci_upper": 6.906}], "trend": [], "mean": 6.9014, "unit": "\u00b5s", "stats": {"mean": "6.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "6.90 \u00b5s", "max": "6.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "6.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_single_thread/sequential_10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.0165, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 68.9682, "ci_upper": 69.0705}], "trend": [], "mean": 69.0165, "unit": "\u00b5s", "stats": {"mean": "69.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "69.02 \u00b5s", "max": "69.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "69.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "in_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 398.5843, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 398.2256, "ci_upper": 399.0399}], "trend": [], "mean": 398.5843, "unit": "ns", "stats": {"mean": "398.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "398.6 ns", "max": "398.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "398.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/1000+100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 60.2792, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 60.0174, "ci_upper": 60.5145}], "trend": [], "mean": 60.2792, "unit": "\u00b5s", "stats": {"mean": "60.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "60.28 \u00b5s", "max": "60.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "60.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/10000+1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 955.6045, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 949.4576, "ci_upper": 961.3519}], "trend": [], "mean": 955.6045, "unit": "\u00b5s", "stats": {"mean": "955.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "955.60 \u00b5s", "max": "955.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "955.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/100000+10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.1922, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.1618, "ci_upper": 8.2228}], "trend": [], "mean": 8.1922, "unit": "ms", "stats": {"mean": "8.19 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.19 ms", "max": "8.19 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.19 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/2": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.5752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 140.156, "ci_upper": 143.4946}], "trend": [], "mean": 141.5752, "unit": "\u00b5s", "stats": {"mean": "141.58 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "141.58 \u00b5s", "max": "141.58 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "141.58 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/4": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 211.6228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 210.6432, "ci_upper": 212.6665}], "trend": [], "mean": 211.6228, "unit": "\u00b5s", "stats": {"mean": "211.62 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "211.62 \u00b5s", "max": "211.62 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "211.62 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/8": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 410.1319, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.3735, "ci_upper": 411.8419}], "trend": [], "mean": 410.1319, "unit": "\u00b5s", "stats": {"mean": "410.13 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "410.13 \u00b5s", "max": "410.13 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "410.13 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/0existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 288.5947, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 238.623, "ci_upper": 340.8245}], "trend": [], "mean": 288.5947, "unit": "ns", "stats": {"mean": "288.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "288.6 ns", "max": "288.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "288.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/100000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289.1802, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 239.8888, "ci_upper": 340.0766}], "trend": [], "mean": 289.1802, "unit": "ns", "stats": {"mean": "289.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "289.2 ns", "max": "289.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "289.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/10000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 183.1639, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 173.8104, "ci_upper": 191.407}], "trend": [], "mean": 183.1639, "unit": "ns", "stats": {"mean": "183.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "183.2 ns", "max": "183.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "183.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/1000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 226.3477, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 217.2657, "ci_upper": 238.195}], "trend": [], "mean": 226.3477, "unit": "ns", "stats": {"mean": "226.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "226.3 ns", "max": "226.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "226.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6151, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.5984, "ci_upper": 32.6334}], "trend": [], "mean": 32.6151, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6383, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6172, "ci_upper": 32.6624}], "trend": [], "mean": 32.6383, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/100edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.65, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6283, "ci_upper": 32.6753}], "trend": [], "mean": 32.65, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/10pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 67.8572, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.551, "ci_upper": 69.5635}], "trend": [], "mean": 67.8572, "unit": "ns", "stats": {"mean": "67.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "67.9 ns", "max": "67.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "67.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/1pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 63.9781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 63.8033, "ci_upper": 64.2524}], "trend": [], "mean": 63.9781, "unit": "ns", "stats": {"mean": "64.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.0 ns", "max": "64.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/5pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.2054, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 63.8661, "ci_upper": 64.703}], "trend": [], "mean": 64.2054, "unit": "ns", "stats": {"mean": "64.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.2 ns", "max": "64.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/1": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.5096}], "mean": 126.5096, "unit": "\u00b5s", "stats": {"mean": "126.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "126.51 \u00b5s", "max": "126.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "126.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/10": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.1122}], "mean": 121.1122, "unit": "\u00b5s", "stats": {"mean": "121.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.11 \u00b5s", "max": "121.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/20": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.2891}], "mean": 123.2891, "unit": "\u00b5s", "stats": {"mean": "123.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.29 \u00b5s", "max": "123.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/5": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.2502}], "mean": 119.2502, "unit": "\u00b5s", "stats": {"mean": "119.25 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.25 \u00b5s", "max": "119.25 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.25 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/50": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.0939}], "mean": 122.0939, "unit": "\u00b5s", "stats": {"mean": "122.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "122.09 \u00b5s", "max": "122.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "122.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.0222}], "mean": 21.0222, "unit": "\u00b5s", "stats": {"mean": "21.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.02 \u00b5s", "max": "21.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.5215}], "mean": 120.5215, "unit": "\u00b5s", "stats": {"mean": "120.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.52 \u00b5s", "max": "120.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.1745}], "mean": 313.1745, "unit": "\u00b5s", "stats": {"mean": "313.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "313.17 \u00b5s", "max": "313.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "313.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/500": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.0848}], "mean": 68.0848, "unit": "\u00b5s", "stats": {"mean": "68.08 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "68.08 \u00b5s", "max": "68.08 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "68.08 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/5000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.3192}], "mean": 242.3192, "unit": "\u00b5s", "stats": {"mean": "242.32 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "242.32 \u00b5s", "max": "242.32 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "242.32 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "labeled_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 465.9282, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 465.3658, "ci_upper": 466.5311}], "trend": [], "mean": 465.9282, "unit": "ns", "stats": {"mean": "465.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "465.9 ns", "max": "465.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "465.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "mixed_read_write_80_20": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5907, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 16.2077, "ci_upper": 16.9809}], "trend": [], "mean": 16.5907, "unit": "ms", "stats": {"mean": "16.59 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "16.59 ms", "max": "16.59 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "16.59 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "multiple_accesses/resolve_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.5674, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.5566, "ci_upper": 3.5799}], "trend": [], "mean": 3.5674, "unit": "\u00b5s", "stats": {"mean": "3.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.57 \u00b5s", "max": "3.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "node_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4332, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.241, "ci_upper": 4.5807}], "trend": [], "mean": 4.4332, "unit": "\u00b5s", "stats": {"mean": "4.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.43 \u00b5s", "max": "4.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "node_lookup": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.5994, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 64.3196, "ci_upper": 64.78}], "trend": [], "mean": 64.5994, "unit": "ns", "stats": {"mean": "64.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.6 ns", "max": "64.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "out_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 406.1903, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 404.2937, "ci_upper": 407.7134}], "trend": [], "mean": 406.1903, "unit": "ns", "stats": {"mean": "406.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "406.2 ns", "max": "406.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "406.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "point_in_time_queries/1000vectors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 30.1798, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 30.0786, "ci_upper": 30.2899}], "trend": [], "mean": 30.1798, "unit": "ns", "stats": {"mean": "30.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "30.2 ns", "max": "30.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "30.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "point_in_time_queries/100vectors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.3891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.3452, "ci_upper": 27.4405}], "trend": [], "mean": 27.3891, "unit": "ns", "stats": {"mean": "27.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.4 ns", "max": "27.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "property_lookup_vs_scan/find_nodes_by_property": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.0306, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 38.9559, "ci_upper": 39.0986}], "trend": [], "mean": 39.0306, "unit": "\u00b5s", "stats": {"mean": "39.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "39.03 \u00b5s", "max": "39.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "39.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "property_lookup_vs_scan/manual_label_scan_filter": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.2924, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 137.9873, "ci_upper": 138.6328}], "trend": [], "mean": 138.2924, "unit": "\u00b5s", "stats": {"mean": "138.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "138.29 \u00b5s", "max": "138.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "138.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_latency_p50_p99": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.7752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.0249, "ci_upper": 9.8609}], "trend": [], "mean": 8.7752, "unit": "ns", "stats": {"mean": "8.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.8 ns", "max": "8.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 339.2398}], "mean": 339.2398, "unit": "ns", "stats": {"mean": "339.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "339.2 ns", "max": "339.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "339.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/0": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4554}], "mean": 4.4554, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.6603}], "mean": 56.6603, "unit": "ms", "stats": {"mean": "56.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.66 ms", "max": "56.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114.751}], "mean": 114.751, "unit": "ms", "stats": {"mean": "114.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "114.75 ms", "max": "114.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "114.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "recovery/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.0642, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 459.8291, "ci_upper": 536.5218}], "trend": [], "mean": 500.0642, "unit": "\u00b5s", "stats": {"mean": "500.06 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "500.06 \u00b5s", "max": "500.06 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "500.06 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "recovery/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.0332, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 438.4822, "ci_upper": 494.3068}], "trend": [], "mean": 457.0332, "unit": "\u00b5s", "stats": {"mean": "457.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "457.03 \u00b5s", "max": "457.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "457.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "recovery/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.9167, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 646.4979, "ci_upper": 649.5903}], "trend": [], "mean": 647.9167, "unit": "\u00b5s", "stats": {"mean": "647.92 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "647.92 \u00b5s", "max": "647.92 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "647.92 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9001, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.1618, "ci_upper": 435.2252}], "trend": [], "mean": 431.9001, "unit": "ns", "stats": {"mean": "431.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "431.9 ns", "max": "431.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "431.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9392, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.5473, "ci_upper": 434.3479}], "trend": [], "mean": 431.9392, "unit": "ns", "stats": {"mean": "431.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "431.9 ns", "max": "431.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "431.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.1358, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.5471, "ci_upper": 431.8251}], "trend": [], "mean": 431.1358, "unit": "ns", "stats": {"mean": "431.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "431.1 ns", "max": "431.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "431.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/async": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 57.2811, "ci_upper": 72.114}], "trend": [], "mean": 65.065, "unit": "\u00b5s", "stats": {"mean": "65.06 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "65.06 \u00b5s", "max": "65.06 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "65.06 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/async_batched_aggressive": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5.0172, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.9949, "ci_upper": 5.0335}], "trend": [], "mean": 5.0172, "unit": "ms", "stats": {"mean": "5.02 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "5.02 ms", "max": "5.02 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "5.02 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/async_batched_default": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.1885, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1837, "ci_upper": 9.1937}], "trend": [], "mean": 9.1885, "unit": "ms", "stats": {"mean": "9.19 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.19 ms", "max": "9.19 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.19 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/group_commit_default": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.7552, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7436, "ci_upper": 2.7678}], "trend": [], "mean": 2.7552, "unit": "ms", "stats": {"mean": "2.76 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.76 ms", "max": "2.76 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.76 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/group_commit_fast": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.799, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.7768, "ci_upper": 1.8225}], "trend": [], "mean": 1.799, "unit": "ms", "stats": {"mean": "1.80 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.80 ms", "max": "1.80 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.80 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/synchronous": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.9769, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 563.8529, "ci_upper": 579.817}], "trend": [], "mean": 571.9769, "unit": "\u00b5s", "stats": {"mean": "571.98 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "571.98 \u00b5s", "max": "571.98 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "571.98 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/time_interval_1s": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 77.0748, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.0192, "ci_upper": 77.1398}], "trend": [], "mean": 77.0748, "unit": "ns", "stats": {"mean": "77.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "77.1 ns", "max": "77.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "77.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/transaction_interval_10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 24.1606, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 24.071, "ci_upper": 24.2429}], "trend": [], "mean": 24.1606, "unit": "\u00b5s", "stats": {"mean": "24.16 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "24.16 \u00b5s", "max": "24.16 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "24.16 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/transaction_interval_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.5038, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.4901, "ci_upper": 2.5173}], "trend": [], "mean": 2.5038, "unit": "\u00b5s", "stats": {"mean": "2.50 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.50 \u00b5s", "max": "2.50 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.50 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_access_single/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.5734, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.5592, "ci_upper": 35.59}], "trend": [], "mean": 35.5734, "unit": "ns", "stats": {"mean": "35.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.6 ns", "max": "35.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_access_single/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.8205, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.8061, "ci_upper": 21.8363}], "trend": [], "mean": 21.8205, "unit": "ns", "stats": {"mean": "21.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.8 ns", "max": "21.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_comparison/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.1669, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.7463, "ci_upper": 36.6306}], "trend": [], "mean": 36.1669, "unit": "ns", "stats": {"mean": "36.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.2 ns", "max": "36.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_comparison/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.1721, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 22.028, "ci_upper": 22.3815}], "trend": [], "mean": 22.1721, "unit": "ns", "stats": {"mean": "22.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.2 ns", "max": "22.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_length/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.5058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 36.2076, "ci_upper": 36.8017}], "trend": [], "mean": 36.5058, "unit": "ns", "stats": {"mean": "36.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.5 ns", "max": "36.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_length/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.0168, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.9521, "ci_upper": 22.09}], "trend": [], "mean": 22.0168, "unit": "ns", "stats": {"mean": "22.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.0 ns", "max": "22.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_10k_versions": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181.7438, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 180.8869, "ci_upper": 182.6944}], "trend": [], "mean": 181.7438, "unit": "ms", "stats": {"mean": "181.74 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "181.74 ms", "max": "181.74 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "181.74 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_10k_versions_fast_reference": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 455.09, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 454.13, "ci_upper": 456.0735}], "trend": [], "mean": 455.09, "unit": "ms", "stats": {"mean": "455.09 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "455.09 ms", "max": "455.09 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "455.09 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 269.4377, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 268.0299, "ci_upper": 271.0013}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 284.2773}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 271.5576}], "mean": 277.9174, "unit": "ns", "stats": {"mean": "277.9 ns", "std_dev": "6.0 ns", "cv": "2.2%", "min": "269.4 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "269.4 ns", "total_change": "-4.5%", "trend": "-4.5%", "count": 3}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 630.4888, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 627.7125, "ci_upper": 633.4295}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 806.5309}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 655.6376}], "mean": 731.0842, "unit": "\u00b5s", "stats": {"mean": "731.08 \u00b5s", "std_dev": "71.13 \u00b5s", "cv": "9.7%", "min": "630.49 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "630.49 \u00b5s", "total_change": "-19.3%", "trend": "-19.3%", "count": 3}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.5098, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 39.4579, "ci_upper": 39.5788}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 43.123}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.0259}], "mean": 41.5744, "unit": "ns", "stats": {"mean": "41.6 ns", "std_dev": "1.5 ns", "cv": "3.5%", "min": "39.5 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "39.5 ns", "total_change": "-7.3%", "trend": "-7.3%", "count": 3}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 272.3004, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 272.1219, "ci_upper": 272.4928}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 284.3073}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 274.0156}], "mean": 279.1614, "unit": "ns", "stats": {"mean": "279.2 ns", "std_dev": "4.9 ns", "cv": "1.7%", "min": "272.3 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "272.3 ns", "total_change": "-3.6%", "trend": "-3.6%", "count": 3}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 279.2666, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 270.6264, "ci_upper": 290.0937}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 274.4322}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 278.576}], "mean": 276.5041, "unit": "ns", "stats": {"mean": "276.5 ns", "std_dev": "2.0 ns", "cv": "0.7%", "min": "275.1 ns", "max": "279.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "279.3 ns", "total_change": "+1.5%", "trend": "+1.5%", "count": 3}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 274.4635, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 274.2626, "ci_upper": 274.6612}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 288.1864}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 276.424}], "mean": 282.3052, "unit": "ns", "stats": {"mean": "282.3 ns", "std_dev": "5.5 ns", "cv": "2.0%", "min": "274.5 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "274.5 ns", "total_change": "-4.1%", "trend": "-4.1%", "count": 3}}, "temporal_insert/append_only/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.5223}], "mean": 20.5223, "unit": "\u00b5s", "stats": {"mean": "20.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.52 \u00b5s", "max": "20.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.7516}], "mean": 210.7516, "unit": "\u00b5s", "stats": {"mean": "210.75 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "210.75 \u00b5s", "max": "210.75 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "210.75 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.1701}], "mean": 2.1701, "unit": "ms", "stats": {"mean": "2.17 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.17 ms", "max": "2.17 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.17 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.4722}], "mean": 147.4722, "unit": "\u00b5s", "stats": {"mean": "147.47 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "147.47 \u00b5s", "max": "147.47 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "147.47 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12.5487}], "mean": 12.5487, "unit": "ms", "stats": {"mean": "12.55 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "12.55 ms", "max": "12.55 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "12.55 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2868}], "mean": 1.2868, "unit": "s", "stats": {"mean": "1.287 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.287 s", "max": "1.287 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.287 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "time_travel/at_anchor_v20": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.9872, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.8817, "ci_upper": 124.109}], "trend": [], "mean": 123.9872, "unit": "ns", "stats": {"mean": "124.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "124.0 ns", "max": "124.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "124.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "time_travel/deep_history_v5": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 124.3222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 124.2538, "ci_upper": 124.4012}], "trend": [], "mean": 124.3222, "unit": "ns", "stats": {"mean": "124.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "124.3 ns", "max": "124.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "124.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "time_travel/with_deltas_v15": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.9411, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.8773, "ci_upper": 124.0033}], "trend": [], "mean": 123.9411, "unit": "ns", "stats": {"mean": "123.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.9 ns", "max": "123.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "time_travel/worst_case_v19": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 124.3814, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 124.3176, "ci_upper": 124.4393}], "trend": [], "mean": 124.3814, "unit": "ns", "stats": {"mean": "124.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "124.4 ns", "max": "124.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "124.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_power_law/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.6454, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 40.5756, "ci_upper": 40.7569}], "trend": [], "mean": 40.6454, "unit": "\u00b5s", "stats": {"mean": "40.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "40.65 \u00b5s", "max": "40.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "40.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_sparse/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2866, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2851, "ci_upper": 1.2882}], "trend": [], "mean": 1.2866, "unit": "\u00b5s", "stats": {"mean": "1.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.29 \u00b5s", "max": "1.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_uniform/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.8933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.8887, "ci_upper": 7.8985}], "trend": [], "mean": 7.8933, "unit": "\u00b5s", "stats": {"mean": "7.89 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.89 \u00b5s", "max": "7.89 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.89 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_power_law/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 47.5431, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 46.0216, "ci_upper": 48.9082}], "trend": [], "mean": 47.5431, "unit": "\u00b5s", "stats": {"mean": "47.54 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "47.54 \u00b5s", "max": "47.54 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "47.54 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_sparse/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2763, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2752, "ci_upper": 1.2775}], "trend": [], "mean": 1.2763, "unit": "\u00b5s", "stats": {"mean": "1.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.28 \u00b5s", "max": "1.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_uniform/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.124, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.1118, "ci_upper": 8.1406}], "trend": [], "mean": 8.124, "unit": "\u00b5s", "stats": {"mean": "8.12 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.12 \u00b5s", "max": "8.12 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.12 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/10000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.3551}], "mean": 22.3551, "unit": "\u00b5s", "stats": {"mean": "22.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.36 \u00b5s", "max": "22.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "valid_at_query/1000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.9012}], "mean": 3.9012, "unit": "\u00b5s", "stats": {"mean": "3.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.90 \u00b5s", "max": "3.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "valid_at_query/100_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5299}], "mean": 1.5299, "unit": "\u00b5s", "stats": {"mean": "1.53 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.53 \u00b5s", "max": "1.53 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.53 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "vector_batch_deserialize/retrieval_workload/100x1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.6376, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 36.5396, "ci_upper": 36.729}], "trend": [], "mean": 36.6376, "unit": "\u00b5s", "stats": {"mean": "36.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.64 \u00b5s", "max": "36.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_batch_serialize/rag_workload/100x1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.9863, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 22.8833, "ci_upper": 23.1147}], "trend": [], "mean": 22.9863, "unit": "\u00b5s", "stats": {"mean": "22.99 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.99 \u00b5s", "max": "22.99 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.99 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 54.6348, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 54.5623, "ci_upper": 54.718}], "trend": [], "mean": 54.6348, "unit": "ns", "stats": {"mean": "54.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "54.6 ns", "max": "54.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "54.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 55.4275, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 55.3586, "ci_upper": 55.5054}], "trend": [], "mean": 55.4275, "unit": "ns", "stats": {"mean": "55.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "55.4 ns", "max": "55.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "55.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/128": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 67.0515, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.955, "ci_upper": 67.1542}], "trend": [], "mean": 67.0515, "unit": "ns", "stats": {"mean": "67.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "67.1 ns", "max": "67.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "67.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 376.7175, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 373.5381, "ci_upper": 380.2115}], "trend": [], "mean": 376.7175, "unit": "ns", "stats": {"mean": "376.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "376.7 ns", "max": "376.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "376.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 751.7691, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 745.1252, "ci_upper": 758.7799}], "trend": [], "mean": 751.7691, "unit": "ns", "stats": {"mean": "751.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "751.8 ns", "max": "751.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "751.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 240.6619, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 239.0724, "ci_upper": 242.3761}], "trend": [], "mean": 240.6619, "unit": "ns", "stats": {"mean": "240.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "240.7 ns", "max": "240.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "240.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 281.7997, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 280.3144, "ci_upper": 283.402}], "trend": [], "mean": 281.7997, "unit": "ns", "stats": {"mean": "281.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "281.8 ns", "max": "281.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "281.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 613.6658, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 611.8239, "ci_upper": 615.3107}], "trend": [], "mean": 613.6658, "unit": "ns", "stats": {"mean": "613.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "613.7 ns", "max": "613.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "613.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.4334, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.4213, "ci_upper": 1.4449}], "trend": [], "mean": 1.4334, "unit": "\u00b5s", "stats": {"mean": "1.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.43 \u00b5s", "max": "1.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 384.864, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4977, "ci_upper": 386.9566}], "trend": [], "mean": 384.864, "unit": "ns", "stats": {"mean": "384.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "384.9 ns", "max": "384.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "384.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 427.7807, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 425.9115, "ci_upper": 429.4511}], "trend": [], "mean": 427.7807, "unit": "ns", "stats": {"mean": "427.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "427.8 ns", "max": "427.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "427.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.6736, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.6323, "ci_upper": 27.7247}], "trend": [], "mean": 27.6736, "unit": "ns", "stats": {"mean": "27.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.7 ns", "max": "27.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.1097, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.0881, "ci_upper": 27.132}], "trend": [], "mean": 27.1097, "unit": "ns", "stats": {"mean": "27.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.1 ns", "max": "27.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/128": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.7801, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.2233, "ci_upper": 35.393}], "trend": [], "mean": 34.7801, "unit": "ns", "stats": {"mean": "34.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.8 ns", "max": "34.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 173.4712, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 173.3446, "ci_upper": 173.6017}], "trend": [], "mean": 173.4712, "unit": "ns", "stats": {"mean": "173.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "173.5 ns", "max": "173.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "173.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 219.1664, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.124, "ci_upper": 220.383}], "trend": [], "mean": 219.1664, "unit": "ns", "stats": {"mean": "219.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "219.2 ns", "max": "219.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "219.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 134.5591, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 134.4308, "ci_upper": 134.7104}], "trend": [], "mean": 134.5591, "unit": "ns", "stats": {"mean": "134.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "134.6 ns", "max": "134.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "134.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.5553, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 128.5746, "ci_upper": 139.648}], "trend": [], "mean": 133.5553, "unit": "ns", "stats": {"mean": "133.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.6 ns", "max": "133.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181.317, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.2098, "ci_upper": 181.4454}], "trend": [], "mean": 181.317, "unit": "ns", "stats": {"mean": "181.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "181.3 ns", "max": "181.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "181.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.6943, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.4263, "ci_upper": 120.0107}], "trend": [], "mean": 119.6943, "unit": "ns", "stats": {"mean": "119.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.7 ns", "max": "119.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.5379, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 141.407, "ci_upper": 141.6805}], "trend": [], "mean": 141.5379, "unit": "ns", "stats": {"mean": "141.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "141.5 ns", "max": "141.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "141.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "write_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 462.4375}], "mean": 462.4375, "unit": "ns", "stats": {"mean": "462.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "462.4 ns", "max": "462.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "462.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}};
 
 const overlays = { trend: true, mean: true, ci: false };
 const charts = {};

--- a/benchmarks/timeseries.html
+++ b/benchmarks/timeseries.html
@@ -397,7 +397,141 @@
     <div class="sidebar-sub">timeseries dashboard</div>
   </div>
   <div class="sidebar-nav">
-    <div class="nav-group-label">target_3_hop</div>
+    <div class="nav-group-label">ungrouped</div>
+<a class="nav-item" href="#bench-closure_write_single_node" data-bench="closure_write_single_node">
+  <span class="nav-bench-name">closure_write_single_node</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-read_transaction_creation" data-bench="read_transaction_creation">
+  <span class="nav-bench-name">read_transaction_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-write_transaction_creation" data-bench="write_transaction_creation">
+  <span class="nav-bench-name">write_transaction_creation</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">concurrent_reads_same_entity</div>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--10000_versions--2_readers" data-bench="concurrent_reads_same_entity--10000_versions--2_readers">
+  <span class="nav-bench-name">2_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--10000_versions--4_readers" data-bench="concurrent_reads_same_entity--10000_versions--4_readers">
+  <span class="nav-bench-name">4_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--1000_versions--16_readers" data-bench="concurrent_reads_same_entity--1000_versions--16_readers">
+  <span class="nav-bench-name">16_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--1000_versions--2_readers" data-bench="concurrent_reads_same_entity--1000_versions--2_readers">
+  <span class="nav-bench-name">2_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--1000_versions--4_readers" data-bench="concurrent_reads_same_entity--1000_versions--4_readers">
+  <span class="nav-bench-name">4_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--1000_versions--8_readers" data-bench="concurrent_reads_same_entity--1000_versions--8_readers">
+  <span class="nav-bench-name">8_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--100_versions--16_readers" data-bench="concurrent_reads_same_entity--100_versions--16_readers">
+  <span class="nav-bench-name">16_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--100_versions--2_readers" data-bench="concurrent_reads_same_entity--100_versions--2_readers">
+  <span class="nav-bench-name">2_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--100_versions--4_readers" data-bench="concurrent_reads_same_entity--100_versions--4_readers">
+  <span class="nav-bench-name">4_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_reads_same_entity--100_versions--8_readers" data-bench="concurrent_reads_same_entity--100_versions--8_readers">
+  <span class="nav-bench-name">8_readers</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">concurrent_writes</div>
+<a class="nav-item" href="#bench-concurrent_writes--different_entities--2" data-bench="concurrent_writes--different_entities--2">
+  <span class="nav-bench-name">2</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_writes--different_entities--4" data-bench="concurrent_writes--different_entities--4">
+  <span class="nav-bench-name">4</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_writes--different_entities--8" data-bench="concurrent_writes--different_entities--8">
+  <span class="nav-bench-name">8</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_writes--same_entity_contention--2" data-bench="concurrent_writes--same_entity_contention--2">
+  <span class="nav-bench-name">2</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_writes--same_entity_contention--4" data-bench="concurrent_writes--same_entity_contention--4">
+  <span class="nav-bench-name">4</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-concurrent_writes--same_entity_contention--8" data-bench="concurrent_writes--same_entity_contention--8">
+  <span class="nav-bench-name">8</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">knn_search</div>
+<a class="nav-item" href="#bench-knn_search--k--1" data-bench="knn_search--k--1">
+  <span class="nav-bench-name">1</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search--k--10" data-bench="knn_search--k--10">
+  <span class="nav-bench-name">10</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search--k--20" data-bench="knn_search--k--20">
+  <span class="nav-bench-name">20</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search--k--5" data-bench="knn_search--k--5">
+  <span class="nav-bench-name">5</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search--k--50" data-bench="knn_search--k--50">
+  <span class="nav-bench-name">50</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">knn_search_index_size</div>
+<a class="nav-item" href="#bench-knn_search_index_size--index_size--100" data-bench="knn_search_index_size--index_size--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search_index_size--index_size--1000" data-bench="knn_search_index_size--index_size--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search_index_size--index_size--10000" data-bench="knn_search_index_size--index_size--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search_index_size--index_size--500" data-bench="knn_search_index_size--index_size--500">
+  <span class="nav-bench-name">500</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-knn_search_index_size--index_size--5000" data-bench="knn_search_index_size--index_size--5000">
+  <span class="nav-bench-name">5000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">read_under_write_contention</div>
+<a class="nav-item" href="#bench-read_under_write_contention--concurrent_writers--0" data-bench="read_under_write_contention--concurrent_writers--0">
+  <span class="nav-bench-name">0</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-read_under_write_contention--concurrent_writers--2" data-bench="read_under_write_contention--concurrent_writers--2">
+  <span class="nav-bench-name">2</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-read_under_write_contention--concurrent_writers--4" data-bench="read_under_write_contention--concurrent_writers--4">
+  <span class="nav-bench-name">4</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">target_3_hop</div>
 <a class="nav-item" href="#bench-target_3_hop--traverse_three_hops" data-bench="target_3_hop--traverse_three_hops">
   <span class="nav-bench-name">traverse_three_hops</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
@@ -425,6 +559,44 @@
   <span class="nav-bench-name">worst_case_9_deltas</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
+<div class="nav-group-label">temporal_insert</div>
+<a class="nav-item" href="#bench-temporal_insert--append_only--100" data-bench="temporal_insert--append_only--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-temporal_insert--append_only--1000" data-bench="temporal_insert--append_only--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-temporal_insert--append_only--10000" data-bench="temporal_insert--append_only--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-temporal_insert--retroactive--100" data-bench="temporal_insert--retroactive--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-temporal_insert--retroactive--1000" data-bench="temporal_insert--retroactive--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-temporal_insert--retroactive--10000" data-bench="temporal_insert--retroactive--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<div class="nav-group-label">valid_at_query</div>
+<a class="nav-item" href="#bench-valid_at_query--10000_versions" data-bench="valid_at_query--10000_versions">
+  <span class="nav-bench-name">10000_versions</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-valid_at_query--1000_versions" data-bench="valid_at_query--1000_versions">
+  <span class="nav-bench-name">1000_versions</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-valid_at_query--100_versions" data-bench="valid_at_query--100_versions">
+  <span class="nav-bench-name">100_versions</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
 
   </div>
 </nav>
@@ -434,19 +606,19 @@
   <div class="page-header">
     <h1>Performance Timeseries</h1>
     <div class="page-meta">
-      <span><span class="label">runs</span> 1</span>
-      <span><span class="label">benchmarks</span> 6</span>
-      <span><span class="label">generated</span> 2026-02-21 18:08 UTC</span>
+      <span><span class="label">runs</span> 2</span>
+      <span><span class="label">benchmarks</span> 47</span>
+      <span><span class="label">generated</span> 2026-02-21 18:57 UTC</span>
     </div>
   </div>
 
   <div class="overview-row">
     <div class="overview-card">
-      <div class="overview-value">1</div>
+      <div class="overview-value">2</div>
       <div class="overview-label">Total Runs</div>
     </div>
     <div class="overview-card">
-      <div class="overview-value">6</div>
+      <div class="overview-value">47</div>
       <div class="overview-label">Benchmarks</div>
     </div>
     <div class="overview-card">
@@ -471,6 +643,1126 @@
   </div>
 
 
+<section class="bench-section" id="bench-closure_write_single_node" data-bench-name="closure_write_single_node">
+  <div class="bench-header">
+    <h2 class="bench-title">closure_write_single_node</h2>
+    <div class="bench-latest">2.81 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.81 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.81 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.81 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-closure_write_single_node" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-read_transaction_creation" data-bench-name="read_transaction_creation">
+  <div class="bench-header">
+    <h2 class="bench-title">read_transaction_creation</h2>
+    <div class="bench-latest">339.2 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">339.2 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">339.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">339.2 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-read_transaction_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-write_transaction_creation" data-bench-name="write_transaction_creation">
+  <div class="bench-header">
+    <h2 class="bench-title">write_transaction_creation</h2>
+    <div class="bench-latest">462.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">462.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">462.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">462.4 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-write_transaction_creation" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--10000_versions--2_readers" data-bench-name="concurrent_reads_same_entity/10000_versions/2_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/10000_versions/2_readers</h2>
+    <div class="bench-latest">133.88 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">133.88 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">133.88 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">133.88 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--10000_versions--2_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--10000_versions--4_readers" data-bench-name="concurrent_reads_same_entity/10000_versions/4_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/10000_versions/4_readers</h2>
+    <div class="bench-latest">474.74 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">474.74 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">474.74 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">474.74 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--10000_versions--4_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--1000_versions--16_readers" data-bench-name="concurrent_reads_same_entity/1000_versions/16_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/1000_versions/16_readers</h2>
+    <div class="bench-latest">767.65 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">767.65 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">767.65 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">767.65 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--1000_versions--16_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--1000_versions--2_readers" data-bench-name="concurrent_reads_same_entity/1000_versions/2_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/1000_versions/2_readers</h2>
+    <div class="bench-latest">130.10 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">130.10 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">130.10 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">130.10 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--1000_versions--2_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--1000_versions--4_readers" data-bench-name="concurrent_reads_same_entity/1000_versions/4_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/1000_versions/4_readers</h2>
+    <div class="bench-latest">220.64 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">220.64 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">220.64 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">220.64 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--1000_versions--4_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--1000_versions--8_readers" data-bench-name="concurrent_reads_same_entity/1000_versions/8_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/1000_versions/8_readers</h2>
+    <div class="bench-latest">422.91 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">422.91 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">422.91 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">422.91 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--1000_versions--8_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--100_versions--16_readers" data-bench-name="concurrent_reads_same_entity/100_versions/16_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/100_versions/16_readers</h2>
+    <div class="bench-latest">696.72 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">696.72 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">696.72 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">696.72 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--100_versions--16_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--100_versions--2_readers" data-bench-name="concurrent_reads_same_entity/100_versions/2_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/100_versions/2_readers</h2>
+    <div class="bench-latest">130.26 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">130.26 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">130.26 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">130.26 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--100_versions--2_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--100_versions--4_readers" data-bench-name="concurrent_reads_same_entity/100_versions/4_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/100_versions/4_readers</h2>
+    <div class="bench-latest">203.70 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">203.70 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">203.70 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">203.70 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--100_versions--4_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_reads_same_entity--100_versions--8_readers" data-bench-name="concurrent_reads_same_entity/100_versions/8_readers">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_reads_same_entity/100_versions/8_readers</h2>
+    <div class="bench-latest">383.87 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">383.87 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">383.87 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">383.87 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_reads_same_entity--100_versions--8_readers" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_writes--different_entities--2" data-bench-name="concurrent_writes/different_entities/2">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_writes/different_entities/2</h2>
+    <div class="bench-latest">139.71 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">139.71 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">139.71 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">139.71 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_writes--different_entities--2" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_writes--different_entities--4" data-bench-name="concurrent_writes/different_entities/4">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_writes/different_entities/4</h2>
+    <div class="bench-latest">220.01 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">220.01 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">220.01 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">220.01 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_writes--different_entities--4" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_writes--different_entities--8" data-bench-name="concurrent_writes/different_entities/8">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_writes/different_entities/8</h2>
+    <div class="bench-latest">417.36 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">417.36 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">417.36 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">417.36 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_writes--different_entities--8" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_writes--same_entity_contention--2" data-bench-name="concurrent_writes/same_entity_contention/2">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_writes/same_entity_contention/2</h2>
+    <div class="bench-latest">214.57 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">214.57 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">214.57 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">214.57 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_writes--same_entity_contention--2" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_writes--same_entity_contention--4" data-bench-name="concurrent_writes/same_entity_contention/4">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_writes/same_entity_contention/4</h2>
+    <div class="bench-latest">1.23 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.23 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.23 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.23 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_writes--same_entity_contention--4" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-concurrent_writes--same_entity_contention--8" data-bench-name="concurrent_writes/same_entity_contention/8">
+  <div class="bench-header">
+    <h2 class="bench-title">concurrent_writes/same_entity_contention/8</h2>
+    <div class="bench-latest">9.48 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">9.48 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">9.48 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">9.48 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-concurrent_writes--same_entity_contention--8" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search--k--1" data-bench-name="knn_search/k/1">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search/k/1</h2>
+    <div class="bench-latest">126.51 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">126.51 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">126.51 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">126.51 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search--k--1" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search--k--10" data-bench-name="knn_search/k/10">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search/k/10</h2>
+    <div class="bench-latest">121.11 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">121.11 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">121.11 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">121.11 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search--k--10" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search--k--20" data-bench-name="knn_search/k/20">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search/k/20</h2>
+    <div class="bench-latest">123.29 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">123.29 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">123.29 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">123.29 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search--k--20" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search--k--5" data-bench-name="knn_search/k/5">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search/k/5</h2>
+    <div class="bench-latest">119.25 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">119.25 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">119.25 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">119.25 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search--k--5" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search--k--50" data-bench-name="knn_search/k/50">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search/k/50</h2>
+    <div class="bench-latest">122.09 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">122.09 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">122.09 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">122.09 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search--k--50" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search_index_size--index_size--100" data-bench-name="knn_search_index_size/index_size/100">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search_index_size/index_size/100</h2>
+    <div class="bench-latest">21.02 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">21.02 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">21.02 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">21.02 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search_index_size--index_size--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search_index_size--index_size--1000" data-bench-name="knn_search_index_size/index_size/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search_index_size/index_size/1000</h2>
+    <div class="bench-latest">120.52 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">120.52 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">120.52 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">120.52 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search_index_size--index_size--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search_index_size--index_size--10000" data-bench-name="knn_search_index_size/index_size/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search_index_size/index_size/10000</h2>
+    <div class="bench-latest">313.17 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">313.17 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">313.17 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">313.17 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search_index_size--index_size--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search_index_size--index_size--500" data-bench-name="knn_search_index_size/index_size/500">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search_index_size/index_size/500</h2>
+    <div class="bench-latest">68.08 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">68.08 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">68.08 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">68.08 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search_index_size--index_size--500" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-knn_search_index_size--index_size--5000" data-bench-name="knn_search_index_size/index_size/5000">
+  <div class="bench-header">
+    <h2 class="bench-title">knn_search_index_size/index_size/5000</h2>
+    <div class="bench-latest">242.32 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">242.32 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">242.32 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">242.32 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-knn_search_index_size--index_size--5000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-read_under_write_contention--concurrent_writers--0" data-bench-name="read_under_write_contention/concurrent_writers/0">
+  <div class="bench-header">
+    <h2 class="bench-title">read_under_write_contention/concurrent_writers/0</h2>
+    <div class="bench-latest">4.46 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">4.46 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">4.46 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">4.46 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-read_under_write_contention--concurrent_writers--0" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-read_under_write_contention--concurrent_writers--2" data-bench-name="read_under_write_contention/concurrent_writers/2">
+  <div class="bench-header">
+    <h2 class="bench-title">read_under_write_contention/concurrent_writers/2</h2>
+    <div class="bench-latest">56.66 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">56.66 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">56.66 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">56.66 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-read_under_write_contention--concurrent_writers--2" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-read_under_write_contention--concurrent_writers--4" data-bench-name="read_under_write_contention/concurrent_writers/4">
+  <div class="bench-header">
+    <h2 class="bench-title">read_under_write_contention/concurrent_writers/4</h2>
+    <div class="bench-latest">114.75 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">114.75 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">114.75 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">114.75 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-read_under_write_contention--concurrent_writers--4" height="260"></canvas>
+  </div>
+</section>
 <section class="bench-section" id="bench-target_3_hop--traverse_three_hops" data-bench-name="target_3_hop/traverse_three_hops">
   <div class="bench-header">
     <h2 class="bench-title">target_3_hop/traverse_three_hops</h2>
@@ -681,6 +1973,321 @@
     <canvas id="chart-target_time_travel--worst_case_9_deltas" height="260"></canvas>
   </div>
 </section>
+<section class="bench-section" id="bench-temporal_insert--append_only--100" data-bench-name="temporal_insert/append_only/100">
+  <div class="bench-header">
+    <h2 class="bench-title">temporal_insert/append_only/100</h2>
+    <div class="bench-latest">20.52 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">20.52 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">20.52 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">20.52 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-temporal_insert--append_only--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-temporal_insert--append_only--1000" data-bench-name="temporal_insert/append_only/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">temporal_insert/append_only/1000</h2>
+    <div class="bench-latest">210.75 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">210.75 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">210.75 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">210.75 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-temporal_insert--append_only--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-temporal_insert--append_only--10000" data-bench-name="temporal_insert/append_only/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">temporal_insert/append_only/10000</h2>
+    <div class="bench-latest">2.17 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">2.17 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">2.17 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">2.17 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-temporal_insert--append_only--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-temporal_insert--retroactive--100" data-bench-name="temporal_insert/retroactive/100">
+  <div class="bench-header">
+    <h2 class="bench-title">temporal_insert/retroactive/100</h2>
+    <div class="bench-latest">147.47 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">147.47 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">147.47 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">147.47 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-temporal_insert--retroactive--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-temporal_insert--retroactive--1000" data-bench-name="temporal_insert/retroactive/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">temporal_insert/retroactive/1000</h2>
+    <div class="bench-latest">12.55 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">12.55 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">12.55 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">12.55 ms <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-temporal_insert--retroactive--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-temporal_insert--retroactive--10000" data-bench-name="temporal_insert/retroactive/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">temporal_insert/retroactive/10000</h2>
+    <div class="bench-latest">1.287 s</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.287 s</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.287 s <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.287 s <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-temporal_insert--retroactive--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-valid_at_query--10000_versions" data-bench-name="valid_at_query/10000_versions">
+  <div class="bench-header">
+    <h2 class="bench-title">valid_at_query/10000_versions</h2>
+    <div class="bench-latest">22.36 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">22.36 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">22.36 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">22.36 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-valid_at_query--10000_versions" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-valid_at_query--1000_versions" data-bench-name="valid_at_query/1000_versions">
+  <div class="bench-header">
+    <h2 class="bench-title">valid_at_query/1000_versions</h2>
+    <div class="bench-latest">3.90 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">3.90 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">3.90 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">3.90 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-valid_at_query--1000_versions" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-valid_at_query--100_versions" data-bench-name="valid_at_query/100_versions">
+  <div class="bench-header">
+    <h2 class="bench-title">valid_at_query/100_versions</h2>
+    <div class="bench-latest">1.53 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.53 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.53 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.53 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-valid_at_query--100_versions" height="260"></canvas>
+  </div>
+</section>
 
   <footer>
     Chronos — The Temporal Benchkeeper &nbsp;·&nbsp; Timeseries Dashboard
@@ -688,7 +2295,7 @@
 </main>
 
 <script>
-const CONFIGS = {"target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}], "trend": [], "mean": 282.1573, "unit": "ns", "stats": {"mean": "282.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.2 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}], "trend": [], "mean": 781.382, "unit": "\u00b5s", "stats": {"mean": "781.38 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "781.38 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "781.38 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}], "trend": [], "mean": 42.6068, "unit": "ns", "stats": {"mean": "42.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "42.6 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "42.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}], "trend": [], "mean": 282.592, "unit": "ns", "stats": {"mean": "282.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.6 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}], "trend": [], "mean": 275.1228, "unit": "ns", "stats": {"mean": "275.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "275.1 ns", "max": "275.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "275.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}], "trend": [], "mean": 286.226, "unit": "ns", "stats": {"mean": "286.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "286.2 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "286.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}};
+const CONFIGS = {"closure_write_single_node": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}], "trend": [], "mean": 2.8058, "unit": "ms", "stats": {"mean": "2.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.81 ms", "max": "2.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/10000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}], "trend": [], "mean": 133.8781, "unit": "\u00b5s", "stats": {"mean": "133.88 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.88 \u00b5s", "max": "133.88 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.88 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/10000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}], "trend": [], "mean": 474.7407, "unit": "\u00b5s", "stats": {"mean": "474.74 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "474.74 \u00b5s", "max": "474.74 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "474.74 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}], "trend": [], "mean": 767.6457, "unit": "\u00b5s", "stats": {"mean": "767.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "767.65 \u00b5s", "max": "767.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "767.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}], "trend": [], "mean": 130.1031, "unit": "\u00b5s", "stats": {"mean": "130.10 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.10 \u00b5s", "max": "130.10 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.10 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}], "trend": [], "mean": 220.6437, "unit": "\u00b5s", "stats": {"mean": "220.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.64 \u00b5s", "max": "220.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/1000_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}], "trend": [], "mean": 422.9052, "unit": "\u00b5s", "stats": {"mean": "422.91 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "422.91 \u00b5s", "max": "422.91 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "422.91 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}], "trend": [], "mean": 696.7185, "unit": "\u00b5s", "stats": {"mean": "696.72 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "696.72 \u00b5s", "max": "696.72 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "696.72 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}], "trend": [], "mean": 130.2643, "unit": "\u00b5s", "stats": {"mean": "130.26 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.26 \u00b5s", "max": "130.26 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.26 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}], "trend": [], "mean": 203.7032, "unit": "\u00b5s", "stats": {"mean": "203.70 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "203.70 \u00b5s", "max": "203.70 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "203.70 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/100_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}], "trend": [], "mean": 383.8675, "unit": "\u00b5s", "stats": {"mean": "383.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "383.87 \u00b5s", "max": "383.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "383.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/different_entities/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}], "trend": [], "mean": 139.7069, "unit": "\u00b5s", "stats": {"mean": "139.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "139.71 \u00b5s", "max": "139.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "139.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/different_entities/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}], "trend": [], "mean": 220.0149, "unit": "\u00b5s", "stats": {"mean": "220.01 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.01 \u00b5s", "max": "220.01 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.01 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/different_entities/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}], "trend": [], "mean": 417.3599, "unit": "\u00b5s", "stats": {"mean": "417.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "417.36 \u00b5s", "max": "417.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "417.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/same_entity_contention/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}], "trend": [], "mean": 214.5742, "unit": "\u00b5s", "stats": {"mean": "214.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "214.57 \u00b5s", "max": "214.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "214.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/same_entity_contention/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}], "trend": [], "mean": 1.2257, "unit": "ms", "stats": {"mean": "1.23 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.23 ms", "max": "1.23 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.23 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_writes/same_entity_contention/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}], "trend": [], "mean": 9.4764, "unit": "ms", "stats": {"mean": "9.48 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.48 ms", "max": "9.48 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.48 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/1": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}], "trend": [], "mean": 126.5096, "unit": "\u00b5s", "stats": {"mean": "126.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "126.51 \u00b5s", "max": "126.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "126.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/10": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}], "trend": [], "mean": 121.1122, "unit": "\u00b5s", "stats": {"mean": "121.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.11 \u00b5s", "max": "121.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/20": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}], "trend": [], "mean": 123.2891, "unit": "\u00b5s", "stats": {"mean": "123.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.29 \u00b5s", "max": "123.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/5": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}], "trend": [], "mean": 119.2502, "unit": "\u00b5s", "stats": {"mean": "119.25 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.25 \u00b5s", "max": "119.25 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.25 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/50": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}], "trend": [], "mean": 122.0939, "unit": "\u00b5s", "stats": {"mean": "122.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "122.09 \u00b5s", "max": "122.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "122.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}], "trend": [], "mean": 21.0222, "unit": "\u00b5s", "stats": {"mean": "21.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.02 \u00b5s", "max": "21.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}], "trend": [], "mean": 120.5215, "unit": "\u00b5s", "stats": {"mean": "120.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.52 \u00b5s", "max": "120.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}], "trend": [], "mean": 313.1745, "unit": "\u00b5s", "stats": {"mean": "313.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "313.17 \u00b5s", "max": "313.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "313.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/500": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}], "trend": [], "mean": 68.0848, "unit": "\u00b5s", "stats": {"mean": "68.08 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "68.08 \u00b5s", "max": "68.08 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "68.08 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search_index_size/index_size/5000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}], "trend": [], "mean": 242.3192, "unit": "\u00b5s", "stats": {"mean": "242.32 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "242.32 \u00b5s", "max": "242.32 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "242.32 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}], "trend": [], "mean": 339.2398, "unit": "ns", "stats": {"mean": "339.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "339.2 ns", "max": "339.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "339.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_under_write_contention/concurrent_writers/0": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}], "trend": [], "mean": 4.4554, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_under_write_contention/concurrent_writers/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}], "trend": [], "mean": 56.6603, "unit": "ms", "stats": {"mean": "56.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.66 ms", "max": "56.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_under_write_contention/concurrent_writers/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}], "trend": [], "mean": 114.751, "unit": "ms", "stats": {"mean": "114.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "114.75 ms", "max": "114.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "114.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573}], "mean": 282.1573, "unit": "ns", "stats": {"mean": "282.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.2 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382}], "mean": 781.382, "unit": "\u00b5s", "stats": {"mean": "781.38 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "781.38 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "781.38 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068}], "mean": 42.6068, "unit": "ns", "stats": {"mean": "42.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "42.6 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "42.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592}], "mean": 282.592, "unit": "ns", "stats": {"mean": "282.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "282.6 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "282.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228}], "mean": 275.1228, "unit": "ns", "stats": {"mean": "275.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "275.1 ns", "max": "275.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "275.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226}], "mean": 286.226, "unit": "ns", "stats": {"mean": "286.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "286.2 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "286.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}], "trend": [], "mean": 20.5223, "unit": "\u00b5s", "stats": {"mean": "20.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.52 \u00b5s", "max": "20.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/append_only/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}], "trend": [], "mean": 210.7516, "unit": "\u00b5s", "stats": {"mean": "210.75 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "210.75 \u00b5s", "max": "210.75 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "210.75 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/append_only/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}], "trend": [], "mean": 2.1701, "unit": "ms", "stats": {"mean": "2.17 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.17 ms", "max": "2.17 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.17 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/retroactive/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}], "trend": [], "mean": 147.4722, "unit": "\u00b5s", "stats": {"mean": "147.47 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "147.47 \u00b5s", "max": "147.47 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "147.47 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/retroactive/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}], "trend": [], "mean": 12.5487, "unit": "ms", "stats": {"mean": "12.55 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "12.55 ms", "max": "12.55 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "12.55 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "temporal_insert/retroactive/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}], "trend": [], "mean": 1.2868, "unit": "s", "stats": {"mean": "1.287 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.287 s", "max": "1.287 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.287 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/10000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}], "trend": [], "mean": 22.3551, "unit": "\u00b5s", "stats": {"mean": "22.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.36 \u00b5s", "max": "22.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/1000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}], "trend": [], "mean": 3.9012, "unit": "\u00b5s", "stats": {"mean": "3.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.90 \u00b5s", "max": "3.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/100_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}], "trend": [], "mean": 1.5299, "unit": "\u00b5s", "stats": {"mean": "1.53 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.53 \u00b5s", "max": "1.53 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.53 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "write_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}], "trend": [], "mean": 462.4375, "unit": "ns", "stats": {"mean": "462.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "462.4 ns", "max": "462.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "462.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}};
 
 const overlays = { trend: true, mean: true, ci: false };
 const charts = {};


### PR DESCRIPTION
Benchmark results for commit 198c57d:

- target_3_hop/traverse_three_hops: 282.2 ns (NEW)
- target_batch_insertion/insert_1000_edges: 781.38 µs (NEW)
- target_single_hop/traverse_one_hop: 42.6 ns (NEW)
- target_time_travel/at_anchor: 282.6 ns (NEW)
- target_time_travel/with_5_deltas: 275.1 ns (NEW)
- target_time_travel/worst_case_9_deltas: 286.2 ns (NEW)

Artifacts generated:
- benchmarks/history.json
- benchmarks/report.html
- benchmarks/timeseries.html

---
*PR created automatically by Jules for task [3069904928789557752](https://jules.google.com/task/3069904928789557752) started by @madmax983*