### PR TITLE
Havoc: Fix HNSW Buffer Over-read Vulnerability in Custom Metrics

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1746,6 +1746,52 @@ impl HnswIndex {
         Ok(())
     }
 
+    /// Verify that the binary index file matches the expected dimensions and quantization.
+    ///
+    /// This reads the first 8 bytes of the file to check the vector size field.
+    /// usearch stores `count` (bytes 0-3) and `vector_byte_size` (bytes 4-7).
+    /// We verify that `vector_byte_size == dimensions * scalar_size`.
+    fn verify_index_header(
+        path: &Path,
+        dimensions: usize,
+        quantization: Quantization,
+    ) -> Result<()> {
+        let mut file = File::open(path).map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to open index file for verification: {}",
+                e
+            )))
+        })?;
+
+        let mut header = [0u8; 8];
+        file.read_exact(&mut header).map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!(
+                "Failed to read index header: {}",
+                e
+            )))
+        })?;
+
+        // Extract vector_byte_size from bytes 4-7 (little-endian u32)
+        let vector_byte_size = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
+
+        let scalar_size = match quantization {
+            Quantization::F32 => 4,
+            Quantization::F16 => 2,
+            Quantization::I8 => 1,
+        };
+
+        let expected_size = dimensions * scalar_size;
+
+        if vector_byte_size != expected_size {
+            return Err(Error::Vector(VectorError::IndexError(format!(
+                "Index file header mismatch: expected {} bytes per vector ({} dims * {} bytes), found {}",
+                expected_size, dimensions, scalar_size, vector_byte_size
+            ))));
+        }
+
+        Ok(())
+    }
+
     /// Validate loaded index metadata against configuration.
     fn validate_metadata(metadata: Option<IndexMetadata>, config: &HnswConfig) -> Result<()> {
         if let Some(meta) = metadata {
@@ -2181,6 +2227,9 @@ impl HnswIndex {
             }));
         }
 
