### PR TITLE
Core Review: Fix manifest node/edge count race condition

### DIFF
--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -239,6 +239,10 @@ impl AletheiaDB {
                     db.current.node_count() as u64,
                     db.current.edge_count() as u64,
                 );
+                // Also initialize string count from current state
+                tracker.update_last_persisted_string_count(
+                    crate::core::GLOBAL_INTERNER.len() as u64,
+                );
             }
         }
 

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -240,9 +240,8 @@ impl AletheiaDB {
                     db.current.edge_count() as u64,
                 );
                 // Also initialize string count from current state
-                tracker.update_last_persisted_string_count(
-                    crate::core::GLOBAL_INTERNER.len() as u64,
-                );
+                tracker
+                    .update_last_persisted_string_count(crate::core::GLOBAL_INTERNER.len() as u64);
             }
         }
 

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -235,6 +235,10 @@ impl AletheiaDB {
                 && let Some(lsn) = loaded_lsn
             {
                 tracker.set_start_lsn(lsn);
+                tracker.update_last_persisted_counts(
+                    db.current.node_count() as u64,
+                    db.current.edge_count() as u64,
+                );
             }
         }
 

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -470,14 +470,22 @@ pub(crate) fn persist_string_interner(
     manager: &Arc<IndexPersistenceManager>,
     tracker: &Arc<PersistenceTracker>,
     current_lsn: u64,
-) -> Result<()> {
+) -> Result<u64> {
     manager.save_string_interner().map_err(|e| {
         StorageError::PersistenceError(format!("Failed to save string interner: {}", e))
     })?;
 
+    // Capture the count *after* save completes. Since GLOBAL_INTERNER is append-only,
+    // this count is at least what was saved. If new strings were interned concurrently,
+    // they might not be in the file yet, but having a slightly higher count in the manifest
+    // is safer than lower (though ideally exact).
+    // Note: save_string_interner likely iterates and saves.
+    let count = crate::core::GLOBAL_INTERNER.len() as u64;
+
     tracker.reset_string_mutations();
     tracker.update_string_lsn(current_lsn);
-    Ok(())
+    tracker.update_last_persisted_string_count(count);
+    Ok(count)
 }
 
 /// Persist temporal adjacency index to disk.
@@ -560,9 +568,10 @@ pub(crate) fn persist_all_indexes(
     let mut manifest = IndexManifest::new(safe_lsn);
 
     // Add string interner entry
+    let string_count = tracker.get_last_persisted_string_count();
     manifest.string_interner = Some(StringInternerManifestEntry {
         interner_file: "strings/interner.idx".to_string(),
-        string_count: crate::core::GLOBAL_INTERNER.len() as u64,
+        string_count,
     });
 
     // Add graph index entry if we have nodes/edges

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -317,7 +317,7 @@ pub(crate) fn persist_graph_index(
     manager: &Arc<IndexPersistenceManager>,
     tracker: Option<&Arc<PersistenceTracker>>,
     current_lsn: u64,
-) -> Result<()> {
+) -> Result<(u64, u64)> {
     use crate::storage::index_persistence::graph::{
         new_graph_index_data, persist_property_map, save_graph_index,
     };
@@ -390,8 +390,9 @@ pub(crate) fn persist_graph_index(
     if let Some(tracker) = tracker {
         tracker.reset_graph_mutations();
         tracker.update_graph_lsn(current_lsn);
+        tracker.update_last_persisted_counts(graph_data.node_count, graph_data.edge_count);
     }
-    Ok(())
+    Ok((graph_data.node_count, graph_data.edge_count))
 }
 
 /// Persist temporal index to disk.
@@ -565,13 +566,15 @@ pub(crate) fn persist_all_indexes(
     });
 
     // Add graph index entry if we have nodes/edges
-    let node_count = current.all_nodes().count();
-    let edge_count = current.all_edges().count();
+    // Use tracker counts to ensure we only point to what was actually persisted
+    let node_count = tracker.get_last_persisted_node_count();
+    let edge_count = tracker.get_last_persisted_edge_count();
+
     if node_count > 0 || edge_count > 0 {
         manifest.graph_index = Some(GraphIndexManifestEntry {
             adjacency_file: "graph/adjacency.idx".to_string(),
-            node_count: node_count as u64,
-            edge_count: edge_count as u64,
+            node_count,
+            edge_count,
         });
     }
 

--- a/src/storage/index_persistence/tracker.rs
+++ b/src/storage/index_persistence/tracker.rs
@@ -62,6 +62,8 @@ pub(crate) struct PersistenceTracker {
     last_persisted_node_count: AtomicU64,
     /// Last persisted edge count (from graph index)
     last_persisted_edge_count: AtomicU64,
+    /// Last persisted string count (from string interner)
+    last_persisted_string_count: AtomicU64,
 
     /// Shutdown signal for background persistence thread
     shutdown: AtomicBool,
@@ -90,6 +92,7 @@ impl PersistenceTracker {
             last_string_lsn: AtomicU64::new(0),
             last_persisted_node_count: AtomicU64::new(0),
             last_persisted_edge_count: AtomicU64::new(0),
+            last_persisted_string_count: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),
         }
     }
