### PR TITLE
👺 Havoc: [AdjacencyIndex::import_csr] DoS via Panic on Invalid CSR Data

### DIFF
--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -94,7 +94,7 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Result<Self, String> {
+    ) -> crate::core::error::Result<Self> {
         if offsets.is_empty() || edge_ids.is_empty() {
             return Ok(Self::new());
         }
@@ -291,23 +291,23 @@ impl AdjacencyIndex {
         node_ids: &[u64],
         offsets: &[u64],
         edge_ids: &[u64],
-    ) -> Result<(), String> {
+    ) -> crate::core::error::Result<()> {
         if offsets.len() != node_ids.len() + 1 {
-            return Err(format!(
+            return Err(crate::core::error::StorageError::CorruptedData(format!(
                 "CSR offsets length mismatch: expected {}, got {}",
                 node_ids.len() + 1,
                 offsets.len()
-            ));
+            )).into());
         }
 
         #[allow(clippy::collapsible_if)]
         if let Some(&last_offset) = offsets.last() {
             if last_offset != edge_ids.len() as u64 {
-                return Err(format!(
+                return Err(crate::core::error::StorageError::CorruptedData(format!(
                     "CSR last offset mismatch: expected {}, got {}",
                     edge_ids.len(),
                     last_offset
-                ));
+                )).into());
             }
         }
 
@@ -810,14 +810,16 @@ mod sentry_tests {
         let invalid_offsets_len = vec![0, 1]; // too short
         let err_len =
             AdjacencyIndex::validate_csr_invariants(&node_ids, &invalid_offsets_len, &edge_ids)
-                .unwrap_err();
+                .unwrap_err()
+                .to_string();
         assert!(err_len.contains("CSR offsets length mismatch"));
 
         // 3. Invalid last offset
         let invalid_offsets_val = vec![0, 1, 5]; // last is 5, but edges len is 2
         let err_val =
             AdjacencyIndex::validate_csr_invariants(&node_ids, &invalid_offsets_val, &edge_ids)
-                .unwrap_err();
+                .unwrap_err()
+                .to_string();
         assert!(err_val.contains("CSR last offset mismatch"));
     }
 
@@ -830,7 +832,7 @@ mod sentry_tests {
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
         let result = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("CSR offsets length mismatch"));
+        assert!(result.unwrap_err().to_string().contains("CSR offsets length mismatch"));
     }
 
     #[test]

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -297,7 +297,8 @@ impl AdjacencyIndex {
                 "CSR offsets length mismatch: expected {}, got {}",
                 node_ids.len() + 1,
                 offsets.len()
-            )).into());
+            ))
+            .into());
         }
 
         #[allow(clippy::collapsible_if)]
@@ -307,7 +308,8 @@ impl AdjacencyIndex {
                     "CSR last offset mismatch: expected {}, got {}",
                     edge_ids.len(),
                     last_offset
-                )).into());
+                ))
+                .into());
             }
         }
 
@@ -832,7 +834,12 @@ mod sentry_tests {
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
         let result = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("CSR offsets length mismatch"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("CSR offsets length mismatch")
+        );
     }
 
     #[test]

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -94,13 +94,13 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Self {
+    ) -> Result<Self, String> {
         if offsets.is_empty() || edge_ids.is_empty() {
-            return Self::new();
+            return Ok(Self::new());
         }
 
         // Validate CSR invariants
-        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids).unwrap();
+        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids)?;
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -128,12 +128,12 @@ impl AdjacencyIndex {
             }
         }
 
-        Self {
+        Ok(Self {
             node_ids: node_ids_typed,
             offsets: offsets_usize,
             edges: adjacency_entries,
             max_node_id,
-        }
+        })
     }
 }
 
