### PR TITLE
⚡ Bolt: Pre-allocate vectors in persistence operations

### DIFF
--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -264,13 +264,18 @@ pub fn load_graph_index(path: &Path) -> Result<GraphIndexData> {
 
 /// Create a new empty GraphIndexData.
 pub fn new_graph_index_data() -> GraphIndexData {
+    new_graph_index_data_with_capacity(0, 0)
+}
+
+/// Create a new GraphIndexData with pre-allocated capacity.
+pub fn new_graph_index_data_with_capacity(node_count: usize, edge_count: usize) -> GraphIndexData {
     GraphIndexData {
         magic: GRAPH_MAGIC,
         version: MANIFEST_VERSION,
         node_count: 0,
         edge_count: 0,
-        nodes: Vec::new(),
-        edges: Vec::new(),
+        nodes: Vec::with_capacity(node_count),
+        edges: Vec::with_capacity(edge_count),
         outgoing_node_ids: Vec::new(),
         outgoing_offsets: Vec::new(),
         outgoing_neighbors: Vec::new(),

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -323,10 +323,8 @@ pub(crate) fn persist_graph_index(
     };
     use crate::storage::index_persistence::{PersistedEdge, PersistedNode};
 
-    let mut graph_data = new_graph_index_data_with_capacity(
-        current.node_count(),
-        current.edge_count(),
-    );
+    let mut graph_data =
+        new_graph_index_data_with_capacity(current.node_count(), current.edge_count());
 
     // Stream all nodes without collecting into intermediate Vec (prevents OOM on large graphs)
     for node in current.all_nodes() {

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -319,11 +319,14 @@ pub(crate) fn persist_graph_index(
     current_lsn: u64,
 ) -> Result<()> {
     use crate::storage::index_persistence::graph::{
-        new_graph_index_data, persist_property_map, save_graph_index,
+        new_graph_index_data_with_capacity, persist_property_map, save_graph_index,
     };
     use crate::storage::index_persistence::{PersistedEdge, PersistedNode};
 
-    let mut graph_data = new_graph_index_data();
+    let mut graph_data = new_graph_index_data_with_capacity(
+        current.node_count(),
+        current.edge_count(),
+    );
 
     // Stream all nodes without collecting into intermediate Vec (prevents OOM on large graphs)
     for node in current.all_nodes() {
@@ -410,7 +413,7 @@ pub(crate) fn persist_temporal_index(
     let historical_guard = historical.read();
 
     // Convert all node versions
-    let mut node_versions = Vec::new();
+    let mut node_versions = Vec::with_capacity(historical_guard.get_node_versions().len());
     for version in historical_guard.get_node_versions().values() {
         let entry = convert_node_version(version).map_err(|e| {
             StorageError::PersistenceError(format!(
@@ -423,7 +426,7 @@ pub(crate) fn persist_temporal_index(
     }
 
     // Convert all edge versions
-    let mut edge_versions = Vec::new();
+    let mut edge_versions = Vec::with_capacity(historical_guard.get_edge_versions().len());
     for version in historical_guard.get_edge_versions().values() {
         let entry = convert_edge_version(version).map_err(|e| {
             StorageError::PersistenceError(format!(

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -525,12 +525,20 @@ pub fn load_temporal_index(path: &Path) -> Result<TemporalIndexData> {
 
 /// Create a new empty TemporalIndexData.
 pub fn new_temporal_index_data() -> TemporalIndexData {
+    new_temporal_index_data_with_capacity(0, 0)
+}
+
+/// Create a new TemporalIndexData with pre-allocated capacity.
+pub fn new_temporal_index_data_with_capacity(
+    node_versions: usize,
+    edge_versions: usize,
+) -> TemporalIndexData {
     TemporalIndexData {
         magic: TEMPORAL_MAGIC,
         version: MANIFEST_VERSION,
-        node_versions: Vec::new(),
+        node_versions: Vec::with_capacity(node_versions),
         node_anchors: Vec::new(),
-        edge_versions: Vec::new(),
+        edge_versions: Vec::with_capacity(edge_versions),
         edge_anchors: Vec::new(),
     }
 }


### PR DESCRIPTION
*   💡 What: Added `new_graph_index_data_with_capacity` and `new_temporal_index_data_with_capacity` constructors, and updated `persist_graph_index` and `persist_temporal_index` to use `Vec::with_capacity` based on known counts.
*   🎯 Why: To avoid O(n) reallocations during persistence of large indexes (hot path during shutdown/checkpoint).
*   📊 Impact: Reduces memory fragmentation and improves performance during persistence.
*   🔬 Measurement: Verified with existing tests in `src/storage/index_persistence`.


---
*PR created automatically by Jules for task [168724983491626253](https://jules.google.com/task/168724983491626253) started by @madmax983*