### PR TITLE
⚡ Bolt: Use IdentityHasher in WriteBuffer for faster lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-27 - Identity Hashing for PropertyMap
 **Learning:** `PropertyMap` uses `InternedString` (u32) as keys but was using default `HashMap` hashing (SipHash), incurring ~15-30ns overhead per lookup. Switching to `IdentityHasher` eliminated this, yielding a 3.6x speedup on interned lookups.
 **Action:** Audit all usages of `HashMap<InternedString, ...>` or `HashMap<u32, ...>` and replace with `HashMap<..., BuildHasherDefault<IdentityHasher>>` where keys are already high-quality IDs.
+
+## 2026-11-20 - Identity Hashing for WriteBuffer Lookups
+**Learning:** `WriteBuffer` used default `HashMap` (SipHash) for `modified_nodes` and `modified_edges` to track dirty state during transactions. Since keys are `NodeId` and `EdgeId` (wrappers around `u64`), hashing overhead was unnecessary and reduced throughput during bulk write operations.
+**Action:** Replaced `HashMap` with `FastHashMap` (`HashMap<..., BuildHasherDefault<IdentityHasher>>`) for `modified_nodes` and `modified_edges` in `WriteBuffer`. Using `IdentityHasher` for already-unique integer-like keys eliminates SipHash overhead and improves lookup/insertion speeds during transaction tracking.

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -153,8 +153,8 @@ impl WriteBuffer {
     pub fn with_max_operations(max_operations: usize) -> Self {
         WriteBuffer {
             operations: Vec::new(),
-            modified_nodes: FastHashMap::with_hasher(BuildHasherDefault::default()),
-            modified_edges: FastHashMap::with_hasher(BuildHasherDefault::default()),
+            modified_nodes: FastHashMap::default(),
+            modified_edges: FastHashMap::default(),
             max_operations,
             has_vector_operations: false,
             has_edge_operations: false,

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -1,11 +1,15 @@
 //! Write buffering for uncommitted transaction changes
 
 use crate::core::error::{Result, StorageError};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
 use crate::core::temporal::Timestamp;
 use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
+
+type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<IdentityHasher>>;
 
 /// Buffered write operation
 ///
@@ -113,11 +117,15 @@ pub struct WriteBuffer {
 
     /// Quick lookup: which nodes have been written to
     /// Maps NodeId → index in operations vector
-    modified_nodes: HashMap<NodeId, usize>,
+    ///
+    /// Using IdentityHasher avoids SipHash overhead since NodeId is already a high-quality unique u64 ID.
+    modified_nodes: FastHashMap<NodeId, usize>,
 
     /// Quick lookup: which edges have been written to
     /// Maps EdgeId → index in operations vector
-    modified_edges: HashMap<EdgeId, usize>,
+    ///
+    /// Using IdentityHasher avoids SipHash overhead since EdgeId is already a high-quality unique u64 ID.
+    modified_edges: FastHashMap<EdgeId, usize>,
 
     /// Maximum number of operations allowed (DoS protection)
     max_operations: usize,
@@ -145,8 +153,8 @@ impl WriteBuffer {
     pub fn with_max_operations(max_operations: usize) -> Self {
         WriteBuffer {
             operations: Vec::new(),
-            modified_nodes: HashMap::new(),
-            modified_edges: HashMap::new(),
+            modified_nodes: FastHashMap::with_hasher(BuildHasherDefault::default()),
+            modified_edges: FastHashMap::with_hasher(BuildHasherDefault::default()),
             max_operations,
             has_vector_operations: false,
             has_edge_operations: false,
@@ -160,8 +168,14 @@ impl WriteBuffer {
     pub fn with_capacity(capacity: usize) -> Self {
         WriteBuffer {
             operations: Vec::with_capacity(capacity),
-            modified_nodes: HashMap::with_capacity(capacity / 2),
-            modified_edges: HashMap::with_capacity(capacity / 2),
+            modified_nodes: FastHashMap::with_capacity_and_hasher(
+                capacity / 2,
+                BuildHasherDefault::default(),
+            ),
+            modified_edges: FastHashMap::with_capacity_and_hasher(
+                capacity / 2,
+                BuildHasherDefault::default(),
+            ),
             max_operations: capacity,
             has_vector_operations: false,
             has_edge_operations: false,


### PR DESCRIPTION
💡 What: Switched `HashMap` to `FastHashMap` (which uses `BuildHasherDefault<IdentityHasher>`) for `modified_nodes` and `modified_edges` in `WriteBuffer`. Also added documentation explaining the optimization.

🎯 Why: Hashing overhead (SipHash) was unnecessary for `NodeId` and `EdgeId` which are already unique integers (`u64`).

📊 Impact: Reduces CPU overhead during transaction writes and improves lookup and insertion speeds.

🔬 Measurement: Run `cargo test` and verify tests pass. To see performance improvements run benchmarks involving heavy transaction writes.

---
*PR created automatically by Jules for task [14754360560565216629](https://jules.google.com/task/14754360560565216629) started by @madmax983*