### PR TITLE
Fix Chameleon panic and unbounded memory usage

### DIFF
--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -33,7 +33,7 @@
 //!
 //! // 1. Analyze Context
 //! // Find 2 distinct aspects of Node 123
-//! let aspects = chameleon.analyze_context(123.into(), "embedding", 2)?;
+//! let aspects = chameleon.analyze_context(123u64.into(), "embedding", 2)?;
 //!
 //! for (i, aspect) in aspects.iter().enumerate() {
 //!     println!("Aspect {}: Weight {:.2}", i, aspect.weight);
@@ -42,7 +42,7 @@
 //!
 //! // 2. Faceted Search
 //! // Search for nodes similar to Aspect 0 (e.g., the 'Tech' aspect)
-//! let results = chameleon.facet_search(123.into(), "embedding", 0, 10)?;
+//! let results = chameleon.facet_search(123u64.into(), "embedding", 0, 10)?;
 //!
 //! for (node, score) in results {
 //!     println!("Found similar node: {} (score: {})", node, score);

--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -90,16 +90,26 @@ impl<'a> Chameleon<'a> {
         property: &str,
         k: usize,
     ) -> Result<Vec<Aspect>> {
-        // 1. Gather Neighbors
+        // 1. Gather Neighbors (Limited)
         let neighbor_ids = self.get_neighbors(node_id)?;
         if neighbor_ids.is_empty() {
             return Ok(Vec::new());
         }
 
-        // 2. Extract Vectors
+        // 2. Extract Vectors with Dimension Consistency
         let mut data = Vec::with_capacity(neighbor_ids.len());
+        let mut expected_dim = None;
+
         for &nid in &neighbor_ids {
             if let Ok(vec) = self.get_node_vector(nid, property) {
+                // Establish expected dimension from the first valid vector
+                if let Some(dim) = expected_dim {
+                    if vec.len() != dim {
+                        continue; // Skip mismatched dimensions to prevent panic
+                    }
+                } else {
+                    expected_dim = Some(vec.len());
+                }
                 data.push((nid, vec));
             }
         }
@@ -197,12 +207,17 @@ impl<'a> Chameleon<'a> {
 
     // --- Helpers ---
 
+    const MAX_CONTEXT_NEIGHBORS: usize = 100;
+
     fn get_neighbors(&self, node_id: NodeId) -> Result<Vec<NodeId>> {
-        let outgoing = self.db.get_outgoing_edges(node_id);
-        let mut neighbors = Vec::with_capacity(outgoing.len());
-        for edge_id in outgoing {
-            let edge = self.db.get_edge(edge_id)?;
-            neighbors.push(edge.target);
+        let outgoing_iter = self.db.get_outgoing_edges_iter(node_id);
+        let mut neighbors = Vec::with_capacity(Self::MAX_CONTEXT_NEIGHBORS);
+
+        for edge_id in outgoing_iter.take(Self::MAX_CONTEXT_NEIGHBORS) {
+            // Use zero-copy access to target node
+            if let Ok(target) = self.db.get_edge_target(edge_id) {
+                neighbors.push(target);
+            }
         }
         Ok(neighbors)
     }

--- a/src/experimental/janus.rs
+++ b/src/experimental/janus.rs
@@ -19,6 +19,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let db = AletheiaDB::new()?;
 //! let janus = JanusDetector::new(&db);
+//! let node_id = 1u64.into();
 //!
 //! let score = janus.analyze_node(node_id, "embedding")?;
 //!

--- a/src/experimental/ripple.rs
+++ b/src/experimental/ripple.rs
@@ -30,8 +30,10 @@
 //! let detector = RippleDetector::new(&db);
 //!
 //! // Look for causal ripples in the last hour, with 1-minute resolution
+//! let now = time::now();
+//! let start = (now.wallclock() - 3600 * 1_000_000).into();
 //! let config = RippleConfig {
-//!     window: TimeRange::new(time::now() - 3600 * 1_000_000, time::now())?,
+//!     window: TimeRange::new(start, now)?,
 //!     bin_size_us: 60 * 1_000_000, // 1 minute
 //!     max_lag_bins: 10,            // Check lag up to 10 minutes
 //!     min_correlation: 0.5,        // Minimum correlation to report

--- a/tests/regression_chameleon.rs
+++ b/tests/regression_chameleon.rs
@@ -1,0 +1,49 @@
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::experimental::chameleon::Chameleon;
+
+#[test]
+fn test_chameleon_dimension_mismatch_handled() {
+    let db = AletheiaDB::new().unwrap();
+
+    let center = db
+        .create_node("Center", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Neighbor 1: Dim 2
+    let n1 = db
+        .create_node(
+            "N1",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Neighbor 2: Dim 3
+    let n2 = db
+        .create_node(
+            "N2",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 0.0, 1.0])
+                .build(),
+        )
+        .unwrap();
+
+    db.create_edge(center, n1, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(center, n2, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let chameleon = Chameleon::new(&db);
+
+    // This should NOT panic anymore
+    let aspects = chameleon.analyze_context(center, "vec", 2).unwrap();
+
+    // One of them should be filtered out, so we expect 1 aspect (since k=2 but valid data=1)
+    assert_eq!(
+        aspects.len(),
+        1,
+        "Should filter out mismatched dimensions and return 1 aspect"
+    );
+}

--- a/tests/regression_chameleon.rs
+++ b/tests/regression_chameleon.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "nova")]
+
 use aletheiadb::AletheiaDB;
 use aletheiadb::core::property::PropertyMapBuilder;
 use aletheiadb::experimental::chameleon::Chameleon;


### PR DESCRIPTION
Identified and fixed a panic in `MiniKMeans` when clustering vectors of inconsistent dimensions, which could be triggered by `Chameleon::analyze_context`. Added a regression test to verify the fix.

Also addressed a potential DoS vector where `analyze_context` would load all neighbors into memory, by adding a hard limit `MAX_CONTEXT_NEIGHBORS` and using iterator-based traversal.

---
*PR created automatically by Jules for task [15144416921286889521](https://jules.google.com/task/15144416921286889521) started by @madmax983*