### PR TITLE
Fix distributed transaction durability by enabling automatic recovery

### DIFF
--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -302,9 +302,15 @@ impl ShardCoordinator {
         // Ensure result is used to avoid dead code elimination/coverage gaps
         if !result.is_complete() {
             #[cfg(feature = "observability")]
-            tracing::warn!(
+            tracing::error!(
                 "Recovered partial state on startup: {} recovered, {} dead lettered",
                 result.recovered.len(),
+                result.dead_letter_count()
+            );
+
+            // Fail fast on startup if we cannot guarantee consistency
+            panic!(
+                "Failed to recover all pending transactions on startup. {} transactions are dead-lettered. Manual intervention required.",
                 result.dead_letter_count()
             );
         }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,11 +283,8 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        if let Err(e) = coordinator.recover_pending_transactions() {
-            // This path is practically unreachable as it only triggers on lock poisoning
-            // within a freshly created struct.
-            panic!("Failed to recover pending transactions on startup: {}", e);
-        }
+        // This will panic if the commit log lock is poisoned (unlikely on startup)
+        coordinator.recover_pending_transactions();
 
         coordinator
     }
@@ -855,14 +852,9 @@ impl ShardCoordinator {
     /// A `RecoveryResult` containing:
     /// *   `recovered`: List of `TxId`s that were successfully completed.
     /// *   `dead_lettered`: List of transactions that failed after max retries and require manual intervention.
-    pub fn recover_pending_transactions(&self) -> Result<RecoveryResult, DistributedTxError> {
+    pub fn recover_pending_transactions(&self) -> RecoveryResult {
         let decisions = {
-            let log = self
-                .commit_log
-                .read()
-                .map_err(|_| DistributedTxError::Aborted {
-                    reason: "Lock poisoned".to_string(),
-                })?;
+            let log = self.commit_log.read().expect("Commit log lock poisoned");
             log.pending_commits()
                 .into_iter()
                 .map(|d| (d.tx_id, d.participants.clone(), d.commit_timestamp))
@@ -946,10 +938,10 @@ impl ShardCoordinator {
             }
         }
 
-        Ok(RecoveryResult {
+        RecoveryResult {
             recovered,
             dead_lettered,
-        })
+        }
     }
 
     /// Get transactions in the dead letter queue.

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,9 +283,7 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        coordinator
-            .recover_pending_transactions()
-            .expect("Failed to recover pending transactions on startup");
+        coordinator.recover_pending_transactions().expect("Failed to recover pending transactions on startup");
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -284,8 +284,9 @@ impl ShardCoordinator {
 
         // Recover pending transactions on startup
         // This will panic if the commit log lock is poisoned (unlikely on startup)
-        let recovery_result = coordinator.recover_pending_transactions();
-        drop(recovery_result);
+        let result = coordinator.recover_pending_transactions();
+        // Ensure result is used to avoid dead code elimination/coverage gaps
+        let _ = result.is_complete();
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,9 +283,9 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        if let Err(e) = coordinator.recover_pending_transactions() {
-            panic!("Failed to recover pending transactions on startup: {}", e);
-        }
+        coordinator
+            .recover_pending_transactions()
+            .expect("Failed to recover pending transactions on startup");
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -267,7 +267,7 @@ impl ShardCoordinator {
 
         let router = ShardRouter::new(config);
 
-        Self {
+        let coordinator = Self {
             router,
             connections: RwLock::new(connections),
             shard_states: RwLock::new(shard_states),
@@ -280,7 +280,14 @@ impl ShardCoordinator {
             rebalance_config: RebalanceConfig::default(),
             transaction_timeout,
             dead_letter_queue: RwLock::new(HashMap::new()),
+        };
+
+        // Recover pending transactions on startup
+        if let Err(e) = coordinator.recover_pending_transactions() {
+            panic!("Failed to recover pending transactions on startup: {}", e);
         }
+
+        coordinator
     }
 
     /// Create a coordinator with custom rebalance config.

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -284,7 +284,8 @@ impl ShardCoordinator {
 
         // Recover pending transactions on startup
         // This will panic if the commit log lock is poisoned (unlikely on startup)
-        let _ = coordinator.recover_pending_transactions();
+        let recovery_result = coordinator.recover_pending_transactions();
+        drop(recovery_result);
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,8 +283,11 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        let recovery_result = coordinator.recover_pending_transactions();
-        recovery_result.expect("Failed to recover pending transactions on startup");
+        if let Err(e) = coordinator.recover_pending_transactions() {
+            // This path is practically unreachable as it only triggers on lock poisoning
+            // within a freshly created struct.
+            panic!("Failed to recover pending transactions on startup: {}", e);
+        }
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -284,7 +284,7 @@ impl ShardCoordinator {
 
         // Recover pending transactions on startup
         // This will panic if the commit log lock is poisoned (unlikely on startup)
-        coordinator.recover_pending_transactions();
+        let _ = coordinator.recover_pending_transactions();
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,8 +283,7 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        coordinator.recover_pending_transactions().unwrap();
-
+        coordinator.recover_pending_transactions().expect("Failed to recover pending transactions on startup");
         coordinator
     }
 

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,7 +283,7 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        coordinator.recover_pending_transactions().expect("Failed to recover pending transactions on startup");
+        coordinator.recover_pending_transactions().unwrap();
 
         coordinator
     }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,7 +283,9 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        coordinator.recover_pending_transactions().expect("Failed to recover pending transactions on startup");
+        coordinator
+            .recover_pending_transactions()
+            .expect("Failed to recover pending transactions on startup");
         coordinator
     }
 

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,10 +283,7 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        // This will panic if the commit log lock is poisoned (unlikely on startup)
-        let result = coordinator.recover_pending_transactions();
-        // Ensure result is used to avoid dead code elimination/coverage gaps
-        let _ = result.is_complete();
+        coordinator.startup_recovery();
 
         coordinator
     }
@@ -295,6 +292,22 @@ impl ShardCoordinator {
     pub fn with_rebalance_config(mut self, config: RebalanceConfig) -> Self {
         self.rebalance_config = config;
         self
+    }
+
+    fn startup_recovery(&self) {
+        // Recover pending transactions on startup
+        // This will panic if the commit log lock is poisoned (unlikely on startup)
+        let result = self.recover_pending_transactions();
+
+        // Ensure result is used to avoid dead code elimination/coverage gaps
+        if !result.is_complete() {
+            #[cfg(feature = "observability")]
+            tracing::warn!(
+                "Recovered partial state on startup: {} recovered, {} dead lettered",
+                result.recovered.len(),
+                result.dead_letter_count()
+            );
+        }
     }
 
     fn reinsert_transaction(&self, tx_id: TxId, transaction: DistributedTransaction) {

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -283,9 +283,9 @@ impl ShardCoordinator {
         };
 
         // Recover pending transactions on startup
-        coordinator
-            .recover_pending_transactions()
-            .expect("Failed to recover pending transactions on startup");
+        let recovery_result = coordinator.recover_pending_transactions();
+        recovery_result.expect("Failed to recover pending transactions on startup");
+
         coordinator
     }
 

--- a/tests/sentry_shard_recovery.rs
+++ b/tests/sentry_shard_recovery.rs
@@ -75,7 +75,10 @@ fn test_shard_recovery_data_loss_repro() {
         .get_metrics(ShardId::new(0).unwrap())
         .expect("Shard 0 metrics should exist");
     assert!(
-        metrics0.writes_total.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+        metrics0
+            .writes_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+            >= 1,
         "Shard 0 should have recorded a write during recovery"
     );
 
@@ -83,7 +86,10 @@ fn test_shard_recovery_data_loss_repro() {
         .get_metrics(ShardId::new(1).unwrap())
         .expect("Shard 1 metrics should exist");
     assert!(
-        metrics1.writes_total.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+        metrics1
+            .writes_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+            >= 1,
         "Shard 1 should have recorded a write during recovery"
     );
 

--- a/tests/sentry_shard_recovery.rs
+++ b/tests/sentry_shard_recovery.rs
@@ -54,31 +54,20 @@ fn test_shard_recovery_data_loss_repro() {
     // Create new coordinator with SAME config (pointing to same WAL)
     let coordinator_recovered = ShardCoordinator::new(config);
 
-    // 6. Attempt Recovery
+    // 6. Attempt Recovery (Manual check)
+    // Since ShardCoordinator::new() now automatically recovers pending transactions,
+    // this manual call should find no pending transactions if auto-recovery worked.
     let result = coordinator_recovered
         .recover_pending_transactions()
         .unwrap();
 
     // 7. Verify Data Recovery (Fix Verification)
-    // The transaction should be in the 'recovered' list (or 'dead_lettered' if retry fails, but recovery logic might retry commit).
-    // Wait, recover_pending_transactions retries commit.
-    // But the shards are still unavailable (new coordinator creates new connections, but they point to "localhost:9000" which is not a real server).
-    // The mock ShardConnection is "healthy" by default.
-    // So recovery should SUCCEED because the new coordinator thinks shards are healthy!
-    // (Unless the mock connection actually tries network).
-    // ShardConnection logic:
-    // "Simulate a prepare call... In a real implementation, this would make an RPC call"
-    // It returns Ok if healthy.
-
-    // New coordinator -> New connections -> Default Healthy.
-    // So recover_pending_transactions -> commit_distributed_transaction -> conn.commit() -> Ok.
-    // So transaction should be in `recovered`.
-
+    // If auto-recovery worked, the transaction was committed and removed from the WAL pending list.
+    // If auto-recovery failed (bug), this list would contain the transaction.
     assert!(
-        !result.recovered.is_empty(),
-        "Transaction should be recovered from WAL"
+        result.recovered.is_empty(),
+        "Transaction should have been automatically recovered by ShardCoordinator::new()"
     );
-    assert!(result.recovered.contains(&tx_id));
     assert!(result.dead_lettered.is_empty());
 
     // Cleanup

--- a/tests/sentry_shard_recovery.rs
+++ b/tests/sentry_shard_recovery.rs
@@ -1,7 +1,6 @@
 use aletheiadb::storage::sharding::config::{ShardConfig, ShardDefinition};
 use aletheiadb::storage::sharding::coordinator::ShardCoordinator;
 use aletheiadb::storage::sharding::types::ShardId;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -76,7 +75,7 @@ fn test_shard_recovery_data_loss_repro() {
         .get_metrics(ShardId::new(0).unwrap())
         .expect("Shard 0 metrics should exist");
     assert!(
-        metrics0.writes_total.load(Ordering::Relaxed) >= 1,
+        metrics0.writes_total.load(std::sync::atomic::Ordering::Relaxed) >= 1,
         "Shard 0 should have recorded a write during recovery"
     );
 
@@ -84,7 +83,7 @@ fn test_shard_recovery_data_loss_repro() {
         .get_metrics(ShardId::new(1).unwrap())
         .expect("Shard 1 metrics should exist");
     assert!(
-        metrics1.writes_total.load(Ordering::Relaxed) >= 1,
+        metrics1.writes_total.load(std::sync::atomic::Ordering::Relaxed) >= 1,
         "Shard 1 should have recorded a write during recovery"
     );
 

--- a/tests/sentry_shard_recovery.rs
+++ b/tests/sentry_shard_recovery.rs
@@ -58,9 +58,7 @@ fn test_shard_recovery_data_loss_repro() {
     // 6. Attempt Recovery (Manual check)
     // Since ShardCoordinator::new() now automatically recovers pending transactions,
     // this manual call should find no pending transactions if auto-recovery worked.
-    let result = coordinator_recovered
-        .recover_pending_transactions()
-        .unwrap();
+    let result = coordinator_recovered.recover_pending_transactions();
 
     // 7. Verify Data Recovery (Fix Verification)
     // If auto-recovery worked, the transaction was committed and removed from the WAL pending list.

--- a/tests/sentry_shard_recovery.rs
+++ b/tests/sentry_shard_recovery.rs
@@ -1,6 +1,7 @@
 use aletheiadb::storage::sharding::config::{ShardConfig, ShardDefinition};
 use aletheiadb::storage::sharding::coordinator::ShardCoordinator;
 use aletheiadb::storage::sharding::types::ShardId;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -69,6 +70,25 @@ fn test_shard_recovery_data_loss_repro() {
         "Transaction should have been automatically recovered by ShardCoordinator::new()"
     );
     assert!(result.dead_lettered.is_empty());
+
+    // Verify that the transaction was actually committed (not just dropped) by checking shard metrics.
+    // The transaction involved shard0 and shard1.
+    // Each should have recorded 1 distributed write during recovery.
+    let metrics0 = coordinator_recovered
+        .get_metrics(ShardId::new(0).unwrap())
+        .expect("Shard 0 metrics should exist");
+    assert!(
+        metrics0.writes_total.load(Ordering::Relaxed) >= 1,
+        "Shard 0 should have recorded a write during recovery"
+    );
+
+    let metrics1 = coordinator_recovered
+        .get_metrics(ShardId::new(1).unwrap())
+        .expect("Shard 1 metrics should exist");
+    assert!(
+        metrics1.writes_total.load(Ordering::Relaxed) >= 1,
+        "Shard 1 should have recorded a write during recovery"
+    );
 
     // Cleanup
     // temp_dir drops automatically


### PR DESCRIPTION
### Fixes
*   **Correctness:** `ShardCoordinator::new` now invokes `recover_pending_transactions()`. This ensures that distributed transactions that were in the "Commit" phase (logged to WAL) but not yet completed (applied to participants) are retried and completed upon restart. Previously, these were ignored, leading to potential data inconsistencies/loss.
*   **Safety:** The application now panics if recovery fails during startup, preventing it from serving requests while in an inconsistent state.

### Review Findings (Residual Risks)
*   **High Severity:** `PersistentCommitLog` ignores the `max_file_size` configuration and lacks log rotation. The WAL will grow indefinitely until disk exhaustion.
*   **Medium Severity:** `PersistentCommitLog::read_entries` stops processing at the first error. Any valid entries following a corrupted entry will be discarded, leading to data loss in case of partial corruption.
*   **Performance:** `PersistentCommitLog` defaults to `sync_on_write: true`, which may impact performance significantly. This is currently not configurable via `ShardConfig`.

### Verification
*   `tests/sentry_shard_recovery.rs`: Updated to verify that `recover_pending_transactions()` returns an empty list after startup (indicating automatic recovery succeeded), whereas previously it would return the pending transaction.
*   `tests/verify_automatic_recovery.rs` (Temporary): Confirmed that without this fix, pending transactions were lost on restart.
*   Ran `storage::sharding` test suite to ensure no regressions.

---
*PR created automatically by Jules for task [11701577915752616437](https://jules.google.com/task/11701577915752616437) started by @madmax983*