### PR TITLE
Core Security and Correctness Fixes

### DIFF
--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -951,18 +951,17 @@ mod tests {
 
         // Should be rejected as forward jump (drift > max_forward).
         // If vulnerable, it returns Ok because -1 < max_forward and > -max_backward.
-        match result {
-            Ok(_) => {
-                panic!("Vulnerability confirmed: Overflow masked huge forward jump as valid drift")
-            }
-            Err(ClockSkewViolation {
-                direction: ClockSkewDirection::Forward,
-                ..
-            }) => {
-                // Correct behavior
-            }
-            Err(e) => panic!("Unexpected error type: {:?}", e),
-        }
+        assert!(
+            matches!(
+                result,
+                Err(ClockSkewViolation {
+                    direction: ClockSkewDirection::Forward,
+                    ..
+                })
+            ),
+            "Expected ClockSkewViolation::Forward, got {:?}",
+            result
+        );
     }
 }
 

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -147,7 +147,10 @@ pub fn evaluate_clock_skew(
     max_forward_jump_us: Option<i64>,
     self_heal_clock_skew: bool,
 ) -> Result<ClockSkewDecision, ClockSkewViolation> {
-    let drift = current_wallclock - frontier_wallclock;
+    // Use saturating_sub to prevent integer overflow attacks.
+    // Without this, huge forward jumps (e.g. current=MAX, frontier=MIN) could wrap around
+    // to small negative values, bypassing drift checks.
+    let drift = current_wallclock.saturating_sub(frontier_wallclock);
     let mut effective_wallclock = current_wallclock;
     let mut healed_direction = None;
 
@@ -932,6 +935,34 @@ mod tests {
             result_backward.is_ok(),
             "Exact max backward drift should be allowed"
         );
+    }
+
+    #[test]
+    fn test_evaluate_clock_skew_integer_overflow_vulnerability() {
+        // 🛡️ Sentry Test: Verify evaluate_clock_skew is robust against integer overflow.
+        // Scenario: Frontier is MIN, Current is MAX. Real drift is +Infinity.
+        // Vulnerable calculation: MAX - MIN = -1 (due to overflow).
+        // If vulnerable, this appears as valid small backward drift.
+
+        let current = i64::MAX;
+        let frontier = i64::MIN;
+
+        let result = evaluate_clock_skew(current, frontier, Some(3_600_000_000), false);
+
+        // Should be rejected as forward jump (drift > max_forward).
+        // If vulnerable, it returns Ok because -1 < max_forward and > -max_backward.
+        match result {
+            Ok(_) => {
+                panic!("Vulnerability confirmed: Overflow masked huge forward jump as valid drift")
+            }
+            Err(ClockSkewViolation {
+                direction: ClockSkewDirection::Forward,
+                ..
+            }) => {
+                // Correct behavior
+            }
+            Err(e) => panic!("Unexpected error type: {:?}", e),
+        }
     }
 }
 

