### PR TITLE
Clean up redundant attributes in src/experimental/alchemy.rs

### DIFF
--- a/src/experimental/alchemy.rs
+++ b/src/experimental/alchemy.rs
@@ -10,13 +10,9 @@
 //! - **Crystallize Wormholes**: Turns potential "wormholes" (semantic gaps) into real edges.
 //! - **Fuse Synonyms**: Merges nodes that are semantically identical.
 //!
-#![allow(clippy::collapsible_if)]
-
 //! # Example
 //! ```rust,no_run
 //! use aletheiadb::AletheiaDB;
-
-#![allow(clippy::collapsible_if)]
 //! use aletheiadb::experimental::alchemy::Alchemist;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
This PR addresses a minor linting issue found during a safety review of the property system. 

It removes duplicate `#![allow(clippy::collapsible_if)]` attributes in `src/experimental/alchemy.rs`. One of these attributes was incorrectly placed inside a documentation comment block, which would break rustdoc rendering for the example code.

The review also confirmed that recent changes to `src/core/property.rs` and `src/core/vector/serialization.rs` (in `property_new.rs` context) are covered by existing tests like `warden_property_safety.rs` and correctly implement DoS protections.


---
*PR created automatically by Jules for task [12305242388194835668](https://jules.google.com/task/12305242388194835668) started by @madmax983*