### PR TITLE
Fix UB in vector normalization logic

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -590,19 +590,19 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
     // This provides ~15% speedup for large vectors by avoiding an extra write pass.
     let mut result = Vec::with_capacity(v.len());
 
-    // SAFETY: We immediately fill the entire vector using scale_and_copy.
-    // scale_and_copy internally asserts that src.len() == dst.len(), guaranteeing
-    // that all elements are written before the vector is exposed.
-    //
-    // The `result` vector is allocated with capacity `v.len()`, so `set_len` is
-    // within capacity bounds. `scale_and_copy` is a trusted function (verified by tests)
-    // that writes to every element of `result`. Even if `scale_and_copy` were to panic,
-    // the `result` vector would be dropped, which is safe for `Vec<f32>` (no Drop impl for f32).
-    // The only risk is if `scale_and_copy` returned early without initializing, but
-    // its implementation guarantees full coverage via exact chunking and remainder handling.
+    // Use spare_capacity_mut to get uninitialized memory safely without creating a
+    // reference to uninitialized data (which would be UB).
+    let dst = result.spare_capacity_mut();
+    // We must limit the slice to the number of elements we're going to write
+    // In case capacity > v.len() (unlikely with with_capacity but possible)
+    let dst = &mut dst[..v.len()];
+
+    scale_and_copy(v, dst, inv_mag);
+
+    // SAFETY: scale_and_copy guarantees it has written to all elements of dst.
+    // We passed a slice of length v.len(), so v.len() elements are now initialized.
     unsafe { result.set_len(v.len()) };
 
-    scale_and_copy(v, &mut result, inv_mag);
     result
 }
 

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -1,5 +1,14 @@
 use super::ops::*;
 use super::simd::*;
+use std::mem::MaybeUninit;
+
+// Helper to cast &mut [f32] to &mut [MaybeUninit<f32>]
+// This is safe because initialized memory is a valid state of MaybeUninit.
+fn as_uninit_mut(slice: &mut [f32]) -> &mut [MaybeUninit<f32>] {
+    unsafe {
+        std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut MaybeUninit<f32>, slice.len())
+    }
+}
 
 #[test]
 fn test_normalize_nan_handling() {
@@ -49,7 +58,7 @@ fn test_scale_and_copy_correctness() {
     let src = vec![1.0, 2.0, 3.0, 4.0, 5.0];
     let mut dst = vec![0.0; 5]; // Pre-fill with 0 to verify overwrite
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    scale_and_copy(&src, as_uninit_mut(&mut dst), 2.0);
 
     assert_eq!(dst, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
 }
@@ -61,7 +70,7 @@ fn test_scale_and_copy_large_vector() {
     let src: Vec<f32> = (0..len).map(|i| i as f32).collect();
     let mut dst = vec![0.0; len];
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    scale_and_copy(&src, as_uninit_mut(&mut dst), 2.0);
 
     for (i, val) in dst.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -2,6 +2,8 @@
 // SIMD Support
 // ============================================================================
 
+use std::mem::MaybeUninit;
+
 /// SIMD-accelerated vector operations for x86/x86_64 platforms.
 ///
 /// Uses runtime feature detection to select the best available instruction set:
@@ -23,6 +25,7 @@ pub(crate) mod x86_ops {
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
+    use std::mem::MaybeUninit;
 
     /// Computes dot product, magnitude_a², and magnitude_b² using AVX2.
     ///
@@ -431,7 +434,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure AVX2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm256_set1_ps(scalar);
@@ -441,14 +444,15 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm256_loadu_ps(s_chunk.as_ptr());
                 let result = _mm256_mul_ps(va, scalar_vec);
-                _mm256_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Safe cast because MaybeUninit<f32> is layout-compatible with f32
+                _mm256_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -459,7 +463,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure SSE2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "sse2")]
     #[inline]
-    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm_set1_ps(scalar);
@@ -469,14 +473,15 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm_loadu_ps(s_chunk.as_ptr());
                 let result = _mm_mul_ps(va, scalar_vec);
-                _mm_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Safe cast because MaybeUninit<f32> is layout-compatible with f32
+                _mm_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -547,10 +552,10 @@ pub(crate) fn scale_in_place_scalar(v: &mut [f32], scalar: f32) {
     all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)),
     allow(dead_code)
 )]
-pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().zip(dst.iter_mut()) {
-        *d = *s * scalar;
+        d.write(*s * scalar);
     }
 }
 
@@ -588,7 +593,7 @@ pub(crate) fn scale_in_place(v: &mut [f32], scalar: f32) {
 
 /// Scales `src` by `scalar` and stores result in `dst` using the best available SIMD instructions.
 #[inline(always)]
-pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -717,6 +722,14 @@ pub(crate) fn dot_product_sum(a: &[f32], b: &[f32]) -> f32 {
 mod tests {
     use super::*;
 
+    // Helper to cast &mut [f32] to &mut [MaybeUninit<f32>]
+    // This is safe because initialized memory is a valid state of MaybeUninit.
+    fn as_uninit_mut(slice: &mut [f32]) -> &mut [MaybeUninit<f32>] {
+        unsafe {
+            std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut MaybeUninit<f32>, slice.len())
+        }
+    }
+
     #[test]
     fn test_scale_and_copy_implementation_coverage() {
         let src = vec![1.0f32; 17]; // 17 to force remainder logic (8*2 + 1)
@@ -725,7 +738,7 @@ mod tests {
         let expected = vec![2.0f32; 17];
 
         // 1. Unconditional Scalar coverage
-        scale_and_copy_scalar(&src, &mut dst, scalar);
+        scale_and_copy_scalar(&src, as_uninit_mut(&mut dst), scalar);
         assert_eq!(dst, expected, "Scalar implementation failed");
         dst.fill(0.0);
 
@@ -734,14 +747,14 @@ mod tests {
         {
             // Try SSE2 if available
             if is_x86_feature_detected!("sse2") {
-                unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst, scalar) };
+                unsafe { x86_ops::scale_and_copy_sse2(&src, as_uninit_mut(&mut dst), scalar) };
                 assert_eq!(dst, expected, "SSE2 implementation failed");
                 dst.fill(0.0);
             }
 
             // Try AVX2 if available
             if is_x86_feature_detected!("avx2") {
-                unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst, scalar) };
+                unsafe { x86_ops::scale_and_copy_avx2(&src, as_uninit_mut(&mut dst), scalar) };
                 assert_eq!(dst, expected, "AVX2 implementation failed");
                 dst.fill(0.0);
             }


### PR DESCRIPTION
Fixes Undefined Behavior in `src/core/vector/ops.rs` by using `spare_capacity_mut` and `MaybeUninit` for vector initialization.

---
*PR created automatically by Jules for task [8774470026085929695](https://jules.google.com/task/8774470026085929695) started by @madmax983*