### PR TITLE
fix(vector): eliminate UB in normalize and improve cosine_similarity stability

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -104,7 +104,11 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Result<f32> {
     // Use SIMD-accelerated computation when available
     let (dot, mag_a_sq, mag_b_sq) = dot_and_magnitudes(a, b);
 
-    let magnitude = (mag_a_sq * mag_b_sq).sqrt();
+    // Compute magnitude as product of individual magnitudes to improve numerical stability
+    // and prevent intermediate overflow/underflow for extreme values.
+    // sqrt(a^2 * b^2) can overflow if a^2 * b^2 > f32::MAX, even if a^2 and b^2 are representable.
+    // sqrt(a^2) * sqrt(b^2) avoids this.
+    let magnitude = mag_a_sq.sqrt() * mag_b_sq.sqrt();
 
     // Handle zero vectors
     if magnitude == 0.0 {
@@ -590,19 +594,17 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
     // This provides ~15% speedup for large vectors by avoiding an extra write pass.
     let mut result = Vec::with_capacity(v.len());
 
-    // SAFETY: We immediately fill the entire vector using scale_and_copy.
-    // scale_and_copy internally asserts that src.len() == dst.len(), guaranteeing
-    // that all elements are written before the vector is exposed.
-    //
-    // The `result` vector is allocated with capacity `v.len()`, so `set_len` is
-    // within capacity bounds. `scale_and_copy` is a trusted function (verified by tests)
-    // that writes to every element of `result`. Even if `scale_and_copy` were to panic,
-    // the `result` vector would be dropped, which is safe for `Vec<f32>` (no Drop impl for f32).
-    // The only risk is if `scale_and_copy` returned early without initializing, but
-    // its implementation guarantees full coverage via exact chunking and remainder handling.
-    unsafe { result.set_len(v.len()) };
+    // SAFETY: We use spare_capacity_mut to safely access uninitialized memory.
+    // scale_and_copy writes to all elements, and we only set_len after successful completion.
+    // spare_capacity_mut returns slice of available capacity (>= v.len())
+    let dst = result.spare_capacity_mut();
+    // We strictly slice to v.len() to ensure length match with src
+    let dst = &mut dst[..v.len()];
 
-    scale_and_copy(v, &mut result, inv_mag);
+    scale_and_copy(v, dst, inv_mag);
+
+    // SAFETY: scale_and_copy has initialized v.len() elements.
+    unsafe { result.set_len(v.len()) };
     result
 }
 

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -47,11 +47,16 @@ fn test_scale_and_copy_correctness() {
     // This is critical because normalize() relies on this to initialize the vector.
 
     let src = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-    let mut dst = vec![0.0; 5]; // Pre-fill with 0 to verify overwrite
+    let mut dst_vec = Vec::with_capacity(5);
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    let dst = dst_vec.spare_capacity_mut();
+    let dst = &mut dst[..5];
 
-    assert_eq!(dst, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
+    scale_and_copy(&src, dst, 2.0);
+
+    unsafe { dst_vec.set_len(5) };
+
+    assert_eq!(dst_vec, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
 }
 
 #[test]
@@ -59,11 +64,16 @@ fn test_scale_and_copy_large_vector() {
     // 🛡️ Sentry: Test with larger vector to trigger SIMD loop + remainder
     let len = 1024 + 7; // 1031 elements
     let src: Vec<f32> = (0..len).map(|i| i as f32).collect();
-    let mut dst = vec![0.0; len];
+    let mut dst_vec = Vec::with_capacity(len);
 
-    scale_and_copy(&src, &mut dst, 2.0);
+    let dst = dst_vec.spare_capacity_mut();
+    let dst = &mut dst[..len];
 
-    for (i, val) in dst.iter().enumerate() {
+    scale_and_copy(&src, dst, 2.0);
+
+    unsafe { dst_vec.set_len(len) };
+
+    for (i, val) in dst_vec.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);
     }
 }

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -21,11 +21,11 @@ use std::mem::MaybeUninit;
 /// where SIMD becomes beneficial is typically around 16-32 dimensions.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86_ops {
-    use std::mem::MaybeUninit;
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
+    use std::mem::MaybeUninit;
 
     /// Computes dot product, magnitude_a², and magnitude_b² using AVX2.
     ///

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 // ============================================================================
 // SIMD Support
 // ============================================================================
@@ -19,6 +21,7 @@
 /// where SIMD becomes beneficial is typically around 16-32 dimensions.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86_ops {
+    use std::mem::MaybeUninit;
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
@@ -431,7 +434,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure AVX2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm256_set1_ps(scalar);
@@ -441,14 +444,14 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm256_loadu_ps(s_chunk.as_ptr());
                 let result = _mm256_mul_ps(va, scalar_vec);
-                _mm256_storeu_ps(d_chunk.as_mut_ptr(), result);
+                _mm256_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -459,7 +462,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure SSE2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "sse2")]
     #[inline]
-    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm_set1_ps(scalar);
@@ -469,14 +472,14 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm_loadu_ps(s_chunk.as_ptr());
                 let result = _mm_mul_ps(va, scalar_vec);
