### PR TITLE
📜 Codex: ADR 054 & Architecture Diagram Update

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,11 +83,14 @@ classDiagram
             +handle_tool_call()
         }
     }
-    namespace Core {
+    namespace DB {
         class AletheiaDB
+    }
+    namespace Core {
         class QueryEngine
         class TemporalPlanner
         class TraversalEngine
+        class StorageEngine
     }
     namespace Storage {
         class CurrentStorage
@@ -101,10 +104,11 @@ classDiagram
         }
     }
 
-    MCPServer --> QueryEngine : Uses
-    QueryEngine --> AletheiaDB : Uses
-    AletheiaDB --> CurrentStorage : "Owns (Arc)"
-    AletheiaDB --> HistoricalStorage : "Owns (Arc<RwLock>)"
+    MCPServer --> DB : Uses
+    DB --> Core : "Uses"
+    DB --> Storage : "Owns (Arc/RwLock)"
+    Core ..> StorageEngine : Defines
+    Storage ..|> StorageEngine : Implements
     %% Removed the circular dependency arrow
     HistoricalStorage --> TieredStorage : Uses
     TieredStorage --> RedbColdStorage : Uses

--- a/docs/adr/0054-decouple-storage.md
+++ b/docs/adr/0054-decouple-storage.md
@@ -1,0 +1,47 @@
+# ADR-0054: Decouple Storage from Core
+
+**Status:** Proposed
+**Date:** 2026-04-10
+**Deciders:** Codex (Architecture Enforcement)
+**Categories:** architecture, storage, core, modularity
+
+## Context
+
+AletheiaDB's initial monolithic architecture placed both core business logic (graph topology, query execution, temporal reasoning) and storage implementation (WAL, page management, serialization) within the same compilation unit.
+
+As the system has grown, several issues have emerged:
+
+1.  **Circular Dependencies:** The `core` logic frequently references `storage` types for persistence, while `storage` needs `core` types (like `Node`, `Edge`) for serialization. This tight coupling makes refactoring difficult and introduces circular dependency risks.
+2.  **Build Times:** Any change in the storage layer (e.g., modifying the WAL format) triggers a rebuild of the entire core, slowing down development cycles.
+3.  **Testing Complexity:** Unit testing core logic requires mocking complex storage interactions or spinning up temporary files, leading to slower and flaky tests.
+4.  **Pluggability:** We want to support multiple storage backends (e.g., in-memory for testing, Redb for embedded, remote for distributed), but the current design assumes a specific storage implementation.
+
+## Decision
+
+We will **decouple the storage logic from the core domain** by moving all persistence-related code into a dedicated `storage` module.
+
+The architectural boundary will be defined by separating pure domain logic into `src/core` and concrete persistence implementations into `src/storage`. `src/db` acts as the composition root that wires the database together. (Note: As refined in ADR-0044, to avoid dynamic dispatch overhead, `AletheiaDB` uses concrete storage types rather than generic trait bounds for its primary engine.)
+
+**Key Changes:**
+1.  **Module Restructuring:**
+    *   `src/core/` - Pure domain logic, identifiers, temporal primitives, graph elements, and vector utilities.
+    *   `src/storage/` - Concrete implementations for persistence (CurrentStorage, HistoricalStorage, WAL, Redb, sharding, and caching).
+    *   `src/db.rs` (or equivalent composition point) - Wires `AletheiaDB` to specific `src/storage` types.
+2.  **Dependency Inversion:** `Core` no longer depends on concrete storage implementations. `Storage` depends on `Core` for domain types (`Node`, `Edge`, `PropertyValue`).
+
+## Consequences
+
+### Positive
+
+-   **Clearer Boundaries:** Enforces strict separation of concerns. `Core` focuses on "what" (graph logic), `Storage` focuses on "how" (bytes on disk/memory).
+-   **Improved Build Times:** Changes to storage internals do not force recompilation of the entire core API layer (where possible).
+-   **Testability:** `Core` logic can be tested more easily in isolation without pulling in complex I/O dependencies.
+
+### Negative
+
+-   **FFI Complexity:** If we move to separate dynamic libraries or cross-language boundaries later, the interface complexity increases.
+-   **Refactoring Effort:** Required a significant one-time effort to move files and break existing cycles.
+
+### Neutral
+
+-   The decision to use concrete types over traits for the main storage engine (to ensure peak performance via static dispatch) means swapping backends requires changing the `AletheiaDB` struct definition, possibly using feature flags, as documented in ADR-0044.


### PR DESCRIPTION
This PR records the architectural decision to decouple the `storage` module from the `core` domain by introducing ADR 0054. It also updates the existing Mermaid diagrams in the main `ARCHITECTURE.md` file to reflect these changes, including removing the circular dependency arrow.

---
*PR created automatically by Jules for task [16216452593421863734](https://jules.google.com/task/16216452593421863734) started by @madmax983*