### PR TITLE
👺 Havoc: Fix PropertyValue stack overflow vulnerabilities

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -81,7 +81,7 @@ pub type PropertyKey = InternedString;
 /// A value that can be stored as a property.
 ///
 /// All complex types (strings, bytes, arrays) use Arc for cheap cloning and sharing.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum PropertyValue {
     /// Null/absent value.
     Null,
@@ -912,8 +912,45 @@ impl PropertyValue {
     }
 }
 
-impl fmt::Display for PropertyValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Drop for PropertyValue {
+    fn drop(&mut self) {
+        // Prevent stack overflow when dropping deeply nested Arrays.
+        // We linearize the drop chain by taking ownership of children
+        // from unique Arcs and processing them iteratively.
+        if let PropertyValue::Array(arc) = self {
+            // Only process if we are the sole owner of the data (refcount == 1)
+            if let Some(vec) = Arc::get_mut(arc) {
+                // Initial work list: take all elements from the current vector
+                // std::mem::take requires Vec to implement Default, which it does (empty vec)
+                let mut stack = std::mem::take(vec);
+
+                while let Some(mut item) = stack.pop() {
+                    if let PropertyValue::Array(ref mut inner_arc) = item {
+                        // Check if we own this inner array
+                        if let Some(inner_vec) = Arc::get_mut(inner_arc) {
+                            // Move its children to the stack to be processed later
+                            // This effectively flattens the recursive structure
+                            let children = std::mem::take(inner_vec);
+                            stack.extend(children);
+                        }
+                    }
+                    // item is dropped here.
+                    // If it was a unique Array, its children were moved to stack, so it's empty.
+                    // If it was shared Array, children remain (handled by other owners).
+                    // If it was non-Array, standard drop.
+                }
+            }
+        }
+    }
+}
+
+impl PropertyValue {
+    /// Safe recursive display formatter with depth limit.
+    fn fmt_display(&self, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+        if depth > 50 {
+            return write!(f, "...");
+        }
+
         match self {
             PropertyValue::Null => write!(f, "null"),
             PropertyValue::Bool(b) => write!(f, "{}", b),
@@ -927,7 +964,11 @@ impl fmt::Display for PropertyValue {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", v)?;
+                    if i >= 20 {
+                        write!(f, "... ({} more)", a.len() - i)?;
+                        break;
+                    }
+                    v.fmt_display(f, depth + 1)?;
                 }
                 write!(f, "]")
             }
@@ -941,6 +982,64 @@ impl fmt::Display for PropertyValue {
                 )
             }
         }
+    }
+
+    /// Safe recursive debug formatter with depth limit.
+    fn fmt_debug(&self, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+        if depth > 50 {
+            return write!(f, "...");
+        }
+
+        match self {
+            PropertyValue::Null => write!(f, "Null"),
+            PropertyValue::Bool(b) => write!(f, "Bool({:?})", b),
+            PropertyValue::Int(i) => write!(f, "Int({:?})", i),
+            PropertyValue::Float(fl) => write!(f, "Float({:?})", fl),
+            PropertyValue::String(s) => write!(f, "String({:?})", s),
+            PropertyValue::Bytes(b) => write!(f, "Bytes({:?})", b),
+            PropertyValue::Array(a) => {
+                write!(f, "Array([")?;
+                for (i, v) in a.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    if i >= 20 {
+                        write!(f, "... ({} more)", a.len() - i)?;
+                        break;
+                    }
+                    v.fmt_debug(f, depth + 1)?;
+                }
+                write!(f, "])")
+            }
+            // Limit vector output in debug to prevent log spam
+            PropertyValue::Vector(v) => {
+                write!(f, "Vector([")?;
+                for (i, val) in v.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    if i >= 10 {
+                        write!(f, "... ({} more)", v.len() - i)?;
+                        break;
+                    }
+                    write!(f, "{:?}", val)?;
+                }
+                write!(f, "])")
+            }
+            PropertyValue::SparseVector(sv) => write!(f, "SparseVector({:?})", sv),
+        }
+    }
+}
+
+impl fmt::Display for PropertyValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_display(f, 0)
+    }
+}
+
+impl fmt::Debug for PropertyValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_debug(f, 0)
     }
 }
 
