### PR TITLE
Fix arithmetic overflow in HLC clock skew evaluation

### DIFF
--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -147,7 +147,9 @@ pub fn evaluate_clock_skew(
     max_forward_jump_us: Option<i64>,
     self_heal_clock_skew: bool,
 ) -> Result<ClockSkewDecision, ClockSkewViolation> {
-    let drift = current_wallclock - frontier_wallclock;
+    // Use saturating subtraction to prevent overflow/wrapping on extreme jumps.
+    // e.g. i64::MAX - i64::MIN would wrap to -1 without this, bypassing checks.
+    let drift = current_wallclock.saturating_sub(frontier_wallclock);
     let mut effective_wallclock = current_wallclock;
     let mut healed_direction = None;
 
@@ -931,6 +933,26 @@ mod tests {
         assert!(
             result_backward.is_ok(),
             "Exact max backward drift should be allowed"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_clock_skew_overflow_protection() {
+        // 🛡️ Security Test: Reproduce arithmetic overflow vulnerability.
+        // Ensure massive forward jumps (e.g. i64::MAX - i64::MIN) are rejected
+        // instead of wrapping around to small negative numbers.
+        let current = i64::MAX;
+        let frontier = i64::MIN;
+        let max_forward = Some(MAX_FORWARD_JUMP_US);
+
+        // This should be rejected as an extreme forward jump.
+        let result = evaluate_clock_skew(current, frontier, max_forward, false);
+
+        assert!(
+            result.is_err(),
+            "Should reject extreme clock jump that wraps around arithmetic limits. Got: {:?} with drift {}",
+            result,
+            result.as_ref().map(|d| d.drift_us).unwrap_or(0)
         );
     }
 }

--- a/src/experimental/janus.rs
+++ b/src/experimental/janus.rs
@@ -80,6 +80,7 @@ impl<'a> JanusDetector<'a> {
             let neighbor_id = self.db.get_edge_target(edge_id)?;
             // Get neighbor node
             let neighbor = self.db.get_node(neighbor_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(prop) = neighbor.get_property(property) {
                 if let Some(vec) = prop.as_vector() {
                     vectors.push(vec.to_vec());
@@ -165,7 +166,7 @@ impl<'a> JanusDetector<'a> {
             // 10 iterations usually enough for local 2-means
             let mut changes = 0;
             let mut sums = vec![vec![0.0; dim]; 2];
-            let mut counts = vec![0; 2];
+            let mut counts = [0; 2];
 
             // Assign
             for (i, v) in data.iter().enumerate() {

--- a/src/experimental/muse.rs
+++ b/src/experimental/muse.rs
@@ -76,6 +76,7 @@ impl<'a> Muse<'a> {
         let mut vectors = Vec::with_capacity(nodes.len());
         for &node_id in nodes {
             let node = self.db.get_node(node_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(val) = node.properties.get(&prop_name) {
                 if let Some(vec) = val.as_vector() {
                     vectors.push(vec.to_vec());


### PR DESCRIPTION
This PR addresses a high-severity correctness/security vulnerability in the Hybrid Logical Clock (HLC) implementation.

### HLC Arithmetic Overflow
The `evaluate_clock_skew` function calculated drift as `current_wallclock - frontier_wallclock`. Since Rust checks for overflow only in debug mode, a release build would allow this calculation to wrap. An attacker (or a corrupted system clock) providing a `current_wallclock` of `i64::MAX` and a `frontier_wallclock` of `i64::MIN` would result in a drift of `-1` (due to wrapping), which satisfies the safety check `drift > max_forward_jump`.

This PR replaces the subtraction with `saturating_sub`, ensuring that such extreme differences saturate to `i64::MAX` or `i64::MIN`, correctly triggering the skew violation handlers.

### Experimental Module Cleanup
While running pre-commit checks, `clippy` identified issues in `src/experimental/janus.rs` and `src/experimental/muse.rs`. These have been fixed by applying `#[allow(clippy::collapsible_if)]` (to avoid unstable `let_chains` syntax) and optimizing vector initialization.

### Verification
- Added `test_evaluate_clock_skew_overflow_protection` in `src/core/hlc.rs`.
- Validated that the test fails (panics in debug) without the fix and passes with the fix.
- Ran full `cargo test` and `cargo clippy`.


---
*PR created automatically by Jules for task [10143505958491410904](https://jules.google.com/task/10143505958491410904) started by @madmax983*