### PR TITLE
docs: improve experimental feature DX with README warning and Sherlock stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ AletheiaDB tracks both **valid time** (when facts were true in reality) and **tr
 
 ## Quick Start
 
+> ⚠️ **IMPORTANT: EXPERIMENTAL FEATURES**
+>
+> Advanced AI features like **Narrative Generation**, **Sherlock**, and **Semantic Navigation** require the `nova` feature flag.
+> If you encounter "Not found" errors or panics mentioning `nova`, please add `features = ["nova"]` to your `Cargo.toml`.
+>
+> ```toml
+> [dependencies]
+> aletheiadb = { version = "0.1", features = ["nova"] }
+> ```
+
 ### Prerequisites
 
 - Rust 1.92+ (edition 2024)

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -124,7 +124,6 @@ pub mod prophet;
 #[cfg(feature = "nova")]
 /// Semantic Navigator for vector-guided pathfinding.
 pub mod semantic_navigator;
-#[cfg(feature = "nova")]
 /// Sherlock: Temporal Pattern Matching Engine.
 pub mod sherlock;
 #[cfg(feature = "nova")]

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -74,6 +74,7 @@ pub struct Sherlock<'a> {
     db: &'a AletheiaDB,
 }
 
+#[cfg(feature = "nova")]
 impl<'a> Sherlock<'a> {
     /// Create a new Sherlock instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -188,14 +189,46 @@ impl<'a> Sherlock<'a> {
     }
 }
 
+#[cfg(not(feature = "nova"))]
+impl<'a> Sherlock<'a> {
+    /// Create a new Sherlock instance.
+    ///
+    /// # Panics
+    ///
+    /// This function **will always panic** because the `nova` feature is not enabled.
+    pub fn new(_db: &'a AletheiaDB) -> Self {
+        panic!(
+            "Experimental features like Sherlock require the 'nova' feature. Please enable it in your Cargo.toml:\n\n[dependencies]\naletheiadb = {{ version = \"...\", features = [\"nova\"] }}\n"
+        );
+    }
+
+    #[cfg(test)]
+    fn new_internal(db: &'a AletheiaDB) -> Self {
+        Self { db }
+    }
+
+    /// Investigate a specific node for the given Mystery.
+    ///
+    /// # Panics
+    ///
+    /// This function **will always panic** because the `nova` feature is not enabled.
+    pub fn investigate(&self, _node_id: NodeId, _mystery: &Mystery) -> Result<Vec<Deduction>> {
+        let _ = self.db;
+        panic!("Experimental features like Sherlock require the 'nova' feature.");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
+    #[cfg(feature = "nova")]
     use crate::core::property::PropertyMapBuilder;
+    #[cfg(feature = "nova")]
     use crate::core::temporal::time;
 
     #[test]
+    #[cfg(feature = "nova")]
     fn test_sherlock_detects_sequence() {
         let db = AletheiaDB::new().unwrap();
         let t0 = time::from_millis(1_000);
@@ -254,6 +287,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "nova")]
     fn test_sherlock_time_window_constraint() {
         let db = AletheiaDB::new().unwrap();
         let t0 = time::from_millis(10_000);
@@ -306,5 +340,25 @@ mod tests {
         assert_eq!(results_pass.len(), 1, "Should match within 500ms");
         assert_eq!(results_pass[0].node_id, node_id);
         assert_eq!(results_pass[0].event_times, vec![t0, t1]);
+    }
+
+    #[test]
+    #[cfg(not(feature = "nova"))]
+    #[should_panic(expected = "Experimental features like Sherlock require the 'nova' feature")]
+    fn test_stub_new_panics() {
+        let db = AletheiaDB::new().unwrap();
+        let _ = Sherlock::new(&db);
+    }
+
+    #[test]
+    #[cfg(not(feature = "nova"))]
+    #[should_panic(expected = "Experimental features like Sherlock require the 'nova' feature")]
+    fn test_stub_investigate_panics() {
+        let db = AletheiaDB::new().unwrap();
+        // Use default (creates PropertyMap::new()) which is fine
+        let node_id = db.write(|tx| tx.create_node("T", Default::default())).unwrap();
+        // Use new_internal to bypass the panic in new()
+        let sherlock = Sherlock::new_internal(&db);
+        let _ = sherlock.investigate(node_id, &Mystery::new(Duration::from_secs(1)));
     }
 }

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -356,7 +356,9 @@ mod tests {
     fn test_stub_investigate_panics() {
         let db = AletheiaDB::new().unwrap();
         // Use default (creates PropertyMap::new()) which is fine
-        let node_id = db.write(|tx| tx.create_node("T", Default::default())).unwrap();
+        let node_id = db
+            .write(|tx| tx.create_node("T", Default::default()))
+            .unwrap();
         // Use new_internal to bypass the panic in new()
         let sherlock = Sherlock::new_internal(&db);
         let _ = sherlock.investigate(node_id, &Mystery::new(Duration::from_secs(1)));


### PR DESCRIPTION
Addressed Developer Experience (DX) friction points identified by "Echo" audit:
1.  **Documentation:** Added a clear warning in `README.md` about experimental features requiring the `nova` feature flag.
2.  **Runtime Guidance:** Modified the `Sherlock` experimental module to compile without the `nova` feature but panic at runtime with a helpful message, replacing a confusing "compiler error" with clear instructions. This aligns `Sherlock`'s behavior with `NarrativeGenerator`.

---
*PR created automatically by Jules for task [7916643699983092024](https://jules.google.com/task/7916643699983092024) started by @madmax983*