### PR TITLE
Fix panic in Chameleon on dimension mismatch

### DIFF
--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -112,7 +112,9 @@ impl<'a> Chameleon<'a> {
                             // Note: Using eprintln! because 'log' crate is not a direct dependency of 'nova' feature
                             eprintln!(
                                 "WARN [Chameleon]: Skipping vector for neighbor {} due to dimension mismatch (expected {}, got {})",
-                                nid, dim, vec.len()
+                                nid,
+                                dim,
+                                vec.len()
                             );
                         }
                     }

--- a/src/experimental/chameleon.rs
+++ b/src/experimental/chameleon.rs
@@ -98,9 +98,29 @@ impl<'a> Chameleon<'a> {
 
         // 2. Extract Vectors
         let mut data = Vec::with_capacity(neighbor_ids.len());
+        // Establish expected dimension from the first valid vector found
+        let mut expected_dim: Option<usize> = None;
+
         for &nid in &neighbor_ids {
             if let Ok(vec) = self.get_node_vector(nid, property) {
-                data.push((nid, vec));
+                match expected_dim {
+                    Some(dim) => {
+                        if vec.len() == dim {
+                            data.push((nid, vec));
+                        } else {
+                            // Ignore vectors with mismatched dimensions to prevent panics in MiniKMeans
+                            // Note: Using eprintln! because 'log' crate is not a direct dependency of 'nova' feature
+                            eprintln!(
+                                "WARN [Chameleon]: Skipping vector for neighbor {} due to dimension mismatch (expected {}, got {})",
+                                nid, dim, vec.len()
+                            );
+                        }
+                    }
+                    None => {
+                        expected_dim = Some(vec.len());
+                        data.push((nid, vec));
+                    }
+                }
             }
         }
 

--- a/tests/regression_chameleon_dim_mismatch.rs
+++ b/tests/regression_chameleon_dim_mismatch.rs
@@ -1,0 +1,65 @@
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::experimental::chameleon::Chameleon;
+
+#[test]
+// This test verifies that Chameleon::analyze_context handles dimension mismatch
+// gracefully by ignoring vectors with inconsistent dimensions, instead of panicking.
+fn test_chameleon_ignores_dimension_mismatch() {
+    let db = AletheiaDB::new().unwrap();
+
+    // Create Central Node
+    let center = db
+        .create_node("Center", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Create Neighbor 1 with dimension 2 (This sets the expected dimension)
+    let n1 = db
+        .create_node(
+            "N1",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[1.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Create Neighbor 2 with dimension 3 (mismatch!)
+    let n2 = db
+        .create_node(
+            "N2",
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[0.0, 1.0, 0.5])
+                .build(),
+        )
+        .unwrap();
+
+    // Connect
+    db.create_edge(center, n1, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(center, n2, "LINK", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let chameleon = Chameleon::new(&db);
+
+    // This should NOT panic. It should return aspects based on valid vectors (n1).
+    let aspects = chameleon.analyze_context(center, "vec", 2);
+
+    assert!(
+        aspects.is_ok(),
+        "analyze_context failed: {:?}",
+        aspects.err()
+    );
+    let aspects = aspects.unwrap();
+
+    // Should find at least 1 aspect (from n1)
+    // n2 is ignored, so effectively we have 1 neighbor.
+    // If K=2 requested but only 1 point, we get 1 cluster.
+    assert!(!aspects.is_empty(), "Should find at least one aspect");
+
+    // Verify the aspect centroid matches n1 (since it's the only valid neighbor)
+    let centroid = &aspects[0].centroid;
+    assert_eq!(centroid.len(), 2, "Aspect centroid should have dimension 2");
+    // n1 is [1.0, 0.0], normalized is [1.0, 0.0]
+    assert!((centroid[0] - 1.0).abs() < 1e-6);
+    assert!((centroid[1] - 0.0).abs() < 1e-6);
+}

--- a/tests/regression_chameleon_dim_mismatch.rs
+++ b/tests/regression_chameleon_dim_mismatch.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "nova")]
+
 use aletheiadb::AletheiaDB;
 use aletheiadb::core::property::PropertyMapBuilder;
 use aletheiadb::experimental::chameleon::Chameleon;


### PR DESCRIPTION
This PR fixes a panic in the experimental Chameleon module where `MiniKMeans` would crash if input vectors had inconsistent dimensions. 

The fix involves:
1.  Establishing an expected dimension from the first valid vector found in `analyze_context`.
2.  Filtering out any subsequent vectors that do not match this expected dimension.
3.  Logging a warning (using `eprintln!`) for each skipped vector.

A new regression test `tests/regression_chameleon_dim_mismatch.rs` has been added to verify that the system now handles mismatched dimensions gracefully instead of panicking.

---
*PR created automatically by Jules for task [7039804270214844374](https://jules.google.com/task/7039804270214844374) started by @madmax983*