### PR TITLE
Fix race condition in StringInterner::get_all_strings

### DIFF
--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -367,8 +367,8 @@ impl StringInterner {
         // Holes occur because intern() increments next_id BEFORE inserting into the map.
         // If we see a hole at index i < strings.len(), it means an insert is in progress.
         // We must wait for it to complete to return a consistent snapshot.
-        for id in 0..strings.len() {
-            if strings[id].is_none() {
+        for (id, val) in strings.iter_mut().enumerate() {
+            if val.is_none() {
                 // Spin-wait for the missing ID to appear.
                 // In practice this is very short (just the time for a DashMap insert).
                 let mut spins = 0;
@@ -384,7 +384,7 @@ impl StringInterner {
 
                     if let Some(entry) = self.id_to_string.get(&InternedString::from_raw(id as u32))
                     {
-                        strings[id] = Some(entry.value().to_string());
+                        *val = Some(entry.value().to_string());
                         break;
                     }
 

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -373,6 +373,15 @@ impl StringInterner {
                 // In practice this is very short (just the time for a DashMap insert).
                 let mut spins = 0;
                 loop {
+                    // Check if ID is still within valid range. If next_id has been rolled back
+                    // (e.g. due to capacity exceeded), we should stop waiting.
+                    // Note: We use relaxed ordering as we are in a spin loop.
+                    let current_max_id = self.next_id.load(Ordering::Relaxed) as usize;
+                    if id >= current_max_id {
+                        // The ID was rolled back or invalid, stop waiting.
+                        break;
+                    }
+
                     if let Some(entry) = self.id_to_string.get(&InternedString::from_raw(id as u32))
                     {
                         strings[id] = Some(entry.value().to_string());
@@ -397,8 +406,9 @@ impl StringInterner {
             }
         }
 
-        // Unwrap all options (safe because we filled all holes)
-        strings.into_iter().map(|s| s.unwrap()).collect()
+        // Return only the strings that were successfully resolved.
+        // This implicitly handles rolled-back IDs by filtering out the Nones.
+        strings.into_iter().flatten().collect()
     }
 
     /// Pre-intern common strings at startup to avoid initial allocation overhead.

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -338,27 +338,67 @@ impl StringInterner {
     /// Returns a vector of strings sorted by their InternedString IDs.
     /// This is useful for persistence where we need to save and restore
     /// the interner state.
+    ///
+    /// This method is thread-safe and consistent. It waits for any concurrent
+    /// interning operations to complete to ensure there are no "holes" in the
+    /// returned sequence.
     pub fn get_all_strings(&self) -> Vec<String> {
-        // Use next_id to estimate the required size. This avoids repeated resizing
-        // inside the loop, which can happen if iteration order doesn't match ID order.
-        // String::new() is non-allocating, so pre-filling the vector is cheap.
+        // Use next_id to estimate the required size.
         let max_id = self.next_id.load(Ordering::Relaxed) as usize;
-        let mut strings = vec![String::new(); max_id];
 
-        // Collect all (id, string) pairs
+        // Use Option<String> to track which IDs we've actually found.
+        // Initialize with None to distinguish "not found" from "empty string".
+        let mut strings: Vec<Option<String>> = vec![None; max_id];
+
+        // First pass: collect all (id, string) pairs currently in the map
         for entry in self.id_to_string.iter() {
             let id = entry.key().as_u32() as usize;
 
             if id < strings.len() {
-                strings[id] = entry.value().to_string();
+                strings[id] = Some(entry.value().to_string());
             } else {
                 // Handle race condition where an ID was added after we read next_id
-                strings.resize(id + 1, String::new());
-                strings[id] = entry.value().to_string();
+                strings.resize(id + 1, None);
+                strings[id] = Some(entry.value().to_string());
             }
         }
 
-        strings
+        // Second pass: Check for holes and resolve them.
+        // Holes occur because intern() increments next_id BEFORE inserting into the map.
+        // If we see a hole at index i < strings.len(), it means an insert is in progress.
+        // We must wait for it to complete to return a consistent snapshot.
+        for id in 0..strings.len() {
+            if strings[id].is_none() {
+                // Spin-wait for the missing ID to appear.
+                // In practice this is very short (just the time for a DashMap insert).
+                let mut spins = 0;
+                loop {
+                    if let Some(entry) = self.id_to_string.get(&InternedString::from_raw(id as u32))
+                    {
+                        strings[id] = Some(entry.value().to_string());
+                        break;
+                    }
+
+                    // Yield to allow the writer thread to proceed
+                    std::thread::yield_now();
+                    spins += 1;
+
+                    // Safety valve: don't spin forever if something is truly broken
+                    if spins > 100_000 {
+                        // This should technically be unreachable given the intern() logic,
+                        // but we panic to be safe rather than returning a corrupted snapshot.
+                        panic!(
+                            "Deadlock detected in get_all_strings: ID {} never appeared after 100k spins. \
+                             This indicates a bug in the interner logic (e.g. rolled back ID not properly handled).",
+                            id
+                        );
+                    }
+                }
+            }
+        }
+
+        // Unwrap all options (safe because we filled all holes)
+        strings.into_iter().map(|s| s.unwrap()).collect()
     }
 
     /// Pre-intern common strings at startup to avoid initial allocation overhead.

--- a/tests/havoc_interner.rs
+++ b/tests/havoc_interner.rs
@@ -26,6 +26,7 @@ fn test_interner_snapshot_consistency() {
                 let s = format!("s-{}", i);
                 let _ = interner.intern(&s);
                 i = i.wrapping_add(1);
+                #[allow(clippy::manual_is_multiple_of)]
                 if i % 100 == 0 {
                     thread::yield_now();
                 }

--- a/tests/havoc_interner.rs
+++ b/tests/havoc_interner.rs
@@ -54,7 +54,8 @@ fn test_interner_snapshot_consistency() {
                         panic!(
                             "Consistency violation! ID {} exists in snapshot (len {}) but string is empty. \
                              Race condition detected: ID reserved but string not yet visible.",
-                            id, snapshot.len()
+                            id,
+                            snapshot.len()
                         );
                     }
                 }

--- a/tests/havoc_interner.rs
+++ b/tests/havoc_interner.rs
@@ -1,0 +1,65 @@
+use aletheiadb::core::interning::StringInterner;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn test_interner_snapshot_consistency() {
+    let interner = Arc::new(StringInterner::new());
+    let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+
+    // Writer thread: continuously interns unique strings
+    let writer = {
+        let interner = interner.clone();
+        let running = running.clone();
+        thread::spawn(move || {
+            let mut i = 0;
+            while running.load(std::sync::atomic::Ordering::Relaxed) {
+                // Intern a non-empty string
+                let s = format!("s-{}", i);
+                let _ = interner.intern(&s);
+                i += 1;
+                if i % 100 == 0 {
+                    thread::yield_now();
+                }
+            }
+        })
+    };
+
+    // Reader thread: continuously gets all strings and checks for consistency
+    let reader = {
+        let interner = interner.clone();
+        let running = running.clone();
+        thread::spawn(move || {
+            let start = std::time::Instant::now();
+            while start.elapsed() < Duration::from_secs(2) {
+                let snapshot = interner.get_all_strings();
+
+                // Check for holes (empty strings)
+                // We assume we only intern "s-{}" which is never empty.
+                // If get_all_strings returns "", it means it allocated space
+                // for an ID but didn't find the string in the map yet.
+                for (id, s) in snapshot.iter().enumerate() {
+                    if s.is_empty() {
+                        running.store(false, std::sync::atomic::Ordering::Relaxed);
+                        panic!(
+                            "Consistency violation! ID {} exists in snapshot (len {}) but string is empty. \
+                             Race condition detected: ID reserved but string not yet visible.",
+                            id, snapshot.len()
+                        );
+                    }
+                }
+                thread::yield_now();
+            }
+            running.store(false, std::sync::atomic::Ordering::Relaxed);
+        })
+    };
+
+    let res = reader.join();
+    writer.join().unwrap();
+
+    // If reader panicked, the test failed (which is what we want for reproduction)
+    if let Err(e) = res {
+        std::panic::resume_unwind(e);
+    }
+}

--- a/tests/havoc_interner.rs
+++ b/tests/havoc_interner.rs
@@ -8,17 +8,24 @@ fn test_interner_snapshot_consistency() {
     let interner = Arc::new(StringInterner::new());
     let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
 
+    struct RunningGuard(Arc<std::sync::atomic::AtomicBool>);
+    impl Drop for RunningGuard {
+        fn drop(&mut self) {
+            self.0.store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
     // Writer thread: continuously interns unique strings
     let writer = {
         let interner = interner.clone();
         let running = running.clone();
         thread::spawn(move || {
-            let mut i = 0;
+            let mut i: u64 = 0;
             while running.load(std::sync::atomic::Ordering::Relaxed) {
                 // Intern a non-empty string
                 let s = format!("s-{}", i);
                 let _ = interner.intern(&s);
-                i += 1;
+                i = i.wrapping_add(1);
                 if i % 100 == 0 {
                     thread::yield_now();
                 }
@@ -31,6 +38,9 @@ fn test_interner_snapshot_consistency() {
         let interner = interner.clone();
         let running = running.clone();
         thread::spawn(move || {
+            // Ensure writer stops even if reader panics
+            let _guard = RunningGuard(running);
+
             let start = std::time::Instant::now();
             while start.elapsed() < Duration::from_secs(2) {
                 let snapshot = interner.get_all_strings();
@@ -41,7 +51,6 @@ fn test_interner_snapshot_consistency() {
                 // for an ID but didn't find the string in the map yet.
                 for (id, s) in snapshot.iter().enumerate() {
                     if s.is_empty() {
-                        running.store(false, std::sync::atomic::Ordering::Relaxed);
                         panic!(
                             "Consistency violation! ID {} exists in snapshot (len {}) but string is empty. \
                              Race condition detected: ID reserved but string not yet visible.",
@@ -51,7 +60,6 @@ fn test_interner_snapshot_consistency() {
                 }
                 thread::yield_now();
             }
-            running.store(false, std::sync::atomic::Ordering::Relaxed);
         })
     };
 


### PR DESCRIPTION
Fix race condition in `StringInterner::get_all_strings` to ensure consistent snapshots under concurrent load.

---
*PR created automatically by Jules for task [13257647178154433797](https://jules.google.com/task/13257647178154433797) started by @madmax983*