### PR TITLE
🦀 Core: Add code review report and fix clippy warnings

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -1,7 +1,6 @@
+# Core🦀 Code Review Report
+
 No high-severity findings.
 
-### Test gaps
-- No missing tests were identified for correctness/regression risks.
-
-### Residual risks
-- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that may cause CI failures when strict linting (`-D warnings`) is enforced, but it poses no correctness or regression risk.
+## Residual risks/test gaps
+* Ensure all tests pass specifically with `--features "http-server"`, as some HTTP tests require that feature flag to compile and execute properly.

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,14 +207,13 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
+            let is_valid_time = vt_start <= time.wallclock() && vt_start >= best_time;
+
+            if is_valid_time {
+                let maybe_vec = v.properties.get(property).and_then(|val| val.as_vector());
+                if let Some(vec) = maybe_vec {
+                    best_vec = Some(vec.to_vec());
+                    best_time = vt_start;
                 }
             }
         }


### PR DESCRIPTION
Added `.jules/core_review.md` text report following the "Core"🦀 persona instructions. Identified a `clippy::collapsible_if` warning in `src/experimental/omen.rs` as a residual risk and proactively fixed it by restructuring nested `if` statements, ensuring strict linting passes. All tests run locally pass cleanly with no regressions.

---
*PR created automatically by Jules for task [12762325379579921177](https://jules.google.com/task/12762325379579921177) started by @madmax983*