### PR TITLE
fix(vector): align normalize_in_place behavior for small vectors

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -266,3 +266,10 @@
 **Finding:** `MAX_VALID_TIMESTAMP` was used in logic but its value was not pinned by tests, allowing potential drift of the sentinel space.
 **Evidence:** Mutation analysis showed changing the constant value didn't fail existing tests.
 **Resolution:** Added sentry test explicitly asserting `MAX_VALID_TIMESTAMP == i64::MAX - 1000`.
+
+## [Vector Normalization Inconsistency]
+**Module:** `src/core/vector/ops.rs`
+**Verdict:** 🟡 Suspect
+**Finding:** `normalize` zeroes out vectors with small squared magnitudes (< `SQUARED_MAGNITUDE_THRESHOLD`), but `normalize_in_place` leaves them unchanged. This creates inconsistent behavior depending on which API is used.
+**Evidence:** Reproduction test `tests/repro_normalize_inconsistency.rs` failed, showing that `normalize_in_place` did not modify a tiny vector.
+**Resolution:** Updated `normalize_in_place` to explicitly zero out the vector if its magnitude is below the threshold. Added regression test `test_normalize_in_place_tiny_vector` in `src/core/vector/tests.rs`.

--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -645,7 +645,8 @@ pub fn normalize_in_place(v: &mut [f32]) {
     // Use squared magnitude threshold to avoid denormal number issues.
     // See SQUARED_MAGNITUDE_THRESHOLD for details.
     if sq_mag < SQUARED_MAGNITUDE_THRESHOLD {
-        // Leave zero/near-zero vector unchanged
+        // Zero out the vector to match `normalize` behavior
+        v.fill(0.0);
         return;
     }
     // Compute 1/sqrt(sq_mag) directly to avoid intermediate variable

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -1232,6 +1232,16 @@ fn test_normalize_in_place_zero_vector() {
 }
 
 #[test]
+fn test_normalize_in_place_tiny_vector() {
+    // Vector with squared magnitude < SQUARED_MAGNITUDE_THRESHOLD (1e-14)
+    // 1e-8 * 1e-8 = 1e-16 < 1e-14
+    let mut v = vec![1e-8_f32];
+    normalize_in_place(&mut v);
+    // Should be zeroed out
+    assert_eq!(v, vec![0.0]);
+}
+
+#[test]
 fn test_normalize_in_place_empty_vector() {
     let mut v: Vec<f32> = vec![];
     normalize_in_place(&mut v);


### PR DESCRIPTION
During an Elenchus test quality audit, a discrepancy was found between `normalize` and `normalize_in_place`. `normalize` would return a zero vector for inputs with very small magnitudes, while `normalize_in_place` would leave them unchanged (potentially containing denormal numbers). This PR fixes `normalize_in_place` to match the behavior of `normalize` and adds a regression test. It also updates the Elenchus journal.

---
*PR created automatically by Jules for task [6964939910113709486](https://jules.google.com/task/6964939910113709486) started by @madmax983*