### PR TITLE
🦀 Core: Fix `clippy::collapsible_if` in `src/experimental/omen.rs`

### DIFF
--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,14 +207,11 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
+            if vt_start <= time.wallclock() && vt_start >= best_time {
+                let vec_opt = v.properties.get(property).and_then(|val| val.as_vector());
+                if let Some(vec) = vec_opt {
+                    best_vec = Some(vec.to_vec());
+                    best_time = vt_start;
                 }
             }
         }


### PR DESCRIPTION
Flattened nested `if` and `if let` blocks in `src/experimental/omen.rs` using logical ANDs (`&&`) and `Option::and_then()`. This addresses the `clippy::collapsible_if` warnings raised during the Core review process, ensuring adherence to strict CI linting rules. The refactor maintains exact original behavior while drastically improving code readability.

---
*PR created automatically by Jules for task [3881219282781936288](https://jules.google.com/task/3881219282781936288) started by @madmax983*