### PR TITLE
Fix CSR validation panic and harden WAL reader

### DIFF
--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -93,6 +93,24 @@ impl AdjacencyIndex {
             return Self::new();
         }
 
+        // CSR Invariant Validation:
+        // 1. offsets array must have length = node_ids.len() + 1
+        // 2. The last offset must equal the total number of edges
+        assert_eq!(
+            offsets.len(),
+            node_ids.len() + 1,
+            "CSR offsets length mismatch: expected {}, got {}",
+            node_ids.len() + 1,
+            offsets.len()
+        );
+        assert_eq!(
+            offsets.last(),
+            Some(&(edge_ids.len() as u64)),
+            "CSR last offset mismatch: expected {}, got {:?}",
+            edge_ids.len(),
+            offsets.last()
+        );
+
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
         let node_ids_typed: Vec<NodeId> = node_ids

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -125,6 +125,11 @@ pub fn read_segment(path: &Path, start_lsn: LSN) -> Result<Vec<WalEntry>> {
         .metadata()
         .map_err(|e| StorageError::IoError(format!("Failed to get file metadata: {}", e)))?;
 
+    // Handle empty files explicitly to prevent mmap failure on some platforms (e.g. Linux)
+    if metadata.len() == 0 {
+        return Ok(Vec::new());
+    }
+
     if metadata.len() > MAX_SEGMENT_SIZE {
         return Err(StorageError::CorruptedData(format!(
             "WAL segment too large: {} bytes (max: {} bytes)",

--- a/tests/sentry_csr_validation.rs
+++ b/tests/sentry_csr_validation.rs
@@ -1,0 +1,47 @@
+
+#[cfg(test)]
+mod reproduction_test {
+    use aletheiadb::index::adjacency::AdjacencyIndex;
+    use aletheiadb::core::id::{NodeId, EdgeId};
+    use aletheiadb::core::interning::InternedString;
+    use std::collections::HashMap;
+
+    #[test]
+    #[should_panic(expected = "CSR offsets length mismatch")]
+    fn test_import_csr_missing_validation_panic() {
+        // Create corrupted CSR data: offsets too short for node_ids
+        let node_ids = vec![1]; // 1 node
+        let offsets = vec![0];  // Should be [0, N], length 2. Here length 1.
+        let edge_ids = vec![100]; // 1 edge to bypass empty check
+
+        let edges_map = HashMap::new();
+
+        // This should panic immediately due to validation
+        let _ = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+    }
+
+    #[test]
+    #[should_panic(expected = "CSR last offset mismatch")]
+    fn test_import_csr_out_of_bounds_offsets() {
+        // Create corrupted CSR data: offsets point outside edges array
+        let node_ids = vec![1];
+        let offsets = vec![0, 100]; // 100 is > edges.len() (1)
+        let edge_ids = vec![100]; // 1 edge
+        let edges_map = HashMap::new();
+
+        // This should panic immediately due to validation
+        let _ = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+    }
+
+    #[test]
+    fn test_import_csr_empty_input_no_panic() {
+        // Regression test: Empty input should NOT panic
+        let node_ids = vec![];
+        let offsets = vec![];
+        let edge_ids = vec![];
+        let edges_map = HashMap::new();
+
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert_eq!(index.edge_count(), 0);
+    }
+}

--- a/tests/sentry_wal_empty.rs
+++ b/tests/sentry_wal_empty.rs
@@ -1,0 +1,25 @@
+
+#[cfg(test)]
+mod reproduction_test {
+    use aletheiadb::storage::wal::segment_reader::read_segment;
+    use aletheiadb::storage::wal::LSN;
+    use tempfile::TempDir;
+    use std::fs::File;
+
+    #[test]
+    fn test_read_zero_byte_segment_panic() {
+        let dir = TempDir::new().unwrap();
+        let segment_path = dir.path().join("zero_byte.log");
+
+        // Create empty file
+        File::create(&segment_path).unwrap();
+
+        // This should not error/panic
+        let result = read_segment(&segment_path, LSN(0));
+
+        match result {
+            Ok(entries) => assert!(entries.is_empty(), "Should return empty entries for zero-byte file"),
+            Err(e) => panic!("read_segment failed on zero-byte file: {}", e),
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses two high-impact correctness/robustness issues:

1.  **CSR Validation**: `AdjacencyIndex::import_csr` previously lacked validation for Compressed Sparse Row (CSR) invariants. Corrupted or malicious input could create an invalid index that would panic during `get_adjacency` (query time) due to index out of bounds.
    -   **Fix**: Added assertions to verify `offsets.len() == node_ids.len() + 1` and `offsets.last() == edge_ids.len()`.
    -   **Regression Fix**: Ensured that valid empty inputs (e.g., empty vectors) do not trigger these assertions by checking for emptiness first.

2.  **WAL Reader Robustness**: `read_segment` relied on implicit behavior of `mmap` for zero-byte files (which fails on Linux with `EINVAL`).
    -   **Fix**: Added an explicit check `if metadata.len() == 0` to return an empty vector immediately, ensuring robust recovery even if empty log files are present.

New sentinel tests were added to verify these fixes and prevent regressions.

---
*PR created automatically by Jules for task [16118706381858823759](https://jules.google.com/task/16118706381858823759) started by @madmax983*