### PR TITLE
test(query): add targeted tests to kill parser mutants

### DIFF
--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -2102,4 +2102,42 @@ mod sentry_tests {
         let result = Parser::parse(&query);
         assert!(result.is_ok(), "Should accept recursion up to the limit");
     }
+
+    #[test]
+    fn test_limit_zero_allowed() {
+        // 🎯 Target: Boundary condition in parse_usize (n < 0 vs n <= 0)
+        // 💣 Risk: LIMIT 0 should be valid but would fail if < became <=
+        let query = Parser::parse("MATCH (n) RETURN n LIMIT 0").unwrap();
+        assert_eq!(query.limit, Some(0));
+    }
+
+    #[test]
+    fn test_skip_zero_allowed() {
+        // 🎯 Target: Boundary condition in parse_usize (n < 0 vs n <= 0)
+        // 💣 Risk: SKIP 0 should be valid but would fail if < became <=
+        let query = Parser::parse("MATCH (n) RETURN n SKIP 0").unwrap();
+        assert_eq!(query.skip, Some(0));
+    }
+
+    #[test]
+    fn test_depth_range_equal_min_max() {
+        // 🎯 Target: Boundary condition in parse_depth_range (min > max vs min >= max)
+        // 💣 Risk: Range *2..2 (exact match syntax) would fail if > became >=
+        let query = Parser::parse("MATCH (a)-[:REL*2..2]->(b) RETURN b").unwrap();
+
+        if let SourceClause::Match(patterns) = &query.source {
+            if let PatternElement::Relationship(rel) = &patterns[0].elements[1] {
+                assert_eq!(
+                    rel.depth,
+                    Some(DepthSpec::Range { min: 2, max: 2 }),
+                    "Expected DepthSpec::Range {{ min: 2, max: 2 }}, got {:?}",
+                    rel.depth
+                );
+            } else {
+                panic!("Expected relationship pattern");
+            }
+        } else {
+            panic!("Expected Match clause");
+        }
+    }
 }


### PR DESCRIPTION
🤖 **Sentinel Report**

**Summary:**
This PR adds 3 targeted unit tests to `src/query/parser.rs` to eliminate surviving mutants found during analysis. The existing test suite allowed off-by-one mutations in boundary checks for `LIMIT`, `SKIP`, and variable-length path depths to survive.

**🧬 Mutants Eliminated:**
- `replace < with <=` in `Parser::parse_usize`: This would cause `LIMIT 0` and `SKIP 0` to be rejected as invalid. The new tests `test_limit_zero_allowed` and `test_skip_zero_allowed` enforce that 0 is a valid value.
- `replace > with >=` in `Parser::parse_depth_range`: This would cause traversal ranges like `*2..2` (min == max) to be rejected. The new test `test_depth_range_equal_min_max` enforces that equal bounds are valid.

**🔍 Verification:**
- Run `cargo test --lib query::parser::sentry_tests` to verify the new tests pass.
- Manually verified that injecting the mutants causes these specific tests to fail (Kill Confirmed).

**Tests Added:**
- `src/query/parser.rs`:
    - `sentry_tests::test_limit_zero_allowed`
    - `sentry_tests::test_skip_zero_allowed`
    - `sentry_tests::test_depth_range_equal_min_max`


---
*PR created automatically by Jules for task [11168309331084959964](https://jules.google.com/task/11168309331084959964) started by @madmax983*