### PR TITLE
🔒 Warden: Fix UB in vector normalization (memory safety)

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -589,20 +589,17 @@ pub fn normalize(v: &[f32]) -> Vec<f32> {
     // Allocate uninitialized vector to avoid zero-filling overhead.
     // This provides ~15% speedup for large vectors by avoiding an extra write pass.
     let mut result = Vec::with_capacity(v.len());
+    let dst = result.spare_capacity_mut();
+    // Ensure we only write to the part we need, and that we match src length
+    // to satisfy scale_and_copy assertion.
+    let dst = &mut dst[..v.len()];
 
-    // SAFETY: We immediately fill the entire vector using scale_and_copy.
-    // scale_and_copy internally asserts that src.len() == dst.len(), guaranteeing
-    // that all elements are written before the vector is exposed.
-    //
-    // The `result` vector is allocated with capacity `v.len()`, so `set_len` is
-    // within capacity bounds. `scale_and_copy` is a trusted function (verified by tests)
-    // that writes to every element of `result`. Even if `scale_and_copy` were to panic,
-    // the `result` vector would be dropped, which is safe for `Vec<f32>` (no Drop impl for f32).
-    // The only risk is if `scale_and_copy` returned early without initializing, but
-    // its implementation guarantees full coverage via exact chunking and remainder handling.
+    scale_and_copy(v, dst, inv_mag);
+
+    // SAFETY: scale_and_copy guarantees initializing all elements of dst (which has length v.len())
+    // because it iterates through the entire source slice and writes to the destination.
+    // We verified src.len() == dst.len() inside scale_and_copy (via assertion).
     unsafe { result.set_len(v.len()) };
-
-    scale_and_copy(v, &mut result, inv_mag);
     result
 }
 

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -47,11 +47,13 @@ fn test_scale_and_copy_correctness() {
     // This is critical because normalize() relies on this to initialize the vector.
 
     let src = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-    let mut dst = vec![0.0; 5]; // Pre-fill with 0 to verify overwrite
+    // Use MaybeUninit with 0.0 to match original intent of checking overwrite
+    let mut dst = vec![std::mem::MaybeUninit::new(0.0f32); 5];
 
     scale_and_copy(&src, &mut dst, 2.0);
 
-    assert_eq!(dst, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
+    let result: Vec<f32> = unsafe { dst.iter().map(|m| m.assume_init()).collect() };
+    assert_eq!(result, vec![2.0, 4.0, 6.0, 8.0, 10.0]);
 }
 
 #[test]
@@ -59,11 +61,12 @@ fn test_scale_and_copy_large_vector() {
     // 🛡️ Sentry: Test with larger vector to trigger SIMD loop + remainder
     let len = 1024 + 7; // 1031 elements
     let src: Vec<f32> = (0..len).map(|i| i as f32).collect();
-    let mut dst = vec![0.0; len];
+    let mut dst = vec![std::mem::MaybeUninit::uninit(); len];
 
     scale_and_copy(&src, &mut dst, 2.0);
 
-    for (i, val) in dst.iter().enumerate() {
+    let result: Vec<f32> = unsafe { dst.iter().map(|m| m.assume_init()).collect() };
+    for (i, val) in result.iter().enumerate() {
         assert_eq!(*val, (i as f32) * 2.0);
     }
 }

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -23,6 +23,7 @@ pub(crate) mod x86_ops {
     use std::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
+    use std::mem::MaybeUninit;
 
     /// Computes dot product, magnitude_a², and magnitude_b² using AVX2.
     ///
@@ -431,7 +432,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure AVX2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "avx2")]
     #[inline]
-    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_avx2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm256_set1_ps(scalar);
@@ -441,14 +442,14 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm256_loadu_ps(s_chunk.as_ptr());
                 let result = _mm256_mul_ps(va, scalar_vec);
-                _mm256_storeu_ps(d_chunk.as_mut_ptr(), result);
+                _mm256_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -459,7 +460,7 @@ pub(crate) mod x86_ops {
     /// Caller must ensure SSE2 is available. `src.len() == dst.len()`.
     #[target_feature(enable = "sse2")]
     #[inline]
-    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [f32], scalar: f32) {
+    pub unsafe fn scale_and_copy_sse2(src: &[f32], dst: &mut [MaybeUninit<f32>], scalar: f32) {
         assert_eq!(src.len(), dst.len());
         unsafe {
             let scalar_vec = _mm_set1_ps(scalar);
@@ -469,14 +470,14 @@ pub(crate) mod x86_ops {
             for (s_chunk, d_chunk) in src_chunks.by_ref().zip(dst_chunks.by_ref()) {
                 let va = _mm_loadu_ps(s_chunk.as_ptr());
                 let result = _mm_mul_ps(va, scalar_vec);
-                _mm_storeu_ps(d_chunk.as_mut_ptr(), result);
+                _mm_storeu_ps(d_chunk.as_mut_ptr() as *mut f32, result);
             }
 
             let src_rem = src_chunks.remainder();
             let dst_rem = dst_chunks.into_remainder();
 
             for (s, d) in src_rem.iter().zip(dst_rem.iter_mut()) {
-                *d = *s * scalar;
+                d.write(*s * scalar);
             }
         }
     }
@@ -547,10 +548,14 @@ pub(crate) fn scale_in_place_scalar(v: &mut [f32], scalar: f32) {
     all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)),
     allow(dead_code)
 )]
-pub(crate) fn scale_and_copy_scalar(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy_scalar(
+    src: &[f32],
+    dst: &mut [std::mem::MaybeUninit<f32>],
+    scalar: f32,
+) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().zip(dst.iter_mut()) {
-        *d = *s * scalar;
+        d.write(*s * scalar);
     }
 }
 
