### PR TITLE
🤖 Sentinel: Kill temporal mutants with TIMESTAMP_MAX tests

### DIFF
--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1847,4 +1847,34 @@ mod sentry_tests {
         let range = TimeRange::new(100.into(), 200.into()).unwrap();
         assert!(!range.is_empty(), "Range [100, 200) should not be empty");
     }
+
+    #[test]
+    fn test_sentry_timerange_at_timestamp_max() {
+        // 🛡️ Sentry Test: Verify TimeRange::at() accepts TIMESTAMP_MAX.
+        // This targets the mutant `if ... timestamp != TIMESTAMP_MAX` -> `if ... timestamp == TIMESTAMP_MAX`.
+        // If the check logic is inverted, this call will panic because TIMESTAMP_MAX > MAX_VALID_TIMESTAMP.
+        let range = TimeRange::at(TIMESTAMP_MAX);
+        assert_eq!(range.start(), TIMESTAMP_MAX);
+        assert_eq!(range.end(), TIMESTAMP_MAX);
+        assert!(range.is_empty());
+    }
+
+    #[test]
+    fn test_sentry_timerange_new_timestamp_max() {
+        // 🛡️ Sentry Test: Verify TimeRange::new() accepts TIMESTAMP_MAX for start/end.
+        // This targets the mutants in TimeRange::new() that invert the sentinel check logic.
+        let range = TimeRange::new(TIMESTAMP_MAX, TIMESTAMP_MAX).unwrap();
+        assert_eq!(range.start(), TIMESTAMP_MAX);
+        assert_eq!(range.end(), TIMESTAMP_MAX);
+    }
+
+    #[test]
+    fn test_sentry_timerange_close_at_timestamp_max() {
+        // 🛡️ Sentry Test: Verify TimeRange::close_at() accepts TIMESTAMP_MAX.
+        // This targets the mutant in TimeRange::close_at() that inverts the sentinel check logic.
+        let range = TimeRange::from(100.into());
+        let closed = range.close_at(TIMESTAMP_MAX).unwrap();
+        assert_eq!(closed.end(), TIMESTAMP_MAX);
+        assert!(closed.is_current());
+    }
 }

--- a/src/experimental/mnemosyne.rs
+++ b/src/experimental/mnemosyne.rs
@@ -234,7 +234,6 @@ mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
     use crate::core::property::PropertyMapBuilder;
-    use crate::core::temporal::time;
     use crate::index::vector::{DistanceMetric, HnswConfig};
 
     #[test]


### PR DESCRIPTION
🤖 Sentinel Report

I have added targeted tests to `src/core/temporal.rs` to eliminate surviving mutants related to `TIMESTAMP_MAX` handling.

**🧬 Mutants Killed:**
- `TimeRange::at`: `!= TIMESTAMP_MAX` -> `== TIMESTAMP_MAX`
- `TimeRange::new`: `!= TIMESTAMP_MAX` -> `== TIMESTAMP_MAX` (start and end)
- `TimeRange::close_at`: `!= TIMESTAMP_MAX` -> `== TIMESTAMP_MAX` (end)

**🎯 Tests Added:**
- `test_sentry_timerange_at_timestamp_max`: Verifies `TimeRange::at(TIMESTAMP_MAX)` succeeds.
- `test_sentry_timerange_new_timestamp_max`: Verifies `TimeRange::new(TIMESTAMP_MAX, TIMESTAMP_MAX)` succeeds.
- `test_sentry_timerange_close_at_timestamp_max`: Verifies `TimeRange::close_at(TIMESTAMP_MAX)` succeeds.

**🧹 Cleanup:**
- Removed unused import `crate::core::temporal::time` in `src/experimental/mnemosyne.rs` discovered by clippy.


---
*PR created automatically by Jules for task [6231458169893625594](https://jules.google.com/task/6231458169893625594) started by @madmax983*