### PR TITLE
🛡️ Elenchus: Strengthen WalRingBuffer safety tests

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -273,3 +273,13 @@
 **Finding:** `normalize` zeroes out vectors with small squared magnitudes (< `SQUARED_MAGNITUDE_THRESHOLD`), but `normalize_in_place` leaves them unchanged. This creates inconsistent behavior depending on which API is used.
 **Evidence:** Reproduction test `tests/repro_normalize_inconsistency.rs` failed, showing that `normalize_in_place` did not modify a tiny vector.
 **Resolution:** Updated `normalize_in_place` to explicitly zero out the vector if its magnitude is below the threshold. Added regression test `test_normalize_in_place_tiny_vector` in `src/core/vector/tests.rs`.
+
+## [WAL RingBuffer Safety Gaps]
+**Module:** `src/storage/wal/ring_buffer.rs`
+**Verdict:** 🟡 Suspect
+**Finding:** `WalRingBuffer` lacked explicit tests for:
+1.  **Drop Safety:** Ensuring pending entries are dropped and waiters notified if the buffer is destroyed (shutdown/panic).
+2.  **Strict Sequence Ordering:** Ensuring `drain` stops at gaps rather than skipping them, which would violate WAL ordering.
+3.  **Wraparound Logic:** Explicit verification of the `distance_behind` check at `u64::MAX`.
+**Evidence:** Existing tests covered concurrency well but missed these specific safety properties.
+**Resolution:** Added 3 sentinel tests in `src/storage/wal/ring_buffer.rs`: `test_buffer_drop_notifies_waiters`, `test_drain_stops_at_gap`, and `test_wraparound_boundary_check`.

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1457,4 +1457,133 @@ mod sentry_tests {
             "Error should mention dropped entry"
         );
     }
