### PR TITLE
fix(wal): enforce contiguous epoch flushing to prevent data loss

### DIFF
--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -110,6 +110,9 @@ pub mod fishing;
 /// Graph context exporter for LLM integration.
 pub mod graph_context;
 #[cfg(feature = "nova")]
+/// Highlander: Semantic Entity Resolution.
+pub mod highlander;
+#[cfg(feature = "nova")]
 /// Hindsight: Counterfactual Graph Analysis Engine.
 pub mod hindsight;
 #[cfg(feature = "nova")]

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -110,9 +110,6 @@ pub mod fishing;
 /// Graph context exporter for LLM integration.
 pub mod graph_context;
 #[cfg(feature = "nova")]
-/// Highlander: Semantic Entity Resolution.
-pub mod highlander;
-#[cfg(feature = "nova")]
 /// Hindsight: Counterfactual Graph Analysis Engine.
 pub mod hindsight;
 #[cfg(feature = "nova")]

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -27,7 +27,7 @@
 //! The flush thread uses `.expect()` to panic on lock poisoning because silent
 //! degradation is worse than fail-fast behavior for background infrastructure.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
@@ -114,6 +114,8 @@ struct GroupCommitState {
     /// The oldest epoch in the recent_errors list (or older if evicted).
     /// Used to detect if we've lost history.
     oldest_error_epoch: u64,
+    /// Set of completed epochs that are ahead of flushed_epoch
+    completed_epochs: BTreeSet<u64>,
 }
 
 impl GroupCommitCoordinator {
@@ -136,6 +138,7 @@ impl GroupCommitCoordinator {
                 flushed_epoch: 0,
                 recent_errors: VecDeque::new(),
                 oldest_error_epoch: 0,
+                completed_epochs: BTreeSet::new(),
             }),
             flush_complete: Condvar::new(),
             config,
@@ -332,11 +335,18 @@ impl GroupCommitCoordinator {
             }
         }
 
-        // Advance flushed_epoch to wake up waiters for this epoch
-        // Note: We use max to handle potential out-of-order completions if we ever support that,
-        // though currently flushes are serialized.
-        if epoch > state.flushed_epoch {
-            state.flushed_epoch = epoch;
+        // Mark this epoch as completed
+        if epoch > state.flushed_epoch { state.completed_epochs.insert(epoch); }
+
+        // Advance flushed_epoch contiguously to wake up waiters
+        // We only advance if we have a contiguous sequence of completed epochs.
+        // This prevents data loss scenarios where a later successful flush
+        // could mask an earlier failed (or still pending) flush.
+        let mut next_epoch = state.flushed_epoch + 1;
+        while state.completed_epochs.contains(&next_epoch) {
+            state.completed_epochs.remove(&next_epoch);
+            state.flushed_epoch = next_epoch;
+            next_epoch += 1;
         }
 
         // Wake all waiting transactions

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -336,7 +336,9 @@ impl GroupCommitCoordinator {
         }
 
         // Mark this epoch as completed
-        if epoch > state.flushed_epoch { state.completed_epochs.insert(epoch); }
+        if epoch > state.flushed_epoch {
+            state.completed_epochs.insert(epoch);
+        }
 
         // Advance flushed_epoch contiguously to wake up waiters
         // We only advance if we have a contiguous sequence of completed epochs.


### PR DESCRIPTION
This PR fixes a critical data integrity bug in the WAL group commit mechanism.

Previously, `GroupCommitCoordinator::finish_flush` would advance `flushed_epoch` to the completed epoch even if earlier epochs were still pending or failed (out-of-order completion). This could lead to a Data Loss scenario where a transaction waiting for an earlier epoch would incorrectly see `flushed_epoch >= epoch` and return success, masking the fact that its data was not actually durable.

The fix introduces `completed_epochs: BTreeSet<u64>` to track finished epochs and enforces that `flushed_epoch` is only advanced contiguously. This ensures that `flushed_epoch` represents a solid range of durable data.

Verified with a reproduction test case (simulating out-of-order flush completion) and existing regression tests.

---
*PR created automatically by Jules for task [14981980221956603163](https://jules.google.com/task/14981980221956603163) started by @madmax983*