### PR TITLE
🤖 Sentinel: Strengthen semantic pathfinding tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Summary:** `SQUARED_MAGNITUDE_THRESHOLD` was set to `1e-14`, causing valid small vectors (magnitude < 1e-7) to be treated as zero vectors, failing normalization and similarity checks.
 **Diagnosis:** SUSPECTED_BUG - The threshold was too aggressive, preventing operations on valid small-scale vectors (e.g., gradients).
 **Kill Shot:** Changed `SQUARED_MAGNITUDE_THRESHOLD` to `1e-25`. Updated `test_normalize_in_place_tiny_vector` to assert correct normalization instead of zeroing out. Added regression tests `test_normalize_small_vector_preserves_direction`, `test_cosine_similarity_small_vectors`, `test_cosine_similarity_mixed_magnitude`.
+
+**[Weak Test Coverage in Semantic Pathfinding]**
+**Module:** src/query/semantic_pathfinding.rs
+**Summary:** Mutants `replace - with /` in cost calculation and constant-cost mutants (`Ok(1.0)`) survived.
+**Diagnosis:** WEAK_TEST - Existing tests were ambiguous (cost ties handled arbitrarily) or did not cover cases where inverted similarity logic (`-` vs `/`) would yield plausible but incorrect results.
+**Kill Shot:** Added `tests/sentinel_semantic_pathfinding.rs` with `test_semantic_pathfinding_penalizes_opposite` (kills `/`) and `test_semantic_pathfinding_overcomes_structural_cost` (kills constant cost by forcing a longer but cheaper path).

