### PR TITLE
Core Review: Fix PersistentCommitLog OOM and harden recovery

### DIFF
--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -33,7 +33,7 @@
 use super::types::ShardId;
 use crate::core::hlc::HybridTimestamp;
 use crate::core::id::TxId;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
@@ -49,6 +49,9 @@ const COMMIT_LOG_VERSION: u8 = 2;
 
 /// Header size in bytes.
 const HEADER_SIZE: usize = 16;
+
+/// Maximum entry size (64MB) to prevent OOM on corrupted logs.
+const MAX_ENTRY_SIZE: usize = 64 * 1024 * 1024;
 
 /// Entry type for commit decision.
 const ENTRY_TYPE_COMMIT: u8 = 1;
@@ -458,25 +461,7 @@ impl PersistentCommitLog {
 
         let (writer, lsn, pending) = if path.exists() {
             // Open existing file and recover state
-            let (entries, max_lsn) = Self::read_entries(&path)?;
-
-            // Build pending map (entries without completion)
-            let mut pending_map = HashMap::new();
-            let mut completed = std::collections::HashSet::new();
-
-            for entry in entries {
-                match entry.entry_type {
-                    EntryType::Commit | EntryType::Abort => {
-                        if !completed.contains(&entry.tx_id) {
-                            pending_map.insert(entry.tx_id, entry);
-                        }
-                    }
-                    EntryType::Complete => {
-                        pending_map.remove(&entry.tx_id);
-                        completed.insert(entry.tx_id);
-                    }
-                }
-            }
+            let (pending_map, max_lsn) = Self::recover_state(&path)?;
 
             // Open for appending
             let file = OpenOptions::new()
@@ -720,27 +705,26 @@ impl PersistentCommitLog {
         Ok(())
     }
 
-    fn read_entries(path: &Path) -> CommitLogResult<(Vec<CommitLogEntry>, u64)> {
+    fn recover_state(path: &Path) -> CommitLogResult<(HashMap<TxId, CommitLogEntry>, u64)> {
         let file = File::open(path)
             .map_err(|e| CommitLogError::IoError(format!("Failed to open log: {}", e)))?;
 
         let mut reader = BufReader::new(file);
-        let mut buffer = Vec::new();
 
-        reader
-            .read_to_end(&mut buffer)
-            .map_err(|e| CommitLogError::IoError(format!("Failed to read log: {}", e)))?;
-
-        // Verify header
-        if buffer.len() < HEADER_SIZE {
-            return Err(CommitLogError::CorruptedLog("File too short".into()));
+        // Read and verify header
+        let mut header = [0u8; HEADER_SIZE];
+        if let Err(e) = reader.read_exact(&mut header) {
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                return Err(CommitLogError::CorruptedLog("File too short".into()));
+            }
+            return Err(CommitLogError::IoError(format!("Failed to read header: {}", e)));
         }
 
-        if buffer[0..4] != COMMIT_LOG_MAGIC {
+        if header[0..4] != COMMIT_LOG_MAGIC {
             return Err(CommitLogError::CorruptedLog("Invalid magic".into()));
         }
 
-        let version = buffer[4];
+        let version = header[4];
         if version > COMMIT_LOG_VERSION {
             return Err(CommitLogError::CorruptedLog(format!(
                 "Unsupported version: {}",
@@ -748,34 +732,69 @@ impl PersistentCommitLog {
             )));
         }
 
-        // Parse entries
-        let mut entries = Vec::new();
-        let mut offset = HEADER_SIZE;
+        // Parse entries via streaming
+        let mut pending_map = HashMap::new();
+        let mut completed_set = HashSet::new();
         let mut max_lsn = 0u64;
+        let mut entry_buffer = Vec::with_capacity(1024); // Reusable buffer
 
-        while offset < buffer.len() {
-            if offset + 4 > buffer.len() {
-                break; // Incomplete length prefix, truncated file
+        loop {
+            // Read length prefix (4 bytes)
+            let mut len_buf = [0u8; 4];
+            match reader.read_exact(&mut len_buf) {
+                Ok(_) => {}
+                Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    // Clean EOF
+                    break;
+                }
+                Err(e) => {
+                    return Err(CommitLogError::IoError(format!("Failed to read entry: {}", e)));
+                }
             }
 
-            let len = u32::from_le_bytes([
-                buffer[offset],
-                buffer[offset + 1],
-                buffer[offset + 2],
-                buffer[offset + 3],
-            ]) as usize;
+            let len = u32::from_le_bytes(len_buf) as usize;
 
-            if offset + 4 + len > buffer.len() {
-                break; // Incomplete entry, truncated file
+            if len > MAX_ENTRY_SIZE {
+                return Err(CommitLogError::CorruptedLog(format!(
+                    "Entry length {} exceeds maximum allowed {}",
+                    len, MAX_ENTRY_SIZE
+                )));
             }
 
-            match CommitLogEntry::deserialize(&buffer[offset..]) {
+            // Read entry data
+            entry_buffer.clear();
+            entry_buffer.extend_from_slice(&len_buf); // Prepend length for deserialize
+            entry_buffer.resize(4 + len, 0);
+
+            match reader.read_exact(&mut entry_buffer[4..]) {
+                Ok(_) => {}
+                Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    // Truncated entry at end of file - ignore
+                    break;
+                }
+                Err(e) => {
+                    return Err(CommitLogError::IoError(format!("Failed to read entry: {}", e)));
+                }
+            }
+
+            // Deserialize
+            match CommitLogEntry::deserialize(&entry_buffer) {
                 Ok(entry) => {
                     if entry.lsn > max_lsn {
                         max_lsn = entry.lsn;
                     }
-                    entries.push(entry);
-                    offset += 4 + len;
+
+                    match entry.entry_type {
+                        EntryType::Commit | EntryType::Abort => {
+                            if !completed_set.contains(&entry.tx_id) {
+                                pending_map.insert(entry.tx_id, entry);
+                            }
+                        }
+                        EntryType::Complete => {
+                            pending_map.remove(&entry.tx_id);
+                            completed_set.insert(entry.tx_id);
+                        }
+                    }
                 }
                 Err(_) => {
                     // Skip corrupted entry at end of file
@@ -784,7 +803,7 @@ impl PersistentCommitLog {
             }
         }
 
-        Ok((entries, max_lsn))
+        Ok((pending_map, max_lsn))
     }
 }
 

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -717,7 +717,10 @@ impl PersistentCommitLog {
             if e.kind() == std::io::ErrorKind::UnexpectedEof {
                 return Err(CommitLogError::CorruptedLog("File too short".into()));
             }
-            return Err(CommitLogError::IoError(format!("Failed to read header: {}", e)));
+            return Err(CommitLogError::IoError(format!(
+                "Failed to read header: {}",
+                e
+            )));
         }
 
         if header[0..4] != COMMIT_LOG_MAGIC {
@@ -748,7 +751,10 @@ impl PersistentCommitLog {
                     break;
                 }
                 Err(e) => {
-                    return Err(CommitLogError::IoError(format!("Failed to read entry: {}", e)));
+                    return Err(CommitLogError::IoError(format!(
+                        "Failed to read entry: {}",
+                        e
+                    )));
                 }
             }
 
@@ -773,7 +779,10 @@ impl PersistentCommitLog {
                     break;
                 }
                 Err(e) => {
-                    return Err(CommitLogError::IoError(format!("Failed to read entry: {}", e)));
+                    return Err(CommitLogError::IoError(format!(
+                        "Failed to read entry: {}",
+                        e
+                    )));
                 }
             }
 

--- a/tests/persistent_log_compat.rs
+++ b/tests/persistent_log_compat.rs
@@ -1,0 +1,58 @@
+use aletheiadb::storage::sharding::persistent_commit_log::{PersistentCommitLog, CommitLogConfig};
+use aletheiadb::storage::sharding::types::ShardId;
+use aletheiadb::core::id::TxId;
+use std::fs::File;
+use std::io::Write;
+use tempfile::TempDir;
+
+#[test]
+fn test_v1_compatibility_read() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("commit_v1.log");
+
+    // Manually construct a V1 log file
+    let mut file = File::create(&path).unwrap();
+
+    // Header (Magic + Version 1 + Reserved + Entry Count)
+    // NOTE: This assumes HEADER_SIZE is 16 bytes.
+    // If PersistentCommitLog::HEADER_SIZE changes, this test will break.
+    file.write_all(b"GDB2").unwrap();
+    file.write_all(&[1u8]).unwrap(); // Version 1
+    file.write_all(&[0u8; 3]).unwrap(); // Reserved
+    // We will write 1 entry
+    file.write_all(&[0u8; 8]).unwrap(); // Entry count (ignored by reader usually, but good to have)
+
+    // Construct V1 Entry: Commit
+    // Format: Len(4) + Type(1) + LSN(8) + TxId(8) + Timestamp(8) + PartCount(2) + Parts(N*2) + Checksum(4)
+    // NO commit_timestamp
+
+    let mut entry_data = Vec::new();
+    entry_data.push(1u8); // Type: Commit
+    entry_data.extend_from_slice(&100u64.to_le_bytes()); // LSN
+    entry_data.extend_from_slice(&TxId::new(1).as_u64().to_le_bytes()); // TxId
+    entry_data.extend_from_slice(&123456789u64.to_le_bytes()); // Timestamp
+    entry_data.extend_from_slice(&1u16.to_le_bytes()); // Participant count
+    entry_data.extend_from_slice(&ShardId::new(0).unwrap().as_u16().to_le_bytes()); // Shard 0
+
+    // Checksum V1 (CRC32 of entry_data)
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&entry_data);
+    let checksum = hasher.finalize();
+    entry_data.extend_from_slice(&checksum.to_le_bytes());
+
+    // Write Length + Entry
+    let len = entry_data.len() as u32;
+    file.write_all(&len.to_le_bytes()).unwrap();
+    file.write_all(&entry_data).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    // Now try to read it with current PersistentCommitLog
+    let log = PersistentCommitLog::new(&path, CommitLogConfig::default()).unwrap();
+    let pending = log.pending_commits();
+
+    assert_eq!(pending.len(), 1);
+    let entry = &pending[0];
+    assert_eq!(entry.tx_id, TxId::new(1));
+    assert!(entry.commit_timestamp.is_none(), "V1 entry should have no commit timestamp");
+}

--- a/tests/persistent_log_compat.rs
+++ b/tests/persistent_log_compat.rs
@@ -1,6 +1,6 @@
-use aletheiadb::storage::sharding::persistent_commit_log::{PersistentCommitLog, CommitLogConfig};
-use aletheiadb::storage::sharding::types::ShardId;
 use aletheiadb::core::id::TxId;
+use aletheiadb::storage::sharding::persistent_commit_log::{CommitLogConfig, PersistentCommitLog};
+use aletheiadb::storage::sharding::types::ShardId;
 use std::fs::File;
 use std::io::Write;
 use tempfile::TempDir;
@@ -54,5 +54,8 @@ fn test_v1_compatibility_read() {
     assert_eq!(pending.len(), 1);
     let entry = &pending[0];
     assert_eq!(entry.tx_id, TxId::new(1));
-    assert!(entry.commit_timestamp.is_none(), "V1 entry should have no commit timestamp");
+    assert!(
+        entry.commit_timestamp.is_none(),
+        "V1 entry should have no commit timestamp"
+    );
 }


### PR DESCRIPTION
# Core Review Findings

## Critical Fixes
- **OOM Prevention**: `PersistentCommitLog` previously read the entire log file into a `Vec<u8>` before parsing. This would cause immediate OOM for multi-GB logs. I refactored it to use a streaming `BufReader` approach, processing one entry at a time and discarding completed transactions immediately.
- **Corruption Hardening**: Added a safety check for entry length prefixes. If a corrupted log claims an entry is >64MB, recovery will now return an error instead of attempting to allocate that memory and crashing.

## Verification
- **V1 Compatibility**: Added `tests/persistent_log_compat.rs` which manually constructs a V1 log entry (without commit timestamp) and verifies it can be read correctly.
- **Streaming Recovery**: Validated that `tests/sentry_shard_recovery.rs` and unit tests still pass with the new streaming implementation.

## Residual Risks
- **Unbounded Disk Growth**: `PersistentCommitLog` ignores `max_file_size` and `files_to_retain` config. It writes to a single append-only file indefinitely. This is a high-severity availability risk for long-running production systems. Recommended follow-up task to implement log rotation/segmentation.
- **Sequential I/O Bottleneck**: `ShardCoordinator` holds a global write lock on the commit log during `fsync`. This serializes all distributed transaction commits, limiting throughput to `1/fsync_latency`.


---
*PR created automatically by Jules for task [8370458181288553670](https://jules.google.com/task/8370458181288553670) started by @madmax983*