### PR TITLE
🦀 Core: Fix clippy warning in experimental module

### DIFF
--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,15 +207,12 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
-                }
+            if vt_start > time.wallclock() || vt_start < best_time {
+                continue;
+            }
+            if let Some(vec) = v.properties.get(property).and_then(|val| val.as_vector()) {
+                best_vec = Some(vec.to_vec());
+                best_time = vt_start;
             }
         }
         best_vec


### PR DESCRIPTION
🦀 Core: Fix `clippy::collapsible_if` in `src/experimental/omen.rs`

Addresses the residual risk identified in the Core review report by correctly fixing the `clippy::collapsible_if` warning.
Refactors the deeply nested `if` and `if let` blocks inside the `predict_encounter` loop to use a flattened structure with early loop continuation and cleaner `Option` handling via `.and_then()`.
Verified with `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`.

---
*PR created automatically by Jules for task [3749377186187226405](https://jules.google.com/task/3749377186187226405) started by @madmax983*