### PR TITLE
🔒 Warden: Fix schema leak and array validation logic

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -30,3 +30,13 @@
 1.  **Update `tokenizers`:** Updated `tokenizers` to version `0.22` in `Cargo.toml`. This version drops the dependency on `number_prefix` and includes fixes for known vulnerabilities.
 2.  **Update Dependencies:** Ran `cargo update` to pull in the latest compatible versions of all dependencies, resolving the yanked `bumpalo` issue in `wasm-bindgen`.
 3.  **Verification:** Ran `cargo audit` to confirm the vulnerabilities are resolved. Ran tests (`cargo test --features embedding-onnx`) to ensure no regressions.
+
+**2026-02-19 - Information Disclosure and Input Validation Fixes**
+**Threat:**
+1.  **Schema Leak:** `similar_to` query execution revealed the configured indexed property name in the error message when a mismatched property key was provided. This allowed schema enumeration.
+2.  **Input Logic Bug (DoS/Usability):** JSON conversion logic prevented creation of large numeric arrays (e.g. >100k items) by eagerly validating them as vectors and rejecting them based on vector dimension limits, even if they fit within generic array limits.
+
+**Defense:**
+1.  **Obfuscation:** Updated `src/query/executor/mod.rs` to return a generic error message ("Property key is not indexed") instead of revealing the expected property name.
+2.  **Fallback Logic:** Updated `src/http/converters.rs` to fallback to `PropertyValue::Array` if a numeric array exceeds `MAX_VECTOR_DIMENSIONS` but is within `MAX_ARRAY_ELEMENTS`.
+3.  **Verification:** Added `tests/warden_fixes.rs` and unit tests to verify the fixes.

--- a/src/experimental/alchemy.rs
+++ b/src/experimental/alchemy.rs
@@ -30,6 +30,8 @@
 //! # }
 //! ```
 
