### PR TITLE
🔒 Warden: Harden CSR import against invalid inputs

### DIFF
--- a/src/experimental/alchemy.rs
+++ b/src/experimental/alchemy.rs
@@ -10,13 +10,9 @@
 //! - **Crystallize Wormholes**: Turns potential "wormholes" (semantic gaps) into real edges.
 //! - **Fuse Synonyms**: Merges nodes that are semantically identical.
 //!
-#![allow(clippy::collapsible_if)]
-
 //! # Example
 //! ```rust,no_run
 //! use aletheiadb::AletheiaDB;
-
-#![allow(clippy::collapsible_if)]
 //! use aletheiadb::experimental::alchemy::Alchemist;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -817,6 +817,25 @@ mod tests {
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
+
+    #[test]
+    fn test_import_csr_empty_nodes_non_empty_edges() {
+        // Test edge case where node_ids is empty but edges exist (offset logic corner case)
+        // This hits the unwrap_or(0) path for max_node_id.
+        let node_ids: Vec<u64> = vec![];
+        let offsets = vec![5];
+        let edge_ids = vec![1, 2, 3, 4, 5];
+        let edges_map = std::collections::HashMap::with_hasher(std::hash::BuildHasherDefault::<
+            crate::core::hasher::IdentityHasher,
+        >::default());
+
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert!(index.is_ok());
+        let idx = index.unwrap();
+        assert_eq!(idx.edge_count(), 5);
+        assert_eq!(idx.node_count(), 0);
+        assert_eq!(idx.max_node_id(), 0);
+    }
 }
 
 #[cfg(test)]

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -85,6 +85,10 @@ impl AdjacencyIndex {
     /// * `offsets` - CSR offset array
     /// * `edge_ids` - Flat array of edge IDs
     /// * `edges_map` - Map from edge ID to (target, label) for reconstruction
+    ///
+    /// # Errors
+    /// Returns an error if the input data violates CSR invariants (e.g. unsorted nodes,
+    /// non-monotonic offsets, or bounds violations).
     pub fn import_csr(
         node_ids: Vec<u64>,
         offsets: Vec<u64>,
@@ -94,13 +98,13 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Self {
+    ) -> Result<Self, String> {
         if offsets.is_empty() || edge_ids.is_empty() {
-            return Self::new();
+            return Ok(Self::new());
         }
 
-        // Validate CSR invariants
-        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids).unwrap();
+        // Validate CSR invariants strictly
+        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids)?;
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -128,12 +132,12 @@ impl AdjacencyIndex {
             }
         }
 
-        Self {
+        Ok(Self {
             node_ids: node_ids_typed,
             offsets: offsets_usize,
             edges: adjacency_entries,
             max_node_id,
-        }
+        })
     }
 }
 
@@ -300,6 +304,20 @@ impl AdjacencyIndex {
             ));
         }
 
+        // Validate monotonicity and bounds of offsets
+        // offsets[i] <= offsets[i+1] and offsets[i] <= edge_ids.len()
+        for i in 0..offsets.len() - 1 {
+            if offsets[i] > offsets[i + 1] {
+                return Err(format!(
+                    "CSR offsets not monotonic: offsets[{}]={} > offsets[{}]={}",
+                    i,
+                    offsets[i],
+                    i + 1,
+                    offsets[i + 1]
+                ));
+            }
+        }
+
         #[allow(clippy::collapsible_if)]
         if let Some(&last_offset) = offsets.last() {
             if last_offset != edge_ids.len() as u64 {
@@ -307,6 +325,19 @@ impl AdjacencyIndex {
                     "CSR last offset mismatch: expected {}, got {}",
                     edge_ids.len(),
                     last_offset
+                ));
+            }
+        }
+
+        // Validate node_ids are sorted
+        for i in 0..node_ids.len().saturating_sub(1) {
+            if node_ids[i] >= node_ids[i + 1] {
+                return Err(format!(
+                    "CSR node_ids not sorted or duplicate: node_ids[{}]={} >= node_ids[{}]={}",
+                    i,
+                    node_ids[i],
+                    i + 1,
+                    node_ids[i + 1]
                 ));
             }
         }
