### PR TITLE
🔒 HTTP Server: Add API Key Authentication Middleware

### DIFF
--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -1,0 +1,141 @@
+//! Authentication middleware.
+
+use std::future::{Ready, ready};
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll};
+
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::{Error, HttpResponse, http::header};
+
+use super::handlers::ApiResponse;
+
+/// Middleware for API Key authentication.
+pub struct ApiKeyMiddleware {
+    key: Rc<String>,
+}
+
+impl ApiKeyMiddleware {
+    /// Create a new API Key middleware.
+    pub fn new(key: String) -> Self {
+        Self { key: Rc::new(key) }
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for ApiKeyMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Transform = ApiKeyMiddlewareService<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(ApiKeyMiddlewareService {
+            service,
+            key: self.key.clone(),
+        }))
+    }
+}
+
+pub struct ApiKeyMiddlewareService<S> {
+    service: S,
+    key: Rc<String>,
+}
+
+impl<S, B> Service<ServiceRequest> for ApiKeyMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    fn poll_ready(&self, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(ctx)
+    }
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let auth_header = req.headers().get(header::AUTHORIZATION);
+        let key = self.key.clone();
+
+        let is_valid = if let Some(auth_val) = auth_header {
+            if let Ok(auth_str) = auth_val.to_str() {
+                if auth_str.starts_with("Bearer ") {
+                    let token = &auth_str[7..];
+                    token == key.as_str()
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if !is_valid {
+            return Box::pin(async move {
+                let json_error = ApiResponse::error("Unauthorized".to_string());
+                let resp = HttpResponse::Unauthorized().json(json_error);
+                // Convert HttpResponse to ServiceResponse
+                // We need to map the body to B, but we don't know B.
+                // However, ServiceResponse::new takes BoxBody usually?
+                // req.into_response(resp) returns ServiceResponse<BoxBody> usually?
+                // Wait, if B is not BoxBody, we have a type mismatch.
+                // But most Actix apps use ServiceResponse<BoxBody> or similar.
+                // Transform trait says Response = ServiceResponse<B>.
+                // So we MUST return ServiceResponse<B>.
+
+                // If B is MessageBody, we can use map_into_boxed_body() or similar?
+                // Or maybe we can't easily return a response here if B is generic.
+
+                // If I use Err(InternalError...), Actix handles it.
+                // In tests, I should handle the error.
+
+                // But wait, if I use Err, the middleware returns Err.
+                // App services return Result<ServiceResponse, Error>.
+                // So the test sees Err.
+                // I should update the test to expect Err or use try_call_service.
+
+                // But wait, I want to verify the JSON content of the error response.
+                // If I use Err, I can't easily check the body unless I convert Error to Response.
+
+                // Let's try to return ServiceResponse using into_response.
+                // But I need to cast the body to B.
+                // Since I don't know B, this is hard.
+
+                // Actually, standard practice is to use Err and let the framework handle it.
+                // In tests, I can use test::try_call_service which returns Result<ServiceResponse, Error>.
+                // Then I can assert it is Err.
+                // And I can check if the error is the one I expect.
+                // But checking JSON body of an Error is hard.
+
+                // Alternative:
+                // Use ? No.
+
+                // If I look at how  middleware works, it usually bounds B.
+                //  middleware handles body types.
+
+                // I will stick to returning Err, and update the TEST to handle it.
+                // Because that's how Actix middleware usually rejects requests.
+                // The issue is just the test helper  panicking.
+
+                use actix_web::error::InternalError;
+                Err(InternalError::from_response("", resp).into())
+            });
+        }
+
+        let fut = self.service.call(req);
+        Box::pin(async move {
+            let res = fut.await?;
+            Ok(res)
+        })
+    }
+}

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -109,6 +109,7 @@ pub struct ServerConfig {
     port: u16,
     host: String,
     cors: CorsConfig,
+    api_key: Option<String>,
 }
 
 impl ServerConfig {
@@ -120,6 +121,7 @@ impl ServerConfig {
             port,
             host: "0.0.0.0".to_string(),
             cors: CorsConfig::default(),
+            api_key: None,
         }
     }
 
@@ -136,6 +138,11 @@ impl ServerConfig {
     /// Get the CORS configuration.
     pub fn cors(&self) -> &CorsConfig {
         &self.cors
+    }
+
+    /// Get the API key if configured.
+    pub fn get_api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
     }
 
     /// Get the bind address as "host:port".
@@ -155,6 +162,7 @@ impl Default for ServerConfig {
             port: 8080,
             host: "0.0.0.0".to_string(),
             cors: CorsConfig::default(),
+            api_key: None,
         }
     }
 }
