### PR TITLE
🦀 Core: fix silent vector truncation in omen dimension mismatch

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -1,7 +1,28 @@
-No high-severity findings.
+# 🦀 Core Review Report
 
-### Test gaps
-- No missing tests were identified for correctness/regression risks.
+**Scope:** `src/experimental/omen.rs` vector prediction and dimension mismatch safety.
 
-### Residual risks
-- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that may cause CI failures when strict linting (`-D warnings`) is enforced, but it poses no correctness or regression risk.
+## Findings
+
+### 1. Silent Dimension Truncation
+- **Severity:** High
+- **File reference:** `src/experimental/omen.rs:104` (prior to fix)
+- **What can break:** When predicting an encounter between two nodes whose vector properties have different dimensions (e.g., node A is 2D, node B is 3D), the implementation used `.zip()`, which silently truncated the longer vector to the length of the shorter one. This lead to incorrect predictions and invalid physics math that could result in confusing or completely wrong trajectory insights without warning.
+- **Why it breaks:** `std::iter::zip` stops yielding as soon as the shorter iterator is exhausted. This silently hid the dimension mismatch invariant which is crucial for valid vector math.
+- **Minimal fix:** Return `Ok(None)` explicitly if `pos_a.len() != pos_b.len()` before performing the zipping operations.
+- **Required tests:** Add `test_omen_dimension_mismatch` to explicitly verify that predicting an encounter between nodes with mismatched vector dimensions returns `Ok(None)` instead of silently generating a false prediction. (Added).
+
+### 2. Collapsible If Statements and Lint Bypass
+- **Severity:** Low (Code quality/Lint bypass)
+- **File reference:** `src/experimental/omen.rs:215`
+- **What can break:** Unnecessary nesting of logic blocks increases cognitive load. The use of `#[allow(clippy::collapsible_if)]` suppresses warnings rather than addressing the structural issues.
+- **Why it breaks:** Overriding lints hides code smells and discourages refactoring towards clean, idiomatic Rust.
+- **Minimal fix:** Use `&&` to combine the time checks and `.and_then()` on the option returned by `.get()` to extract the vector without nesting `if let` blocks. Remove `#[allow(clippy::collapsible_if)]`.
+- **Required tests:** `cargo clippy --all-targets --all-features -- -D warnings` must pass cleanly. (Verified).
+
+## Test Gaps
+- Consider testing the behavior of the engine with `NaN` and `Infinity` values explicitly, as well as extremely large or small velocity magnitudes that might cause floating-point instability.
+- Fuzz testing `predict_encounter` with random vectors and time ranges.
+
+## Conclusion
+The high-severity silent dimension truncation has been successfully fixed, and the code quality smell involving `collapsible_if` has been refactored. Tests pass cleanly. No further high-severity findings remain within the scope of this review.

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -92,10 +92,15 @@ impl<'a> Omen<'a> {
             Some(t) => t,
             None => return Ok(None),
         };
+
         let (pos_b, vel_b) = match traj_b {
             Some(t) => t,
             None => return Ok(None),
         };
+
+        if pos_a.len() != pos_b.len() {
+            return Ok(None);
+        }
 
         // 2. Physics Math
         // Relative Position P = Pb - Pa (at t=0, which is window.end)
@@ -207,15 +212,11 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            #[allow(clippy::collapsible_if)]
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
+            if vt_start <= time.wallclock() && vt_start >= best_time {
+                let vec_opt = v.properties.get(property).and_then(|val| val.as_vector());
+                if let Some(vec) = vec_opt {
+                    best_vec = Some(vec.to_vec());
+                    best_time = vt_start;
                 }
             }
         }
@@ -226,6 +227,7 @@ impl<'a> Omen<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::api::transaction::WriteOps;
     use crate::core::property::PropertyMapBuilder;
     use crate::index::vector::{DistanceMetric, HnswConfig};