+        // Verify binary index file header (prevents quantization mismatch vulnerability)
+        Self::verify_index_header(path, config.dimensions, config.quantization)?;
+
         let options = IndexOptions {
             dimensions: config.dimensions,
             metric: to_usearch_metric(config.metric),
@@ -2321,6 +2370,9 @@ impl HnswIndex {
             // Legacy index: fallback to defaults
             (Quantization::default(), DistanceMetric::Cosine)
         };
+
+        // Verify binary index file header (prevents quantization mismatch vulnerability)
+        Self::verify_index_header(path, dimensions, quantization)?;
 
         Ok(HnswIndex {
             inner: Arc::new(RwLock::new(index)),

--- a/tests/regress_buffer_overread.rs
+++ b/tests/regress_buffer_overread.rs
@@ -1,8 +1,9 @@
-
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization, VectorIndex, HnswConfig, HnswIndex};
 use aletheiadb::core::id::NodeId;
-use std::sync::{Arc, Mutex};
+use aletheiadb::index::vector::{
+    DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization, VectorIndex,
+};
 use std::fs;
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn test_regress_buffer_overread() -> Result<(), Box<dyn std::error::Error>> {
@@ -70,7 +71,9 @@ fn test_regress_buffer_overread() -> Result<(), Box<dyn std::error::Error>> {
         Ok(_) => {
             // If load succeeded, check if we actually have the vulnerability
             // (Only if we proceed to search, but here we just check load)
-            panic!("Index loaded successfully! Vulnerability not prevented. Expected header mismatch error.");
+            panic!(
+                "Index loaded successfully! Vulnerability not prevented. Expected header mismatch error."
+            );
         }
         Err(e) => {
             let msg = e.to_string();

--- a/tests/regress_buffer_overread.rs
+++ b/tests/regress_buffer_overread.rs
@@ -1,0 +1,85 @@
+
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization, VectorIndex, HnswConfig, HnswIndex};
+use aletheiadb::core::id::NodeId;
+use std::sync::{Arc, Mutex};
+use std::fs;
+
+#[test]
+fn test_regress_buffer_overread() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let f32_path = dir.path().join("f32.index");
+    let f16_path = dir.path().join("f16.index");
+
+    // 1. Create F32 index template
+    {
+        let index = HnswIndexBuilder::new(16, DistanceMetric::Cosine)
+            .quantization(Quantization::F32)
+            .build()?;
+
+        // Add some vectors
+        for i in 0..100 {
+            let vec = vec![1.0f32; 16];
+            index.add(NodeId::new(i).unwrap(), &vec)?;
+        }
+        index.save(&f32_path)?;
+    }
+
+    // 2. Create F16 index (same content)
+    {
+        let index = HnswIndexBuilder::new(16, DistanceMetric::Cosine)
+            .quantization(Quantization::F16)
+            .build()?;
+
+        for i in 0..100 {
+            let vec = vec![1.0f32; 16];
+            index.add(NodeId::new(i).unwrap(), &vec)?;
+        }
+        index.save(&f16_path)?;
+    }
+
+    // 3. The Attack: Overwrite F32 index file with F16 index file
+    // BUT keep the F32 mappings file!
+    fs::copy(&f16_path, &f32_path)?;
+    // We do NOT copy the mappings file, so f32.usearch.mappings remains F32.
+
+    // Shared state to detect anomaly (in case verify fails to catch it)
+    let saw_anomaly = Arc::new(Mutex::new(false));
+    let anomaly_clone = saw_anomaly.clone();
+
+    // 4. Load the "F32" index (which is now F16 binary + F32 mappings)
+    println!("Loading corrupted index...");
+
+    // This config matches the mappings file (F32), so validate_metadata passes.
+    let config = HnswConfig::new(16, DistanceMetric::Cosine)
+        .with_quantization(Quantization::F32)
+        .with_custom_metric("test", move |a, _b| {
+            let sum_a: f32 = a.iter().sum();
+
+            // Expected sum for 16 * 1.0 is 16.0.
+            if (sum_a - 16.0).abs() > 1.0 {
+                // Anomaly detected! We are reading garbage.
+                *anomaly_clone.lock().unwrap() = true;
+            }
+            0.0
+        });
+
+    let result = HnswIndex::load(&f32_path, config);
+
+    // 5. Verify the fix: Load MUST fail with header mismatch error
+    match result {
+        Ok(_) => {
+            // If load succeeded, check if we actually have the vulnerability
+            // (Only if we proceed to search, but here we just check load)
+            panic!("Index loaded successfully! Vulnerability not prevented. Expected header mismatch error.");
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            println!("Got expected error: {}", msg);
+            assert!(msg.contains("Index file header mismatch"));
+            assert!(msg.contains("expected 64 bytes"));
+            assert!(msg.contains("found 32"));
+        }
+    }
+
+    Ok(())
+}

--- a/tests/vector_verify_header_coverage.rs
+++ b/tests/vector_verify_header_coverage.rs
@@ -1,0 +1,71 @@
+
+use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization, VectorIndex, HnswConfig, HnswIndex};
+use aletheiadb::core::id::NodeId;
+use std::fs::File;
+use std::io::Write;
+
+#[test]
+fn test_verify_header_file_open_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("non_existent.index");
+    let config = HnswConfig::default();
+
+    let result = HnswIndex::load(&path, config);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("Failed to open index file for verification"));
+}
+
+#[test]
+fn test_verify_header_read_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("truncated.index");
+
+    // Create a file smaller than 8 bytes
+    let mut file = File::create(&path).unwrap();
+    file.write_all(&[0u8; 4]).unwrap(); // Only 4 bytes
+
+    let config = HnswConfig::default();
+
+    let result = HnswIndex::load(&path, config);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("Failed to read index header"));
+}
+
+#[test]
+fn test_verify_header_quantization_coverage() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // F16
+    {
+        let path = dir.path().join("f16_valid.index");
+        let index = HnswIndexBuilder::new(16, DistanceMetric::Cosine)
+            .quantization(Quantization::F16)
+            .build()
+            .unwrap();
+        index.add(NodeId::new(1).unwrap(), &vec![1.0; 16]).unwrap();
+        index.save(&path).unwrap();
+
+        let config = HnswConfig::new(16, DistanceMetric::Cosine)
+            .with_quantization(Quantization::F16);
+        let loaded = HnswIndex::load(&path, config);
+        assert!(loaded.is_ok());
+    }
+
+    // I8
+    {
+        let path = dir.path().join("i8_valid.index");
+        let index = HnswIndexBuilder::new(16, DistanceMetric::Cosine)
+            .quantization(Quantization::I8)
+            .build()
+            .unwrap();
+        index.add(NodeId::new(1).unwrap(), &vec![1.0; 16]).unwrap();
+        index.save(&path).unwrap();
+
+        let config = HnswConfig::new(16, DistanceMetric::Cosine)
+            .with_quantization(Quantization::I8);
+        let loaded = HnswIndex::load(&path, config);
+        assert!(loaded.is_ok());
+    }
+}

