### PR TITLE
🔒 Warden: Fix UB in vector normalization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -47,3 +47,7 @@
 **2026-02-18 - Silent Data Loss in Property Interning**
 **Threat:** `PropertyMapBuilder::try_insert` silently swallowed errors when the string interner was full (e.g. DoS attack filling capacity). This resulted in properties being silently dropped during node/edge creation or updates, potentially leading to security bypasses (e.g. missing "role: admin" or "acl" properties) or data integrity issues.
 **Defense:** Modified `try_insert` to propagate the `CapacityExceeded` error instead of returning `Ok(self)`. Added regression test `tests/security_interner_dos.rs` which verifies that insertion fails when the interner is full.
+
+**2026-02-18 - Undefined Behavior in Vector Normalization**
+**Threat:** The `normalize` function in `src/core/vector/ops.rs` violated the safety contract of `Vec::set_len` by calling it on uninitialized memory before initialization. While memory was subsequently filled by `scale_and_copy`, this pattern is technically Undefined Behavior (UB) and relies on implementation details of `Vec` and `f32` (no Drop). Future compiler optimizations or changes to `Vec` could turn this into a crash or security vulnerability.
+**Defense:** Refactored `scale_and_copy` (and its SIMD backends in `src/core/vector/simd.rs`) to accept `&mut [MaybeUninit<f32>]`. Updated `normalize` to use `Vec::spare_capacity_mut` to safely access uninitialized memory, initializing it via `scale_and_copy` before calling `set_len`. This eliminates the UB while maintaining the "zero-overhead initialization" performance optimization.

