### PR TITLE
docs: improve feature flag visibility in README example

### DIFF
--- a/DX_AUDIT_REPORT.md
+++ b/DX_AUDIT_REPORT.md
@@ -1,0 +1,26 @@
+# DX Audit Report - Echo 🗣️
+
+## Summary
+Audit performed by Echo to verify the Developer Experience of "Getting Started" with AletheiaDB.
+
+## Findings
+
+### 1. Feature Flag Visibility (Fixed)
+**Issue:** The "Narrative Generation" example requires the `nova` feature flag, which might be missed by users copying code blocks directly.
+**Fix:** Added explicit `// REQUIRES FEATURE: nova` comment to the top of the example code block in `README.md`.
+
+### 2. Result Type Shadowing (Action Required)
+**Issue:** `aletheiadb::prelude::Result` shadows `std::result::Result`.
+**Impact:** Users writing `fn main() -> Result<(), Box<dyn std::error::Error>>` will encounter a compilation error:
+```
+error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
+```
+This is because `aletheiadb::Result` expects 1 argument (`T`), defaulting `E` to `aletheiadb::Error`.
+
+**Recommendation:** Rename `Result` in `prelude` to `DbResult` or `AletheiaResult` in a future breaking release, or document this shadowing behavior prominently. Currently reverted to avoid breaking changes in patch/minor updates.
+
+### 3. Version Clarity
+**Observation:** `Cargo.toml` is at `0.1.0`. Documentation examples consistently use `0.1`. No discrepancies found in current state.
+
+## Conclusion
+The documentation has been improved to reduce friction regarding feature flags. The `Result` shadowing remains a potential stumble point for new users relying on standard Result patterns with prelude imports.

--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ for (node_id, drift_score) in drifted_nodes {
 > ```
 
 ```rust
+// REQUIRES FEATURE: nova
 // [dependencies]
 // aletheiadb = { version = "0.1", features = ["nova"] }
 


### PR DESCRIPTION
Performed a DX audit acting as "Echo".
Identified that the "Narrative Generation" example requires the `nova` feature, which can be missed.
Added a prominent comment to the example code block in `README.md`.
Also identified `Result` type shadowing in `prelude` as a friction point, but deferred fixing it to avoid breaking changes (documented in `DX_AUDIT_REPORT.md`).

---
*PR created automatically by Jules for task [7886286923571537957](https://jules.google.com/task/7886286923571537957) started by @madmax983*