-                _mm_storeu_ps(d_chunk.as_mut_ptr(), result);
+                _mm_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -547,10 +550,10 @@ pub(crate) fn scale_in_place_scalar(v: &mut [f32], scalar: f32) {
     all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)),
     allow(dead_code)
 )]
-pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().zip(dst.iter_mut()) {
-        *d = *s * scalar;
+        d.write(*s * scalar);
     }
 }
 
@@ -588,7 +591,7 @@ pub(crate) fn scale_in_place(v: &mut [f32], scalar: f32) {
 
 /// Scales `src` by `scalar` and stores result in `dst` using the best available SIMD instructions.
 #[inline(always)]
-pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -720,30 +723,42 @@ mod tests {
     #[test]
     fn test_scale_and_copy_implementation_coverage() {
         let src = vec![1.0f32; 17]; // 17 to force remainder logic (8*2 + 1)
-        let mut dst = vec![0.0f32; 17];
+        let mut dst = Vec::with_capacity(17);
         let scalar = 2.0;
         let expected = vec![2.0f32; 17];
 
         // 1. Unconditional Scalar coverage
-        scale_and_copy_scalar(&src, &mut dst, scalar);
+        // Create uninit slice
+        let dst_uninit = dst.spare_capacity_mut();
+        // Since spare_capacity_mut uses capacity, and dst is empty with cap 17, it returns len 17.
+        scale_and_copy_scalar(&src, dst_uninit, scalar);
+
+        // Mark as init
+        unsafe { dst.set_len(17) };
         assert_eq!(dst, expected, "Scalar implementation failed");
-        dst.fill(0.0);
+
+        // Reset
+        dst.clear();
 
         // 2. Conditional x86 SIMD coverage
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
             // Try SSE2 if available
             if is_x86_feature_detected!("sse2") {
-                unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst, scalar) };
+                let dst_uninit = dst.spare_capacity_mut();
+                unsafe { x86_ops::scale_and_copy_sse2(&src, dst_uninit, scalar) };
+                unsafe { dst.set_len(17) };
                 assert_eq!(dst, expected, "SSE2 implementation failed");
-                dst.fill(0.0);
+                dst.clear();
             }
 
             // Try AVX2 if available
             if is_x86_feature_detected!("avx2") {
-                unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst, scalar) };
+                let dst_uninit = dst.spare_capacity_mut();
+                unsafe { x86_ops::scale_and_copy_avx2(&src, dst_uninit, scalar) };
+                unsafe { dst.set_len(17) };
                 assert_eq!(dst, expected, "AVX2 implementation failed");
-                dst.fill(0.0);
+                dst.clear();
             }
         }
     }

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2915,5 +2915,9 @@ fn test_cosine_similarity_overflow_stability() {
 
     let sim = cosine_similarity(&a, &b).unwrap();
     assert!(!sim.is_nan());
-    assert!(sim.abs() <= 1.0 + 1e-5, "Similarity {} exceeded bounds", sim);
+    assert!(
+        sim.abs() <= 1.0 + 1e-5,
+        "Similarity {} exceeded bounds",
+        sim
+    );
 }

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2902,3 +2902,18 @@ fn test_simd_mismatched_lengths_safety() {
         );
     }
 }
+
+#[test]
+fn test_cosine_similarity_overflow_stability() {
+    // Values derived from repro_search.rs that previously caused instability
+    let a_base = -8.161245e-22f32;
+    let b_base = -125.53673f32;
+
+    // Construct vectors that trigger large intermediate products
+    let a = vec![a_base];
+    let b = vec![b_base];
+
+    let sim = cosine_similarity(&a, &b).unwrap();
+    assert!(!sim.is_nan());
+    assert!(sim.abs() <= 1.0 + 1e-5, "Similarity {} exceeded bounds", sim);
+}


### PR DESCRIPTION
This PR addresses two critical issues in the vector operations module:

1.  **Safety/UB Fix**: The `normalize` function previously used `unsafe { result.set_len(v.len()) }` immediately after allocation, effectively creating a `&mut [f32]` to uninitialized memory when calling `scale_and_copy`. This is Undefined Behavior in Rust. The fix uses `Vec::spare_capacity_mut()` to pass `&mut [MaybeUninit<f32>]` to `scale_and_copy`, which is now updated to handle uninitialized memory safely using pointer casts for SIMD intrinsics.

2.  **Numerical Stability**: The `cosine_similarity` function computed the denominator as `(mag_a_sq * mag_b_sq).sqrt()`. For very small (denormal) or very large vectors, the intermediate product `mag_a_sq * mag_b_sq` could underflow to zero or overflow to infinity, even if the final result should be valid. The implementation was changed to `mag_a_sq.sqrt() * mag_b_sq.sqrt()` to avoid this. A regression test covers this scenario.

All vector tests passed.

---
*PR created automatically by Jules for task [2328275701983235434](https://jules.google.com/task/2328275701983235434) started by @madmax983*