### PR TITLE
⚡ Bolt: Use IdentityHasher for ID-keyed HashMaps

### DIFF
--- a/src/core/hasher.rs
+++ b/src/core/hasher.rs
@@ -1,0 +1,92 @@
+//! Optimized hasher for unique integer keys.
+//!
+//! This module provides `IdentityHasher`, a hasher that passes through integer values
+//! unchanged. It is intended for use with `HashMap` and `HashSet` where the keys
+//! are already high-quality unique identifiers (like `NodeId`, `EdgeId`, or `InternedString`),
+//! avoiding the unnecessary overhead of hashing (SipHash).
+
+use std::hash::Hasher;
+
+/// A hasher that passes through u32 and u64 values unchanged.
+///
+/// Used for maps where keys are already unique integers or IDs.
+/// This avoids the overhead of hashing (SipHash) for lookups.
+#[derive(Default)]
+pub struct IdentityHasher(u64);
+
+impl Hasher for IdentityHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        // Fallback for types that don't call write_u32/write_u64 directly.
+        // Try to interpret as u64 (little endian) if length matches.
+        if let Ok(bytes) = bytes.try_into() {
+            self.0 = u64::from_le_bytes(bytes);
+        } else if let Ok(bytes) = bytes.try_into() {
+            self.0 = u32::from_le_bytes(bytes) as u64;
+        } else {
+            // Fallback for unknown types - just use length to avoid collision on empty vs non-empty
+            // This case shouldn't happen for primitive integer keys we care about.
+            self.0 = bytes.len() as u64;
+        }
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.0 = i as u64;
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::Hasher;
+
+    #[test]
+    fn test_identity_hasher_u32() {
+        let mut hasher = IdentityHasher::default();
+        hasher.write_u32(42);
+        assert_eq!(hasher.finish(), 42);
+    }
+
+    #[test]
+    fn test_identity_hasher_u64() {
+        let mut hasher = IdentityHasher::default();
+        hasher.write_u64(u64::MAX);
+        assert_eq!(hasher.finish(), u64::MAX);
+    }
+
+    #[test]
+    fn test_identity_hasher_write_fallback_u32() {
+        let mut hasher = IdentityHasher::default();
+        let bytes = 12345u32.to_le_bytes();
+        hasher.write(&bytes);
+        assert_eq!(hasher.finish(), 12345);
+    }
+
+    #[test]
+    fn test_identity_hasher_write_fallback_u64() {
+        let mut hasher = IdentityHasher::default();
+        let val = 0x1234567890ABCDEFu64;
+        let bytes = val.to_le_bytes();
+        hasher.write(&bytes);
+        assert_eq!(hasher.finish(), val);
+    }
+
+    #[test]
+    fn test_identity_hasher_write_fallback_other() {
+        let mut hasher = IdentityHasher::default();
+        let bytes = [1u8, 2, 3];
+        hasher.write(&bytes);
+        // Fallback is length
+        assert_eq!(hasher.finish(), 3);
+    }
+}

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -9,9 +9,10 @@
 //! - Enables O(1) string equality checks (compare u32 instead of string contents)
 //! - Thread-safe without locking (uses DashMap)
 
+use crate::core::hasher::IdentityHasher;
 use dashmap::DashMap;
 use std::fmt;
-use std::hash::{BuildHasherDefault, Hasher};
+use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -85,32 +86,6 @@ impl fmt::Debug for InternedString {
             Some(res) => res,
             None => write!(f, "InternedString({})", self.0),
         }
-    }
-}
-
-/// A hasher that passes through u32 values unchanged.
-/// Used for the ID -> String map where keys are already unique integers.
-/// This avoids the overhead of hashing (SipHash) for lookups.
-#[derive(Default)]
-pub struct IdentityHasher(u64);
-
-impl Hasher for IdentityHasher {
-    fn write(&mut self, bytes: &[u8]) {
-        // Fallback: treat bytes as little-endian u32 if length matches
-        if let Ok(bytes) = bytes.try_into() {
-            self.0 = u32::from_le_bytes(bytes) as u64;
-        } else {
-            // Should not happen for InternedString keys
-            self.0 = bytes.len() as u64;
-        }
-    }
-
-    fn write_u32(&mut self, i: u32) {
-        self.0 = i as u64;
-    }
-
-    fn finish(&self) -> u64 {
-        self.0
     }
 }
 
@@ -1096,27 +1071,6 @@ mod tests {
             COMMON_STRINGS.len(),
             GLOBAL_INTERNER.len()
         );
