### PR TITLE
🔒 Implement Rate Limiting Middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-governor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0954b0f27aabd8f56bb03f2a77b412ddf3f8c034a3c27b2086c1fc75415760df"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "futures",
+ "governor",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +246,7 @@ name = "aletheiadb"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
+ "actix-governor",
  "actix-rt",
  "actix-web",
  "arc-swap",
@@ -246,7 +259,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crossterm",
- "dashmap",
+ "dashmap 6.1.0",
  "lazy_static",
  "loom",
  "memmap2",
@@ -1032,6 +1045,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1370,6 +1396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1488,26 @@ name = "glam"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34627c5158214743a374170fed714833fdf4e4b0cbcc1ea98417866a4c5d4441"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap 5.5.3",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "h2"
@@ -2238,6 +2290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2304,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3434,6 +3498,15 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ base64 = { version = "0.22", optional = true }
 actix-web = { version = "4.9", optional = true }
 actix-cors = { version = "0.7", optional = true }
 actix-rt = { version = "2.10", optional = true }
+actix-governor = { version = "0.6", optional = true }
 
 # Embedding generation dependencies (all optional via feature flags)
 # Async runtime for API-based embedding providers
@@ -144,7 +145,7 @@ sharding-rpc = ["dep:reqwest", "dep:serde"]
 sql = ["dep:sqlparser"]
 
 # HTTP server support (Issue #465)
-http-server = ["dep:actix-web", "dep:actix-cors", "dep:actix-rt", "dep:tokio", "dep:serde"]
+http-server = ["dep:actix-web", "dep:actix-cors", "dep:actix-rt", "dep:tokio", "dep:serde", "dep:actix-governor"]
 
 # MVCC snapshot-focused integration tests
 mvcc-snapshots-tdd = []

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -103,23 +103,64 @@ impl Default for CorsConfig {
     }
 }
 
+/// Rate limiting configuration.
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    /// Number of requests allowed per second per IP.
+    requests_per_second: u32,
+    /// Maximum burst size (concurrent requests) per IP.
+    burst_size: u32,
+}
+
+impl RateLimitConfig {
+    /// Create a new rate limit configuration.
+    pub fn new(requests_per_second: u32, burst_size: u32) -> Self {
+        Self {
+            requests_per_second,
+            burst_size,
+        }
+    }
+
+    /// Get requests per second.
+    pub fn requests_per_second(&self) -> u32 {
+        self.requests_per_second
+    }
+
+    /// Get burst size.
+    pub fn burst_size(&self) -> u32 {
+        self.burst_size
+    }
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            requests_per_second: 10,
+            burst_size: 20,
+        }
+    }
+}
+
 /// Configuration for the HTTP server.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     port: u16,
     host: String,
     cors: CorsConfig,
+    rate_limit: RateLimitConfig,
 }
 
 impl ServerConfig {
     /// Create a new server config with the specified port.
     ///
-    /// Uses default host of "0.0.0.0" (all interfaces) and restrictive CORS.
+    /// Uses default host of "0.0.0.0" (all interfaces), restrictive CORS,
+    /// and default rate limiting (10 req/s, 20 burst).
     pub fn new(port: u16) -> Self {
         Self {
             port,
             host: "0.0.0.0".to_string(),
             cors: CorsConfig::default(),
+            rate_limit: RateLimitConfig::default(),
         }
     }
 
@@ -136,6 +177,11 @@ impl ServerConfig {
     /// Get the CORS configuration.
     pub fn cors(&self) -> &CorsConfig {
         &self.cors
+    }
+
+    /// Get the rate limit configuration.
+    pub fn rate_limit(&self) -> &RateLimitConfig {
+        &self.rate_limit
     }
 
     /// Get the bind address as "host:port".
@@ -155,6 +201,7 @@ impl Default for ServerConfig {
             port: 8080,
             host: "0.0.0.0".to_string(),
             cors: CorsConfig::default(),
+            rate_limit: RateLimitConfig::default(),
         }
     }
 }
