### PR TITLE
🎻 Bard: Semantic Pathfinding Documentation and Cleanup

### DIFF
--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,15 +207,12 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
-                }
+            if vt_start > time.wallclock() || vt_start < best_time {
+                continue;
+            }
+            if let Some(vec) = v.properties.get(property).and_then(|val| val.as_vector()) {
+                best_vec = Some(vec.to_vec());
+                best_time = vt_start;
             }
         }
         best_vec

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -3,9 +3,25 @@
 //! This module implements pathfinding algorithms that consider semantic similarity
 //! (vector embeddings) as part of the cost function.
 //!
+//! # The Story of Semantic Pathfinding
+//!
+//! Traditional graph pathfinding algorithms like Dijkstra's or A* are brilliant at finding the *shortest*
+//! physical path between two nodes. But in a knowledge graph, the "shortest" path isn't always the
+//! most *relevant* one.
+//!
+//! Imagine searching for a path between `Node(Alice)` and `Node(Machine Learning)`. A traditional algorithm
+//! might route you through `Node(Bob)` simply because Alice knows Bob, and Bob read a book on Machine Learning.
+//! But what if Alice has a deep connection to `Node(Data Science)`, which then links to `Node(Machine Learning)`?
+//!
+//! Semantic Pathfinding solves this by combining structural graph traversal with vector similarity.
+//! By treating the semantic distance (e.g., cosine distance) between a node's embedding and a *target concept*
+//! as an edge weight penalty, the algorithm naturally "steers" the traversal through nodes that are
+//! conceptually related to what you are looking for. It's like asking the algorithm to "stay on topic"
+//! while it searches the graph.
+//!
 //! # Features
 //! - **Semantic A***: Finds paths where nodes are semantically similar to a query concept.
-//! - **Time-Travel Pathfinding**: Finds paths that were valid at a specific point in time.
+//! - **Time-Travel Pathfinding**: Finds paths that were valid at a specific point in time using the bi-temporal model.
 
 use crate::core::error::Result;
 use crate::core::id::NodeId;
@@ -48,14 +64,43 @@ impl PartialOrd for State {
     }
 }
 
-/// A pathfinder that uses semantic similarity as a heuristic/cost.
+/// A pathfinder that uses semantic similarity as a traversal cost.
+///
+/// This engine wraps a standard `GraphView` and uses Dijkstra's algorithm augmented with vector distance
+/// to bias paths toward a specific semantic concept.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use aletheiadb::AletheiaDB;
+/// use aletheiadb::query::semantic_pathfinding::SemanticPathfinder;
+/// use aletheiadb::core::id::NodeId;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let db = AletheiaDB::new()?;
+/// let start_node = NodeId::new(1).unwrap();
+/// let target_node = NodeId::new(100).unwrap();
+/// let query_concept = vec![0.1, 0.5, 0.9]; // e.g., an embedding for "AI"
+///
+/// let pathfinder = SemanticPathfinder::new(&db, "embedding");
+///
+/// // Find a path up to 5 hops deep that stays semantically close to "AI"
+/// if let Some(path) = pathfinder.find_path(start_node, target_node, &query_concept, 5, false)? {
+///     println!("Found semantic path: {:?}", path);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub struct SemanticPathfinder<'a, G: GraphView + ?Sized> {
     db: &'a G,
     vector_property: String,
 }
 
 impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
-    /// Create a new SemanticPathfinder.
+    /// Creates a new `SemanticPathfinder`.
+    ///
+    /// The `vector_property` tells the pathfinder which property key to inspect when retrieving a node's
+    /// embedding to compute its semantic cost against the query vector.
     ///
     /// # Arguments
     /// * `db` - Reference to the graph view (e.g., database instance).
@@ -107,11 +152,8 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             }
 
             // Optimization: Skip if we found a better path already
