### PR TITLE
fix(experimental): prevent panic and DoS in Chameleon context analysis

### DIFF
--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -96,10 +96,27 @@ impl<'a> Chameleon<'a> {
             return Ok(Vec::new());
         }
 
-        // 2. Extract Vectors
-        let mut data = Vec::with_capacity(neighbor_ids.len());
-        for &nid in &neighbor_ids {
+        // 2. Extract Vectors (with dimension consistency check)
+        // We limit analysis to a subset of neighbors to keep it interactive and prevent DoS
+        const MAX_CONTEXT_NEIGHBORS: usize = 100;
+        let limit = neighbor_ids.len().min(MAX_CONTEXT_NEIGHBORS);
+
+        let mut data = Vec::with_capacity(limit);
+        let mut expected_dim: Option<usize> = None;
+
+        for &nid in neighbor_ids.iter().take(limit) {
             if let Ok(vec) = self.get_node_vector(nid, property) {
+                // Initialize expected dimension from first valid vector
+                let dim = vec.len();
+                if let Some(expected) = expected_dim {
+                    if dim != expected {
+                        // Skip vectors with mismatched dimensions to prevent clustering panic
+                        continue;
+                    }
+                } else {
+                    expected_dim = Some(dim);
+                }
+
                 data.push((nid, vec));
             }
         }


### PR DESCRIPTION
This change addresses two risks in the `Chameleon` experimental module:
1.  **Panic on mixed vector dimensions:** `MiniKMeans` would panic if vectors of different lengths were passed. The fix enforces dimension consistency by filtering out vectors that do not match the dimension of the first valid vector found.
2.  **DoS on large neighborhoods:** `analyze_context` previously fetched all neighbors. The fix adds a hard limit (`MAX_CONTEXT_NEIGHBORS = 100`) to the number of neighbors analyzed, preventing performance cliffs and excessive memory usage on supernodes.

Verified with a reproduction test case (since deleted) and existing unit tests.

---
*PR created automatically by Jules for task [2746133919451932998](https://jules.google.com/task/2746133919451932998) started by @madmax983*