### PR TITLE
docs: fix compiler warnings in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,6 @@ let similar = db.find_similar(doc_id, 10)?;
 ### Hybrid Queries (Graph + Vector + Temporal)
 
 ```rust
-use aletheiadb::query::ir::Predicate;
-
 // Setup query parameters
 let query_embedding = vec![0.1f32; 384];
 let valid_time = aletheiadb::time::now();
@@ -481,7 +479,7 @@ for row in results {
 }
 
 // Property-specific vector queries
-let results = db.query()
+let _results = db.query()
     .find_similar_builder(&query_embedding, 10)
     .property("embedding")  // Query specific property
     .metric(DistanceMetric::Cosine)


### PR DESCRIPTION
This PR addresses DX audit findings reported by "Echo". Specifically, it fixes compiler warnings in the "Hybrid Queries" example in `README.md` by removing an unused import and silencing an unused variable. Other reported issues (Time-Travel type mismatch, Vector Search missing variable, Narrative Generation context gap) were verified to be invalid or already fixed in the current codebase.

Testing:
- Created a reproduction script `examples/readme_repro_fixed.rs` containing all modified and audited README examples.
- Verified that the script compiles and runs successfully with `cargo run --features nova`.


---
*PR created automatically by Jules for task [16042505510271615916](https://jules.google.com/task/16042505510271615916) started by @madmax983*