### PR TITLE
Fix WAL Shutdown Deadlock and Report Critical Risks

### DIFF
--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -1086,16 +1086,14 @@ mod tests {
 
         // Spawn a producer thread that fills the WAL
         let handle = thread::spawn(move || {
-            let mut i = 0;
             // Append enough to definitely fill the buffer multiple times
-            for _ in 0..1000 {
+            for i in 0..1000 {
                 let op = create_test_operation(i);
                 // This will block when buffer is full.
                 // If shutdown happens, it should return Err (closed).
                 if wal_inner.append_async(op).is_err() {
                     break;
                 }
-                i += 1;
             }
         });
 

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -697,6 +697,12 @@ impl ConcurrentWalSystem {
     /// This signals the background thread to stop, waits for it to finish,
     /// and performs a final flush of all pending entries.
     pub fn shutdown(&mut self) {
+        // Close the WAL (prevent new appends)
+        // This must be called BEFORE signaling the flush thread to stop,
+        // because closing waits for active appends, and active appends might
+        // be blocked waiting for the flush thread to drain the buffer.
+        self.wal.close();
+
         // Signal shutdown
         self.shutdown_signal.store(true, Ordering::Relaxed);
 
@@ -707,9 +713,6 @@ impl ConcurrentWalSystem {
         if let Some(handle) = self.flush_thread.take() {
             let _ = handle.join();
         }
-
-        // Close the WAL (prevent new appends)
-        self.wal.close();
     }
 }
 
@@ -1059,5 +1062,52 @@ mod tests {
             "Batch should be flushed immediately"
         );
         assert_eq!(lsns.len(), 2);
+    }
+
+    #[test]
+    fn test_shutdown_deadlock_repro() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let dir = tempdir().unwrap();
+        // Use a tiny buffer to force backpressure quickly
+        let config = ConcurrentWalSystemConfig::new(dir.path())
+            .with_num_stripes(1)
+            .with_durability_mode(DurabilityMode::Async {
+                flush_interval_ms: 100,
+            });
+
+        let mut config = config;
+        config.stripe_capacity = 2; // Very small capacity
+
+        let mut wal_system = ConcurrentWalSystem::new(config).unwrap();
+        // Access the private field 'wal'
+        let wal_inner = Arc::clone(&wal_system.wal);
+
+        // Spawn a producer thread that fills the WAL
+        let handle = thread::spawn(move || {
+            let mut i = 0;
+            // Append enough to definitely fill the buffer multiple times
+            for _ in 0..1000 {
+                let op = create_test_operation(i);
+                // This will block when buffer is full.
+                // If shutdown happens, it should return Err (closed).
+                if wal_inner.append_async(op).is_err() {
+                    break;
+                }
+                i += 1;
+            }
+        });
+
+        // Wait a bit for producer to fill buffer and likely block
+        thread::sleep(Duration::from_millis(50));
+
+        println!("Shutting down WAL system...");
+        // This call is expected to hang if there is a deadlock
+        // because shutdown stops flush thread -> buffer full -> append blocks -> close waits for append -> deadlock
+        wal_system.shutdown();
+        println!("Shutdown complete.");
+
+        handle.join().unwrap();
     }
 }


### PR DESCRIPTION
# Findings

## Critical: ShardCoordinator bypasses network layer
The `ShardCoordinator` (`src/storage/sharding/coordinator.rs`) uses a stub `ShardConnection` that pretends to succeed for all operations (`prepare`, `commit`) without performing any network I/O.
- **Risk**: Distributed transactions are simulated locally. Writing to a sharded database results in data loss (data not sent to shards) or false positive commit confirmations.
- **Verification**: Created `examples/repro_shard_stub.rs` which confirmed that 2PC operations succeed even when configured with non-existent endpoints.
- **Recommendation**: Refactor `ShardCoordinator` to inject `HttpShardClient` (or another implementation of `ShardClient`) instead of the hardcoded stub.

## High: ConcurrentWalSystem Shutdown Deadlock
`ConcurrentWalSystem::shutdown` was stopping the background flush thread *before* closing the WAL and waiting for active appends.
- **Risk**: If the ring buffer is full, active appends block waiting for the flush thread to drain space. If the flush thread is stopped first, these appends hang forever, causing `wal.close()` (and thus `shutdown()`) to deadlock.
- **Fix**: Reordered `shutdown()` to call `self.wal.close()` (which waits for appends) *before* signaling the flush thread to stop.
- **Verification**: Added `test_shutdown_deadlock_repro` to `src/storage/wal/concurrent_system.rs` which reliably reproduced the hang (timeout) before the fix and passes after the fix.

## High: Sequential Query Execution
`QueryExecutor` (`src/storage/sharding/executor.rs`) and `ShardCoordinator` execute distributed operations sequentially (looping over shards and blocking).
- **Risk**: Performance regression. Latency scales linearly with shard count ($O(N)$) instead of parallel ($O(\max(T_i))$).
- **Recommendation**: Use `rayon` or async/await (with a runtime) to parallelize scatter-gather operations.

# Changes
- Modified `src/storage/wal/concurrent_system.rs` to fix the shutdown deadlock.
- Added regression test `test_shutdown_deadlock_repro` to `src/storage/wal/concurrent_system.rs`.

---
*PR created automatically by Jules for task [16085591753497385209](https://jules.google.com/task/16085591753497385209) started by @madmax983*