@@ -165,6 +173,7 @@ pub struct ServerConfigBuilder {
     port: Option<u16>,
     host: Option<String>,
     cors: Option<CorsConfig>,
+    api_key: Option<String>,
 }
 
 impl ServerConfigBuilder {
@@ -205,12 +214,19 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Set the API key for authentication.
+    pub fn api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
     /// Build the server configuration.
     pub fn build(self) -> ServerConfig {
         ServerConfig {
             port: self.port.unwrap_or(8080),
             host: self.host.unwrap_or_else(|| "0.0.0.0".to_string()),
             cors: self.cors.unwrap_or_default(),
+            api_key: self.api_key,
         }
     }
 }
@@ -225,6 +241,7 @@ mod tests {
         assert_eq!(config.port(), 8080);
         assert_eq!(config.host(), "0.0.0.0");
         assert!(!config.cors().is_permissive());
+        assert!(config.get_api_key().is_none());
     }
 
     #[test]
@@ -232,6 +249,7 @@ mod tests {
         let config = ServerConfig::new(3000);
         assert_eq!(config.port(), 3000);
         assert_eq!(config.host(), "0.0.0.0");
+        assert!(config.get_api_key().is_none());
     }
 
     #[test]
@@ -277,5 +295,11 @@ mod tests {
             .cors(CorsConfig::permissive())
             .build();
         assert!(config.cors().is_permissive());
+    }
+
+    #[test]
+    fn test_builder_with_api_key() {
+        let config = ServerConfig::builder().api_key("secret").build();
+        assert_eq!(config.get_api_key(), Some("secret"));
     }
 }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -233,7 +233,7 @@ pub struct ApiResponse {
 
 impl ApiResponse {
     /// Create a success response.
-    fn success(data: serde_json::Value) -> Self {
+    pub fn success(data: serde_json::Value) -> Self {
         Self {
             success: true,
             data: Some(data),
@@ -242,7 +242,7 @@ impl ApiResponse {
     }
 
     /// Create an error response.
-    fn error(msg: impl Into<String>) -> Self {
+    pub fn error(msg: impl Into<String>) -> Self {
         Self {
             success: false,
             data: None,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -27,6 +27,7 @@
 //! }
 //! ```
 
+mod auth;
 mod config;
 pub(crate) mod converters;
 pub mod handlers;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -4,11 +4,12 @@ use actix_cors::Cors;
 use actix_web::{
     App, HttpServer,
     dev::Server,
-    middleware::{DefaultHeaders, Logger},
+    middleware::{Condition, DefaultHeaders, Logger},
     web,
 };
 use tokio::sync::oneshot;
 
+use super::auth::ApiKeyMiddleware;
 use super::config::{CorsConfig, ServerConfig};
 use super::handlers::{configure_health_routes, handle_query};
 
@@ -105,6 +106,39 @@ fn build_cors(cors_config: &CorsConfig) -> Cors {
 
 /// Create a configured Actix-web application factory with all middleware.
 ///
+/// This function is used by [`create_server`] and [`run_server`] to ensure consistent configuration.
+///
+/// # Arguments
+///
+/// * `config` - Server configuration including port, host, CORS, and API key settings.
+pub fn create_app_with_config(
+    config: ServerConfig,
+) -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+> {
+    let cors_config = config.cors();
+    let api_key = config.get_api_key().map(|k| k.to_string());
+    let has_key = api_key.is_some();
+
+    App::new()
+        .wrap(Logger::default())
+        .wrap(build_security_headers())
+        .wrap(build_cors(cors_config))
+        .wrap(Condition::new(
+            has_key,
+            ApiKeyMiddleware::new(api_key.unwrap_or_default()),
+        ))
+        .configure(configure_app)
+}
+
+/// Create a configured Actix-web application factory with all middleware.
+///
 /// This creates an app with **permissive CORS** suitable for development/testing.
 /// For production use, prefer [`create_app_with_config`] with proper CORS settings.
 ///
@@ -115,8 +149,8 @@ fn build_cors(cors_config: &CorsConfig) -> Cors {
 ///
 /// # Security Warning
 ///
-/// This function uses permissive CORS settings. For production deployments,
-/// use [`create_app_with_config`] with a properly configured [`ServerConfig`].
+/// This function uses permissive CORS settings and NO authentication.
+/// For production deployments, use [`create_app_with_config`] with a properly configured [`ServerConfig`].
 pub fn create_app() -> App<
     impl actix_web::dev::ServiceFactory<
         actix_web::dev::ServiceRequest,
@@ -126,12 +160,12 @@ pub fn create_app() -> App<
         InitError = (),
     >,
 > {
-    let cors_config = CorsConfig::permissive();
-    App::new()
-        .wrap(Logger::default())
-        .wrap(build_security_headers())
-        .wrap(build_cors(&cors_config))
-        .configure(configure_app)
+    // Create a default config which has permissive CORS for backward compatibility
+    let config = ServerConfig::builder()
+        .cors(CorsConfig::permissive())
+        .build();
+
+    create_app_with_config(config)
 }
 
 /// Create an HTTP server with the given configuration.
@@ -168,18 +202,13 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
     let shutdown_handle = ShutdownHandle::new(shutdown_tx);
 
     let bind_address = config.bind_address();
-    let cors_config = config.cors().clone();
+    // We need to clone config for the factory closure
+    let config = std::sync::Arc::new(config);
 
-    let server = HttpServer::new(move || {
-        App::new()
-            .wrap(Logger::default())
-            .wrap(build_security_headers())
-            .wrap(build_cors(&cors_config))
-            .configure(configure_app)
-    })
-    .bind(&bind_address)?
-    .disable_signals() // We handle signals ourselves
-    .run();
+    let server = HttpServer::new(move || create_app_with_config((*config).clone()))
+        .bind(&bind_address)?
+        .disable_signals() // We handle signals ourselves
+        .run();
 
     // Spawn a task that waits for shutdown signal using actix runtime
     let server_handle = server.handle();
@@ -215,32 +244,30 @@ pub async fn create_server(config: ServerConfig) -> std::io::Result<(Server, Shu
 /// ```
 pub async fn run_server(config: ServerConfig) -> std::io::Result<()> {
     let bind_address = config.bind_address();
-    let cors_config = config.cors().clone();
 
     eprintln!("Starting AletheiaDB HTTP server on {}", bind_address);
-    if cors_config.is_permissive() {
+    if config.cors().is_permissive() {
         eprintln!(
-            "WARNING: CORS is configured in permissive mode (any origin allowed). \
-             This is not recommended for production."
+            "WARNING: CORS is configured in permissive mode (any origin allowed).              This is not recommended for production."
         );
     }
+    if config.get_api_key().is_none() {
+        eprintln!("WARNING: No API key configured. The server is open to public access.");
+    }
 
-    HttpServer::new(move || {
-        App::new()
-            .wrap(Logger::default())
-            .wrap(build_security_headers())
-            .wrap(build_cors(&cors_config))
-            .configure(configure_app)
-    })
-    .bind(&bind_address)?
-    .run()
-    .await
+    // Clone config for factory
+    let config = std::sync::Arc::new(config);
+
+    HttpServer::new(move || create_app_with_config((*config).clone()))
+        .bind(&bind_address)?
+        .run()
+        .await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::test;
+    use actix_web::{ResponseError, test};
 
     #[actix_rt::test]
     async fn test_configure_app_has_health_endpoint() {
@@ -309,5 +336,66 @@ mod tests {
             headers.get("Content-Security-Policy").unwrap(),
             "default-src 'none'; frame-ancestors 'none'"
         );
+    }
+
+    #[actix_rt::test]
+    async fn test_auth_middleware_blocks_request_without_key() {
+        let config = ServerConfig::builder().api_key("secret").build();
+        let app = test::init_service(create_app_with_config(config)).await;
+
+        let req = test::TestRequest::get().uri("/status").to_request();
+
+        // Use match instead of unwrap_err because Debug is missing
+        match test::try_call_service(&app, req).await {
+            Ok(_) => panic!("Should have failed with 401"),
+            Err(err) => {
+                let resp = err.error_response();
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_auth_middleware_blocks_request_with_wrong_key() {
+        let config = ServerConfig::builder().api_key("secret").build();
+        let app = test::init_service(create_app_with_config(config)).await;
+
+        let req = test::TestRequest::get()
+            .uri("/status")
+            .insert_header(("Authorization", "Bearer wrong"))
+            .to_request();
+
+        match test::try_call_service(&app, req).await {
+            Ok(_) => panic!("Should have failed with 401"),
+            Err(err) => {
+                let resp = err.error_response();
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_auth_middleware_allows_request_with_correct_key() {
+        let config = ServerConfig::builder().api_key("secret").build();
+        let app = test::init_service(create_app_with_config(config)).await;
+
+        let req = test::TestRequest::get()
+            .uri("/status")
+            .insert_header(("Authorization", "Bearer secret"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+    }
+
+    #[actix_rt::test]
+    async fn test_no_auth_by_default() {
+        let config = ServerConfig::default();
+        let app = test::init_service(create_app_with_config(config)).await;
+
+        let req = test::TestRequest::get().uri("/status").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
     }
 }


### PR DESCRIPTION
This PR addresses a security vulnerability where the HTTP server lacked authentication.

🎯 **What:** The HTTP server setup was refactored to support optional API Key authentication.
⚠️ **Risk:** Without authentication, the database API was open to public access, allowing unauthorized queries and data modification.
🛡️ **Solution:**
- Introduced `ApiKeyMiddleware` that checks for a valid `Authorization: Bearer <KEY>` header.
- Updated `ServerConfig` to include an optional `api_key`.
- Updated `create_server` and `run_server` to conditionally apply the authentication middleware if an API key is provided.
- Added comprehensive tests to verify that requests are blocked when authentication fails and allowed when valid.

The changes ensure that production deployments can be secured while maintaining backward compatibility for development (via permissive defaults if no key is set, though a warning is logged).

---
*PR created automatically by Jules for task [116362275386565291](https://jules.google.com/task/116362275386565291) started by @madmax983*