@@ -1816,7 +1915,7 @@ mod tests {
         // Note: `original` is now moved and cannot be used
 
         // Extract the Arc<[u8]> from the PropertyValue
-        if let PropertyValue::Bytes(arc_bytes) = prop_value {
+        if let PropertyValue::Bytes(ref arc_bytes) = prop_value {
             // Verify the length is correct
             assert_eq!(
                 arc_bytes.len(),
@@ -2806,7 +2905,7 @@ mod tests {
         assert_eq!(consumed, bytes.len());
 
         match deserialized {
-            PropertyValue::SparseVector(sv) => {
+            PropertyValue::SparseVector(ref sv) => {
                 assert_eq!(sv.nnz(), 3);
                 assert_eq!(sv.dimension(), 5);
                 assert_eq!(sv.indices(), &[0, 2, 4]);

--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -826,7 +826,7 @@ mod tests {
 
         let result = restore_property_value(&persisted);
         assert!(result.is_ok());
-        if let PropertyValue::Vector(v) = result.unwrap() {
+        if let PropertyValue::Vector(ref v) = result.unwrap() {
             assert_eq!(v.len(), super::super::MAX_VECTOR_DIMENSIONS);
         } else {
             panic!("Expected vector property");

--- a/tests/havoc/havoc_property.rs
+++ b/tests/havoc/havoc_property.rs
@@ -229,7 +229,7 @@ fn test_unaligned_vector_access() {
     );
     let (val, consumed) = result.unwrap();
     assert_eq!(consumed, vec_bytes.len());
-    if let PropertyValue::Vector(v) = val {
+    if let PropertyValue::Vector(ref v) = val {
         assert_eq!(v.len(), 4);
     } else {
         panic!("Expected Vector");

--- a/tests/repro_debug_overflow.rs
+++ b/tests/repro_debug_overflow.rs
@@ -1,0 +1,30 @@
+use aletheiadb::core::property::PropertyValue;
+use std::sync::Arc;
+
+#[test]
+fn test_debug_stack_overflow() {
+    // Construct a deeply nested PropertyValue iteratively.
+    // Depth 20,000 is usually enough to blow the default stack (2MB-8MB).
+    let depth = 20_000;
+    let mut value = PropertyValue::Int(42);
+
+    for _ in 0..depth {
+        value = PropertyValue::Array(Arc::new(vec![value]));
+    }
+
+    // Try to debug print it.
+    // This should NOT crash with safe implementation.
+    println!("Attempting to print deeply nested value...");
+    let debug_str = format!("{:?}", value);
+    println!("Successfully printed debug: {:.20}...", debug_str);
+
+    // Try to display print it.
+    let display_str = format!("{}", value);
+    println!("Successfully printed display: {:.20}...", display_str);
+
+    // Drop the value.
+    // This should NOT crash with safe Drop implementation.
+    println!("Dropping deeply nested value...");
+    drop(value);
+    println!("Successfully dropped value.");
+}


### PR DESCRIPTION
This PR addresses two critical vulnerabilities in `PropertyValue` related to deeply nested structures (e.g. `Array` containing `Array`...):

1.  **Stack Overflow on Drop**: The default recursive `Drop` implementation for `PropertyValue` caused a stack overflow when dropping deeply nested arrays (depth > 20,000). A custom iterative `Drop` implementation has been added to linearize the destruction process using `Arc::get_mut` and a work stack.
2.  **Stack Overflow on Debug/Display**: The `derive(Debug)` and `Display` implementations were recursive without depth limits. A deeply nested structure would crash the process if logged. Manual `fmt::Debug` and `fmt::Display` implementations with a depth limit (50) and length limits for collections have been added.

**Changes:**
- Modified `src/core/property.rs`:
    - Removed `derive(Debug)` from `PropertyValue`.
    - Added custom `Drop` implementation.
    - Added custom, depth-limited `Debug` and `Display` implementations.
    - Updated call sites in `tests/havoc/havoc_property.rs`, `src/core/property.rs` and `src/storage/index_persistence/graph.rs` to use `ref` bindings instead of moving values, as `Drop` types cannot be moved out of.
- Added `tests/repro_debug_overflow.rs`: A regression test that constructs a 20,000-deep property value, prints it, and drops it, asserting no crash occurs.

**Risk:**
- `PropertyValue` no longer moves fields out in pattern matching; code must use `ref`. All known occurrences in the codebase have been updated.


---
*PR created automatically by Jules for task [10707019518073621578](https://jules.google.com/task/10707019518073621578) started by @madmax983*