--- a/tests/sentinel_semantic_pathfinding.rs
+++ b/tests/sentinel_semantic_pathfinding.rs
@@ -1,0 +1,197 @@
+//! Sentinel targeted tests for Semantic Pathfinding mutants.
+//!
+//! These tests are specifically designed to catch regressions in semantic cost calculation
+//! and pathfinding logic identified by mutation testing.
+
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::query::semantic_pathfinding::SemanticPathfinder;
+use aletheiadb::{AletheiaDB, WriteOps};
+
+fn create_test_db() -> AletheiaDB {
+    let db = AletheiaDB::new().unwrap();
+    // Enable vector index
+    db.vector_index("embedding")
+        .hnsw(HnswConfig::new(3, DistanceMetric::Cosine))
+        .enable()
+        .unwrap();
+    db
+}
+
+#[test]
+fn test_semantic_pathfinding_penalizes_opposite() {
+    // 🎯 Target: Kills `replace - with /` in `1.0 - sim` (line 292)
+    // 💣 Risk: If cost = 1.0 / sim, negative similarity (opposite vectors) becomes negative cost,
+    // which effectively rewards dissimilarity instead of penalizing it.
+
+    let db = create_test_db();
+
+    // Start -> End
+    let start = db
+        .create_node("Start", PropertyMapBuilder::new().build())
+        .unwrap();
+    let end = db
+        .create_node("End", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Query vector: [1.0, 0.0, 0.0]
+    let query = vec![1.0, 0.0, 0.0];
+
+    // Path 1: "Neutral" node (orthogonal, sim = 0.0)
+    // Cost should be 1.0 - 0.0 = 1.0.
+    // Structural cost adds 0.1 -> Total ~1.1 per hop.
+    let neutral = db
+        .create_node(
+            "Neutral",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[0.0, 1.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Path 2: "Opposite" node (opposite, sim = -0.9ish)
+    // Cost should be 1.0 - (-0.9) = 1.9 (Very high).
+    // If mutant `1.0 / sim`: 1.0 / -0.9 = -1.1 (Very low/negative).
+    let opposite = db
+        .create_node(
+            "Opposite",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[-0.9, 0.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    // Connect paths
+    // Start -> Neutral -> End
+    db.create_edge(start, neutral, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(neutral, end, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Start -> Opposite -> End
+    db.create_edge(start, opposite, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(opposite, end, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let pathfinder = SemanticPathfinder::new(&db, "embedding");
+    let path = pathfinder
+        .find_path(start, end, &query, 10, false)
+        .unwrap()
+        .expect("Path should be found");
+
+    // Assert we chose the Neutral path (sim=0) over Opposite path (sim=-0.9)
+    // because 0.0 > -0.9 in similarity, so cost(0.0) < cost(-0.9).
+    assert_eq!(path.len(), 3);
+    assert_eq!(
+        path[1], neutral,
+        "Should prefer neutral node (cost 1.0) over opposite node (cost 1.9)"
+    );
+}
+
+#[test]
+fn test_semantic_pathfinding_overcomes_structural_cost() {
+    // 🎯 Target: Kills constant cost mutants `Ok(1.0)`, `Ok(0.0)`
+    // 💣 Risk: If semantic cost is ignored, pathfinding degrades to BFS (shortest path).
+    // We construct a case where the semantically "good" path is longer (more hops)
+    // but semantically cheaper than the "bad" path.
+
+    let db = create_test_db();
+
+    let start = db
+        .create_node("Start", PropertyMapBuilder::new().build())
+        .unwrap();
+    let end = db
+        .create_node("End", PropertyMapBuilder::new().build())
+        .unwrap();
+    let query = vec![1.0, 0.0, 0.0];
+
+    // Path 1: "Good" but long (3 hops)
+    // Nodes match query perfectly (sim = 1.0, cost = 0.0).
+    // Total cost calculation:
+    // Start -> Good1 -> Good2 -> End.
+    // Cost(Good1) = 0.0 (perfect match) + 0.1 (structural).
+    // Cost(Good2) = 0.0 (perfect match) + 0.1 (structural).
+    // Cost(End)   = 0.0 (perfect match) + 0.1 (structural).
+    // Total Cost = 0.3.
+
+    // Ensure End node has an embedding so cost calculation is consistent
+    db.write(|tx| {
+        tx.update_node(
+            end,
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                .build(),
+        )
+    })
+    .unwrap();
+
+    // Construct the Good Path: Start -> Good1 -> Good2 -> End
+    let good1 = db
+        .create_node(
+            "Good1",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+    let good2 = db
+        .create_node(
+            "Good2",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    db.create_edge(start, good1, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(good1, good2, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(good2, end, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Path 2: "Bad" but short (2 hops)
+    // Start -> Bad -> End
+    // Bad node is opposite (sim = -1.0, cost = 2.0).
+    // Cost(Bad) = 2.0 (opposite) + 0.1 (structural) = 2.1.
+    // Cost(End) = 0.0 (perfect match) + 0.1 (structural) = 0.1.
+    // Total Cost = 2.2.
+
+    let bad = db
+        .create_node(
+            "Bad",
+            PropertyMapBuilder::new()
+                .insert_vector("embedding", &[-1.0, 0.0, 0.0])
+                .build(),
+        )
+        .unwrap();
+
+    db.create_edge(start, bad, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.create_edge(bad, end, "NEXT", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Analysis:
+    // Correct Logic: Cost(Good Path) 0.3 < Cost(Bad Path) 2.2. Should choose Good Path.
+
+    // Mutant Ok(1.0) (Constant cost):
+    // Good Path Cost: (1.0 + 0.1) * 3 nodes = 3.3.
+    // Bad Path Cost:  (1.0 + 0.1) * 2 nodes = 2.2.
+    // Mutant Logic: 3.3 > 2.2. Should choose Bad Path (Shortest path/BFS).
+
+    let pathfinder = SemanticPathfinder::new(&db, "embedding");
+    let path = pathfinder
+        .find_path(start, end, &query, 10, false)
+        .unwrap()
+        .expect("Path should be found");
+
+    // Should choose the longer Good path
+    assert_eq!(
+        path.len(),
+        4,
+        "Should choose longer path (len 4) because it is semantically cheaper"
+    );
+    assert_eq!(path[1], good1);
+    assert_eq!(path[2], good2);
+}

--- a/tests/sentinel_semantic_pathfinding.rs
+++ b/tests/sentinel_semantic_pathfinding.rs
@@ -7,6 +7,7 @@ use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
 use aletheiadb::core::property::PropertyMapBuilder;
 use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 use aletheiadb::query::semantic_pathfinding::SemanticPathfinder;
+use aletheiadb::storage::index_persistence::PersistenceConfig;
 use aletheiadb::{AletheiaDB, WriteOps};
 use tempfile::TempDir;
 
@@ -16,6 +17,12 @@ fn create_test_db() -> (AletheiaDB, TempDir) {
 
     let config = AletheiaDBConfig::builder()
         .wal(WalConfigBuilder::new().wal_dir(wal_dir).build())
+        // Disable persistence to prevent loading from shared "data" directory
+        // or race conditions with other tests.
+        .persistence(PersistenceConfig {
+            enabled: false,
+            ..Default::default()
+        })
         .build();
 
     let db = AletheiaDB::with_unified_config(config).unwrap();

--- a/tests/sentinel_semantic_pathfinding.rs
+++ b/tests/sentinel_semantic_pathfinding.rs
@@ -3,19 +3,29 @@
 //! These tests are specifically designed to catch regressions in semantic cost calculation
 //! and pathfinding logic identified by mutation testing.
 
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
 use aletheiadb::core::property::PropertyMapBuilder;
 use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 use aletheiadb::query::semantic_pathfinding::SemanticPathfinder;
 use aletheiadb::{AletheiaDB, WriteOps};
+use tempfile::TempDir;
 
-fn create_test_db() -> AletheiaDB {
-    let db = AletheiaDB::new().unwrap();
+fn create_test_db() -> (AletheiaDB, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let wal_dir = temp_dir.path().join("wal");
+
+    let config = AletheiaDBConfig::builder()
+        .wal(WalConfigBuilder::new().wal_dir(wal_dir).build())
+        .build();
+
+    let db = AletheiaDB::with_unified_config(config).unwrap();
+
     // Enable vector index
     db.vector_index("embedding")
         .hnsw(HnswConfig::new(3, DistanceMetric::Cosine))
         .enable()
         .unwrap();
-    db
+    (db, temp_dir)
 }
 
 #[test]
@@ -24,7 +34,7 @@ fn test_semantic_pathfinding_penalizes_opposite() {
     // 💣 Risk: If cost = 1.0 / sim, negative similarity (opposite vectors) becomes negative cost,
     // which effectively rewards dissimilarity instead of penalizing it.
 
-    let db = create_test_db();
+    let (db, _temp_dir) = create_test_db();
 
     // Start -> End
     let start = db
@@ -96,7 +106,7 @@ fn test_semantic_pathfinding_overcomes_structural_cost() {
     // We construct a case where the semantically "good" path is longer (more hops)
     // but semantically cheaper than the "bad" path.
 
-    let db = create_test_db();
+    let (db, _temp_dir) = create_test_db();
 
     let start = db
         .create_node("Start", PropertyMapBuilder::new().build())


### PR DESCRIPTION
**Summary:**
Added targeted regression tests to `tests/sentinel_semantic_pathfinding.rs` to eliminate surviving mutants in `src/query/semantic_pathfinding.rs`.

**🧬 Mutants Found:**
- 1 Logic Inversion: `replace - with /` in `calculate_semantic_cost`. This mutant caused the pathfinder to aggressively prefer opposite vectors (negative similarity) due to resulting negative costs.
- 4 Constant Cost Equivalents: `Ok(1.0)`, `Ok(0.0)`, etc. These mutants caused the pathfinder to ignore semantic similarity and degrade to BFS (shortest path).

**🎯 Kill Shots:**
- `test_semantic_pathfinding_penalizes_opposite`: Constructs a graph where a path with `sim=0` (neutral) competes with a path with `sim=-0.9` (opposite). The test asserts the neutral path is chosen, killing the mutant which would prefer the opposite path.
- `test_semantic_pathfinding_overcomes_structural_cost`: Constructs a graph where a semantically perfect path (`sim=1.0`) is structurally longer (3 hops) than a semantically opposite path (`sim=-1.0`, 2 hops). The test asserts the longer, semantically cheaper path is chosen, killing constant-cost mutants that would pick the shorter path.

**⚠️ Suspected Bugs:**
None. The surviving mutants indicated weak test coverage (ambiguous tie-breaking or lack of negative similarity tests), not incorrect logic.

**📊 Verification:**
Tests pass and logic confirms they distinguish correct behavior from mutant behavior.


---
*PR created automatically by Jules for task [11392916609528781619](https://jules.google.com/task/11392916609528781619) started by @madmax983*