### PR TITLE
🛡️ Sentry: Fix vector normalization for extreme magnitudes

### DIFF
--- a/src/core/vector/constants.rs
+++ b/src/core/vector/constants.rs
@@ -19,10 +19,10 @@ pub const NORMALIZATION_TOLERANCE: f32 = 1e-6;
 /// in normalization operations. This prevents numerical instability from denormal
 /// numbers and avoids division by very small values that could cause overflow.
 ///
-/// Value: 1e-14 corresponds to magnitude ≈ 1e-7, providing safety margin for f32
-/// precision (which has ~7 significant digits). This is more conservative than
-/// 1e-20 (magnitude ≈ 1e-10) which is too close to f32's precision limits.
-pub(crate) const SQUARED_MAGNITUDE_THRESHOLD: f32 = 1e-14;
+/// Value: 1e-30 corresponds to magnitude ≈ 1e-15, which is safely above the smallest
+/// normal f32 (≈ 1e-38) but allows normalizing small valid vectors (e.g. 1e-8).
+/// This prevents valid but small vectors from being incorrectly zeroed out.
+pub(crate) const SQUARED_MAGNITUDE_THRESHOLD: f32 = 1e-30;
 
 /// Maximum allowed vector dimension.
 ///

--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -104,6 +104,12 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Result<f32> {
     // Use SIMD-accelerated computation when available
     let (dot, mag_a_sq, mag_b_sq) = dot_and_magnitudes(a, b);
 
+    // Fallback for extreme magnitudes (Inf)
+    // If we have overflow, we need a more robust (but slower) calculation
+    if mag_a_sq.is_infinite() || mag_b_sq.is_infinite() {
+        return cosine_similarity_robust(a, b);
+    }
+
     let magnitude = (mag_a_sq * mag_b_sq).sqrt();
 
     // Handle zero vectors
@@ -576,6 +582,38 @@ pub fn squared_magnitude(v: &[f32]) -> f32 {
 #[allow(clippy::uninit_vec)] // Performance optimization: we explicitly fill the vector
 pub fn normalize(v: &[f32]) -> Vec<f32> {
     let sq_mag = squared_magnitude(v);
+
+    // Handle overflow (Inf) by scaling down
+    if sq_mag.is_infinite() {
+        let max_val = v.iter().fold(0.0f32, |m, x| m.max(x.abs()));
+        if max_val.is_infinite() {
+            // Vector contains actual Infinity. Return [0, NaN, 0] behavior via multiplication by 0.0.
+            let mut result = Vec::with_capacity(v.len());
+            unsafe { result.set_len(v.len()) };
+            scale_and_copy(v, &mut result, 0.0);
+            return result;
+        }
+        if max_val == 0.0 {
+            return vec![0.0; v.len()];
+        }
+
+        let scaled_sq_mag: f32 = v
+            .iter()
+            .map(|x| {
+                let s = x / max_val;
+                s * s
+            })
+            .sum();
+
+        let inv_mag = 1.0 / scaled_sq_mag.sqrt();
+        let final_scale = (1.0 / max_val) * inv_mag;
+
+        let mut result = Vec::with_capacity(v.len());
+        unsafe { result.set_len(v.len()) };
+        scale_and_copy(v, &mut result, final_scale);
+        return result;
+    }
+
     // Use squared magnitude threshold to avoid denormal number issues.
     // See SQUARED_MAGNITUDE_THRESHOLD for details.
     if sq_mag < SQUARED_MAGNITUDE_THRESHOLD {
@@ -639,6 +677,32 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
 #[inline]
 pub fn normalize_in_place(v: &mut [f32]) {
     let sq_mag = squared_magnitude(v);
+
+    // Handle overflow (Inf) by scaling down
+    if sq_mag.is_infinite() {
+        let max_val = v.iter().fold(0.0f32, |m, x| m.max(x.abs()));
+        if max_val.is_infinite() {
+            scale_in_place(v, 0.0);
+            return;
+        }
+        if max_val == 0.0 {
+            return;
+        }
+
+        let scaled_sq_mag: f32 = v
+            .iter()
+            .map(|x| {
+                let s = x / max_val;
+                s * s
+            })
+            .sum();
+
+        let inv_mag = 1.0 / scaled_sq_mag.sqrt();
+        let final_scale = (1.0 / max_val) * inv_mag;
+        scale_in_place(v, final_scale);
+        return;
+    }
+
     // Use squared magnitude threshold to avoid denormal number issues.
     // See SQUARED_MAGNITUDE_THRESHOLD for details.
     if sq_mag < SQUARED_MAGNITUDE_THRESHOLD {
@@ -648,6 +712,44 @@ pub fn normalize_in_place(v: &mut [f32]) {
     // Compute 1/sqrt(sq_mag) directly to avoid intermediate variable
     let inv_mag = 1.0 / sq_mag.sqrt();
     scale_in_place(v, inv_mag);
+}
+
+/// Robust cosine similarity calculation for vectors with extreme magnitudes.
+///
+/// This is used as a fallback when `dot_and_magnitudes` encounters overflow (Inf).
+/// It scales down the vectors by their maximum absolute value to bring them
+/// into a safe range before computing the dot product and magnitudes.
+fn cosine_similarity_robust(a: &[f32], b: &[f32]) -> Result<f32> {
+    // Find maximum absolute value to use as scaling factor
+    let max_a = a.iter().fold(0.0f32, |m, x| m.max(x.abs()));
+    let max_b = b.iter().fold(0.0f32, |m, x| m.max(x.abs()));
+
+    if max_a == 0.0 || max_b == 0.0 {
+        return Ok(0.0);
+    }
+
+    // Compute scaled dot product and magnitudes
+    // We can do this in one pass to be somewhat efficient
+    let mut dot = 0.0;
+    let mut mag_a_sq = 0.0;
+    let mut mag_b_sq = 0.0;
+
+    for (ai, bi) in a.iter().zip(b.iter()) {
+        let val_a = ai / max_a;
+        let val_b = bi / max_b;
+        dot += val_a * val_b;
+        mag_a_sq += val_a * val_a;
+        mag_b_sq += val_b * val_b;
+    }
+
+    let magnitude = (mag_a_sq * mag_b_sq).sqrt();
+
+    if magnitude == 0.0 {
+        return Ok(0.0);
+    }
+
+    let result = dot / magnitude;
+    Ok(result.clamp(-1.0, 1.0))
 }
 
 /// Checks if a vector is normalized (has magnitude approximately 1.0).

--- a/src/core/vector/repro_normalization.rs
+++ b/src/core/vector/repro_normalization.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+mod tests {
+    use crate::core::vector::ops::*;
+
+    #[test]
+    fn test_normalize_small_vector() {
+        // 1e-8 is small but valid (sq_mag 1e-16)
+        // Current threshold is 1e-14, so this returns zero vector.
+        let v = vec![1e-8, 0.0];
+        let normalized = normalize(&v);
+
+        // Should be [1.0, 0.0]
+        assert!((normalized[0] - 1.0).abs() < 1e-6, "Small vector normalization failed: {:?}", normalized);
+    }
+
+    #[test]
+    fn test_normalize_large_vector() {
+        // 1e20 is large (sq_mag 1e40 -> Inf)
+        // Returns zero vector due to inv_mag = 0.
+        let v = vec![1e20, 0.0];
+        let normalized = normalize(&v);
+
+        // Should be [1.0, 0.0]
+        assert!((normalized[0] - 1.0).abs() < 1e-6, "Large vector normalization failed: {:?}", normalized);
+    }
+
+    #[test]
+    fn test_cosine_similarity_large_vector() {
+        // 1e20 -> Inf dot product and magnitude
+        let v = vec![1e20, 0.0];
+        let result = cosine_similarity(&v, &v).unwrap();
+
+        // Should be 1.0
+        assert!((result - 1.0).abs() < 1e-6, "Large vector cosine similarity failed: {}", result);
+    }
+}

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -481,3 +481,55 @@ fn test_scale_in_place_zero_scalar() {
     assert!(v[2].is_nan()); // Inf * 0 = NaN
     assert!(v[3].is_nan()); // NaN * 0 = NaN
 }
+
+// ============================================================================
+// Normalization Edge Case Tests (Small/Large Vectors)
+// ============================================================================
+
+#[test]
+fn test_sentry_normalize_small_vector() {
+    // 🛡️ Sentry Test: Verify normalization works for small but valid vectors.
+    // 1e-8 is safely within f32 range, but 1e-8^2 = 1e-16 was previously
+    // below the 1e-14 threshold, causing it to be zeroed out.
+    let v = vec![1e-8, 0.0];
+    let normalized = normalize(&v);
+
+    // Should be [1.0, 0.0]
+    assert!(
+        (normalized[0] - 1.0).abs() < 1e-6,
+        "Small vector normalization failed: {:?}",
+        normalized
+    );
+}
+
+#[test]
+fn test_sentry_normalize_large_vector() {
+    // 🛡️ Sentry Test: Verify normalization works for large vectors that cause intermediate overflow.
+    // 1e20^2 = 1e40 (Inf). Previously this caused 1/Inf = 0, returning zero vector.
+    // Now it should scale down and normalize correctly.
+    let v = vec![1e20, 0.0];
+    let normalized = normalize(&v);
+
+    // Should be [1.0, 0.0]
+    assert!(
+        (normalized[0] - 1.0).abs() < 1e-6,
+        "Large vector normalization failed: {:?}",
+        normalized
+    );
+}
+
+#[test]
+fn test_sentry_cosine_similarity_large_vector() {
+    // 🛡️ Sentry Test: Verify cosine similarity works for large vectors that cause intermediate overflow.
+    // 1e20 -> Inf dot product and magnitude. Previously returned NaN (Inf/Inf).
+    // Now falls back to robust calculation.
+    let v = vec![1e20, 0.0];
+    let result = cosine_similarity(&v, &v).unwrap();
+
+    // Should be 1.0
+    assert!(
+        (result - 1.0).abs() < 1e-6,
+        "Large vector cosine similarity failed: {}",
+        result
+    );
+}

--- a/src/core/vector/sentry_tests.rs
+++ b/src/core/vector/sentry_tests.rs
@@ -519,6 +519,38 @@ fn test_sentry_normalize_large_vector() {
 }
 
 #[test]
+fn test_sentry_normalize_in_place_large_vector() {
+    // 🛡️ Sentry Test: Verify normalize_in_place also handles large vectors.
+    let mut v = vec![1e20, 0.0];
+    normalize_in_place(&mut v);
+
+    assert!(
+        (v[0] - 1.0).abs() < 1e-6,
+        "Large vector normalize_in_place failed: {:?}",
+        v
+    );
+}
+
+#[test]
+fn test_sentry_normalize_in_place_inf() {
+    // 🛡️ Sentry: Ensure normalize_in_place handles Infinity by zeroing the vector
+    // (consistent with normalize behavior [0, NaN, 0] or similar, but here we explicitly zero if max is inf?
+    // Wait, implementation for Inf scalar is: scale_in_place(v, 0.0).
+    // So it zeroes out the vector.
+    let mut v = vec![1.0, f32::INFINITY, 3.0];
+    normalize_in_place(&mut v);
+
+    // Should be all zeros?
+    // Implementation: if max_val.is_infinite() -> scale_in_place(v, 0.0).
+    // 1.0 * 0.0 = 0.0
+    // Inf * 0.0 = NaN
+    // 3.0 * 0.0 = 0.0
+    assert_eq!(v[0], 0.0);
+    assert!(v[1].is_nan());
+    assert_eq!(v[2], 0.0);
+}
+
+#[test]
 fn test_sentry_cosine_similarity_large_vector() {
     // 🛡️ Sentry Test: Verify cosine similarity works for large vectors that cause intermediate overflow.
     // 1e20 -> Inf dot product and magnitude. Previously returned NaN (Inf/Inf).
@@ -532,4 +564,20 @@ fn test_sentry_cosine_similarity_large_vector() {
         "Large vector cosine similarity failed: {}",
         result
     );
+}
+
+#[test]
+fn test_sentry_cosine_similarity_large_vs_zero() {
+    // 🛡️ Sentry: Verify robust cosine similarity handles large vs zero correctly.
+    // Logic: if max_a == 0 or max_b == 0 -> return 0.0.
+    // This hits the coverage point in cosine_similarity_robust.
+    let large = vec![1e20, 0.0];
+    let zero = vec![0.0, 0.0];
+
+    // mag_sq of large is Inf.
+    // Enters fallback.
+    // max_a = 1e20. max_b = 0.
+    // Checks max_b == 0. Returns 0.0.
+    let result = cosine_similarity(&large, &zero).unwrap();
+    assert_eq!(result, 0.0);
 }


### PR DESCRIPTION
This PR addresses numerical stability issues in vector operations found during Sentry audit.

1.  **Small Vector Normalization:**
    *   Previously, vectors with squared magnitude < `1e-14` (magnitude < `1e-7`) were treated as zero vectors. This is problematic for small but valid vectors (e.g., embeddings with small values).
    *   **Fix:** Lowered the threshold to `1e-30` (magnitude `1e-15`), which is safely within the normal range of `f32`.

2.  **Large Vector Normalization:**
    *   Vectors with large components (e.g., `1e20`) would cause `squared_magnitude` to overflow to `Infinity`.
    *   This resulted in `inv_mag = 1.0 / Inf = 0.0`, causing `normalize` to return a zero vector `[0, 0, ...]`, which is mathematically incorrect (should be a unit vector).
    *   **Fix:** Added a fallback path for infinite magnitudes that scales the vector by `1.0 / max_abs_element` before normalization.

3.  **Cosine Similarity Overflow:**
    *   Similar to normalization, large vectors caused intermediate overflow in `cosine_similarity` (`dot` or `magnitude` becoming `Inf`), leading to `NaN` results.
    *   **Fix:** Added a fallback to a robust implementation that scales vectors down when overflow is detected.

4.  **Tests:**
    *   Added regression tests in `src/core/vector/sentry_tests.rs` covering small vector normalization, large vector normalization, and large vector cosine similarity.

---
*PR created automatically by Jules for task [15946187699606469613](https://jules.google.com/task/15946187699606469613) started by @madmax983*