### PR TITLE
🗺️ Atlas: Break Circular Dependency Between Core and SQL

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -67,3 +67,7 @@
 1. Updated `storage/index_persistence/operations.rs` to import `TxId` from `core::id` instead of `api`.
 2. Moved `VectorIndexBuilder` from `api` to `db`, as it is a concrete helper for `AletheiaDB`.
 3. Moved `utils/error.rs` to `core/error.rs` and deleted `utils` module, consolidating core domain types.
+
+## 2026-03-05 - Breaking core <-> sql Dependency Cycle
+**Tangle:** The `core` module depended on `sql` because `core::error::Error` implemented `From<crate::sql::SqlError>`. Meanwhile, `sql` depended on `core` for types like `Timestamp` and `TimeRange`, creating a circular dependency. The core domain should not depend on higher-level query parsing modules.
+**Blueprint:** Moved the `From<SqlError> for crate::core::error::Error` implementation out of `src/core/error.rs` and into `src/sql/error.rs`. This leverages Rust's orphan rules (since both types are local to the crate) to allow `sql` to define how its errors convert into `core` errors, completely removing `sql` from `core`'s dependency graph.

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -149,20 +149,6 @@ impl From<crate::config::ConfigError> for Error {
     }
 }
 
-#[cfg(feature = "sql")]
-impl From<crate::sql::SqlError> for Error {
-    fn from(e: crate::sql::SqlError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_query_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-        Error::Query(QueryError::SyntaxError {
-            message: e.to_string(),
-        })
-    }
-}
-
 /// Errors related to storage operations.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum StorageError {

--- a/src/sql/error.rs
+++ b/src/sql/error.rs
@@ -47,3 +47,16 @@ impl From<sqlparser::parser::ParserError> for SqlError {
         SqlError::ParseError(err.to_string())
     }
 }
+
+impl From<SqlError> for crate::core::error::Error {
+    fn from(e: SqlError) -> Self {
+        #[cfg(feature = "observability")]
+        crate::observability::METRICS
+            .error_query_total
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        crate::core::error::Error::Query(crate::core::error::QueryError::SyntaxError {
+            message: e.to_string(),
+        })
+    }
+}

--- a/src/sql/error.rs
+++ b/src/sql/error.rs
@@ -48,14 +48,14 @@ impl From<sqlparser::parser::ParserError> for SqlError {
     }
 }
 
-impl From<SqlError> for Error {
+impl From<SqlError> for crate::core::error::Error {
     fn from(e: SqlError) -> Self {
         #[cfg(feature = "observability")]
         crate::observability::METRICS
             .error_query_total
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        Error::Query(QueryError::SyntaxError {
+        crate::core::error::Error::Query(crate::core::error::QueryError::SyntaxError {
             message: e.to_string(),
         })
     }

--- a/src/sql/error.rs
+++ b/src/sql/error.rs
@@ -48,14 +48,14 @@ impl From<sqlparser::parser::ParserError> for SqlError {
     }
 }
 
-impl From<SqlError> for crate::core::error::Error {
+impl From<SqlError> for Error {
     fn from(e: SqlError) -> Self {
         #[cfg(feature = "observability")]
         crate::observability::METRICS
             .error_query_total
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        crate::core::error::Error::Query(crate::core::error::QueryError::SyntaxError {
+        Error::Query(QueryError::SyntaxError {
             message: e.to_string(),
         })
     }


### PR DESCRIPTION
🕸️ **Tangle:**
The `core` module depended on `sql` because `core::error::Error` explicitly implemented `From<crate::sql::SqlError>`. Concurrently, the `sql` module rightfully depended on `core` for primitives like `Timestamp` and `TimeRange`. This formed a classic circular dependency, violating the rule that the core domain should not rely on higher-level feature implementations.

📐 **Blueprint:**
Moved the `From<SqlError> for crate::core::error::Error` trait implementation out of `src/core/error.rs` and placed it into `src/sql/error.rs`. By taking advantage of Rust's local trait implementation rules (orphan rules), the `sql` module now defines how its errors convert into `core` errors without `core` needing to know about `sql`.

🧱 **Stability:**
Strictly enforces unidirectional dependencies (`sql` -> `core`). Removes `sql` parsing knowledge from the core domain error type, lowering coupling.

🔬 **Verification:**
- Verified no circular dependency (`core` <-> `sql`) exists using our dependency mapping script.
- Ran `cargo test --lib core::error` and `cargo test --lib sql::error` successfully.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all` passed cleanly.

---
*PR created automatically by Jules for task [8345156833331500929](https://jules.google.com/task/8345156833331500929) started by @madmax983*