### PR TITLE
DX: Improve first-time user experience (Spec 001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ See **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for complete architecture d
 ### Basic Graph Operations
 
 ```rust
-use aletheiadb::{AletheiaDB, properties};
+use aletheiadb::prelude::*;
 
 // Create a new database
 let db = AletheiaDB::new().unwrap();
@@ -533,10 +533,10 @@ for (node_id, drift_score) in drifted_nodes {
 > ```
 
 ```rust
-use aletheiadb::{AletheiaDB, properties, WriteOps};
-// ⚠️ REQUIRES FEATURE 'NOVA' IN CARGO.TOML
 // [dependencies]
 // aletheiadb = { version = "0.1", features = ["nova"] }
+
+use aletheiadb::prelude::*;
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
 
 // 1. Setup database and node (for self-contained example)
@@ -722,10 +722,10 @@ See **[docs/guides/tiered-storage-guide.md](docs/guides/tiered-storage-guide.md)
 
 For complex operations involving multiple updates, use explicit transactions.
 
-**Note**: The `WriteOps` trait must be imported to use methods on the transaction object.
+**Note**: The `prelude` module exports `WriteOps` and `ReadOps`, which are required to use methods on the transaction object.
 
 ```rust
-use aletheiadb::{PropertyMap, WriteOps};
+use aletheiadb::prelude::*;
 
 // Explicit read transaction
 let result = db.read(|tx| {

--- a/docs/specs/001-dx-improvements.md
+++ b/docs/specs/001-dx-improvements.md
@@ -1,0 +1,57 @@
+# Spec 001: Developer Experience (DX) Improvements
+
+**Status:** Draft
+**Date:** 2026-02-02
+**Author:** Vantage (Product Manager)
+**Driver:** Jules (Engineer)
+
+## 1. Problem Statement
+
+New users encounter significant friction in the first 5 minutes of using AletheiaDB:
+
+1.  ** opaque identifiers**: Printing a node label results in `Interned(11)` instead of the string value (e.g., "Person"). This forces users to learn internal implementation details (`GLOBAL_INTERNER`) just to debug their "Hello World" app.
+2.  **Trait Import Tax**: Common operations like `db.create_node` require importing the `WriteOps` trait, which is not obvious to new Rust users who just want to use the `db` struct.
+3.  **Feature Flag Confusion**: Copy-pasting examples from the README often fails because experimental features (like `nova`) are not enabled by default, leading to confusing compile errors.
+
+## 2. User Stories
+
+### Story 1: Human-Readable Debugging
+*   **As a** Developer debugging my application,
+*   **I want** `println!("{:?}", node.label)` to print `InternedString("Person")` instead of `InternedString(11)`,
+*   **So that** I can verify my data without manually resolving interner IDs.
+
+### Story 2: The "Prelude"
+*   **As a** Developer starting a new project,
+*   **I want** to import `use aletheiadb::prelude::*;`,
+*   **So that** I have all necessary traits (`WriteOps`, `ReadOps`) and types (`PropertyMap`) available immediately without hunting for imports.
+
+### Story 3: Clear Feature Requirements
+*   **As a** Developer reading the documentation,
+*   **I want** code examples to explicitly state required feature flags,
+*   **So that** I don't waste time debugging "module not found" errors.
+
+## 3. Acceptance Criteria
+
+### AC1: Smart InternedString Debug
+- [ ] `InternedString` implements `fmt::Debug` manually.
+- [ ] `{:?}` prints `InternedString("Value")` if the ID exists in `GLOBAL_INTERNER`.
+- [ ] `{:?}` falls back to `InternedString(ID)` if not found.
+- [ ] `Display` remains unchanged (or is verified to work correctly).
+
+### AC2: The Prelude Module
+- [ ] `src/prelude.rs` exists.
+- [ ] It re-exports:
+    - `AletheiaDB`
+    - `WriteOps`, `ReadOps` (Traits)
+    - `NodeId`, `EdgeId`
+    - `PropertyMap`, `PropertyMapBuilder`
+    - `Result`, `Error`
+- [ ] `src/lib.rs` exports `prelude`.
+
+### AC3: Documentation Updates
+- [ ] `README.md` examples for `nova` features include `// [dependencies] aletheiadb = { ..., features = ["nova"] }` or equivalent comments.
+- [ ] `README.md` "Quick Start" uses the new `prelude`.
+
+## 4. Out of Scope (Phase 2)
+- Visualizing the graph structure (see `test_vis`).
+- Interactive CLI.

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -78,7 +78,8 @@ impl fmt::Display for InternedString {
 impl fmt::Debug for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Try to resolve using the global interner first
-        let result = GLOBAL_INTERNER.resolve_with(*self, |s| write!(f, "InternedString(\"{}\")", s));
+        let result =
+            GLOBAL_INTERNER.resolve_with(*self, |s| write!(f, "InternedString(\"{}\")", s));
 
         match result {
             Some(res) => res,

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -40,7 +40,7 @@ pub const COMMON_STRINGS: &[&str] = &[
 ///
 /// This is just a u32 ID that can be used to look up the original string
 /// in the interner. It's Copy, so passing it around is very cheap.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct InternedString(u32);
 
 impl InternedString {
@@ -71,6 +71,18 @@ impl fmt::Display for InternedString {
         match result {
             Some(res) => res,
             None => write!(f, "Interned({})", self.0),
+        }
+    }
+}
+
+impl fmt::Debug for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Try to resolve using the global interner first
+        let result = GLOBAL_INTERNER.resolve_with(*self, |s| write!(f, "InternedString(\"{}\")", s));
+
+        match result {
+            Some(res) => res,
+            None => write!(f, "InternedString({})", self.0),
         }
     }
 }

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -110,6 +110,9 @@ pub mod fishing;
 /// Graph context exporter for LLM integration.
 pub mod graph_context;
 #[cfg(feature = "nova")]
+/// Highlander: Semantic Entity Resolution.
+pub mod highlander;
+#[cfg(feature = "nova")]
 /// Hindsight: Counterfactual Graph Analysis Engine.
 pub mod hindsight;
 #[cfg(feature = "nova")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,9 @@ pub mod http;
 #[cfg(test)]
 pub mod test_utils;
 
+/// Prelude for convenient imports of common types and traits.
+pub mod prelude;
+
 // Re-export commonly used types at the crate root
 pub use config::{
     AletheiaDBConfig, AletheiaDBConfigBuilder, ConfigError, HistoricalConfig,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,19 @@
+//! AletheiaDB Prelude
+//!
+//! The prelude module re-exports the most commonly used traits and types
+//! to make starting with AletheiaDB easier.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use aletheiadb::prelude::*;
+//! ```
+
+pub use crate::AletheiaDB;
+pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};
+pub use crate::core::error::{Error, Result};
+pub use crate::core::id::{EdgeId, NodeId, VersionId};
+pub use crate::core::interning::{GLOBAL_INTERNER, InternedString};
+pub use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+pub use crate::core::temporal::{BiTemporalInterval, TimeRange, Timestamp, time};
+pub use crate::storage::wal::{DurabilityMode, WriteOptions};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,10 @@ pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};
 pub use crate::core::error::{Error, Result};
 pub use crate::core::id::{EdgeId, NodeId, VersionId};
-pub use crate::core::interning::{GLOBAL_INTERNER, InternedString};
+pub use crate::core::interning::InternedString;
 pub use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
 pub use crate::core::temporal::{BiTemporalInterval, TimeRange, Timestamp, time};
+// Re-export the properties! macro. It is exported at the crate root because of #[macro_export],
+// so we re-export it from there.
+pub use crate::properties;
 pub use crate::storage::wal::{DurabilityMode, WriteOptions};


### PR DESCRIPTION
This PR addresses key friction points identified in the DX Report:
1.  **InternedString Debugging**: `InternedString` now prints `InternedString("Value")` instead of `InternedString(11)` when debug-printed, making it easier to verify data without manual resolution.
2.  **Prelude**: A new `prelude` module simplifies imports, allowing users to access `WriteOps`, `ReadOps`, and `PropertyMap` with a single `use aletheiadb::prelude::*;`.
3.  **Documentation**: Updated README examples to use the prelude and explicitly document required feature flags for experimental modules.

These changes improve the "first 5 minutes" experience for new users by reducing boilerplate and making the API more intuitive.

---
*PR created automatically by Jules for task [7267294483676111341](https://jules.google.com/task/7267294483676111341) started by @madmax983*