### PR TITLE
Fix integer overflow in StringInterner capacity on 64-bit systems

### DIFF
--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -116,11 +116,20 @@ impl StringInterner {
 
     /// Create a new string interner with a custom maximum capacity.
     pub fn with_max_capacity(max_capacity: usize) -> Self {
+        // Clamp max_capacity to u32::MAX to prevent overflow issues when casting
+        // on 64-bit platforms (where usize is u64).
+        // InternedString IDs are u32, so we can't support more than u32::MAX strings anyway.
+        let effective_capacity = if max_capacity > u32::MAX as usize {
+            u32::MAX as usize
+        } else {
+            max_capacity
+        };
+
         StringInterner {
             string_to_id: DashMap::new(),
             id_to_string: DashMap::with_hasher(BuildHasherDefault::default()),
             next_id: AtomicU32::new(0),
-            max_capacity,
+            max_capacity: effective_capacity,
         }
     }
 

--- a/tests/regression_interner_overflow.rs
+++ b/tests/regression_interner_overflow.rs
@@ -1,0 +1,16 @@
+
+use aletheiadb::core::interning::StringInterner;
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn test_interner_large_capacity_overflow() {
+    // Set capacity to 2^32. On 64-bit, this fits in usize.
+    // If we cast to u32 without clamping, it becomes 0, causing immediate CapacityExceeded.
+    let large_capacity: usize = 1usize << 32;
+    let interner = StringInterner::with_max_capacity(large_capacity);
+
+    // With the fix, effective capacity should be u32::MAX, so this should succeed.
+    let result = interner.intern("test_string");
+
+    assert!(result.is_ok(), "Expected intern to succeed with large capacity, but got error: {:?}", result.err());
+}

--- a/tests/regression_interner_overflow.rs
+++ b/tests/regression_interner_overflow.rs
@@ -1,4 +1,3 @@
-
 use aletheiadb::core::interning::StringInterner;
 
 #[test]
@@ -12,5 +11,9 @@ fn test_interner_large_capacity_overflow() {
     // With the fix, effective capacity should be u32::MAX, so this should succeed.
     let result = interner.intern("test_string");
 
-    assert!(result.is_ok(), "Expected intern to succeed with large capacity, but got error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Expected intern to succeed with large capacity, but got error: {:?}",
+        result.err()
+    );
 }


### PR DESCRIPTION
Fixed an integer overflow bug in `StringInterner::with_max_capacity` where capacities larger than `u32::MAX` on 64-bit systems would cause immediate `CapacityExceeded` errors due to casting truncation. The capacity is now clamped to `u32::MAX`. Added a regression test to verify the fix.

---
*PR created automatically by Jules for task [11760338865032312335](https://jules.google.com/task/11760338865032312335) started by @madmax983*