--- a/tests/vector_verify_header_coverage.rs
+++ b/tests/vector_verify_header_coverage.rs
@@ -45,7 +45,7 @@ fn test_verify_header_quantization_coverage() {
             .quantization(Quantization::F16)
             .build()
             .unwrap();
-        index.add(NodeId::new(1).unwrap(), &vec![1.0; 16]).unwrap();
+        index.add(NodeId::new(1).unwrap(), &[1.0; 16]).unwrap();
         index.save(&path).unwrap();
 
         let config =
@@ -61,7 +61,7 @@ fn test_verify_header_quantization_coverage() {
             .quantization(Quantization::I8)
             .build()
             .unwrap();
-        index.add(NodeId::new(1).unwrap(), &vec![1.0; 16]).unwrap();
+        index.add(NodeId::new(1).unwrap(), &[1.0; 16]).unwrap();
         index.save(&path).unwrap();
 
         let config =

--- a/tests/vector_verify_header_coverage.rs
+++ b/tests/vector_verify_header_coverage.rs
@@ -1,6 +1,7 @@
-
-use aletheiadb::index::vector::{HnswIndexBuilder, DistanceMetric, Quantization, VectorIndex, HnswConfig, HnswIndex};
 use aletheiadb::core::id::NodeId;
+use aletheiadb::index::vector::{
+    DistanceMetric, HnswConfig, HnswIndex, HnswIndexBuilder, Quantization, VectorIndex,
+};
 use std::fs::File;
 use std::io::Write;
 
@@ -47,8 +48,8 @@ fn test_verify_header_quantization_coverage() {
         index.add(NodeId::new(1).unwrap(), &vec![1.0; 16]).unwrap();
         index.save(&path).unwrap();
 
-        let config = HnswConfig::new(16, DistanceMetric::Cosine)
-            .with_quantization(Quantization::F16);
+        let config =
+            HnswConfig::new(16, DistanceMetric::Cosine).with_quantization(Quantization::F16);
         let loaded = HnswIndex::load(&path, config);
         assert!(loaded.is_ok());
     }
@@ -63,8 +64,8 @@ fn test_verify_header_quantization_coverage() {
         index.add(NodeId::new(1).unwrap(), &vec![1.0; 16]).unwrap();
         index.save(&path).unwrap();
 
-        let config = HnswConfig::new(16, DistanceMetric::Cosine)
-            .with_quantization(Quantization::I8);
+        let config =
+            HnswConfig::new(16, DistanceMetric::Cosine).with_quantization(Quantization::I8);
         let loaded = HnswIndex::load(&path, config);
         assert!(loaded.is_ok());
     }

--- a/tests/warden_hnsw_exploit.rs
+++ b/tests/warden_hnsw_exploit.rs
@@ -58,10 +58,19 @@ fn test_warden_hnsw_dimension_mismatch_exploit() {
         Err(e) => {
             println!("Load failed as expected: {}", e);
             let msg = e.to_string();
-            assert!(msg.contains("Index dimension mismatch"));
-            // Verify detail: usearch index has 4, config has 100
-            assert!(msg.contains("usearch index has 4"));
-            assert!(msg.contains("config has 100"));
+            // The error can be either "Index file header mismatch" (caught early by verifying header)
+            // or "Index dimension mismatch" (caught later by verifying loaded index dims).
+            // Both are valid rejections.
+            if msg.contains("Index file header mismatch") {
+                // Expected 400 bytes (100 dims * 4), found 16 (4 dims * 4)
+                assert!(msg.contains("expected 400 bytes"));
+                assert!(msg.contains("found 16"));
+            } else {
+                assert!(msg.contains("Index dimension mismatch"));
+                // Verify detail: usearch index has 4, config has 100
+                assert!(msg.contains("usearch index has 4"));
+                assert!(msg.contains("config has 100"));
+            }
         }
     }
 }


### PR DESCRIPTION
Havoc identified a buffer over-read vulnerability where a malicious or corrupted index file could claim to use F16 quantization while the configuration expects F32. This mismatch caused custom metrics (which assume F32 pointers) to read past the end of the vector data.

This PR adds a `verify_index_header` check that validates the binary index file's vector size against the expected configuration before loading. This prevents the vulnerability.

---
*PR created automatically by Jules for task [16466499309037458517](https://jules.google.com/task/16466499309037458517) started by @madmax983*