### PR TITLE
Elenchus: Audit and Fix TimeRange::overlaps Logic

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -252,3 +252,17 @@
 **Finding:** `WalEntry::verify_checksum` only had a negative test case (short buffer). There was no positive confirmation that a validly serialized entry passes verification.
 **Evidence:** Only `test_verify_checksum_short_data` existed.
 **Recommendation:** Added `test_verify_checksum_success` which performs a full round-trip serialization and verification.
+
+## [TimeRange Overlap Inconsistency]
+**Module:** `src/core/temporal.rs`
+**Verdict:** 🟡 Suspect
+**Finding:** `TimeRange::overlaps` returned `true` for empty ranges (e.g., `TimeRange::at(100)`) overlapping non-empty ranges, violating the set-theoretic definition of overlap (non-empty intersection).
+**Evidence:** `TimeRange::at(100)` (empty) reported overlap with `[0, 200)`.
+**Resolution:** Updated `overlaps` to return `false` if `self.is_empty()` or `other.is_empty()`. Added regression tests in `src/core/temporal.rs`.
+
+## [Unpinned System Constant MAX_VALID_TIMESTAMP]
+**Module:** `src/core/temporal.rs`
+**Verdict:** 🟡 Suspect
+**Finding:** `MAX_VALID_TIMESTAMP` was used in logic but its value was not pinned by tests, allowing potential drift of the sentinel space.
+**Evidence:** Mutation analysis showed changing the constant value didn't fail existing tests.
+**Resolution:** Added sentry test explicitly asserting `MAX_VALID_TIMESTAMP == i64::MAX - 1000`.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -174,12 +174,24 @@ impl TimeRange {
         timestamp >= self.start
     }
 
+    /// Returns true if the range is empty (start == end).
+    ///
+    /// An empty range contains no timestamps and has zero duration.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
     /// Returns true if this range overlaps with another range.
     ///
     /// Two ranges overlap if there exists any timestamp that is in both ranges.
+    /// Note: Returns false if either range is empty, as an empty set cannot overlap anything.
     /// Note: Phase 2 - removed const due to HybridTimestamp comparison.
     #[inline]
     pub fn overlaps(&self, other: &TimeRange) -> bool {
+        if self.is_empty() || other.is_empty() {
+            return false;
+        }
         self.start < other.end && other.start < self.end
     }
 
@@ -1681,5 +1693,39 @@ mod sentry_tests {
             outer.contains_range(&same_range),
             "Should contain itself (reflexive)"
         );
+    }
+
+    #[test]
+    fn test_sentry_max_valid_timestamp_constant() {
+        // 🛡️ Sentry Test: Verify MAX_VALID_TIMESTAMP is exactly i64::MAX - 1000.
+        // This pins the reserved range size to prevent accidental drift.
+        assert_eq!(
+            MAX_VALID_TIMESTAMP,
+            i64::MAX - 1000,
+            "MAX_VALID_TIMESTAMP must be exactly i64::MAX - 1000 to preserve sentinel space"
+        );
+    }
+
+    #[test]
+    fn test_sentry_point_range_is_empty() {
+        // 🛡️ Sentry Test: Verify point range behavior.
+        // A point range [T, T) is empty and contains nothing.
+        let point = TimeRange::at(100.into());
+        assert!(point.is_empty());
+        assert!(!point.contains(100.into()));
+        assert_eq!(point.duration_micros(), Some(0));
+    }
+
+    #[test]
+    fn test_sentry_point_range_no_overlap() {
+        // 🛡️ Sentry Test: Verify empty range overlap logic.
+        // An empty range cannot overlap any other range (intersection is empty).
+        // Before Elenchus fix, this would return true.
+        let point = TimeRange::at(100.into());
+        let wide = TimeRange::new(0.into(), 200.into()).unwrap();
+
+        assert!(!point.overlaps(&wide), "Empty range should not overlap anything");
+        assert!(!wide.overlaps(&point), "Range should not overlap empty range");
+        assert!(!point.overlaps(&point), "Empty range should not overlap itself");
     }
 }

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1724,8 +1724,17 @@ mod sentry_tests {
         let point = TimeRange::at(100.into());
         let wide = TimeRange::new(0.into(), 200.into()).unwrap();
 
-        assert!(!point.overlaps(&wide), "Empty range should not overlap anything");
-        assert!(!wide.overlaps(&point), "Range should not overlap empty range");
-        assert!(!point.overlaps(&point), "Empty range should not overlap itself");
+        assert!(
+            !point.overlaps(&wide),
+            "Empty range should not overlap anything"
+        );
+        assert!(
+            !wide.overlaps(&point),
+            "Range should not overlap empty range"
+        );
+        assert!(
+            !point.overlaps(&point),
+            "Empty range should not overlap itself"
+        );
     }
 }


### PR DESCRIPTION
Audited `src/core/temporal.rs` and identified a logical inconsistency where empty point ranges (`[T, T)`) were considered to overlap with containing ranges, violating set theory. 

Changes:
- Modified `TimeRange::overlaps` to explicitly check for emptiness.
- Added `TimeRange::is_empty()` public method.
- Added permanent regression tests (`mod sentry_tests`) for point range behavior.
- Added a sentinel test explicitly pinning `MAX_VALID_TIMESTAMP` to `i64::MAX - 1000`.
- Documented findings in `.jules/elenchus.md`.

---
*PR created automatically by Jules for task [3568550553119469039](https://jules.google.com/task/3568550553119469039) started by @madmax983*