### PR TITLE
Harden adaptive overfetch concurrency and clock-skew test determinism

### DIFF
--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2418,6 +2418,7 @@ mod conflict_detection_tests {
 mod clock_skew_tests {
     use super::*;
     use crate::api::transaction::TxIdGenerator;
+    use crate::core::hlc::ClockSkewAutoHealTestGuard;
     use crate::core::property::PropertyMapBuilder;
     use crate::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
     use std::time::{Duration, Instant};
@@ -2515,6 +2516,7 @@ mod clock_skew_tests {
 
     #[test]
     fn test_clock_skew_backward_error() {
+        let _auto_heal_guard = ClockSkewAutoHealTestGuard::force(false);
         let harness = TestHarness::new();
         let mut tx = harness.create_tx();
 
@@ -2547,6 +2549,7 @@ mod clock_skew_tests {
 
     #[test]
     fn test_clock_skew_forward_error() {
+        let _auto_heal_guard = ClockSkewAutoHealTestGuard::force(false);
         let harness = TestHarness::new();
         let mut tx = harness.create_tx();
 
@@ -2578,6 +2581,7 @@ mod clock_skew_tests {
 
     #[test]
     fn test_clock_skew_failure_does_not_advance_observation_timestamp() {
+        let _auto_heal_guard = ClockSkewAutoHealTestGuard::force(false);
         let harness = TestHarness::new();
         let mut tx = harness.create_tx_with_shared_observation_clock();
 
@@ -2615,6 +2619,7 @@ mod clock_skew_tests {
 
     #[test]
     fn test_clock_skew_allows_idle_forward_drift_with_shared_observation_clock() {
+        let _auto_heal_guard = ClockSkewAutoHealTestGuard::force(false);
         let harness = TestHarness::new();
         let mut tx = harness.create_tx_with_shared_observation_clock();
 

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -7,6 +7,8 @@
 
 use crate::core::error::{StorageError, TemporalError};
 use crate::core::temporal::MAX_VALID_TIMESTAMP;
+#[cfg(test)]
+use std::cell::Cell;
 use std::sync::OnceLock;
 
 /// Hybrid Logical Clock timestamp combining wallclock and logical components.
@@ -37,10 +39,48 @@ pub const MAX_BACKWARD_DRIFT_US: i64 = 5 * 60 * 1_000_000;
 /// forward drift is measured against the last commit timestamp).
 pub const MAX_FORWARD_JUMP_US: i64 = 60 * 60 * 1_000_000;
 
+#[cfg(test)]
+thread_local! {
+    static CLOCK_SKEW_AUTO_HEAL_TEST_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+/// Test-only guard to force auto-heal behavior for the current thread.
+///
+/// This lets unit tests stay deterministic regardless of ambient process environment.
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct ClockSkewAutoHealTestGuard {
+    previous: Option<bool>,
+}
+
+#[cfg(test)]
+impl ClockSkewAutoHealTestGuard {
+    pub(crate) fn force(enabled: bool) -> Self {
+        let previous = CLOCK_SKEW_AUTO_HEAL_TEST_OVERRIDE.with(|cell| {
+            let prev = cell.get();
+            cell.set(Some(enabled));
+            prev
+        });
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ClockSkewAutoHealTestGuard {
+    fn drop(&mut self) {
+        CLOCK_SKEW_AUTO_HEAL_TEST_OVERRIDE.with(|cell| cell.set(self.previous));
+    }
+}
+
 /// Whether clock-skew self-healing is enabled via environment variable.
 ///
 /// Enabled values: `1`, `true`, `on`, `yes`, `enabled` (case-insensitive).
 pub fn is_clock_skew_self_heal_enabled() -> bool {
+    #[cfg(test)]
+    if let Some(forced) = CLOCK_SKEW_AUTO_HEAL_TEST_OVERRIDE.with(|cell| cell.get()) {
+        return forced;
+    }
+
     static CLOCK_SKEW_AUTO_HEAL: OnceLock<Option<bool>> = OnceLock::new();
     CLOCK_SKEW_AUTO_HEAL
         .get_or_init(|| {

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2136,19 +2136,33 @@ impl CurrentStorage {
             let label_id = GLOBAL_INTERNER.intern(label)?;
             let (candidates, stats) = self.calculate_adaptive_candidates(k, label);
 
-            let mut results = index.search_with_filter(query, candidates, |node_id| {
+            // Important: apply adaptive over-fetch exactly once.
+            //
+            // `search_with_filter` already performs its own iterative over-fetch expansion to satisfy
+            // the requested `k`. Passing our already-overfetched candidate count into that API causes
+            // redundant expansion under contention. Instead, fetch `candidates` once and filter locally.
+            let candidate_results = index.search(query, candidates)?;
+            let candidate_count = candidate_results.len();
+            let mut results = Vec::with_capacity(candidate_count);
+
+            for (node_id, similarity) in candidate_results {
                 // HOT PATH: Use zero-copy label lookup to avoid cloning entire Node
-                self.indexes
-                    .get_node_label(*node_id)
+                if self
+                    .indexes
+                    .get_node_label(node_id)
                     .map(|l| l == label_id)
                     .unwrap_or(false)
-            })?;
+                {
+                    results.push((node_id, similarity));
+                }
+            }
 
             if let Some(exclude_id) = exclude_node {
                 results.retain(|(id, _)| *id != exclude_id);
             }
 
-            stats.record_search(candidates, results.len());
+            // Track observed pass rate from actual candidates examined.
+            stats.record_search(candidate_count, results.len());
             results
         } else {
             // If we need to exclude a node, we might need one more result

--- a/tests/adaptive_overfetch.rs
+++ b/tests/adaptive_overfetch.rs
@@ -282,11 +282,52 @@ fn test_adaptive_overfetch_statistics_tracking() {
     assert!(db.__test_get_filter_stats("B").is_none());
 }
 
+fn adaptive_overfetch_concurrent_timeout_secs() -> u64 {
+    if std::env::var("CI").is_ok() { 180 } else { 30 }
+}
+
 #[test]
+#[serial_test::serial]
 fn test_adaptive_overfetch_concurrent_safety() {
+    use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, mpsc};
+    use std::time::Duration;
+
+    let progress = Arc::new(AtomicUsize::new(0));
+    let progress_worker = Arc::clone(&progress);
+
+    let (tx, rx) = mpsc::channel::<std::thread::Result<()>>();
+    std::thread::spawn(move || {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            run_adaptive_overfetch_concurrent_safety(progress_worker);
+        }));
+        let _ = tx.send(result);
+    });
+
+    let timeout_secs = adaptive_overfetch_concurrent_timeout_secs();
+    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
+        Ok(Ok(())) => {}
+        Ok(Err(panic_payload)) => {
+            resume_unwind(panic_payload);
+        }
+        Err(_) => {
+            let completed = progress.load(Ordering::Relaxed);
+            panic!(
+                "Potential deadlock in adaptive overfetch concurrent test: timed out after {}s ({} searches completed)",
+                timeout_secs, completed
+            );
+        }
+    }
+}
+
+fn run_adaptive_overfetch_concurrent_safety(
+    progress: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) {
     // Verify that concurrent searches don't cause panics or data corruption
     // Reduced workload for CI performance
     use std::sync::Arc;
+    use std::sync::atomic::Ordering;
     use std::thread;
 
     let db = Arc::new(AletheiaDB::new().unwrap());
@@ -314,6 +355,7 @@ fn test_adaptive_overfetch_concurrent_safety() {
 
     for thread_id in 0..4 {
         let db_clone = Arc::clone(&db);
+        let progress_clone = Arc::clone(&progress);
         let handle = thread::spawn(move || {
             let label = if thread_id % 2 == 0 { "TypeA" } else { "TypeB" };
             let query_embedding = vec![0.5f32, 0.5, 0.3, 0.2];
@@ -326,6 +368,7 @@ fn test_adaptive_overfetch_concurrent_safety() {
 
                 // Basic sanity check
                 assert!(results.len() <= 3);
+                progress_clone.fetch_add(1, Ordering::Relaxed);
             }
         });
 


### PR DESCRIPTION
## Summary
- fix adaptive overfetch filtered-search path to avoid deadlock-prone double over-fetch behavior under contention
- harden 	est_adaptive_overfetch_concurrent_safety with timeout watchdog, progress accounting, and panic forwarding
- make clock-skew tests deterministic regardless of ALETHEIADB_AUTO_HEAL_CLOCK_SKEW by adding a test-only override guard

## Verification
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- ALETHEIADB_AUTO_HEAL_CLOCK_SKEW=true cargo test clock_skew_tests:: -- --nocapture