### PR TITLE
🦀 Core: [Review] Empty diff scope evaluation

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -1,7 +1,7 @@
 No high-severity findings.
 
 ### Test gaps
-- No missing tests were identified for correctness/regression risks. The core logic of finding the valid history version correctly maintains bounds checks and type validations.
+- No missing tests were identified for correctness/regression risks.
 
 ### Residual risks
-- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that is explicitly suppressed with `#[allow(clippy::collapsible_if)]`. This prevents CI failures under strict linting (`-D warnings`) but leaves nested `if` statements in the codebase. However, it poses no correctness, regression, or concurrency risk, and correctly resolves the issue without relying on unstable Rust features like let chains.
+- No residual risks were identified as there were no code changes in the reviewed scope.


### PR DESCRIPTION
The review process was executed per the strict "Core" persona directives. However, as the working tree contained no changes relative to the baseline state (trunk), there were no diffs to evaluate for correctness, data loss, concurrency, security, or regression risks.

Following the prescribed fallback instructions, I have updated the `.jules/core_review.md` file to explicitly state "No high-severity findings." alongside placeholders for test gaps and residual risks. All pre-commit validations (`cargo fmt`, `cargo clippy`, and `cargo test`) passed.

---
*PR created automatically by Jules for task [3784640028444598296](https://jules.google.com/task/3784640028444598296) started by @madmax983*