### PR TITLE
⚡ Bolt: Fix UB in vector normalization and avoid zero-initialization

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -590,19 +590,14 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
     // This provides ~15% speedup for large vectors by avoiding an extra write pass.
     let mut result = Vec::with_capacity(v.len());
 
-    // SAFETY: We immediately fill the entire vector using scale_and_copy.
-    // scale_and_copy internally asserts that src.len() == dst.len(), guaranteeing
-    // that all elements are written before the vector is exposed.
-    //
-    // The `result` vector is allocated with capacity `v.len()`, so `set_len` is
-    // within capacity bounds. `scale_and_copy` is a trusted function (verified by tests)
-    // that writes to every element of `result`. Even if `scale_and_copy` were to panic,
-    // the `result` vector would be dropped, which is safe for `Vec<f32>` (no Drop impl for f32).
-    // The only risk is if `scale_and_copy` returned early without initializing, but
-    // its implementation guarantees full coverage via exact chunking and remainder handling.
-    unsafe { result.set_len(v.len()) };
+    // Use spare_capacity_mut to safely access uninitialized memory.
+    // We slice to v.len() to ensure length match for scale_and_copy assertion.
+    let dst = &mut result.spare_capacity_mut()[..v.len()];
+    scale_and_copy(v, dst, inv_mag);
 
-    scale_and_copy(v, &mut result, inv_mag);
+    // SAFETY: scale_and_copy guarantees that all elements in the slice are written.
+    // We ensured the slice length is exactly v.len().
+    unsafe { result.set_len(v.len()) };
     result
 }
 

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -47,9 +47,10 @@ fn test_scale_and_copy_correctness() {
     // This is critical because normalize() relies on this to initialize the vector.
 
     let src = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-    let mut dst = vec![0.0; 5]; // Pre-fill with 0 to verify overwrite
+    let mut dst = Vec::with_capacity(5);
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    scale_and_copy(&src, dst.spare_capacity_mut(), 2.0);
+    unsafe { dst.set_len(5) };
 
     assert_eq!(dst, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
 }
@@ -59,9 +60,10 @@ fn test_scale_and_copy_large_vector() {
     // 🛡️ Sentry: Test with larger vector to trigger SIMD loop + remainder
     let len = 1024 + 7; // 1031 elements
     let src: Vec<f32> = (0..len).map(|i| i as f32).collect();
-    let mut dst = vec![0.0; len];
+    let mut dst = Vec::with_capacity(len);
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    scale_and_copy(&src, dst.spare_capacity_mut(), 2.0);
+    unsafe { dst.set_len(len) };
 
     for (i, val) in dst.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -2,6 +2,8 @@
 // SIMD Support
 // ============================================================================
 
+use std::mem::MaybeUninit;
+
 /// SIMD-accelerated vector operations for x86/x86_64 platforms.
 ///
 /// Uses runtime feature detection to select the best available instruction set:
@@ -19,6 +21,8 @@
 /// where SIMD becomes beneficial is typically around 16-32 dimensions.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86_ops {
+    use std::mem::MaybeUninit;
+
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
@@ -431,7 +435,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure AVX2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm256_set1_ps(scalar);
@@ -441,14 +445,15 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm256_loadu_ps(s_chunk.as_ptr());
                 let result = _mm256_mul_ps(va, scalar_vec);
-                _mm256_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Cast *mut MaybeUninit<f32> to *mut f32
+                _mm256_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -459,7 +464,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure SSE2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "sse2")]
     #[inline]
-    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm_set1_ps(scalar);
@@ -469,14 +474,15 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm_loadu_ps(s_chunk.as_ptr());
                 let result = _mm_mul_ps(va, scalar_vec);
-                _mm_storeu_ps(d_chunk.as_mut_ptr(), result);
+                // Cast *mut MaybeUninit<f32> to *mut f32
+                _mm_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -547,10 +553,10 @@ pub(crate) fn scale_in_place_scalar(v: &mut [f32], scalar: f32) {
     all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)),
     allow(dead_code)
 )]
-pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().zip(dst.iter_mut()) {
-        *d = *s * scalar;
+        d.write(*s * scalar);
     }
 }
 
@@ -588,7 +594,7 @@ pub(crate) fn scale_in_place(v: &mut [f32], scalar: f32) {
 
 /// Scales `src` by `scalar` and stores result in `dst` using the best available SIMD instructions.
 #[inline(always)]
-pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -720,30 +726,34 @@ mod tests {
     #[test]
     fn test_scale_and_copy_implementation_coverage() {
         let src = vec![1.0f32; 17]; // 17 to force remainder logic (8*2 + 1)
-        let mut dst = vec![0.0f32; 17];
+        let mut dst: Vec<f32> = Vec::with_capacity(17);
         let scalar = 2.0;
         let expected = vec![2.0f32; 17];
 
         // 1. Unconditional Scalar coverage
-        scale_and_copy_scalar(&src, &mut dst, scalar);
+        scale_and_copy_scalar(&src, dst.spare_capacity_mut(), scalar);
+        // SAFETY: We just initialized the vector
+        unsafe { dst.set_len(17) };
         assert_eq!(dst, expected, "Scalar implementation failed");
-        dst.fill(0.0);
+        dst.clear();
 
         // 2. Conditional x86 SIMD coverage
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
             // Try SSE2 if available
             if is_x86_feature_detected!("sse2") {
-                unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst, scalar) };
+                unsafe { x86_ops::scale_and_copy_sse2(&src, dst.spare_capacity_mut(), scalar) };
+                unsafe { dst.set_len(17) };
                 assert_eq!(dst, expected, "SSE2 implementation failed");
-                dst.fill(0.0);
+                dst.clear();
             }
 
             // Try AVX2 if available
             if is_x86_feature_detected!("avx2") {
-                unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst, scalar) };
+                unsafe { x86_ops::scale_and_copy_avx2(&src, dst.spare_capacity_mut(), scalar) };
+                unsafe { dst.set_len(17) };
                 assert_eq!(dst, expected, "AVX2 implementation failed");
-                dst.fill(0.0);
+                dst.clear();
             }
         }
     }


### PR DESCRIPTION
This PR fixes a potential Undefined Behavior (UB) issue in the `normalize` function within `src/core/vector/ops.rs`.

Previously, `normalize` allocated a vector with capacity, set its length using `unsafe { set_len }` *before* initialization, and then passed a mutable slice of this uninitialized memory to `scale_and_copy`. Creating a reference (`&mut [f32]`) to uninitialized memory is immediate UB in Rust.

The fix involves:
1.  Modifying `scale_and_copy` (and its SIMD/scalar backends in `src/core/vector/simd.rs`) to accept `&mut [MaybeUninit<f32>]`.
2.  Updating `normalize` to use `result.spare_capacity_mut()` to safely access the uninitialized buffer.
3.  Calling `unsafe { result.set_len() }` only *after* the buffer has been initialized.

This change maintains the performance characteristic (no zero-initialization overhead) while adhering to Rust's safety rules. Tests in `sentry_safety_tests.rs` were also updated to verify the fix using safe patterns.

---
*PR created automatically by Jules for task [16327572344146536398](https://jules.google.com/task/16327572344146536398) started by @madmax983*