### PR TITLE
🔒 Warden: Eliminate unsafe code and harden WAL/Adjacency

### DIFF
--- a/src/experimental/chronos.rs
+++ b/src/experimental/chronos.rs
@@ -494,9 +494,9 @@ mod stub_tests {
         expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_find_path_at_time() {
-        // Safety: Unsafe transmute to get a Chronos instance since new() panics.
-        // This is valid because Chronos is a ZST with PhantomData in the stub implementation.
-        let chronos: Chronos<'_> = unsafe { std::mem::transmute(()) };
+        let chronos = Chronos {
+            _marker: std::marker::PhantomData,
+        };
         let _ = chronos.find_path_at_time(
             NodeId::new(0).unwrap(),
             NodeId::new(1).unwrap(),
@@ -510,7 +510,9 @@ mod stub_tests {
         expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_node_volatility() {
-        let chronos: Chronos<'_> = unsafe { std::mem::transmute(()) };
+        let chronos = Chronos {
+            _marker: std::marker::PhantomData,
+        };
         let _ = chronos.node_volatility(
             NodeId::new(0).unwrap(),
             TimeRange::new(
@@ -526,7 +528,9 @@ mod stub_tests {
         expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_path_stability() {
-        let chronos: Chronos<'_> = unsafe { std::mem::transmute(()) };
+        let chronos = Chronos {
+            _marker: std::marker::PhantomData,
+        };
         let _ = chronos.path_stability(
             &[],
             TimeRange::new(

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -373,7 +373,9 @@ mod stub_tests {
         expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_with_resonator() {
-        let chamber: EchoChamber<'_> = unsafe { std::mem::transmute(()) };
+        let chamber = EchoChamber {
+            _marker: std::marker::PhantomData,
+        };
         // We need a dummy resonator. Since Resonator trait is public but ActivityDensityResonator is only stubbed out...
         // Actually ActivityDensityResonator is not gated?
         // Let's check the code above. ActivityDensityResonator struct definition is NOT gated.
@@ -387,7 +389,9 @@ mod stub_tests {
         expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_find_echoes() {
-        let chamber: EchoChamber<'_> = unsafe { std::mem::transmute(()) };
+        let chamber = EchoChamber {
+            _marker: std::marker::PhantomData,
+        };
         let _ = chamber.find_echoes(NodeId::new(0).unwrap(), &[]);
     }
 }

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -419,8 +419,9 @@ mod stub_tests {
         expected = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_add_clue() {
-        // Safety: Mystery is a ZST in stub mode.
-        let mystery: Mystery = unsafe { std::mem::transmute(()) };
+        let mystery = Mystery {
+            _marker: std::marker::PhantomData,
+        };
         let clue = Clue::PropertyState {
             key: "test".to_string(),
             value: None,
@@ -433,11 +434,12 @@ mod stub_tests {
         expected = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_investigate() {
-        // Safety: Unsafe transmute to get a Sherlock instance since new() panics.
-        // This is valid because Sherlock is a ZST with PhantomData in the stub implementation.
-        let sherlock: Sherlock<'_> = unsafe { std::mem::transmute(()) };
-        // We also need a fake Mystery to pass in. Mystery is also ZST in stub mode.
-        let mystery: Mystery = unsafe { std::mem::transmute(()) };
+        let sherlock = Sherlock {
+            _marker: std::marker::PhantomData,
+        };
+        let mystery = Mystery {
+            _marker: std::marker::PhantomData,
+        };
         let _ = sherlock.investigate(NodeId::new(0).unwrap(), &mystery);
     }
 }

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -336,6 +336,10 @@ impl AdjacencyIndex {
     /// # Safety
     /// T and U must have same layout, size, and alignment.
     unsafe fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U> {
+        // Enforce safety invariants at compile time/runtime
+        assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<U>());
+        assert_eq!(std::mem::align_of::<T>(), std::mem::align_of::<U>());
+
         let mut v = std::mem::ManuallyDrop::new(v);
         // SAFETY: Caller ensures T and U layout compatibility.
         // from_raw_parts is unsafe, but we are inside an unsafe function.

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -724,16 +724,13 @@ pub(crate) fn parse_entry_at(
 /// Helper to deserialize and validate a NodeId from WAL buffer
 #[inline]
 fn deserialize_node_id(buffer: &[u8], offset: usize, context: &str) -> Result<NodeId> {
-    let raw_id = u64::from_le_bytes([
-        buffer[offset],
-        buffer[offset + 1],
-        buffer[offset + 2],
-        buffer[offset + 3],
-        buffer[offset + 4],
-        buffer[offset + 5],
-        buffer[offset + 6],
-        buffer[offset + 7],
-    ]);
+    let bytes = buffer.get(offset..offset + 8).ok_or_else(|| {
+        Error::Storage(StorageError::CorruptedData(format!(
+            "Insufficient buffer size for NodeId in {}",
+            context
+        )))
+    })?;
+    let raw_id = u64::from_le_bytes(bytes.try_into().unwrap());
     NodeId::new(raw_id).map_err(|e| {
         Error::Storage(StorageError::CorruptedData(format!(
             "Invalid node ID in WAL {}: {}",
@@ -745,16 +742,13 @@ fn deserialize_node_id(buffer: &[u8], offset: usize, context: &str) -> Result<No
 /// Helper to deserialize and validate an EdgeId from WAL buffer
 #[inline]
 fn deserialize_edge_id(buffer: &[u8], offset: usize, context: &str) -> Result<EdgeId> {
-    let raw_id = u64::from_le_bytes([
-        buffer[offset],
-        buffer[offset + 1],
-        buffer[offset + 2],
-        buffer[offset + 3],
-        buffer[offset + 4],
-        buffer[offset + 5],
-        buffer[offset + 6],
-        buffer[offset + 7],
-    ]);
+    let bytes = buffer.get(offset..offset + 8).ok_or_else(|| {
+        Error::Storage(StorageError::CorruptedData(format!(
+            "Insufficient buffer size for EdgeId in {}",
+            context
+        )))
+    })?;
+    let raw_id = u64::from_le_bytes(bytes.try_into().unwrap());
     EdgeId::new(raw_id).map_err(|e| {
         Error::Storage(StorageError::CorruptedData(format!(
             "Invalid edge ID in WAL {}: {}",
@@ -766,16 +760,13 @@ fn deserialize_edge_id(buffer: &[u8], offset: usize, context: &str) -> Result<Ed
 /// Helper to deserialize and validate a VersionId from WAL buffer
 #[inline]
 fn deserialize_version_id(buffer: &[u8], offset: usize, context: &str) -> Result<VersionId> {
-    let raw_id = u64::from_le_bytes([
-        buffer[offset],
-        buffer[offset + 1],
-        buffer[offset + 2],
-        buffer[offset + 3],
-        buffer[offset + 4],
-        buffer[offset + 5],
-        buffer[offset + 6],
-        buffer[offset + 7],
-    ]);
+    let bytes = buffer.get(offset..offset + 8).ok_or_else(|| {
+        Error::Storage(StorageError::CorruptedData(format!(
+            "Insufficient buffer size for VersionId in {}",
+            context
+        )))
+    })?;
+    let raw_id = u64::from_le_bytes(bytes.try_into().unwrap());
     VersionId::new(raw_id).map_err(|e| {
         Error::Storage(StorageError::CorruptedData(format!(
             "Invalid version ID in WAL {}: {}",


### PR DESCRIPTION
**Threats Mitigated:**
1.  **Undefined Behavior (UB):** Eliminated `unsafe { std::mem::transmute(()) }` in experimental feature stubs (`EchoChamber`, `Sherlock`, `Chronos`). This was used to bypass constructor checks in tests but relied on UB. Replaced with safe `PhantomData` construction.
2.  **Denial of Service (Panic):** Hardened WAL segment reader deserialization helpers (`deserialize_node_id`, etc.). Previously used unchecked indexing (`buffer[offset]`), which could panic on truncated or corrupted WAL files. Now uses `buffer.get()` and returns proper `StorageError::CorruptedData`.
3.  **Memory Safety (Layout Mismatch):** Added explicit runtime assertions (`assert_eq!(size_of::<T>(), size_of::<U>())`) to `AdjacencyIndex::transmute_vec`. This `unsafe` function performs zero-copy vector transmutation. The assertions ensure the input and output types have compatible memory layouts, preventing potential memory corruption if types change in the future.

**Verification:**
- Ran `cargo test --lib experimental`: Confirmed stub tests (`test_stub_panic_*`) pass safely.
- Ran `cargo test --lib storage::wal`: 219 tests passed, confirming WAL hardening works without regression.
- Ran `cargo test --lib index::adjacency`: 16 tests passed, confirming adjacency index safety checks hold.
- Checked for clippy warnings (none introduced).

---
*PR created automatically by Jules for task [4818065062735807013](https://jules.google.com/task/4818065062735807013) started by @madmax983*