### PR TITLE
🦀 Core: Add code review report

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -1,0 +1,7 @@
+No high-severity findings.
+
+### Test gaps
+- No missing tests were identified for correctness/regression risks.
+
+### Residual risks
+- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that may cause CI failures when strict linting (`-D warnings`) is enforced, but it poses no correctness or regression risk.


### PR DESCRIPTION
Added the required `.jules/core_review.md` text report following the "Core"🦀 persona instructions. Verified that no functional regressions were introduced and correctly classified the `clippy::collapsible_if` warning as a residual test/linting risk.

---
*PR created automatically by Jules for task [15859577145573071196](https://jules.google.com/task/15859577145573071196) started by @madmax983*