### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -51,3 +51,7 @@
 ## 2026-02-25 - The Case of the Sequential Scatter
 **Confusion:** The architecture documentation described a "Scatter-Gather" query executor and "Distributed Transactions", implying high-concurrency parallelism. However, the implementation actually processes shards sequentially (one by one), meaning latency scales linearly ((N)$) rather than remaining constant.
 **Clarification:** Updated `src/storage/sharding/executor.rs`, `coordinator.rs`, and `network.rs` to explicitly document the sequential, blocking nature of the current implementation. Added performance warnings to the `README.md` to set correct expectations for Phase 1 sharding.
+
+## 2026-10-27 - The Filter-Scan Fusion Mystery
+**Confusion:** The purpose and performance impact of the `FilterScanFusion` optimization rule in `src/query/planner/rules/filter_scan_fusion.rs` were not fully explained. It was unclear why a standalone `NodeScan` combined with a `Filter` operation could be heavily unoptimized.
+**Clarification:** Added a detailed module-level narrative and an executable doc-test in `src/query/planner/rules/filter_scan_fusion.rs` to explain how delegating this query to `CurrentStorage::find_nodes_by_property` turns an O(N) full table scan into an O(1) or O(log N) lookup.

--- a/src/experimental/gestalt.rs
+++ b/src/experimental/gestalt.rs
@@ -6,7 +6,7 @@
 //! not just by label, but by **semantic similarity** to a concept vector.
 //!
 //! This enables queries like:
-//! "Find a [Person ~ 'Engineer'] connected to a [Company ~ 'Startup'] via [WORKS_FOR]."
+//! "Find a `[Person ~ 'Engineer']` connected to a `[Company ~ 'Startup']` via `[WORKS_FOR]`."
 //!
 //! # Concepts
 //! - **Pattern**: A template subgraph with constraints.

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,7 +207,11 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
+            // Since we aren't using #![feature(let_chains)], we suppress the
+            // `collapsible_if` lint here to avoid build failures with stable Rust.
+            #[allow(clippy::collapsible_if)]
             if vt_start <= time.wallclock() && vt_start >= best_time {
+                #[allow(clippy::collapsible_if)]
                 if let Some(val) = v.properties.get(property) {
                     if let Some(vec) = val.as_vector() {
                         best_vec = Some(vec.to_vec());

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,13 +207,11 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
+            if vt_start <= time.wallclock() && vt_start >= best_time {
+                if let Some(val) = v.properties.get(property) {
+                    if let Some(vec) = val.as_vector() {
+                        best_vec = Some(vec.to_vec());
+                        best_time = vt_start;
                     }
                 }
             }

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -43,7 +43,8 @@ use super::{OptimizationRule, Statistics};
 /// ```rust
 /// use aletheiadb::query::plan::{LogicalPlan, LogicalOp, ScanOp, UnaryOp};
 /// use aletheiadb::query::ir::Predicate;
-/// use aletheiadb::query::planner::rules::{OptimizationRule, FilterScanFusion, Statistics};
+/// use aletheiadb::query::planner::rules::{OptimizationRule, FilterScanFusion};
+/// use aletheiadb::query::planner::stats::Statistics;
 ///
 /// // Create a naïve query plan: "Scan all Persons, then filter for name = Alice"
 /// let naive_plan = LogicalPlan::new(LogicalOp::unary(

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -1,8 +1,31 @@
 //! Filter-Scan Fusion Optimization
 //!
-//! When a `Filter(Eq { key, value })` sits directly above a `Scan(NodeScan { label: Some(l) })`,
-//! fuse them into a single `Scan(PropertyScan { label, key, value })`. This avoids the full
-//! scan + per-node predicate evaluation by delegating to `CurrentStorage::find_nodes_by_property`.
+//! The "Filter-Scan Fusion" is an essential query planner rule that dramatically accelerates
+//! query execution. When a logical plan requires finding a node by a specific label and a
+//! specific property value, the naïve approach is to scan *all* nodes of that label, and
+//! apply a filter to each one in memory.
+//!
+//! Instead, this rule intercepts a `Filter(Eq { key, value })` operation sitting directly
+//! above a `Scan(NodeScan { label: Some(l) })` and fuses them into a single, highly-optimized
+//! `Scan(PropertyScan { label, key, value })` operation.
+//!
+//! By delegating this combined operation to the storage layer
+//! (`CurrentStorage::find_nodes_by_property`), AletheiaDB can utilize internal property
+//! indices or optimized storage layouts, turning an $O(N)$ full table scan into an $O(1)$
+//! or $O(\log N)$ targeted lookup.
+//!
+//! # Example Transformation
+//!
+//! **Before (Naïve Plan)**:
+//! ```text
+//! Filter(Eq { key: "name", value: "Alice" })
+//!   └─ NodeScan { label: Some("Person") }
+//! ```
+//!
+//! **After (Optimized Plan)**:
+//! ```text
+//! PropertyScan { label: "Person", key: "name", value: "Alice" }
+//! ```
 
 use crate::core::error::Result;
 use crate::query::ir::Predicate;
@@ -10,22 +33,50 @@ use crate::query::plan::{LogicalOp, LogicalPlan, ScanOp, UnaryOp};
 
 use super::{OptimizationRule, Statistics};
 
-/// Fuses `Filter(Eq)` + `NodeScan(label)` into a single `PropertyScan`.
+/// Fuses a `Filter(Eq)` operation and a `NodeScan(label)` operation into a single `PropertyScan`.
 ///
-/// # Example Transformation
+/// This optimizer rule traverses the logical query plan tree looking for opportunities to
+/// push down equality predicates directly into the storage scan phase.
 ///
-/// **Before**:
-/// ```text
-/// Filter(Eq { key: "name", value: "Alice" })
-///   NodeScan { label: Some("Person") }
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::query::plan::{LogicalPlan, LogicalOp, ScanOp, UnaryOp};
+/// use aletheiadb::query::ir::Predicate;
+/// use aletheiadb::query::planner::rules::{OptimizationRule, FilterScanFusion, Statistics};
+///
+/// // Create a naïve query plan: "Scan all Persons, then filter for name = Alice"
+/// let naive_plan = LogicalPlan::new(LogicalOp::unary(
+///     UnaryOp::Filter(Predicate::eq("name", "Alice")),
+///     LogicalOp::Scan(ScanOp::NodeScan {
+///         label: Some("Person".to_string()),
+///         estimated_rows: None,
+///     }),
+/// ));
+///
+/// // Apply the FilterScanFusion rule
+/// let rule = FilterScanFusion;
+/// let stats = Statistics::default();
+/// let optimized_plan = rule.apply(&naive_plan, &stats).unwrap().unwrap();
+///
+/// // The plan is now fused into a single PropertyScan
+/// match &optimized_plan.root {
+///     LogicalOp::Scan(ScanOp::PropertyScan { label, key, .. }) => {
+///         assert_eq!(label, "Person");
+///         assert_eq!(key, "name");
+///     }
+///     _ => panic!("Plan was not fused!"),
+/// }
 /// ```
 ///
-/// **After**:
-/// ```text
-/// PropertyScan { label: "Person", key: "name", value: "Alice" }
-/// ```
+/// ## Panics
+/// This rule itself does not panic under normal execution.
 ///
-/// Non-Eq predicates and scans without a label are left unchanged.
+/// ## Limits & Exclusions
+/// - Non-Eq predicates (e.g., `Gt`, `Lt`, `Like`) are not currently fused and are left unchanged.
+/// - Scans without a label (e.g., scan all nodes in the database) are not fused, as property
+///   scans require a label context for optimal performance.
+/// - Internal system keys (starting with `_`, like `_label`) are ignored.
 pub struct FilterScanFusion;
 
 impl OptimizationRule for FilterScanFusion {

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -1,12 +1,12 @@
 //! String interner persistence.
 //!
-//! This module handles the serialization and deserialization of the [`GLOBAL_INTERNER`](crate::core::GLOBAL_INTERNER).
+//! This module handles the serialization and deserialization of the [`GLOBAL_INTERNER`].
 //! The interner is critical for the database's operation as it maps all string labels and property keys to
 //! compact integer IDs.
 //!
 //! # Format
 //!
-//! The interner is saved as a Bitcode-encoded [`StringInternerData`](super::formats::StringInternerData) struct,
+//! The interner is saved as a Bitcode-encoded [`StringInternerData`] struct,
 //! followed by a 4-byte CRC32 checksum.
 //!
 //! ```text


### PR DESCRIPTION
📖 Chapter: The `Query Planner` module and Documentation Links
🔦 Insight: Explained the `FilterScanFusion` optimization rule which turns O(N) full table scans into O(1) targeted lookups. Fixed broken/unresolved links in `experimental/gestalt.rs` and `storage/index_persistence/strings.rs`. Fixed clippy nested `if` warning in `experimental/omen.rs`.
🧪 Example: Added an executable doctest for `FilterScanFusion` explaining the `LogicalPlan` transformation.

---
*PR created automatically by Jules for task [11248484526973992441](https://jules.google.com/task/11248484526973992441) started by @madmax983*