### PR TITLE
Fix ConcurrentWal partial batch writes on shutdown

### DIFF
--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -68,7 +68,7 @@
 
 use std::cell::Cell;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use super::lsn_allocator::LsnAllocator;
 use super::ring_buffer::{CompletionHandle, PendingEntry};
@@ -160,6 +160,26 @@ pub struct ConcurrentWal {
     stripe_mask: usize,
     /// Total entries appended across all stripes.
     total_appends: AtomicU64,
+    /// Flag indicating if shutdown has been requested.
+    shutdown_requested: AtomicBool,
+    /// Counter for active batch operations.
+    active_batches: AtomicUsize,
+}
+
+/// Guard for tracking active batch operations.
+struct ActiveBatchGuard<'a>(&'a AtomicUsize);
+
+impl<'a> ActiveBatchGuard<'a> {
+    fn new(counter: &'a AtomicUsize) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self(counter)
+    }
+}
+
+impl<'a> Drop for ActiveBatchGuard<'a> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl ConcurrentWal {
@@ -180,6 +200,8 @@ impl ConcurrentWal {
             num_stripes,
             stripe_mask,
             total_appends: AtomicU64::new(0),
+            shutdown_requested: AtomicBool::new(false),
+            active_batches: AtomicUsize::new(0),
         })
     }
 
@@ -253,6 +275,13 @@ impl ConcurrentWal {
     ///
     /// The allocated LSN for this entry.
     pub fn append_async(&self, operation: WalOperation) -> Result<LSN> {
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL is shutting down".to_string(),
+            }));
+        }
+        let _guard = ActiveBatchGuard::new(&self.active_batches);
+
         let lsn = self.lsn_allocator.allocate();
         let data = self.serialize_entry(lsn, &operation)?;
         let stripe = self.get_stripe();
@@ -278,6 +307,13 @@ impl ConcurrentWal {
     /// - `Ok(lsn)` - The entry is now durable
     /// - `Err(...)` - Flush failed
     pub fn append_sync(&self, operation: WalOperation) -> Result<LSN> {
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL is shutting down".to_string(),
+            }));
+        }
+        let _guard = ActiveBatchGuard::new(&self.active_batches);
+
         let lsn = self.lsn_allocator.allocate();
         let data = self.serialize_entry(lsn, &operation)?;
         let stripe = self.get_stripe();
@@ -305,6 +341,13 @@ impl ConcurrentWal {
     /// This method will block if the buffer is full until space becomes
     /// available (backpressure).
     pub fn append_with_handle(&self, operation: WalOperation) -> Result<(LSN, CompletionHandle)> {
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL is shutting down".to_string(),
+            }));
+        }
+        let _guard = ActiveBatchGuard::new(&self.active_batches);
+
         let lsn = self.lsn_allocator.allocate();
         let data = self.serialize_entry(lsn, &operation)?;
         let stripe = self.get_stripe();
