### PR TITLE
🤖 Sentinel: Add robustness tests for observer notifications

### DIFF
--- a/src/core/observer.rs
+++ b/src/core/observer.rs
@@ -591,3 +591,97 @@ mod tests {
         notify_observers(&observers, &event);
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::core::id::{NodeId, VersionId};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TrackingObserver {
+        interested: bool,
+        should_fail: bool,
+        call_count: AtomicUsize,
+    }
+
+    impl TrackingObserver {
+        fn new(interested: bool, should_fail: bool) -> Self {
+            Self {
+                interested,
+                should_fail,
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn count(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl StorageObserver for TrackingObserver {
+        fn on_event(&self, _event: &StorageEvent) -> Result<()> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            if self.should_fail {
+                Err(crate::core::error::Error::Other("Intentional failure".into()))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn interested_in(&self, _event: &StorageEvent) -> bool {
+            self.interested
+        }
+    }
+
+    #[test]
+    fn test_sentry_filtering_does_not_block_subsequent_observers() {
+        // 🛡️ Sentry Test: Verify that if an observer returns false for interested_in,
+        // the loop continues to the next observer (does not break).
+        // This targets mutants that replace `continue` with `break` in the loop.
+
+        let uninterested = Arc::new(TrackingObserver::new(false, false));
+        let interested = Arc::new(TrackingObserver::new(true, false));
+
+        let observers: Vec<Observer> = vec![
+            Arc::clone(&uninterested) as Observer,
+            Arc::clone(&interested) as Observer,
+        ];
+
+        let event = StorageEvent::NodeAnchorCreated {
+            version_id: VersionId::new(1).unwrap(),
+            node_id: NodeId::new(1).unwrap(),
+            timestamp: 1000.into(),
+        };
+
+        notify_observers(&observers, &event);
+
+        assert_eq!(uninterested.count(), 0, "Uninterested observer should not be called");
+        assert_eq!(interested.count(), 1, "Subsequent interested observer SHOULD be called");
+    }
+
+    #[test]
+    fn test_sentry_error_does_not_block_subsequent_observers() {
+        // 🛡️ Sentry Test: Verify that if an observer returns an error,
+        // the loop continues to the next observer.
+        // This targets mutants that might abort notification on error.
+
+        let failing = Arc::new(TrackingObserver::new(true, true));
+        let success = Arc::new(TrackingObserver::new(true, false));
+
+        let observers: Vec<Observer> = vec![
+            Arc::clone(&failing) as Observer,
+            Arc::clone(&success) as Observer,
+        ];
+
+        let event = StorageEvent::NodeAnchorCreated {
+            version_id: VersionId::new(1).unwrap(),
+            node_id: NodeId::new(1).unwrap(),
+            timestamp: 1000.into(),
+        };
+
+        notify_observers(&observers, &event);
+
+        assert_eq!(failing.count(), 1, "Failing observer should be called");
+        assert_eq!(success.count(), 1, "Subsequent observer SHOULD be called despite previous error");
+    }
+}

--- a/src/core/observer.rs
+++ b/src/core/observer.rs
@@ -622,7 +622,9 @@ mod sentry_tests {
         fn on_event(&self, _event: &StorageEvent) -> Result<()> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             if self.should_fail {
-                Err(crate::core::error::Error::Other("Intentional failure".into()))
+                Err(crate::core::error::Error::Other(
+                    "Intentional failure".into(),
+                ))
             } else {
                 Ok(())
             }
@@ -655,8 +657,16 @@ mod sentry_tests {
 
         notify_observers(&observers, &event);
 
-        assert_eq!(uninterested.count(), 0, "Uninterested observer should not be called");
-        assert_eq!(interested.count(), 1, "Subsequent interested observer SHOULD be called");
+        assert_eq!(
+            uninterested.count(),
+            0,
+            "Uninterested observer should not be called"
+        );
+        assert_eq!(
+            interested.count(),
+            1,
+            "Subsequent interested observer SHOULD be called"
+        );
     }
 
     #[test]
@@ -682,6 +692,10 @@ mod sentry_tests {
         notify_observers(&observers, &event);
 
         assert_eq!(failing.count(), 1, "Failing observer should be called");
-        assert_eq!(success.count(), 1, "Subsequent observer SHOULD be called despite previous error");
+        assert_eq!(
+            success.count(),
+            1,
+            "Subsequent observer SHOULD be called despite previous error"
+        );
     }
 }


### PR DESCRIPTION
**🧬 Mutants Found:**
*   Identified potential mutants in `src/core/observer.rs`:
    *   Replacing `continue` with `break` in `notify_observers` loop (when `!interested_in`).
    *   Aborting the loop if an observer returns an error.
*   `cargo mutants` timed out due to environmental constraints, necessitating manual analysis.

**🎯 Tests Added/Strengthened:**
*   Added `mod sentry_tests` to `src/core/observer.rs`.
*   `test_sentry_filtering_does_not_block_subsequent_observers`: Verifies that if an observer is not interested, the loop continues to notify subsequent observers.
*   `test_sentry_error_does_not_block_subsequent_observers`: Verifies that if an observer fails, the loop continues to notify subsequent observers.

**⚠️ Suspected Bugs:**
*   None found. The existing code correctly uses `continue` and logs errors without aborting. The new tests enforce this behavior.

**📊 Kill Rate:**
*   N/A (Manual process due to tool timeouts).

**🔗 Havoc Interaction:**
*   None. This logic is deterministic and unlikely to be targeted by fuzzing in a meaningful way beyond basic coverage.

---
*PR created automatically by Jules for task [1291743019810380855](https://jules.google.com/task/1291743019810380855) started by @madmax983*