@@ -782,7 +813,7 @@ mod tests {
         edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
         edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
@@ -815,17 +846,31 @@ mod sentry_tests {
             AdjacencyIndex::validate_csr_invariants(&node_ids, &invalid_offsets_val, &edge_ids)
                 .unwrap_err();
         assert!(err_val.contains("CSR last offset mismatch"));
+
+        // 4. Non-monotonic offsets
+        let non_monotonic = vec![0, 2, 1];
+        let err_mono = AdjacencyIndex::validate_csr_invariants(&node_ids, &non_monotonic, &edge_ids)
+            .unwrap_err();
+        assert!(err_mono.contains("CSR offsets not monotonic"));
+
+        // 5. Unsorted node_ids
+        let unsorted_nodes = vec![20, 10];
+        let err_unsorted =
+            AdjacencyIndex::validate_csr_invariants(&unsorted_nodes, &offsets, &edge_ids)
+                .unwrap_err();
+        assert!(err_unsorted.contains("CSR node_ids not sorted"));
     }
 
     #[test]
-    #[should_panic(expected = "CSR offsets length mismatch")]
-    fn test_import_csr_panics_on_invalid() {
-        // Integration check: ensure import_csr actually calls validate and panics
+    fn test_import_csr_errors_on_invalid() {
+        // Integration check: ensure import_csr actually calls validate and returns error
         let node_ids = vec![10];
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
-        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let res = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("CSR offsets length mismatch"));
     }
 
     #[test]
@@ -844,7 +889,7 @@ mod sentry_tests {
         edges_map.insert(EdgeId::new(101).unwrap(), (target, label));
 
         // Should not panic
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
 
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -849,8 +849,9 @@ mod sentry_tests {
 
         // 4. Non-monotonic offsets
         let non_monotonic = vec![0, 2, 1];
-        let err_mono = AdjacencyIndex::validate_csr_invariants(&node_ids, &non_monotonic, &edge_ids)
-            .unwrap_err();
+        let err_mono =
+            AdjacencyIndex::validate_csr_invariants(&node_ids, &non_monotonic, &edge_ids)
+                .unwrap_err();
         assert!(err_mono.contains("CSR offsets not monotonic"));
 
         // 5. Unsorted node_ids

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -144,6 +144,12 @@ impl CurrentIndexes {
         self.outgoing.frozen_edge_count()
     }
 
+    /// Inject panic into outgoing index for testing shutdown error handling.
+    #[cfg(test)]
+    pub fn test_inject_panic_on_check(&self) {
+        self.outgoing.test_inject_panic_on_check();
+    }
+
     /// Get the number of edges in the delta buffer.
     ///
     /// This represents edges that have been inserted but not yet compacted into frozen.
@@ -2044,5 +2050,49 @@ mod zero_copy_access_tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&EdgeId::new(1).unwrap()));
         assert!(ids.contains(&EdgeId::new(2).unwrap()));
+    }
+
+    #[test]
+    fn test_shutdown_reports_panic() {
+        use std::thread;
+        use std::time::Duration;
+
+        let mut indexes = CurrentIndexes::new_with_background_compaction();
+
+        // Inject panic into the background thread's check loop
+        indexes.test_inject_panic_on_check();
+
+        // Wait for the thread to wake up and panic.
+        // Default interval is 1s, so we wait 1.2s to be safe.
+        thread::sleep(Duration::from_millis(1200));
+
+        // Shutdown should return Err because the thread panicked
+        let result = indexes.shutdown_background_compaction();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("panicked"));
+    }
+
+    #[test]
+    fn test_import_csr_fails_with_tombstones() {
+        let indexes = CurrentIndexes::new();
+
+        // Insert edge
+        indexes.insert_edge(create_test_edge(1, 0, 1, "KNOWS"));
+
+        // Delete edge (creates tombstone)
+        indexes.remove_edge(EdgeId::new(1).unwrap());
+
+        // Try import
+        let result = indexes.import_csr(
+            vec![],
+            vec![0],
+            vec![], // Empty outgoing
+            vec![],
+            vec![0],
+            vec![], // Empty incoming
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("uncommitted tombstones"));
     }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -107,21 +107,29 @@ impl CurrentIndexes {
     /// - `Ok(())` if shutdown was successful or no scheduler was running
     /// - `Err(String)` if the background thread panicked during shutdown
     pub fn shutdown_background_compaction(&mut self) -> Result<(), String> {
+        let mut result = Ok(());
+
         // Shutdown outgoing compaction
         if let Some((scheduler, handle)) = self.outgoing_compaction.take() {
             scheduler.shutdown();
-            handle
-                .join()
-                .map_err(|e| format!("Outgoing compaction thread panicked: {:?}", e))?;
+            if let Err(e) = handle.join() {
+                eprintln!("Outgoing compaction thread panicked during shutdown: {:?}", e);
+                if result.is_ok() {
+                    result = Err("Outgoing compaction thread panicked".to_string());
+                }
+            }
         }
         // Shutdown incoming compaction
         if let Some((scheduler, handle)) = self.incoming_compaction.take() {
             scheduler.shutdown();
-            handle
-                .join()
-                .map_err(|e| format!("Incoming compaction thread panicked: {:?}", e))?;
+            if let Err(e) = handle.join() {
+                eprintln!("Incoming compaction thread panicked during shutdown: {:?}", e);
+                if result.is_ok() {
+                    result = Err("Incoming compaction thread panicked".to_string());
+                }
+            }
         }
-        Ok(())
+        result
     }
 
     /// Get frozen edge count for outgoing adjacency (for testing).
@@ -781,7 +789,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> Result<(), String> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -790,14 +798,14 @@ impl CurrentIndexes {
         // If we have tombstones, importing would cause deleted edges to reappear.
         let outgoing_tombstones = self.outgoing.tombstone_count();
         let incoming_tombstones = self.incoming.tombstone_count();
-        assert!(
-            outgoing_tombstones == 0 && incoming_tombstones == 0,
-            "Cannot import CSR with uncommitted tombstones: {} outgoing, {} incoming. \
-             Deleted edges would reappear! Call compact() first or ensure import is \
-             only called on a fresh index during startup.",
-            outgoing_tombstones,
-            incoming_tombstones
-        );
+        if outgoing_tombstones > 0 || incoming_tombstones > 0 {
+            return Err(format!(
+                "Cannot import CSR with uncommitted tombstones: {} outgoing, {} incoming. \
+                 Deleted edges would reappear! Call compact() first or ensure import is \
+                 only called on a fresh index during startup.",
+                outgoing_tombstones, incoming_tombstones
+            ));
+        }
 
         // Build edges map for CSR reconstruction
         let mut edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
@@ -812,7 +820,7 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        );
+        ).map_err(|e| format!("Outgoing CSR import failed: {}", e))?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -828,7 +836,7 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        );
+        ).map_err(|e| format!("Incoming CSR import failed: {}", e))?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====
@@ -858,6 +866,8 @@ impl CurrentIndexes {
                 );
             }
         }