-    }
-
-    #[test]
-    fn test_identity_hasher() {
-        use std::hash::Hasher;
-        let mut hasher = IdentityHasher::default();
-
-        // Test write_u32 (primary path)
-        hasher.write_u32(42);
-        assert_eq!(hasher.finish(), 42);
-
-        // Test write with 4 bytes (fallback success path)
-        let bytes = 12345u32.to_le_bytes();
-        hasher.write(&bytes);
-        assert_eq!(hasher.finish(), 12345);
-
-        // Test write with other length (fallback fail path)
-        // This covers the else branch in IdentityHasher::write
-        let bytes = [1u8, 2, 3];
-        hasher.write(&bytes);
-        assert_eq!(hasher.finish(), 3); // Should use len()
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod error;
 pub mod graph;
+pub mod hasher;
 pub mod history;
 pub mod hlc;
 pub mod id;

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -12,7 +12,8 @@ use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 
 use crate::core::error::{Result, StorageError};
-use crate::core::interning::{GLOBAL_INTERNER, IdentityHasher, InternedString};
+use crate::core::hasher::IdentityHasher;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
 use crate::core::vector::SparseVec;
 
 // ============================================================================

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -10,8 +10,9 @@
 //! - `VersionData`: Payload (Anchor or Delta).
 
 use crate::core::error::Result;
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId, TxId, VersionId};
-use crate::core::interning::{IdentityHasher, InternedString};
+use crate::core::interning::InternedString;
 use crate::core::property::{MAX_VECTOR_DIMENSIONS, PropertyKey, PropertyMap, PropertyValue};
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use std::collections::{HashMap, HashSet};
@@ -478,10 +479,11 @@ impl PropertyDelta {
 
         // Use standard HashMap for construction, PropertyMap::from_iter will handle internal structure
         // PropertyMap uses IdentityHasher internally too
-        let mut result = FastHashMap::with_capacity_and_hasher(
-            estimated_capacity,
-            BuildHasherDefault::<IdentityHasher>::default(),
-        );
+        let mut result: FastHashMap<PropertyKey, PropertyValue> =
+            FastHashMap::with_capacity_and_hasher(
+                estimated_capacity,
+                BuildHasherDefault::<IdentityHasher>::default(),
+            );
 
         // Copy all base properties except removed ones (single lookup per property)
         // This is optimal when changes << base (typical case: ~1-10% change rate)

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -13,9 +13,11 @@
 //! This layout is cache-friendly because traversing from a node requires
 //! sequential access to a contiguous region of memory.
 
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
 use rayon::prelude::*;
+use std::hash::BuildHasherDefault;
 
 /// A single entry in the adjacency list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,7 +89,11 @@ impl AdjacencyIndex {
         node_ids: Vec<u64>,
         offsets: Vec<u64>,
         edge_ids: Vec<u64>,
-        edges_map: &std::collections::HashMap<EdgeId, (NodeId, InternedString)>,
+        edges_map: &std::collections::HashMap<
+            EdgeId,
+            (NodeId, InternedString),
+            BuildHasherDefault<IdentityHasher>,
+        >,
     ) -> Self {
         if offsets.is_empty() || edge_ids.is_empty() {
             return Self::new();

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -782,7 +782,9 @@ impl CurrentIndexes {
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
     ) {
+        use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
+        use std::hash::BuildHasherDefault;
 
         // Safety check: tombstones cannot be reconstructed from CSR import.
         // If we have tombstones, importing would cause deleted edges to reappear.
@@ -798,7 +800,7 @@ impl CurrentIndexes {
         );
 
         // Build edges map for CSR reconstruction
-        let mut edges_map = HashMap::new();
+        let mut edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
         for entry in self.edges.iter() {
             let edge = entry.value();
             edges_map.insert(edge.id, (edge.target, edge.label));

--- a/src/index/temporal.rs
+++ b/src/index/temporal.rs
@@ -179,7 +179,11 @@ struct EntityTimeline {
     versions: Vec<TimelineEntry>,
     /// Fast lookup: metadata_idx -> position in versions vec.
     /// Enables O(1) updates instead of O(n) linear search.
-    metadata_to_position: std::collections::HashMap<VersionMetadataIndex, usize>,
+    metadata_to_position: std::collections::HashMap<
+        VersionMetadataIndex,
+        usize,
+        std::hash::BuildHasherDefault<crate::core::hasher::IdentityHasher>,
+    >,
 }
 
 impl EntityTimeline {

--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -58,6 +58,7 @@
 //! ```
 
 use crate::core::error::{Error, Result, VectorError};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::vector::validate_vector;
 use crate::index::vector::{DistanceMetric, Quantization, VectorIndex};
@@ -66,7 +67,7 @@ use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -1110,7 +1111,8 @@ impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
 pub struct MockVectorNodeClient {
     node_id: u16,
     healthy: AtomicBool,
-    vectors: RwLock<std::collections::HashMap<NodeId, Vec<f32>>>,
+    vectors:
+        RwLock<std::collections::HashMap<NodeId, Vec<f32>, BuildHasherDefault<IdentityHasher>>>,
     dimensions: usize,
     metric: DistanceMetric,
     fail_next: RwLock<Option<String>>,
@@ -1122,7 +1124,9 @@ impl MockVectorNodeClient {
         Self {
             node_id,
             healthy: AtomicBool::new(true),
-            vectors: RwLock::new(std::collections::HashMap::new()),
+            vectors: RwLock::new(std::collections::HashMap::with_hasher(
+                BuildHasherDefault::default(),
+            )),
             dimensions,
             metric,
             fail_next: RwLock::new(None),

--- a/src/index/vector/temporal/coverage_tests.rs
+++ b/src/index/vector/temporal/coverage_tests.rs
@@ -5,7 +5,10 @@ use crate::core::observer::{StorageEvent, StorageObserver};
 use crate::index::vector::hnsw::HnswIndex;
 use crate::index::vector::{DistanceMetric, HnswConfig};
 use std::collections::{HashMap, HashSet};
+use std::hash::BuildHasherDefault;
 use std::sync::Arc;
+
+use crate::core::hasher::IdentityHasher;
 
 #[test]
 fn test_config_coverage() {
@@ -71,7 +74,7 @@ fn test_snapshot_debug_coverage() -> Result<()> {
     let delta = SnapshotIndex::Delta(Arc::new(DeltaIndex {
         base: Arc::new(SnapshotIndex::Full(hnsw.clone())),
         added: hnsw.clone(),
-        removed: Arc::new(HashSet::new()),
+        removed: Arc::new(HashSet::with_hasher(BuildHasherDefault::default())),
     }));
     let debug_str = format!("{:?}", delta);
     assert!(debug_str.contains("SnapshotIndex::Delta"));
@@ -81,7 +84,7 @@ fn test_snapshot_debug_coverage() -> Result<()> {
     let delta_struct = DeltaIndex {
         base: Arc::new(SnapshotIndex::Full(hnsw.clone())),
         added: hnsw.clone(),
-        removed: Arc::new(HashSet::new()),
+        removed: Arc::new(HashSet::with_hasher(BuildHasherDefault::default())),
     };
     let debug_str_struct = format!("{:?}", delta_struct);
     assert!(debug_str_struct.contains("DeltaIndex"));
@@ -152,7 +155,9 @@ fn test_max_delta_chain_depth_error() {
     let root_time: i64 = 0;
     snapshots.insert(
         root_time.into(),
-        VectorSnapshot::Full(Arc::new(HashMap::new())),
+        VectorSnapshot::Full(Arc::new(
+            HashMap::with_hasher(BuildHasherDefault::default()),
+        )),
     );
 
     let mut last_time = root_time;
@@ -162,8 +167,8 @@ fn test_max_delta_chain_depth_error() {
             time.into(),
             VectorSnapshot::Delta {
                 base_time: last_time.into(),
-                added: Arc::new(HashMap::new()),
-                removed: Arc::new(HashSet::new()),
+                added: Arc::new(HashMap::with_hasher(BuildHasherDefault::default())),
+                removed: Arc::new(HashSet::with_hasher(BuildHasherDefault::default())),
             },
         );
         last_time = time;
@@ -195,15 +200,15 @@ fn test_vector_snapshot_delta_len_coverage() {
 
     let delta = VectorSnapshot::Delta {
         base_time: 0.into(),
-        added: Arc::new(HashMap::new()),
-        removed: Arc::new(HashSet::new()),
+        added: Arc::new(HashMap::with_hasher(BuildHasherDefault::default())),
+        removed: Arc::new(HashSet::with_hasher(BuildHasherDefault::default())),
     };
 
     // Should return MIN_CAPACITY_ESTIMATE since added is empty
     assert_eq!(delta.len(), MIN_CAPACITY_ESTIMATE);
 
     // Create one with more items than MIN
-    let mut added = HashMap::new();
+    let mut added = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
     for i in 0..MIN_CAPACITY_ESTIMATE + 10 {
         added.insert(NodeId::new(i as u64).unwrap(), Arc::from(vec![0.0f32]));
     }
@@ -211,7 +216,7 @@ fn test_vector_snapshot_delta_len_coverage() {
     let delta_large = VectorSnapshot::Delta {
         base_time: 0.into(),
         added: Arc::new(added.clone()),
-        removed: Arc::new(HashSet::new()),
+        removed: Arc::new(HashSet::with_hasher(BuildHasherDefault::default())),
     };
 
     assert_eq!(delta_large.len(), MIN_CAPACITY_ESTIMATE + 10);
@@ -222,12 +227,12 @@ fn test_delta_get_vector_removed_coverage() -> Result<()> {
     use super::snapshot::VectorSnapshot;
 
     let id = NodeId::new(1).unwrap();
-    let mut removed = HashSet::new();
+    let mut removed = HashSet::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
     removed.insert(id);
 
     let delta = VectorSnapshot::Delta {
         base_time: 0.into(),
-        added: Arc::new(HashMap::new()),
+        added: Arc::new(HashMap::with_hasher(BuildHasherDefault::default())),
         removed: Arc::new(removed),
     };
 

--- a/src/index/vector/temporal/mod.rs
+++ b/src/index/vector/temporal/mod.rs
@@ -73,11 +73,15 @@
 //! - `docs/VECTOR_SEARCH_DESIGN.md` - Overall vector search architecture
 
 use std::collections::{HashMap, HashSet};
+use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::core::hasher::IdentityHasher;
 use parking_lot::RwLock;
 use rayon::prelude::*;
+
+type IdentityBuildHasher = BuildHasherDefault<IdentityHasher>;
 
 use crate::core::error::{Error, Result, TemporalError, VectorError};
 use crate::core::id::NodeId;
@@ -378,7 +382,10 @@ impl TemporalVectorIndex {
 
         // Read current state to get vectors
         let state = self.current_state.read();
-        let mut vector_snapshot = HashMap::with_capacity(state.vectors.len());
+        let mut vector_snapshot = HashMap::with_capacity_and_hasher(
+            state.vectors.len(),
+            BuildHasherDefault::<IdentityHasher>::default(),
+        );
 
         for (node_id, vector) in state.vectors.iter() {
             snapshot.add(*node_id, vector.as_ref())?;
@@ -406,7 +413,7 @@ impl TemporalVectorIndex {
         base: Arc<SnapshotIndex>,
         base_vectors: &VectorSnapshot,
         base_time: Timestamp,
-        changes: &HashSet<NodeId>,
+        changes: &HashSet<NodeId, IdentityBuildHasher>,
     ) -> Result<(SnapshotIndex, VectorSnapshot)> {
         // SAFETY VALIDATION: Ensure base is a Full snapshot, not a Delta
         // This prevents delta-of-delta chains which would violate our performance guarantees
@@ -429,12 +436,15 @@ impl TemporalVectorIndex {
         let added = HnswIndex::new(added_config)?;
 
         // Build delta vector snapshot - only store changed vectors
-        let mut added_vectors = HashMap::new();
-        let mut removed_vectors = HashSet::new();
+        let mut added_vectors =
+            HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+        let mut removed_vectors =
+            HashSet::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
 
         // For DeltaIndex.removed: only nodes that WERE in base and are now invalid
         // This is crucial for correct len() calculation
-        let mut invalidated_in_base = HashSet::new();
+        let mut invalidated_in_base =
+            HashSet::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
 
         // We need access to all snapshots to check containment in base
         // Since we're inside write lock, we can't easily access snapshot_data
@@ -3364,13 +3374,18 @@ mod tests {
         use std::collections::BTreeMap;
 
         // Create a delta snapshot that references a missing base
+        let mut added = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+        added.insert(
+            NodeId::new(1).unwrap(),
+            Arc::from(vec![1.0f32, 0.0f32, 0.0f32, 0.0f32]) as Arc<[f32]>,
+        );
+
         let delta_snapshot = VectorSnapshot::Delta {
             base_time: 1000.into(), // This base won't exist
-            added: Arc::new(HashMap::from([(
-                NodeId::new(1).unwrap(),
-                Arc::from(vec![1.0f32, 0.0f32, 0.0f32, 0.0f32]) as Arc<[f32]>,
-            )])),
-            removed: Arc::new(HashSet::new()),
+            added: Arc::new(added),
+            removed: Arc::new(HashSet::with_hasher(
+                BuildHasherDefault::<IdentityHasher>::default(),
+            )),
         };
 
         let snapshots: BTreeMap<Timestamp, VectorSnapshot> = BTreeMap::new(); // Empty - no base

--- a/src/index/vector/temporal/snapshot.rs
+++ b/src/index/vector/temporal/snapshot.rs
@@ -5,12 +5,16 @@
 
 use super::config::{MAX_DELTA_CHAIN_DEPTH, MIN_CAPACITY_ESTIMATE};
 use crate::core::error::{Result, VectorError};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;
 use crate::index::vector::VectorIndex;
 use crate::index::vector::hnsw::HnswIndex;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::hash::BuildHasherDefault;
 use std::sync::Arc;
+
+type IdentityBuildHasher = BuildHasherDefault<IdentityHasher>;
 
 /// Type alias for vector snapshot: map of NodeId to vector data
 /// Represents vector data in a snapshot, supporting both full and delta formats.
@@ -20,16 +24,16 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub(crate) enum VectorSnapshot {
     /// Full snapshot containing all vectors
-    Full(Arc<HashMap<NodeId, Arc<[f32]>>>),
+    Full(Arc<HashMap<NodeId, Arc<[f32]>, IdentityBuildHasher>>),
 
     /// Delta snapshot storing only differences
     Delta {
         /// Timestamp of the base snapshot this delta is relative to
         base_time: Timestamp,
         /// Vectors added or updated since the base snapshot
-        added: Arc<HashMap<NodeId, Arc<[f32]>>>,
+        added: Arc<HashMap<NodeId, Arc<[f32]>, IdentityBuildHasher>>,
         /// NodeIds removed since the base snapshot
-        removed: Arc<HashSet<NodeId>>,
+        removed: Arc<HashSet<NodeId, IdentityBuildHasher>>,
     },
 }
 
@@ -109,14 +113,14 @@ impl VectorSnapshot {
     pub(crate) fn to_hashmap(
         &self,
         all_snapshots: &BTreeMap<Timestamp, VectorSnapshot>,
-    ) -> Result<HashMap<NodeId, Arc<[f32]>>> {
+    ) -> Result<HashMap<NodeId, Arc<[f32]>, IdentityBuildHasher>> {
         // Collect layers
         let mut current = self;
         let mut delta_layers = Vec::new();
         let mut depth = 0;
 
         // Walk backwards through delta chain to find the Full snapshot base
-        let base_vectors: HashMap<NodeId, Arc<[f32]>> = loop {
+        let base_vectors: HashMap<NodeId, Arc<[f32]>, IdentityBuildHasher> = loop {
             if depth >= MAX_DELTA_CHAIN_DEPTH {
                 // Return error instead of partial results to prevent silent data loss
                 return Err(VectorError::IndexError(format!(
@@ -141,8 +145,8 @@ impl VectorSnapshot {
                 } => {
                     // Store delta layer to apply later (in reverse order)
                     struct DeltaLayer<'a> {
-                        added: &'a HashMap<NodeId, Arc<[f32]>>,
-                        removed: &'a HashSet<NodeId>,
+                        added: &'a HashMap<NodeId, Arc<[f32]>, IdentityBuildHasher>,
+                        removed: &'a HashSet<NodeId, IdentityBuildHasher>,
                     }
                     delta_layers.push(DeltaLayer {
                         added: added.as_ref(),
@@ -313,7 +317,7 @@ impl SnapshotIndex {
 pub(crate) struct DeltaIndex {
     pub(crate) base: Arc<SnapshotIndex>,
     pub(crate) added: Arc<HnswIndex>,
-    pub(crate) removed: Arc<HashSet<NodeId>>,
+    pub(crate) removed: Arc<HashSet<NodeId, IdentityBuildHasher>>,
 }
 
 impl std::fmt::Debug for DeltaIndex {
@@ -451,7 +455,7 @@ pub(crate) struct SnapshotMetadata {
     pub(crate) last_snapshot_time: Timestamp,
 
     /// Set of NodeIds changed since last snapshot (for ChangeThreshold)
-    pub(crate) vectors_changed_since_snapshot: HashSet<NodeId>,
+    pub(crate) vectors_changed_since_snapshot: HashSet<NodeId, IdentityBuildHasher>,
 
     /// Last FULL snapshot time (for delta calculation)
     pub(crate) last_full_snapshot_time: Timestamp,
@@ -461,7 +465,7 @@ pub(crate) struct SnapshotMetadata {
 
     /// Accumulator for ALL changes since last FULL snapshot
     /// Used to build the delta index.
-    pub(crate) changes_accumulated: HashSet<NodeId>,
+    pub(crate) changes_accumulated: HashSet<NodeId, IdentityBuildHasher>,
 }
 
 impl SnapshotMetadata {
@@ -470,10 +474,10 @@ impl SnapshotMetadata {
             total_snapshots: 0,
             transactions_since_snapshot: 0,
             last_snapshot_time: initial_time,
-            vectors_changed_since_snapshot: HashSet::new(),
+            vectors_changed_since_snapshot: HashSet::with_hasher(BuildHasherDefault::default()),
             last_full_snapshot_time: initial_time,
             snapshots_since_full: 0,
-            changes_accumulated: HashSet::new(),
+            changes_accumulated: HashSet::with_hasher(BuildHasherDefault::default()),
         }
     }
 
@@ -507,7 +511,7 @@ impl SnapshotMetadata {
 /// from 3 to 1 during hot-path operations like `add()`.
 pub(crate) struct VectorState {
     /// In-memory storage of current vectors
-    pub(crate) vectors: HashMap<NodeId, Arc<[f32]>>,
+    pub(crate) vectors: HashMap<NodeId, Arc<[f32]>, IdentityBuildHasher>,
 
     /// Metadata for snapshot tracking
     pub(crate) metadata: SnapshotMetadata,
@@ -516,7 +520,7 @@ pub(crate) struct VectorState {
 impl VectorState {
     pub(crate) fn new(initial_time: Timestamp) -> Self {
         Self {
-            vectors: HashMap::new(),
+            vectors: HashMap::with_hasher(BuildHasherDefault::default()),
             metadata: SnapshotMetadata::new(initial_time),
         }
     }

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -728,7 +728,11 @@ impl CheckpointManager {
                         builder = builder.insert_by_key(*key, value.clone());
                     }
                     let changed_props = builder.build();
-                    let removed_keys: Vec<u32> = delta.removed.iter().map(|k| k.as_u32()).collect();
+                    let removed_keys: Vec<u32> = delta
+                        .removed
+                        .iter()
+                        .map(|k: &crate::core::interning::InternedString| k.as_u32())
+                        .collect();
 
                     (
                         PersistedVersionType::Delta {
@@ -796,7 +800,11 @@ impl CheckpointManager {
                         builder = builder.insert_by_key(*key, value.clone());
                     }
                     let changed_props = builder.build();
-                    let removed_keys: Vec<u32> = delta.removed.iter().map(|k| k.as_u32()).collect();
+                    let removed_keys: Vec<u32> = delta
+                        .removed
+                        .iter()
+                        .map(|k: &crate::core::interning::InternedString| k.as_u32())
+                        .collect();
 
                     (
                         PersistedVersionType::Delta {

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -106,7 +106,11 @@ pub fn convert_node_version(version: &NodeVersion) -> Result<NodeVersionEntry> {
             }
 
             // Collect removed property keys (as interned string indices)
-            let removed_keys: Vec<u32> = delta.removed.iter().map(|k| k.as_u32()).collect();
+            let removed_keys: Vec<u32> = delta
+                .removed
+                .iter()
+                .map(|k: &crate::core::interning::InternedString| k.as_u32())
+                .collect();
 
             let props = builder.build();
             (


### PR DESCRIPTION
💡 What: Introduced a shared `IdentityHasher` and applied it to `HashMap`/`HashSet` instances keyed by integer IDs (`NodeId`, `EdgeId`, `VersionMetadataIndex`, `InternedString`).

🎯 Why: To reduce hashing overhead. These keys are already high-quality unique identifiers, so re-hashing them with SipHash is unnecessary and costly in hot paths.

📊 Impact: Reduces CPU cycles spent on hashing during map lookups and insertions. This should improve throughput for operations involving adjacency lists, vector indexes, and temporal version lookups.

🔬 Measurement: Verified with existing tests. No functional changes, purely performance optimization. `cargo test` passed.


---
*PR created automatically by Jules for task [2908600361511955582](https://jules.google.com/task/2908600361511955582) started by @madmax983*