### PR TITLE
Standardize compile-time gating for Nova experimental features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,4 +381,4 @@ required-features = []
 # Experimental features
 [[example]]
 name = "story_demo"
-# required-features = ["nova"]  <-- Removed to allow runtime error message
+required-features = ["nova"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ just test
 > aletheiadb = { version = "0.1", features = ["nova"] }
 > ```
 >
-> If you see a runtime panic saying "Experimental features like X require the 'nova' feature", this is why!
+> If you see a compiler error saying "unresolved import" or "item is gated behind the `nova` feature", this is why!
 
 ### Development Commands
 

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -127,6 +127,7 @@ pub mod prophet;
 #[cfg(feature = "nova")]
 /// Semantic Navigator for vector-guided pathfinding.
 pub mod semantic_navigator;
+#[cfg(feature = "nova")]
 /// Sherlock: Temporal Pattern Matching Engine.
 pub mod sherlock;
 #[cfg(feature = "nova")]
@@ -141,100 +142,6 @@ pub mod temporal_diff;
 #[cfg(feature = "nova")]
 /// Temporal narrative generator for natural language history logs.
 pub mod temporal_narrative;
-
-#[cfg(not(feature = "nova"))]
-/// Temporal narrative generator for natural language history logs.
-pub mod temporal_narrative {
-    use crate::AletheiaDB;
-    use crate::core::error::Result;
-    use crate::core::id::NodeId;
-
-    /// A single event in the narrative history of an entity.
-    #[derive(Debug, Clone)]
-    pub struct NarrativeEvent {
-        /// ISO 8601 timestamp of when the event was recorded (transaction time).
-        pub timestamp: String,
-        /// Sequential version number.
-        pub version_number: u64,
-        /// High-level description of what happened.
-        pub description: String,
-        /// Detailed list of changes (if any).
-        pub changes: Vec<String>,
-    }
-
-    /// Generator for creating natural language narratives from temporal history.
-    ///
-    /// # ⚠️ EXPERIMENTAL FEATURE
-    ///
-    /// This is a **stub implementation** that exists to provide helpful error messages.
-    /// You must enable the `nova` feature to use this functionality.
-    ///
-    /// Add this to your `Cargo.toml`:
-    /// ```toml
-    /// [dependencies]
-    /// aletheiadb = { version = "...", features = ["nova"] }
-    /// ```
-    pub struct NarrativeGenerator<'a> {
-        _marker: std::marker::PhantomData<&'a ()>,
-    }
-
-    impl<'a> NarrativeGenerator<'a> {
-        /// Create a new narrative generator.
-        ///
-        /// # Panics
-        ///
-        /// This function **will always panic** because the `nova` feature is not enabled.
-        pub fn new(_db: &'a AletheiaDB) -> Self {
-            panic!(
-                "Experimental features like NarrativeGenerator require the 'nova' feature. Please enable it in your Cargo.toml:\n\n[dependencies]\naletheiadb = {{ version = \"...\", features = [\"nova\"] }}\n"
-            );
-        }
-
-        #[cfg(test)]
-        fn new_internal() -> Self {
-            Self {
-                _marker: std::marker::PhantomData,
-            }
-        }
-
-        /// Generate a narrative for a specific node.
-        ///
-        /// # Panics
-        ///
-        /// This function **will always panic** because the `nova` feature is not enabled.
-        pub fn generate_node_narrative(&self, _node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-            panic!("Experimental features like NarrativeGenerator require the 'nova' feature.");
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use crate::AletheiaDB;
-        use crate::core::id::NodeId;
-
-        #[test]
-        #[should_panic(
-            expected = "Experimental features like NarrativeGenerator require the 'nova' feature. Please enable it in your Cargo.toml"
-        )]
-        fn test_stub_new_panics() {
-            let db = AletheiaDB::new().unwrap();
-            let _ = NarrativeGenerator::new(&db);
-        }
-
-        #[test]
-        #[should_panic(
-            expected = "Experimental features like NarrativeGenerator require the 'nova' feature."
-        )]
-        fn test_stub_generate_panics() {
-            let generator = NarrativeGenerator::new_internal();
-            // NodeId::from(0) is a valid way to create a NodeId in tests if implemented,
-            // or use new_unchecked if available to crate. Since we are in the crate, we might have access?
-            // Actually, NodeId::new(0) is public safe constructor.
-            let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
-        }
-    }
-}
 
 #[cfg(feature = "nova")]
 /// Thermos: Semantic Temperature & Volatility Gauge.

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -75,7 +75,6 @@ pub struct Sherlock<'a> {
     db: &'a AletheiaDB,
 }
 
-#[cfg(feature = "nova")]
 impl<'a> Sherlock<'a> {
     /// Create a new Sherlock instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -190,27 +189,7 @@ impl<'a> Sherlock<'a> {
     }
 }
 
-#[cfg(not(feature = "nova"))]
-impl<'a> Sherlock<'a> {
-    /// Create a new Sherlock instance.
-    pub fn new(_db: &'a AletheiaDB) -> Self {
-        panic!(
-            "Experimental features like Sherlock require the 'nova' feature. Please enable it in your Cargo.toml:\n\n[dependencies]\naletheiadb = {{ version = \"...\", features = [\"nova\"] }}\n"
-        );
-    }
-
-    #[cfg(test)]
-    fn new_internal(db: &'a AletheiaDB) -> Self {
-        Self { db }
-    }
-
-    /// Investigate a specific node for the given Mystery.
-    pub fn investigate(&self, _node_id: NodeId, _mystery: &Mystery) -> Result<Vec<Deduction>> {
-        panic!("Experimental features like Sherlock require the 'nova' feature.");
-    }
-}
-
-#[cfg(all(test, feature = "nova"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
@@ -328,34 +307,5 @@ mod tests {
         assert_eq!(results_pass.len(), 1, "Should match within 500ms");
         assert_eq!(results_pass[0].node_id, node_id);
         assert_eq!(results_pass[0].event_times, vec![t0, t1]);
-    }
-}
-
-#[cfg(all(test, not(feature = "nova")))]
-mod tests_stub {
-    use super::*;
-    use crate::AletheiaDB;
-    use crate::core::id::NodeId;
-    use std::time::Duration;
-
-    #[test]
-    #[should_panic(
-        expected = "Experimental features like Sherlock require the 'nova' feature. Please enable it in your Cargo.toml"
-    )]
-    fn test_stub_new_panics() {
-        let db = AletheiaDB::new().unwrap();
-        let _ = Sherlock::new(&db);
-    }
-
-    #[test]
-    #[should_panic(expected = "Experimental features like Sherlock require the 'nova' feature.")]
-    fn test_stub_investigate_panics() {
-        let db = AletheiaDB::new().unwrap();
-        // Use internal constructor to bypass the panic in new()
-        let sherlock = Sherlock::new_internal(&db);
-        let _ = sherlock.investigate(
-            NodeId::new(0).unwrap(),
-            &Mystery::new(Duration::from_secs(1)),
-        );
     }
 }


### PR DESCRIPTION
Standardized the gating of experimental 'Nova' features (`Sherlock`, `NarrativeGenerator`) to use compile-time checks (`cfg`) instead of runtime panic stubs. This resolves inconsistency where some experimental modules would crash at runtime while others failed to compile. The `README.md` was updated to reflect this behavior, guiding users to enable the `nova` feature if they encounter compiler errors. This improves DX by providing earlier feedback (compile-time vs runtime).

---
*PR created automatically by Jules for task [2184565650197002530](https://jules.google.com/task/2184565650197002530) started by @madmax983*