+
+        Ok(())
     }
 }
 
@@ -875,11 +885,15 @@ impl Drop for CurrentIndexes {
             scheduler.shutdown();
             // Give thread a moment to finish, but don't block indefinitely
             // on drop since that could cause deadlocks.
-            let _ = handle.join();
+            if let Err(e) = handle.join() {
+                eprintln!("Outgoing compaction thread panicked during drop: {:?}", e);
+            }
         }
         if let Some((scheduler, handle)) = self.incoming_compaction.take() {
             scheduler.shutdown();
-            let _ = handle.join();
+            if let Err(e) = handle.join() {
+                eprintln!("Incoming compaction thread panicked during drop: {:?}", e);
+            }
         }
     }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -113,7 +113,10 @@ impl CurrentIndexes {
         if let Some((scheduler, handle)) = self.outgoing_compaction.take() {
             scheduler.shutdown();
             if let Err(e) = handle.join() {
-                eprintln!("Outgoing compaction thread panicked during shutdown: {:?}", e);
+                eprintln!(
+                    "Outgoing compaction thread panicked during shutdown: {:?}",
+                    e
+                );
                 if result.is_ok() {
                     result = Err("Outgoing compaction thread panicked".to_string());
                 }
@@ -123,7 +126,10 @@ impl CurrentIndexes {
         if let Some((scheduler, handle)) = self.incoming_compaction.take() {
             scheduler.shutdown();
             if let Err(e) = handle.join() {
-                eprintln!("Incoming compaction thread panicked during shutdown: {:?}", e);
+                eprintln!(
+                    "Incoming compaction thread panicked during shutdown: {:?}",
+                    e
+                );
                 if result.is_ok() {
                     result = Err("Incoming compaction thread panicked".to_string());
                 }
@@ -820,7 +826,8 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        ).map_err(|e| format!("Outgoing CSR import failed: {}", e))?;
+        )
+        .map_err(|e| format!("Outgoing CSR import failed: {}", e))?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -836,7 +843,8 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        ).map_err(|e| format!("Incoming CSR import failed: {}", e))?;
+        )
+        .map_err(|e| format!("Incoming CSR import failed: {}", e))?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====

--- a/src/index/incremental_adjacency.rs
+++ b/src/index/incremental_adjacency.rs
@@ -52,6 +52,10 @@ pub struct IncrementalAdjacencyIndex {
     /// Test-only: Force panic during next compaction (hidden from public API)
     #[doc(hidden)]
     test_panic_on_compact: AtomicBool,
+
+    /// Test-only: Force panic during next threshold check (hidden from public API)
+    #[doc(hidden)]
+    test_panic_on_check: AtomicBool,
 }
 
 /// Tombstone record for deleted edges with temporal metadata.
@@ -148,6 +152,7 @@ impl IncrementalAdjacencyIndex {
             },
             config,
             test_panic_on_compact: AtomicBool::new(false),
+            test_panic_on_check: AtomicBool::new(false),
         }
     }
 
