### PR TITLE
Fix transaction ID collision on recovery

### DIFF
--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -265,13 +265,14 @@ impl ShardCoordinator {
             PersistentCommitLog::in_memory()
         };
 
+        let max_tx_id = commit_log.max_seen_tx_id();
         let router = ShardRouter::new(config);
 
         Self {
             router,
             connections: RwLock::new(connections),
             shard_states: RwLock::new(shard_states),
-            tx_id_generator: IdGenerator::new(),
+            tx_id_generator: IdGenerator::with_start(max_tx_id + 1),
             active_transactions: RwLock::new(HashMap::new()),
             commit_log: RwLock::new(commit_log),
             commit_clock: Mutex::new(time::now()),

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -487,7 +487,12 @@ impl PersistentCommitLog {
                 .open(&path)
                 .map_err(|e| CommitLogError::IoError(format!("Failed to open log: {}", e)))?;
 
-            (Some(BufWriter::new(file)), max_lsn + 1, pending_map, max_tx_id)
+            (
+                Some(BufWriter::new(file)),
+                max_lsn + 1,
+                pending_map,
+                max_tx_id,
+            )
         } else {
             // Create new file with header
             let file = OpenOptions::new()
@@ -540,7 +545,8 @@ impl PersistentCommitLog {
     ) -> CommitLogResult<u64> {
         let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
         let entry = CommitLogEntry::commit(lsn, tx_id, participants, commit_timestamp);
-        self.max_seen_tx_id.fetch_max(tx_id.as_u64(), Ordering::SeqCst);
+        self.max_seen_tx_id
+            .fetch_max(tx_id.as_u64(), Ordering::SeqCst);
 
         self.write_entry(&entry)?;
 
@@ -556,7 +562,8 @@ impl PersistentCommitLog {
     pub fn log_abort(&self, tx_id: TxId, participants: Vec<ShardId>) -> CommitLogResult<u64> {
         let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
         let entry = CommitLogEntry::abort(lsn, tx_id, participants);
-        self.max_seen_tx_id.fetch_max(tx_id.as_u64(), Ordering::SeqCst);
+        self.max_seen_tx_id
+            .fetch_max(tx_id.as_u64(), Ordering::SeqCst);
 
         self.write_entry(&entry)?;
 
@@ -574,7 +581,8 @@ impl PersistentCommitLog {
     pub fn log_complete(&self, tx_id: TxId) -> CommitLogResult<u64> {
         let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
         let entry = CommitLogEntry::complete(lsn, tx_id);
-        self.max_seen_tx_id.fetch_max(tx_id.as_u64(), Ordering::SeqCst);
+        self.max_seen_tx_id
+            .fetch_max(tx_id.as_u64(), Ordering::SeqCst);
 
         self.write_entry(&entry)?;
 

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -418,6 +418,8 @@ pub struct PersistentCommitLog {
     entries_written: AtomicU64,
     /// Total bytes written.
     bytes_written: AtomicU64,
+    /// Maximum transaction ID seen.
+    max_seen_tx_id: AtomicU64,
 }
 
 /// Configuration for the persistent commit log.
@@ -456,9 +458,9 @@ impl PersistentCommitLog {
             })?;
         }
 
-        let (writer, lsn, pending) = if path.exists() {
+        let (writer, lsn, pending, max_tx_id) = if path.exists() {
             // Open existing file and recover state
-            let (entries, max_lsn) = Self::read_entries(&path)?;
+            let (entries, max_lsn, max_tx_id) = Self::read_entries(&path)?;
 
             // Build pending map (entries without completion)
             let mut pending_map = HashMap::new();
@@ -485,7 +487,7 @@ impl PersistentCommitLog {
                 .open(&path)
                 .map_err(|e| CommitLogError::IoError(format!("Failed to open log: {}", e)))?;
 
-            (Some(BufWriter::new(file)), max_lsn + 1, pending_map)
+            (Some(BufWriter::new(file)), max_lsn + 1, pending_map, max_tx_id)
         } else {
             // Create new file with header
             let file = OpenOptions::new()
@@ -498,7 +500,7 @@ impl PersistentCommitLog {
             let mut writer = BufWriter::new(file);
             Self::write_header(&mut writer)?;
 
-            (Some(writer), 1, HashMap::new())
+            (Some(writer), 1, HashMap::new(), 0)
         };
 
         Ok(Self {
@@ -509,6 +511,7 @@ impl PersistentCommitLog {
             config,
             entries_written: AtomicU64::new(0),
             bytes_written: AtomicU64::new(0),
+            max_seen_tx_id: AtomicU64::new(max_tx_id),
         })
     }
 
@@ -522,6 +525,7 @@ impl PersistentCommitLog {
             config: CommitLogConfig::default(),
             entries_written: AtomicU64::new(0),
             bytes_written: AtomicU64::new(0),
+            max_seen_tx_id: AtomicU64::new(0),
         }
     }
 
@@ -536,6 +540,7 @@ impl PersistentCommitLog {
     ) -> CommitLogResult<u64> {
         let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
         let entry = CommitLogEntry::commit(lsn, tx_id, participants, commit_timestamp);
+        self.max_seen_tx_id.fetch_max(tx_id.as_u64(), Ordering::SeqCst);
 
         self.write_entry(&entry)?;
 
@@ -551,6 +556,7 @@ impl PersistentCommitLog {
     pub fn log_abort(&self, tx_id: TxId, participants: Vec<ShardId>) -> CommitLogResult<u64> {
         let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
         let entry = CommitLogEntry::abort(lsn, tx_id, participants);
+        self.max_seen_tx_id.fetch_max(tx_id.as_u64(), Ordering::SeqCst);
 
         self.write_entry(&entry)?;
 
@@ -568,6 +574,7 @@ impl PersistentCommitLog {
     pub fn log_complete(&self, tx_id: TxId) -> CommitLogResult<u64> {
         let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
         let entry = CommitLogEntry::complete(lsn, tx_id);
+        self.max_seen_tx_id.fetch_max(tx_id.as_u64(), Ordering::SeqCst);
 
         self.write_entry(&entry)?;
 
@@ -624,6 +631,11 @@ impl PersistentCommitLog {
     /// Get the decision for a transaction.
     pub fn get_decision(&self, tx_id: TxId) -> Option<CommitLogEntry> {
         self.pending.read().ok()?.get(&tx_id).cloned()
+    }
+
+    /// Get the maximum transaction ID seen in the log.
+    pub fn max_seen_tx_id(&self) -> u64 {
+        self.max_seen_tx_id.load(Ordering::SeqCst)
     }
 
     /// Get the current LSN.
@@ -720,7 +732,7 @@ impl PersistentCommitLog {
         Ok(())
     }
 
-    fn read_entries(path: &Path) -> CommitLogResult<(Vec<CommitLogEntry>, u64)> {
+    fn read_entries(path: &Path) -> CommitLogResult<(Vec<CommitLogEntry>, u64, u64)> {
         let file = File::open(path)
             .map_err(|e| CommitLogError::IoError(format!("Failed to open log: {}", e)))?;
 
@@ -752,6 +764,7 @@ impl PersistentCommitLog {
         let mut entries = Vec::new();
         let mut offset = HEADER_SIZE;
         let mut max_lsn = 0u64;
+        let mut max_tx_id = 0u64;
 
         while offset < buffer.len() {
             if offset + 4 > buffer.len() {
@@ -774,6 +787,10 @@ impl PersistentCommitLog {
                     if entry.lsn > max_lsn {
                         max_lsn = entry.lsn;
                     }
+                    let tx_id_val = entry.tx_id.as_u64();
+                    if tx_id_val > max_tx_id {
+                        max_tx_id = tx_id_val;
+                    }
                     entries.push(entry);
                     offset += 4 + len;
                 }
@@ -784,7 +801,7 @@ impl PersistentCommitLog {
             }
         }
 
-        Ok((entries, max_lsn))
+        Ok((entries, max_lsn, max_tx_id))
     }
 }
 

--- a/tests/regressions/mod.rs
+++ b/tests/regressions/mod.rs
@@ -8,5 +8,5 @@ mod persistence_version_ids;
 mod property_deserialization_dos;
 mod temporal_query_visibility;
 mod temporal_version_lookup;
-mod wal_group_commit_epochs;
 mod tx_id_recovery_collision;
+mod wal_group_commit_epochs;

--- a/tests/regressions/mod.rs
+++ b/tests/regressions/mod.rs
@@ -9,3 +9,4 @@ mod property_deserialization_dos;
 mod temporal_query_visibility;
 mod temporal_version_lookup;
 mod wal_group_commit_epochs;
+mod tx_id_recovery_collision;

--- a/tests/regressions/tx_id_recovery_collision.rs
+++ b/tests/regressions/tx_id_recovery_collision.rs
@@ -1,0 +1,66 @@
+use aletheiadb::core::id::TxId;
+use aletheiadb::storage::sharding::config::{ShardConfig, ShardDefinition};
+use aletheiadb::storage::sharding::coordinator::ShardCoordinator;
+use aletheiadb::storage::sharding::types::ShardId;
+use tempfile::TempDir;
+
+#[test]
+fn test_coordinator_tx_id_collision_on_restart() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().to_path_buf();
+    let wal_path = db_path.join("commit.log");
+
+    let shard_config = ShardConfig::new(vec![ShardDefinition::new(
+        0,
+        "shard0:9000",
+        vec!["Person"],
+    )])
+    .with_wal_path(wal_path.clone());
+
+    // 1. Start Coordinator and generate some transactions
+    let mut last_tx_id_run1 = TxId::new(0);
+    {
+        let coordinator = ShardCoordinator::new(shard_config.clone());
+
+        // Generate 10 transactions
+        for _ in 0..10 {
+            let tx_id = coordinator
+                .begin_distributed_transaction(vec![ShardId::new(0).unwrap()])
+                .unwrap();
+            last_tx_id_run1 = tx_id;
+
+            // Log them as committed so they persist in WAL
+            // Note: In real life, we'd go through prepare/commit, but we can cheat by accessing log if needed,
+            // but going through public API is better.
+            coordinator
+                .prepare_distributed_transaction(tx_id)
+                .unwrap();
+            coordinator
+                .commit_distributed_transaction(tx_id)
+                .unwrap();
+        }
+    }
+
+    println!("Last TxId from Run 1: {}", last_tx_id_run1);
+
+    // 2. Restart Coordinator
+    {
+        let coordinator = ShardCoordinator::new(shard_config.clone());
+
+        // 3. Generate a NEW transaction
+        let new_tx_id = coordinator
+            .begin_distributed_transaction(vec![ShardId::new(0).unwrap()])
+            .unwrap();
+        println!("First TxId from Run 2: {}", new_tx_id);
+
+        // 4. Verify Monotonicity
+        // The new TxId MUST be greater than the last one from Run 1.
+        // If it reset to 0 (or 1), this assertion will fail.
+        assert!(
+            new_tx_id > last_tx_id_run1,
+            "TxId regression detected! Run 1 ended at {}, Run 2 started at {}",
+            last_tx_id_run1,
+            new_tx_id
+        );
+    }
+}

--- a/tests/regressions/tx_id_recovery_collision.rs
+++ b/tests/regressions/tx_id_recovery_collision.rs
@@ -10,12 +10,9 @@ fn test_coordinator_tx_id_collision_on_restart() {
     let db_path = dir.path().to_path_buf();
     let wal_path = db_path.join("commit.log");
 
-    let shard_config = ShardConfig::new(vec![ShardDefinition::new(
-        0,
-        "shard0:9000",
-        vec!["Person"],
-    )])
-    .with_wal_path(wal_path.clone());
+    let shard_config =
+        ShardConfig::new(vec![ShardDefinition::new(0, "shard0:9000", vec!["Person"])])
+            .with_wal_path(wal_path.clone());
 
     // 1. Start Coordinator and generate some transactions
     let mut last_tx_id_run1 = TxId::new(0);
@@ -32,12 +29,8 @@ fn test_coordinator_tx_id_collision_on_restart() {
             // Log them as committed so they persist in WAL
             // Note: In real life, we'd go through prepare/commit, but we can cheat by accessing log if needed,
             // but going through public API is better.
-            coordinator
-                .prepare_distributed_transaction(tx_id)
-                .unwrap();
-            coordinator
-                .commit_distributed_transaction(tx_id)
-                .unwrap();
+            coordinator.prepare_distributed_transaction(tx_id).unwrap();
+            coordinator.commit_distributed_transaction(tx_id).unwrap();
         }
     }
 


### PR DESCRIPTION
- **Fix Critical Data Loss Bug**: `PersistentCommitLog` now tracks `max_seen_tx_id` from the log. `ShardCoordinator` uses this to initialize `IdGenerator`, preventing ID reuse and collision with recovered transactions.
- **Added Regression Test**: `tests/regressions/tx_id_recovery_collision.rs` verifies that `TxId`s are monotonic across restarts.

Findings:
- **Severity**: Critical
- **Issue**: `TxId` generator reset to 0 on restart.
- **Impact**: New transactions could overwrite pending transactions during recovery, leading to data loss.
- **Root Cause**: `PersistentCommitLog` did not expose max ID, and `ShardCoordinator` did not use it.


---
*PR created automatically by Jules for task [9631090586649507852](https://jules.google.com/task/9631090586649507852) started by @madmax983*