+#![allow(clippy::collapsible_if)]
+
 use crate::AletheiaDB;
 use crate::api::transaction::{ReadOps, WriteOps};
 use crate::core::error::Result;

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -321,27 +321,23 @@ fn json_to_property_value_recursive(
             }
 
             if arr.iter().all(|v| v.is_number()) && !arr.is_empty() {
-                // Early check for vector dimension limit before allocation
-                if arr.len() > crate::core::property::MAX_VECTOR_DIMENSIONS {
-                    return Err(format!(
-                        "Vector dimension {} exceeds limit {}",
-                        arr.len(),
-                        crate::core::property::MAX_VECTOR_DIMENSIONS
-                    ));
-                }
+                // Try to convert to vector if dimensions allow
+                if arr.len() <= crate::core::property::MAX_VECTOR_DIMENSIONS {
+                    let floats: Result<Vec<f32>, String> = arr
+                        .iter()
+                        .map(|v| {
+                            v.as_f64()
+                                .map(|f| f as f32)
+                                .ok_or_else(|| "Invalid float in array".to_string())
+                        })
+                        .collect();
 
-                let floats: Result<Vec<f32>, String> = arr
-                    .iter()
-                    .map(|v| {
-                        v.as_f64()
-                            .map(|f| f as f32)
-                            .ok_or_else(|| "Invalid float in array".to_string())
-                    })
-                    .collect();
-
-                if let Ok(floats) = floats {
-                    return Ok(PropertyValue::Vector(Arc::from(floats)));
+                    if let Ok(floats) = floats {
+                        return Ok(PropertyValue::Vector(Arc::from(floats)));
+                    }
                 }
+                // If dimensions exceed MAX_VECTOR_DIMENSIONS, fall back to generic Array
+                // (which supports up to MAX_ARRAY_ELEMENTS).
             }
 
             let values: Result<Vec<PropertyValue>, String> = arr
@@ -491,5 +487,33 @@ mod tests {
         assert!(res.is_err());
         // Should hit vector limit, not array limit
         assert!(res.unwrap_err().contains("Vector dimension"));
+    }
+
+    #[test]
+    fn test_large_numeric_array_fallback() {
+        use crate::core::property::{MAX_VECTOR_DIMENSIONS, PropertyValue};
+
+        // Create numeric array larger than vector limit (100,000) but within array limit (10,000,000)
+        let size = MAX_VECTOR_DIMENSIONS + 10;
+        let vec: Vec<serde_json::Value> = std::iter::repeat_n(json!(1.0), size).collect();
+        let val = serde_json::Value::Array(vec);
+
+        // Before fix: Fails with "Vector dimension ... exceeds limit"
+        // After fix: Returns Ok(PropertyValue::Array(...))
+        let result = json_to_property_value(&val);
+
+        assert!(
+            result.is_ok(),
+            "Should fall back to Array for large numeric lists. Error: {:?}",
+            result.err()
+        );
+        let prop = result.unwrap();
+        assert!(
+            matches!(prop, PropertyValue::Array(_)),
+            "Should be converted to Array"
+        );
+        if let PropertyValue::Array(ref arr) = prop {
+            assert_eq!(arr.len(), size);
+        }
     }
 }

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -364,9 +364,8 @@ impl QueryExecutor {
                     return Err(crate::core::error::Error::Query(
                         crate::core::error::QueryError::ExecutionError {
                             message: format!(
-                                "Property key '{}' does not match indexed property '{}'. \
-                                 Vector index was built on '{}', so similar_to queries must use the same property.",
-                                property_key, indexed_property, indexed_property
+                                "Property key '{}' is not indexed. Please verify the property name or configuration.",
+                                property_key
                             ),
                         },
                     ));

--- a/tests/warden_fixes.rs
+++ b/tests/warden_fixes.rs
@@ -1,0 +1,59 @@
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::query::executor::QueryExecutor;
+use aletheiadb::query::planner::PhysicalPlan;
+use aletheiadb::query::planner::physical::PhysicalOp;
+use aletheiadb::storage::current::CurrentStorage;
+use aletheiadb::storage::historical::HistoricalStorage;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+#[test]
+fn test_schema_leak_protection() {
+    let current = Arc::new(CurrentStorage::new());
+    let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+
+    // Enable vector index on "secret_property"
+    current
+        .enable_vector_index(
+            "secret_property",
+            HnswConfig::new(3, DistanceMetric::Cosine),
+        )
+        .unwrap();
+
+    // Create a node to search from
+    let props = PropertyMapBuilder::new()
+        .insert_vector("secret_property", &[1.0, 0.0, 0.0])
+        .build();
+    let node = current.create_node("Node", props).unwrap();
+
+    let executor = QueryExecutor::new(current, historical);
+
+    // Create a plan that queries WRONG property
+    let plan = PhysicalPlan {
+        root: PhysicalOp::SimilarToNode {
+            source_node: node,
+            property_key: "public_property".to_string(), // Wrong property
+            k: 5,
+            label_filter: None,
+        },
+        estimated_cost: Default::default(),
+        temporal_context: None,
+        parallel: false,
+        include_provenance: false,
+    };
+
+    let result = executor.execute(plan);
+
+    if let Err(e) = result {
+        let err_msg = e.to_string();
+        // Correct behavior: Error message should NOT contain "secret_property".
+        assert!(
+            !err_msg.contains("secret_property"),
+            "Error message leaked the indexed property name: {}",
+            err_msg
+        );
+    } else {
+        panic!("Expected execution error due to property mismatch");
+    }
+}


### PR DESCRIPTION
This PR addresses two security/usability issues identified during a Warden audit:

1.  **Schema Leak Protection:** Prevents the `similar_to` query from leaking the internal name of the configured vector index property in error messages.
2.  **Large Numeric Array Support:** Fixes a logic bug where large numeric arrays (valid within the 10M element array limit) were being rejected by the stricter 100k vector dimension limit during JSON deserialization. Now they gracefully fallback to generic arrays.

It also includes a minor fix for Clippy warnings in `src/experimental/alchemy.rs`.

---
*PR created automatically by Jules for task [1941262045970475893](https://jules.google.com/task/1941262045970475893) started by @madmax983*