### PR TITLE
Fix cosine_similarity inconsistency for small vectors

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -104,6 +104,12 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Result<f32> {
     // Use SIMD-accelerated computation when available
     let (dot, mag_a_sq, mag_b_sq) = dot_and_magnitudes(a, b);
 
+    // Handle effectively zero vectors early to avoid numerical instability
+    // and match behavior of normalize()
+    if mag_a_sq < SQUARED_MAGNITUDE_THRESHOLD || mag_b_sq < SQUARED_MAGNITUDE_THRESHOLD {
+        return Ok(0.0);
+    }
+
     // Compute magnitude as product of individual square roots to avoid intermediate overflow.
     // If we did (mag_a_sq * mag_b_sq).sqrt(), the product could overflow f32::MAX
     // even if individual squared magnitudes are within range.
@@ -215,14 +221,18 @@ pub fn cosine_similarity_normalized(a: &[f32], b: &[f32]) -> Result<f32> {
         let mag_a_sq: f32 = a.iter().map(|x| x * x).sum();
         let mag_b_sq: f32 = b.iter().map(|x| x * x).sum();
 
+        // Allow unit vectors (mag ≈ 1.0) OR zero vectors (mag ≈ 0.0) produced by normalize()
+        let a_valid = (mag_a_sq - 1.0).abs() < 1e-4 || mag_a_sq < SQUARED_MAGNITUDE_THRESHOLD;
         debug_assert!(
-            (mag_a_sq - 1.0).abs() < 1e-4,
+            a_valid,
             "First vector is not unit length: ||a||² = {} (expected 1.0). \
              Use cosine_similarity() for non-normalized vectors.",
             mag_a_sq
         );
+
+        let b_valid = (mag_b_sq - 1.0).abs() < 1e-4 || mag_b_sq < SQUARED_MAGNITUDE_THRESHOLD;
         debug_assert!(
-            (mag_b_sq - 1.0).abs() < 1e-4,
+            b_valid,
             "Second vector is not unit length: ||b||² = {} (expected 1.0). \
              Use cosine_similarity() for non-normalized vectors.",
             mag_b_sq

--- a/src/experimental/janus.rs
+++ b/src/experimental/janus.rs
@@ -80,6 +80,7 @@ impl<'a> JanusDetector<'a> {
             let neighbor_id = self.db.get_edge_target(edge_id)?;
             // Get neighbor node
             let neighbor = self.db.get_node(neighbor_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(prop) = neighbor.get_property(property) {
                 if let Some(vec) = prop.as_vector() {
                     vectors.push(vec.to_vec());
@@ -165,7 +166,7 @@ impl<'a> JanusDetector<'a> {
             // 10 iterations usually enough for local 2-means
             let mut changes = 0;
             let mut sums = vec![vec![0.0; dim]; 2];
-            let mut counts = vec![0; 2];
+            let mut counts = [0; 2];
 
             // Assign
             for (i, v) in data.iter().enumerate() {

--- a/src/experimental/muse.rs
+++ b/src/experimental/muse.rs
@@ -76,6 +76,7 @@ impl<'a> Muse<'a> {
         let mut vectors = Vec::with_capacity(nodes.len());
         for &node_id in nodes {
             let node = self.db.get_node(node_id)?;
+            #[allow(clippy::collapsible_if)]
             if let Some(val) = node.properties.get(&prop_name) {
                 if let Some(vec) = val.as_vector() {
                     vectors.push(vec.to_vec());

--- a/tests/cosine_consistency.rs
+++ b/tests/cosine_consistency.rs
@@ -1,0 +1,44 @@
+use aletheiadb::core::vector::ops::{cosine_similarity, cosine_similarity_normalized, normalize};
+
+#[test]
+fn test_small_vector_consistency() {
+    // Vector with squared magnitude significantly below SQUARED_MAGNITUDE_THRESHOLD (1e-14).
+    // e.g. magnitude 1e-10 -> squared 1e-20
+    let small_vec = vec![1e-10f32];
+    let normal_vec = vec![1.0f32];
+
+    // normalize(small_vec) should return a zero vector because magnitude is too small.
+    let small_norm = normalize(&small_vec);
+    assert_eq!(small_norm, vec![0.0f32], "normalize should return zero vector for small magnitude input");
+
+    // cosine_similarity(small_vec, normal_vec) currently returns ~1.0 (if collinear) or whatever.
+    // After fix, it should return 0.0 because small_vec is effectively zero.
+    let sim_raw = cosine_similarity(&small_vec, &normal_vec).unwrap();
+
+    // cosine_similarity_normalized(small_norm, normal_vec) currently panics in debug because small_norm is 0 vector.
+    // After fix, it should return 0.0 without panic.
+    let normal_norm = normalize(&normal_vec);
+    let sim_norm = cosine_similarity_normalized(&small_norm, &normal_norm).unwrap();
+
+    println!("sim_raw: {}, sim_norm: {}", sim_raw, sim_norm);
+
+    // Assert consistency: raw similarity should match normalized similarity (both 0.0).
+    assert!((sim_raw - sim_norm).abs() < 1e-6, "Raw similarity {} does not match normalized similarity {}", sim_raw, sim_norm);
+
+    // Specifically, both should be 0.0
+    assert_eq!(sim_raw, 0.0, "cosine_similarity should return 0.0 for small vectors");
+    assert_eq!(sim_norm, 0.0, "cosine_similarity_normalized should return 0.0 for zero vectors");
+}
+
+#[test]
+fn test_small_vector_pair_consistency() {
+    // Both vectors small
+    let a = vec![1e-10f32];
+    let b = vec![1e-10f32];
+
+    let sim_raw = cosine_similarity(&a, &b).unwrap();
+    let sim_norm = cosine_similarity_normalized(&normalize(&a), &normalize(&b)).unwrap();
+
+    assert_eq!(sim_raw, 0.0, "cosine_similarity should return 0.0 for small vector pair");
+    assert_eq!(sim_norm, 0.0, "cosine_similarity_normalized should return 0.0 for zero vector pair");
+}

--- a/tests/cosine_consistency.rs
+++ b/tests/cosine_consistency.rs
@@ -9,7 +9,11 @@ fn test_small_vector_consistency() {
 
     // normalize(small_vec) should return a zero vector because magnitude is too small.
     let small_norm = normalize(&small_vec);
-    assert_eq!(small_norm, vec![0.0f32], "normalize should return zero vector for small magnitude input");
+    assert_eq!(
+        small_norm,
+        vec![0.0f32],
+        "normalize should return zero vector for small magnitude input"
+    );
 
     // cosine_similarity(small_vec, normal_vec) currently returns ~1.0 (if collinear) or whatever.
     // After fix, it should return 0.0 because small_vec is effectively zero.
@@ -23,11 +27,22 @@ fn test_small_vector_consistency() {
     println!("sim_raw: {}, sim_norm: {}", sim_raw, sim_norm);
 
     // Assert consistency: raw similarity should match normalized similarity (both 0.0).
-    assert!((sim_raw - sim_norm).abs() < 1e-6, "Raw similarity {} does not match normalized similarity {}", sim_raw, sim_norm);
+    assert!(
+        (sim_raw - sim_norm).abs() < 1e-6,
+        "Raw similarity {} does not match normalized similarity {}",
+        sim_raw,
+        sim_norm
+    );
 
     // Specifically, both should be 0.0
-    assert_eq!(sim_raw, 0.0, "cosine_similarity should return 0.0 for small vectors");
-    assert_eq!(sim_norm, 0.0, "cosine_similarity_normalized should return 0.0 for zero vectors");
+    assert_eq!(
+        sim_raw, 0.0,
+        "cosine_similarity should return 0.0 for small vectors"
+    );
+    assert_eq!(
+        sim_norm, 0.0,
+        "cosine_similarity_normalized should return 0.0 for zero vectors"
+    );
 }
 
 #[test]
@@ -39,6 +54,12 @@ fn test_small_vector_pair_consistency() {
     let sim_raw = cosine_similarity(&a, &b).unwrap();
     let sim_norm = cosine_similarity_normalized(&normalize(&a), &normalize(&b)).unwrap();
 
-    assert_eq!(sim_raw, 0.0, "cosine_similarity should return 0.0 for small vector pair");
-    assert_eq!(sim_norm, 0.0, "cosine_similarity_normalized should return 0.0 for zero vector pair");
+    assert_eq!(
+        sim_raw, 0.0,
+        "cosine_similarity should return 0.0 for small vector pair"
+    );
+    assert_eq!(
+        sim_norm, 0.0,
+        "cosine_similarity_normalized should return 0.0 for zero vector pair"
+    );
 }

--- a/tests/havoc_vector_math.rs
+++ b/tests/havoc_vector_math.rs
@@ -65,11 +65,13 @@ fn test_cosine_similarity_repro_regression() {
     let b = vec![-125.53673f32];
 
     // This call should NOT panic, even in debug mode.
-    // It should return 1.0 (clamped).
+    // Previously it returned 1.0 (clamped).
+    // Now, since `a` has squared magnitude < 1e-14, it is treated as a zero vector.
+    // This ensures consistency with normalize().
     let res = cosine_similarity(&a, &b).unwrap();
 
     assert!((-1.0..=1.0).contains(&res), "Result {} out of range", res);
 
-    // Ideally it should be exactly 1.0 or very close
-    assert!((res - 1.0).abs() < 1e-6, "Result {} should be ~1.0", res);
+    // Should be 0.0 because `a` is effectively zero
+    assert_eq!(res, 0.0, "Result {} should be 0.0 (noise vector)", res);
 }


### PR DESCRIPTION
This PR addresses an inconsistency where `cosine_similarity` returned high similarity scores (~1.0) for extremely small "noise" vectors (squared magnitude < 1e-14), while `normalize` treated them as zero vectors. This led to `cosine_similarity_normalized` panicking in debug mode when processing such vectors.

Key changes:
- `src/core/vector/ops.rs`: Added threshold check to `cosine_similarity` and relaxed debug assertions in `cosine_similarity_normalized`.
- `tests/cosine_consistency.rs`: Added new test case verifying consistency between raw and normalized similarity for small vectors.
- `tests/havoc_vector_math.rs`: Updated regression test to expect 0.0 for noise inputs.

---
*PR created automatically by Jules for task [2010661393785632588](https://jules.google.com/task/2010661393785632588) started by @madmax983*