### PR TITLE
🎻 Bard: Enhance MCP Server and Parser Documentation

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -287,7 +287,7 @@ impl AletheiaMcpServer {
     /// # Example Request
     ///
     /// ```rust
-    /// use aletheiadb::mcp::tools::CreateNodeRequest;
+    /// use aletheiadb::mcp::CreateNodeRequest;
     /// use std::collections::HashMap;
     /// use serde_json::json;
     ///

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -25,6 +25,78 @@
 //! | **Temporal** | `get_node_at_time`, `get_node_history` | Time-travel queries and history |
 //! | **Hybrid** | `hybrid_query` | Combined graph + vector + temporal queries |
 //!
+//! # Examples
+//!
+//! Below are examples of how to interact with the key tools using JSON-RPC requests (the underlying protocol of MCP).
+//!
+//! ## 1. Creating a Node
+//!
+//! **Request:** `create_node`
+//! ```json
+//! {
+//!   "label": "Person",
+//!   "properties": {
+//!     "name": "Alice",
+//!     "age": 30,
+//!     "interests": ["Rust", "Graphs"]
+//!   }
+//! }
+//! ```
+//!
+//! **Response:**
+//! ```json
+//! {
+//!   "id": 1,
+//!   "label": "Person",
+//!   "properties": {
+//!     "name": "Alice",
+//!     "age": 30,
+//!     "interests": ["Rust", "Graphs"]
+//!   }
+//! }
+//! ```
+//!
+//! ## 2. Vector Search
+//!
+//! **Request:** `find_similar`
+//! ```json
+//! {
+//!   "property_name": "embedding",
+//!   "embedding": [0.1, 0.2, 0.3, ...],
+//!   "k": 5
+//! }
+//! ```
+//!
+//! **Response:**
+//! ```json
+//! {
+//!   "results": [
+//!     {
+//!       "node": {
+//!         "id": 42,
+//!         "label": "Document",
+//!         "properties": { "title": "Rust Guide", ... }
+//!       },
+//!       "score": 0.98
+//!     },
+//!     ...
+//!   ],
+//!   "count": 5
+//! }
+//! ```
+//!
+//! ## 3. Hybrid Query (Graph + Vector + Time)
+//!
+//! **Request:** `hybrid_query`
+//! ```json
+//! {
+//!   "start_node_id": 1,
+//!   "traverse_edge": "KNOWS",
+//!   "query_embedding": [0.1, 0.2, ...],
+//!   "valid_time": "2024-01-01T00:00:00Z"
+//! }
+//! ```
+//!
 //! # Usage
 //!
 //! The server is typically run as a standalone binary communicating over stdio:
@@ -181,7 +253,26 @@ impl AletheiaMcpServer {
     /// Get a node by its ID.
     ///
     /// Returns the node's label and all properties in JSON format.
-    /// If the node is not found, returns an error JSON.
+    ///
+    /// # Output Format
+    ///
+    /// ```json
+    /// {
+    ///   "id": 123,
+    ///   "label": "Person",
+    ///   "properties": {
+    ///     "name": "Alice",
+    ///     "age": 30
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a JSON object with an "error" key if the node is not found.
+    /// ```json
+    /// { "error": "Node not found: 123" }
+    /// ```
     pub fn get_node(&self, req: GetNodeRequest) -> String {
         Self::extract_text(self.handle_get_node(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -191,7 +282,35 @@ impl AletheiaMcpServer {
     /// Create a new node.
     ///
     /// Creates a node with the specified label and optional properties.
-    /// Returns the created node's ID and details.
+    /// Returns the created node's ID and details in JSON format.
+    ///
+    /// # Example Request
+    ///
+    /// ```rust
+    /// use aletheiadb::mcp::tools::CreateNodeRequest;
+    /// use std::collections::HashMap;
+    /// use serde_json::json;
+    ///
+    /// let mut props = HashMap::new();
+    /// props.insert("name".to_string(), json!("Alice"));
+    ///
+    /// let req = CreateNodeRequest {
+    ///     label: "Person".to_string(),
+    ///     properties: Some(props),
+    /// };
+    /// ```
+    ///
+    /// # Output Format
+    ///
+    /// Returns the complete node object including the newly assigned ID.
+    ///
+    /// ```json
+    /// {
+    ///   "id": 1,
+    ///   "label": "Person",
+    ///   "properties": { "name": "Alice" }
+    /// }
+    /// ```
     pub fn create_node(&self, req: CreateNodeRequest) -> String {
         Self::extract_text(self.handle_create_node(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -200,8 +319,14 @@ impl AletheiaMcpServer {
 
     /// Update a node's properties.
     ///
-    /// Merges the provided properties with existing ones. Set a property to `null` to delete it.
-    /// Returns the updated node.
+    /// Merges the provided properties with existing ones.
+    /// - New keys are added.
+    /// - Existing keys are updated.
+    /// - Keys set to `null` are removed (future feature, currently sets to Null).
+    ///
+    /// # Output Format
+    ///
+    /// Returns the updated node object.
     pub fn update_node(&self, req: UpdateNodeRequest) -> String {
         Self::extract_text(self.handle_update_node(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -332,7 +457,31 @@ impl AletheiaMcpServer {
     /// Find similar nodes.
     ///
     /// Performs a K-Nearest Neighbors (k-NN) search using vector embeddings.
-    /// Requires a vector index to be enabled on the target property.
+    ///
+    /// # Prerequisites
+    ///
+    /// A vector index must be enabled on the target property using `enable_vector_index`
+    /// before this method can be used.
+    ///
+    /// # Output Format
+    ///
+    /// Returns a list of matches with their similarity scores.
+    ///
+    /// ```json
+    /// {
+    ///   "results": [
+    ///     {
+    ///       "node": {
+    ///         "id": 123,
+    ///         "label": "Document",
+    ///         "properties": { "title": "..." }
+    ///       },
+    ///       "score": 0.95
+    ///     }
+    ///   ],
+    ///   "count": 1
+    /// }
+    /// ```
     pub fn find_similar(&self, req: FindSimilarRequest) -> String {
         Self::extract_text(self.handle_find_similar(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -343,6 +492,25 @@ impl AletheiaMcpServer {
     ///
     /// Configures and builds an HNSW index on a specific property, enabling semantic search.
     /// This is a prerequisite for `find_similar`.
+    ///
+    /// # Arguments
+    ///
+    /// * `property_name`: The property to index (e.g., "embedding").
+    /// * `dimensions`: The size of the vector (e.g., 1536 for OpenAI).
+    /// * `distance_metric`: "cosine" (default), "euclidean", or "dot".
+    ///
+    /// # Output Format
+    ///
+    /// Returns a success confirmation.
+    ///
+    /// ```json
+    /// {
+    ///   "success": true,
+    ///   "property_name": "embedding",
+    ///   "dimensions": 1536,
+    ///   "distance_metric": "cosine"
+    /// }
+    /// ```
     pub fn enable_vector_index(&self, req: EnableVectorIndexRequest) -> String {
         Self::extract_text(self.handle_enable_vector_index(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -352,6 +520,21 @@ impl AletheiaMcpServer {
     /// List vector indexes.
     ///
     /// Returns a list of all active vector indexes and their configuration (dimensions, metric).
+    ///
+    /// # Output Format
+    ///
+    /// ```json
+    /// {
+    ///   "indexes": [
+    ///     {
+    ///       "property_name": "embedding",
+    ///       "dimensions": 1536,
+    ///       "distance_metric": "Cosine"
+    ///     }
+    ///   ],
+    ///   "count": 1
+    /// }
+    /// ```
     pub fn list_vector_indexes(&self, req: ListVectorIndexesRequest) -> String {
         Self::extract_text(self.handle_list_vector_indexes(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -378,8 +561,44 @@ impl AletheiaMcpServer {
 
     /// Execute a hybrid query.
     ///
-    /// Combines graph traversal, vector similarity, and temporal filtering into a single query.
-    /// Example: "Find 10 documents similar to this embedding, linked to User X, as of last week."
+    /// Combines **graph traversal**, **vector similarity**, and **temporal filtering** into a single query.
+    /// This is the most powerful tool for "reasoning" about data.
+    ///
+    /// # Capabilities
+    ///
+    /// - **Start**: From a specific node (`start_node_id`) OR by vector search (`query_embedding`).
+    /// - **Traverse**: Follow edges (`traverse_edge`) up to `traverse_depth`.
+    /// - **Filter**: By time (`valid_time`) or label (`filter_label`).
+    /// - **Rank**: Re-rank results by vector similarity (`query_embedding`).
+    ///
+    /// # Example Scenarios
+    ///
+    /// 1. **"Find similar documents written by Alice"**
+    ///    - Start at Alice (`start_node_id`)
+    ///    - Traverse `WROTE` edges
+    ///    - Rank by similarity to `query_embedding`
+    ///
+    /// 2. **"Find papers about AI published last year"**
+    ///    - Vector search (`query_embedding`)
+    ///    - Filter by `valid_time`
+    ///
+    /// # Output Format
+    ///
+    /// Returns a list of hybrid results containing the node, optional score, path, and timestamp.
+    ///
+    /// ```json
+    /// {
+    ///   "results": [
+    ///     {
+    ///       "node": { "id": 10, "label": "Document", "properties": {...} },
+    ///       "similarity_score": 0.92,
+    ///       "traversal_path": [1, 5, 10],
+    ///       "timestamp": "2023-01-01T12:00:00Z"
+    ///     }
+    ///   ],
+    ///   "count": 1
+    /// }
+    /// ```
     pub fn hybrid_query(&self, req: HybridQueryRequest) -> String {
         Self::extract_text(self.handle_hybrid_query(
             serde_json::to_value(req).expect("request serialization should not fail"),

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -147,7 +147,22 @@ impl Parser {
         parser.parse_query()
     }
 
-    /// Parse a complete query.
+    /// Parse a complete AQL query.
+    ///
+    /// This is the top-level parsing function. It expects the query to follow the general structure:
+    /// `[Temporal] [Source] [Rank] [Where] [Return] [Order] [Skip] [Limit]`
+    ///
+    /// # Grammar
+    /// ```text
+    /// query ::= temporal_clause?
+    ///           source_clause
+    ///           rank_clause?
+    ///           where_clause?
+    ///           return_clause?
+    ///           order_clause?
+    ///           skip_clause?
+    ///           limit_clause?
+    /// ```
     fn parse_query(&mut self) -> Result<QueryAst, ParseError> {
         // Parse optional temporal clause
         let temporal = self.parse_temporal_clause()?;
@@ -208,11 +223,18 @@ impl Parser {
 
     /// Parse an optional temporal clause (`AS OF ...` or `BETWEEN ...`).
     ///
-    /// Grammar:
+    /// The temporal clause sets the context for the query (valid time and transaction time).
+    ///
+    /// # Grammar
     /// ```text
     /// temporal_clause ::= "AS OF" timestamp ("," timestamp)?
     ///                   | "BETWEEN" timestamp "AND" timestamp
     /// ```
+    ///
+    /// # Examples
+    /// - `AS OF '2024-01-01'` (Valid time only)
+    /// - `AS OF '2024-01-01', '2024-01-02'` (Valid time + Transaction time)
+    /// - `BETWEEN '2024-01-01' AND '2024-02-01'` (Valid time range)
     fn parse_temporal_clause(&mut self) -> Result<Option<TemporalClause>, ParseError> {
         if self.check(&Token::As) {
             self.advance(); // consume AS
@@ -277,8 +299,15 @@ impl Parser {
 
     /// Parse the main source of data for the query.
     ///
-    /// This can be either a graph pattern match (`MATCH`) or a vector search
-    /// (`SIMILAR TO` or `FIND SIMILAR`).
+    /// This parses the `MATCH` clause or vector search clauses (`SIMILAR TO`, `FIND SIMILAR`).
+    /// Every query must have exactly one source clause.
+    ///
+    /// # Grammar
+    /// ```text
+    /// source_clause ::= match_clause
+    ///                 | similar_clause
+    ///                 | find_similar_clause
+    /// ```
     fn parse_source_clause(&mut self) -> Result<SourceClause, ParseError> {
         if self.check(&Token::Match) {
             return self.parse_match_clause();
@@ -300,7 +329,10 @@ impl Parser {
 
     /// Parse a `MATCH` clause containing one or more patterns.
     ///
-    /// Grammar:
+    /// The `MATCH` clause defines the graph patterns to search for. Multiple patterns
+    /// can be comma-separated (e.g., `MATCH (a), (b)`).
+    ///
+    /// # Grammar
     /// ```text
     /// match_clause ::= "MATCH" pattern ("," pattern)*
     /// ```
@@ -825,7 +857,9 @@ impl Parser {
 
     /// Parse a `WHERE` clause containing predicates.
     ///
-    /// Grammar:
+    /// The `WHERE` clause filters the results from the source clause using boolean logic.
+    ///
+    /// # Grammar
     /// ```text
     /// where_clause ::= "WHERE" predicate
     /// ```
@@ -840,10 +874,23 @@ impl Parser {
         Ok(Some(WhereClause { predicate }))
     }
 
+    /// Parse a boolean predicate expression.
+    ///
+    /// This is the entry point for parsing conditions in `WHERE` clauses.
+    /// It delegates to `parse_or_predicate` to handle operator precedence (OR has lowest precedence).
+    ///
+    /// # Recursion Limit
+    ///
+    /// Takes a `depth` argument to enforce `MAX_RECURSION_DEPTH` (100) to prevent stack overflows.
     fn parse_predicate(&mut self, depth: usize) -> Result<PredicateExpr, ParseError> {
         self.parse_or_predicate(depth)
     }
 
+    /// Parse logical OR expressions.
+    ///
+    /// ```text
+    /// or_predicate ::= and_predicate ("OR" and_predicate)*
+    /// ```
     fn parse_or_predicate(&mut self, depth: usize) -> Result<PredicateExpr, ParseError> {
         let mut left = self.parse_and_predicate(depth)?;
 
@@ -1131,6 +1178,17 @@ impl Parser {
     // RETURN Clause
     // =========================================================
 
+    /// Parse a `RETURN` clause.
+    ///
+    /// The `RETURN` clause specifies which data to include in the result set.
+    /// It supports aliasing (`AS alias`) and `DISTINCT` projections.
+    ///
+    /// # Grammar
+    /// ```text
+    /// return_clause ::= "RETURN" ("DISTINCT")? return_item ("," return_item)*
+    /// return_item   ::= expression ("AS" identifier)?
+    ///                 | "COUNT" "(" ("*" | expression) ")"
+    /// ```
     fn parse_return_clause(&mut self) -> Result<Option<ReturnClause>, ParseError> {
         if !self.check(&Token::Return) {
             return Ok(None);
@@ -1195,6 +1253,13 @@ impl Parser {
     // ORDER BY Clause
     // =========================================================
 
+    /// Parse an `ORDER BY` clause.
+    ///
+    /// # Grammar
+    /// ```text
+    /// order_clause ::= "ORDER BY" order_item ("," order_item)*
+    /// order_item   ::= expression ("ASC" | "DESC")?
+    /// ```
     fn parse_order_clause(&mut self) -> Result<Option<OrderClause>, ParseError> {
         if !self.check(&Token::Order) {
             return Ok(None);

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2107,6 +2107,33 @@ mod tests {
         assert!(err.message.contains("Unexpected character"));
         // This implicitly tests From<LexerError> for ParseError
     }
+
+    #[test]
+    fn test_parse_error_unexpected_tokens() {
+        let result = Parser::parse("MATCH (n) RETURN n UNEXPECTED");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unexpected tokens"));
+    }
+
+    #[test]
+    fn test_parse_match_multiple_patterns() {
+        let query = Parser::parse("MATCH (a), (b) RETURN a").unwrap();
+        if let SourceClause::Match(patterns) = &query.source {
+            assert_eq!(patterns.len(), 2);
+        } else {
+            panic!("Expected MATCH clause");
+        }
+    }
+
+    #[test]
+    fn test_parse_error_invalid_start_token() {
+        // 'ORDER' is not a valid start token for the source clause
+        let result = Parser::parse("ORDER BY n");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Expected MATCH, SIMILAR, or FIND"));
+    }
 }
 
 #[cfg(test)]

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1824,6 +1824,12 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_parse_no_return_clause() {
+        let query = Parser::parse("MATCH (n)").unwrap();
+        assert!(query.return_clause.is_none());
+    }
+
     // =====================================================
     // ORDER BY Tests
     // =====================================================


### PR DESCRIPTION
This PR enhances the documentation for the MCP Server and AQL Parser modules, aligning with the "Bard" persona guidelines for clear, narrative-driven documentation.

### Changes
- **`src/mcp/server.rs`**: Added a new "Examples" section to the module documentation showing how to interact with the server via JSON-RPC. Updated public methods with clear `Output Format` and `Example Request` sections.
- **`src/query/parser.rs`**: Added BNF-style grammar definitions to key parsing methods (`parse_query`, `parse_match_clause`, `parse_where_clause`, etc.) to explain the expected syntax.

### Verification
- Ran `cargo test` to ensure no regressions.
- Verified `cargo doc` output renders correctly.


---
*PR created automatically by Jules for task [2358300207536699370](https://jules.google.com/task/2358300207536699370) started by @madmax983*