### PR TITLE
🤖 Sentinel: Closed gaps in PropertyValue::eq

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,9 @@
 **Summary:** Default implementations (returning `None` or `false`) for `EntityVersion` methods like `is_anchor`, `prev_version`, etc., survived. This suggests generic tests for this trait are missing or not exercising concrete implementations.
 **Diagnosis:** WEAK_TEST - No test iterates through the version chain using the trait methods on `NodeVersion` / `EdgeVersion`.
 **Kill Shot:** Added `test_entity_version_trait_round_trip_links_for_node_and_edge` to verify trait methods correctly proxy to struct fields.
+
+**[Weak Test Coverage in PropertyValue Equality]**
+**Module:** src/core/property.rs
+**Summary:** The mutants replacing `||` with `&&` in `PartialEq::eq` for `PropertyValue` survived. This affected `String`, `Bytes`, `Array`, `Vector`, and `SparseVector` variants which compare values using `Arc::ptr_eq(a, b) || a == b`. If this could be mutated to `&&` without tests failing, it indicates a lack of testing for equal values that use distinct heap allocations (different `Arc` addresses).
+**Diagnosis:** WEAK_TEST - No negative test cases explicitly vary only the heap allocation (i.e. having identical values inside different `Arc` references). The equality short-circuit mechanism wasn't completely tested.
+**Kill Shot:** Added `test_property_value_partial_eq_distinct_allocations` which manually instantiates pairs of each variant type with equal content but distinct `Arc` pointers.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -2191,6 +2191,55 @@ mod tests {
     }
 
     #[test]
+    fn test_property_value_partial_eq_distinct_allocations() {
+        // String
+        let s1 = PropertyValue::String(Arc::from("hello".to_string()));
+        let s2 = PropertyValue::String(Arc::from("hello".to_string()));
+        if let (PropertyValue::String(a), PropertyValue::String(b)) = (&s1, &s2) {
+            assert!(!Arc::ptr_eq(a, b), "Arcs must be distinct");
+        }
+        assert_eq!(s1, s2, "Strings with distinct allocations should be equal");
+
+        // Bytes
+        let b1 = PropertyValue::Bytes(Arc::from(vec![1, 2, 3]));
+        let b2 = PropertyValue::Bytes(Arc::from(vec![1, 2, 3]));
+        if let (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) = (&b1, &b2) {
+            assert!(!Arc::ptr_eq(a, b), "Arcs must be distinct");
+        }
+        assert_eq!(b1, b2, "Bytes with distinct allocations should be equal");
+
+        // Array
+        let a1 = PropertyValue::Array(Arc::new(vec![PropertyValue::Int(42)]));
+        let a2 = PropertyValue::Array(Arc::new(vec![PropertyValue::Int(42)]));
+        if let (PropertyValue::Array(a), PropertyValue::Array(b)) = (&a1, &a2) {
+            assert!(!Arc::ptr_eq(a, b), "Arcs must be distinct");
+        }
+        assert_eq!(a1, a2, "Arrays with distinct allocations should be equal");
+
+        // Vector
+        let v1 = PropertyValue::Vector(Arc::from(vec![1.0f32, 2.0, 3.0]));
+        let v2 = PropertyValue::Vector(Arc::from(vec![1.0f32, 2.0, 3.0]));
+        if let (PropertyValue::Vector(a), PropertyValue::Vector(b)) = (&v1, &v2) {
+            assert!(!Arc::ptr_eq(a, b), "Arcs must be distinct");
+        }
+        assert_eq!(v1, v2, "Vectors with distinct allocations should be equal");
+
+        // SparseVector
+        use crate::core::vector::SparseVec;
+        let sv1 =
+            PropertyValue::SparseVector(Arc::new(SparseVec::new(vec![0], vec![1.0], 5).unwrap()));
+        let sv2 =
+            PropertyValue::SparseVector(Arc::new(SparseVec::new(vec![0], vec![1.0], 5).unwrap()));
+        if let (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) = (&sv1, &sv2) {
+            assert!(!Arc::ptr_eq(a, b), "Arcs must be distinct");
+        }
+        assert_eq!(
+            sv1, sv2,
+            "SparseVectors with distinct allocations should be equal"
+        );
+    }
+
+    #[test]
     fn test_vector_in_property_map() {
         let embedding = vec![0.1f32, 0.2, 0.3, 0.4];
         let map = PropertyMapBuilder::new()

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,15 +207,13 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
-                }
+            if vt_start <= time.wallclock()
+                && vt_start >= best_time
+                && let Some(val) = v.properties.get(property)
+                && let Some(vec) = val.as_vector()
+            {
+                best_vec = Some(vec.to_vec());
+                best_time = vt_start;
             }
         }
         best_vec


### PR DESCRIPTION
🤖 Sentinel: Closed gaps in PropertyValue::eq

### 🧬 Mutants Found
Multiple surviving mutants in `src/core/property.rs` where the `||` operator inside `PartialEq::eq` was replaced with `&&` for the Arc-wrapped variants (`String`, `Bytes`, `Array`, `Vector`, `SparseVector`). 

### 🎯 Tests Added/Strengthened
Added `test_property_value_partial_eq_distinct_allocations` to explicitly construct `PropertyValue` instances with the same internal data but distinct `Arc` pointers, and assert their equality. This kills the `||` -> `&&` mutants because it proves the fallback deep equality (`a == b`) correctly works when the pointer equality (`Arc::ptr_eq(a, b)`) is false.

### ⚠️ Suspected Bugs
None identified; just weak test assertions covering the pointer-equality fast path but missing the distinct allocation value-equality fallback.

### 📊 Kill Rate
Addressed the surviving mutants in `src/core/property.rs` related to equality checks. 

### 🔗 Havoc Interaction
None directly relevant.

(Also included a slight fix in `src/experimental/omen.rs` to satisfy Clippy and recorded the findings in `.jules/sentinel.md`)

---
*PR created automatically by Jules for task [5852952721176668007](https://jules.google.com/task/5852952721176668007) started by @madmax983*