@@ -233,6 +235,7 @@ mod tests {
     #[test]
     fn test_omen_head_on_collision() {
         let db = AletheiaDB::new().unwrap();
+
         // Enable index
         db.enable_vector_index("vec", HnswConfig::new(2, DistanceMetric::Euclidean))
             .unwrap();
@@ -315,6 +318,7 @@ mod tests {
     #[test]
     fn test_omen_diverging() {
         let db = AletheiaDB::new().unwrap();
+
         db.enable_vector_index("vec", HnswConfig::new(2, DistanceMetric::Euclidean))
             .unwrap();
 
@@ -372,6 +376,7 @@ mod tests {
     #[test]
     fn test_omen_static_target() {
         let db = AletheiaDB::new().unwrap();
+
         db.enable_vector_index("vec", HnswConfig::new(2, DistanceMetric::Euclidean))
             .unwrap();
 
@@ -418,6 +423,7 @@ mod tests {
     #[test]
     fn test_omen_parallel() {
         let db = AletheiaDB::new().unwrap();
+
         db.enable_vector_index("vec", HnswConfig::new(2, DistanceMetric::Euclidean))
             .unwrap();
 
@@ -477,5 +483,76 @@ mod tests {
         // Should report immediate encounter (t=0) with current distance.
         assert_eq!(encounter.time_to_encounter.as_secs(), 0);
         assert!((encounter.predicted_distance - 1.0).abs() < 0.01);
+    }
+}
+
+#[cfg(test)]
+mod additional_tests {
+    use super::*;
+    use crate::AletheiaDB;
+
+    use crate::core::temporal::{TimeRange, time};
+    use std::time::Duration;
+
+    #[test]
+    fn test_omen_dimension_mismatch() {
+        let db = AletheiaDB::new().unwrap();
+        use crate::api::transaction::WriteOps;
+        use crate::core::property::PropertyMapBuilder;
+
+        // Node A: Starts at [0, 0]
+        let props_a = PropertyMapBuilder::new()
+            .insert_vector("vec", &[0.0, 0.0])
+            .build();
+        let a = db.create_node("A", props_a).unwrap();
+
+        // Node B: Starts at [10, 0, 0] (Different Dimension!)
+        let props_b = PropertyMapBuilder::new()
+            .insert_vector("vec", &[10.0, 0.0, 0.0])
+            .build();
+        let b = db.create_node("B", props_b).unwrap();
+
+        // Wait to establish initial state time
+        std::thread::sleep(Duration::from_millis(10));
+        let t_start = time::now();
+
+        // Wait 50ms
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Update A
+        db.write(|tx| {
+            tx.update_node(
+                a,
+                PropertyMapBuilder::new()
+                    .insert_vector("vec", &[1.0, 0.0])
+                    .build(),
+            )
+        })
+        .unwrap();
+
+        // Update B
+        db.write(|tx| {
+            tx.update_node(
+                b,
+                PropertyMapBuilder::new()
+                    .insert_vector("vec", &[9.0, 0.0, 0.0])
+                    .build(),
+            )
+        })
+        .unwrap();
+
+        let t_end = time::now();
+
+        let omen = Omen::new(&db);
+        let window = TimeRange::new(t_start, t_end).unwrap();
+
+        // Since dimensions don't match (2 vs 3), predict_encounter should return None to avoid silent truncation.
+        let encounter = omen.predict_encounter(a, b, window, "vec").unwrap();
+
+        assert!(
+            encounter.is_none(),
+            "Expected None due to dimension mismatch, but got {:?}",
+            encounter
+        );
     }
 }


### PR DESCRIPTION
This PR addresses high-severity correctness risks identified in `src/experimental/omen.rs`.

**Risk Fixed:**
- The engine previously used `std::iter::zip` to compute relative velocities and positions. If two nodes possessed vector properties of differing dimensions, `zip` silently truncated the longer vector to match the shorter. This yielded invalid dot products and meaningless interaction predictions without returning an error or `None`.
- Added explicit length validation (`pos_a.len() != pos_b.len()`) to safely return `Ok(None)` when vectors don't align in dimensionality.

**Refactoring:**
- Addressed `clippy::collapsible_if` lint violation by chaining the logic and `and_then` directly, avoiding unnecessary nesting and bypassing of warnings.

**Testing:**
- Added `test_omen_dimension_mismatch` test to confirm the early exit logic works securely.
- Documented findings in `.jules/core_review.md`.

---
*PR created automatically by Jules for task [3171440081820742366](https://jules.google.com/task/3171440081820742366) started by @madmax983*