### PR TITLE
Optimize group commit wait path and benchmark guardrails

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,6 +111,16 @@ jobs:
             exit 1
           fi
 
+      - name: Check fused group-commit threshold benchmark
+        env:
+          BENCH_SAMPLE_SIZE: 10
+          BENCH_MEASUREMENT_TIME: 1
+          BENCH_WARMUP_TIME: 1
+        run: |
+          python scripts/check_group_commit_fused_benchmark.py \
+            --baseline-name fused_commit_wait_threshold \
+            --max-ratio 0.70
+
       - name: Generate benchmark JSON
         run: |
           python scripts/generate_benchmark_tables.py \

--- a/benches/durability_modes.rs
+++ b/benches/durability_modes.rs
@@ -23,7 +23,10 @@ use aletheiadb::{
 };
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use std::thread;
 use tempfile::TempDir;
 
@@ -283,6 +286,67 @@ fn bench_concurrent_writes(c: &mut Criterion) {
                         }
                     });
                     handles.push(handle);
+                }
+
+                for handle in handles {
+                    handle.join().unwrap();
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark the fused GroupCommit path (`append_async` + `commit_group_commit_and_wait`)
+/// under concurrent load, comparing adaptive trigger thresholds against timer-only behavior.
+fn bench_group_commit_fused_concurrent(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group_commit_fused_concurrent");
+    group.throughput(Throughput::Elements(100));
+
+    let thread_count = 10usize;
+    let ops_per_thread = 10usize;
+    let max_delay_ms = 10u64;
+    let max_batch_size = 20usize;
+    let half_batch_threshold = max_batch_size.max(1).saturating_add(1) / 2;
+
+    for (name, trigger_threshold) in [
+        ("half_batch_threshold", half_batch_threshold),
+        ("timer_only_threshold", max_batch_size),
+    ] {
+        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+            let temp_dir = TempDir::new().unwrap();
+            let config = ConcurrentWalSystemConfig::new(temp_dir.path().to_path_buf())
+                .with_durability_mode(DurabilityMode::GroupCommit {
+                    max_delay_ms,
+                    max_batch_size,
+                })
+                .with_flush_interval_ms(max_delay_ms)
+                .with_group_commit_flush_trigger_batch_size(trigger_threshold);
+
+            let wal = Arc::new(ConcurrentWalSystem::new(config).unwrap());
+            let id_alloc = Arc::new(AtomicU64::new(1));
+            let label = GLOBAL_INTERNER.intern("FusedConcurrent").unwrap();
+
+            b.iter(|| {
+                let mut handles = Vec::with_capacity(thread_count);
+                for _ in 0..thread_count {
+                    let wal = Arc::clone(&wal);
+                    let id_alloc = Arc::clone(&id_alloc);
+                    let thread_label = label;
+                    handles.push(thread::spawn(move || {
+                        for _ in 0..ops_per_thread {
+                            let node_id = id_alloc.fetch_add(1, Ordering::Relaxed);
+                            let operation = WalOperation::CreateNode {
+                                node_id: aletheiadb::core::id::NodeId::new(node_id).unwrap(),
+                                label: thread_label,
+                                properties: PropertyMapBuilder::new().build(),
+                                valid_from: time::now(),
+                            };
+                            wal.append_async(operation).unwrap();
+                            wal.commit_group_commit_and_wait().unwrap();
+                        }
+                    }));
                 }
 
                 for handle in handles {
@@ -762,6 +826,7 @@ criterion_group!(
     targets = bench_single_transaction_latency,
     bench_batch_throughput,
     bench_concurrent_writes,
+    bench_group_commit_fused_concurrent,
     bench_group_commit_batch_sizes,
     bench_group_commit_delays,
     bench_async_batched_batch_sizes,

--- a/justfile
+++ b/justfile
@@ -29,6 +29,10 @@ bench-tables:
     @echo "✓ Benchmark tables generated in benchmark-results/"
     @echo "  Open benchmark-results/index.html to view results"
 
+# Run fused group-commit threshold benchmark check and save baseline
+bench-group-commit-fused-check:
+    python scripts/check_group_commit_fused_benchmark.py --baseline-name fused_commit_wait_threshold
+
 # Build the project
 build:
     cargo build
@@ -312,3 +316,4 @@ worktree-pr TITLE BODY="":
     else
         bash scripts/worktree-pr.sh "{{TITLE}}" "{{BODY}}"
     fi
+

--- a/scripts/check_group_commit_fused_benchmark.py
+++ b/scripts/check_group_commit_fused_benchmark.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run and validate the fused GroupCommit threshold benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(command: list[str]) -> None:
+    print(f"[bench-check] running: {' '.join(command)}")
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"benchmark command failed with exit code {result.returncode}")
+
+
+def load_mean_point_estimate_ns(path: Path) -> float:
+    if not path.exists():
+        raise FileNotFoundError(f"missing criterion estimates file: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return float(payload["mean"]["point_estimate"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run group_commit_fused_concurrent benchmark, save baseline, and verify "
+            "half-batch threshold remains significantly faster than timer-only."
+        )
+    )
+    parser.add_argument(
+        "--criterion-root",
+        default="target/criterion",
+        help="Criterion output root directory (default: target/criterion)",
+    )
+    parser.add_argument(
+        "--baseline-name",
+        default="fused_commit_wait_threshold",
+        help="Criterion baseline name for --save-baseline",
+    )
+    parser.add_argument(
+        "--max-ratio",
+        type=float,
+        default=0.70,
+        help=(
+            "Maximum allowed ratio of half_batch/timer_only mean runtime. "
+            "Lower is stricter (default: 0.70)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-run",
+        action="store_true",
+        help="Skip cargo bench execution and only validate existing Criterion output.",
+    )
+    args = parser.parse_args()
+
+    if args.max_ratio <= 0:
+        print("[bench-check] --max-ratio must be > 0", file=sys.stderr)
+        return 2
+
+    if not args.skip_run:
+        run_command(
+            [
+                "cargo",
+                "bench",
+                "--all-features",
+                "--bench",
+                "durability_modes",
+                "--",
+                "group_commit_fused_concurrent",
+                "--save-baseline",
+                args.baseline_name,
+            ]
+        )
+
+    criterion_root = Path(args.criterion_root)
+    half_path = (
+        criterion_root
+        / "group_commit_fused_concurrent"
+        / "half_batch_threshold"
+        / "new"
+        / "estimates.json"
+    )
+    timer_path = (
+        criterion_root
+        / "group_commit_fused_concurrent"
+        / "timer_only_threshold"
+        / "new"
+        / "estimates.json"
+    )
+
+    half_ns = load_mean_point_estimate_ns(half_path)
+    timer_ns = load_mean_point_estimate_ns(timer_path)
+    if timer_ns <= 0:
+        print("[bench-check] timer-only estimate must be > 0", file=sys.stderr)
+        return 2
+
+    ratio = half_ns / timer_ns
+    speedup = timer_ns / half_ns if half_ns > 0 else float("inf")
+    print(f"[bench-check] half_batch mean: {half_ns:.0f} ns")
+    print(f"[bench-check] timer_only mean: {timer_ns:.0f} ns")
+    print(f"[bench-check] half_batch/timer_only ratio: {ratio:.4f}")
+    print(f"[bench-check] half_batch speedup vs timer_only: {speedup:.2f}x")
+
+    if ratio > args.max_ratio:
+        print(
+            (
+                f"[bench-check] FAILURE: ratio {ratio:.4f} exceeded allowed "
+                f"max {args.max_ratio:.4f}"
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print("[bench-check] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -473,7 +473,7 @@ impl WriteTransaction {
 
             // Log operations to WAL (lock-free striped append!)
             // This must happen BEFORE applying changes for durability.
-            wal::log_operations_to_wal(&self, commit)?;
+            let wal_disposition = wal::log_operations_to_wal(&self, commit)?;
 
             #[cfg(feature = "observability")]
             let wal_logged = std::time::Instant::now();
@@ -482,7 +482,19 @@ impl WriteTransaction {
             // For Sync: drains and flushes immediately
             // For Async: returns immediately
             // For GroupCommit: registers and returns epoch
-            let wait_epoch = self.wal.commit()?;
+            let wait_epoch = match wal_disposition {
+                wal::WalLogDisposition::NeedsCommit => {
+                    if matches!(self.durability_mode, DurabilityMode::GroupCommit { .. })
+                        && self.durability_mode.waits_for_durability()
+                    {
+                        self.wal.commit_group_commit_and_wait()?;
+                        None
+                    } else {
+                        self.wal.commit()?
+                    }
+                }
+                wal::WalLogDisposition::AlreadyDurable => None,
+            };
 
             #[cfg(feature = "observability")]
             let wal_commit_completed = std::time::Instant::now();

--- a/src/api/transaction/write/wal.rs
+++ b/src/api/transaction/write/wal.rs
@@ -1,7 +1,103 @@
 use super::WriteTransaction;
+use crate::api::transaction::BufferedWrite;
 use crate::core::error::Result;
 use crate::core::temporal::Timestamp;
-use crate::storage::wal::WalOperation;
+use crate::storage::wal::{DurabilityMode, WalOperation};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WalLogDisposition {
+    /// Operations are buffered and caller must execute `wal.commit()`.
+    NeedsCommit,
+    /// Operation is already durably flushed by logging path.
+    AlreadyDurable,
+}
+
+fn to_wal_operation(write: &BufferedWrite) -> WalOperation {
+    match write {
+        BufferedWrite::CreateNode {
+            node_id,
+            label,
+            properties,
+            valid_from,
+            ..
+        } => {
+            // No allocation! Just copy the 4-byte InternedString ID
+            WalOperation::CreateNode {
+                node_id: *node_id,
+                label: *label,
+                properties: properties.clone(),
+                valid_from: *valid_from,
+            }
+        }
+        BufferedWrite::CreateEdge {
+            edge_id,
+            source,
+            target,
+            label,
+            properties,
+            valid_from,
+            ..
+        } => {
+            // No allocation! Just copy the 4-byte InternedString ID
+            WalOperation::CreateEdge {
+                edge_id: *edge_id,
+                source: *source,
+                target: *target,
+                label: *label,
+                properties: properties.clone(),
+                valid_from: *valid_from,
+            }
+        }
+        BufferedWrite::UpdateNode {
+            node_id,
+            version_id,
+            label,
+            properties,
+            valid_from,
+            ..
+        } => {
+            // No allocation! Just copy the 4-byte InternedString ID
+            WalOperation::UpdateNode {
+                node_id: *node_id,
+                version_id: *version_id,
+                label: *label,
+                properties: properties.clone(),
+                valid_from: *valid_from,
+            }
+        }
+        BufferedWrite::UpdateEdge {
+            edge_id,
+            version_id,
+            label,
+            properties,
+            valid_from,
+            ..
+        } => {
+            // No allocation! Just copy the 4-byte InternedString ID
+            WalOperation::UpdateEdge {
+                edge_id: *edge_id,
+                version_id: *version_id,
+                label: *label,
+                properties: properties.clone(),
+                valid_from: *valid_from,
+            }
+        }
+        BufferedWrite::DeleteNode {
+            node_id,
+            valid_from,
+        } => WalOperation::DeleteNode {
+            node_id: *node_id,
+            valid_from: *valid_from,
+        },
+        BufferedWrite::DeleteEdge {
+            edge_id,
+            valid_from,
+        } => WalOperation::DeleteEdge {
+            edge_id: *edge_id,
+            valid_from: *valid_from,
+        },
+    }
+}
 
 /// Log all buffered operations to WAL.
 ///
@@ -10,96 +106,20 @@ use crate::storage::wal::WalOperation;
 pub(crate) fn log_operations_to_wal(
     tx: &WriteTransaction,
     _commit_timestamp: Timestamp,
-) -> Result<()> {
-    for write in tx.buffer.operations() {
-        let operation = match write {
-            crate::api::transaction::BufferedWrite::CreateNode {
-                node_id,
-                label,
-                properties,
-                valid_from,
-                ..
-            } => {
-                // No allocation! Just copy the 4-byte InternedString ID
-                WalOperation::CreateNode {
-                    node_id: *node_id,
-                    label: *label,
-                    properties: properties.clone(),
-                    valid_from: *valid_from,
-                }
-            }
-            crate::api::transaction::BufferedWrite::CreateEdge {
-                edge_id,
-                source,
-                target,
-                label,
-                properties,
-                valid_from,
-                ..
-            } => {
-                // No allocation! Just copy the 4-byte InternedString ID
-                WalOperation::CreateEdge {
-                    edge_id: *edge_id,
-                    source: *source,
-                    target: *target,
-                    label: *label,
-                    properties: properties.clone(),
-                    valid_from: *valid_from,
-                }
-            }
-            crate::api::transaction::BufferedWrite::UpdateNode {
-                node_id,
-                version_id,
-                label,
-                properties,
-                valid_from,
-                ..
-            } => {
-                // No allocation! Just copy the 4-byte InternedString ID
-                WalOperation::UpdateNode {
-                    node_id: *node_id,
-                    version_id: *version_id,
-                    label: *label,
-                    properties: properties.clone(),
-                    valid_from: *valid_from,
-                }
-            }
-            crate::api::transaction::BufferedWrite::UpdateEdge {
-                edge_id,
-                version_id,
-                label,
-                properties,
-                valid_from,
-                ..
-            } => {
-                // No allocation! Just copy the 4-byte InternedString ID
-                WalOperation::UpdateEdge {
-                    edge_id: *edge_id,
-                    version_id: *version_id,
-                    label: *label,
-                    properties: properties.clone(),
-                    valid_from: *valid_from,
-                }
-            }
-            crate::api::transaction::BufferedWrite::DeleteNode {
-                node_id,
-                valid_from,
-            } => WalOperation::DeleteNode {
-                node_id: *node_id,
-                valid_from: *valid_from,
-            },
-            crate::api::transaction::BufferedWrite::DeleteEdge {
-                edge_id,
-                valid_from,
-            } => WalOperation::DeleteEdge {
-                edge_id: *edge_id,
-                valid_from: *valid_from,
-            },
-        };
+) -> Result<WalLogDisposition> {
+    let writes = tx.buffer.operations();
 
+    // Single-op synchronous transactions can bypass striped buffering.
+    if matches!(tx.durability_mode, DurabilityMode::Synchronous) && writes.len() == 1 {
+        tx.wal.append_sync_isolated(to_wal_operation(&writes[0]))?;
+        return Ok(WalLogDisposition::AlreadyDurable);
+    }
+
+    for write in writes {
+        let operation = to_wal_operation(write);
         // Append to WAL (lock-free!)
         tx.wal.append_async(operation)?;
     }
 
-    Ok(())
+    Ok(WalLogDisposition::NeedsCommit)
 }

--- a/src/bin/group_commit_wait_profile.rs
+++ b/src/bin/group_commit_wait_profile.rs
@@ -1,0 +1,262 @@
+use std::fs;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use aletheiadb::core::{PropertyMapBuilder, interning::GLOBAL_INTERNER, temporal::time};
+use aletheiadb::storage::wal::{
+    DurabilityMode, WalOperation,
+    concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig},
+};
+
+#[derive(Debug, Clone)]
+struct ProfileConfig {
+    threads: usize,
+    ops_per_thread: usize,
+    warmup_ops: usize,
+    max_delay_ms: u64,
+    max_batch_size: usize,
+    trigger_threshold: Option<usize>,
+}
+
+impl Default for ProfileConfig {
+    fn default() -> Self {
+        Self {
+            threads: 8,
+            ops_per_thread: 500,
+            warmup_ops: 100,
+            max_delay_ms: 10,
+            max_batch_size: 20,
+            trigger_threshold: None,
+        }
+    }
+}
+
+fn parse_args() -> ProfileConfig {
+    let mut cfg = ProfileConfig::default();
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1usize;
+    while i + 1 < args.len() {
+        let key = &args[i];
+        let value = &args[i + 1];
+        match key.as_str() {
+            "--threads" => {
+                if let Ok(v) = value.parse::<usize>() {
+                    cfg.threads = v.max(1);
+                }
+            }
+            "--ops" => {
+                if let Ok(v) = value.parse::<usize>() {
+                    cfg.ops_per_thread = v.max(1);
+                }
+            }
+            "--warmup" => {
+                if let Ok(v) = value.parse::<usize>() {
+                    cfg.warmup_ops = v;
+                }
+            }
+            "--delay-ms" => {
+                if let Ok(v) = value.parse::<u64>() {
+                    cfg.max_delay_ms = v.max(1);
+                }
+            }
+            "--batch-size" => {
+                if let Ok(v) = value.parse::<usize>() {
+                    cfg.max_batch_size = v.max(1);
+                }
+            }
+            "--trigger-threshold" => {
+                if let Ok(v) = value.parse::<usize>() {
+                    cfg.trigger_threshold = Some(v.max(1));
+                }
+            }
+            _ => {}
+        }
+        i += 2;
+    }
+    cfg
+}
+
+fn percentile_ns(sorted_ns: &[u64], pct: f64) -> u64 {
+    if sorted_ns.is_empty() {
+        return 0;
+    }
+    let max_index = sorted_ns.len() - 1;
+    let rank = ((pct * max_index as f64).ceil() as usize).min(max_index);
+    sorted_ns[rank]
+}
+
+fn mean_ns(values: &[u64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let sum: u128 = values.iter().map(|&v| v as u128).sum();
+    (sum as f64) / (values.len() as f64)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cfg = parse_args();
+    println!("group_commit_wait_profile config: {:?}", cfg);
+
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let wal_dir = std::env::temp_dir().join(format!("aletheiadb-gc-profile-{}", ts));
+    fs::create_dir_all(&wal_dir)?;
+
+    let mut wal_config = ConcurrentWalSystemConfig::new(&wal_dir)
+        .with_durability_mode(DurabilityMode::GroupCommit {
+            max_delay_ms: cfg.max_delay_ms,
+            max_batch_size: cfg.max_batch_size,
+        })
+        .with_flush_interval_ms(cfg.max_delay_ms);
+    if let Some(trigger_threshold) = cfg.trigger_threshold {
+        wal_config = wal_config.with_group_commit_flush_trigger_batch_size(trigger_threshold);
+    }
+    let wal = Arc::new(ConcurrentWalSystem::new(wal_config)?);
+
+    wal.set_group_commit_metrics_enabled(true);
+    if let Some(gc) = wal.group_commit_coordinator() {
+        gc.reset_metrics();
+        println!(
+            "group_commit_wait_profile trigger threshold: {}",
+            gc.flush_trigger_batch_size()
+        );
+    }
+
+    // Warmup to reduce one-time startup effects.
+    for i in 0..cfg.warmup_ops {
+        let op = WalOperation::CreateNode {
+            node_id: aletheiadb::core::id::NodeId::new((i + 1) as u64)?,
+            label: GLOBAL_INTERNER.intern("Warmup")?,
+            properties: PropertyMapBuilder::new().insert("warmup", i as i64).build(),
+            valid_from: time::now(),
+        };
+        wal.append_async(op)?;
+        wal.commit_group_commit_and_wait()?;
+    }
+
+    wal.reset_group_commit_metrics();
+
+    let latencies = Arc::new(Mutex::new(Vec::with_capacity(
+        cfg.threads * cfg.ops_per_thread,
+    )));
+
+    let start_total = Instant::now();
+    let mut handles = Vec::with_capacity(cfg.threads);
+    for thread_id in 0..cfg.threads {
+        let wal = Arc::clone(&wal);
+        let latencies = Arc::clone(&latencies);
+        handles.push(thread::spawn(move || -> Result<(), String> {
+            let base = (thread_id as u64) * 1_000_000_000;
+            for i in 0..cfg.ops_per_thread {
+                let op = WalOperation::CreateNode {
+                    node_id: aletheiadb::core::id::NodeId::new(base + i as u64 + 1)
+                        .map_err(|e| e.to_string())?,
+                    label: GLOBAL_INTERNER
+                        .intern("Profile")
+                        .map_err(|e| e.to_string())?,
+                    properties: PropertyMapBuilder::new()
+                        .insert("thread", thread_id as i64)
+                        .insert("counter", i as i64)
+                        .build(),
+                    valid_from: time::now(),
+                };
+                wal.append_async(op).map_err(|e| e.to_string())?;
+                let start = Instant::now();
+                wal.commit_group_commit_and_wait()
+                    .map_err(|e| e.to_string())?;
+                let elapsed_ns = start.elapsed().as_nanos() as u64;
+                latencies
+                    .lock()
+                    .map_err(|_| "latencies lock poisoned".to_string())?
+                    .push(elapsed_ns);
+            }
+            Ok(())
+        }));
+    }
+
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| "worker thread panicked")?
+            .map_err(|e| format!("worker failed: {}", e))?;
+    }
+    let elapsed_total = start_total.elapsed();
+
+    let mut latencies_ns = latencies
+        .lock()
+        .map_err(|_| "latencies lock poisoned")?
+        .clone();
+    latencies_ns.sort_unstable();
+
+    let p50_ns = percentile_ns(&latencies_ns, 0.50);
+    let p95_ns = percentile_ns(&latencies_ns, 0.95);
+    let p99_ns = percentile_ns(&latencies_ns, 0.99);
+    let avg_ns = mean_ns(&latencies_ns);
+    let max_ns = latencies_ns.last().copied().unwrap_or(0);
+    let total_ops = latencies_ns.len() as f64;
+    let throughput = if elapsed_total > Duration::ZERO {
+        total_ops / elapsed_total.as_secs_f64()
+    } else {
+        0.0
+    };
+
+    println!(
+        "commit_wait latency (us): count={} p50={:.2} p95={:.2} p99={:.2} avg={:.2} max={:.2}",
+        latencies_ns.len(),
+        p50_ns as f64 / 1_000.0,
+        p95_ns as f64 / 1_000.0,
+        p99_ns as f64 / 1_000.0,
+        avg_ns / 1_000.0,
+        max_ns as f64 / 1_000.0
+    );
+    println!(
+        "workload: duration={:.3}s throughput={:.1} commits/sec",
+        elapsed_total.as_secs_f64(),
+        throughput
+    );
+
+    if let Some(metrics) = wal.group_commit_metrics_snapshot() {
+        let avg_state_lock_wait_ns = if metrics.state_lock_acquires > 0 {
+            metrics.state_lock_wait_ns as f64 / metrics.state_lock_acquires as f64
+        } else {
+            0.0
+        };
+        let avg_waiters_lock_wait_ns = if metrics.waiters_lock_acquires > 0 {
+            metrics.waiters_lock_wait_ns as f64 / metrics.waiters_lock_acquires as f64
+        } else {
+            0.0
+        };
+        let avg_commit_wait_ns = if metrics.wait_calls > 0 {
+            metrics.wait_total_ns as f64 / metrics.wait_calls as f64
+        } else {
+            0.0
+        };
+
+        println!("group_commit metrics:");
+        println!(
+            "  locks: state(acquires={}, avg_wait_ns={:.1}) waiters(acquires={}, avg_wait_ns={:.1})",
+            metrics.state_lock_acquires,
+            avg_state_lock_wait_ns,
+            metrics.waiters_lock_acquires,
+            avg_waiters_lock_wait_ns
+        );
+        println!(
+            "  waits: calls={} success={} timeouts={} errors={} avg_wait_ns={:.1}",
+            metrics.wait_calls,
+            metrics.wait_successes,
+            metrics.wait_timeouts,
+            metrics.wait_errors,
+            avg_commit_wait_ns
+        );
+        println!(
+            "  lifecycle: waiter_created={} waiter_removed={} trigger_flush_calls={} epoch_completions={}",
+            metrics.waiter_created,
+            metrics.waiter_removed,
+            metrics.trigger_flush_calls,
+            metrics.epoch_completions
+        );
+    }
+
+    let _ = fs::remove_dir_all(&wal_dir);
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,14 @@ pub struct WalConfig {
     /// This determines the tradeoff between durability guarantees and performance.
     /// Default: GroupCommit (10ms delay, 200 batch size)
     pub durability_mode: crate::storage::wal::DurabilityMode,
+
+    /// Optional immediate flush trigger threshold for GroupCommit/AsyncBatched modes.
+    ///
+    /// When `None`, runtime uses the durability mode's `max_batch_size` as the trigger.
+    /// When set, this value wakes the flush thread earlier once the in-epoch batch reaches
+    /// the threshold, while preserving epoch durability guarantees.
+    /// Default: None
+    pub group_commit_flush_trigger_batch_size: Option<usize>,
 }
 
 impl Default for WalConfig {
@@ -104,6 +112,7 @@ impl Default for WalConfig {
             wal_dir: std::path::PathBuf::from("aletheiadb/wal"),
             segments_to_retain: 10,
             durability_mode: crate::storage::wal::DurabilityMode::group_commit_default(),
+            group_commit_flush_trigger_batch_size: None,
         }
     }
 }
@@ -297,6 +306,24 @@ impl WalConfigBuilder {
     pub fn durability_mode(mut self, mode: crate::storage::wal::DurabilityMode) -> Self {
         self.config.durability_mode = mode;
         self
+    }
+
+    /// Set optional immediate flush trigger threshold for GroupCommit/AsyncBatched modes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidValue` if `threshold` is 0.
+    pub fn group_commit_flush_trigger_batch_size(
+        mut self,
+        threshold: usize,
+    ) -> Result<Self, ConfigError> {
+        if threshold == 0 {
+            return Err(ConfigError::InvalidValue(
+                "group_commit_flush_trigger_batch_size must be greater than 0".into(),
+            ));
+        }
+        self.config.group_commit_flush_trigger_batch_size = Some(threshold);
+        Ok(self)
     }
 
     /// Build the configuration.
@@ -869,6 +896,7 @@ mod tests {
         assert_eq!(config.write_buffer_size, 64 * 1024);
         assert_eq!(config.segment_size, 64 * 1024 * 1024);
         assert_eq!(config.flush_interval_ms, 10);
+        assert_eq!(config.group_commit_flush_trigger_batch_size, None);
     }
 
     #[test]
@@ -884,6 +912,8 @@ mod tests {
             .unwrap()
             .flush_interval_ms(20)
             .unwrap()
+            .group_commit_flush_trigger_batch_size(50)
+            .unwrap()
             .build();
 
         assert_eq!(config.num_stripes, 32);
@@ -891,6 +921,7 @@ mod tests {
         assert_eq!(config.write_buffer_size, 128 * 1024);
         assert_eq!(config.segment_size, 128 * 1024 * 1024);
         assert_eq!(config.flush_interval_ms, 20);
+        assert_eq!(config.group_commit_flush_trigger_batch_size, Some(50));
     }
 
     #[test]
@@ -1171,6 +1202,7 @@ stripe_capacity = 2048
 write_buffer_size = 131072
 segment_size = 134217728
 flush_interval_ms = 20
+group_commit_flush_trigger_batch_size = 75
 
 [historical]
 max_versions_per_entity = 5000
@@ -1192,6 +1224,7 @@ max_layer = 32
         assert_eq!(config.wal.write_buffer_size, 131072);
         assert_eq!(config.wal.segment_size, 134217728);
         assert_eq!(config.wal.flush_interval_ms, 20);
+        assert_eq!(config.wal.group_commit_flush_trigger_batch_size, Some(75));
 
         // Historical config
         assert_eq!(config.historical.max_versions_per_entity, 5000);
@@ -1433,6 +1466,13 @@ wal_dir = "/custom/path/to/wal"
     #[test]
     fn test_wal_config_zero_flush_interval() {
         let result = WalConfigBuilder::new().flush_interval_ms(0);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConfigError::InvalidValue(_)));
+    }
+
+    #[test]
+    fn test_wal_config_zero_group_commit_flush_trigger_batch_size() {
+        let result = WalConfigBuilder::new().group_commit_flush_trigger_batch_size(0);
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ConfigError::InvalidValue(_)));
     }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -166,6 +166,7 @@ impl AletheiaDB {
                 _ => config.wal.flush_interval_ms, // Use config default
             },
             durability_mode,
+            group_commit_flush_trigger_batch_size: config.wal.group_commit_flush_trigger_batch_size,
             write_buffer_size: config.wal.write_buffer_size,
         };
 
@@ -314,6 +315,7 @@ impl AletheiaDB {
                 _ => wal_config.flush_interval_ms,
             },
             durability_mode,
+            group_commit_flush_trigger_batch_size: wal_config.group_commit_flush_trigger_batch_size,
             write_buffer_size: wal_config.write_buffer_size,
         };
 

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -422,6 +422,36 @@ fn test_with_unified_config_returns_result() {
 }
 
 #[test]
+fn test_with_unified_config_propagates_group_commit_flush_trigger_threshold() {
+    use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+    use crate::storage::wal::DurabilityMode;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let wal_dir = temp_dir.path().join("wal");
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(wal_dir)
+                .durability_mode(DurabilityMode::GroupCommit {
+                    max_delay_ms: 10,
+                    max_batch_size: 20,
+                })
+                .group_commit_flush_trigger_batch_size(7)
+                .expect("threshold must be valid")
+                .build(),
+        )
+        .build();
+
+    let db = AletheiaDB::with_unified_config(config).expect("database should initialize");
+    let threshold = db
+        .wal
+        .group_commit_coordinator()
+        .expect("group commit coordinator should exist")
+        .flush_trigger_batch_size();
+    assert_eq!(threshold, 7);
+}
+
+#[test]
 fn test_cold_storage_configuration() {
     use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
     use std::time::Duration;

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -299,6 +299,27 @@ impl ConcurrentWal {
         }
     }
 
+    /// Check whether any stripe currently has buffered entries.
+    pub(crate) fn has_pending_entries(&self) -> bool {
+        self.stripes.iter().any(|stripe| !stripe.is_empty())
+    }
+
+    /// Prepare a serialized WAL entry without enqueueing it in stripe buffers.
+    ///
+    /// This is used by synchronous fast paths that flush a single entry directly.
+    pub(crate) fn prepare_direct_entry(&self, operation: WalOperation) -> Result<PendingEntry> {
+        if self.is_closed() {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL buffer closed".to_string(),
+            }));
+        }
+
+        let lsn = self.lsn_allocator.allocate();
+        let data = self.serialize_entry(lsn, &operation)?;
+        self.total_appends.fetch_add(1, Ordering::Relaxed);
+        Ok(PendingEntry::new_async(lsn, data))
+    }
+
     /// Append an operation with a completion handle (for group commit).
     ///
     /// Returns with a handle that can be used to wait for durability later.

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -51,7 +51,7 @@ use std::time::Duration;
 
 use super::concurrent::{ConcurrentWal, ConcurrentWalConfig};
 use super::flush_coordinator::{FlushCoordinator, FlushCoordinatorConfig, FlushStats};
-use super::group_commit::GroupCommitCoordinator;
+use super::group_commit::{GroupCommitConfig, GroupCommitCoordinator};
 use super::{LSN, WalOperation};
 use crate::core::error::{Error, Result, StorageError};
 use crate::storage::wal::DurabilityMode;
@@ -73,6 +73,11 @@ pub struct ConcurrentWalSystemConfig {
     pub flush_interval_ms: u64,
     /// Durability mode.
     pub durability_mode: DurabilityMode,
+    /// Optional override for immediate group-commit flush trigger threshold.
+    ///
+    /// When `None`, the system uses an adaptive threshold derived from
+    /// `max_batch_size`.
+    pub group_commit_flush_trigger_batch_size: Option<usize>,
     /// Write buffer size for segment files.
     pub write_buffer_size: usize,
 }
@@ -87,6 +92,7 @@ impl Default for ConcurrentWalSystemConfig {
             segments_to_retain: 10,
             flush_interval_ms: 10,
             durability_mode: DurabilityMode::Synchronous,
+            group_commit_flush_trigger_batch_size: None,
             write_buffer_size: 64 * 1024, // 64 KB
         }
     }