-            #[allow(clippy::collapsible_if)]
-            if let Some(&d) = dist.get(&node) {
-                if cost > d {
-                    continue;
-                }
+            if dist.get(&node).is_some_and(|&d| cost > d) {
+                continue;
             }
 
             // Check depth limit
@@ -206,11 +248,8 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
                 return Ok(Some(self.reconstruct_path(came_from, end)));
             }
 
-            #[allow(clippy::collapsible_if)]
-            if let Some(&d) = dist.get(&node) {
-                if cost > d {
-                    continue;
-                }
+            if dist.get(&node).is_some_and(|&d| cost > d) {
+                continue;
             }
 
             // Check depth limit to prevent infinite loops

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -611,21 +611,61 @@ mod tests {
 
             let db = create_test_db();
 
-            let start = db.create_node("Start", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0, 0.0]).build()).unwrap();
-            let a = db.create_node("A", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0, 0.0]).build()).unwrap();
-            let b = db.create_node("B", PropertyMapBuilder::new().insert_vector("embedding", &[0.5, 0.5, 0.0]).build()).unwrap();
-            let middle = db.create_node("Middle", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0, 0.0]).build()).unwrap();
+            let start = db
+                .create_node(
+                    "Start",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
+            let a = db
+                .create_node(
+                    "A",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
+            let b = db
+                .create_node(
+                    "B",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[0.5, 0.5, 0.0])
+                        .build(),
+                )
+                .unwrap();
+            let middle = db
+                .create_node(
+                    "Middle",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[1.0, 0.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
 
             // End has a very bad semantic cost, so it's pushed with high cost
-            let end = db.create_node("End", PropertyMapBuilder::new().insert_vector("embedding", &[0.0, 1.0, 0.0]).build()).unwrap();
+            let end = db
+                .create_node(
+                    "End",
+                    PropertyMapBuilder::new()
+                        .insert_vector("embedding", &[0.0, 1.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
 
-            db.create_edge(start, a, "NEXT", PropertyMapBuilder::new().build()).unwrap();
-            db.create_edge(start, b, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+            db.create_edge(start, a, "NEXT", PropertyMapBuilder::new().build())
+                .unwrap();
+            db.create_edge(start, b, "NEXT", PropertyMapBuilder::new().build())
+                .unwrap();
 
-            db.create_edge(a, middle, "NEXT", PropertyMapBuilder::new().build()).unwrap();
-            db.create_edge(b, middle, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+            db.create_edge(a, middle, "NEXT", PropertyMapBuilder::new().build())
+                .unwrap();
+            db.create_edge(b, middle, "NEXT", PropertyMapBuilder::new().build())
+                .unwrap();
 
-            db.create_edge(middle, end, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+            db.create_edge(middle, end, "NEXT", PropertyMapBuilder::new().build())
+                .unwrap();
 
             let query = vec![1.0, 0.0, 0.0];
             let pathfinder = SemanticPathfinder::new(&db, "embedding");
@@ -635,7 +675,16 @@ mod tests {
             assert_eq!(path.unwrap(), vec![start, a, middle, end]);
 
             // Also hit `find_path_at_time`
-            let path_temporal = pathfinder.find_path_at_time(start, end, &query, crate::core::temporal::time::now(), 10, false).unwrap();
+            let path_temporal = pathfinder
+                .find_path_at_time(
+                    start,
+                    end,
+                    &query,
+                    crate::core::temporal::time::now(),
+                    10,
+                    false,
+                )
+                .unwrap();
             assert!(path_temporal.is_some());
         }
 

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -580,6 +580,66 @@ mod tests {
         use super::*;
 
         #[test]
+        fn test_pathfinding_suboptimal_path_skipped() {
+            // This test ensures we hit the `continue` when a suboptimal path is popped from PQ.
+            // Setup a diamond graph: Start -> A -> End, Start -> B -> End.
+            // B has very bad semantic cost, so Start->A is explored first.
+            // Actually, we need Start -> A -> Target, and Start -> Target directly.
+            // The direct path is slightly worse than going through A, so A is explored first,
+            // Target is added to PQ via A, then Target is added to PQ via Start.
+            // Wait, Dijkstra always pops minimum cost first.
+            // So if Target is added to PQ with cost 10 (via Start) and cost 5 (via A).
+            // Cost 5 is popped first, Target is found and RETURNED immediately since it's the end.
+            // If Target is the end, it returns immediately.
+            // So to pop a suboptimal state *without* returning, the node must NOT be the end node.
+
+            // Graph: Start -> A -> Middle -> End
+            //        Start -> B -> Middle
+            // A has semantic cost 0.1
+            // B has semantic cost 1.0
+            // Start -> A (cost 0.1) -> Middle (cost 0.1 + 0.1 = 0.2)
+            // Start -> B (cost 1.0) -> Middle (cost 1.0 + 0.1 = 1.1)
+            // PQ will have: (0.0, Start)
+            // Pop Start. Push A(cost 0.1+structural), Push B(cost 1.0+structural).
+            // Pop A. Push Middle(cost 0.2+structural).
+            // Pop Middle. Push End.
+            // But wait, if we pop Middle, we push End, then pop End and return. B is never popped!
+
+            // To make B be popped and push Middle (cost 1.1), but Middle was ALREADY visited via A:
+            // We need B's cost to be SMALLER than End's cost, so B is popped BEFORE End is reached.
+            // Let End be very far away or have high cost.
+
+            let db = create_test_db();
+
+            let start = db.create_node("Start", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0, 0.0]).build()).unwrap();
+            let a = db.create_node("A", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0, 0.0]).build()).unwrap();
+            let b = db.create_node("B", PropertyMapBuilder::new().insert_vector("embedding", &[0.5, 0.5, 0.0]).build()).unwrap();
+            let middle = db.create_node("Middle", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0, 0.0]).build()).unwrap();
+
+            // End has a very bad semantic cost, so it's pushed with high cost
+            let end = db.create_node("End", PropertyMapBuilder::new().insert_vector("embedding", &[0.0, 1.0, 0.0]).build()).unwrap();
+
+            db.create_edge(start, a, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+            db.create_edge(start, b, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+
+            db.create_edge(a, middle, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+            db.create_edge(b, middle, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+
+            db.create_edge(middle, end, "NEXT", PropertyMapBuilder::new().build()).unwrap();
+
+            let query = vec![1.0, 0.0, 0.0];
+            let pathfinder = SemanticPathfinder::new(&db, "embedding");
+
+            let path = pathfinder.find_path(start, end, &query, 10, false).unwrap();
+            assert!(path.is_some());
+            assert_eq!(path.unwrap(), vec![start, a, middle, end]);
+
+            // Also hit `find_path_at_time`
+            let path_temporal = pathfinder.find_path_at_time(start, end, &query, crate::core::temporal::time::now(), 10, false).unwrap();
+            assert!(path_temporal.is_some());
+        }
+
+        #[test]
         fn test_pathfinding_zero_max_depth() {
             let db = create_test_db();
             // Create a minimal graph A -> B


### PR DESCRIPTION
### 📖 Chapter
The `SemanticPathfinding` module and clippy cleanup in experimental modules.

### 🔦 Insight
Explained the core concept of semantic pathfinding: using vector similarity to steer traditional graph traversal (like Dijkstra's) toward conceptual relevance, rather than just physical shortest paths. Also cleaned up technical debt by addressing `clippy::collapsible_if` warnings in both `omen.rs` and `semantic_pathfinding.rs` instead of suppressing them.

### 🧪 Example
Added an executable doctest to `SemanticPathfinder` demonstrating how to search for a path that stays semantically close to an embedding (e.g. for "AI").

### 🖼️ Preview
N/A

---
*PR created automatically by Jules for task [9920911039519929365](https://jules.google.com/task/9920911039519929365) started by @madmax983*