### PR TITLE
Sentinel: Harden TimeRange::close_at validation

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1695,10 +1695,7 @@ mod sentry_tests {
         let result = range.close_at(invalid_end);
 
         assert!(
-            matches!(
-                result,
-                Err(TemporalError::InvalidTimestamp { .. })
-            ),
+            matches!(result, Err(TemporalError::InvalidTimestamp { .. })),
             "close_at should reject invalid timestamps"
         );
     }

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -85,29 +85,24 @@ impl TimeRange {
             return Err(TemporalError::InvalidTimeRange { start, end });
         }
 
-        // Warden: Validate that timestamps don't exceed MAX_VALID_TIMESTAMP
-        // This prevents invalid timestamps from entering via unchecked constructors
-        if start.wallclock() > MAX_VALID_TIMESTAMP && start != TIMESTAMP_MAX {
-            return Err(TemporalError::InvalidTimestamp {
-                timestamp: start,
-                reason: format!(
-                    "Start timestamp exceeds MAX_VALID_TIMESTAMP ({})",
-                    MAX_VALID_TIMESTAMP
-                ),
-            });
-        }
-
-        if end.wallclock() > MAX_VALID_TIMESTAMP && end != TIMESTAMP_MAX {
-            return Err(TemporalError::InvalidTimestamp {
-                timestamp: end,
-                reason: format!(
-                    "End timestamp exceeds MAX_VALID_TIMESTAMP ({})",
-                    MAX_VALID_TIMESTAMP
-                ),
-            });
-        }
+        Self::validate_timestamp(start, "Start")?;
+        Self::validate_timestamp(end, "End")?;
 
         Ok(TimeRange { start, end })
+    }
+
+    /// Validate that a timestamp doesn't exceed MAX_VALID_TIMESTAMP (unless it's TIMESTAMP_MAX).
+    fn validate_timestamp(timestamp: Timestamp, name: &str) -> Result<(), TemporalError> {
+        if timestamp.wallclock() > MAX_VALID_TIMESTAMP && timestamp != TIMESTAMP_MAX {
+            return Err(TemporalError::InvalidTimestamp {
+                timestamp,
+                reason: format!(
+                    "{} timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                    name, MAX_VALID_TIMESTAMP
+                ),
+            });
+        }
+        Ok(())
     }
 
     /// Create a time range that starts at the given timestamp and is still current.
@@ -205,15 +200,7 @@ impl TimeRange {
             });
         }
 
-        if end.wallclock() > MAX_VALID_TIMESTAMP && end != TIMESTAMP_MAX {
-            return Err(TemporalError::InvalidTimestamp {
-                timestamp: end,
-                reason: format!(
-                    "End timestamp exceeds MAX_VALID_TIMESTAMP ({})",
-                    MAX_VALID_TIMESTAMP
-                ),
-            });
-        }
+        Self::validate_timestamp(end, "End")?;
 
         Ok(TimeRange {
             start: self.start,
@@ -1707,10 +1694,12 @@ mod sentry_tests {
 
         let result = range.close_at(invalid_end);
 
-        assert!(result.is_err(), "close_at should reject invalid timestamps");
-        assert!(matches!(
-            result.unwrap_err(),
-            TemporalError::InvalidTimestamp { .. }
-        ));
+        assert!(
+            matches!(
+                result,
+                Err(TemporalError::InvalidTimestamp { .. })
+            ),
+            "close_at should reject invalid timestamps"
+        );
     }
 }

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -204,6 +204,17 @@ impl TimeRange {
                 end,
             });
         }
+
+        if end.wallclock() > MAX_VALID_TIMESTAMP && end != TIMESTAMP_MAX {
+            return Err(TemporalError::InvalidTimestamp {
+                timestamp: end,
+                reason: format!(
+                    "End timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                    MAX_VALID_TIMESTAMP
+                ),
+            });
+        }
+
         Ok(TimeRange {
             start: self.start,
             end,
@@ -1681,5 +1692,25 @@ mod sentry_tests {
             outer.contains_range(&same_range),
             "Should contain itself (reflexive)"
         );
+    }
+
+    #[test]
+    fn test_sentry_close_at_rejects_invalid_timestamps() {
+        // 🛡️ Sentry Test: Verify close_at rejects timestamps exceeding MAX_VALID_TIMESTAMP.
+        // This mirrors the validation in TimeRange::new.
+
+        let start = HybridTimestamp::new(100, 0).unwrap();
+        let range = TimeRange::from(start);
+
+        // Invalid end (exceeds MAX_VALID_TIMESTAMP)
+        let invalid_end = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+
+        let result = range.close_at(invalid_end);
+
+        assert!(result.is_err(), "close_at should reject invalid timestamps");
+        assert!(matches!(
+            result.unwrap_err(),
+            TemporalError::InvalidTimestamp { .. }
+        ));
     }
 }


### PR DESCRIPTION
🤖 Sentinel: Harden `TimeRange::close_at` validation

**🧬 Mutants Found:** 
- Manual analysis revealed a gap in `TimeRange::close_at` validation compared to `TimeRange::new`.
- `cargo mutants` attempts timed out, but the gap was confirmed by code inspection and reproduction.

**🎯 Tests Added/Strengthened:**
- Added `test_sentry_close_at_rejects_invalid_timestamps` in `src/core/temporal.rs`.
- This test explicitly attempts to close a range with an invalid timestamp (created via `new_unchecked`) and asserts that it fails.

**⚠️ Suspected Bugs:**
- The inconsistency between `TimeRange::new` and `TimeRange::close_at` was a suspected bug/weakness. This PR fixes it.

**📊 Kill Rate:**
- The new test ensures that any future mutation removing this validation will be caught.


---
*PR created automatically by Jules for task [16946546000843945302](https://jules.google.com/task/16946546000843945302) started by @madmax983*