### PR TITLE
🤖 Sentinel: [Killed mutant in WalRingBuffer backpressure logic]

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1457,4 +1457,54 @@ mod sentry_tests {
             "Error should mention dropped entry"
         );
     }
+
+    #[test]
+    fn test_sentry_backpressure_hang_protection() {
+        // 🛡️ Sentry: Verify that if a previous writer stalls (claims slot but doesn't write),
+        // a subsequent writer (lapping) returns Err instead of hanging forever.
+        // This targets the mutation: `distance_behind <= self.capacity` -> `distance_behind < self.capacity`
+
+        let config = BackpressureConfig {
+            initial_spins: 1,
+            max_spins: 1, // Fail fast
+            base_sleep_us: 0,
+            max_sleep_us: 0,
+        };
+        let buf = WalRingBuffer::with_config(2, config); // Capacity 2
+
+        // Simulate Writer A claiming slot 0 but stalling (not writing data/updating sequence)
+        // We do this by manually advancing write_pos
+        buf.write_pos.fetch_add(1, Ordering::Relaxed);
+
+        // At this point:
+        // write_pos = 1
+        // slot[0].sequence = 0 (Initial)
+        // expected_seq for writer at 0 was 0. It claimed it.
+        // But it didn't update sequence to 1.
+
+        // Writer B claims slot 1.
+        let entry_b = PendingEntry::new_async(LSN(1), vec![]);
+        buf.try_append(entry_b)
+            .expect("Writer B should succeed at slot 1");
+        // write_pos = 2.
+        // slot[1].sequence = 2 (Updated by try_append)
+
+        // Writer C tries to claim slot 0 (wrapping).
+        // expected_seq = 2.
+        // current_seq = 0 (Writer A stalled).
+        // distance_behind = 2 - 0 = 2.
+        // capacity = 2.
+        // distance_behind == capacity.
+
+        // If the code is correct (<= capacity), it should detect "Buffer Full" and return Err after spinning.
+        // If the mutant is present (< capacity), it will think "Another producer claimed it" and continue/loop forever.
+
+        let entry_c = PendingEntry::new_async(LSN(2), vec![]);
+        let result = buf.try_append(entry_c);
+
+        assert!(
+            result.is_err(),
+            "Should return Err (backpressure) when slot is stalled by previous writer"
+        );
+    }
 }

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1499,8 +1499,23 @@ mod sentry_tests {
         // If the code is correct (<= capacity), it should detect "Buffer Full" and return Err after spinning.
         // If the mutant is present (< capacity), it will think "Another producer claimed it" and continue/loop forever.
 
-        let entry_c = PendingEntry::new_async(LSN(2), vec![]);
-        let result = buf.try_append(entry_c);
+        // Wrap the call in a separate thread with a timeout to prevent hanging the entire test suite
+        // if the regression reappears.
+        let buf = std::sync::Arc::new(buf);
+        let buf_clone = buf.clone();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            let entry_c = PendingEntry::new_async(LSN(2), vec![]);
+            let result = buf_clone.try_append(entry_c);
+            tx.send(result).unwrap();
+        });
+
+        // Wait for the result with a timeout
+        let result = rx
+            .recv_timeout(std::time::Duration::from_millis(500))
+            .expect("Test timed out: try_append hung (likely regression of infinite loop bug)");
 
         assert!(
             result.is_err(),


### PR DESCRIPTION
**🧬 Mutants Found:** 1 surviving mutant in `src/storage/wal/ring_buffer.rs` (replaced `<=` with `<` in backpressure check).
**🎯 Tests Added/Strengthened:** Added `test_sentry_backpressure_hang_protection` to `mod sentry_tests`.
**Diagnosis:** The mutation `distance_behind <= self.capacity` -> `distance_behind < self.capacity` caused `try_append` to enter an infinite loop (hang) instead of returning `Err` when a previous writer stalled and the buffer was full (distance == capacity). Existing tests did not cover this specific "stalled writer" boundary condition.
**Kill Shot:** The new test manually simulates a stalled writer (advancing `write_pos` without updating sequence) and asserts that `try_append` returns `Err` (backpressure) instead of hanging. This test passes on the original code and fails (times out) on the mutant.
**📊 Kill Rate:** Improved coverage for `WalRingBuffer` concurrent edge cases.

---
*PR created automatically by Jules for task [10677579489204376379](https://jules.google.com/task/10677579489204376379) started by @madmax983*