### PR TITLE
Sentinel: Kill mutants in query converter and HNSW metadata

### DIFF
--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -2096,4 +2096,22 @@ mod sentry_tests {
             "Filter operation must precede Project operation"
         );
     }
+
+    #[test]
+    fn test_inline_property_filter_does_not_use_start_node() {
+        // 🎯 Target: convert_node_pattern "id" check
+        // 💣 Risk: Treating other properties as ID -> StartNode optimization -> Wrong results
+        // 🧪 Strategy: Match with inline property (not id), ensure StartNode is NOT used.
+
+        let ast = Parser::parse("MATCH (n {age: 30}) RETURN n").unwrap();
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).unwrap();
+
+        let has_start_node = query.ops.iter().any(|op| matches!(op, QueryOp::StartNode(_)));
+        assert!(!has_start_node, "Should not use StartNode for non-id property");
+
+        // Also ensure it produces a Filter
+        let has_filter = query.ops.iter().any(|op| matches!(op, QueryOp::Filter(_)));
+        assert!(has_filter, "Should produce Filter for age");
+    }
 }

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -2107,8 +2107,14 @@ mod sentry_tests {
         let converter = AstConverter::new();
         let query = converter.convert(&ast).unwrap();
 
-        let has_start_node = query.ops.iter().any(|op| matches!(op, QueryOp::StartNode(_)));
-        assert!(!has_start_node, "Should not use StartNode for non-id property");
+        let has_start_node = query
+            .ops
+            .iter()
+            .any(|op| matches!(op, QueryOp::StartNode(_)));
+        assert!(
+            !has_start_node,
+            "Should not use StartNode for non-id property"
+        );
 
         // Also ensure it produces a Filter
         let has_filter = query.ops.iter().any(|op| matches!(op, QueryOp::Filter(_)));

--- a/tests/sentry_hnsw_metadata.rs
+++ b/tests/sentry_hnsw_metadata.rs
@@ -1,7 +1,7 @@
-use aletheiadb::core::property::MAX_VECTOR_DIMENSIONS;
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, HnswIndex};
+use aletheiadb::core::property::MAX_VECTOR_DIMENSIONS;
 use aletheiadb::index::VectorIndex;
+use aletheiadb::index::vector::{DistanceMetric, HnswIndex, HnswIndexBuilder};
 use tempfile::tempdir;
 
 #[test]
@@ -35,7 +35,10 @@ fn test_hnsw_max_dimensions_load() {
 
     let loaded = HnswIndex::load(&path, config_template);
 
-    assert!(loaded.is_ok(), "Should successfully load index with MAX_VECTOR_DIMENSIONS");
+    assert!(
+        loaded.is_ok(),
+        "Should successfully load index with MAX_VECTOR_DIMENSIONS"
+    );
     let loaded_index = loaded.unwrap();
     assert_eq!(loaded_index.config().dimensions, dims);
 }

--- a/tests/sentry_hnsw_metadata.rs
+++ b/tests/sentry_hnsw_metadata.rs
@@ -1,0 +1,41 @@
+use aletheiadb::core::property::MAX_VECTOR_DIMENSIONS;
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, HnswIndex};
+use aletheiadb::index::VectorIndex;
+use tempfile::tempdir;
+
+#[test]
+fn test_hnsw_max_dimensions_load() {
+    // 🎯 Target: HnswIndex::validate_metadata boundary check
+    // 💣 Risk: Off-by-one error (replace > with >=) causing rejection of MAX_VECTOR_DIMENSIONS
+    // 🧪 Strategy: Create an index with exactly MAX_VECTOR_DIMENSIONS, save, and load.
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("max_dims.index");
+
+    let dims = MAX_VECTOR_DIMENSIONS;
+
+    // 1. Build index with max dims
+    let index = HnswIndexBuilder::new(dims, DistanceMetric::Cosine)
+        .build()
+        .expect("Should support MAX_VECTOR_DIMENSIONS");
+
+    // 2. Add a vector to ensure mappings are written
+    let vec = vec![0.0f32; dims];
+    index.add(NodeId::new(1).unwrap(), &vec).unwrap();
+
+    // 3. Save
+    index.save(&path).expect("Save should succeed");
+
+    // 4. Load
+    let config_template = HnswIndexBuilder::new(dims, DistanceMetric::Cosine)
+        .build()
+        .unwrap()
+        .config();
+
+    let loaded = HnswIndex::load(&path, config_template);
+
+    assert!(loaded.is_ok(), "Should successfully load index with MAX_VECTOR_DIMENSIONS");
+    let loaded_index = loaded.unwrap();
+    assert_eq!(loaded_index.config().dimensions, dims);
+}


### PR DESCRIPTION
🤖 **Sentinel Report**

This PR strengthens the test suite by eliminating surviving mutants identified during mutation testing.

**🧬 Mutants Found & Killed:**
1.  **Query Converter Logic:** A mutant replacing `==` with `!=` in `convert_node_pattern` (checking for "id" property) survived existing tests. This could cause queries like `MATCH (n {age: 30})` to incorrectly trigger `StartNode` optimization (treating 30 as an ID).
    *   **Kill Shot:** Added `test_inline_property_filter_does_not_use_start_node` which explicitly verifies that non-ID property filters produce `Filter` ops, not `StartNode`.

2.  **HNSW Metadata Validation:** A mutant replacing `>` with `>=` in `validate_metadata` (checking against `MAX_VECTOR_DIMENSIONS`) survived. This would cause valid indexes with exactly 4096 dimensions to be rejected.
    *   **Kill Shot:** Added `tests/sentry_hnsw_metadata.rs` which builds, saves, and loads an index with exactly `MAX_VECTOR_DIMENSIONS`, asserting success.

**📊 Impact:**
- Closes logic gaps in query optimization safety.
- Ensures correct boundary handling for maximum vector dimensions.
- Improves regression protection for core constraints.

**🔗 Context:**
Part of the Sentinel autonomous testing initiative.

---
*PR created automatically by Jules for task [13965561446604675529](https://jules.google.com/task/13965561446604675529) started by @madmax983*