@@ -116,6 +122,12 @@ impl ConcurrentWalSystemConfig {
     /// Set the flush interval in milliseconds.
     pub fn with_flush_interval_ms(mut self, ms: u64) -> Self {
         self.flush_interval_ms = ms;
+        self
+    }
+
+    /// Override group-commit immediate flush trigger threshold.
+    pub fn with_group_commit_flush_trigger_batch_size(mut self, threshold: usize) -> Self {
+        self.group_commit_flush_trigger_batch_size = Some(threshold);
         self
     }
 }
@@ -318,18 +330,36 @@ impl ConcurrentWalSystem {
             DurabilityMode::GroupCommit {
                 max_batch_size,
                 max_delay_ms,
-            } => Some(Arc::new(GroupCommitCoordinator::new(
-                max_delay_ms,
-                max_batch_size,
-            ))),
+            } => {
+                let flush_trigger_batch_size = config
+                    .group_commit_flush_trigger_batch_size
+                    .unwrap_or(max_batch_size.max(1));
+                Some(Arc::new(GroupCommitCoordinator::with_config(
+                    GroupCommitConfig {
+                        max_delay_ms,
+                        max_batch_size,
+                        flush_trigger_batch_size,
+                        ..GroupCommitConfig::default()
+                    },
+                )))
+            }
             DurabilityMode::AsyncBatched {
                 max_batch_size,
                 max_delay_ms,
                 ..
-            } => Some(Arc::new(GroupCommitCoordinator::new(
-                max_delay_ms,
-                max_batch_size,
-            ))),
+            } => {
+                let flush_trigger_batch_size = config
+                    .group_commit_flush_trigger_batch_size
+                    .unwrap_or(max_batch_size.max(1));
+                Some(Arc::new(GroupCommitCoordinator::with_config(
+                    GroupCommitConfig {
+                        max_delay_ms,
+                        max_batch_size,
+                        flush_trigger_batch_size,
+                        ..GroupCommitConfig::default()
+                    },
+                )))
+            }
             _ => None,
         };
 
