### PR TITLE
🛡️ Sentry: Fix Undefined Behavior in vector normalization

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -573,7 +573,6 @@ pub fn squared_magnitude(v: &[f32]) -> f32 {
 /// - Dimension limits are enforced at storage time (see [`crate::core::PropertyValue::vector`])
 /// - Additional checks would add overhead without safety benefit
 #[inline]
-#[allow(clippy::uninit_vec)] // Performance optimization: we explicitly fill the vector
 pub fn normalize(v: &[f32]) -> Vec<f32> {
     let sq_mag = squared_magnitude(v);
     // Use squared magnitude threshold to avoid denormal number issues.
@@ -590,19 +589,14 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
     // This provides ~15% speedup for large vectors by avoiding an extra write pass.
     let mut result = Vec::with_capacity(v.len());
 
-    // SAFETY: We immediately fill the entire vector using scale_and_copy.
-    // scale_and_copy internally asserts that src.len() == dst.len(), guaranteeing
-    // that all elements are written before the vector is exposed.
-    //
-    // The `result` vector is allocated with capacity `v.len()`, so `set_len` is
-    // within capacity bounds. `scale_and_copy` is a trusted function (verified by tests)
-    // that writes to every element of `result`. Even if `scale_and_copy` were to panic,
-    // the `result` vector would be dropped, which is safe for `Vec<f32>` (no Drop impl for f32).
-    // The only risk is if `scale_and_copy` returned early without initializing, but
-    // its implementation guarantees full coverage via exact chunking and remainder handling.
+    // SAFETY: We initialize the vector using scale_and_copy which takes MaybeUninit
+    // We slice spare_capacity_mut() to v.len() to ensure length equality for scale_and_copy assertions.
+    let dst = &mut result.spare_capacity_mut()[..v.len()];
+    scale_and_copy(v, dst, inv_mag);
+
+    // SAFETY: scale_and_copy guarantees initialization of the slice via assertion src.len() == dst.len()
     unsafe { result.set_len(v.len()) };
 
-    scale_and_copy(v, &mut result, inv_mag);
     result
 }
 

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -47,9 +47,18 @@ fn test_scale_and_copy_correctness() {
     // This is critical because normalize() relies on this to initialize the vector.
 
     let src = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-    let mut dst = vec![0.0; 5]; // Pre-fill with 0 to verify overwrite
+    // Use proper MaybeUninit pattern via Vec capacity
+    let mut dst = Vec::with_capacity(5);
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    // Get uninitialized slice
+    let dst_uninit = dst.spare_capacity_mut();
+    // Slice to exact length (though capacity should be 5, defensive coding)
+    let dst_slice = &mut dst_uninit[..5];
+
+    scale_and_copy(&src, dst_slice, 2.0);
+
+    // Safety: scale_and_copy initializes the memory
+    unsafe { dst.set_len(5) };
 
     assert_eq!(dst, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
 }
@@ -59,11 +68,30 @@ fn test_scale_and_copy_large_vector() {
     // 🛡️ Sentry: Test with larger vector to trigger SIMD loop + remainder
     let len = 1024 + 7; // 1031 elements
     let src: Vec<f32> = (0..len).map(|i| i as f32).collect();
-    let mut dst = vec![0.0; len];
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    let mut dst = Vec::with_capacity(len);
+    let dst_uninit = dst.spare_capacity_mut();
+    let dst_slice = &mut dst_uninit[..len];
+
+    scale_and_copy(&src, dst_slice, 2.0);
+
+    unsafe { dst.set_len(len) };
 
     for (i, val) in dst.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);
     }
+}
+
+#[test]
+fn test_normalize_initialization_safety() {
+    // 🛡️ Sentry: Explicitly verify that normalize returns a fully initialized vector
+    // This targets the new implementation using spare_capacity_mut
+    let v = vec![1.0, 2.0, 3.0];
+    let normalized = normalize(&v);
+
+    // Check values are correct (and thus initialized)
+    let mag = (1.0*1.0 + 2.0*2.0 + 3.0*3.0f32).sqrt();
+    assert!((normalized[0] - 1.0/mag).abs() < 1e-6);
+    assert!((normalized[1] - 2.0/mag).abs() < 1e-6);
+    assert!((normalized[2] - 3.0/mag).abs() < 1e-6);
 }

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -90,8 +90,8 @@ fn test_normalize_initialization_safety() {
     let normalized = normalize(&v);
 
     // Check values are correct (and thus initialized)
-    let mag = (1.0*1.0 + 2.0*2.0 + 3.0*3.0f32).sqrt();
-    assert!((normalized[0] - 1.0/mag).abs() < 1e-6);
-    assert!((normalized[1] - 2.0/mag).abs() < 1e-6);
-    assert!((normalized[2] - 3.0/mag).abs() < 1e-6);
+    let mag = (1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0f32).sqrt();
+    assert!((normalized[0] - 1.0 / mag).abs() < 1e-6);
+    assert!((normalized[1] - 2.0 / mag).abs() < 1e-6);
+    assert!((normalized[2] - 3.0 / mag).abs() < 1e-6);
 }

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -21,11 +21,11 @@ use std::mem::MaybeUninit;
 /// where SIMD becomes beneficial is typically around 16-32 dimensions.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86_ops {