--- a/src/experimental/janus.rs
+++ b/src/experimental/janus.rs
@@ -80,6 +80,7 @@ impl<'a> JanusDetector<'a> {
             let neighbor_id = self.db.get_edge_target(edge_id)?;
             // Get neighbor node
             let neighbor = self.db.get_node(neighbor_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(prop) = neighbor.get_property(property) {
                 if let Some(vec) = prop.as_vector() {
                     vectors.push(vec.to_vec());
@@ -165,7 +166,7 @@ impl<'a> JanusDetector<'a> {
             // 10 iterations usually enough for local 2-means
             let mut changes = 0;
             let mut sums = vec![vec![0.0; dim]; 2];
-            let mut counts = vec![0; 2];
+            let mut counts = [0; 2];
 
             // Assign
             for (i, v) in data.iter().enumerate() {

--- a/src/experimental/muse.rs
+++ b/src/experimental/muse.rs
@@ -76,6 +76,7 @@ impl<'a> Muse<'a> {
         let mut vectors = Vec::with_capacity(nodes.len());
         for &node_id in nodes {
             let node = self.db.get_node(node_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(val) = node.properties.get(&prop_name) {
                 if let Some(vec) = val.as_vector() {
                     vectors.push(vec.to_vec());

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -78,6 +78,11 @@ impl AdjacencyIndex {
 
     /// Import CSR data from persistence, reconstructing adjacency entries from edges.
     ///
+    /// # Panics
+    /// Panics if the input arrays do not satisfy CSR invariants:
+    /// - `offsets.len() == node_ids.len() + 1`
+    /// - `offsets.last() == Some(edge_ids.len())`
+    ///
     /// # Arguments
     /// * `node_ids` - Sorted array of node IDs that have outgoing edges
     /// * `offsets` - CSR offset array
@@ -92,6 +97,18 @@ impl AdjacencyIndex {
         if offsets.is_empty() || edge_ids.is_empty() {
             return Self::new();
         }
+
+        // Validate invariants to prevent late panics or corruption
+        assert_eq!(
+            offsets.len(),
+            node_ids.len() + 1,
+            "CSR invariant violated: offsets length must be node_ids length + 1"
+        );
+        assert_eq!(
+            offsets.last().copied(),
+            Some(edge_ids.len() as u64),
+            "CSR invariant violated: last offset must equal total edge count"
+        );
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -668,5 +685,27 @@ mod tests {
             1000,
             "max_node_id should consider target nodes"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "CSR invariant violated")]
+    fn test_import_csr_invalid_offsets_len() {
+        let node_ids = vec![1, 2];
+        let offsets = vec![0, 1]; // Should be len 3
+        let edge_ids = vec![100];
+        let map = std::collections::HashMap::new();
+
+        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &map);
+    }
+
+    #[test]
+    #[should_panic(expected = "CSR invariant violated: last offset must equal total edge count")]
+    fn test_import_csr_invalid_last_offset() {
+        let node_ids = vec![1];
+        let offsets = vec![0, 2]; // Last offset 2 implies 2 edges
+        let edge_ids = vec![100]; // But only 1 edge provided
+        let map = std::collections::HashMap::new();
+
+        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &map);
     }
 }

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -725,7 +725,7 @@ mod tests {
             node_ids.iter().map(|&x| x as u64).collect(),
             offsets.iter().map(|&x| x as u64).collect(),
             edge_ids.iter().map(|&x| x as u64).collect(),
-            &map
+            &map,
         );
 
         assert_eq!(index.node_count(), 2);

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -708,4 +708,27 @@ mod tests {
 
         AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &map);
     }
+
+    #[test]
+    fn test_import_csr_valid() {
+        // Valid CSR import to cover "success" paths of assertions
+        let node_ids = vec![1, 2];
+        let offsets = vec![0, 1, 2]; // 2 nodes, 1 edge each (total 2)
+        let edge_ids = vec![100, 200]; // 2 edges
+        let mut map = std::collections::HashMap::new();
+        let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+
+        map.insert(EdgeId::new(100).unwrap(), (NodeId::new(10).unwrap(), label));
+        map.insert(EdgeId::new(200).unwrap(), (NodeId::new(20).unwrap(), label));
+
+        let index = AdjacencyIndex::import_csr(
+            node_ids.iter().map(|&x| x as u64).collect(),
+            offsets.iter().map(|&x| x as u64).collect(),
+            edge_ids.iter().map(|&x| x as u64).collect(),
+            &map
+        );
+
+        assert_eq!(index.node_count(), 2);
+        assert_eq!(index.edge_count(), 2);
+    }
 }

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -712,9 +712,9 @@ mod tests {
     #[test]
     fn test_import_csr_valid() {
         // Valid CSR import to cover "success" paths of assertions
-        let node_ids = vec![1, 2];
-        let offsets = vec![0, 1, 2]; // 2 nodes, 1 edge each (total 2)
-        let edge_ids = vec![100, 200]; // 2 edges
+        let node_ids = [1, 2];
+        let offsets = [0, 1, 2]; // 2 nodes, 1 edge each (total 2)
+        let edge_ids = [100, 200]; // 2 edges
         let mut map = std::collections::HashMap::new();
         let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
 

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -227,10 +227,27 @@ impl GroupCommitCoordinator {
         //
         // EPOCH SEMANTICS: flushed_epoch = N means "epoch N has been flushed".
         // Transaction at epoch E waits while flushed_epoch < E (i.e., E has not been flushed yet).
+
+        // Use absolute deadline to ensure we don't wait indefinitely due to spurious wakeups
+        let start = std::time::Instant::now();
+
         while state.flushed_epoch < epoch {
+            // Check if we've already exceeded the timeout (absolute check)
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return Err(Error::Storage(StorageError::WalError {
+                    reason: format!(
+                        "Group commit timeout waiting for epoch {} (current flushed: {})",
+                        epoch, state.flushed_epoch
+                    ),
+                }));
+            }
+
+            let remaining = timeout - elapsed;
+
             let (new_state, timeout_result) = self
                 .flush_complete
-                .wait_timeout(state, timeout)
+                .wait_timeout(state, remaining)
                 .map_err(|_| {
                     Error::Storage(StorageError::LockPoisoned {
                         resource: "group_commit_state".to_string(),

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -799,4 +799,61 @@ mod tests {
         // 8. Transaction B should be done
         assert!(coord.wait_for_flush(epoch_b).is_ok());
     }
+
+    #[test]
+    fn test_wait_for_flush_timeout_spurious() {
+        // Attempt to trigger the absolute timeout check inside the loop.
+        // We set a very short timeout and simulate spurious wakeups by notifying without advancing flushed_epoch.
+        let config = GroupCommitConfig {
+            max_delay_ms: 0,
+            max_batch_size: 100,
+            timeout_multiplier: 0,
+            timeout_base_ms: 1, // 1ms timeout
+            timeout_min_ms: 1,
+            timeout_max_ms: 1000,
+            recent_errors_capacity: 1024,
+        };
+        let coord = Arc::new(GroupCommitCoordinator::with_config(config));
+
+        let (epoch, _) = coord.register_transaction().unwrap();
+
+        // Spawn a thread that keeps waking up waiters but doesn't advance the epoch enough
+        let coord_clone = Arc::clone(&coord);
+        let handle = thread::spawn(move || {
+            // Wait a bit to ensure the main thread enters wait_for_flush
+            thread::sleep(Duration::from_millis(2));
+            // Trigger spurious wakeups by notifying (finish_flush calls notify_all)
+            // We flush epoch 0 (which is already flushed or irrelevant) just to trigger notify
+            // But finish_flush expects epoch > flushed_epoch to insert into completed.
+            // If we pass an error, it notifies? Yes.
+            // Or if we finish a future epoch but not the one waited for (gap)?
+            // Let's just use the condvar directly if we could, but we can't.
+            // finish_flush calls notify_all unconditionally.
+            // So we can "finish" a fake epoch (e.g. current epoch + 100) or just same epoch with error?
+            // If we finish with error, wait_for_flush returns error immediately.
+            // We want it to loop.
+            // Loop condition: flushed_epoch < epoch.
+            // So flushed_epoch must NOT advance to epoch.
+            // We can finish flush for a *smaller* epoch?
+            // flushed_epoch starts at 0. Target epoch is 1.
+            // If we finish flush for epoch 0? It's already flushed.
+            // Does finish_flush notify if epoch <= flushed_epoch? Yes, it notifies unconditionally.
+            for _ in 0..10 {
+                // Finish epoch 0 (no-op on logic, but triggers notify)
+                let _ = coord_clone.finish_flush(0, Ok(()));
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+
+        let start = std::time::Instant::now();
+        let result = coord.wait_for_flush(epoch);
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("timeout"));
+        // Ensure it didn't hang
+        assert!(elapsed < Duration::from_millis(500));
+
+        handle.join().unwrap();
+    }
 }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -2015,4 +2015,59 @@ mod sentry_tests {
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("Too many WAL entries"));
     }
+
+    #[test]
+    fn test_read_entries_from_dir_max_recovery_entries() {
+        // 🛡️ Sentry Test: Verify MAX_RECOVERY_ENTRIES is enforced in read_entries_from_dir.
+        // Create 2 segments.
+        // Seg 1: 1500 entries.
+        // Seg 2: 1000 entries.
+        // Total: 2500 > 2000 (test limit).
+
+        let dir = TempDir::new().unwrap();
+
+        // Segment 1
+        let path1 = dir.path().join("1.log");
+        let mut file1 = File::create(&path1).unwrap();
+        file1.write_all(&WAL_MAGIC).unwrap();
+        file1.write_all(&[WAL_VERSION]).unwrap();
+        for i in 0..1500 {
+            let operation = WalOperation::CreateNode {
+                node_id: NodeId::new(i as u64 + 1).unwrap(),
+                label: GLOBAL_INTERNER.intern("Node").unwrap(),
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+            };
+            let entry = WalEntry::new(LSN(i as u64 + 1), operation);
+            let mut buffer = Vec::new();
+            serialize_entry_into(&entry, &mut buffer).unwrap();
+            file1.write_all(&buffer).unwrap();
+        }
+        file1.sync_all().unwrap();
+
+        // Segment 2
+        let path2 = dir.path().join("2.log");
+        let mut file2 = File::create(&path2).unwrap();
+        file2.write_all(&WAL_MAGIC).unwrap();
+        file2.write_all(&[WAL_VERSION]).unwrap();
+        for i in 0..1000 {
+            let operation = WalOperation::CreateNode {
+                node_id: NodeId::new(i as u64 + 10000).unwrap(),
+                label: GLOBAL_INTERNER.intern("Node").unwrap(),
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+            };
+            let entry = WalEntry::new(LSN(i as u64 + 10000), operation);
+            let mut buffer = Vec::new();
+            serialize_entry_into(&entry, &mut buffer).unwrap();
+            file2.write_all(&buffer).unwrap();
+        }
+        file2.sync_all().unwrap();
+
+        // Read all
+        let result = read_entries_from_dir(dir.path(), LSN(1));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Too many WAL entries"));
+    }
 }

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -39,6 +39,14 @@ pub(crate) const WAL_HEADER_SIZE: usize = 5;
 /// Default segments are 64MB, so 1GB allows for 16x growth
 pub(crate) const MAX_SEGMENT_SIZE: u64 = 1024 * 1024 * 1024; // 1GB
 
+/// Maximum number of WAL entries to read during recovery to prevent OOM.
+/// Production limit: 10,000,000
+/// Test limit: 2,000
+#[cfg(not(test))]
+pub(crate) const MAX_RECOVERY_ENTRIES: usize = 10_000_000;
+#[cfg(test)]
+pub(crate) const MAX_RECOVERY_ENTRIES: usize = 2_000;
+
 /// Read all WAL entries from a directory, starting from the specified LSN.
 ///
 /// This function scans the directory for segment files (*.log), reads them in order,
@@ -76,6 +84,16 @@ pub fn read_entries_from_dir(wal_dir: &Path, start_lsn: LSN) -> Result<Vec<WalEn
     // Read entries from each segment
     for (_, path) in segments {
         let segment_entries = read_segment(&path, start_lsn)?;
+
+        if entries.len() + segment_entries.len() > MAX_RECOVERY_ENTRIES {
+            return Err(StorageError::CorruptedData(format!(
+                "Too many WAL entries during recovery: {} (limit: {})",
+                entries.len() + segment_entries.len(),
+                MAX_RECOVERY_ENTRIES
+            ))
+            .into());
+        }
+
         entries.extend(segment_entries);
     }
 
@@ -173,6 +191,15 @@ pub fn read_segment(path: &Path, start_lsn: LSN) -> Result<Vec<WalEntry>> {
 
     // Parse entries using the extracted helper function (issue #218)
     while offset < buffer.len() {
+        if entries.len() >= MAX_RECOVERY_ENTRIES {
+            return Err(StorageError::CorruptedData(format!(
+                "Too many WAL entries in segment: {} (limit: {})",
+                entries.len(),
+                MAX_RECOVERY_ENTRIES
+            ))
+            .into());
+        }
+
         // Try to parse an entry at the current offset
         match parse_entry_at(buffer, offset, version) {
             Ok((entry, bytes_consumed)) => {
@@ -1851,6 +1878,9 @@ mod fuzz_tests {
 #[cfg(test)]
 mod sentry_tests {
     use super::*;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::temporal::time;
+    use crate::storage::wal::serialization::serialize_entry_into;
     use std::fs::File;
     use std::io::Write;
     use tempfile::TempDir;
@@ -1949,5 +1979,40 @@ mod sentry_tests {
             "Should read op type and fail validation. Got: {}",
             msg
         );
+    }
+
+    #[test]
+    fn test_read_segment_max_recovery_entries() {
+        // 🛡️ Sentry Test: Verify MAX_RECOVERY_ENTRIES is enforced.
+        // Test limit is 2,000. We write 2,001 entries.
+        use std::io::Write;
+
+        let dir = TempDir::new().unwrap();
+        let segment_path = dir.path().join("too_many.log");
+        let mut file = File::create(&segment_path).unwrap();
+
+        file.write_all(&WAL_MAGIC).unwrap();
+        file.write_all(&[WAL_VERSION]).unwrap();
+
+        for i in 0..MAX_RECOVERY_ENTRIES + 1 {
+            let operation = WalOperation::CreateNode {
+                node_id: NodeId::new(i as u64 + 1).unwrap(),
+                label: GLOBAL_INTERNER.intern("Node").unwrap(),
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+            };
+            let entry = WalEntry::new(LSN(i as u64 + 1), operation);
+            let mut buffer = Vec::new();
+            serialize_entry_into(&entry, &mut buffer).unwrap();
+            file.write_all(&buffer).unwrap();
+        }
+
+        file.sync_all().unwrap();
+        drop(file);
+
+        let result = read_segment(&segment_path, LSN(1));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Too many WAL entries"));
     }
 }


### PR DESCRIPTION
This PR addresses 4 critical/high severity findings identified during the Core review:

1.  **Correctness/Security**: Fixed an integer overflow vulnerability in `src/core/hlc.rs` where `evaluate_clock_skew` could accept invalid timestamps (e.g., future time `i64::MAX`) if the frontier was far in the past (`i64::MIN`). Used `saturating_sub` to correctly calculate drift. Added a regression test `test_evaluate_clock_skew_integer_overflow_vulnerability`.
2.  **Security/DoS**: Enforced a hard limit on the number of WAL entries read during recovery in `src/storage/wal/segment_reader.rs`. Introduced `MAX_RECOVERY_ENTRIES` (10M prod / 2k test) to prevent OOM attacks. Added verification test `test_read_segment_max_recovery_entries`.
3.  **Reliability**: Added `assert_eq!` validations in `src/index/adjacency.rs` `AdjacencyIndex::import_csr` to enforce CSR invariants and prevent undefined behavior. Added documentation about panics and regression tests `test_import_csr_invalid_*`.
4.  **Performance/Correctness**: Fixed `GroupCommitCoordinator::wait_for_flush` in `src/storage/wal/group_commit.rs` to use an absolute deadline (`Instant::now()`), preventing indefinite waits caused by resetting the timeout on spurious wakeups.

Also resolved `clippy::collapsible_if`, `clippy::useless_vec`, and `clippy::inconsistent_digit_grouping` warnings.

---
*PR created automatically by Jules for task [16108294347690102075](https://jules.google.com/task/16108294347690102075) started by @madmax983*