### PR TITLE
feat: Implement Debug for AletheiaDB to improve DX

### DIFF
--- a/DX_AUDIT_REPORT_ECHO.md
+++ b/DX_AUDIT_REPORT_ECHO.md
@@ -1,0 +1,36 @@
+# 🗣️ Echo DX Report: The Audit
+
+**Auditor:** Echo (Voice of the User)
+**Subject:** Developer Experience Audit & Fixes
+
+## 🔍 The Walkthrough
+
+I performed a comprehensive audit of the "Getting Started" experience, running examples from the README and verifying their behavior.
+
+### ✅ What Works
+- **Basic Graph Operations:** Copy-pasting the example works flawlessly.
+- **Vector Search:** Works (with minor warnings about unused variables in some contexts).
+- **Narrative Generation:** The feature flag requirement is clearly communicated by the compiler error message ("item is gated behind the `nova` feature").
+- **Sharding:** The example code compiles and runs even without the optional RPC feature (which correctly errors at runtime if used).
+
+### 🚧 Friction Points & Fixes
+
+#### 1. `AletheiaDB` Debug Output (Major)
+**Scenario:** Tried to inspect the database state with `println!("{:?}", db)`.
+**Result:** `error[E0277]: AletheiaDB doesn't implement Debug`.
+**Fix:** Implemented `std::fmt::Debug` for `AletheiaDB` in `src/db/mod.rs`. It now prints useful info like timestamp and durability mode without deadlocking (used `try_lock()`).
+
+#### 2. Unused Variable Warnings (Minor)
+**Scenario:** Running examples often results in `warning: unused variable: ...`.
+**Status:** This is a minor annoyance. The actual example files in `examples/` are mostly clean, but snippets in README might need updates to use the results (e.g., printing them).
+
+#### 3. Type Inference in Docs (Minor)
+**Scenario:** `cold_storage_path("path".into())` vs `cold_storage_path("path")`.
+**Status:** The README uses the correct string literal form which works due to `Into<PathBuf>`. Adding `.into()` manually caused ambiguity errors. The docs are correct.
+
+## 🏁 Conclusion
+
+The library is in good shape. The `Debug` implementation for the main struct significantly improves inspectability for new users.
+
+Signed,
+**Echo** 🗣️

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -144,6 +144,23 @@ pub struct AletheiaDB {
     pub(crate) persistence_thread_handle: Option<std::thread::JoinHandle<()>>,
 }
 
+impl std::fmt::Debug for AletheiaDB {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let current_ts = self
+            .current_timestamp
+            .try_lock()
+            .map(|ts| format!("{:?}", ts))
+            .unwrap_or_else(|_| "<locked>".to_string());
+
+        f.debug_struct("AletheiaDB")
+            .field("current_timestamp", &current_ts)
+            .field("default_durability", &self.default_durability)
+            .field("persistence_enabled", &self.persistence_manager.is_some())
+            .field("stats", &self.stats)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Drop for AletheiaDB {
     fn drop(&mut self) {
         // Signal shutdown to background persistence thread

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2241,3 +2241,15 @@ fn test_multiple_edges_same_nodes() {
     assert_eq!(db.out_degree(bob), 1);
     assert_eq!(db.in_degree(bob), 2);
 }
+
+#[test]
+fn test_debug_implementation() {
+    let db = AletheiaDB::new().unwrap();
+    let debug_output = format!("{:?}", db);
+
+    assert!(debug_output.contains("AletheiaDB"));
+    assert!(debug_output.contains("current_timestamp"));
+    assert!(debug_output.contains("default_durability"));
+    assert!(debug_output.contains("persistence_enabled"));
+    assert!(debug_output.contains("stats"));
+}

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -484,7 +484,7 @@ fn test_wal_creation_failure_propagates_error() {
     );
 
     // Error should mention an I/O issue
-    let err = result.err().expect("Expected an error");
+    let err = result.expect_err("Expected an error");
     let err_msg = err.to_string().to_lowercase();
     assert!(
         err_msg.contains("i/o")


### PR DESCRIPTION
This PR implements `std::fmt::Debug` for the main `AletheiaDB` struct. Previously, users attempting to print the database handle (e.g., for debugging configuration) would encounter a compile error. This change allows for safe, non-blocking inspection of the database state, including current timestamp, durability settings, and statistics status.

Key changes:
- Manual `Debug` implementation for `AletheiaDB`.
- Use of `.try_lock()` to avoid deadlocks when printing debug info from a thread that might hold the lock.
- Added regression test `test_debug_implementation`.
- Created `DX_AUDIT_REPORT_ECHO.md` documenting the DX audit findings.

---
*PR created automatically by Jules for task [12246519926796842730](https://jules.google.com/task/12246519926796842730) started by @madmax983*