### PR TITLE
🤖 Sentinel: Kill BackpressureConfig mutation in ring_buffer.rs

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -822,6 +822,18 @@ mod tests {
     }
 
     #[test]
+    fn test_backpressure_config_equal_spins() {
+        let config = BackpressureConfig {
+            initial_spins: 10,
+            max_spins: 10, // Equal is valid
+            base_sleep_us: 1,
+            max_sleep_us: 10,
+        };
+        // Should not panic
+        let _ = WalRingBuffer::with_config(1024, config);
+    }
+
+    #[test]
     fn test_completion_notifier_error() {
         let notifier = CompletionNotifier::new();
 


### PR DESCRIPTION
**🧬 Mutants Found:**
- Found 1 surviving mutant in `src/storage/wal/ring_buffer.rs`.
- The mutant `replace < with <=` in `BackpressureConfig::validate` survived because no test verified that `initial_spins == max_spins` is a valid configuration.

**🎯 Tests Added:**
- Added `test_backpressure_config_equal_spins` to `src/storage/wal/ring_buffer.rs`.
- This test explicitly constructs a config where `initial_spins == max_spins` (10 == 10) and asserts it does not panic.
- This kills the mutant which would incorrectly reject this configuration.

**📊 Kill Rate:**
- `lsn_allocator.rs` seems robust (100% kill rate on sample).
- `ring_buffer.rs` had at least one gap in validation logic coverage.

**🔗 Havoc Interaction:**
- `cargo mutants` initially timed out due to `havoc` tests. I used targeted testing (`-- --lib storage::wal::ring_buffer`) to bypass this.

---
*PR created automatically by Jules for task [5128472679433594236](https://jules.google.com/task/5128472679433594236) started by @madmax983*