### PR TITLE
dx: add friendly error stubs for experimental features

### DIFF
--- a/src/experimental/alchemy.rs
+++ b/src/experimental/alchemy.rs
@@ -10,13 +10,9 @@
 //! - **Crystallize Wormholes**: Turns potential "wormholes" (semantic gaps) into real edges.
 //! - **Fuse Synonyms**: Merges nodes that are semantically identical.
 //!
-#![allow(clippy::collapsible_if)]
-
 //! # Example
 //! ```rust,no_run
 //! use aletheiadb::AletheiaDB;
-
-#![allow(clippy::collapsible_if)]
 //! use aletheiadb::experimental::alchemy::Alchemist;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/experimental/chronos.rs
+++ b/src/experimental/chronos.rs
@@ -488,4 +488,52 @@ mod stub_tests {
         let db = AletheiaDB::new().unwrap();
         let _ = Chronos::new(&db);
     }
+
+    #[test]
+    #[should_panic(
+        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_find_path_at_time() {
+        // Safety: Unsafe transmute to get a Chronos instance since new() panics.
+        // This is valid because Chronos is a ZST with PhantomData in the stub implementation.
+        let chronos: Chronos<'_> = unsafe { std::mem::transmute(()) };
+        let _ = chronos.find_path_at_time(
+            NodeId::new(0).unwrap(),
+            NodeId::new(1).unwrap(),
+            crate::core::temporal::time::now(),
+            crate::core::temporal::time::now(),
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_node_volatility() {
+        let chronos: Chronos<'_> = unsafe { std::mem::transmute(()) };
+        let _ = chronos.node_volatility(
+            NodeId::new(0).unwrap(),
+            TimeRange::new(
+                crate::core::temporal::time::now(),
+                crate::core::temporal::time::now(),
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_path_stability() {
+        let chronos: Chronos<'_> = unsafe { std::mem::transmute(()) };
+        let _ = chronos.path_stability(
+            &[],
+            TimeRange::new(
+                crate::core::temporal::time::now(),
+                crate::core::temporal::time::now(),
+            )
+            .unwrap(),
+        );
+    }
 }

--- a/src/experimental/chronos.rs
+++ b/src/experimental/chronos.rs
@@ -78,13 +78,25 @@ use crate::AletheiaDB;
 use crate::core::error::Result;
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::temporal::{TimeRange, Timestamp};
+#[cfg(feature = "nova")]
 use std::collections::{HashSet, VecDeque};
 
+#[cfg(feature = "nova")]
 /// The Time Lord of the Graph.
 pub struct Chronos<'a> {
     db: &'a AletheiaDB,
 }
 
+#[cfg(not(feature = "nova"))]
+/// The Time Lord of the Graph.
+#[deprecated(
+    note = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+)]
+pub struct Chronos<'a> {
+    _marker: std::marker::PhantomData<&'a AletheiaDB>,
+}
+
+#[cfg(feature = "nova")]
 impl<'a> Chronos<'a> {
     /// Create a new Chronos instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -304,7 +316,69 @@ impl<'a> Chronos<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(not(feature = "nova"))]
+#[allow(deprecated)]
+impl<'a> Chronos<'a> {
+    /// Create a new Chronos instance.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn new(db: &'a AletheiaDB) -> Self {
+        panic!(
+            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Find a path from `start` to `end` that existed at `valid_time`.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn find_path_at_time(
+        &self,
+        start: NodeId,
+        end: NodeId,
+        valid_time: Timestamp,
+        tx_time: Timestamp,
+    ) -> Result<Option<Vec<NodeId>>> {
+        panic!(
+            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Calculate the volatility of a node over a time window.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn node_volatility(&self, node_id: NodeId, window: TimeRange) -> Result<f32> {
+        panic!(
+            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Calculate the stability of a path over a time window.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn path_stability(&self, path: &[EdgeId], window: TimeRange) -> Result<f32> {
+        panic!(
+            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+}
+
+#[cfg(all(test, feature = "nova"))]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
@@ -393,5 +467,20 @@ mod tests {
         assert!(vol > 0.0);
         // Loose check because time is non-deterministic
         assert!(vol > 10.0, "Volatility should be high (got {})", vol);
+    }
+}
+
+#[cfg(all(test, not(feature = "nova")))]
+#[allow(deprecated)]
+mod stub_tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(
+        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_new() {
+        let db = AletheiaDB::new().unwrap();
+        let _ = Chronos::new(&db);
     }
 }

--- a/src/experimental/chronos.rs
+++ b/src/experimental/chronos.rs
@@ -25,6 +25,8 @@
 //! > ⚠️ **REQUIRES FEATURE 'NOVA'**
 //!
 //! ```rust
+//! # #[cfg(feature = "nova")]
+//! # {
 //! use aletheiadb::{AletheiaDB, properties, ReadOps, WriteOps, Error};
 //! use aletheiadb::core::temporal::time;
 //! use aletheiadb::experimental::chronos::Chronos;
@@ -72,6 +74,9 @@
 //! println!("🕵️ Chronos confirmed: The connection existed in the past!");
 //! # Ok(())
 //! # }
+//! # }
+//! # #[cfg(not(feature = "nova"))]
+//! # fn main() {}
 //! ```
 
 use crate::AletheiaDB;

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -124,12 +124,23 @@ impl Resonator for ActivityDensityResonator {
     }
 }
 
+#[cfg(feature = "nova")]
 /// The Echo Chamber finds resonant nodes.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
     resonator: Box<dyn Resonator>,
 }
 
+#[cfg(not(feature = "nova"))]
+/// The Echo Chamber finds resonant nodes.
+#[deprecated(
+    note = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+)]
+pub struct EchoChamber<'a> {
+    _marker: std::marker::PhantomData<&'a AletheiaDB>,
+}
+
+#[cfg(feature = "nova")]
 impl<'a> EchoChamber<'a> {
     /// Create a new EchoChamber with default settings.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -179,7 +190,50 @@ impl<'a> EchoChamber<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(not(feature = "nova"))]
+#[allow(deprecated)]
+impl<'a> EchoChamber<'a> {
+    /// Create a new EchoChamber with default settings.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn new(db: &'a AletheiaDB) -> Self {
+        panic!(
+            "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Configure the EchoChamber with a custom resonator.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+        panic!(
+            "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Find nodes that resonate with the target node.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn find_echoes(&self, target: NodeId, candidates: &[NodeId]) -> Result<Vec<(NodeId, f32)>> {
+        panic!(
+            "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+}
+
+#[cfg(all(test, feature = "nova"))]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
@@ -297,5 +351,20 @@ mod tests {
                 score
             );
         }
+    }
+}
+
+#[cfg(all(test, not(feature = "nova")))]
+#[allow(deprecated)]
+mod stub_tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(
+        expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_new() {
+        let db = AletheiaDB::new().unwrap();
+        let _ = EchoChamber::new(&db);
     }
 }

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -367,4 +367,27 @@ mod stub_tests {
         let db = AletheiaDB::new().unwrap();
         let _ = EchoChamber::new(&db);
     }
+
+    #[test]
+    #[should_panic(
+        expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_with_resonator() {
+        let chamber: EchoChamber<'_> = unsafe { std::mem::transmute(()) };
+        // We need a dummy resonator. Since Resonator trait is public but ActivityDensityResonator is only stubbed out...
+        // Actually ActivityDensityResonator is not gated?
+        // Let's check the code above. ActivityDensityResonator struct definition is NOT gated.
+        // So we can use it.
+        let resonator = ActivityDensityResonator::default();
+        let _ = chamber.with_resonator(resonator);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_find_echoes() {
+        let chamber: EchoChamber<'_> = unsafe { std::mem::transmute(()) };
+        let _ = chamber.find_echoes(NodeId::new(0).unwrap(), &[]);
+    }
 }

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -102,7 +102,6 @@ pub mod chameleon;
 #[cfg(feature = "nova")]
 /// Chimera: Hybrid Entity Synthesis Engine.
 pub mod chimera;
-#[cfg(feature = "nova")]
 /// Chronos: Temporal Graph Analysis & Pathfinding.
 pub mod chronos;
 #[cfg(feature = "nova")]
@@ -114,7 +113,6 @@ pub mod dissonance;
 #[cfg(feature = "nova")]
 /// Semantic Trajectory Extrapolation ("Dreamer").
 pub mod dreamer;
-#[cfg(feature = "nova")]
 /// Temporal Resonance Engine ("Echo") for finding nodes with similar activity patterns.
 pub mod echo;
 #[cfg(feature = "nova")]
@@ -150,7 +148,6 @@ pub mod ripple;
 #[cfg(feature = "nova")]
 /// Semantic Navigator for vector-guided pathfinding.
 pub mod semantic_navigator;
-#[cfg(feature = "nova")]
 /// Sherlock: Temporal Pattern Matching Engine.
 pub mod sherlock;
 #[cfg(feature = "nova")]

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -53,10 +53,12 @@
 //! > This feature is experimental and requires the `nova` feature flag.
 //! > Add `features = ["nova"]` to your `Cargo.toml`.
 //!
-//! ```rust,ignore
+//! ```rust
 //! // [dependencies]
 //! // aletheiadb = { version = "0.1", features = ["nova"] }
 //!
+//! # #[cfg(feature = "nova")]
+//! # {
 //! use aletheiadb::AletheiaDB;
 //! use aletheiadb::experimental::sherlock::{Sherlock, Mystery, Clue};
 //! use aletheiadb::core::property::PropertyValue;
@@ -85,6 +87,9 @@
 //! }
 //! # Ok(())
 //! # }
+//! # }
+//! # #[cfg(not(feature = "nova"))]
+//! # fn main() {}
 //! ```
 
 #[cfg(feature = "nova")]

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -413,4 +413,31 @@ mod stub_tests {
     fn test_stub_panic_on_mystery() {
         let _ = Mystery::new(Duration::from_secs(1));
     }
+
+    #[test]
+    #[should_panic(
+        expected = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_add_clue() {
+        // Safety: Mystery is a ZST in stub mode.
+        let mystery: Mystery = unsafe { std::mem::transmute(()) };
+        let clue = Clue::PropertyState {
+            key: "test".to_string(),
+            value: None,
+        };
+        let _ = mystery.add_clue(clue);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_investigate() {
+        // Safety: Unsafe transmute to get a Sherlock instance since new() panics.
+        // This is valid because Sherlock is a ZST with PhantomData in the stub implementation.
+        let sherlock: Sherlock<'_> = unsafe { std::mem::transmute(()) };
+        // We also need a fake Mystery to pass in. Mystery is also ZST in stub mode.
+        let mystery: Mystery = unsafe { std::mem::transmute(()) };
+        let _ = sherlock.investigate(NodeId::new(0).unwrap(), &mystery);
+    }
 }

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -35,6 +35,7 @@ pub enum Clue {
     // Future: Edge addition/removal, etc.
 }
 
+#[cfg(feature = "nova")]
 /// A Mystery defines the pattern to search for.
 #[derive(Debug, Clone)]
 pub struct Mystery {
@@ -44,6 +45,16 @@ pub struct Mystery {
     pub time_window: Duration,
 }
 
+#[cfg(not(feature = "nova"))]
+/// A Mystery defines the pattern to search for.
+#[deprecated(
+    note = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+)]
+pub struct Mystery {
+    _marker: std::marker::PhantomData<Duration>,
+}
+
+#[cfg(feature = "nova")]
 impl Mystery {
     /// Create a new Mystery builder.
     pub fn new(time_window: Duration) -> Self {
@@ -60,6 +71,36 @@ impl Mystery {
     }
 }
 
+#[cfg(not(feature = "nova"))]
+#[allow(deprecated)]
+impl Mystery {
+    /// Create a new Mystery builder.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn new(time_window: Duration) -> Self {
+        panic!(
+            "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Add a clue to the sequence.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn add_clue(self, clue: Clue) -> Self {
+        panic!(
+            "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+}
+
 /// A Deduction represents a successful match.
 #[derive(Debug, Clone)]
 pub struct Deduction {
@@ -69,12 +110,23 @@ pub struct Deduction {
     pub event_times: Vec<Timestamp>,
 }
 
+#[cfg(feature = "nova")]
 /// The Sherlock Engine.
 pub struct Sherlock<'a> {
     #[allow(dead_code)]
     db: &'a AletheiaDB,
 }
 
+#[cfg(not(feature = "nova"))]
+/// The Sherlock Engine.
+#[deprecated(
+    note = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+)]
+pub struct Sherlock<'a> {
+    _marker: std::marker::PhantomData<&'a AletheiaDB>,
+}
+
+#[cfg(feature = "nova")]
 impl<'a> Sherlock<'a> {
     /// Create a new Sherlock instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -189,7 +241,37 @@ impl<'a> Sherlock<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(not(feature = "nova"))]
+#[allow(deprecated)]
+impl<'a> Sherlock<'a> {
+    /// Create a new Sherlock instance.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn new(db: &'a AletheiaDB) -> Self {
+        panic!(
+            "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+
+    /// Investigate a specific node for the given Mystery.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the `nova` feature is not enabled.
+    #[allow(unused_variables)]
+    #[track_caller]
+    pub fn investigate(&self, node_id: NodeId, mystery: &Mystery) -> Result<Vec<Deduction>> {
+        panic!(
+            "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        );
+    }
+}
+
+#[cfg(all(test, feature = "nova"))]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
@@ -307,5 +389,28 @@ mod tests {
         assert_eq!(results_pass.len(), 1, "Should match within 500ms");
         assert_eq!(results_pass[0].node_id, node_id);
         assert_eq!(results_pass[0].event_times, vec![t0, t1]);
+    }
+}
+
+#[cfg(all(test, not(feature = "nova")))]
+#[allow(deprecated)]
+mod stub_tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(
+        expected = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_new() {
+        let db = AletheiaDB::new().unwrap();
+        let _ = Sherlock::new(&db);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    )]
+    fn test_stub_panic_on_mystery() {
+        let _ = Mystery::new(Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
Added stubs for experimental features (Sherlock, Chronos, Echo) that provide helpful error messages and deprecation warnings when the `nova` feature flag is missing, instead of "unresolved import" errors.

---
*PR created automatically by Jules for task [1447478329148291788](https://jules.google.com/task/1447478329148291788) started by @madmax983*