### PR TITLE
Clean up regression tests for WAL Group Commit sparse error list behavior

### DIFF
--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -263,6 +263,7 @@ impl GroupCommitCoordinator {
         // Note: We do NOT check against recent_errors.front() because a sparse error list
         // is valid. If epoch 1 succeeded and epoch 2 failed, recent_errors = [(2, ...)].
         // epoch 1 < 2, but it shouldn't fail unless 1 < oldest_error_epoch.
+        // See regression test: tests/regressions/wal_group_commit_epochs.rs
 
         if epoch < state.oldest_error_epoch {
             return Err(Error::Storage(StorageError::WalError {

--- a/tests/regressions/wal_group_commit_epochs.rs
+++ b/tests/regressions/wal_group_commit_epochs.rs
@@ -20,7 +20,7 @@ fn havoc_repro_group_commit_false_success() {
     // 5. T1 checks status.
     //
     // EXPECTED: T1 should receive an error.
-    // ACTUAL (BUG): T1 receives Ok.
+    // ACTUAL: T1 receives Error.
 
     let coord = Arc::new(GroupCommitCoordinator::new(100, 100));
     let barrier = Arc::new(Barrier::new(2));
@@ -85,7 +85,7 @@ fn havoc_repro_group_commit_false_failure() {
     // 5. T1 calls wait_for_flush(1).
     //
     // EXPECTED: T1 should receive Ok.
-    // ACTUAL (BUG): T1 receives Err.
+    // ACTUAL: T1 receives Ok.
 
     let config = GroupCommitConfig {
         recent_errors_capacity: 100,
@@ -172,9 +172,6 @@ fn havoc_repro_group_commit_false_failure() {
     // That assumption is WRONG for a sparse error list.
     // We should ONLY check `epoch < state.oldest_error_epoch`.
     //
-    // I need to fix `src/storage/wal/group_commit.rs` first.
-    // But for this test, I will temporarily comment out this assertion logic to fix the file in next step.
-    // Actually, I should just fix the file now.
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
- Update `tests/regressions/wal_group_commit_epochs.rs` to remove stale TODO comments and correct expected/actual behavior descriptions to match the passing tests.
- Add a cross-reference in `src/storage/wal/group_commit.rs` to the regression test to ensure future developers are aware of the sparse error list handling requirements.

The logic in `src/storage/wal/group_commit.rs` correctly handles sparse error lists by checking `epoch < state.oldest_error_epoch` instead of relying on `recent_errors.front()`. Verified with `cargo test --test regressions wal_group_commit_epochs`.

---
*PR created automatically by Jules for task [6660376714229266757](https://jules.google.com/task/6660376714229266757) started by @madmax983*