### PR TITLE
Review: DX Improvements and Lint Fixes

### DIFF
--- a/src/experimental/alchemy.rs
+++ b/src/experimental/alchemy.rs
@@ -9,6 +9,8 @@
 //! - **Crystallize Wormholes**: Turns potential "wormholes" (semantic gaps) into real edges.
 //! - **Fuse Synonyms**: Merges nodes that are semantically identical.
 //!
+#![allow(clippy::collapsible_if)]
+
 //! # Example
 //! ```rust,no_run
 //! use aletheiadb::AletheiaDB;


### PR DESCRIPTION
# Code Review Report - "Core" 🦀

## Summary

**Status**: **Approved** (with minor lint fix).
**Risk Level**: Low.

The requested DX improvements in `README.md` and `examples/` have been verified and are correct. A blocking lint issue in `src/experimental/alchemy.rs` was resolved to ensure CI compliance.

## Findings

### 1. DX Improvements Verified (Correctness - Low Risk)
- **Scope**: `examples/quick_start.rs`, `examples/vector_quick_start.rs`, `examples/story_demo.rs`, `README.md`.
- **Observation**:
    - `quick_start.rs`: Correctly resolves `Result` shadowing.
    - `vector_quick_start.rs`: Correctly demonstrates vector search by adding a second node.
    - `story_demo.rs`: Correctly gated behind `nova` feature.
- **Verification**: Manually compiled and ran examples; analyzed code structure.

### 2. Demo Timestamp Semantics (Correctness - Low Risk)
- **File**: `examples/doctor_who_demo.rs`
- **Observation**: The demo uses `std::thread::sleep` to force distinct timestamps.
- **Analysis**: This is required because `valid_from` defaults to `start_timestamp` (wallclock). Rapid updates in the same microsecond would result in the same `valid_from`, causing version shadowing. The sleep correctly ensures distinct historical versions for the demo.
- **Action**: No change needed; behavior is correct for the API.

### 3. Lint Fix (Build Stability - Low Risk)
- **File**: `src/experimental/alchemy.rs`
- **Issue**: `clippy::collapsible_if` error blocking strict CI.
- **Fix**: Applied `#![allow(clippy::collapsible_if)]` as per `AGENTS.md` guidelines for experimental modules.
- **Reasoning**: Avoids unnecessary code churn in experimental features while satisfying `cargo clippy -D warnings`.

## Test Coverage
- `cargo test --lib`: **2941 passed**.
- Manual verification of examples.

## Residual Risks (Out of Scope)
- **HNSW Global Lock**: Known performance bottleneck (tracked).
- **HLC Logical Counter**: `time::now()` resets logical counter to 0. `WriteTransaction` handles this correctly via `send_with_overflow_self_heal`, but direct use of `time::now()` for causality in other contexts should be cautious.


---
*PR created automatically by Jules for task [11736319160432627923](https://jules.google.com/task/11736319160432627923) started by @madmax983*