### PR TITLE
🎻 Bard: Statistics documentation & fix magic constant

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -43,3 +43,7 @@
 ## 2024-05-29 - Experimental Feature Leaks
 **Confusion:** The `experimental` module documentation claimed that all features were gated behind `feature = "nova"`. However, `metaphor` and `muse` were publicly exposed even without the feature enabled, leading to inconsistent API availability and potential runtime panics (as `metaphor` used internal runtime checks instead of compile-time gating).
 **Clarification:** Updated `src/experimental/mod.rs` to explicitly gate `metaphor` and `muse` with `#[cfg(feature = "nova")]`, aligning the code with the documentation and ensuring a consistent compile-time experience.
+
+## 2024-05-30 - The Case of the Fake Statistic
+**Confusion:** The `Statistics::avg_delta_chain` field (used for cost-based optimization of temporal queries) was documented as "collected statistics" but was actually hardcoded to `5.0` in `refresh_statistics`, with a TODO comment (Issue #366) hidden in the implementation. This could mislead users debugging query performance on deep historical graphs.
+**Clarification:** Refactored `AletheiaDB::refresh_statistics` to calculate the actual average chain length from `HistoricalStorage` metadata (`total_versions / total_anchors`). Updated `Statistics` documentation to explain its lifecycle and role in query planning.

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -269,8 +269,7 @@ impl AletheiaDB {
         let historical_stats = self.historical.read().stats();
         let total_versions =
             historical_stats.total_node_versions + historical_stats.total_edge_versions;
-        let total_anchors =
-            historical_stats.node_anchor_count + historical_stats.edge_anchor_count;
+        let total_anchors = historical_stats.node_anchor_count + historical_stats.edge_anchor_count;
 
         let avg_delta_chain = if total_anchors > 0 {
             let interval = total_versions as f64 / total_anchors as f64;

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -265,9 +265,22 @@ impl AletheiaDB {
         let label_counts = self.current.label_counts();
 
         // Calculate average delta chain length from historical storage
-        // (using default estimate if historical storage is empty)
-        // See issue #366: Calculate from historical storage instead of hardcoding
-        let avg_delta_chain = 5.0;
+        // This is used for cost estimation of temporal lookups.
+        let historical_stats = self.historical.read().stats();
+        let total_versions =
+            historical_stats.total_node_versions + historical_stats.total_edge_versions;
+        let total_anchors =
+            historical_stats.node_anchor_count + historical_stats.edge_anchor_count;
+
+        let avg_delta_chain = if total_anchors > 0 {
+            let interval = total_versions as f64 / total_anchors as f64;
+            // Average reconstruction depth is roughly (interval - 1) / 2
+            (interval - 1.0) / 2.0
+        } else {
+            // Default estimate if historical storage is empty or has no anchors
+            // (Assumes anchor_interval=10, so avg depth ~5)
+            5.0
+        };
 
         self.stats.refresh(
             node_count,

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -1,7 +1,27 @@
 //! Statistics Collection for Query Optimization
 //!
 //! Provides cardinality and selectivity estimates for cost-based optimization.
-//! Statistics are collected lazily and cached until invalidated.
+//!
+//! # Role in Query Planning
+//!
+//! The query planner relies on accurate statistics to make informed decisions about:
+//! - **Join Order**: Which side of a join should be the build vs. probe side?
+//! - **Access Methods**: Should we use a full scan, an index lookup, or a vector search?
+//! - **Filter Ordering**: Which predicates should be applied first?
+//!
+//! # Lifecycle
+//!
+//! Statistics are **not** updated in real-time with every write operation to avoid
+//! lock contention on the shared `Statistics` structure. Instead, they follow a
+//! lazy/manual refresh model:
+//!
+//! 1. **Initialization**: Created with default/empty values.
+//! 2. **Lazy Refresh**: The database triggers a refresh on the first query execution.
+//! 3. **Manual Refresh**: Administrators can trigger a refresh via [`AletheiaDB::refresh_statistics`].
+//! 4. **Invalidation**: Schema changes (e.g., adding an index) invalidate the cache,
+//!    forcing a refresh on the next query.
+//!
+//! [`AletheiaDB::refresh_statistics`]: crate::db::AletheiaDB::refresh_statistics
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -46,30 +66,75 @@ impl Default for AtomicF64 {
 /// Statistics are collected lazily on first query and cached.
 /// They can be manually refreshed or automatically invalidated
 /// on schema changes.
+///
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::Statistics;
+/// use aletheiadb::core::interning::InternedString;
+///
+/// let stats = Statistics::new();
+///
+/// // Statistics are initially empty
+/// assert_eq!(stats.node_count(), 0);
+/// assert!(!stats.is_initialized());
+///
+/// // Manually refreshing statistics
+/// // In a real app, AletheiaDB::refresh_statistics() calls this
+/// stats.refresh(
+///     1000, // node_count
+///     5000, // edge_count
+///     100,  // vector_count
+///     vec![], // label_counts
+///     5.0   // avg_delta_chain
+/// );
+///
+/// assert_eq!(stats.node_count(), 1000);
+/// assert!(stats.is_initialized());
+/// ```
 #[derive(Debug, Default)]
 pub struct Statistics {
-    /// Whether statistics have been collected
+    /// Whether statistics have been collected.
+    ///
+    /// If false, the query engine will trigger a refresh before planning.
     initialized: AtomicBool,
 
-    /// Total node count
+    /// Total node count in the current graph.
+    ///
+    /// Used to estimate scan costs and filter selectivity.
     node_count: AtomicUsize,
 
-    /// Total edge count
+    /// Total edge count in the current graph.
+    ///
+    /// Used to estimate traversal costs and average degree.
     edge_count: AtomicUsize,
 
-    /// Number of indexed vectors
+    /// Number of indexed vectors.
+    ///
+    /// Used to estimate the cost of vector search operations.
     vector_count: AtomicUsize,
 
-    /// Label cardinalities
+    /// Label cardinalities (count of nodes per label).
+    ///
+    /// Used to estimate the output size of `ScanNodes(label)`.
     label_counts: DashMap<InternedString, usize>,
 
-    /// Average out-degree (edges per node)
+    /// Average out-degree (edges per node).
+    ///
+    /// Critical for estimating the explosion factor of graph traversals.
+    /// A high degree increases the cost of multi-hop queries exponentially.
     avg_out_degree: AtomicF64,
 
-    /// Average delta chain length in historical storage
+    /// Average delta chain length in historical storage.
+    ///
+    /// Represents the average number of versions one must walk back to find an anchor.
+    /// Used to estimate the I/O cost of temporal lookups (`AS OF` queries).
+    ///
+    /// - **Low value (near 1.0)**: Most lookups hit anchors directly (fast).
+    /// - **High value**: Lookups require applying many deltas (slow).
     avg_delta_chain: AtomicF64,
 
-    /// Property statistics for selectivity estimation
+    /// Property statistics for selectivity estimation.
     property_stats: RwLock<PropertyStats>,
 }
 
@@ -121,7 +186,7 @@ impl Statistics {
     pub fn average_delta_chain_length(&self) -> f64 {
         let avg = self.avg_delta_chain.load(Ordering::Relaxed);
         if avg < f64::EPSILON {
-            // Default estimate (anchor every 10 versions)
+            // Default estimate (anchor every 10 versions -> avg depth ~5)
             5.0
         } else {
             avg
@@ -138,6 +203,24 @@ impl Statistics {
     ///
     /// Returns a value between 0.0 and 1.0 indicating what fraction
     /// of rows would pass an equality predicate.
+    ///
+    /// If distinct counts are available, uses `1.0 / distinct_count`.
+    /// Otherwise, assumes a default selectivity of 10% (0.1).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    ///
+    /// // Default selectivity (unknown distribution)
+    /// assert_eq!(stats.estimate_selectivity("status", "active"), 0.1);
+    ///
+    /// // With known distinct counts (e.g. 2 statuses: active, inactive)
+    /// stats.update_property_stats("status", 2);
+    /// assert_eq!(stats.estimate_selectivity("status", "active"), 0.5);
+    /// ```
     #[must_use]
     pub fn estimate_selectivity(&self, property: &str, _value: &str) -> f64 {
         let stats = self.property_stats.read();
@@ -148,9 +231,10 @@ impl Statistics {
             .unwrap_or(0.1) // Default 10% selectivity
     }
 
-    /// Update statistics from storage
+    /// Update statistics from storage.
     ///
-    /// This is called lazily on first query or when explicitly requested.
+    /// This is called by [`AletheiaDB::refresh_statistics`](crate::db::AletheiaDB::refresh_statistics)
+    /// to populate the cache with fresh values from the storage engine.
     pub fn refresh(
         &self,
         node_count: usize,
@@ -181,12 +265,16 @@ impl Statistics {
         self.initialized.store(true, Ordering::Release);
     }
 
-    /// Invalidate cached statistics
+    /// Invalidate cached statistics.
+    ///
+    /// Forces the next query to trigger a refresh.
     pub fn invalidate(&self) {
         self.initialized.store(false, Ordering::Release);
     }
 
-    /// Update property statistics
+    /// Update property statistics.
+    ///
+    /// Used to feed distinct counts from background analysis jobs.
     pub fn update_property_stats(&self, property: &str, distinct_count: usize) {
         let mut stats = self.property_stats.write();
         stats


### PR DESCRIPTION
This PR improves the documentation of the `Statistics` module in the query planner, adding context about its lifecycle (lazy/manual refresh) and role in cost-based optimization. It also includes executable examples (doc tests).

Furthermore, it resolves a "magic constant" issue in `src/db/admin.rs` where the `avg_delta_chain` statistic was hardcoded to `5.0`. This has been replaced with a dynamic calculation based on historical storage metadata (`(total_versions / total_anchors - 1) / 2`).

This aligns with the "Bard" persona's goal of "Code as a medium for human communication" by making the code self-explanatory and the documentation robust.

---
*PR created automatically by Jules for task [14160440306359295524](https://jules.google.com/task/14160440306359295524) started by @madmax983*