### PR TITLE
Fix panic in Chameleon context analysis due to mixed vector dimensions

### DIFF
--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -108,6 +108,15 @@ impl<'a> Chameleon<'a> {
             return Ok(Vec::new());
         }
 
+        // Validate dimensions to prevent panic in MiniKMeans
+        let dim = data[0].1.len();
+        if dim == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Filter out vectors with inconsistent dimensions
+        data.retain(|(_, vec)| vec.len() == dim);
+
         // 3. Cluster (K-Means)
         // If k > data.len(), we clamp it.
         let effective_k = k.min(data.len());

--- a/tests/regression_chameleon_dim_mismatch.rs
+++ b/tests/regression_chameleon_dim_mismatch.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "nova")]
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::experimental::chameleon::Chameleon;
+
+#[test]
+fn test_chameleon_panic_with_mixed_dimensions() {
+    let db = AletheiaDB::new().unwrap();
+
+    // Create center node
+    let center = db
+        .create_node("Center", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Create neighbor 1 with 2D vector
+    let n1 = db
+        .create_node(
+            "A",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Create neighbor 2 with 3D vector
+    let n2 = db
+        .create_node(
+            "A",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 0.0, 0.5])
+                .build(),
+        )
+        .unwrap();
+
+    db.create_edge(center, n1, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(center, n2, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let chameleon = Chameleon::new(&db);
+
+    // This is expected to panic in the current implementation
+    let result = chameleon.analyze_context(center, "vec", 2);
+
+    // We want to see if it panicked or returned an error
+    assert!(result.is_err() || result.is_ok());
+}


### PR DESCRIPTION
Fixes a panic in `Chameleon::analyze_context` when processing neighbors with inconsistent vector dimensions. This prevents a potential DoS where malformed data could crash the application. The fix enforces uniform vector dimensions by filtering out inconsistencies before clustering.

---
*PR created automatically by Jules for task [2240590471561593332](https://jules.google.com/task/2240590471561593332) started by @madmax983*