-    use std::mem::MaybeUninit;
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
+    use std::mem::MaybeUninit;
 
     /// Computes dot product, magnitude_a², and magnitude_b² using AVX2.
     ///

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -2,6 +2,8 @@
 // SIMD Support
 // ============================================================================
 
+use std::mem::MaybeUninit;
+
 /// SIMD-accelerated vector operations for x86/x86_64 platforms.
 ///
 /// Uses runtime feature detection to select the best available instruction set:
@@ -19,6 +21,7 @@
 /// where SIMD becomes beneficial is typically around 16-32 dimensions.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86_ops {
+    use std::mem::MaybeUninit;
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
@@ -431,7 +434,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure AVX2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm256_set1_ps(scalar);
@@ -441,14 +444,17 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm256_loadu_ps(s_chunk.as_ptr());
                 let result = _mm256_mul_ps(va, scalar_vec);
-                _mm256_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Cast destination pointer to *mut f32 for storage.
+                // This is safe because MaybeUninit<f32> has the same layout as f32
+                // and we are just writing to it.
+                _mm256_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -459,7 +465,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure SSE2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "sse2")]
     #[inline]
-    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm_set1_ps(scalar);
@@ -469,14 +475,17 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm_loadu_ps(s_chunk.as_ptr());
                 let result = _mm_mul_ps(va, scalar_vec);
-                _mm_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Cast destination pointer to *mut f32 for storage.
+                // This is safe because MaybeUninit<f32> has the same layout as f32
+                // and we are just writing to it.
+                _mm_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -547,10 +556,10 @@ pub(crate) fn scale_in_place_scalar(v: &mut [f32], scalar: f32) {
     all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)),
     allow(dead_code)
 )]
-pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().zip(dst.iter_mut()) {
-        *d = *s * scalar;
+        d.write(*s * scalar);
     }
 }
 
@@ -588,7 +597,7 @@ pub(crate) fn scale_in_place(v: &mut [f32], scalar: f32) {
 
 /// Scales `src` by `scalar` and stores result in `dst` using the best available SIMD instructions.
 #[inline(always)]
-pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -721,27 +730,42 @@ mod tests {
     fn test_scale_and_copy_implementation_coverage() {
         let src = vec![1.0f32; 17]; // 17 to force remainder logic (8*2 + 1)
         let mut dst = vec![0.0f32; 17];
+        // SAFETY: We're casting &mut [f32] to &mut [MaybeUninit<f32>] which is safe
+        // because MaybeUninit<f32> has the same layout and alignment as f32.
+        // This is safe because we are just treating initialized memory as maybe-uninitialized
+        // and writing to it, which is valid.
+        let dst_uninit = unsafe {
+            std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, dst.len())
+        };
         let scalar = 2.0;
         let expected = vec![2.0f32; 17];
 
         // 1. Unconditional Scalar coverage
-        scale_and_copy_scalar(&src, &mut dst, scalar);
+        scale_and_copy_scalar(&src, dst_uninit, scalar);
         assert_eq!(dst, expected, "Scalar implementation failed");
         dst.fill(0.0);
 
         // 2. Conditional x86 SIMD coverage
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
+            let dst_uninit = unsafe {
+                std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, dst.len())
+            };
+
             // Try SSE2 if available
             if is_x86_feature_detected!("sse2") {
-                unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst, scalar) };
+                unsafe { x86_ops::scale_and_copy_sse2(&src, dst_uninit, scalar) };
                 assert_eq!(dst, expected, "SSE2 implementation failed");
                 dst.fill(0.0);
             }
 
+            let dst_uninit = unsafe {
+                std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, dst.len())
+            };
+
             // Try AVX2 if available
             if is_x86_feature_detected!("avx2") {
-                unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst, scalar) };
+                unsafe { x86_ops::scale_and_copy_avx2(&src, dst_uninit, scalar) };
                 assert_eq!(dst, expected, "AVX2 implementation failed");
                 dst.fill(0.0);
             }


### PR DESCRIPTION
This PR fixes a potential Undefined Behavior (UB) in the `normalize` function within the vector core module.

Previously, `normalize` used `Vec::with_capacity` followed by `unsafe { set_len() }`, effectively exposing uninitialized memory as a `&mut [f32]` slice passed to `scale_and_copy`. While `scale_and_copy` initializes the memory, creating a reference to uninitialized memory is technically UB in Rust.

**Changes:**
1.  **SIMD Refactor**: Updated `scale_and_copy` (and its variants `avx2`, `sse2`, `scalar`) in `src/core/vector/simd.rs` to accept `&mut [MaybeUninit<f32>]`. This explicitly signals that the destination buffer is uninitialized and uses safe pointer casts for SIMD intrinsics.
2.  **Normalize Fix**: Updated `normalize` in `src/core/vector/ops.rs` to use `Vec::spare_capacity_mut()` to get a slice of `MaybeUninit`, pass it to `scale_and_copy`, and only call `set_len` *after* the buffer has been fully written.
3.  **Tests**: Updated `sentry_safety_tests.rs` and internal `simd.rs` tests to use the correct `spare_capacity_mut` pattern when testing `scale_and_copy`, ensuring tests are sound and free of aliasing violations.

This change improves the safety and correctness of the low-level vector operations without sacrificing performance.


---
*PR created automatically by Jules for task [2719152516001687541](https://jules.google.com/task/2719152516001687541) started by @madmax983*