### PR TITLE
Havoc: Fix Lost Wakeup Deadlock in WAL CompletionNotifier

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -281,6 +281,10 @@ impl CompletionNotifier {
 
     /// Notify successful completion.
     pub fn notify_success(&self) {
+        // Acquire mutex to prevent lost wakeups
+        // We must hold the mutex to ensure the waiter sees the state change
+        // immediately after waking up or before going to sleep.
+        let _guard = self.wait_mutex.lock().unwrap_or_else(|e| e.into_inner());
         self.state
             .store(CompletionState::Complete as u64, Ordering::Release);
         self.condvar.notify_all();
@@ -288,6 +292,10 @@ impl CompletionNotifier {
 
     /// Notify completion with error.
     pub fn notify_error(&self, error: &str) {
+        // Acquire mutex to prevent lost wakeups
+        // Note: We acquire wait_mutex BEFORE error mutex to match the lock order in wait()
+        // wait(): locks wait_mutex -> locks error mutex (if state is Error)
+        let _guard = self.wait_mutex.lock().unwrap_or_else(|e| e.into_inner());
         {
             let mut err = self.error.lock().unwrap_or_else(|e| e.into_inner());
             *err = Some(error.to_string());

--- a/tests/havoc_wal_notifier.rs
+++ b/tests/havoc_wal_notifier.rs
@@ -1,0 +1,83 @@
+#![allow(unexpected_cfgs)]
+
+mod loom_tests {
+    //! # Completion Notifier Model
+    //!
+    //! This test file implements a **Loom Model** of the `CompletionNotifier` found in
+    //! `src/storage/wal/ring_buffer.rs`.
+    //!
+    //! ## Why a Model?
+    //!
+    //! The production `CompletionNotifier` uses `std::sync` primitives which are
+    //! not instrumented by Loom. To verify the deadlock fix (Lost Wakeup), we
+    //! model the exact logic using `loom::sync` primitives.
+    //!
+    //! This model verified that acquiring the mutex in `notify_success` prevents
+    //! the lost wakeup bug.
+
+    use loom::sync::atomic::{AtomicU64, Ordering};
+    use loom::sync::{Condvar, Mutex};
+    use loom::thread;
+    use std::sync::Arc;
+
+    struct CompletionNotifier {
+        state: AtomicU64,
+        condvar: Condvar,
+        wait_mutex: Mutex<()>,
+    }
+
+    impl CompletionNotifier {
+        fn new() -> Self {
+            Self {
+                state: AtomicU64::new(0), // 0 = Pending, 1 = Complete
+                condvar: Condvar::new(),
+                wait_mutex: Mutex::new(()),
+            }
+        }
+
+        fn notify_success(&self) {
+            // FIX: Acquire mutex before updating state and notifying
+            // This prevents the "lost wakeup" scenario where a waiter checks the state (Pending),
+            // then the notifier updates state and signals (Lost), then the waiter sleeps forever.
+            let _guard = self.wait_mutex.lock().unwrap();
+            self.state.store(1, Ordering::Release);
+            self.condvar.notify_all();
+        }
+
+        fn wait(&self) {
+            let mut guard = self.wait_mutex.lock().unwrap();
+
+            // Check if already complete
+            if self.state.load(Ordering::Acquire) == 1 {
+                return;
+            }
+
+            // Wait for notification
+            // loom::sync::Condvar doesn't have wait_while, so we implement the loop manually
+            while self.state.load(Ordering::Acquire) == 0 {
+                guard = self.condvar.wait(guard).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn test_notify_race_condition() {
+        loom::model(|| {
+            let notifier = Arc::new(CompletionNotifier::new());
+            let notifier_clone = notifier.clone();
+
+            // Thread 1: Waiter
+            let t1 = thread::spawn(move || {
+                notifier_clone.wait();
+            });
+
+            // Thread 2: Notifier
+            let t2 = thread::spawn(move || {
+                notifier.notify_success();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+        });
+    }
+}


### PR DESCRIPTION
👺 Havoc: Fix Lost Wakeup Deadlock in WAL CompletionNotifier

**The Trigger:**
A race condition existed in `CompletionNotifier::notify_success` and `notify_error`.
The `state` (AtomicU64) was updated and `condvar.notify_all()` was called *without* holding the `wait_mutex`.
A waiter thread could check the state (finding it Pending), then get preempted.
The notifier thread could then update the state to Complete and signal the condition variable.
Since the waiter wasn't sleeping yet, the signal is lost.
The waiter then resumes and calls `condvar.wait()`, sleeping forever because it missed the signal.

**The Stack Trace:**
(Simulated via `loom` in `tests/havoc_wal_notifier.rs`)
`deadlock; threads = [(Id(0), Blocked(Location(None))), (Id(1), Blocked(Location(None))), (Id(2), Terminated)]`

**The Fix:**
Modified `notify_success` and `notify_error` in `src/storage/wal/ring_buffer.rs` to acquire `wait_mutex` before updating the state and notifying. This ensures the check-and-wait sequence in the waiter is atomic with respect to the notification.

**Verification:**
Added `tests/havoc_wal_notifier.rs` which uses `loom` to model the `CompletionNotifier` and verify the fix.
Ran `cargo test --test havoc_wal_notifier` (Pass).
Ran `cargo test storage` (Pass).


---
*PR created automatically by Jules for task [14335839138533371041](https://jules.google.com/task/14335839138533371041) started by @madmax983*