### PR TITLE
⚡ Bolt: Remove intermediate allocations in query result collection

### DIFF
--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,13 +207,12 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
+            #[allow(clippy::collapsible_if)]
+            if vt_start <= time.wallclock() && vt_start >= best_time {
+                if let Some(val) = v.properties.get(property) {
+                    if let Some(vec) = val.as_vector() {
+                        best_vec = Some(vec.to_vec());
+                        best_time = vt_start;
                     }
                 }
             }

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -168,33 +168,37 @@ impl QueryResults {
     }
 
     /// Collect all nodes from results
-    pub fn collect_nodes(self) -> Result<Vec<Node>> {
-        let rows = self.collect_all()?;
-        Ok(rows
-            .into_iter()
-            .filter_map(|row| {
-                if let EntityResult::Node(n) = row.entity {
-                    Some(n)
-                } else {
-                    None
-                }
-            })
-            .collect())
+    ///
+    /// # Performance
+    ///
+    /// ⚡ This avoids allocating an intermediate `Vec<QueryRow>` by extracting
+    /// nodes directly from the iterator, reducing memory allocations.
+    pub fn collect_nodes(mut self) -> Result<Vec<Node>> {
+        let mut nodes = Vec::new();
+        while let Some(row_result) = self.iterator.next() {
+            let row = row_result?;
+            if let EntityResult::Node(n) = row.entity {
+                nodes.push(n);
+            }
+        }
+        Ok(nodes)
     }
 
     /// Collect nodes with their scores
-    pub fn collect_nodes_with_scores(self) -> Result<Vec<(Node, f32)>> {
-        let rows = self.collect_all()?;
-        Ok(rows
-            .into_iter()
-            .filter_map(|row| {
-                if let (EntityResult::Node(n), Some(score)) = (row.entity, row.score) {
-                    Some((n, score))
-                } else {
-                    None
-                }
-            })
-            .collect())
+    ///
+    /// # Performance
+    ///
+    /// ⚡ This avoids allocating an intermediate `Vec<QueryRow>` by extracting
+    /// nodes and scores directly from the iterator, reducing memory allocations.
+    pub fn collect_nodes_with_scores(mut self) -> Result<Vec<(Node, f32)>> {
+        let mut results = Vec::new();
+        while let Some(row_result) = self.iterator.next() {
+            let row = row_result?;
+            if let (EntityResult::Node(n), Some(score)) = (row.entity, row.score) {
+                results.push((n, score));
+            }
+        }
+        Ok(results)
     }
 
     /// Take at most n results


### PR DESCRIPTION
💡 **What**: The optimization implements a direct iteration loop (`while let Some(row_result) = self.iterator.next()`) in `QueryResults::collect_nodes` and `QueryResults::collect_nodes_with_scores`. It avoids first calling `self.collect_all()`, which allocated an intermediate `Vec<QueryRow>`.
🎯 **Why**: Calling `collect_all()` before `.into_iter().filter_map()` creates an unnecessary full-size heap allocation for the intermediate dataset, wasting memory and execution time.
📊 **Impact**: Reduces heap allocations, preventing an O(N) memory spike relative to the number of query results.
🔬 **Measurement**: Run the executor tests via `cargo test -p aletheiadb --lib query::executor` to ensure no regression in logic.

---
*PR created automatically by Jules for task [7871540872619041171](https://jules.google.com/task/7871540872619041171) started by @madmax983*