### PR TITLE
docs: perform risk-first core review for omen.rs

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -1,7 +1,7 @@
 No high-severity findings.
 
 ### Test gaps
-- No missing tests were identified for correctness/regression risks.
+- No missing tests were identified for correctness/regression risks. The core logic of finding the valid history version correctly maintains bounds checks and type validations.
 
 ### Residual risks
-- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that may cause CI failures when strict linting (`-D warnings`) is enforced, but it poses no correctness or regression risk.
+- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that is explicitly suppressed with `#[allow(clippy::collapsible_if)]`. This prevents CI failures under strict linting (`-D warnings`) but leaves nested `if` statements in the codebase. However, it poses no correctness, regression, or concurrency risk, and correctly resolves the issue without relying on unstable Rust features like let chains.


### PR DESCRIPTION
Added `No high-severity findings` to `.jules/core_review.md` after verifying the recent lint-fix commit in `src/experimental/omen.rs`. Included test gaps and residual risks (acknowledging a `clippy::collapsible_if` workaround for strict CI), as requested by the "Core"🦀 persona rules.

---
*PR created automatically by Jules for task [3968857202479038534](https://jules.google.com/task/3968857202479038534) started by @madmax983*