### PR TITLE
Fix panic in Chameleon: dimension mismatch & DoS protection

### DIFF
--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -90,17 +90,37 @@ impl<'a> Chameleon<'a> {
         property: &str,
         k: usize,
     ) -> Result<Vec<Aspect>> {
+        const MAX_CONTEXT_NEIGHBORS: usize = 100;
+
         // 1. Gather Neighbors
         let neighbor_ids = self.get_neighbors(node_id)?;
         if neighbor_ids.is_empty() {
             return Ok(Vec::new());
         }
 
+        // Limit to prevent DoS
+        let neighbor_iter = neighbor_ids.iter().take(MAX_CONTEXT_NEIGHBORS);
+
         // 2. Extract Vectors
-        let mut data = Vec::with_capacity(neighbor_ids.len());
-        for &nid in &neighbor_ids {
+        let mut data = Vec::with_capacity(neighbor_ids.len().min(MAX_CONTEXT_NEIGHBORS));
+        let mut expected_dim = None;
+
+        for &nid in neighbor_iter {
             if let Ok(vec) = self.get_node_vector(nid, property) {
-                data.push((nid, vec));
+                match expected_dim {
+                    None => {
+                        // First valid vector establishes the dimension
+                        expected_dim = Some(vec.len());
+                        data.push((nid, vec));
+                    }
+                    Some(dim) => {
+                        // Subsequent vectors must match
+                        if vec.len() == dim {
+                            data.push((nid, vec));
+                        }
+                        // Else: ignore mismatching vectors to prevent panic/garbage
+                    }
+                }
             }
         }
 

--- a/tests/chameleon_regression.rs
+++ b/tests/chameleon_regression.rs
@@ -1,0 +1,46 @@
+#![cfg(feature = "nova")]
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::experimental::chameleon::Chameleon;
+
+#[test]
+fn test_chameleon_dimension_mismatch_panic() {
+    let db = AletheiaDB::new().unwrap();
+    // Do NOT enable vector index to allow mixed dimensions in storage
+
+    let center = db
+        .create_node("Center", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Node 1: Dimension 2
+    let n1 = db
+        .create_node(
+            "A",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 1.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Node 2: Dimension 3
+    let n2 = db
+        .create_node(
+            "B",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 1.0, 1.0])
+                .build(),
+        )
+        .unwrap();
+
+    db.create_edge(center, n1, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(center, n2, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let chameleon = Chameleon::new(&db);
+
+    // This should no longer panic, and return a valid result (even if partial)
+    let result = chameleon.analyze_context(center, "vec", 2);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Fixed a critical panic in `analyze_context` caused by mismatched vector dimensions in `MiniKMeans` by filtering out inconsistent vectors. Also added `MAX_CONTEXT_NEIGHBORS = 100` to prevent Denial of Service on supernodes. Added regression test `tests/chameleon_regression.rs`.

---
*PR created automatically by Jules for task [7106018411610460528](https://jules.google.com/task/7106018411610460528) started by @madmax983*