+
+    #[test]
+    fn test_buffer_drop_notifies_waiters() {
+        // 🛡️ Sentry: Verify that dropping the WalRingBuffer (e.g. during shutdown or panic)
+        // correctly drops all pending entries, which in turn triggers their error notification.
+        // This ensures no threads are left hanging waiting for a flush that will never happen.
+
+        let buf = WalRingBuffer::new(16);
+        let (entry, handle) = PendingEntry::new_sync(LSN(100), vec![]);
+
+        // Append entry to buffer
+        buf.try_append(entry).expect("Append should succeed");
+
+        // Verify it hasn't been flushed/completed yet
+        assert!(!handle.is_complete());
+
+        // Drop the buffer. The entry is inside.
+        // This simulates a shutdown or crash where the buffer is destroyed before flush.
+        drop(buf);
+
+        // The handle MUST return an error. If it blocks or returns Ok, we have a problem.
+        let result = handle.wait();
+        assert!(
+            result.is_err(),
+            "Waiter should be notified of error on buffer drop"
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("PendingEntry dropped"),
+            "Error should identify that entry was dropped"
+        );
+    }
+
+    #[test]
+    fn test_drain_stops_at_gap() {
+        // 🛡️ Sentry: Verify that drain() strictly adheres to sequence numbers and stops
+        // at the first gap. This ensures we never flush entries out of order.
+        //
+        // Scenario:
+        // - Buffer capacity 4
+        // - Write Pos 2 (expecting Slot 0 and Slot 1 to be filled)
+        // - Slot 1 is READY (seq updated)
+        // - Slot 0 is NOT READY (seq not updated)
+        //
+        // Outcome:
+        // - drain() should see Slot 0 is not ready and return NOTHING.
+        // - It must NOT skip Slot 0 and return Slot 1.
+
+        let mut buf = WalRingBuffer::new(4);
+
+        // Initialize state: write_pos=2, read_pos=0.
+        // set_state_for_wraparound_test initializes slots to "Available for Write" state.
+        // For Slot 0 (pos 0) this means seq=0.
+        // For Slot 1 (pos 1) this means seq=1.
+        //
+        // Expected seq for drain(read_pos=0) is 1.
+        // Expected seq for drain(read_pos=1) is 2.
+        buf.set_state_for_wraparound_test(2, 0);
+
+        // Manually set Slot 1 to READY (simulating a completed write).
+        // Position 1 has index 1.
+        // Ready sequence = pos + 1 = 1 + 1 = 2.
+        buf.slots[1].sequence.store(2, Ordering::Relaxed);
+        let (entry1, _) = PendingEntry::new_sync(LSN(1), vec![1]);
+        unsafe { *buf.slots[1].entry.get() = Some(entry1); }
+
+        // Leave Slot 0 as NOT READY (simulating a slow writer or crash).
+        // Current seq is 0 (from set_state). Expected is 1.
+        // 0 != 1, so not ready.
+        let (entry0, _) = PendingEntry::new_sync(LSN(0), vec![0]);
+        // We put the entry in, but don't update sequence.
+        unsafe { *buf.slots[0].entry.get() = Some(entry0); }
+
+        // Attempt drain
+        let drained = buf.drain();
+
+        // 🛡️ CRITICAL ASSERTION: Must be empty!
+        // If it returns [entry1], we have violated ordering guarantees.
+        assert!(
+            drained.is_empty(),
+            "Drain must stop at gap (slot 0) even if subsequent slots (slot 1) are ready"
+        );
+
+        // Now "fix" the gap by marking Slot 0 as READY.
+        // Position 0. Ready sequence = 0 + 1 = 1.
+        buf.slots[0].sequence.store(1, Ordering::Relaxed);
+
+        // Attempt drain again
+        let drained_retry = buf.drain();
+
+        // Should now get both entries in order
+        assert_eq!(drained_retry.len(), 2, "Should drain both entries after gap is filled");
+        assert_eq!(drained_retry[0].lsn, LSN(0));
+        assert_eq!(drained_retry[1].lsn, LSN(1));
+    }
+
+    #[test]
+    fn test_wraparound_boundary_check() {
+        // 🛡️ Sentry: Verify try_append logic exactly at the u64::MAX boundary.
+        // Specifically check the logic `distance_behind <= capacity`.
+
+        let capacity = 4;
+        let mut buf = WalRingBuffer::new(capacity);
+
+        // Set state to u64::MAX.
+        // We want write_pos = u64::MAX.
+        let boundary = u64::MAX;
+        buf.set_state_for_wraparound_test(boundary, boundary);
+
+        // 1. First append at u64::MAX.
+        // Should wrap to 0 for next pos.
+        let entry = PendingEntry::new_async(LSN(1), vec![]);
+        assert!(buf.try_append(entry).is_ok());
+
+        // New write_pos should be 0 (u64::MAX + 1 wrapped).
+        assert_eq!(buf.write_pos.load(Ordering::Relaxed), 0);
+
+        // 2. Check the slot state.
+        // The slot for u64::MAX is (MAX % 4) = 3.
+        // Its sequence should now be (MAX + 1) = 0.
+        // Wait, logic is:
+        // store(expected_seq.wrapping_add(1))
+        // expected_seq was u64::MAX.
+        // MAX + 1 = 0.
+        let slot_idx = (boundary % capacity as u64) as usize; // 3
+        let seq = buf.slots[slot_idx].sequence.load(Ordering::Relaxed);
+        assert_eq!(seq, 0, "Sequence should wrap to 0");
+    }
 }

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1509,30 +1509,30 @@ mod sentry_tests {
         let mut buf = WalRingBuffer::new(4);
 
         // Initialize state: write_pos=2, read_pos=0.
-        // set_state_for_wraparound_test initializes slots to "Available for Write" state.
-        // For Slot 0 (pos 0) this means seq=0.
-        // For Slot 1 (pos 1) this means seq=1.
-        //
-        // Expected seq for drain(read_pos=0) is 1.
-        // Expected seq for drain(read_pos=1) is 2.
+        // set_state_for_wraparound_test initializes slots starting from write_pos.
+        // For write_pos=2:
+        // - Slot 2 (pos 2): seq 2
+        // - Slot 3 (pos 3): seq 3
+        // - Slot 0 (pos 4): seq 4
+        // - Slot 1 (pos 5): seq 5
         buf.set_state_for_wraparound_test(2, 0);
 
-        // Manually set Slot 1 to READY (simulating a completed write).
-        // Position 1 has index 1.
-        // Ready sequence = pos + 1 = 1 + 1 = 2.
+        // Manually overwrite Slot 0 to simulate a GAP (write started but not ready).
+        // For read_pos=0, expected_seq is 1.
+        // We set seq=0 (initial state), so 0 < 1. This is a true "behind" gap.
+        buf.slots[0].sequence.store(0, Ordering::Relaxed);
+        let (entry0, _) = PendingEntry::new_sync(LSN(0), vec![0]);
+        unsafe {
+            *buf.slots[0].entry.get() = Some(entry0);
+        }
+
+        // Manually overwrite Slot 1 to simulate READY (write completed).
+        // For read_pos=1, expected_seq is 2.
+        // We set seq=2 (ready state).
         buf.slots[1].sequence.store(2, Ordering::Relaxed);
         let (entry1, _) = PendingEntry::new_sync(LSN(1), vec![1]);
         unsafe {
             *buf.slots[1].entry.get() = Some(entry1);
-        }
-
-        // Leave Slot 0 as NOT READY (simulating a slow writer or crash).
-        // Current seq is 0 (from set_state). Expected is 1.
-        // 0 != 1, so not ready.
-        let (entry0, _) = PendingEntry::new_sync(LSN(0), vec![0]);
-        // We put the entry in, but don't update sequence.
-        unsafe {
-            *buf.slots[0].entry.get() = Some(entry0);
         }
 
         // Attempt drain
@@ -1540,6 +1540,7 @@ mod sentry_tests {
 
         // 🛡️ CRITICAL ASSERTION: Must be empty!
         // If it returns [entry1], we have violated ordering guarantees.
+        // drain() should see Slot 0's seq(0) != expected(1) and stop.
         assert!(
             drained.is_empty(),
             "Drain must stop at gap (slot 0) even if subsequent slots (slot 1) are ready"
@@ -1575,23 +1576,46 @@ mod sentry_tests {
         let boundary = u64::MAX;
         buf.set_state_for_wraparound_test(boundary, boundary);
 
-        // 1. First append at u64::MAX.
-        // Should wrap to 0 for next pos.
-        let entry = PendingEntry::new_async(LSN(1), vec![]);
-        assert!(buf.try_append(entry).is_ok());
+        // Slot for boundary (u64::MAX) is index 3.
+        let slot_idx = (boundary % capacity as u64) as usize; // 3
+
+        // Case 1: Simulate "Buffer Full" at boundary.
+        // We want try_append to hit the `distance_behind` check and fail.
+        // expected_seq = boundary (MAX).
+        // We set current_seq to simulate it holding data from previous cycle (MAX - capacity + 1).
+        // distance_behind = MAX - (MAX - 4 + 1) = 3.
+        // 0 < 3 <= 4. Condition met -> Return Err.
+        let busy_seq = boundary.wrapping_sub(capacity as u64).wrapping_add(1);
+        buf.slots[slot_idx]
+            .sequence
+            .store(busy_seq, Ordering::Relaxed);
+
+        let entry_fail = PendingEntry::new_async(LSN(1), vec![]);
+        let result = buf.try_append(entry_fail);
+        assert!(
+            result.is_err(),
+            "Should return error when buffer is full at boundary"
+        );
+
+        // Case 2: Simulate "Available" at boundary.
+        // We set current_seq = boundary (MAX).
+        // Condition `current_seq == expected_seq` -> Success.
+        buf.slots[slot_idx]
+            .sequence
+            .store(boundary, Ordering::Relaxed);
+
+        let entry_ok = PendingEntry::new_async(LSN(1), vec![]);
+        assert!(
+            buf.try_append(entry_ok).is_ok(),
+            "Should append successfully when slot is available at boundary"
+        );
 
         // New write_pos should be 0 (u64::MAX + 1 wrapped).
         assert_eq!(buf.write_pos.load(Ordering::Relaxed), 0);
 
-        // 2. Check the slot state.
-        // The slot for u64::MAX is (MAX % 4) = 3.
-        // Its sequence should now be (MAX + 1) = 0.
-        // Wait, logic is:
-        // store(expected_seq.wrapping_add(1))
-        // expected_seq was u64::MAX.
-        // MAX + 1 = 0.
-        let slot_idx = (boundary % capacity as u64) as usize; // 3
+        // Check the slot state updated correctly.
+        // Logic: store(expected_seq.wrapping_add(1)) -> MAX + 1 -> 0.
         let seq = buf.slots[slot_idx].sequence.load(Ordering::Relaxed);
-        assert_eq!(seq, 0, "Sequence should wrap to 0");
+        assert_eq!(seq, 0, "Sequence should wrap to 0 after write at boundary");
     }
 }

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1522,14 +1522,18 @@ mod sentry_tests {
         // Ready sequence = pos + 1 = 1 + 1 = 2.
         buf.slots[1].sequence.store(2, Ordering::Relaxed);
         let (entry1, _) = PendingEntry::new_sync(LSN(1), vec![1]);
-        unsafe { *buf.slots[1].entry.get() = Some(entry1); }
+        unsafe {
+            *buf.slots[1].entry.get() = Some(entry1);
+        }
 
         // Leave Slot 0 as NOT READY (simulating a slow writer or crash).
         // Current seq is 0 (from set_state). Expected is 1.
         // 0 != 1, so not ready.
         let (entry0, _) = PendingEntry::new_sync(LSN(0), vec![0]);
         // We put the entry in, but don't update sequence.
-        unsafe { *buf.slots[0].entry.get() = Some(entry0); }
+        unsafe {
+            *buf.slots[0].entry.get() = Some(entry0);
+        }
 
         // Attempt drain
         let drained = buf.drain();
@@ -1549,7 +1553,11 @@ mod sentry_tests {
         let drained_retry = buf.drain();
 
         // Should now get both entries in order
-        assert_eq!(drained_retry.len(), 2, "Should drain both entries after gap is filled");
+        assert_eq!(
+            drained_retry.len(),
+            2,
+            "Should drain both entries after gap is filled"
+        );
         assert_eq!(drained_retry[0].lsn, LSN(0));
         assert_eq!(drained_retry[1].lsn, LSN(1));
     }


### PR DESCRIPTION
Strengthened the test suite for `WalRingBuffer` by adding targeted safety tests for drop behavior, sequence gaps, and wraparound boundaries. This ensures that the WAL ring buffer handles edge cases correctly and prevents potential deadlocks or data corruption.


---
*PR created automatically by Jules for task [5750567160305692419](https://jules.google.com/task/5750567160305692419) started by @madmax983*