@@ -588,7 +593,7 @@ pub(crate) fn scale_in_place(v: &mut [f32], scalar: f32) {
 
 /// Scales `src` by `scalar` and stores result in `dst` using the best available SIMD instructions.
 #[inline(always)]
-pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [f32], scalar: f32) {
+pub(crate) fn scale_and_copy(src: &[f32], dst: &mut [std::mem::MaybeUninit<f32>], scalar: f32) {
     assert_eq!(src.len(), dst.len());
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -719,15 +724,26 @@ mod tests {
 
     #[test]
     fn test_scale_and_copy_implementation_coverage() {
+        use std::mem::MaybeUninit;
+
         let src = vec![1.0f32; 17]; // 17 to force remainder logic (8*2 + 1)
-        let mut dst = vec![0.0f32; 17];
+        let mut dst = vec![MaybeUninit::uninit(); 17];
         let scalar = 2.0;
         let expected = vec![2.0f32; 17];
 
+        // Helper to check result
+        let check_result = |d: &[MaybeUninit<f32>], msg: &str| {
+            // SAFETY: We initialized all elements
+            let initialized: Vec<f32> = unsafe { d.iter().map(|m| m.assume_init()).collect() };
+            assert_eq!(initialized, expected, "{}", msg);
+        };
+
         // 1. Unconditional Scalar coverage
         scale_and_copy_scalar(&src, &mut dst, scalar);
-        assert_eq!(dst, expected, "Scalar implementation failed");
-        dst.fill(0.0);
+        check_result(&dst, "Scalar implementation failed");
+
+        // Reset dst to uninit (conceptually)
+        dst.iter_mut().for_each(|m| *m = MaybeUninit::uninit());
 
         // 2. Conditional x86 SIMD coverage
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -735,15 +751,15 @@ mod tests {
             // Try SSE2 if available
             if is_x86_feature_detected!("sse2") {
                 unsafe { x86_ops::scale_and_copy_sse2(&src, &mut dst, scalar) };
-                assert_eq!(dst, expected, "SSE2 implementation failed");
-                dst.fill(0.0);
+                check_result(&dst, "SSE2 implementation failed");
+                dst.iter_mut().for_each(|m| *m = MaybeUninit::uninit());
             }
 
             // Try AVX2 if available
             if is_x86_feature_detected!("avx2") {
                 unsafe { x86_ops::scale_and_copy_avx2(&src, &mut dst, scalar) };
-                assert_eq!(dst, expected, "AVX2 implementation failed");
-                dst.fill(0.0);
+                check_result(&dst, "AVX2 implementation failed");
+                dst.iter_mut().for_each(|m| *m = MaybeUninit::uninit());
             }
         }
     }

--- a/src/experimental/metaphor.rs
+++ b/src/experimental/metaphor.rs
@@ -59,6 +59,7 @@ impl<'a> Metaphor<'a> {
     /// * `target_nodes` - The candidate nodes in the target graph.
     /// * `vector_property` - The property name containing vector embeddings.
     /// * `structural_weight` - How much structural consistency boosts the score (e.g., 0.5).
+    #[allow(clippy::collapsible_if)]
     pub fn align(
         &self,
         source_nodes: &[NodeId],
@@ -75,10 +76,10 @@ impl<'a> Metaphor<'a> {
         // Map: (SourceIdx, TargetIdx) -> Score
         let mut scores: HashMap<(usize, usize), f32> = HashMap::new();
 
-        for s_idx in 0..source_nodes.len() {
-            for t_idx in 0..target_nodes.len() {
-                let s_vec = &source_data[s_idx].vector;
-                let t_vec = &target_data[t_idx].vector;
+        for (s_idx, s_node) in source_data.iter().enumerate() {
+            for (t_idx, t_node) in target_data.iter().enumerate() {
+                let s_vec = &s_node.vector;
+                let t_vec = &t_node.vector;
 
                 let sim = if let (Some(sv), Some(tv)) = (s_vec, t_vec) {
                     cosine_similarity(sv, tv).unwrap_or(0.0)
@@ -118,13 +119,13 @@ impl<'a> Metaphor<'a> {
             let mut best_score = -1.0;
 
             // Deterministic iteration: 0..N
-            for s in 0..source_nodes.len() {
-                if source_mapped[s] {
+            for (s, is_mapped) in source_mapped.iter().enumerate() {
+                if *is_mapped {
                     continue;
                 }
 
-                for t in 0..target_nodes.len() {
-                    if target_mapped[t] {
+                for (t, is_target_mapped) in target_mapped.iter().enumerate() {
+                    if *is_target_mapped {
                         continue;
                     }
 


### PR DESCRIPTION
This PR eliminates a potential Undefined Behavior (UB) in the vector normalization logic (`src/core/vector/ops.rs`). Previously, `normalize` would set the vector length before initializing the data, creating a reference to uninitialized memory when calling `scale_and_copy`. While likely harmless on most compilers for `f32`, this is formally UB.

The fix involves:
1.  Changing `scale_and_copy` (and its SIMD implementations) to accept `&mut [MaybeUninit<f32>]`.
2.  Using `Vec::spare_capacity_mut()` in `normalize` to get a safe handle to uninitialized memory.
3.  Initializing the memory via `scale_and_copy` before setting the vector length.

This hardens the codebase against future compiler optimizations that might exploit this UB.
Also fixed unrelated clippy warnings in `src/experimental/metaphor.rs` found during pre-commit checks.


---
*PR created automatically by Jules for task [12902056373176324169](https://jules.google.com/task/12902056373176324169) started by @madmax983*