### PR TITLE
DX: Improve error messages for experimental features

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ cargo test
 just test
 ```
 
+### Experimental Features ("Nova")
+
+> ⚠️ **IMPORTANT**
+>
+> Experimental features like **Narrative Generation**, **Sherlock**, and **Semantic Pathfinding** require the `nova` feature flag.
+>
+> Add this to your `Cargo.toml` to use them:
+> ```toml
+> [dependencies]
+> aletheiadb = { version = "0.1", features = ["nova"] }
+> ```
+>
+> If you see a runtime panic saying "Experimental features like X require the 'nova' feature", this is why!
+
 ### Development Commands
 
 ```bash

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -124,7 +124,6 @@ pub mod prophet;
 #[cfg(feature = "nova")]
 /// Semantic Navigator for vector-guided pathfinding.
 pub mod semantic_navigator;
-#[cfg(feature = "nova")]
 /// Sherlock: Temporal Pattern Matching Engine.
 pub mod sherlock;
 #[cfg(feature = "nova")]

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -71,9 +71,11 @@ pub struct Deduction {
 
 /// The Sherlock Engine.
 pub struct Sherlock<'a> {
+    #[allow(dead_code)]
     db: &'a AletheiaDB,
 }
 
+#[cfg(feature = "nova")]
 impl<'a> Sherlock<'a> {
     /// Create a new Sherlock instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -188,7 +190,23 @@ impl<'a> Sherlock<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(not(feature = "nova"))]
+impl<'a> Sherlock<'a> {
+    /// Create a new Sherlock instance.
+    pub fn new(_db: &'a AletheiaDB) -> Self {
+        panic!(
+            "Experimental features like Sherlock require the 'nova' feature. Please enable it in your Cargo.toml:\n\n[dependencies]\naletheiadb = {{ version = \"...\", features = [\"nova\"] }}\n"
+        );
+    }
+
+    /// Investigate a specific node for the given Mystery.
+    pub fn investigate(&self, _node_id: NodeId, _mystery: &Mystery) -> Result<Vec<Deduction>> {
+        panic!("Experimental features like Sherlock require the 'nova' feature.");
+    }
+}
+
+
+#[cfg(all(test, feature = "nova"))]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
@@ -306,5 +324,20 @@ mod tests {
         assert_eq!(results_pass.len(), 1, "Should match within 500ms");
         assert_eq!(results_pass[0].node_id, node_id);
         assert_eq!(results_pass[0].event_times, vec![t0, t1]);
+    }
+}
+
+#[cfg(all(test, not(feature = "nova")))]
+mod tests_stub {
+    use super::*;
+    use crate::AletheiaDB;
+
+    #[test]
+    #[should_panic(
+        expected = "Experimental features like Sherlock require the 'nova' feature. Please enable it in your Cargo.toml"
+    )]
+    fn test_stub_new_panics() {
+        let db = AletheiaDB::new().unwrap();
+        let _ = Sherlock::new(&db);
     }
 }

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -199,6 +199,11 @@ impl<'a> Sherlock<'a> {
         );
     }
 
+    #[cfg(test)]
+    fn new_internal(db: &'a AletheiaDB) -> Self {
+        Self { db }
+    }
+
     /// Investigate a specific node for the given Mystery.
     pub fn investigate(&self, _node_id: NodeId, _mystery: &Mystery) -> Result<Vec<Deduction>> {
         panic!("Experimental features like Sherlock require the 'nova' feature.");
@@ -331,6 +336,8 @@ mod tests {
 mod tests_stub {
     use super::*;
     use crate::AletheiaDB;
+    use crate::core::id::NodeId;
+    use std::time::Duration;
 
     #[test]
     #[should_panic(
@@ -339,5 +346,17 @@ mod tests_stub {
     fn test_stub_new_panics() {
         let db = AletheiaDB::new().unwrap();
         let _ = Sherlock::new(&db);
+    }
+
+    #[test]
+    #[should_panic(expected = "Experimental features like Sherlock require the 'nova' feature.")]
+    fn test_stub_investigate_panics() {
+        let db = AletheiaDB::new().unwrap();
+        // Use internal constructor to bypass the panic in new()
+        let sherlock = Sherlock::new_internal(&db);
+        let _ = sherlock.investigate(
+            NodeId::new(0).unwrap(),
+            &Mystery::new(Duration::from_secs(1)),
+        );
     }
 }

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -210,7 +210,6 @@ impl<'a> Sherlock<'a> {
     }
 }
 
-
 #[cfg(all(test, feature = "nova"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR addresses a DX friction point where experimental features (like Sherlock) would cause compiler errors when copy-pasted from the README without enabling the `nova` feature flag.

Changes:
1.  **Stub Pattern for Sherlock**: `src/experimental/sherlock.rs` now compiles without the `nova` feature, but its methods (`new`, `investigate`) panic with a clear message instructing the user to enable the feature. This matches the behavior of `NarrativeGenerator`.
2.  **README Banner**: Added a "IMPORTANT" warning block in the Quick Start section of `README.md` explicitly listing experimental features and the required configuration.

Verified:
- `cargo run --example echo_sherlock` (created for testing) panics with the expected message.
- `cargo test experimental::sherlock` passes (verifies panic).
- `cargo test --features nova experimental::sherlock` passes (verifies functionality).
- `cargo run --example story_demo` still works (panics gracefully).

---
*PR created automatically by Jules for task [6355699044413235831](https://jules.google.com/task/6355699044413235831) started by @madmax983*