### PR TITLE
📜 Codex: ADR 046 & Storage Architecture Update

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,7 @@ classDiagram
 
     MCPServer --> QueryEngine : Uses
     QueryEngine --> AletheiaDB : Uses
+    %% Crate Boundary: Core defines traits, Storage implements them
     AletheiaDB --> CurrentStorage : "Owns (Arc)"
     AletheiaDB --> HistoricalStorage : "Owns (Arc<RwLock>)"
     %% Removed the circular dependency arrow

--- a/docs/adr/0046-decouple-storage-from-core.md
+++ b/docs/adr/0046-decouple-storage-from-core.md
@@ -1,0 +1,40 @@
+# 46. Decouple Storage from Core
+
+Date: 2024-05-23
+
+## Status
+
+Proposed
+
+## Context
+
+Circular dependencies between the core domain logic and the storage implementation were causing build failures and preventing efficient refactoring. The monolithic structure meant that any change in persistence logic triggered a rebuild of the entire core system.
+
+We needed a way to isolate the storage mechanism (how data is saved) from the business logic (what the data means).
+
+## Decision
+
+We will move all persistence logic to a dedicated `storage` module (intended to become a separate crate `aletheiadb-storage`).
+
+The architectural boundary will be defined by a set of **Storage Traits** located in the `core` module:
+
+```rust
+// In Core
+pub trait StorageEngine: Send + Sync {
+    fn get_node(&self, id: NodeId) -> Result<Node>;
+    fn save_node(&self, node: &Node) -> Result<()>;
+}
+```
+
+The `storage` module will implement these traits. This inverts the dependency: `Core` defines the interface, and `Storage` depends on `Core` to implement it.
+
+## Consequences
+
+### Positive
+*   **Build Times**: Improving modularity reduces incremental build times significantly.
+*   **Clarity**: Strict separation of concerns makes the codebase easier to navigate.
+*   **Pluggability**: Easier to swap out storage backends (e.g., in-memory for testing).
+
+### Negative
+*   **FFI Complexity**: Moving types across crate boundaries can complicate FFI if we expose a C API.
+*   **Boilerplate**: Requires defining traits and potentially duplicating data structures for serialization.


### PR DESCRIPTION
Drafted `docs/adr/0046-decouple-storage-from-core.md` to document the decision to move persistence logic to a dedicated `storage` module.
Updated `docs/ARCHITECTURE.md` to explicitly annotate the Core/Storage crate boundary in the Class Diagram.

This addresses the scenario where the storage module was moved to resolve circular dependencies.

---
*PR created automatically by Jules for task [7295583789274720873](https://jules.google.com/task/7295583789274720873) started by @madmax983*