### PR TITLE
Enforce MAX_VALID_TIMESTAMP in TimeRange constructors

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -151,8 +151,17 @@ impl TimeRange {
     }
 
     /// Create a time range that starts at the given timestamp and is still current.
+    ///
+    /// # Panics
+    /// Panics if start > MAX_VALID_TIMESTAMP and start != TIMESTAMP_MAX.
     #[inline]
     pub fn from(start: Timestamp) -> Self {
+        if start.wallclock() > MAX_VALID_TIMESTAMP && start != TIMESTAMP_MAX {
+            panic!(
+                "Start timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                MAX_VALID_TIMESTAMP
+            );
+        }
         TimeRange {
             start,
             end: TIMESTAMP_MAX,
@@ -166,8 +175,17 @@ impl TimeRange {
     }
 
     /// Create a point-in-time range (instant with zero duration).
+    ///
+    /// # Panics
+    /// Panics if timestamp > MAX_VALID_TIMESTAMP and timestamp != TIMESTAMP_MAX.
     #[inline]
     pub fn at(timestamp: Timestamp) -> Self {
+        if timestamp.wallclock() > MAX_VALID_TIMESTAMP && timestamp != TIMESTAMP_MAX {
+            panic!(
+                "Timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                MAX_VALID_TIMESTAMP
+            );
+        }
         TimeRange {
             start: timestamp,
             end: timestamp,
@@ -248,6 +266,7 @@ impl TimeRange {
     ///
     /// # Errors
     /// Returns `TemporalError::InvalidTimeRange` if end < start.
+    /// Returns `TemporalError::InvalidTimestamp` if end > MAX_VALID_TIMESTAMP.
     #[inline]
     pub fn close_at(self, end: Timestamp) -> Result<Self, TemporalError> {
         if end < self.start {
@@ -256,6 +275,17 @@ impl TimeRange {
                 end,
             });
         }
+
+        if end.wallclock() > MAX_VALID_TIMESTAMP && end != TIMESTAMP_MAX {
+            return Err(TemporalError::InvalidTimestamp {
+                timestamp: end,
+                reason: format!(
+                    "End timestamp exceeds MAX_VALID_TIMESTAMP ({})",
+                    MAX_VALID_TIMESTAMP
+                ),
+            });
+        }
+
         Ok(TimeRange {
             start: self.start,
             end,

--- a/src/experimental/janus.rs
+++ b/src/experimental/janus.rs
@@ -80,6 +80,7 @@ impl<'a> JanusDetector<'a> {
             let neighbor_id = self.db.get_edge_target(edge_id)?;
             // Get neighbor node
             let neighbor = self.db.get_node(neighbor_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(prop) = neighbor.get_property(property) {
                 if let Some(vec) = prop.as_vector() {
                     vectors.push(vec.to_vec());
@@ -165,7 +166,7 @@ impl<'a> JanusDetector<'a> {
             // 10 iterations usually enough for local 2-means
             let mut changes = 0;
             let mut sums = vec![vec![0.0; dim]; 2];
-            let mut counts = vec![0; 2];
+            let mut counts = [0; 2];
 
             // Assign
             for (i, v) in data.iter().enumerate() {

--- a/src/experimental/muse.rs
+++ b/src/experimental/muse.rs
@@ -76,6 +76,7 @@ impl<'a> Muse<'a> {
         let mut vectors = Vec::with_capacity(nodes.len());
         for &node_id in nodes {
             let node = self.db.get_node(node_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(val) = node.properties.get(&prop_name) {
                 if let Some(vec) = val.as_vector() {
                     vectors.push(vec.to_vec());

--- a/tests/time_range_validation.rs
+++ b/tests/time_range_validation.rs
@@ -1,0 +1,48 @@
+use aletheiadb::core::error::TemporalError;
+use aletheiadb::core::hlc::HybridTimestamp;
+use aletheiadb::core::temporal::{MAX_VALID_TIMESTAMP, TIMESTAMP_MAX, TimeRange};
+
+#[test]
+#[should_panic(expected = "Start timestamp exceeds MAX_VALID_TIMESTAMP")]
+fn test_timerange_from_panics_on_invalid_timestamp() {
+    let invalid_wallclock = MAX_VALID_TIMESTAMP + 1;
+    let invalid_ts: HybridTimestamp = invalid_wallclock.into();
+    let _ = TimeRange::from(invalid_ts);
+}
+
+#[test]
+#[should_panic(expected = "Timestamp exceeds MAX_VALID_TIMESTAMP")]
+fn test_timerange_at_panics_on_invalid_timestamp() {
+    let invalid_wallclock = MAX_VALID_TIMESTAMP + 1;
+    let invalid_ts: HybridTimestamp = invalid_wallclock.into();
+    let _ = TimeRange::at(invalid_ts);
+}
+
+#[test]
+fn test_timerange_close_at_returns_error_on_invalid_timestamp() {
+    let invalid_wallclock = MAX_VALID_TIMESTAMP + 1;
+    let invalid_ts: HybridTimestamp = invalid_wallclock.into();
+
+    let valid_start = HybridTimestamp::new(100, 0).unwrap();
+    let range = TimeRange::from(valid_start);
+
+    let result = range.close_at(invalid_ts);
+    assert!(result.is_err());
+
+    match result {
+        Err(TemporalError::InvalidTimestamp { .. }) => (),
+        _ => panic!("Expected InvalidTimestamp error, got {:?}", result),
+    }
+}
+
+#[test]
+fn test_timerange_methods_accept_timestamp_max() {
+    // TIMESTAMP_MAX is a special sentinel that should be accepted
+    let _ = TimeRange::from(TIMESTAMP_MAX);
+    let _ = TimeRange::at(TIMESTAMP_MAX);
+
+    let valid_start = HybridTimestamp::new(100, 0).unwrap();
+    let range = TimeRange::from(valid_start);
+    let closed = range.close_at(TIMESTAMP_MAX).unwrap();
+    assert!(closed.is_current());
+}


### PR DESCRIPTION
Modified TimeRange::from, TimeRange::at, and TimeRange::close_at to enforce MAX_VALID_TIMESTAMP checks. This prevents invalid timestamps (e.g., created via HybridTimestamp::from<i64>) from entering the system and violating invariants. Added regression tests in tests/time_range_validation.rs. Also fixed minor clippy issues in experimental modules.

---
*PR created automatically by Jules for task [18323933232738947753](https://jules.google.com/task/18323933232738947753) started by @madmax983*