### PR TITLE
🗺️ Atlas: [fix collapsible if warnings]

### DIFF
--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,15 +207,14 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
-                }
+
+            if vt_start > time.wallclock() || vt_start < best_time {
+                continue;
+            }
+
+            if let Some(vec) = v.properties.get(property).and_then(|val| val.as_vector()) {
+                best_vec = Some(vec.to_vec());
+                best_time = vt_start;
             }
         }
         best_vec


### PR DESCRIPTION
🕸️ **Tangle**: 
Clippy reported `collapsible_if` warnings in `src/experimental/omen.rs` due to deeply nested `if` and `if let` conditions within the `find_vector_at` method, creating code smell and structural bloat.

📐 **Blueprint**:
Refactored the conditional logic in the time boundary check loop. We replaced the nested `if` statements by using an early `continue` when the condition `vt_start > time.wallclock() || vt_start < best_time` is met. This effectively flattens the execution flow without relying on unstable nightly features like `let chains`.

🧱 **Stability**:
Maintained exact existing logic but reduced nesting depth, leading to cleaner code flow and resolving the clippy warning. 

🔬 **Verification**:
- `cargo clippy --all-targets --all-features -- -D warnings` ran successfully.
- `cargo test --features nova omen` passed successfully.

---
*PR created automatically by Jules for task [9155195875193753625](https://jules.google.com/task/9155195875193753625) started by @madmax983*