### PR TITLE
Sentinel: Harden TimeRange deserialization and fix AdjacencyIndex tests

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1847,4 +1847,29 @@ mod sentry_tests {
         let range = TimeRange::new(100.into(), 200.into()).unwrap();
         assert!(!range.is_empty(), "Range [100, 200) should not be empty");
     }
+
+    #[test]
+    fn test_sentry_timerange_deserialize_checks_invariants() {
+        // 🛡️ Sentry Test: Verify deserialize rejects start > end.
+        // This targets mutants that might remove the invariant check in deserialize.
+
+        let start = HybridTimestamp::new_unchecked(200, 0);
+        let end = HybridTimestamp::new_unchecked(100, 0);
+
+        let mut bytes = Vec::new();
+        start.serialize_into(&mut bytes);
+        end.serialize_into(&mut bytes);
+
+        let result = TimeRange::deserialize(&bytes);
+        assert!(result.is_err(), "Should reject start > end in deserialize");
+        match result.unwrap_err() {
+            StorageError::CorruptedData(msg) => {
+                assert!(
+                    msg.contains("start") && msg.contains("end"),
+                    "Error message should mention start and end"
+                );
+            }
+            _ => panic!("Expected CorruptedData error"),
+        }
+    }
 }

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -711,7 +711,9 @@ mod tests {
 #[cfg(test)]
 mod sentry_tests {
     use super::*;
+    use crate::core::hasher::IdentityHasher;
     use std::collections::HashMap;
+    use std::hash::BuildHasherDefault;
 
     #[test]
     fn test_validate_csr_invariants_logic() {
@@ -743,7 +745,8 @@ mod sentry_tests {
         let node_ids = vec![10];
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
-        let edges_map = HashMap::new();
+        let edges_map: HashMap<EdgeId, (NodeId, InternedString), BuildHasherDefault<IdentityHasher>> =
+            HashMap::with_hasher(BuildHasherDefault::default());
         AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
     }
 
@@ -755,7 +758,11 @@ mod sentry_tests {
         let offsets: Vec<u64> = vec![0, 1, 2];
         let edge_ids: Vec<u64> = vec![100, 101];
 
-        let mut edges_map = HashMap::new();
+        let mut edges_map: HashMap<
+            EdgeId,
+            (NodeId, InternedString),
+            BuildHasherDefault<IdentityHasher>,
+        > = HashMap::with_hasher(BuildHasherDefault::default());
         let target = NodeId::new(99).unwrap();
         let label = crate::core::interning::InternedString::from_raw(1);
 


### PR DESCRIPTION
This PR addresses test gaps identified during a Sentinel mutation analysis session.

### 🎯 Test Hardening
- **`src/core/temporal.rs`**: Added a new test `test_sentry_timerange_deserialize_checks_invariants` inside the module. This test manually constructs an invalid `TimeRange` byte sequence (where `start > end`) and asserts that `deserialize` returns a `CorruptedData` error. This ensures that the invariant check in `deserialize` is covered and cannot be removed without failing tests.

### 🐛 Bug Fixes
- **`src/index/adjacency.rs`**: Fixed a type mismatch in `sentry_tests` where `HashMap::new()` (using `RandomState`) was passed to `import_csr` which expects `BuildHasherDefault<IdentityHasher>`. This unblocks running tests for this module.

### 🧬 Mutation Testing Notes
- `cargo mutants` was run on `src/core/temporal.rs` but the baseline build time (~4.5 minutes) made full iteration impractical within the session. The added test is a proactive measure based on manual analysis of potential mutants (specifically, removing the validation logic in `deserialize`).

---
*PR created automatically by Jules for task [17266834815226359972](https://jules.google.com/task/17266834815226359972) started by @madmax983*