### PR TITLE
🪒 Razor: Flatten nested conditions in omen.rs

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+
+## [Reduction]
+**Bloat:** Nested `if` blocks with multiple condition checks inside `omen.rs`.
+**Cut:** Flattened the nested `if` statements using `.and_then()` and `&&` logical operators.
+**Saved:** Removed deep nesting and reduced complexity, keeping logic straightforward and readable.

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -31,7 +31,8 @@
 //! let omen = Omen::new(&db);
 //!
 //! // Analyze last hour
-//! let window = TimeRange::new(time::now() - 3600 * 1_000_000, time::now())?;
+//! let start = time::now().wallclock() - 3600 * 1_000_000;
+//! let window = TimeRange::new(aletheiadb::core::hlc::HybridTimestamp::from_micros(start), time::now())?;
 //!
 //! if let Some(encounter) = omen.predict_encounter(node_a, node_b, window, "embedding")? {
 //!     println!("Predicted encounter in {:.2} seconds.", encounter.time_to_encounter.as_secs_f32());
@@ -207,14 +208,11 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
+            if vt_start <= time.wallclock() && vt_start >= best_time {
+                let vec_opt = v.properties.get(property).and_then(|val| val.as_vector());
+                if let Some(vec) = vec_opt {
+                    best_vec = Some(vec.to_vec());
+                    best_time = vt_start;
                 }
             }
         }

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -77,6 +77,7 @@ async fn test_cors_headers_present() {
         .uri("/status")
         .insert_header(("Origin", "http://example.com"))
         .insert_header(("Access-Control-Request-Method", "GET"))
+        .peer_addr("127.0.0.1:8080".parse().unwrap())
         .to_request();
 
     let resp = test::call_service(&app, req).await;


### PR DESCRIPTION
- **omen.rs**: Flattened nested `if` statements using logical `&&` and `.and_then()` to improve readability and fix `clippy::collapsible_if` warnings.
- **omen.rs**: Fixed failing doctests due to incorrect timestamp operations.
- **http_server.rs**: Supplied `peer_addr` in `test_cors_headers_present` to prevent test failures.
- **razor.md**: Documented the reduction logic and what was saved.

---
*PR created automatically by Jules for task [7153060754803520153](https://jules.google.com/task/7153060754803520153) started by @madmax983*