@@ -446,6 +476,27 @@ impl ConcurrentWalSystem {
             self.coordinator.flush(entries, true)?;
         }
 
+        Ok(lsn)
+    }
+
+    /// Append an operation via synchronous isolated fast path.
+    ///
+    /// This bypasses stripe buffers and flushes the serialized entry directly when
+    /// there are no pending buffered entries. If buffered entries exist, it falls
+    /// back to normal synchronous append semantics that drain and flush all pending data.
+    pub fn append_sync_isolated(&self, operation: WalOperation) -> Result<LSN> {
+        if !matches!(self.durability_mode, DurabilityMode::Synchronous) {
+            return self.append(operation);
+        }
+
+        // Preserve existing semantics if there is already buffered work.
+        if self.wal.has_pending_entries() {
+            return self.append_sync(operation);
+        }
+
+        let entry = self.wal.prepare_direct_entry(operation)?;
+        let lsn = entry.lsn;
+        self.coordinator.flush_single(entry, true)?;
         Ok(lsn)
     }
 
@@ -614,11 +665,66 @@ impl ConcurrentWalSystem {
         }
     }
 
+    /// Commit and wait for durability in GroupCommit mode using a fused control path.
+    ///
+    /// This avoids the separate `register_transaction()` and `wait_for_flush()` lock
+    /// round-trips on hot transaction commit paths.
+    pub fn commit_group_commit_and_wait(&self) -> Result<()> {
+        if !matches!(self.durability_mode, DurabilityMode::GroupCommit { .. }) {
+            let wait_epoch = self.commit()?;
+            if let Some(epoch) = wait_epoch
+                && let Some(gc) = self.group_commit_coordinator()
+                && self.durability_mode.waits_for_durability()
+            {
+                gc.wait_for_flush(epoch)?;
+            }
+            return Ok(());
+        }
+
+        if let Some(ref gc) = self.group_commit {
+            gc.register_transaction_and_wait(|| self.flush_notifier.notify())
+                .map_err(|e| {
+                    Error::Storage(StorageError::WalError {
+                        reason: format!("GroupCommit fused commit/wait failed: {}", e),
+                    })
+                })?;
+            Ok(())
+        } else {
+            // Fallback to sync if no coordinator (shouldn't happen)
+            let entries = self.wal.drain_all();
+            if !entries.is_empty() {
+                self.coordinator.flush(entries, true)?;
+            }
+            Ok(())
+        }
+    }
+
     /// Get the group commit coordinator for waiting on epochs.
     ///
     /// Returns `None` for modes that don't use group commit.
     pub fn group_commit_coordinator(&self) -> Option<&Arc<GroupCommitCoordinator>> {
         self.group_commit.as_ref()
+    }
+
+    /// Snapshot internal group-commit coordination metrics, if enabled for this mode.
+    pub fn group_commit_metrics_snapshot(
+        &self,
+    ) -> Option<super::group_commit::GroupCommitMetricsSnapshot> {
+        self.group_commit.as_ref().map(|gc| gc.metrics_snapshot())
+    }
+
+    /// Reset internal group-commit coordination metrics.
+    pub fn reset_group_commit_metrics(&self) {
+        if let Some(gc) = self.group_commit.as_ref() {
+            gc.reset_metrics();
+        }
+    }
+
+    /// Enable or disable internal group-commit metrics instrumentation.
+    pub fn set_group_commit_metrics_enabled(&self, enabled: bool) {
+        if let Some(gc) = self.group_commit.as_ref() {
+            gc.set_metrics_enabled(enabled);
+        }
     }
 
     /// Get the current (next to be allocated) LSN.