--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -573,7 +573,6 @@ pub fn squared_magnitude(v: &[f32]) -> f32 {
 /// - Dimension limits are enforced at storage time (see [`crate::core::PropertyValue::vector`])
 /// - Additional checks would add overhead without safety benefit
 #[inline]
-#[allow(clippy::uninit_vec)] // Performance optimization: we explicitly fill the vector
 pub fn normalize(v: &[f32]) -> Vec<f32> {
     let sq_mag = squared_magnitude(v);
     // Use squared magnitude threshold to avoid denormal number issues.
@@ -590,19 +589,20 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
     // This provides ~15% speedup for large vectors by avoiding an extra write pass.
     let mut result = Vec::with_capacity(v.len());
 
-    // SAFETY: We immediately fill the entire vector using scale_and_copy.
-    // scale_and_copy internally asserts that src.len() == dst.len(), guaranteeing
-    // that all elements are written before the vector is exposed.
-    //
-    // The `result` vector is allocated with capacity `v.len()`, so `set_len` is
-    // within capacity bounds. `scale_and_copy` is a trusted function (verified by tests)
-    // that writes to every element of `result`. Even if `scale_and_copy` were to panic,
-    // the `result` vector would be dropped, which is safe for `Vec<f32>` (no Drop impl for f32).
-    // The only risk is if `scale_and_copy` returned early without initializing, but
-    // its implementation guarantees full coverage via exact chunking and remainder handling.
+    // Use spare_capacity_mut to safely access uninitialized memory.
+    // scale_and_copy now accepts &mut [MaybeUninit<f32>] and guarantees full initialization.
+    // Warden: Must slice to v.len() because spare_capacity_mut() might return more than requested capacity.
+    let dst = &mut result.spare_capacity_mut()[..v.len()];
+
+    // Fill the vector using SIMD-accelerated scale_and_copy.
+    // This function initializes all elements in dst.
+    scale_and_copy(v, dst, inv_mag);
+
+    // SAFETY: We have initialized all elements using scale_and_copy.
+    // The capacity was set to v.len(), and scale_and_copy asserts that src.len() == dst.len().
+    // Therefore, all v.len() elements are now initialized.
     unsafe { result.set_len(v.len()) };
 
-    scale_and_copy(v, &mut result, inv_mag);
     result
 }
 

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -1,5 +1,6 @@
 use super::ops::*;
 use super::simd::*;
+use std::mem::MaybeUninit;
 
 #[test]
 fn test_normalize_nan_handling() {
@@ -47,11 +48,17 @@ fn test_scale_and_copy_correctness() {
     // This is critical because normalize() relies on this to initialize the vector.
 
     let src = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-    let mut dst = vec![0.0; 5]; // Pre-fill with 0 to verify overwrite
+    // Create uninitialized destination
+    let mut dst_vec: Vec<MaybeUninit<f32>> = Vec::with_capacity(5);
+    unsafe { dst_vec.set_len(5) };
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    scale_and_copy(&src, &mut dst_vec, 2.0);
 
-    assert_eq!(dst, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
+    // Verify result without transmute
+    // SAFETY: We initialized dst_vec with valid floats via scale_and_copy
+    let dst_slice = unsafe { std::slice::from_raw_parts(dst_vec.as_ptr() as *const f32, dst_vec.len()) };
+
+    assert_eq!(dst_slice, &[2.0, 4.0, 6.0, 8.0, 10.0]);
 }
 
 #[test]
@@ -59,11 +66,16 @@ fn test_scale_and_copy_large_vector() {
     // 🛡️ Sentry: Test with larger vector to trigger SIMD loop + remainder
     let len = 1024 + 7; // 1031 elements
     let src: Vec<f32> = (0..len).map(|i| i as f32).collect();
-    let mut dst = vec![0.0; len];
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    let mut dst_vec: Vec<MaybeUninit<f32>> = Vec::with_capacity(len);
+    unsafe { dst_vec.set_len(len) };
 
-    for (i, val) in dst.iter().enumerate() {
+    scale_and_copy(&src, &mut dst_vec, 2.0);
+
+    // Verify result without transmute
+    let dst_slice = unsafe { std::slice::from_raw_parts(dst_vec.as_ptr() as *const f32, dst_vec.len()) };
+
+    for (i, val) in dst_slice.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);
     }
 }

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -56,7 +56,8 @@ fn test_scale_and_copy_correctness() {
 
     // Verify result without transmute
     // SAFETY: We initialized dst_vec with valid floats via scale_and_copy
-    let dst_slice = unsafe { std::slice::from_raw_parts(dst_vec.as_ptr() as *const f32, dst_vec.len()) };
+    let dst_slice =
+        unsafe { std::slice::from_raw_parts(dst_vec.as_ptr() as *const f32, dst_vec.len()) };
 
     assert_eq!(dst_slice, &[2.0, 4.0, 6.0, 8.0, 10.0]);
 }
@@ -73,7 +74,8 @@ fn test_scale_and_copy_large_vector() {
     scale_and_copy(&src, &mut dst_vec, 2.0);
 
     // Verify result without transmute
-    let dst_slice = unsafe { std::slice::from_raw_parts(dst_vec.as_ptr() as *const f32, dst_vec.len()) };
+    let dst_slice =
+        unsafe { std::slice::from_raw_parts(dst_vec.as_ptr() as *const f32, dst_vec.len()) };
 
     for (i, val) in dst_slice.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -736,7 +736,9 @@ mod tests {
         // Helper to check result
         let check_result = |dst_uninit: &[MaybeUninit<f32>]| {
             // SAFETY: We assume the test function wrote valid data
-            let result_slice = unsafe { std::slice::from_raw_parts(dst_uninit.as_ptr() as *const f32, dst_uninit.len()) };
+            let result_slice = unsafe {
+                std::slice::from_raw_parts(dst_uninit.as_ptr() as *const f32, dst_uninit.len())
+            };
             assert_eq!(result_slice, expected);
         };
 

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -2,6 +2,8 @@
 // SIMD Support
 // ============================================================================
 
+use std::mem::MaybeUninit;
+
 /// SIMD-accelerated vector operations for x86/x86_64 platforms.
 ///
 /// Uses runtime feature detection to select the best available instruction set:
@@ -19,6 +21,7 @@
 /// where SIMD becomes beneficial is typically around 16-32 dimensions.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86_ops {
+    use super::*;
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
@@ -429,9 +432,10 @@ pub(crate) mod x86_ops {
     ///
     /// # Safety
     /// Caller must ensure AVX2 is available. `src.len() == dst.len()`.
+    /// `dst` elements may be uninitialized, but they are guaranteed to be written.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm256_set1_ps(scalar);
@@ -441,14 +445,16 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm256_loadu_ps(s_chunk.as_ptr());
                 let result = _mm256_mul_ps(va, scalar_vec);
-                _mm256_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Cast MaybeUninit pointer to f32 pointer
+                // Safe because MaybeUninit<f32> has same layout as f32
+                _mm256_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -457,9 +463,10 @@ pub(crate) mod x86_ops {
     ///
     /// # Safety
     /// Caller must ensure SSE2 is available. `src.len() == dst.len()`.
+    /// `dst` elements may be uninitialized, but they are guaranteed to be written.
     #[target_feature(enable = "sse2")]
     #[inline]
-    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm_set1_ps(scalar);
@@ -469,14 +476,15 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm_loadu_ps(s_chunk.as_ptr());
                 let result = _mm_mul_ps(va, scalar_vec);
-                _mm_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Cast MaybeUninit pointer to f32 pointer
+                _mm_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -547,10 +555,10 @@ pub(crate) fn scale_in_place_scalar(v: &mut [f32], scalar: f32) {
     all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)),
     allow(dead_code)
 )]
-pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().zip(dst.iter_mut()) {
-        *d = *s * scalar;
+        d.write(*s * scalar);
     }
 }
 
@@ -587,8 +595,10 @@ pub(crate) fn scale_in_place(v: &mut [f32], scalar: f32) {
 }
 
 /// Scales `src` by `scalar` and stores result in `dst` using the best available SIMD instructions.
+///
+/// `dst` is allowed to be uninitialized, as this function guarantees writing to all elements.
 #[inline(always)]
-pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -720,30 +730,42 @@ mod tests {
     #[test]
     fn test_scale_and_copy_implementation_coverage() {
         let src = vec![1.0f32; 17]; // 17 to force remainder logic (8*2 + 1)
-        let mut dst = vec![0.0f32; 17];
         let scalar = 2.0;
         let expected = vec![2.0f32; 17];
 
+        // Helper to check result
+        let check_result = |dst_uninit: &[MaybeUninit<f32>]| {
+            // SAFETY: We assume the test function wrote valid data
+            let result_slice = unsafe { std::slice::from_raw_parts(dst_uninit.as_ptr() as *const f32, dst_uninit.len()) };
+            assert_eq!(result_slice, expected);
+        };
+
         // 1. Unconditional Scalar coverage
-        scale_and_copy_scalar(&src, &mut dst, scalar);
-        assert_eq!(dst, expected, "Scalar implementation failed");
-        dst.fill(0.0);
+        let mut dst_vec: Vec<MaybeUninit<f32>> = Vec::with_capacity(17);
+        unsafe { dst_vec.set_len(17) };
+
+        scale_and_copy_scalar(&src, &mut dst_vec, scalar);
+        check_result(&dst_vec);
 
         // 2. Conditional x86 SIMD coverage
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
             // Try SSE2 if available
             if is_x86_feature_detected!("sse2") {
-                unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst, scalar) };
-                assert_eq!(dst, expected, "SSE2 implementation failed");
-                dst.fill(0.0);
+                let mut dst_sse2: Vec<MaybeUninit<f32>> = Vec::with_capacity(17);
+                unsafe { dst_sse2.set_len(17) };
+
+                unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst_sse2, scalar) };
+                check_result(&dst_sse2);
             }
 
             // Try AVX2 if available
             if is_x86_feature_detected!("avx2") {
-                unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst, scalar) };
-                assert_eq!(dst, expected, "AVX2 implementation failed");
-                dst.fill(0.0);
+                let mut dst_avx2: Vec<MaybeUninit<f32>> = Vec::with_capacity(17);
+                unsafe { dst_avx2.set_len(17) };
+
+                unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst_avx2, scalar) };
+                check_result(&dst_avx2);
             }
         }
     }


### PR DESCRIPTION
Eliminated Undefined Behavior in `normalize` by using `MaybeUninit` and `spare_capacity_mut`. Refactored `scale_and_copy` to support writing to uninitialized memory safely.

---
*PR created automatically by Jules for task [10420952585664840483](https://jules.google.com/task/10420952585664840483) started by @madmax983*