@@ -786,7 +786,7 @@ mod tests {
         edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
         edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
@@ -822,14 +822,15 @@ mod sentry_tests {
     }
 
     #[test]
-    #[should_panic(expected = "CSR offsets length mismatch")]
-    fn test_import_csr_panics_on_invalid() {
-        // Integration check: ensure import_csr actually calls validate and panics
+    fn test_import_csr_returns_error_on_invalid() {
+        // Integration check: ensure import_csr actually calls validate and returns error
         let node_ids = vec![10];
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
-        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let result = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("CSR offsets length mismatch"));
     }
 
     #[test]
@@ -848,7 +849,7 @@ mod sentry_tests {
         edges_map.insert(EdgeId::new(101).unwrap(), (target, label));
 
         // Should not panic
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
 
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -795,8 +795,7 @@ impl CurrentIndexes {
                 "Cannot import CSR with uncommitted tombstones: {} outgoing, {} incoming. \
                  Deleted edges would reappear! Call compact() first or ensure import is \
                  only called on a fresh index during startup.",
-                outgoing_tombstones,
-                incoming_tombstones
+                outgoing_tombstones, incoming_tombstones
             ));
         }
 
@@ -2056,7 +2055,11 @@ mod test_import_csr {
         // At this point we have a tombstone. import_csr should fail.
         let result = indexes.import_csr(vec![], vec![0], vec![], vec![], vec![0], vec![]);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Cannot import CSR with uncommitted tombstones"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Cannot import CSR with uncommitted tombstones")
+        );
     }
 
     #[test]
@@ -2064,10 +2067,12 @@ mod test_import_csr {
         let indexes = CurrentIndexes::new();
         // Provide mismatched CSR arrays to trigger an error from AdjacencyIndex::import_csr
         let result = indexes.import_csr(
-            vec![1],       // node_ids len 1
-            vec![0],       // offsets len 1 (invalid, should be 2)
-            vec![100],     // edge_ids
-            vec![], vec![0], vec![]
+            vec![1],   // node_ids len 1
+            vec![0],   // offsets len 1 (invalid, should be 2)
+            vec![100], // edge_ids
+            vec![],
+            vec![0],
+            vec![],
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("CSR offsets length mismatch"));

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -796,7 +796,8 @@ impl CurrentIndexes {
                  Deleted edges would reappear! Call compact() first or ensure import is \
                  only called on a fresh index during startup.",
                 outgoing_tombstones, incoming_tombstones
-            )).into());
+            ))
+            .into());
         }
 
         // Build edges map for CSR reconstruction
@@ -2076,6 +2077,11 @@ mod test_import_csr {
             vec![],
         );
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("CSR offsets length mismatch"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("CSR offsets length mismatch")
+        );
     }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -106,7 +106,7 @@ impl CurrentIndexes {
     ///
     /// - `Ok(())` if shutdown was successful or no scheduler was running
     /// - `Err(String)` if the background thread panicked during shutdown
-    pub fn shutdown_background_compaction(&mut self) -> Result<(), String> {
+    pub fn shutdown_background_compaction(&mut self) -> std::result::Result<(), String> {
         // Shutdown outgoing compaction
         if let Some((scheduler, handle)) = self.outgoing_compaction.take() {
             scheduler.shutdown();
@@ -781,7 +781,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) -> Result<(), String> {
+    ) -> crate::core::error::Result<()> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -791,12 +791,12 @@ impl CurrentIndexes {
         let outgoing_tombstones = self.outgoing.tombstone_count();
         let incoming_tombstones = self.incoming.tombstone_count();
         if outgoing_tombstones != 0 || incoming_tombstones != 0 {
-            return Err(format!(
+            return Err(crate::core::error::StorageError::CorruptedData(format!(
                 "Cannot import CSR with uncommitted tombstones: {} outgoing, {} incoming. \
                  Deleted edges would reappear! Call compact() first or ensure import is \
                  only called on a fresh index during startup.",
                 outgoing_tombstones, incoming_tombstones
-            ));
+            )).into());
         }
 
         // Build edges map for CSR reconstruction
@@ -2058,6 +2058,7 @@ mod test_import_csr {
         assert!(
             result
                 .unwrap_err()
+                .to_string()
                 .contains("Cannot import CSR with uncommitted tombstones")
         );
     }
@@ -2075,6 +2076,6 @@ mod test_import_csr {
             vec![],
         );
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("CSR offsets length mismatch"));
+        assert!(result.unwrap_err().to_string().contains("CSR offsets length mismatch"));
     }
 }

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -2027,3 +2027,49 @@ mod zero_copy_access_tests {
         assert!(ids.contains(&EdgeId::new(2).unwrap()));
     }
 }
