### PR TITLE
Sentinel: Strengthen temporal duration and empty checks

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1790,4 +1790,31 @@ mod sentry_tests {
             "Empty range should not overlap itself"
         );
     }
+
+    #[test]
+    fn test_sentry_duration_micros_overflow() {
+        // 🛡️ Sentry Test: Verify duration_micros saturates instead of panicking on overflow.
+        // This targets mutants that replace checked_sub with sub.
+
+        let start = HybridTimestamp::new_unchecked(i64::MIN, 0);
+        let end = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP, 0);
+
+        let range =
+            TimeRange::new(start, end).expect("Should create valid range with extreme start");
+
+        assert_eq!(
+            range.duration_micros(),
+            Some(i64::MAX),
+            "Duration should saturate at i64::MAX on overflow"
+        );
+    }
+
+    #[test]
+    fn test_sentry_range_is_not_empty_for_valid_interval() {
+        // 🛡️ Sentry Test: Verify is_empty() returns false for non-empty ranges.
+        // This targets mutants that make is_empty() always return true.
+
+        let range = TimeRange::new(100.into(), 200.into()).unwrap();
+        assert!(!range.is_empty(), "Range [100, 200) should not be empty");
+    }
 }

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -98,9 +98,6 @@ pub mod concept_algebra;
 /// Dissonance: Semantic Stress Detector.
 pub mod dissonance;
 #[cfg(feature = "nova")]
-/// Highlander: Semantic Entity Resolution.
-pub mod highlander;
-#[cfg(feature = "nova")]
 /// Semantic Trajectory Extrapolation ("Dreamer").
 pub mod dreamer;
 #[cfg(feature = "nova")]
@@ -112,6 +109,9 @@ pub mod fishing;
 #[cfg(feature = "nova")]
 /// Graph context exporter for LLM integration.
 pub mod graph_context;
+#[cfg(feature = "nova")]
+/// Highlander: Semantic Entity Resolution.
+pub mod highlander;
 #[cfg(feature = "nova")]
 /// Hindsight: Counterfactual Graph Analysis Engine.
 pub mod hindsight;


### PR DESCRIPTION
Sentinel analysis of `src/core/temporal.rs` identified gaps in mutation coverage, specifically regarding:
1.  **Duration Overflow**: `TimeRange::duration_micros` handles overflow by saturating, but this path was not explicitly tested, allowing mutants that remove or break this safety check to survive.
2.  **Empty Range Logic**: `is_empty()` lacked a negative test case (asserting non-empty for valid ranges), allowing mutants that make it always return true to potentially survive (though indirectly covered by overlaps, explicit coverage is safer).

This PR adds two new tests to the `sentry_tests` module in `src/core/temporal.rs` to close these gaps.

Verified with `cargo test` and targeted `cargo mutants` analysis.
Ran `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [10525304166774366896](https://jules.google.com/task/10525304166774366896) started by @madmax983*