@@ -356,6 +399,13 @@ impl ConcurrentWal {
     /// assert_eq!(lsns.len(), 3);
     /// ```
     pub fn append_batch(&self, operations: Vec<WalOperation>) -> Result<Vec<LSN>> {
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL is shutting down".to_string(),
+            }));
+        }
+        let _guard = ActiveBatchGuard::new(&self.active_batches);
+
         // Handle empty batch early
         if operations.is_empty() {
             return Ok(Vec::new());
@@ -410,6 +460,13 @@ impl ConcurrentWal {
         &self,
         operations: Vec<WalOperation>,
     ) -> Result<(Vec<LSN>, Vec<CompletionHandle>)> {
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL is shutting down".to_string(),
+            }));
+        }
+        let _guard = ActiveBatchGuard::new(&self.active_batches);
+
         // Handle empty batch early
         if operations.is_empty() {
             return Ok((Vec::new(), Vec::new()));
@@ -519,6 +576,29 @@ impl ConcurrentWal {
         for stripe in &self.stripes {
             stripe.close();
         }
+    }
+
+    /// Gracefully shutdown the WAL.
+    ///
+    /// This signals that shutdown is requested (preventing new batches),
+    /// waits for all active batches to complete, and then closes the ring buffers.
+    pub fn shutdown_graceful(&self) {
+        // 1. Signal shutdown
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+
+        // 2. Wait for active batches to complete
+        let mut spins = 0;
+        while self.active_batches.load(Ordering::SeqCst) > 0 {
+            if spins < 100 {
+                std::hint::spin_loop();
+            } else {
+                std::thread::yield_now();
+            }
+            spins += 1;
+        }
+
+        // 3. Close buffers
+        self.close();
     }
 
     /// Check if the WAL is closed.

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -697,9 +697,10 @@ impl ConcurrentWalSystem {
     /// This signals the background thread to stop, waits for it to finish,
     /// and performs a final flush of all pending entries.
     pub fn shutdown(&mut self) {
-        // Close the WAL first to prevent new appends.
-        // This ensures that we don't accept new writes while we are stopping the flush thread.
-        self.wal.close();
+        // Gracefully shutdown the WAL.
+        // This stops accepting new writes, waits for active batches to complete,
+        // and then closes the ring buffers.
+        self.wal.shutdown_graceful();
 
         // Signal shutdown
         self.shutdown_signal.store(true, Ordering::Relaxed);

--- a/tests/shutdown_correctness.rs
+++ b/tests/shutdown_correctness.rs
@@ -107,3 +107,77 @@ fn test_shutdown_data_consistency() {
     // Also verify internal counters match
     assert_eq!(total_appends, flushed, "Internal counters mismatch");
 }
+
+#[test]
+fn test_shutdown_batch_atomicity() {
+    // Verifies that a batch append either fully succeeds or is fully rejected,
+    // and never results in partial writes during shutdown.
+    // This specifically tests the `active_batches` wait logic.
+
+    let dir = tempdir().unwrap();
+
+    // Use ConcurrentWal directly to allow simultaneous append and shutdown
+    // (ConcurrentWalSystem shutdown requires &mut self which forces Mutex serialization)
+    // We simulate the flush thread with a background drainer.
+    use aletheiadb::storage::wal::concurrent::{ConcurrentWal, ConcurrentWalConfig};
+
+    let config = ConcurrentWalConfig::new(dir.path())
+        .with_stripe_capacity(2) // Capacity 2
+        .with_num_stripes(1); // Single stripe
+
+    let wal = Arc::new(ConcurrentWal::new(config).unwrap());
+
+    // Background drainer (simulates flush thread)
+    let wal_drain = Arc::clone(&wal);
+    let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let running_clone = Arc::clone(&running);
+    let collected_entries = Arc::new(Mutex::new(Vec::new()));
+    let collected_clone = Arc::clone(&collected_entries);
+
+    let drainer = thread::spawn(move || {
+        while running_clone.load(Ordering::SeqCst) {
+            let mut entries = wal_drain.drain_all();
+            if !entries.is_empty() {
+                collected_clone.lock().unwrap().append(&mut entries);
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        // Final drain
+        let mut entries = wal_drain.drain_all();
+        if !entries.is_empty() {
+            collected_clone.lock().unwrap().append(&mut entries);
+        }
+    });
+
+    // Thread 1: Append batch
+    let wal_clone = Arc::clone(&wal);
+    let writer = thread::spawn(move || {
+        let ops = vec![
+            create_test_operation(1),
+            create_test_operation(2),
+            create_test_operation(3),
+            create_test_operation(4),
+        ];
+        wal_clone.append_batch(ops)
+    });
+
+    // Wait for writer to block
+    thread::sleep(Duration::from_millis(50));
+
+    // Thread 2: Shutdown
+    wal.shutdown_graceful();
+
+    // Stop drainer
+    running.store(false, Ordering::SeqCst);
+    drainer.join().unwrap();
+
+    // Verify
+    let result = writer.join().unwrap();
+    assert!(
+        result.is_ok(),
+        "append_batch should succeed with graceful shutdown"
+    );
+
+    let entries = collected_entries.lock().unwrap();
+    assert_eq!(entries.len(), 4, "Expected all 4 entries (full batch)");
+}


### PR DESCRIPTION
Identified and fixed a critical data loss risk where `ConcurrentWal::append_batch` could result in partial writes if `shutdown()` was called concurrently. Implemented `active_batches` tracking and a graceful shutdown sequence that waits for pending batches to complete. Added a regression test verifying batch atomicity under shutdown pressure.

---
*PR created automatically by Jules for task [5536904940153075430](https://jules.google.com/task/5536904940153075430) started by @madmax983*