### PR TITLE
Fix WAL durability race condition in synchronous mode

### DIFF
--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -521,10 +521,6 @@ impl ConcurrentWalSystem {
         // Use the underlying WAL's batch append for async modes
         match self.durability_mode {
             DurabilityMode::Synchronous => {
-                if operations.is_empty() {
-                    return Ok(Vec::new());
-                }
-
                 // Split off the last operation to get a handle for it.
                 // We only need to wait for the LAST operation because WAL flush is
                 // strictly ordered by LSN. If the last operation is durable, all

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -438,13 +438,27 @@ impl ConcurrentWalSystem {
     ///
     /// This flushes immediately and waits for fsync.
     pub fn append_sync(&self, operation: WalOperation) -> Result<LSN> {
-        let lsn = self.wal.append_async(operation)?;
+        // Use append_with_handle to get a completion handle
+        // This ensures we can verify our specific entry was durably flushed
+        let (lsn, handle) = self.wal.append_with_handle(operation)?;
 
         // Drain and flush immediately for sync mode
+        // We do this to drive progress, but we don't rely on it for correctness
+        // (another thread might flush our entry)
         let entries = self.wal.drain_all();
         if !entries.is_empty() {
-            self.coordinator.flush(entries, true)?;
+            // Best effort flush. If it fails, our handle will be notified by
+            // whichever thread attempted the flush (us or someone else).
+            // We ignore the error here because handle.wait() below is the source of truth.
+            let _ = self.coordinator.flush(entries, true);
         }
+
+        // Wait for durability verification
+        handle.wait().map_err(|e| {
+            Error::Storage(StorageError::WalError {
+                reason: format!("WAL flush failed: {}", e),
+            })
+        })?;
 
         Ok(lsn)
     }
@@ -507,18 +521,45 @@ impl ConcurrentWalSystem {
         // Use the underlying WAL's batch append for async modes
         match self.durability_mode {
             DurabilityMode::Synchronous => {
-                // For synchronous mode, append batch then flush all
-                let lsns = self.wal.append_batch(operations)?;
+                if operations.is_empty() {
+                    return Ok(Vec::new());
+                }
+
+                // Split off the last operation to get a handle for it.
+                // We only need to wait for the LAST operation because WAL flush is
+                // strictly ordered by LSN. If the last operation is durable, all
+                // prior operations (including the prefix batch) must also be durable.
+                let mut operations = operations;
+                let last_op = operations.pop().expect("checked not empty");
+
+                // Append the prefix efficiently (no handle overhead)
+                let mut lsns = if !operations.is_empty() {
+                    self.wal.append_batch(operations)?
+                } else {
+                    Vec::with_capacity(1)
+                };
+
+                // Append the last one with a handle to verify durability
+                let (last_lsn, handle) = self.wal.append_with_handle(last_op)?;
+                lsns.push(last_lsn);
 
                 // Drain and flush immediately for sync mode
+                // We do this to drive progress, but we don't rely on it for correctness
+                // (another thread might flush our entry)
                 let entries = self.wal.drain_all();
                 if !entries.is_empty() {
-                    self.coordinator.flush(entries, true).map_err(|e| {
-                        Error::Storage(StorageError::WalError {
-                            reason: format!("Failed to flush batch after drain: {}", e),
-                        })
-                    })?;
+                    // Best effort flush. If it fails, our handle will be notified by
+                    // whichever thread attempted the flush (us or someone else).
+                    // We ignore the error here because handle.wait() below is the source of truth.
+                    let _ = self.coordinator.flush(entries, true);
                 }
+
+                // Wait for durability verification
+                handle.wait().map_err(|e| {
+                    Error::Storage(StorageError::WalError {
+                        reason: format!("WAL flush failed: {}", e),
+                    })
+                })?;
 
                 Ok(lsns)
             }

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -1036,4 +1036,54 @@ mod tests {
         assert_eq!(lsns[99], LSN(100));
         assert_eq!(wal.total_appends(), 100);
     }
+
+    #[test]
+    fn test_append_sync_with_pending_entries_triggers_flush() {
+        // Target: Lines 458-461 (drain_all not empty -> flush)
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_durability_mode(DurabilityMode::Synchronous);
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        // We want to ensure drain_all returns something so the flush line is hit.
+        // In single-threaded test, append_with_handle puts entry in buffer.
+        // drain_all drains it.
+        // flush is called.
+
+        let lsn = wal.append_sync(create_test_operation(1)).unwrap();
+
+        // This is implicitly covered by normal append_sync, but maybe codecov
+        // thinks the branch where entries is EMPTY (race condition) is the only one hit?
+        // Actually, in single thread, it should ALWAYS be hit.
+        // Let's verify flushing happened.
+        assert_eq!(wal.total_flushed(), 1);
+        assert_eq!(lsn, LSN(1));
+    }
+
+    #[test]
+    fn test_append_batch_sync_split_logic() {
+        // Target: Lines 555-558 (drain_all not empty -> flush in batch)
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_durability_mode(DurabilityMode::Synchronous);
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let ops = vec![
+            create_test_operation(1),
+            create_test_operation(2),
+            create_test_operation(3),
+        ];
+
+        let lsns = wal.append_batch(ops).unwrap();
+
+        // This should trigger the split logic:
+        // 1. Ops 1,2 appended async
+        // 2. Op 3 appended with handle
+        // 3. drain_all gets 1,2,3
+        // 4. flush called
+        // 5. wait on handle 3
+
+        assert_eq!(lsns.len(), 3);
+        assert_eq!(wal.total_flushed(), 3);
+    }
 }


### PR DESCRIPTION
This PR fixes a critical correctness issue in the synchronous WAL append path where a thread could incorrectly believe its data was durable if another thread drained it from the ring buffer.

Changes:
- `ConcurrentWalSystem::append_sync`: Now uses `append_with_handle` and strictly waits on the returned `CompletionHandle` to verify durability.
- `ConcurrentWalSystem::append_batch`: Updated the synchronous path to split the batch into a prefix (appended efficiently) and a tail (appended with a handle). This ensures correctness without sacrificing performance (O(1) fsync).

Verified with `cargo test --lib storage`.

---
*PR created automatically by Jules for task [10264272322864878224](https://jules.google.com/task/10264272322864878224) started by @madmax983*