+
+#[cfg(test)]
+mod test_import_csr {
+    use super::*;
+    use crate::core::id::VersionId;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::core::property::PropertyMapBuilder;
+
+    fn create_test_edge(id: u64, source: u64, target: u64, label: &str) -> Edge {
+        Edge::new(
+            EdgeId::new(id).unwrap(),
+            GLOBAL_INTERNER.intern(label).unwrap(),
+            NodeId::new(source).unwrap(),
+            NodeId::new(target).unwrap(),
+            PropertyMapBuilder::new().build(),
+            VersionId::new(1).unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_import_csr_errors_with_tombstones() {
+        let indexes = CurrentIndexes::new();
+        // Insert an edge and then delete it to create a tombstone
+        indexes.insert_edge(create_test_edge(1, 0, 1, "KNOWS"));
+        indexes.remove_edge(EdgeId::new(1).unwrap());
+
+        // At this point we have a tombstone. import_csr should fail.
+        let result = indexes.import_csr(vec![], vec![0], vec![], vec![], vec![0], vec![]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Cannot import CSR with uncommitted tombstones"));
+    }
+
+    #[test]
+    fn test_import_csr_propagates_adjacency_error() {
+        let indexes = CurrentIndexes::new();
+        // Provide mismatched CSR arrays to trigger an error from AdjacencyIndex::import_csr
+        let result = indexes.import_csr(
+            vec![1],       // node_ids len 1
+            vec![0],       // offsets len 1 (invalid, should be 2)
+            vec![100],     // edge_ids
+            vec![], vec![0], vec![]
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("CSR offsets length mismatch"));
+    }
+}

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -781,7 +781,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> Result<(), String> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -790,14 +790,15 @@ impl CurrentIndexes {
         // If we have tombstones, importing would cause deleted edges to reappear.
         let outgoing_tombstones = self.outgoing.tombstone_count();
         let incoming_tombstones = self.incoming.tombstone_count();
-        assert!(
-            outgoing_tombstones == 0 && incoming_tombstones == 0,
-            "Cannot import CSR with uncommitted tombstones: {} outgoing, {} incoming. \
-             Deleted edges would reappear! Call compact() first or ensure import is \
-             only called on a fresh index during startup.",
-            outgoing_tombstones,
-            incoming_tombstones
-        );
+        if outgoing_tombstones != 0 || incoming_tombstones != 0 {
+            return Err(format!(
+                "Cannot import CSR with uncommitted tombstones: {} outgoing, {} incoming. \
+                 Deleted edges would reappear! Call compact() first or ensure import is \
+                 only called on a fresh index during startup.",
+                outgoing_tombstones,
+                incoming_tombstones
+            ));
+        }
 
         // Build edges map for CSR reconstruction
         let mut edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
@@ -812,7 +813,7 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -828,7 +829,7 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====
@@ -858,6 +859,8 @@ impl CurrentIndexes {
                 );
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -985,7 +985,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> std::result::Result<(), String> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,
@@ -993,7 +993,7 @@ impl CurrentStorage {
             incoming_node_ids,
             incoming_offsets,
             incoming_edge_ids,
-        );
+        )
     }
 
     /// Get the number of nodes.

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -985,7 +985,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) -> std::result::Result<(), String> {
+    ) -> crate::core::error::Result<()> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -850,14 +850,20 @@ pub(crate) fn load_indexes_startup(
                 if !graph_data.outgoing_offsets.is_empty()
                     && !graph_data.incoming_offsets.is_empty()
                 {
-                    current.import_csr(
+                    if let Err(e) = current.import_csr(
                         graph_data.outgoing_node_ids,
                         graph_data.outgoing_offsets,
                         graph_data.outgoing_neighbors,
                         graph_data.incoming_node_ids,
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
-                    );
+                    ) {
+                        eprintln!(
+                            "Warning: Failed to import CSR adjacency, falling back to rebuild: {}",
+                            e
+                        );
+                        current.compact_adjacency();
+                    }
                 } else {
                     // Fallback for older index files without CSR data
                     current.compact_adjacency();

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -858,8 +858,8 @@ pub(crate) fn load_indexes_startup(
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
                     ) {
-                        eprintln!(
-                            "Warning: Failed to import CSR adjacency, falling back to rebuild: {}",
+                        log::warn!(
+                            "Failed to import CSR adjacency, falling back to rebuild: {}",
                             e
                         );
                         current.compact_adjacency();

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -858,8 +858,8 @@ pub(crate) fn load_indexes_startup(
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
                     ) {
-                        log::warn!(
-                            "Failed to import CSR adjacency, falling back to rebuild: {}",
+                        eprintln!(
+                            "Warning: Failed to import CSR adjacency, falling back to rebuild: {}",
                             e
                         );
                         current.compact_adjacency();

--- a/tests/havoc_proptest_adjacency.proptest-regressions
+++ b/tests/havoc_proptest_adjacency.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc bf1b202f5f792a69b5c4f74770a64b6f35443bf836337cd17dba74a3e2edace3 # shrinks to node_ids = [], offsets = [25], edge_ids = [0]

--- a/tests/havoc_proptest_adjacency.rs
+++ b/tests/havoc_proptest_adjacency.rs
@@ -1,0 +1,16 @@
+use aletheiadb::index::adjacency::AdjacencyIndex;
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+proptest! {
+    #[test]
+    fn prop_import_csr_no_panic(
+        node_ids in proptest::collection::vec(any::<u64>(), 0..100),
+        offsets in proptest::collection::vec(any::<u64>(), 0..100),
+        edge_ids in proptest::collection::vec(any::<u64>(), 0..100),
+    ) {
+        // We only care about ensuring `import_csr` doesn't panic on invalid inputs
+        let edges_map = HashMap::with_hasher(std::hash::BuildHasherDefault::default());
+        let _ = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+    }
+}

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1381,7 +1381,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1447,7 +1447,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1526,7 +1526,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1592,7 +1592,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Delta should be empty
         assert_eq!(

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1374,14 +1374,16 @@ mod phase7_persistence_integration {
         }
 
         // Import CSR - should reconstruct delta from diff
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1440,14 +1442,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1519,14 +1523,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1585,14 +1591,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        ).unwrap();
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Delta should be empty
         assert_eq!(

--- a/update_result.sh
+++ b/update_result.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sed -i 's/-> Result<Self, String>/-> crate::core::error::Result<Self>/g' src/index/adjacency.rs
+sed -i 's/-> std::result::Result<(), String>/-> crate::core::error::Result<()>/g' src/storage/current/mod.rs
+sed -i 's/-> Result<(), String>/-> crate::core::error::Result<()>/g' src/index/current.rs

--- a/update_result2.sh
+++ b/update_result2.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sed -i 's/-> std::result::Result<(), String>/-> crate::core::error::Result<()>/g' src/storage/current/mod.rs
+sed -i 's/return Err(format!(/return Err(crate::core::error::StorageError::CorruptedData(format!(/g' src/index/current.rs
+sed -i 's/incoming_tombstones/incoming_tombstones\n            )).into());/g' src/index/current.rs


### PR DESCRIPTION
🧨 **The Trigger:** Fuzzing the `import_csr` function with arbitrary garbage offsets/edge ids. `AdjacencyIndex::import_csr` was unconditionally `.unwrap()`ing the result of `validate_csr_invariants`.
📉 **The Stack Trace:**
```
called `Result::unwrap()` on an `Err` value: "CSR last offset mismatch: expected 1, got 25"
thread 'prop_import_csr_no_panic' panicked at src/index/adjacency.rs:103:71
```
🧪 **Reproduction:** Run `cargo test --test havoc_proptest_adjacency`.
😈 **Comment:** You assumed the persistence layer would never hand you corrupted data. You were wrong. A bad disk sector shouldn't take down the entire process—now it falls back gracefully to a rebuild.

---
*PR created automatically by Jules for task [6306555314352943415](https://jules.google.com/task/6306555314352943415) started by @madmax983*