### PR TITLE
🤖 Sentinel: Add tests for spaced negative property values in AQL parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Summary:** The mutant `delete !` in `EntityTimeline::insert_batch` (DeduplicationPolicy::Reject) survived because existing tests only checked that `Reject` works for duplicates (failure case), but never verified it works for valid data (success case).
 **Diagnosis:** WEAK_TEST - Missing positive test case for `DeduplicationPolicy::Reject`.
 **Kill Shot:** Added `test_batch_insert_reject_policy_valid_batch` which asserts that `insert_batch` with `Reject` policy succeeds for a batch with unique items. Verified manually that this test fails if the mutant is applied.
+
+**[Missing Coverage for Negative Property Values]**
+**Module:** src/query/parser.rs
+**Summary:** The mutant `delete -` in `Parser::parse_value` (specifically in the `Token::Dash` branch) survived because existing tests only used positive property values or unspaced negative literals handled by the Lexer directly.
+**Diagnosis:** MISSING_COVERAGE - No test covered the parsing of spaced negative numeric literals (e.g., `- 5`) which are handled via the `Dash` token branch in the parser.
+**Kill Shot:** Added `tests/sentinel_parser.rs` with `test_parse_negative_property_value_spaced` and `test_parse_negative_float_property_value_spaced` to verify that spaced negative numbers are parsed correctly as negative values.

--- a/tests/sentinel_parser.rs
+++ b/tests/sentinel_parser.rs
@@ -1,0 +1,84 @@
+use aletheiadb::query::ast::{NodePattern, PatternElement, PropertyValue, SourceClause};
+use aletheiadb::query::parser::Parser;
+
+#[test]
+fn test_parse_negative_property_value_spaced() {
+    // This test targets the mutant: delete - in Parser::parse_value
+    // It specifically tests the path where a negative number is parsed as `Dash` then `IntegerLiteral`.
+    // Example: {score: - 5}
+    let query = Parser::parse("MATCH (n {score: - 5}) RETURN n").unwrap();
+
+    if let SourceClause::Match(patterns) = &query.source {
+        if let PatternElement::Node(NodePattern {
+            properties: Some(props),
+            ..
+        }) = &patterns[0].elements[0]
+        {
+            let (_, value) = props.iter().find(|(k, _)| k == "score").unwrap();
+            assert_eq!(
+                *value,
+                PropertyValue::Int(-5),
+                "Expected -5, got {:?}",
+                value
+            );
+        } else {
+            panic!("Expected node pattern with properties");
+        }
+    } else {
+        panic!("Expected MATCH clause");
+    }
+}
+
+#[test]
+fn test_parse_negative_float_property_value_spaced() {
+    // This test targets the mutant: delete - in Parser::parse_value (float branch)
+    // Example: {score: - 0.5}
+    let query = Parser::parse("MATCH (n {score: - 0.5}) RETURN n").unwrap();
+
+    if let SourceClause::Match(patterns) = &query.source {
+        if let PatternElement::Node(NodePattern {
+            properties: Some(props),
+            ..
+        }) = &patterns[0].elements[0]
+        {
+            let (_, value) = props.iter().find(|(k, _)| k == "score").unwrap();
+            if let PropertyValue::Float(f) = value {
+                assert!((f - -0.5).abs() < f64::EPSILON, "Expected -0.5, got {}", f);
+            } else {
+                panic!("Expected float property value, got {:?}", value);
+            }
+        } else {
+            panic!("Expected node pattern with properties");
+        }
+    } else {
+        panic!("Expected MATCH clause");
+    }
+}
+
+#[test]
+fn test_parse_negative_property_value_unspaced() {
+    // This tests the path where negative number is parsed as a single token (if lexer supports it)
+    // or unspaced sequence. The mutant might not affect this if lexer produces `IntegerLiteral(-5)`.
+    // Example: {score: -5}
+    let query = Parser::parse("MATCH (n {score: -5}) RETURN n").unwrap();
+
+    if let SourceClause::Match(patterns) = &query.source {
+        if let PatternElement::Node(NodePattern {
+            properties: Some(props),
+            ..
+        }) = &patterns[0].elements[0]
+        {
+            let (_, value) = props.iter().find(|(k, _)| k == "score").unwrap();
+            assert_eq!(
+                *value,
+                PropertyValue::Int(-5),
+                "Expected -5, got {:?}",
+                value
+            );
+        } else {
+            panic!("Expected node pattern with properties");
+        }
+    } else {
+        panic!("Expected MATCH clause");
+    }
+}


### PR DESCRIPTION
🤖 Sentinel: [Closed gap in AQL parser test coverage]

**🧬 Mutants Found:**
- 1 surviving mutant in `src/query/parser.rs` (delete `-` in `Parser::parse_value`).
- Diagnosis: MISSING_COVERAGE. existing tests only exercised the unspaced negative number path (handled by Lexer), leaving the parser's `Token::Dash` branch (for spaced negatives) vulnerable to mutation.

**🎯 Tests Added/Strengthened:**
- Created `tests/sentinel_parser.rs`.
- Added `test_parse_negative_property_value_spaced`: Verifies `{a: - 5}` parses as `-5`.
- Added `test_parse_negative_float_property_value_spaced`: Verifies `{a: - 0.5}` parses as `-0.5`.
- Added `test_parse_negative_property_value_unspaced`: Control test for standard negative numbers.

**⚠️ Suspected Bugs:**
- None. The code was correct, but untested.

**📊 Kill Rate:**
- The mutant is logically killed by the new tests, which would fail if the negation were removed.

**🔗 Havoc Interaction:**
- None.


---
*PR created automatically by Jules for task [3114925723194348687](https://jules.google.com/task/3114925723194348687) started by @madmax983*