### PR TITLE
Fix race condition in synchronous WAL appends

### DIFF
--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -396,6 +396,57 @@ impl ConcurrentWal {
         Ok(lsns)
     }
 
+    /// Append a batch of operations with completion handles (sync mode).
+    ///
+    /// This provides batch efficiency while allowing the caller to wait for durability.
+    /// Used by `ConcurrentWalSystem` in synchronous mode.
+    ///
+    /// # Returns
+    ///
+    /// Vector of (LSN, CompletionHandle) pairs.
+    pub fn append_batch_with_handles(
+        &self,
+        operations: Vec<WalOperation>,
+    ) -> Result<Vec<(LSN, CompletionHandle)>> {
+        // Handle empty batch early
+        if operations.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let count = operations.len() as u64;
+
+        // Defensive check: ensure count > 0 to prevent panic in allocate_batch
+        debug_assert!(count > 0, "count should be > 0 after empty check");
+
+        // Allocate all LSNs in a single atomic operation
+        let (first_lsn, _last_lsn) = self.lsn_allocator.allocate_batch(count);
+
+        // Pre-allocate result vector
+        let mut results = Vec::with_capacity(operations.len());
+
+        // Serialize and append each operation individually
+        for (idx, operation) in operations.into_iter().enumerate() {
+            let lsn = LSN(first_lsn.0 + idx as u64);
+
+            let data = self.serialize_entry(lsn, &operation)?;
+            let stripe = self.get_stripe();
+
+            match stripe.append_sync_blocking(lsn, data) {
+                Ok(handle) => {
+                    self.total_appends.fetch_add(1, Ordering::Relaxed);
+                    results.push((lsn, handle));
+                }
+                Err(_entry) => {
+                    return Err(Error::Storage(StorageError::WalError {
+                        reason: "WAL buffer closed".to_string(),
+                    }));
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Serialize a WAL entry to bytes.
     ///
     /// # Performance Optimization
@@ -840,6 +891,31 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].lsn, lsns[0]);
         assert_eq!(entries[1].lsn, lsns[1]);
+    }
+
+    #[test]
+    fn test_append_batch_with_handles() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalConfig::new(dir.path());
+        let wal = ConcurrentWal::new(config).unwrap();
+
+        let ops = vec![test_operation(), test_operation()];
+        let results = wal.append_batch_with_handles(ops).unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, LSN(1));
+        assert!(!results[0].1.is_complete());
+        assert_eq!(results[1].0, LSN(2));
+        assert!(!results[1].1.is_complete());
+
+        // Drain and notify
+        let entries = wal.drain_all();
+        for entry in entries {
+            entry.notify_completion();
+        }
+
+        assert!(results[0].1.is_complete());
+        assert!(results[1].1.is_complete());
     }
 
     #[test]

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -438,13 +438,25 @@ impl ConcurrentWalSystem {
     ///
     /// This flushes immediately and waits for fsync.
     pub fn append_sync(&self, operation: WalOperation) -> Result<LSN> {
-        let lsn = self.wal.append_async(operation)?;
+        // Use append_with_handle to get a completion handle so we can
+        // wait for durability even if another thread performs the flush.
+        let (lsn, handle) = self.wal.append_with_handle(operation)?;
 
-        // Drain and flush immediately for sync mode
+        // Drain and flush immediately for sync mode.
+        // We attempt to drive the flush ourselves, but if drain_all() returns
+        // empty (because another thread took the entries), we just wait on the handle.
         let entries = self.wal.drain_all();
         if !entries.is_empty() {
             self.coordinator.flush(entries, true)?;
         }
+
+        // Wait for durability.
+        // This ensures we don't return success until the data is actually on disk.
+        handle.wait().map_err(|e| {
+            Error::Storage(StorageError::WalError {
+                reason: format!("WAL flush failed: {}", e),
+            })
+        })?;
 
         Ok(lsn)
     }
@@ -507,8 +519,8 @@ impl ConcurrentWalSystem {
         // Use the underlying WAL's batch append for async modes
         match self.durability_mode {
             DurabilityMode::Synchronous => {
-                // For synchronous mode, append batch then flush all
-                let lsns = self.wal.append_batch(operations)?;
+                // For synchronous mode, use append_batch_with_handles so we can wait
+                let results = self.wal.append_batch_with_handles(operations)?;
 
                 // Drain and flush immediately for sync mode
                 let entries = self.wal.drain_all();
@@ -516,6 +528,17 @@ impl ConcurrentWalSystem {
                     self.coordinator.flush(entries, true).map_err(|e| {
                         Error::Storage(StorageError::WalError {
                             reason: format!("Failed to flush batch after drain: {}", e),
+                        })
+                    })?;
+                }
+
+                // Collect LSNs and wait for all handles
+                let mut lsns = Vec::with_capacity(results.len());
+                for (lsn, handle) in results {
+                    lsns.push(lsn);
+                    handle.wait().map_err(|e| {
+                        Error::Storage(StorageError::WalError {
+                            reason: format!("WAL batch flush failed: {}", e),
                         })
                     })?;
                 }


### PR DESCRIPTION
Fixed a race condition in synchronous WAL appends where `drain_all` returning empty could lead to premature success return before durability. Implemented by enforcing a wait on `CompletionHandle`.

---
*PR created automatically by Jules for task [15030690432702505860](https://jules.google.com/task/15030690432702505860) started by @madmax983*