@@ -165,6 +212,7 @@ pub struct ServerConfigBuilder {
     port: Option<u16>,
     host: Option<String>,
     cors: Option<CorsConfig>,
+    rate_limit: Option<RateLimitConfig>,
 }
 
 impl ServerConfigBuilder {
@@ -205,12 +253,19 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Set the rate limit configuration.
+    pub fn rate_limit(mut self, rate_limit: RateLimitConfig) -> Self {
+        self.rate_limit = Some(rate_limit);
+        self
+    }
+
     /// Build the server configuration.
     pub fn build(self) -> ServerConfig {
         ServerConfig {
             port: self.port.unwrap_or(8080),
             host: self.host.unwrap_or_else(|| "0.0.0.0".to_string()),
             cors: self.cors.unwrap_or_default(),
+            rate_limit: self.rate_limit.unwrap_or_default(),
         }
     }
 }
@@ -277,5 +332,20 @@ mod tests {
             .cors(CorsConfig::permissive())
             .build();
         assert!(config.cors().is_permissive());
+    }
+
+    #[test]
+    fn test_default_rate_limit() {
+        let config = ServerConfig::default();
+        assert_eq!(config.rate_limit().requests_per_second(), 10);
+        assert_eq!(config.rate_limit().burst_size(), 20);
+    }
+
+    #[test]
+    fn test_custom_rate_limit() {
+        let rate_limit = RateLimitConfig::new(100, 200);
+        let config = ServerConfig::builder().rate_limit(rate_limit).build();
+        assert_eq!(config.rate_limit().requests_per_second(), 100);
+        assert_eq!(config.rate_limit().burst_size(), 200);
     }
 }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,6 +1,7 @@
 //! HTTP server creation and management.
 
 use actix_cors::Cors;
+use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::{
     App, HttpServer,
     dev::Server,
@@ -9,7 +10,7 @@ use actix_web::{
 };
 use tokio::sync::oneshot;
 
-use super::config::{CorsConfig, ServerConfig};
+use super::config::{CorsConfig, RateLimitConfig, ServerConfig};
 use super::handlers::{configure_health_routes, handle_query};
 
 /// Handle for gracefully shutting down the server.
@@ -103,6 +104,21 @@ fn build_cors(cors_config: &CorsConfig) -> Cors {
     cors.max_age(cors_config.get_max_age() as usize)
 }
 
+/// Build rate limiting middleware from configuration.
+fn build_rate_limit(
+    rate_limit_config: &RateLimitConfig,
+) -> Governor<
+    actix_governor::PeerIpKeyExtractor,
+    actix_governor::governor::middleware::NoOpMiddleware,
+> {
+    let governor_conf = GovernorConfigBuilder::default()
+        .requests_per_second(u64::from(rate_limit_config.requests_per_second()))
+        .burst_size(rate_limit_config.burst_size())
+        .finish()
+        .expect("Failed to build rate limit configuration");
+    Governor::new(&governor_conf)
+}
+
 /// Create a configured Actix-web application factory with all middleware.
 ///
 /// This creates an app with **permissive CORS** suitable for development/testing.
@@ -127,10 +143,12 @@ pub fn create_app() -> App<
     >,
 > {
     let cors_config = CorsConfig::permissive();
+    let rate_limit_config = RateLimitConfig::default();
     App::new()
         .wrap(Logger::default())
         .wrap(build_security_headers())
         .wrap(build_cors(&cors_config))
+        .wrap(build_rate_limit(&rate_limit_config))
         .configure(configure_app)
 }
 
@@ -169,12 +187,14 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
 
     let bind_address = config.bind_address();
     let cors_config = config.cors().clone();
+    let rate_limit_config = config.rate_limit().clone();
 
     let server = HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
             .wrap(build_security_headers())
             .wrap(build_cors(&cors_config))
+            .wrap(build_rate_limit(&rate_limit_config))
             .configure(configure_app)
     })
     .bind(&bind_address)?
@@ -216,6 +236,7 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
 pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
     let bind_address = config.bind_address();
     let cors_config = config.cors().clone();
+    let rate_limit_config = config.rate_limit().clone();
 
     eprintln!("Starting AletheiaDB HTTP server on {}", bind_address);
     if cors_config.is_permissive() {
@@ -230,6 +251,7 @@ pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
             .wrap(Logger::default())
             .wrap(build_security_headers())
             .wrap(build_cors(&cors_config))
+            .wrap(build_rate_limit(&rate_limit_config))
             .configure(configure_app)
     })
     .bind(&bind_address)?
