### PR TITLE
⚡ Bolt: Zero-copy node access optimization

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -80,6 +80,13 @@ impl AletheiaDB {
     /// - **No allocation**: Does not clone the Node
     /// - **No Arc increment**: Does not increment PropertyMap reference count (unless cloned in closure)
     /// - **Lock duration**: Holds DashMap read lock only during closure execution
+    ///
+    /// # Safety & Deadlocks
+    ///
+    /// **WARNING**: The closure is executed while holding a read lock on the node shard.
+    /// Do NOT attempt to modify the graph or perform operations that might acquire a
+    /// write lock on the same shard (e.g., `update_node`, `delete_node`) within the closure.
+    /// Doing so will cause a deadlock (lock re-entrancy hazard).
     #[inline]
     pub fn with_node<F, R>(&self, id: NodeId, f: F) -> Result<R>
     where

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -70,6 +70,24 @@ impl AletheiaDB {
         self.current.get_node(node_id)
     }
 
+    /// Access a node without cloning, executing a closure on the node data.
+    ///
+    /// This method provides zero-copy read access to node data for hot paths
+    /// where only specific fields are needed.
+    ///
+    /// # Performance
+    ///
+    /// - **No allocation**: Does not clone the Node
+    /// - **No Arc increment**: Does not increment PropertyMap reference count (unless cloned in closure)
+    /// - **Lock duration**: Holds DashMap read lock only during closure execution
+    #[inline]
+    pub fn with_node<F, R>(&self, id: NodeId, f: F) -> Result<R>
+    where
+        F: FnOnce(&Node) -> R,
+    {
+        self.current.with_node(id, f)
+    }
+
     /// Get the current state of an edge.
     pub fn get_edge(&self, edge_id: EdgeId) -> Result<Edge> {
         self.current.get_edge(edge_id)

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -483,6 +483,26 @@ impl CurrentStorage {
             .ok_or_else(|| StorageError::NodeNotFound(id).into())
     }
 
+    /// Access a node without cloning, executing a closure on the node data.
+    ///
+    /// This method provides zero-copy read access to node data for hot paths
+    /// where only specific fields are needed.
+    ///
+    /// # Performance
+    ///
+    /// - **No allocation**: Does not clone the Node
+    /// - **No Arc increment**: Does not increment PropertyMap reference count (unless cloned in closure)
+    /// - **Lock duration**: Holds DashMap read lock only during closure execution
+    #[inline]
+    pub fn with_node<F, R>(&self, id: NodeId, f: F) -> Result<R>
+    where
+        F: FnOnce(&Node) -> R,
+    {
+        self.indexes
+            .with_node(id, f)
+            .ok_or_else(|| StorageError::NodeNotFound(id).into())
+    }
+
     /// Get an edge by ID.
     pub fn get_edge(&self, id: EdgeId) -> Result<Edge> {
         self.indexes
@@ -644,12 +664,12 @@ impl CurrentStorage {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
         // Save old node for vector index update
-        let old_node = self.indexes.get_node(node.id);
+        let old_props = self.indexes.with_node(node.id, |n| n.properties.clone());
 
         // Update vector index BEFORE updating node in main indexes.
         // If vector indexing fails, we haven't modified any state yet.
-        if let Some(ref old) = old_node {
-            self.update_vector_index(node.id, &node.properties, &old.properties)?;
+        if let Some(old_p) = old_props {
+            self.update_vector_index(node.id, &node.properties, &old_p)?;
         }
 
         // Update temporal vector index if enabled
@@ -2096,20 +2116,20 @@ impl CurrentStorage {
     ///
     /// Returns (property_name, index, config).
     fn get_node_vector(&self, node_id: NodeId, prop_name: &str) -> Result<Arc<[f32]>> {
-        let node = self
-            .indexes
-            .get_node(node_id)
-            .ok_or(StorageError::NodeNotFound(node_id))?;
-
-        node.properties
-            .get(prop_name)
-            .ok_or_else(|| StorageError::PropertyNotFound(prop_name.to_string()))?
-            .as_arc_vector()
-            .ok_or_else(|| {
-                crate::core::error::Error::Vector(crate::core::error::VectorError::InvalidVector {
-                    reason: "Property is not a vector".to_string(),
+        self.indexes
+            .with_node(node_id, |node| {
+                let val = node.properties.get(prop_name).ok_or_else(|| {
+                    crate::core::error::Error::Storage(StorageError::PropertyNotFound(
+                        prop_name.to_string(),
+                    ))
+                })?;
+                val.as_arc_vector().ok_or_else(|| {
+                    crate::core::error::Error::Vector(crate::core::error::VectorError::InvalidVector {
+                        reason: "Property is not a vector".to_string(),
+                    })
                 })
             })
+            .ok_or_else(|| crate::core::error::Error::Storage(StorageError::NodeNotFound(node_id)))?
     }
 
     fn get_vector_index_internal(

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2142,7 +2142,9 @@ impl CurrentStorage {
                     })
             })
             .transpose()?
-            .ok_or_else(|| crate::core::error::Error::Storage(StorageError::NodeNotFound(node_id)))
+            .ok_or(crate::core::error::Error::Storage(StorageError::NodeNotFound(
+                node_id,
+            )))
     }
 
     fn get_vector_index_internal(

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -493,6 +493,13 @@ impl CurrentStorage {
     /// - **No allocation**: Does not clone the Node
     /// - **No Arc increment**: Does not increment PropertyMap reference count (unless cloned in closure)
     /// - **Lock duration**: Holds DashMap read lock only during closure execution
+    ///
+    /// # Safety & Deadlocks
+    ///
+    /// **WARNING**: The closure is executed while holding a read lock on the node shard.
+    /// Do NOT attempt to modify the graph or perform operations that might acquire a
+    /// write lock on the same shard (e.g., `update_node`, `delete_node`) within the closure.
+    /// Doing so will cause a deadlock (lock re-entrancy hazard).
     #[inline]
     pub fn with_node<F, R>(&self, id: NodeId, f: F) -> Result<R>
     where
@@ -2118,18 +2125,26 @@ impl CurrentStorage {
     fn get_node_vector(&self, node_id: NodeId, prop_name: &str) -> Result<Arc<[f32]>> {
         self.indexes
             .with_node(node_id, |node| {
-                let val = node.properties.get(prop_name).ok_or_else(|| {
-                    crate::core::error::Error::Storage(StorageError::PropertyNotFound(
-                        prop_name.to_string(),
-                    ))
-                })?;
-                val.as_arc_vector().ok_or_else(|| {
-                    crate::core::error::Error::Vector(crate::core::error::VectorError::InvalidVector {
-                        reason: "Property is not a vector".to_string(),
+                node.properties
+                    .get(prop_name)
+                    .ok_or_else(|| {
+                        crate::core::error::Error::Storage(StorageError::PropertyNotFound(
+                            prop_name.to_string(),
+                        ))
+                    })?
+                    .as_arc_vector()
+                    .ok_or_else(|| {
+                        crate::core::error::Error::Vector(
+                            crate::core::error::VectorError::InvalidVector {
+                                reason: "Property is not a vector".to_string(),
+                            },
+                        )
                     })
-                })
             })
-            .ok_or_else(|| crate::core::error::Error::Storage(StorageError::NodeNotFound(node_id)))?
+            .transpose()?
+            .ok_or_else(|| {
+                crate::core::error::Error::Storage(StorageError::NodeNotFound(node_id))
+            })
     }
 
     fn get_vector_index_internal(

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2142,9 +2142,9 @@ impl CurrentStorage {
                     })
             })
             .transpose()?
-            .ok_or(crate::core::error::Error::Storage(StorageError::NodeNotFound(
-                node_id,
-            )))
+            .ok_or(crate::core::error::Error::Storage(
+                StorageError::NodeNotFound(node_id),
+            ))
     }
 
     fn get_vector_index_internal(

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2142,9 +2142,7 @@ impl CurrentStorage {
                     })
             })
             .transpose()?
-            .ok_or_else(|| {
-                crate::core::error::Error::Storage(StorageError::NodeNotFound(node_id))
-            })
+            .ok_or_else(|| crate::core::error::Error::Storage(StorageError::NodeNotFound(node_id)))
     }
 
     fn get_vector_index_internal(

--- a/tests/coverage_bolt_optimization.rs
+++ b/tests/coverage_bolt_optimization.rs
@@ -1,21 +1,26 @@
-use aletheiadb::{AletheiaDB, PropertyMapBuilder, NodeId};
+use aletheiadb::{AletheiaDB, NodeId, PropertyMapBuilder};
 
 #[test]
 fn test_with_node_api_coverage() {
     let db = AletheiaDB::new().expect("Failed to open DB");
 
     // 1. Create a node
-    let props = PropertyMapBuilder::new()
-        .insert("name", "Alice")
-        .build();
-    let node_id = db.create_node("Person", props).expect("Failed to create node");
+    let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+    let node_id = db
+        .create_node("Person", props)
+        .expect("Failed to create node");
 
     // 2. Test success path: AletheiaDB::with_node
     // This exercises AletheiaDB::with_node -> CurrentStorage::with_node -> CurrentIndexes::with_node
-    let name_len = db.with_node(node_id, |n| {
-        // Access property without cloning entire node
-        n.properties.get("name").map(|v| v.as_str().unwrap_or("").len()).unwrap_or(0)
-    }).expect("with_node failed");
+    let name_len = db
+        .with_node(node_id, |n| {
+            // Access property without cloning entire node
+            n.properties
+                .get("name")
+                .map(|v| v.as_str().unwrap_or("").len())
+                .unwrap_or(0)
+        })
+        .expect("with_node failed");
 
     assert_eq!(name_len, 5); // "Alice".len()
 
@@ -33,9 +38,10 @@ fn test_get_node_vector_failure_coverage() {
 
     // 1. Test failure: node not found (should trigger the NodeNotFound path in get_node_vector)
     // We can trigger get_node_vector via find_similar, but vector index must be enabled first
-    use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+    use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
     let config = HnswConfig::new(2, DistanceMetric::Cosine);
-    db.enable_vector_index("embedding", config).expect("Failed to enable index");
+    db.enable_vector_index("embedding", config)
+        .expect("Failed to enable index");
 
     let non_existent = NodeId::new(9999).unwrap();
     // This calls find_similar -> get_vector_index_internal -> get_node_vector
@@ -55,17 +61,27 @@ fn test_get_node_vector_failure_coverage() {
     assert!(result.is_err());
     let err = result.unwrap_err();
     let err_msg = format!("{}", err);
-    assert!(err_msg.contains("Property") && err_msg.contains("not found"), "Actual error: {}", err_msg);
+    assert!(
+        err_msg.contains("Property") && err_msg.contains("not found"),
+        "Actual error: {}",
+        err_msg
+    );
 
     // 3. Test failure: invalid vector (triggers InvalidVector path in get_node_vector)
     let props_invalid = PropertyMapBuilder::new()
         .insert("embedding", "not a vector")
         .build();
-    let node_id_invalid = db.create_node("Person", props_invalid).expect("Created node");
+    let node_id_invalid = db
+        .create_node("Person", props_invalid)
+        .expect("Created node");
 
     let result = db.find_similar(node_id_invalid, 1);
     assert!(result.is_err());
     let err = result.unwrap_err();
     let err_msg = format!("{}", err);
-    assert!(err_msg.contains("Property is not a vector"), "Actual error: {}", err_msg);
+    assert!(
+        err_msg.contains("Property is not a vector"),
+        "Actual error: {}",
+        err_msg
+    );
 }

--- a/tests/coverage_bolt_optimization.rs
+++ b/tests/coverage_bolt_optimization.rs
@@ -1,0 +1,71 @@
+use aletheiadb::{AletheiaDB, PropertyMapBuilder, NodeId};
+
+#[test]
+fn test_with_node_api_coverage() {
+    let db = AletheiaDB::new().expect("Failed to open DB");
+
+    // 1. Create a node
+    let props = PropertyMapBuilder::new()
+        .insert("name", "Alice")
+        .build();
+    let node_id = db.create_node("Person", props).expect("Failed to create node");
+
+    // 2. Test success path: AletheiaDB::with_node
+    // This exercises AletheiaDB::with_node -> CurrentStorage::with_node -> CurrentIndexes::with_node
+    let name_len = db.with_node(node_id, |n| {
+        // Access property without cloning entire node
+        n.properties.get("name").map(|v| v.as_str().unwrap_or("").len()).unwrap_or(0)
+    }).expect("with_node failed");
+
+    assert_eq!(name_len, 5); // "Alice".len()
+
+    // 3. Test failure path: AletheiaDB::with_node (non-existent node)
+    let non_existent = NodeId::new(9999).unwrap();
+    let result = db.with_node(non_existent, |_| 0);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(format!("{}", err).contains("not found"));
+}
+
+#[test]
+fn test_get_node_vector_failure_coverage() {
+    let db = AletheiaDB::new().expect("Failed to open DB");
+
+    // 1. Test failure: node not found (should trigger the NodeNotFound path in get_node_vector)
+    // We can trigger get_node_vector via find_similar, but vector index must be enabled first
+    use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+    let config = HnswConfig::new(2, DistanceMetric::Cosine);
+    db.enable_vector_index("embedding", config).expect("Failed to enable index");
+
+    let non_existent = NodeId::new(9999).unwrap();
+    // This calls find_similar -> get_vector_index_internal -> get_node_vector
+    let result = db.find_similar(non_existent, 1);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    // The exact error message depends on how StorageError is formatted
+    let err_msg = format!("{}", err);
+    assert!(err_msg.contains("not found"), "Actual error: {}", err_msg);
+
+    // 2. Test failure: property not found (triggers PropertyNotFound path in get_node_vector)
+    let props = PropertyMapBuilder::new().insert("name", "Bob").build();
+    let node_id = db.create_node("Person", props).expect("Created node");
+
+    let result = db.find_similar(node_id, 1);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let err_msg = format!("{}", err);
+    assert!(err_msg.contains("Property") && err_msg.contains("not found"), "Actual error: {}", err_msg);
+
+    // 3. Test failure: invalid vector (triggers InvalidVector path in get_node_vector)
+    let props_invalid = PropertyMapBuilder::new()
+        .insert("embedding", "not a vector")
+        .build();
+    let node_id_invalid = db.create_node("Person", props_invalid).expect("Created node");
+
+    let result = db.find_similar(node_id_invalid, 1);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let err_msg = format!("{}", err);
+    assert!(err_msg.contains("Property is not a vector"), "Actual error: {}", err_msg);
+}


### PR DESCRIPTION
💡 What: Introduced `with_node` method in `CurrentStorage` and `AletheiaDB` to access node data via a closure without cloning the entire `Node` struct. Updated `update_node_direct` and `get_node_vector` to use this new method.

🎯 Why: To reduce unnecessary memory allocations and Arc cloning on hot paths like node updates and vector searches. `get_node` clones the `Node` struct (including `Arc<PropertyMap>`), which is wasteful when only specific fields are needed.

📊 Impact: Removes one `Node` struct allocation/clone per update and per vector search query.

🔬 Measurement: Verified with `tests/repro_update_node.rs` ensuring functional correctness of updates and vector searches.

---
*PR created automatically by Jules for task [3883153045607373876](https://jules.google.com/task/3883153045607373876) started by @madmax983*