### PR TITLE
⚡ Bolt: Zero-copy CSR import optimization

### DIFF
--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -22,6 +22,7 @@ pub const MAX_VALID_ID: u64 = u64::MAX - 1000;
 
 /// Unique identifier for a node in the graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct NodeId(u64);
 
 impl NodeId {
@@ -65,6 +66,7 @@ impl fmt::Display for NodeId {
 
 /// Unique identifier for an edge in the graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct EdgeId(u64);
 
 impl EdgeId {
@@ -108,6 +110,7 @@ impl fmt::Display for EdgeId {
 
 /// Unique identifier for a version of a node or edge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct VersionId(u64);
 
 impl VersionId {
@@ -1445,6 +1448,7 @@ mod proptests {
 
 /// Transaction ID - globally unique identifier for transactions
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct TxId(u64);
 
 impl TxId {

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -771,19 +771,16 @@ mod tests {
         let node_ids = vec![1, 2];
         let offsets = vec![0, 1, 2];
         let edge_ids = vec![10, 20];
-        let mut edges_map = std::collections::HashMap::with_hasher(std::hash::BuildHasherDefault::<
-            crate::core::hasher::IdentityHasher,
-        >::default());
+        let mut edges_map =
+            std::collections::HashMap::with_hasher(std::hash::BuildHasherDefault::<
+                crate::core::hasher::IdentityHasher,
+            >::default());
 
-        let label = crate::core::interning::GLOBAL_INTERNER.intern("TEST").unwrap();
-        edges_map.insert(
-            EdgeId::new(10).unwrap(),
-            (NodeId::new(2).unwrap(), label),
-        );
-        edges_map.insert(
-            EdgeId::new(20).unwrap(),
-            (NodeId::new(1).unwrap(), label),
-        );
+        let label = crate::core::interning::GLOBAL_INTERNER
+            .intern("TEST")
+            .unwrap();
+        edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
+        edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
         let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
         assert_eq!(index.node_count(), 2);

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -108,12 +108,9 @@ impl AdjacencyIndex {
         // SAFETY: NodeId is #[repr(transparent)] wrapper around u64.
         let node_ids_typed: Vec<NodeId> = unsafe { Self::transmute_vec(node_ids) };
 
-        // Zero-copy conversion for offsets if pointer width is 64-bit (usize == u64)
-        #[cfg(target_pointer_width = "64")]
-        let offsets_usize: Vec<usize> = unsafe { Self::transmute_vec(offsets) };
+        // Convert offsets (zero-copy on 64-bit, allocating on 32-bit)
+        let offsets_usize = Self::convert_offsets(offsets);
 
-        #[cfg(not(target_pointer_width = "64"))]
-        let offsets_usize: Vec<usize> = offsets.iter().map(|&x| x as usize).collect();
         let mut adjacency_entries = Vec::with_capacity(edge_ids.len());
 
         for &edge_id_u64 in &edge_ids {
@@ -317,11 +314,27 @@ impl AdjacencyIndex {
         Ok(())
     }
 
+    /// Convert offsets to usize vector.
+    ///
+    /// On 64-bit systems, this is a zero-copy operation because usize == u64.
+    /// On 32-bit systems, this allocates a new vector because usize == u32 != u64.
+    fn convert_offsets(offsets: Vec<u64>) -> Vec<usize> {
+        #[cfg(target_pointer_width = "64")]
+        {
+            // SAFETY: usize == u64 on 64-bit platforms, so layout is compatible.
+            unsafe { Self::transmute_vec(offsets) }
+        }
+
+        #[cfg(not(target_pointer_width = "64"))]
+        {
+            offsets.iter().map(|&x| x as usize).collect()
+        }
+    }
+
     /// Helper for zero-copy Vec conversion
     ///
     /// # Safety
     /// T and U must have same layout, size, and alignment.
-    #[inline]
     unsafe fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U> {
         let mut v = std::mem::ManuallyDrop::new(v);
         // SAFETY: Caller ensures T and U layout compatibility.
@@ -730,6 +743,51 @@ mod tests {
             1000,
             "max_node_id should consider target nodes"
         );
+    }
+
+    #[test]
+    fn test_transmute_vec_correctness() {
+        let original = vec![1u64, 2, 3];
+        let ptr = original.as_ptr();
+        let cap = original.capacity();
+
+        // Use NodeId which is transparent wrapper around u64
+        // SAFETY: NodeId is repr(transparent) and same size/align as u64
+        let transmuted: Vec<NodeId> = unsafe { AdjacencyIndex::transmute_vec(original) };
+
+        assert_eq!(transmuted.len(), 3);
+        assert_eq!(transmuted.capacity(), cap);
+        assert_eq!(transmuted[0], NodeId::new(1).unwrap());
+        assert_eq!(transmuted[1], NodeId::new(2).unwrap());
+        assert_eq!(transmuted[2], NodeId::new(3).unwrap());
+
+        // Verify no copy happened (best effort check, pointers should match)
+        assert_eq!(transmuted.as_ptr() as *const u64, ptr);
+    }
+
+    #[test]
+    fn test_import_csr_integration() {
+        // This test ensures import_csr works in the standard test module scope
+        let node_ids = vec![1, 2];
+        let offsets = vec![0, 1, 2];
+        let edge_ids = vec![10, 20];
+        let mut edges_map = std::collections::HashMap::with_hasher(std::hash::BuildHasherDefault::<
+            crate::core::hasher::IdentityHasher,
+        >::default());
+
+        let label = crate::core::interning::GLOBAL_INTERNER.intern("TEST").unwrap();
+        edges_map.insert(
+            EdgeId::new(10).unwrap(),
+            (NodeId::new(2).unwrap(), label),
+        );
+        edges_map.insert(
+            EdgeId::new(20).unwrap(),
+            (NodeId::new(1).unwrap(), label),
+        );
+
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert_eq!(index.node_count(), 2);
+        assert_eq!(index.edge_count(), 2);
     }
 }
 

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -104,10 +104,21 @@ impl AdjacencyIndex {
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
-        let node_ids_typed: Vec<NodeId> = node_ids
-            .iter()
-            .map(|&id| NodeId::new_unchecked(id))
-            .collect();
+        // Zero-copy conversion: NodeId(u64) has same layout as u64
+        // SAFETY: NodeId is #[repr(transparent)] wrapper around u64.
+        let node_ids_typed: Vec<NodeId> = unsafe {
+            let mut v = std::mem::ManuallyDrop::new(node_ids);
+            Vec::from_raw_parts(v.as_mut_ptr() as *mut NodeId, v.len(), v.capacity())
+        };
+
+        // Zero-copy conversion for offsets if pointer width is 64-bit (usize == u64)
+        #[cfg(target_pointer_width = "64")]
+        let offsets_usize: Vec<usize> = unsafe {
+            let mut v = std::mem::ManuallyDrop::new(offsets);
+            Vec::from_raw_parts(v.as_mut_ptr() as *mut usize, v.len(), v.capacity())
+        };
+
+        #[cfg(not(target_pointer_width = "64"))]
         let offsets_usize: Vec<usize> = offsets.iter().map(|&x| x as usize).collect();
         let mut adjacency_entries = Vec::with_capacity(edge_ids.len());
 

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -106,17 +106,11 @@ impl AdjacencyIndex {
 
         // Zero-copy conversion: NodeId(u64) has same layout as u64
         // SAFETY: NodeId is #[repr(transparent)] wrapper around u64.
-        let node_ids_typed: Vec<NodeId> = unsafe {
-            let mut v = std::mem::ManuallyDrop::new(node_ids);
-            Vec::from_raw_parts(v.as_mut_ptr() as *mut NodeId, v.len(), v.capacity())
-        };
+        let node_ids_typed: Vec<NodeId> = unsafe { Self::transmute_vec(node_ids) };
 
         // Zero-copy conversion for offsets if pointer width is 64-bit (usize == u64)
         #[cfg(target_pointer_width = "64")]
-        let offsets_usize: Vec<usize> = unsafe {
-            let mut v = std::mem::ManuallyDrop::new(offsets);
-            Vec::from_raw_parts(v.as_mut_ptr() as *mut usize, v.len(), v.capacity())
-        };
+        let offsets_usize: Vec<usize> = unsafe { Self::transmute_vec(offsets) };
 
         #[cfg(not(target_pointer_width = "64"))]
         let offsets_usize: Vec<usize> = offsets.iter().map(|&x| x as usize).collect();
@@ -321,6 +315,19 @@ impl AdjacencyIndex {
         }
 
         Ok(())
+    }
+
+    /// Helper for zero-copy Vec conversion
+    ///
+    /// # Safety
+    /// T and U must have same layout, size, and alignment.
+    #[inline]
+    unsafe fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U> {
+        let mut v = std::mem::ManuallyDrop::new(v);
+        // SAFETY: Caller ensures T and U layout compatibility.
+        // from_raw_parts is unsafe, but we are inside an unsafe function.
+        // In Rust 2024 (and newer editions), unsafe blocks are required inside unsafe functions.
+        unsafe { Vec::from_raw_parts(v.as_mut_ptr() as *mut U, v.len(), v.capacity()) }
     }
 }
 


### PR DESCRIPTION
This PR implements a zero-copy optimization for importing Compressed Sparse Row (CSR) adjacency indexes.

### 💡 What
- Added `#[repr(transparent)]` to `NodeId`, `EdgeId`, `VersionId`, and `TxId` structs in `src/core/id.rs`.
- Refactored `AdjacencyIndex::import_csr` in `src/index/adjacency.rs` to use `Vec::from_raw_parts` for converting `Vec<u64>` to `Vec<NodeId>` and `Vec<usize>` (on 64-bit systems).

### 🎯 Why
- Previously, `import_csr` allocated new vectors and copied every element to convert `u64` to `NodeId` and `usize`.
- For large graphs with millions of nodes/edges, this resulted in significant memory churn and slower startup times.

### 📊 Impact
- Reduces heap allocations by 2 vectors of size `N` (nodes) and `M` (offsets) during graph loading.
- On a graph with 10M nodes, this saves allocating ~160MB of memory and the associated copy overhead.

### 🔬 Measurement
- Verified with `cargo test --lib index::adjacency` to ensure correctness.
- `cargo clippy` passes.


---
*PR created automatically by Jules for task [16745155533996935845](https://jules.google.com/task/16745155533996935845) started by @madmax983*