### PR TITLE
Fix intermediate overflow in cosine_similarity calculation

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -104,7 +104,10 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Result<f32> {
     // Use SIMD-accelerated computation when available
     let (dot, mag_a_sq, mag_b_sq) = dot_and_magnitudes(a, b);
 
-    let magnitude = (mag_a_sq * mag_b_sq).sqrt();
+    // Compute magnitude as product of individual square roots to avoid intermediate overflow.
+    // If we did (mag_a_sq * mag_b_sq).sqrt(), the product could overflow f32::MAX
+    // even if individual squared magnitudes are within range.
+    let magnitude = mag_a_sq.sqrt() * mag_b_sq.sqrt();
 
     // Handle zero vectors
     if magnitude == 0.0 {

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -337,10 +337,16 @@ fn test_cosine_similarity_overflow_resilience() {
     // Verify squared magnitude is finite but large
     let mag_sq: f32 = a.iter().map(|x| x * x).sum();
     assert!(mag_sq.is_finite(), "Squared magnitude should be finite");
-    assert!(mag_sq > 1.8e19, "Squared magnitude should be large enough to trigger overflow risk");
+    assert!(
+        mag_sq > 1.8e19,
+        "Squared magnitude should be large enough to trigger overflow risk"
+    );
 
     // Verify product of squared magnitudes WOULD overflow
-    assert!((mag_sq * mag_sq).is_infinite(), "Product of squared magnitudes should overflow");
+    assert!(
+        (mag_sq * mag_sq).is_infinite(),
+        "Product of squared magnitudes should overflow"
+    );
 
     let sim = cosine_similarity(&a, &b).unwrap();
 

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -323,6 +323,34 @@ fn test_cosine_similarity_large_dimension_opposite() {
     );
 }
 
+#[test]
+fn test_cosine_similarity_overflow_resilience() {
+    // Regression test for intermediate overflow in magnitude calculation.
+    // Values around 4.5e9 result in squared magnitude approx 2.0e19.
+    // Product of squared magnitudes would be approx 4.0e38, which exceeds f32::MAX (3.4e38).
+    // This previously caused the magnitude to be INF, resulting in similarity 0.0.
+
+    let val = 4.5e9_f32;
+    let a = vec![val];
+    let b = vec![val];
+
+    // Verify squared magnitude is finite but large
+    let mag_sq: f32 = a.iter().map(|x| x * x).sum();
+    assert!(mag_sq.is_finite(), "Squared magnitude should be finite");
+    assert!(mag_sq > 1.8e19, "Squared magnitude should be large enough to trigger overflow risk");
+
+    // Verify product of squared magnitudes WOULD overflow
+    assert!((mag_sq * mag_sq).is_infinite(), "Product of squared magnitudes should overflow");
+
+    let sim = cosine_similarity(&a, &b).unwrap();
+
+    assert!(
+        (sim - 1.0).abs() < 1e-6,
+        "Should correctly compute similarity 1.0 even with large values, got {}",
+        sim
+    );
+}
+
 // ========================================================================
 // NaN/Inf Propagation Tests
 // ========================================================================


### PR DESCRIPTION
This PR fixes a correctness issue in `cosine_similarity` where large vector values could cause intermediate overflow, resulting in incorrect 0.0 or NaN similarity scores.

The fix changes the magnitude calculation from `(mag_a_sq * mag_b_sq).sqrt()` to `mag_a_sq.sqrt() * mag_b_sq.sqrt()`. This extends the safe range of input values.

A regression test was added to verify the fix with values that previously triggered the overflow.

---
*PR created automatically by Jules for task [11796845751314015407](https://jules.google.com/task/11796845751314015407) started by @madmax983*