### PR TITLE
fix(hnsw): prevent blocking async runtime during search retry

### DIFF
--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -4403,6 +4403,27 @@ mod coverage_additions {
         assert_eq!(index.stats.search_retry_failures.load(Ordering::Relaxed), 0);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_retry_usearch_logic_async_context() {
+        // This test replicates test_retry_usearch_logic but runs inside a multi-threaded tokio runtime.
+        // This ensures the block_in_place path is covered.
+        let index = create_test_index();
+        let mut attempts = 0;
+
+        // Simulate transient error loop
+        let result: crate::core::error::Result<()> = index.retry_usearch(
+            || {
+                attempts += 1;
+                Err("No available threads to lock".to_string())
+            },
+            "test_context",
+        );
+
+        // Should fail after retries (MAX_SEARCH_ATTEMPTS is 4)
+        assert!(result.is_err());
+        assert_eq!(attempts, 4);
+    }
+
     #[test]
     fn test_save_async_context() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/index/vector/hnsw.rs
+++ b/src/index/vector/hnsw.rs
@@ -1257,6 +1257,19 @@ impl VectorIndex for HnswIndex {
 
                         // Exponential backoff: 1ms, 2ms, 4ms
                         let delay_ms = 1u64 << attempt;
+
+                        #[cfg(any(feature = "tokio", feature = "embeddings"))]
+                        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                            #[allow(clippy::collapsible_if)]
+                            if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread
+                            {
+                                tokio::task::block_in_place(|| {
+                                    std::thread::sleep(std::time::Duration::from_millis(delay_ms))
+                                });
+                                continue;
+                            }
+                        }
+
                         std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                         continue;
                     }
@@ -1371,6 +1384,22 @@ impl VectorIndex for HnswIndex {
                                 {
                                     self.stats.search_retries.fetch_add(1, Ordering::Relaxed);
                                     let delay_ms = 1u64 << attempt;
+
+                                    #[cfg(any(feature = "tokio", feature = "embeddings"))]
+                                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                                        #[allow(clippy::collapsible_if)]
+                                        if handle.runtime_flavor()
+                                            == tokio::runtime::RuntimeFlavor::MultiThread
+                                        {
+                                            tokio::task::block_in_place(|| {
+                                                std::thread::sleep(
+                                                    std::time::Duration::from_millis(delay_ms),
+                                                )
+                                            });
+                                            continue;
+                                        }
+                                    }
+
                                     std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                                     continue;
                                 }
@@ -1528,6 +1557,19 @@ impl HnswIndex {
                     if is_retryable_usearch_error(&error_msg) && attempt + 1 < MAX_SEARCH_ATTEMPTS {
                         self.stats.search_retries.fetch_add(1, Ordering::Relaxed);
                         let delay_ms = 1u64 << attempt;
+
+                        #[cfg(any(feature = "tokio", feature = "embeddings"))]
+                        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                            #[allow(clippy::collapsible_if)]
+                            if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread
+                            {
+                                tokio::task::block_in_place(|| {
+                                    std::thread::sleep(std::time::Duration::from_millis(delay_ms))
+                                });
+                                continue;
+                            }
+                        }
+
                         std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                         continue;
                     }


### PR DESCRIPTION
Applied a fix to `src/index/vector/hnsw.rs` to use `tokio::task::block_in_place` for backoff sleeps when the `tokio` feature is enabled. This prevents the `search` retry loop from blocking the async reactor.

Also identified residual risks regarding `usearch` FFI safety and a missing loom test file.

---
*PR created automatically by Jules for task [2120905859338321897](https://jules.google.com/task/2120905859338321897) started by @madmax983*