### PR TITLE
Refactor WAL Group Commit regression tests

### DIFF
--- a/tests/regressions/wal_group_commit_epochs.rs
+++ b/tests/regressions/wal_group_commit_epochs.rs
@@ -4,14 +4,13 @@ use aletheiadb::storage::wal::group_commit::{GroupCommitConfig, GroupCommitCoord
 use std::sync::{Arc, Barrier};
 use std::thread;
 
-// 👺 Havoc: Proving that Group Commit is fragile.
-// These tests are designed to FAIL if the bug exists.
-// A failing test proves I have found a weakness.
+// Regression tests for WAL Group Commit issues.
+// These tests verify fixes for Data Loss and Ghost Error scenarios.
 
 #[test]
-fn havoc_repro_group_commit_false_success() {
-    // SCENARIO: Data Loss
-    // A transaction thinks it's durable, but it failed.
+fn regression_group_commit_data_loss_prevention() {
+    // SCENARIO: Data Loss Prevention
+    // Verifies that if a flush fails, the waiting transaction receives an error.
     //
     // 1. T1 registers for Epoch 1.
     // 2. Flush 1 fails.
@@ -19,8 +18,7 @@ fn havoc_repro_group_commit_false_success() {
     // 4. Flush 2 succeeds.
     // 5. T1 checks status.
     //
-    // EXPECTED: T1 should receive an error.
-    // ACTUAL (BUG): T1 receives Ok.
+    // EXPECTED: T1 should receive an error (not Ok).
 
     let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
     let barrier = Arc::new(Barrier::new(2));
@@ -40,7 +38,6 @@ fn havoc_repro_group_commit_false_success() {
     });
 
     // 2. Mark Epoch 1 as FAILED
-    // Use start/finish explicitly to be safe, though mark_flushed is available
     let f1 = coord.start_flush().unwrap();
     coord
         .finish_flush(
@@ -66,17 +63,16 @@ fn havoc_repro_group_commit_false_success() {
     // 5. Join T1 and Verify
     let result = t1_handle.join().unwrap();
 
-    // THIS ASSERTION SHOULD FAIL if the bug exists.
     assert!(
         result.is_err(),
-        "👺 Havoc: Data Loss Detected! Transaction returned Ok, but Epoch 1 flush failed."
+        "Regression: Data Loss Detected! Transaction returned Ok, but Epoch 1 flush failed."
     );
 }
 
 #[test]
-fn havoc_repro_group_commit_false_failure() {
-    // SCENARIO: Ghost Error
-    // A successful transaction reports failure because a LATER transaction failed.
+fn regression_group_commit_ghost_error_prevention() {
+    // SCENARIO: Ghost Error Prevention
+    // Verifies that a successful transaction does NOT report failure even if a LATER transaction fails.
     //
     // 1. T1 registers for Epoch 1.
     // 2. Flush 1 succeeds.
@@ -85,13 +81,11 @@ fn havoc_repro_group_commit_false_failure() {
     // 5. T1 calls wait_for_flush(1).
     //
     // EXPECTED: T1 should receive Ok.
-    // ACTUAL (BUG): T1 receives Err.
 
     let config = GroupCommitConfig {
         recent_errors_capacity: 100,
         ..GroupCommitConfig::default()
     };
-    // We need to use with_config to set the capacity properly if we want to rely on history
     let coord = Arc::new(GroupCommitCoordinator::with_config(config));
 
     // 1. Register T1 (Epoch 1)
@@ -99,7 +93,6 @@ fn havoc_repro_group_commit_false_failure() {
     assert_eq!(epoch1, 1);
 
     // 2. Mark Epoch 1 as SUCCESS
-    // Use start/finish explicitly
     let f1 = coord.start_flush().unwrap();
     coord.finish_flush(f1, Ok(())).unwrap();
 
@@ -121,64 +114,13 @@ fn havoc_repro_group_commit_false_failure() {
     // 5. T1 checks status
     let result = coord.wait_for_flush(epoch1);
 
-    // THIS ASSERTION SHOULD FAIL if the bug exists.
-    // The previous implementation returned Err because T1's epoch (1) was evicted.
-    // With recent_errors_capacity=100, epoch 1 is still in history (we only flushed epoch 2).
-    // Wait, in this scenario:
-    // Epoch 1: OK
-    // Epoch 2: Fail
-    // Since Epoch 1 succeeded, it is NOT in recent_errors.
-    // However, if we don't have oldest_error_epoch tracking, we might think it was evicted if history is empty or starts later.
-    // BUT here, history has [ (2, "Disk Full") ].
-    // Oldest error is 2.
-    // We are looking for 1.
-    // 1 < 2.
-    // So if we just check `epoch < oldest_in_history`, we return Err.
-    // This is CORRECT behavior if we assume strict ordering and eviction.
-    // BUT wait, Epoch 1 succeeded. It was never an error.
-    // The issue is distinguishing "Succeeded and not in error list" from "Failed and evicted from error list".
-    //
-    // If we maintain `oldest_error_epoch` (which defaults to 0), and we haven't evicted anything:
-    // oldest_error_epoch = 0.
-    // recent_errors = [(2, "Fail")].
-    // We check epoch 1.
-    // 1 < 2 (oldest in list).
-    // This triggers the "evicted" check if we only look at the list front.
-    //
-    // CORRECTION in logic:
-    // We only lose information if we *popped* from the deque.
-    // `oldest_error_epoch` tracks the highest popped epoch + 1.
-    // Initial state: oldest_error_epoch = 0.
-    // After Epoch 2 fail: recent_errors = [(2, "Fail")]. Nothing popped. oldest_error_epoch = 0.
-    // Check Epoch 1:
-    // 1. Is 1 in recent_errors? No.
-    // 2. Is 1 < oldest_error_epoch (0)? No.
-    // 3. Is 1 < recent_errors.front().0 (2)? Yes.
-    //
-    // PROBLEM: If 1 < 2, does it mean 1 succeeded or 1 failed and was evicted?
-    // If we haven't evicted anything, then 1 must have succeeded (or be pending).
-    // We know we haven't evicted anything because `state.oldest_error_epoch` is 0.
-    // So we should ONLY check against `state.oldest_error_epoch`.
-    // Checking against `recent_errors.front()` is aggressive and incorrect if we have sparse errors.
-    //
-    // The code I wrote in `group_commit.rs` was:
-    // if !state.recent_errors.is_empty() {
-    //    if let Some((first_failed_epoch, _)) = state.recent_errors.front() {
-    //        if epoch < *first_failed_epoch { return Err(...) }
-    //    }
-    // }
-    //
-    // This logic assumes that if we have an error for epoch N, we have "forgotten" everything before N.
-    // That assumption is WRONG for a sparse error list.
-    // We should ONLY check `epoch < state.oldest_error_epoch`.
-    //
-    // I need to fix `src/storage/wal/group_commit.rs` first.
-    // But for this test, I will temporarily comment out this assertion logic to fix the file in next step.
-    // Actually, I should just fix the file now.
+    // This ensures that we correctly distinguish between "failed and evicted" vs "succeeded and not in error list".
+    // Since we maintain `oldest_error_epoch` and haven't evicted anything (history is short),
+    // checking epoch 1 should correctly determine it succeeded.
 
     assert!(
         result.is_ok(),
-        "👺 Havoc: False Failure Detected! Successful transaction returned Error: {:?}",
+        "Regression: False Failure (Ghost Error) Detected! Successful transaction returned Error: {:?}",
         result.err()
     );
 }


### PR DESCRIPTION
Clean up `tests/regressions/wal_group_commit_epochs.rs` by removing verbose 'havoc' comments and renaming tests to standard regression test names. The underlying 'Ghost Error' bug was already fixed in `src/storage/wal/group_commit.rs` by correctly checking `epoch < state.oldest_error_epoch` instead of comparing against `recent_errors` directly. These tests now correctly verify the fix for both Data Loss and Ghost Error scenarios.

---
*PR created automatically by Jules for task [8269529916297272771](https://jules.google.com/task/8269529916297272771) started by @madmax983*