@@ -161,6 +166,12 @@ impl IncrementalAdjacencyIndex {
     #[doc(hidden)]
     pub fn test_inject_panic_on_compact(&self) {
         self.test_panic_on_compact.store(true, Ordering::Relaxed);
+    }
+
+    /// Test-only: Enable panic injection during next threshold check.
+    #[doc(hidden)]
+    pub fn test_inject_panic_on_check(&self) {
+        self.test_panic_on_check.store(true, Ordering::Relaxed);
     }
 
     /// Get frozen edge count.
@@ -325,6 +336,10 @@ impl IncrementalAdjacencyIndex {
     /// - Delta edges exceed or equal `frozen_edges * compaction_ratio` (ratio threshold)
     /// - Tombstones exceed or equal `max_tombstones`
     pub fn should_compact(&self) -> bool {
+        if self.test_panic_on_check.swap(false, Ordering::Relaxed) {
+            panic!("Test-injected panic during should_compact check");
+        }
+
         let delta = self.stats.delta_edge_count.load(Ordering::Relaxed);
         let frozen = self.stats.frozen_edge_count.load(Ordering::Acquire);
         let tombstones = self.stats.tombstone_count.load(Ordering::Relaxed);

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -977,6 +977,9 @@ impl CurrentStorage {
     /// Import CSR adjacency data from persistence.
     ///
     /// This bypasses the need to rebuild adjacency structures from scratch.
+    ///
+    /// # Errors
+    /// Returns an error if the CSR data is invalid (e.g. non-monotonic offsets).
     pub fn import_csr(
         &self,
         outgoing_node_ids: Vec<u64>,
@@ -985,7 +988,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> std::result::Result<(), String> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,
@@ -993,7 +996,7 @@ impl CurrentStorage {
             incoming_node_ids,
             incoming_offsets,
             incoming_edge_ids,
-        );
+        )
     }
 
     /// Get the number of nodes.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -850,14 +850,22 @@ pub(crate) fn load_indexes_startup(
                 if !graph_data.outgoing_offsets.is_empty()
                     && !graph_data.incoming_offsets.is_empty()
                 {
-                    current.import_csr(
+                    if let Err(e) = current.import_csr(
                         graph_data.outgoing_node_ids,
                         graph_data.outgoing_offsets,
                         graph_data.outgoing_neighbors,
                         graph_data.incoming_node_ids,
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
-                    );
+                    ) {
+                        eprintln!(
+                            "Warning: Failed to import CSR adjacency (corruption detected): {}. \
+                             Falling back to full adjacency rebuild.",
+                            e
+                        );
+                        // Fallback to rebuilding from edge map
+                        current.compact_adjacency();
+                    }
                 } else {
                     // Fallback for older index files without CSR data
                     current.compact_adjacency();

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -118,6 +118,72 @@ fn test_graph_persist_keeps_interner_consistent_with_graph_string_ids() {
 }
 
 #[test]
+fn test_load_indexes_with_corrupted_adjacency_falls_back_to_rebuild() {
+    use crate::core::graph::Edge;
+    use crate::core::id::IdGenerator;
+    use crate::storage::index_persistence::graph::{load_graph_index, save_graph_index};
+
+    // This test simulates loading a corrupted adjacency.idx file and verifies
+    // that the loading logic catches the error and falls back to a full rebuild.
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    let current = Arc::new(CurrentStorage::new());
+    let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+    let node_id_gen = Arc::new(IdGenerator::new());
+    let edge_id_gen = Arc::new(IdGenerator::new());
+    let version_id_gen = Arc::new(IdGenerator::new());
+
+    // 1. Create a valid graph with one edge
+    let knows = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let edge = Edge::new(
+        EdgeId::new(1).unwrap(),
+        knows,
+        NodeId::new(0).unwrap(),
+        NodeId::new(1).unwrap(),
+        PropertyMapBuilder::new().build(),
+        VersionId::new(1).unwrap(),
+    );
+    current.insert_edge_direct(edge.clone()).unwrap();
+    current.compact_adjacency(); // Build CSR
+
+    // 2. Persist it
+    persist_graph_index(&current, &manager, None, 0).unwrap();
+
+    // 3. Corrupt the saved file
+    let graph_path = manager.graph_path().join("adjacency.idx");
+    let mut graph_data = load_graph_index(&graph_path).unwrap();
+
+    // Corrupt offsets: make them non-monotonic
+    // Ensure we have enough space (should have offsets for node 0 and end)
+    if graph_data.outgoing_offsets.len() >= 2 {
+        graph_data.outgoing_offsets[1] = 9999; // Corrupt it
+        // Ensure invalid state: 9999 > num_edges (1)
+    }
+
+    save_graph_index(&graph_data, &graph_path).unwrap();
+
+    // 4. Create NEW storage and load
+    let new_current = Arc::new(CurrentStorage::new());
+
+    // 5. Load
+    load_indexes_startup(
+        &manager,
+        &new_current,
+        &historical,
+        &node_id_gen,
+        &edge_id_gen,
+        &version_id_gen,
+    );
+
+    // 6. Verify fallback worked
+    // Adjacency should be valid despite corrupted file, because it rebuilt from edges
+    let guard = new_current.get_outgoing_edges(NodeId::new(0).unwrap());
+    assert_eq!(guard.len(), 1);
+    assert_eq!(guard[0], EdgeId::new(1).unwrap());
+}
+
+#[test]
 fn test_persist_all_indexes_creates_manifest() {
     let temp_dir = tempfile::tempdir().unwrap();
     let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1381,7 +1381,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1447,7 +1447,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1526,7 +1526,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1592,7 +1592,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Delta should be empty
         assert_eq!(

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1374,14 +1374,16 @@ mod phase7_persistence_integration {
         }
 
         // Import CSR - should reconstruct delta from diff
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1440,14 +1442,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1519,14 +1523,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1585,14 +1591,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Delta should be empty
         assert_eq!(


### PR DESCRIPTION
Hardened `AdjacencyIndex::import_csr` to validate input data (CSR invariants) and return a `Result` instead of panicking. This prevents Denial of Service (DoS) attacks via malformed index files and allows the system to recover by falling back to a full adjacency rebuild if corruption is detected. Also improved observability of background thread panics during shutdown.

---
*PR created automatically by Jules for task [4136873670171826336](https://jules.google.com/task/4136873670171826336) started by @madmax983*