@@ -738,6 +844,23 @@ mod tests {
         let lsn = wal.append(create_test_operation(1)).unwrap();
         assert_eq!(lsn, LSN(1));
         assert_eq!(wal.total_appends(), 1);
+    }
+
+    #[test]
+    fn test_append_sync_isolated_mode() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_durability_mode(DurabilityMode::Synchronous);
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let lsn = wal.append_sync_isolated(create_test_operation(1)).unwrap();
+        assert_eq!(lsn, LSN(1));
+        assert_eq!(wal.total_appends(), 1);
+        assert_eq!(wal.total_flushed(), 1);
+
+        // Isolated path should flush directly, leaving buffered queue empty.
+        let stats = wal.flush().unwrap();
+        assert_eq!(stats.entries_flushed, 0);
     }
 
     #[test]
@@ -875,6 +998,100 @@ mod tests {
             timeout.as_millis(),
             wal.total_flushed()
         );
+
+        wal.shutdown();
+    }
+
+    #[test]
+    fn test_group_commit_default_flush_trigger_matches_max_batch_size() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path()).with_durability_mode(
+            DurabilityMode::GroupCommit {
+                max_batch_size: 20,
+                max_delay_ms: 10,
+            },
+        );
+        let mut wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let threshold = wal
+            .group_commit_coordinator()
+            .expect("group commit coordinator should be available")
+            .flush_trigger_batch_size();
+        assert_eq!(threshold, 20);
+
+        wal.shutdown();
+    }
+
+    #[test]
+    fn test_group_commit_flush_trigger_threshold_override() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_durability_mode(DurabilityMode::GroupCommit {
+                max_batch_size: 20,
+                max_delay_ms: 10,
+            })
+            .with_group_commit_flush_trigger_batch_size(20);
+        let mut wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let threshold = wal
+            .group_commit_coordinator()
+            .expect("group commit coordinator should be available")
+            .flush_trigger_batch_size();
+        assert_eq!(threshold, 20);
+
+        wal.shutdown();
+    }
+
+    #[test]
+    fn test_commit_group_commit_and_wait() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_durability_mode(DurabilityMode::GroupCommit {
+                max_batch_size: 8,
+                max_delay_ms: 5,
+            })
+            .with_flush_interval_ms(2);
+        let mut wal = ConcurrentWalSystem::new(config).unwrap();
+        wal.set_group_commit_metrics_enabled(true);
+
+        wal.append_async(create_test_operation(1)).unwrap();
+        wal.commit_group_commit_and_wait().unwrap();
+
+        assert!(
+            wal.total_flushed() >= 1,
+            "Expected at least one flushed entry after fused commit/wait"
+        );
+
+        wal.shutdown();
+    }
+
+    #[test]
+    fn test_group_commit_metrics_snapshot() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_durability_mode(DurabilityMode::GroupCommit {
+                max_batch_size: 8,
+                max_delay_ms: 5,
+            })
+            .with_flush_interval_ms(2);
+        let mut wal = ConcurrentWalSystem::new(config).unwrap();
+        wal.set_group_commit_metrics_enabled(true);
+
+        wal.append_async(create_test_operation(1)).unwrap();
+        wal.commit_group_commit_and_wait().unwrap();
+
+        let metrics = wal
+            .group_commit_metrics_snapshot()
+            .expect("group commit metrics should be available");
+        assert!(metrics.wait_calls > 0);
+        assert!(metrics.epoch_completions > 0);
+
+        wal.reset_group_commit_metrics();
+        let reset = wal
+            .group_commit_metrics_snapshot()
+            .expect("group commit metrics should be available");
+        assert_eq!(reset.wait_calls, 0);
+        assert_eq!(reset.epoch_completions, 0);
 
         wal.shutdown();
     }

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -587,9 +587,16 @@ impl FlushCoordinator {
     /// # Returns
     ///
     /// Statistics about the flush operation.
-    pub fn flush(&self, entries: Vec<PendingEntry>, sync: bool) -> Result<FlushStats> {
+    pub fn flush(&self, mut entries: Vec<PendingEntry>, sync: bool) -> Result<FlushStats> {
         if entries.is_empty() {
             return Ok(FlushStats::default());
+        }
+
+        if entries.len() == 1 {
+            let entry = entries
+                .pop()
+                .expect("entries.len() == 1 should always yield one entry");
+            return self.flush_single(entry, sync);
         }
 
         let start = Instant::now();
@@ -697,6 +704,96 @@ impl FlushCoordinator {
                 for entry in entries {
                     entry.notify_error(&error_msg);
                 }
+                Err(e)
+            }
+        }
+    }
+
+    /// Flush exactly one entry to disk.
+    ///
+    /// This is a latency-oriented path used by synchronous single-entry commits to
+    /// avoid vector allocation and generic batch iteration overhead.
+    pub fn flush_single(&self, entry: PendingEntry, sync: bool) -> Result<FlushStats> {
+        let start = Instant::now();
+        let entry_lsn = entry.lsn.0;
+
+        // Inner function to perform I/O operations.
+        // This allows us to catch errors and notify pending entries before returning.
+        let do_flush = || -> Result<FlushStats> {
+            // Acquire lock once for the entire operation to ensure thread safety
+            let mut writer_guard = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+
+            // Ensure segment is open
+            self.ensure_segment_open(&mut writer_guard)?;
+
+            let writer = writer_guard.as_mut().ok_or_else(|| {
+                Error::Storage(StorageError::WalError {
+                    reason: "WAL writer not initialized".to_string(),
+                })
+            })?;
+
+            writer.write_all(&entry.data).map_err(|e| {
+                Error::Storage(StorageError::IoError(format!(
+                    "Failed to write WAL entry: {}",
+                    e
+                )))
+            })?;
+            let bytes_written = entry.data.len();
+
+            // Flush buffer to OS
+            writer.flush().map_err(|e| {
+                Error::Storage(StorageError::IoError(format!(
+                    "Failed to flush WAL buffer: {}",
+                    e
+                )))
+            })?;
+
+            // Update segment LSN tracking (ADR-0025)
+            self.current_segment_min_lsn
+                .fetch_min(entry_lsn, Ordering::Relaxed);
+            self.current_segment_max_lsn
+                .fetch_max(entry_lsn, Ordering::Relaxed);
+            self.current_segment_entry_count
+                .fetch_add(1, Ordering::Relaxed);
+
+            // Sync to disk if requested.
+            // We sync via the active writer file handle to avoid extra mutex traffic.
+            if sync && self.config.sync_on_flush {
+                writer.get_ref().sync_data().map_err(|e| {
+                    Error::Storage(StorageError::IoError(format!("Failed to sync WAL: {}", e)))
+                })?;
+            }
+
+            // Update size
+            self.current_segment_size
+                .fetch_add(bytes_written as u64, Ordering::Relaxed);
+
+            // Check for rotation
+            let segment_rotated = self.maybe_rotate_segment(&mut writer_guard)?;
+
+            // Update metrics
+            self.total_entries_flushed.fetch_add(1, Ordering::Relaxed);
+            self.total_bytes_written
+                .fetch_add(bytes_written as u64, Ordering::Relaxed);
+            self.total_flushes.fetch_add(1, Ordering::Relaxed);
+
+            Ok(FlushStats {
+                entries_flushed: 1,
+                bytes_written,
+                flush_duration: start.elapsed(),
+                segment_rotated,
+            })
+        };
+
+        // Execute flush logic
+        match do_flush() {
+            Ok(stats) => {
+                entry.notify_completion();
+                Ok(stats)
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                entry.notify_error(&error_msg);
                 Err(e)
             }
         }

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -27,9 +27,10 @@
 //! The flush thread uses `.expect()` to panic on lock poisoning because silent
 //! degradation is worse than fail-fast behavior for background infrastructure.
 
-use std::collections::VecDeque;
-use std::sync::{Condvar, Mutex};
-use std::time::Duration;
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
 
 use crate::core::error::{Error, StorageError};
 
@@ -61,10 +62,83 @@ use crate::core::error::{Error, StorageError};
 pub struct GroupCommitCoordinator {
     /// State protected by mutex
     state: Mutex<GroupCommitState>,
-    /// Condition variable for flush completion
-    flush_complete: Condvar,
+    /// Per-epoch wait latches protected separately from coordinator state.
+    waiters: Mutex<HashMap<u64, Arc<EpochLatch>>>,
+    /// Lightweight internal metrics for profiling group-commit coordination.
+    metrics: GroupCommitMetrics,
+    /// Enables internal metrics instrumentation on hot paths.
+    metrics_enabled: AtomicBool,
     /// Configuration
     config: GroupCommitConfig,
+    /// Precomputed wait timeout used by `wait_for_flush`.
+    wait_timeout: Duration,
+}
+
+/// Per-epoch wait latch.
+///
+/// Transactions waiting for a specific epoch block on that epoch's latch so a
+/// completed flush only wakes relevant waiters (no global thundering-herd wakeup).
+struct EpochLatch {
+    state: Mutex<EpochLatchState>,
+    condvar: Condvar,
+}
+
+#[derive(Default)]
+struct EpochLatchState {
+    completed: bool,
+    error: Option<String>,
+}
+
+impl EpochLatch {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(EpochLatchState::default()),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn complete(&self, result: Result<(), Error>) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if state.completed {
+            return;
+        }
+        state.completed = true;
+        if let Err(e) = result {
+            state.error = Some(e.to_string());
+        }
+        self.condvar.notify_all();
+    }
+
+    fn wait(&self, timeout: Duration, epoch: u64) -> Result<(), Error> {
+        let mut state = self.state.lock().map_err(|_| {
+            Error::Storage(StorageError::LockPoisoned {
+                resource: "group_commit_epoch_latch".to_string(),
+            })
+        })?;
+
+        while !state.completed {
+            let (new_state, timeout_result) =
+                self.condvar.wait_timeout(state, timeout).map_err(|_| {
+                    Error::Storage(StorageError::LockPoisoned {
+                        resource: "group_commit_epoch_latch".to_string(),
+                    })
+                })?;
+            state = new_state;
+            if timeout_result.timed_out() && !state.completed {
+                return Err(Error::Storage(StorageError::WalError {
+                    reason: format!("Group commit timeout waiting for epoch {}", epoch),
+                }));
+            }
+        }
+
+        if let Some(error_msg) = &state.error {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: format!("Group commit flush failed: {}", error_msg),
+            }));
+        }
+
+        Ok(())
+    }
 }
 
 /// Configuration for group commit behavior.