@@ -246,7 +268,10 @@ mod tests {
     async fn test_configure_app_has_health_endpoint() {
         let app = test::init_service(App::new().configure(configure_app)).await;
 
-        let req = test::TestRequest::get().uri("/status").to_request();
+        let req = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
         let resp = test::call_service(&app, req).await;
 
         assert!(resp.status().is_success());
@@ -257,6 +282,7 @@ mod tests {
         let app = test::init_service(create_app()).await;
 
         let req = test::TestRequest::default()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
             .method(actix_web::http::Method::OPTIONS)
             .uri("/status")
             .insert_header(("Origin", "http://example.com"))
@@ -273,7 +299,10 @@ mod tests {
     async fn test_unknown_route_returns_404() {
         let app = test::init_service(create_app()).await;
 
-        let req = test::TestRequest::get().uri("/nonexistent").to_request();
+        let req = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/nonexistent")
+            .to_request();
         let resp = test::call_service(&app, req).await;
 
         assert_eq!(resp.status().as_u16(), 404);
@@ -297,7 +326,10 @@ mod tests {
     async fn test_security_headers() {
         let app = test::init_service(create_app()).await;
 
-        let req = test::TestRequest::get().uri("/status").to_request();
+        let req = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
         let resp = test::call_service(&app, req).await;
 
         assert!(resp.status().is_success());
@@ -308,6 +340,74 @@ mod tests {
         assert_eq!(
             headers.get("Content-Security-Policy").unwrap(),
             "default-src 'none'; frame-ancestors 'none'"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_rate_limiting() {
+        // Configure a very strict rate limit: 1 request per second, burst 1
+        let rate_limit_config = RateLimitConfig::new(1, 1);
+
+        let app = test::init_service(
+            App::new()
+                .wrap(build_rate_limit(&rate_limit_config))
+                .configure(configure_app),
+        )
+        .await;
+
+        // First request should succeed
+        let req1 = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
+        let resp1 = test::call_service(&app, req1).await;
+        assert!(resp1.status().is_success());
+
+        // Second request immediately after should fail with 429 Too Many Requests
+        let req2 = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
+        let resp2 = test::call_service(&app, req2).await;
+        assert_eq!(resp2.status().as_u16(), 429);
+    }
+
+    #[actix_rt::test]
+    async fn test_rate_limit_replenishment() {
+        // 2 requests per second, burst 1
+        // If per_second(2) means 2 req/s, then after 500ms we should have 1 token.
+        // If per_second(2) means 1 req per 2s, then after 500ms we have 0.25 tokens.
+        let rate_limit_config = RateLimitConfig::new(2, 1);
+
+        let app = test::init_service(
+            App::new()
+                .wrap(build_rate_limit(&rate_limit_config))
+                .configure(configure_app),
+        )
+        .await;
+
+        // First request
+        let req1 = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
+        let resp1 = test::call_service(&app, req1).await;
+        assert!(resp1.status().is_success());
+
+        // Wait 600ms
+        actix_rt::time::sleep(std::time::Duration::from_millis(600)).await;
+
+        // Second request
+        let req2 = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
+        let resp2 = test::call_service(&app, req2).await;
+
+        // If this succeeds, it confirms per_second(2) means 2 req/s
+        assert!(
+            resp2.status().is_success(),
+            "Rate limit did not replenish in time"
         );
     }
 }


### PR DESCRIPTION
Implemented rate limiting middleware using `actix-governor`.

**Changes:**
- Added `actix-governor` dependency (v0.6).
- Added `RateLimitConfig` to `ServerConfig` in `src/http/config.rs`.
- Implemented rate limiting middleware in `src/http/server.rs` using `actix-governor`.
- Updated `create_app`, `create_server`, and `run_server` to use rate limiting.
- Updated existing tests to include `peer_addr` for IP-based rate limiting.
- Added new tests `test_rate_limiting` and `test_rate_limit_replenishment` to verify strict limits and token replenishment.

**Rationale:**
- Fixes the security vulnerability where the API was unprotected against brute-force attacks.
- Configurable rate limits allow fine-tuning for different environments.
- Defaults (10 req/s, burst 20) are permissive enough for most legitimate use cases but prevent abuse.


---
*PR created automatically by Jules for task [6997707432040758080](https://jules.google.com/task/6997707432040758080) started by @madmax983*