@@ -138,6 +141,16 @@ impl PersistenceTracker {
     /// Get the last persisted edge count.
     pub fn get_last_persisted_edge_count(&self) -> u64 {
         self.last_persisted_edge_count.load(Ordering::Acquire)
+    }
+
+    /// Update the last persisted string count.
+    pub fn update_last_persisted_string_count(&self, count: u64) {
+        self.last_persisted_string_count.store(count, Ordering::Release);
+    }
+
+    /// Get the last persisted string count.
+    pub fn get_last_persisted_string_count(&self) -> u64 {
+        self.last_persisted_string_count.load(Ordering::Acquire)
     }
 
     /// Get the safe manifest LSN (minimum of all component LSNs).

--- a/src/storage/index_persistence/tracker.rs
+++ b/src/storage/index_persistence/tracker.rs
@@ -145,7 +145,8 @@ impl PersistenceTracker {
 
     /// Update the last persisted string count.
     pub fn update_last_persisted_string_count(&self, count: u64) {
-        self.last_persisted_string_count.store(count, Ordering::Release);
+        self.last_persisted_string_count
+            .store(count, Ordering::Release);
     }
 
     /// Get the last persisted string count.

--- a/src/storage/index_persistence/tracker.rs
+++ b/src/storage/index_persistence/tracker.rs
@@ -58,6 +58,11 @@ pub(crate) struct PersistenceTracker {
     /// Last persisted LSN for string interner
     last_string_lsn: AtomicU64,
 
+    /// Last persisted node count (from graph index)
+    last_persisted_node_count: AtomicU64,
+    /// Last persisted edge count (from graph index)
+    last_persisted_edge_count: AtomicU64,
+
     /// Shutdown signal for background persistence thread
     shutdown: AtomicBool,
 }
@@ -83,6 +88,8 @@ impl PersistenceTracker {
             last_graph_lsn: AtomicU64::new(0),
             last_temporal_lsn: AtomicU64::new(0),
             last_string_lsn: AtomicU64::new(0),
+            last_persisted_node_count: AtomicU64::new(0),
+            last_persisted_edge_count: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),
         }
     }