@@ -74,6 +148,11 @@ pub struct GroupCommitConfig {
     pub max_delay_ms: u64,
     /// Maximum transactions to batch before forcing a flush.
     pub max_batch_size: usize,
+    /// Batch size threshold that triggers an immediate flush wakeup.
+    ///
+    /// Values greater than `max_batch_size` are clamped to `max_batch_size`.
+    /// A value of `0` is treated as `1`.
+    pub flush_trigger_batch_size: usize,
 
     /// Multiplier for max_delay_ms to calculate base timeout.
     pub timeout_multiplier: u32,
@@ -92,6 +171,7 @@ impl Default for GroupCommitConfig {
         Self {
             max_delay_ms: 10,
             max_batch_size: 200,
+            flush_trigger_batch_size: 200,
             timeout_multiplier: 50,
             timeout_base_ms: 5000,
             timeout_min_ms: 10000,
@@ -116,12 +196,61 @@ struct GroupCommitState {
     oldest_error_epoch: u64,
 }
 
+#[derive(Debug, Default)]
+struct GroupCommitMetrics {
+    state_lock_wait_ns: AtomicU64,
+    state_lock_acquires: AtomicU64,
+    waiters_lock_wait_ns: AtomicU64,
+    waiters_lock_acquires: AtomicU64,
+    wait_calls: AtomicU64,
+    wait_successes: AtomicU64,
+    wait_timeouts: AtomicU64,
+    wait_errors: AtomicU64,
+    wait_total_ns: AtomicU64,
+    waiter_created: AtomicU64,
+    waiter_removed: AtomicU64,
+    trigger_flush_calls: AtomicU64,
+    epoch_completions: AtomicU64,
+}
+
+/// Snapshot of internal group-commit coordination metrics.
+#[derive(Debug, Clone, Default)]
+pub struct GroupCommitMetricsSnapshot {
+    /// Total nanoseconds spent waiting to acquire the coordinator state lock.
+    pub state_lock_wait_ns: u64,
+    /// Number of successful coordinator state lock acquisitions.
+    pub state_lock_acquires: u64,
+    /// Total nanoseconds spent waiting to acquire the waiters map lock.
+    pub waiters_lock_wait_ns: u64,
+    /// Number of successful waiters map lock acquisitions.
+    pub waiters_lock_acquires: u64,
+    /// Total number of commit wait operations started.
+    pub wait_calls: u64,
+    /// Number of successful commit wait operations.
+    pub wait_successes: u64,
+    /// Number of commit wait operations that timed out.
+    pub wait_timeouts: u64,
+    /// Number of commit wait operations that completed with an error.
+    pub wait_errors: u64,
+    /// Total nanoseconds spent waiting in commit wait operations.
+    pub wait_total_ns: u64,
+    /// Number of epoch waiter latches created.
+    pub waiter_created: u64,
+    /// Number of epoch waiter latches removed.
+    pub waiter_removed: u64,
+    /// Number of times group commit requested a flush trigger.
+    pub trigger_flush_calls: u64,
+    /// Number of epochs marked as completed by flush.
+    pub epoch_completions: u64,
+}
+
 impl GroupCommitCoordinator {
     /// Create a new GroupCommitCoordinator with the given configuration.
     pub fn new(max_delay_ms: u64, max_batch_size: usize) -> Self {
         Self::with_config(GroupCommitConfig {
             max_delay_ms,
             max_batch_size,
+            flush_trigger_batch_size: max_batch_size,
             recent_errors_capacity: 1024,
             ..GroupCommitConfig::default()
         })
@@ -129,6 +258,13 @@ impl GroupCommitCoordinator {
 
     /// Create a new GroupCommitCoordinator with the given full configuration.
     pub fn with_config(config: GroupCommitConfig) -> Self {
+        let base_timeout =
+            Duration::from_millis(config.max_delay_ms * config.timeout_multiplier as u64)
+                + Duration::from_millis(config.timeout_base_ms);
+        let wait_timeout = base_timeout
+            .max(Duration::from_millis(config.timeout_min_ms))
+            .min(Duration::from_millis(config.timeout_max_ms));
+
         Self {
             state: Mutex::new(GroupCommitState {
                 current_epoch: 1, // Start at 1 so flushed_epoch=0 means "nothing flushed yet"
@@ -137,8 +273,11 @@ impl GroupCommitCoordinator {
                 recent_errors: VecDeque::new(),
                 oldest_error_epoch: 0,
             }),
-            flush_complete: Condvar::new(),
+            waiters: Mutex::new(HashMap::new()),
+            metrics: GroupCommitMetrics::default(),
+            metrics_enabled: AtomicBool::new(false),
             config,
+            wait_timeout,
         }
     }
 
@@ -148,10 +287,192 @@ impl GroupCommitCoordinator {
         Self::new(config.max_delay_ms, config.max_batch_size)
     }
 
+    #[inline]
+    fn metrics_enabled(&self) -> bool {
+        self.metrics_enabled.load(Ordering::Relaxed)
+    }
+
+    fn lock_state(&self) -> Result<MutexGuard<'_, GroupCommitState>, Error> {
+        if self.metrics_enabled() {
+            let start = Instant::now();
+            let guard = self.state.lock().map_err(|_| {
+                Error::Storage(StorageError::LockPoisoned {
+                    resource: "group_commit_state".to_string(),
+                })
+            })?;
+            self.metrics
+                .state_lock_wait_ns
+                .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            self.metrics
+                .state_lock_acquires
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(guard)
+        } else {
+            self.state.lock().map_err(|_| {
+                Error::Storage(StorageError::LockPoisoned {
+                    resource: "group_commit_state".to_string(),
+                })
+            })
+        }
+    }
+
+    fn lock_waiters(&self) -> Result<MutexGuard<'_, HashMap<u64, Arc<EpochLatch>>>, Error> {
+        if self.metrics_enabled() {
+            let start = Instant::now();
+            let guard = self.waiters.lock().map_err(|_| {
+                Error::Storage(StorageError::LockPoisoned {
+                    resource: "group_commit_waiters".to_string(),
+                })
+            })?;
+            self.metrics
+                .waiters_lock_wait_ns
+                .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            self.metrics
+                .waiters_lock_acquires
+                .fetch_add(1, Ordering::Relaxed);
+            Ok(guard)
+        } else {
+            self.waiters.lock().map_err(|_| {
+                Error::Storage(StorageError::LockPoisoned {
+                    resource: "group_commit_waiters".to_string(),
+                })
+            })
+        }
+    }
+
+    fn wait_on_epoch_latch(&self, waiter: &Arc<EpochLatch>, epoch: u64) -> Result<(), Error> {
+        if self.metrics_enabled() {
+            self.metrics.wait_calls.fetch_add(1, Ordering::Relaxed);
+            let start = Instant::now();
+            let result = waiter.wait(self.wait_timeout, epoch);
+            self.metrics
+                .wait_total_ns
+                .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+
+            match &result {
+                Ok(()) => {
+                    self.metrics.wait_successes.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("timeout waiting for epoch") {
+                        self.metrics.wait_timeouts.fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        self.metrics.wait_errors.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+
+            result
+        } else {
+            waiter.wait(self.wait_timeout, epoch)
+        }
+    }
+
+    /// Snapshot current internal coordination metrics.
+    pub fn metrics_snapshot(&self) -> GroupCommitMetricsSnapshot {
+        GroupCommitMetricsSnapshot {
+            state_lock_wait_ns: self.metrics.state_lock_wait_ns.load(Ordering::Relaxed),
+            state_lock_acquires: self.metrics.state_lock_acquires.load(Ordering::Relaxed),
+            waiters_lock_wait_ns: self.metrics.waiters_lock_wait_ns.load(Ordering::Relaxed),
+            waiters_lock_acquires: self.metrics.waiters_lock_acquires.load(Ordering::Relaxed),
+            wait_calls: self.metrics.wait_calls.load(Ordering::Relaxed),
+            wait_successes: self.metrics.wait_successes.load(Ordering::Relaxed),
+            wait_timeouts: self.metrics.wait_timeouts.load(Ordering::Relaxed),
+            wait_errors: self.metrics.wait_errors.load(Ordering::Relaxed),
+            wait_total_ns: self.metrics.wait_total_ns.load(Ordering::Relaxed),
+            waiter_created: self.metrics.waiter_created.load(Ordering::Relaxed),
+            waiter_removed: self.metrics.waiter_removed.load(Ordering::Relaxed),
+            trigger_flush_calls: self.metrics.trigger_flush_calls.load(Ordering::Relaxed),
+            epoch_completions: self.metrics.epoch_completions.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Reset internal coordination metrics to zero.
+    pub fn reset_metrics(&self) {
+        self.metrics.state_lock_wait_ns.store(0, Ordering::Relaxed);
+        self.metrics.state_lock_acquires.store(0, Ordering::Relaxed);
+        self.metrics
+            .waiters_lock_wait_ns
+            .store(0, Ordering::Relaxed);
+        self.metrics
+            .waiters_lock_acquires
+            .store(0, Ordering::Relaxed);
+        self.metrics.wait_calls.store(0, Ordering::Relaxed);
+        self.metrics.wait_successes.store(0, Ordering::Relaxed);
+        self.metrics.wait_timeouts.store(0, Ordering::Relaxed);
+        self.metrics.wait_errors.store(0, Ordering::Relaxed);
+        self.metrics.wait_total_ns.store(0, Ordering::Relaxed);
+        self.metrics.waiter_created.store(0, Ordering::Relaxed);
+        self.metrics.waiter_removed.store(0, Ordering::Relaxed);
+        self.metrics.trigger_flush_calls.store(0, Ordering::Relaxed);
+        self.metrics.epoch_completions.store(0, Ordering::Relaxed);
+    }
+
+    /// Enable or disable metrics instrumentation.
+    pub fn set_metrics_enabled(&self, enabled: bool) {
+        self.metrics_enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    fn validate_epoch_outcome(state: &GroupCommitState, epoch: u64) -> Result<(), Error> {
+        // Check for flush errors specifically for this epoch.
+        for (failed_epoch, error_msg) in &state.recent_errors {
+            if *failed_epoch == epoch {
+                return Err(Error::Storage(StorageError::WalError {
+                    reason: format!("Group commit flush failed: {}", error_msg),
+                }));
+            }
+        }
+
+        // Check for history eviction (False Success protection).
+        if epoch < state.oldest_error_epoch {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: format!(
+                    "Group commit status unknown: epoch {} evicted from error history (history starts at {})",
+                    epoch, state.oldest_error_epoch
+                ),
+            }));
+        }
+
+        Ok(())
+    }
+
+    fn get_or_create_waiter(&self, epoch: u64) -> Result<Arc<EpochLatch>, Error> {
+        let mut waiters = self.lock_waiters()?;
+        if let Some(waiter) = waiters.get(&epoch) {
+            return Ok(waiter.clone());
+        }
+        let waiter = Arc::new(EpochLatch::new());
+        waiters.insert(epoch, waiter.clone());
+        if self.metrics_enabled() {
+            self.metrics.waiter_created.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(waiter)
+    }
+
+    fn remove_waiter(&self, epoch: u64) -> Result<Option<Arc<EpochLatch>>, Error> {
+        let mut waiters = self.lock_waiters()?;
+        let removed = waiters.remove(&epoch);
+        if removed.is_some() && self.metrics_enabled() {
+            self.metrics.waiter_removed.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(removed)
+    }
+
+    fn immediate_flush_threshold(&self) -> usize {
+        if self.config.max_batch_size == 0 {
+            return 1;
+        }
+        self.config
+            .flush_trigger_batch_size
+            .max(1)
+            .min(self.config.max_batch_size)
+    }
+
     /// Register a transaction for group commit.
     ///
     /// Returns the epoch number that this transaction should wait for.
-    /// If the batch is full, returns `true` in the second element to signal
+    /// If the immediate flush threshold is reached, returns `true` in the second element to signal
     /// that an immediate flush should be triggered.
     ///
     /// # Returns
@@ -162,19 +483,63 @@ impl GroupCommitCoordinator {
     ///
     /// Returns `StorageError::LockPoisoned` if the coordinator lock is poisoned.
     pub fn register_transaction(&self) -> Result<(u64, bool), Error> {
-        let mut state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
+        let mut state = self.lock_state()?;
 
         state.batch_count += 1;
         let epoch = state.current_epoch;
 
-        // Check if we should trigger immediate flush (batch full)
-        let should_flush = state.batch_count >= self.config.max_batch_size;
+        // Check if we should trigger immediate flush (threshold reached)
+        let should_flush = state.batch_count >= self.immediate_flush_threshold();
 
         Ok((epoch, should_flush))
+    }
+
+    /// Register a transaction and synchronously wait for its epoch to flush.
+    ///
+    /// This fuses the control path of `register_transaction()` + `wait_for_flush()`
+    /// into one lock acquisition path to reduce mutex round-trips on hot commit paths.
+    ///
+    /// The provided callback is invoked when the batch reaches max size and an
+    /// immediate flush should be triggered (e.g., wake the flush thread).
+    pub fn register_transaction_and_wait<F>(&self, trigger_flush: F) -> Result<(), Error>
+    where
+        F: FnOnce(),
+    {
+        let (epoch, should_trigger) = {
+            let mut state = self.lock_state()?;
+
+            state.batch_count += 1;
+            let epoch = state.current_epoch;
+            (epoch, state.batch_count >= self.immediate_flush_threshold())
+        };
+
+        let waiter = self.get_or_create_waiter(epoch)?;
+
+        if should_trigger {
+            if self.metrics_enabled() {
+                self.metrics
+                    .trigger_flush_calls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            trigger_flush();
+        }
+
+        {
+            let state = self.lock_state()?;
+            if state.flushed_epoch >= epoch {
+                let outcome = Self::validate_epoch_outcome(&state, epoch);
+                drop(state);
+                let completion = match &outcome {
+                    Ok(()) => Ok(()),
+                    Err(e) => Err(Error::other(e.to_string())),
+                };
+                waiter.complete(completion);
+                let _ = self.remove_waiter(epoch)?;
+                return outcome;
+            }
+        }
+
+        self.wait_on_epoch_latch(&waiter, epoch)
     }
 
     /// Wait for the specified epoch to be flushed.
@@ -204,76 +569,60 @@ impl GroupCommitCoordinator {
     /// - The flush for this epoch failed
     /// - The wait times out (indicates a stuck flush thread or excessive system load)
     pub fn wait_for_flush(&self, epoch: u64) -> Result<(), Error> {
-        let mut state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
-
-        // Deadlock detection timeout (NOT a performance SLA)
-        let base_timeout =
-            Duration::from_millis(self.config.max_delay_ms * self.config.timeout_multiplier as u64)
-                + Duration::from_millis(self.config.timeout_base_ms);
-        let timeout = base_timeout
-            .max(Duration::from_millis(self.config.timeout_min_ms))
-            .min(Duration::from_millis(self.config.timeout_max_ms));
-
-        // RACE CONDITION SAFETY: If the epoch was already flushed between register_transaction()
-        // and this wait (rare but possible on fast systems), this loop exits immediately since
-        // flushed_epoch >= epoch, and we return Ok(()) without waiting.
-        //
-        // EPOCH SEMANTICS: flushed_epoch = N means "epoch N has been flushed".
-        // Transaction at epoch E waits while flushed_epoch < E (i.e., E has not been flushed yet).
-        while state.flushed_epoch < epoch {
-            let (new_state, timeout_result) = self
-                .flush_complete
-                .wait_timeout(state, timeout)
-                .map_err(|_| {
-                    Error::Storage(StorageError::LockPoisoned {
-                        resource: "group_commit_state".to_string(),
-                    })
-                })?;
-
-            state = new_state;
-
-            if timeout_result.timed_out() && state.flushed_epoch < epoch {
-                return Err(Error::Storage(StorageError::WalError {
-                    reason: format!(
-                        "Group commit timeout waiting for epoch {} (current flushed: {})",
-                        epoch, state.flushed_epoch
-                    ),
-                }));
+        {
+            let state = self.lock_state()?;
+            if state.flushed_epoch >= epoch {
+                return Self::validate_epoch_outcome(&state, epoch);
             }
         }
 
-        // Check for flush errors specifically for this epoch
-        for (failed_epoch, error_msg) in &state.recent_errors {
-            if *failed_epoch == epoch {
-                return Err(Error::Storage(StorageError::WalError {
-                    reason: format!("Group commit flush failed: {}", error_msg),
-                }));
+        let waiter = self.get_or_create_waiter(epoch)?;
+
+        // Re-check after registering waiter to avoid missed flush completion races.
+        {
+            let state = self.lock_state()?;
+            if state.flushed_epoch >= epoch {
+                let outcome = Self::validate_epoch_outcome(&state, epoch);
+                drop(state);
+                let completion = match &outcome {
+                    Ok(()) => Ok(()),
+                    Err(e) => Err(Error::other(e.to_string())),
+                };
+                waiter.complete(completion);
+                let _ = self.remove_waiter(epoch)?;
+                return outcome;
             }
         }
 
-        // Check for history eviction (False Success protection)
-        // We only lose certainty about an epoch's status if its error record was EVICTED.
-        // state.oldest_error_epoch tracks the threshold of lost history.
-        // If epoch < state.oldest_error_epoch, it might have failed and been forgotten.
-        //
-        // Note: We do NOT check against recent_errors.front() because a sparse error list
-        // is valid. If epoch 1 succeeded and epoch 2 failed, recent_errors = [(2, ...)].
-        // epoch 1 < 2, but it shouldn't fail unless 1 < oldest_error_epoch.
+        self.wait_on_epoch_latch(&waiter, epoch)
+    }
 
-        if epoch < state.oldest_error_epoch {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: format!(
-                    "Group commit status unknown: epoch {} evicted from error history (history starts at {})",
-                    epoch, state.oldest_error_epoch
-                ),
-            }));
+    fn record_flush_result(
+        state: &mut GroupCommitState,
+        config: &GroupCommitConfig,
+        epoch: u64,
+        result: Result<(), Error>,
+    ) {
+        if let Err(e) = result {
+            state.recent_errors.push_back((epoch, e.to_string()));
+
+            // Keep history limited
+            while state.recent_errors.len() > config.recent_errors_capacity {
+                if let Some((evicted_epoch, _)) = state.recent_errors.pop_front() {
+                    // Track the newest evicted epoch to know what we've lost
+                    // We set oldest_error_epoch to evicted_epoch + 1 because if
+                    // evicted_epoch is gone, any check for it (or older) is invalid.
+                    state.oldest_error_epoch = evicted_epoch + 1;
+                }
+            }
         }
 
-        Ok(())
+        // Advance flushed_epoch to wake up waiters for this epoch
+        // Note: We use max to handle potential out-of-order completions if we ever support that,
+        // though currently flushes are serialized.
+        if epoch > state.flushed_epoch {
+            state.flushed_epoch = epoch;
+        }
     }
 
     /// Start a flush operation.
@@ -287,11 +636,7 @@ impl GroupCommitCoordinator {
     ///
     /// The epoch number that is being flushed.
     pub fn start_flush(&self) -> Result<u64, Error> {
-        let mut state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
+        let mut state = self.lock_state()?;
 
         let epoch_to_flush = state.current_epoch;
 
@@ -311,51 +656,69 @@ impl GroupCommitCoordinator {
     /// * `epoch` - The epoch that was flushed (returned by `start_flush`).
     /// * `result` - The result of the flush operation.
     pub fn finish_flush(&self, epoch: u64, result: Result<(), Error>) -> Result<(), Error> {
-        let mut state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
+        let completion_error = result.err().map(|e| e.to_string());
+        {
+            let mut state = self.lock_state()?;
 
-        // Store error if any
-        if let Err(e) = result {
-            state.recent_errors.push_back((epoch, e.to_string()));
-
-            // Keep history limited
-            while state.recent_errors.len() > self.config.recent_errors_capacity {
-                if let Some((evicted_epoch, _)) = state.recent_errors.pop_front() {
-                    // Track the newest evicted epoch to know what we've lost
-                    // We set oldest_error_epoch to evicted_epoch + 1 because if
-                    // evicted_epoch is gone, any check for it (or older) is invalid.
-                    state.oldest_error_epoch = evicted_epoch + 1;
-                }
-            }
+            let state_result = match &completion_error {
+                Some(msg) => Err(Error::other(msg.clone())),
+                None => Ok(()),
+            };
+            Self::record_flush_result(&mut state, &self.config, epoch, state_result);
         }
 
-        // Advance flushed_epoch to wake up waiters for this epoch
-        // Note: We use max to handle potential out-of-order completions if we ever support that,
-        // though currently flushes are serialized.
-        if epoch > state.flushed_epoch {
-            state.flushed_epoch = epoch;
+        if self.metrics_enabled() {
+            self.metrics
+                .epoch_completions
+                .fetch_add(1, Ordering::Relaxed);
         }
 
-        // Wake all waiting transactions
-        self.flush_complete.notify_all();
+        if let Some(waiter) = self.remove_waiter(epoch)? {
+            let waiter_result = match completion_error {
+                Some(msg) => Err(Error::other(msg)),
+                None => Ok(()),
+            };
+            waiter.complete(waiter_result);
+        }
 
         Ok(())
     }
 
     /// Mark the current batch as flushed (Legacy/Combined Helper).
     ///
-    /// WARNING: This method combines `start_flush` and `finish_flush` but IS NOT SAFE
-    /// against the race condition described in security review (transactions registering
-    /// during the flush).
-    ///
-    /// It is kept for backward compatibility with existing tests but `start_flush`
-    /// and `finish_flush` should be used in production.
+    /// This is a convenience method for tests and simple callers.
+    /// It advances epoch and stores flush result under one lock acquisition.
     pub fn mark_flushed(&self, result: Result<(), Error>) -> Result<(), Error> {
-        let epoch = self.start_flush()?;
-        self.finish_flush(epoch, result)
+        let completion_error = result.err().map(|e| e.to_string());
+        let epoch_to_flush = {
+            let mut state = self.lock_state()?;
+
+            let epoch_to_flush = state.current_epoch;
+            state.current_epoch += 1;
+            state.batch_count = 0;
+
+            let state_result = match &completion_error {
+                Some(msg) => Err(Error::other(msg.clone())),
+                None => Ok(()),
+            };
+            Self::record_flush_result(&mut state, &self.config, epoch_to_flush, state_result);
+            epoch_to_flush
+        };
+
+        if self.metrics_enabled() {
+            self.metrics
+                .epoch_completions
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        if let Some(waiter) = self.remove_waiter(epoch_to_flush)? {
+            let waiter_result = match completion_error {
+                Some(msg) => Err(Error::other(msg)),
+                None => Ok(()),
+            };
+            waiter.complete(waiter_result);
+        }
+        Ok(())
     }
 
     /// Get the current batch size.
@@ -366,11 +729,7 @@ impl GroupCommitCoordinator {
     ///
     /// Returns `StorageError::LockPoisoned` if the coordinator lock is poisoned.
     pub fn current_batch_size(&self) -> Result<usize, Error> {
-        let state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
+        let state = self.lock_state()?;
         Ok(state.batch_count)
     }
 
@@ -382,11 +741,7 @@ impl GroupCommitCoordinator {
     ///
     /// Returns `StorageError::LockPoisoned` if the coordinator lock is poisoned.
     pub fn current_epoch(&self) -> Result<u64, Error> {
-        let state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
+        let state = self.lock_state()?;
         Ok(state.current_epoch)
     }
 
@@ -398,15 +753,11 @@ impl GroupCommitCoordinator {
     ///
     /// Returns `StorageError::LockPoisoned` if the coordinator lock is poisoned.
     pub fn flushed_epoch(&self) -> Result<u64, Error> {
-        let state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
+        let state = self.lock_state()?;
         Ok(state.flushed_epoch)
     }
 
-    /// Check if a flush should be triggered based on batch size.
+    /// Check if an immediate flush should be triggered based on batch threshold.
     ///
     /// Called by the flush thread to check if the batch is full.
     ///
@@ -414,17 +765,18 @@ impl GroupCommitCoordinator {
     ///
     /// Returns `StorageError::LockPoisoned` if the coordinator lock is poisoned.
     pub fn should_flush(&self) -> Result<bool, Error> {
-        let state = self.state.lock().map_err(|_| {
-            Error::Storage(StorageError::LockPoisoned {
-                resource: "group_commit_state".to_string(),
-            })
-        })?;
-        Ok(state.batch_count >= self.config.max_batch_size)
+        let state = self.lock_state()?;
+        Ok(state.batch_count >= self.immediate_flush_threshold())
     }
 
     /// Get the maximum delay for this coordinator.
     pub fn max_delay(&self) -> Duration {
         Duration::from_millis(self.config.max_delay_ms)
+    }
+
+    /// Get the effective immediate flush trigger threshold.
+    pub fn flush_trigger_batch_size(&self) -> usize {
+        self.immediate_flush_threshold()
     }
 }
 
@@ -459,6 +811,34 @@ mod tests {
         let (epoch, should_flush) = coord.register_transaction().unwrap();
         assert_eq!(epoch, 1); // Still in epoch 1
         assert!(should_flush, "should flush when batch is full");
+    }
+
+    #[test]
+    fn test_register_transaction_with_custom_trigger_threshold() {
+        let config = GroupCommitConfig {
+            max_delay_ms: 10,
+            max_batch_size: 20,
+            flush_trigger_batch_size: 5,
+            timeout_multiplier: 50,
+            timeout_base_ms: 5000,
+            timeout_min_ms: 10000,
+            timeout_max_ms: 60000,
+            recent_errors_capacity: 1024,
+        };
+        let coord = GroupCommitCoordinator::with_config(config);
+
+        for i in 0..4 {
+            let (_, should_flush) = coord.register_transaction().unwrap();
+            assert!(
+                !should_flush,
+                "should not flush before threshold, batch size {}",
+                i + 1
+            );
+        }
+
+        let (_, should_flush) = coord.register_transaction().unwrap();
+        assert!(should_flush, "should flush when threshold is reached");
+        assert_eq!(coord.flush_trigger_batch_size(), 5);
     }
 
     #[test]
@@ -499,6 +879,53 @@ mod tests {
     }
 
     #[test]
+    fn test_register_transaction_and_wait_success() {
+        let coord = Arc::new(GroupCommitCoordinator::new(100, 1));
+        let coord_clone = Arc::clone(&coord);
+        let triggered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let triggered_clone = Arc::clone(&triggered);
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            coord_clone.mark_flushed(Ok(())).unwrap();
+        });
+
+        let result = coord.register_transaction_and_wait(move || {
+            triggered_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+        });
+        assert!(result.is_ok());
+        assert!(triggered.load(std::sync::atomic::Ordering::Relaxed));
+
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_register_transaction_and_wait_propagates_error() {
+        let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
+        let coord_clone = Arc::clone(&coord);
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            coord_clone
+                .mark_flushed(Err(Error::Storage(StorageError::WalError {
+                    reason: "injected flush error".to_string(),
+                })))
+                .unwrap();
+        });
+
+        let result = coord.register_transaction_and_wait(|| {});
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("injected flush error")
+        );
+
+        handle.join().unwrap();
+    }
+
+    #[test]
     fn test_wait_for_flush_error_propagation() {
         let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
         let coord_clone = Arc::clone(&coord);
@@ -530,6 +957,7 @@ mod tests {
         let config = GroupCommitConfig {
             max_delay_ms: 10,
             max_batch_size: 100,
+            flush_trigger_batch_size: 100,
             timeout_multiplier: 2, // 10 * 2 = 20ms
             timeout_base_ms: 10,   // + 10 = 30ms
             timeout_min_ms: 20,    // clamp min
@@ -640,6 +1068,7 @@ mod tests {
         let config = GroupCommitConfig {
             max_delay_ms: 1,
             max_batch_size: 100,
+            flush_trigger_batch_size: 100,
             timeout_multiplier: 2,
             timeout_base_ms: 10,
             timeout_min_ms: 20,
@@ -671,6 +1100,7 @@ mod tests {
         let config = GroupCommitConfig {
             max_delay_ms: 10,
             max_batch_size: 100,
+            flush_trigger_batch_size: 100,
             timeout_multiplier: 2,
             timeout_base_ms: 10,
             timeout_min_ms: 20,
@@ -769,5 +1199,36 @@ mod tests {
 
         // 8. Transaction B should be done
         assert!(coord.wait_for_flush(epoch_b).is_ok());
+    }
+
+    #[test]
+    fn test_metrics_snapshot_and_reset() {
+        let coord = Arc::new(GroupCommitCoordinator::new(100, 1));
+        coord.set_metrics_enabled(true);
+        let coord_clone = Arc::clone(&coord);
+
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            coord_clone.mark_flushed(Ok(())).unwrap();
+        });
+
+        coord
+            .register_transaction_and_wait(|| {})
+            .expect("register_transaction_and_wait should succeed");
+        handle.join().unwrap();
+
+        let snapshot = coord.metrics_snapshot();
+        assert!(snapshot.state_lock_acquires > 0);
+        assert!(snapshot.waiters_lock_acquires > 0);
+        assert!(snapshot.wait_calls > 0);
+        assert_eq!(snapshot.wait_successes, 1);
+        assert_eq!(snapshot.wait_errors, 0);
+        assert!(snapshot.epoch_completions > 0);
+
+        coord.reset_metrics();
+        let reset = coord.metrics_snapshot();
+        assert_eq!(reset.state_lock_acquires, 0);
+        assert_eq!(reset.wait_calls, 0);
+        assert_eq!(reset.epoch_completions, 0);
     }
 }

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -60,9 +60,12 @@ use crate::core::error::{Error, StorageError};
 /// If a flush fails, the error is stored and propagated to all waiting transactions.
 /// This ensures no transaction incorrectly believes its data is durable.
 pub struct GroupCommitCoordinator {
-    /// State protected by mutex
+    /// Core epoch and flush state.
     state: Mutex<GroupCommitState>,
     /// Per-epoch wait latches protected separately from coordinator state.
+    ///
+    /// Keeping waiter latches in a separate mutex avoids coupling waiter-map churn
+    /// with the hot epoch-state lock and keeps lock hold times short.
     waiters: Mutex<HashMap<u64, Arc<EpochLatch>>>,
     /// Lightweight internal metrics for profiling group-commit coordination.
     metrics: GroupCommitMetrics,
@@ -617,9 +620,18 @@ impl GroupCommitCoordinator {
             }
         }
 
-        // Advance flushed_epoch to wake up waiters for this epoch
-        // Note: We use max to handle potential out-of-order completions if we ever support that,
-        // though currently flushes are serialized.
+        // Flush completion order is serialized by the single flush thread.
+        // In debug builds, assert if this invariant is violated so we fail loud.
+        debug_assert!(
+            epoch <= state.flushed_epoch.saturating_add(1),
+            "out-of-order flush completion: epoch {} after flushed_epoch {}",
+            epoch,
+            state.flushed_epoch
+        );
+
+        // Advance flushed_epoch to wake up waiters for this epoch.
+        // If we ever support out-of-order completion, this watermark logic must
+        // be replaced with gap tracking to prevent false-success scenarios.
         if epoch > state.flushed_epoch {
             state.flushed_epoch = epoch;
         }


### PR DESCRIPTION
## Summary
- optimize group commit coordination on the synchronous/single-transaction hot path
- add configurable `group_commit_flush_trigger_batch_size` through unified config and wire it into concurrent WAL system startup
- gate group-commit metrics collection behind an explicit enable flag to remove default-path overhead
- add fused concurrent group-commit benchmark coverage and CI/justfile automation for threshold-vs-timer regression checks
- add a standalone `group_commit_wait_profile` binary and supporting benchmark-check script for repeatable profiling

## Validation
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ❌ (known pre-existing failures in clock skew tests):
  - `api::transaction::write::tests::clock_skew_tests::test_clock_skew_backward_error`
  - `api::transaction::write::tests::clock_skew_tests::test_clock_skew_forward_error`
  - `api::transaction::write::tests::clock_skew_tests::test_clock_skew_failure_does_not_advance_observation_timestamp`