### PR TITLE
Enforce vector dimension safety in experimental modules

### DIFF
--- a/src/experimental/dreamer.rs
+++ b/src/experimental/dreamer.rs
@@ -107,6 +107,14 @@ impl<'a> Dreamer<'a> {
         } else {
             let (first_time, first_vec) = snapshots.first().unwrap();
 
+            // Validate dimensions to prevent silent truncation/extrapolation errors
+            if first_vec.len() != last_vec.len() {
+                return Err(Error::Vector(VectorError::DimensionMismatch {
+                    expected: first_vec.len(),
+                    actual: last_vec.len(),
+                }));
+            }
+
             let duration_micros = last_time - first_time;
 
             if duration_micros <= 0 {

--- a/src/experimental/mnemosyne.rs
+++ b/src/experimental/mnemosyne.rs
@@ -115,10 +115,18 @@ impl<'a> Mnemosyne<'a> {
             if let (Some(last_vec), Some(curr_vec)) = (&last_kept_vector, &current_vector) {
                 // Calculate distance from LAST KEPT frame, not just previous version.
                 // This captures slow drift.
-                if let Ok(d) = euclidean_distance(last_vec, curr_vec) {
-                    distance = d;
-                    if distance > threshold {
+                match euclidean_distance(last_vec, curr_vec) {
+                    Ok(d) => {
+                        distance = d;
+                        if distance > threshold {
+                            semantic_change = true;
+                        }
+                    }
+                    Err(_) => {
+                        // Dimension mismatch or other vector error.
+                        // Treat as a significant structural change.
                         semantic_change = true;
+                        distance = f32::INFINITY;
                     }
                 }
             } else if last_kept_vector.is_some() != current_vector.is_some() {


### PR DESCRIPTION
Identified and fixed two correctness issues in experimental modules related to vector dimension handling:
1. `Dreamer` silently truncated vectors when zipping historical versions of different lengths, leading to mathematically invalid trajectory extrapolations. Added an explicit length check.
2. `Mnemosyne` silently ignored frames where `euclidean_distance` failed (due to dimension mismatch), causing data loss during memory consolidation. Added error handling to treat this as a significant change.

Verified with reproduction tests `dreamer_repro` and `mnemosyne_repro`.

---
*PR created automatically by Jules for task [4923976942867120550](https://jules.google.com/task/4923976942867120550) started by @madmax983*