@@ -113,6 +120,24 @@ impl PersistenceTracker {
     /// Update the last persisted LSN for string interner.
     pub fn update_string_lsn(&self, lsn: u64) {
         self.last_string_lsn.fetch_max(lsn, Ordering::Release);
+    }
+
+    /// Update the last persisted node and edge counts.
+    pub fn update_last_persisted_counts(&self, node_count: u64, edge_count: u64) {
+        self.last_persisted_node_count
+            .store(node_count, Ordering::Release);
+        self.last_persisted_edge_count
+            .store(edge_count, Ordering::Release);
+    }
+
+    /// Get the last persisted node count.
+    pub fn get_last_persisted_node_count(&self) -> u64 {
+        self.last_persisted_node_count.load(Ordering::Acquire)
+    }
+
+    /// Get the last persisted edge count.
+    pub fn get_last_persisted_edge_count(&self) -> u64 {
+        self.last_persisted_edge_count.load(Ordering::Acquire)
     }
 
     /// Get the safe manifest LSN (minimum of all component LSNs).

--- a/src/storage/index_persistence/worker.rs
+++ b/src/storage/index_persistence/worker.rs
@@ -218,7 +218,6 @@ pub(crate) fn spawn_background_persistence_thread(
                 // to be consistent with what gets written to disk, preventing data loss
                 // during recovery if concurrent writes happen during persistence.
                 let snapshot_lsn = wal.current_lsn().0;
-                let string_count = crate::core::GLOBAL_INTERNER.len() as u64;
 
                 // Check vector index policy
                 let vector_mutations = tracker.get_vector_mutations();
@@ -284,7 +283,7 @@ pub(crate) fn spawn_background_persistence_thread(
                     || string_seconds >= policies.strings.time_interval_secs as u64
                 {
                     match persist_string_interner(&manager, &tracker, snapshot_lsn) {
-                        Ok(()) => any_index_persisted = true,
+                        Ok(_) => any_index_persisted = true,
                         Err(e) => {
                             eprintln!(
                                 "Background persistence: Failed to persist string interner: {}",
@@ -309,7 +308,7 @@ pub(crate) fn spawn_background_persistence_thread(
                         &tracker,
                         tracker.get_last_persisted_node_count(),
                         tracker.get_last_persisted_edge_count(),
-                        string_count,
+                        tracker.get_last_persisted_string_count(),
                     );
                 }
             }

--- a/src/storage/index_persistence/worker.rs
+++ b/src/storage/index_persistence/worker.rs
@@ -214,12 +214,10 @@ pub(crate) fn spawn_background_persistence_thread(
                 let mut any_index_persisted = false;
 
                 // CRITICAL: Capture snapshot state BEFORE persistence operations start
-                // This ensures the manifest records a conservative LSN/counts that are
-                // guaranteed to be consistent with what gets written to disk, preventing
-                // data loss during recovery if concurrent writes happen during persistence.
+                // This ensures the manifest records a conservative LSN that is guaranteed
+                // to be consistent with what gets written to disk, preventing data loss
+                // during recovery if concurrent writes happen during persistence.
                 let snapshot_lsn = wal.current_lsn().0;
-                let node_count = current.node_count() as u64;
-                let edge_count = current.edge_count() as u64;
                 let string_count = crate::core::GLOBAL_INTERNER.len() as u64;
 
                 // Check vector index policy
@@ -246,7 +244,7 @@ pub(crate) fn spawn_background_persistence_thread(
                     || graph_seconds >= policies.graph.time_interval_secs as u64
                 {
                     match persist_graph_index(&current, &manager, Some(&tracker), snapshot_lsn) {
-                        Ok(()) => any_index_persisted = true,
+                        Ok(_) => any_index_persisted = true,
                         Err(e) => {
                             eprintln!(
                                 "Background persistence: Failed to persist graph index: {}",
@@ -309,8 +307,8 @@ pub(crate) fn spawn_background_persistence_thread(
                         &manager,
                         &historical,
                         &tracker,
-                        node_count,
-                        edge_count,
+                        tracker.get_last_persisted_node_count(),
+                        tracker.get_last_persisted_edge_count(),
                         string_count,
                     );
                 }


### PR DESCRIPTION
Core Review Findings:
- Identified a race condition where `node_count` captured at the start of the persistence cycle was used for the manifest, while `persist_graph_index` might persist a different state due to concurrent writes.
- Identified a correctness issue where manifest counts were updated with in-memory counts even if `persist_graph_index` was skipped.

Fix:
- `PersistenceTracker` now tracks the node/edge counts of the *last successfully persisted* graph index.
- Manifest generation now relies on these authoritative counts.
- Startup logic initializes these counts from the loaded state.


---
*PR created automatically by Jules for task [12529493922579306350](https://jules.google.com/task/12529493922579306350) started by @madmax983*