### PR TITLE
🪒 Razor: remove single-implementation StorageSnapshot trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+## [Reduction]
+**Bloat:** `StorageSnapshot` trait (Single-implementation abstraction used only by `CurrentStorageSnapshot`).
+**Cut:** Deleted the `StorageSnapshot` trait. Converted `impl StorageSnapshot for CurrentStorageSnapshot` into inherent public methods on `CurrentStorageSnapshot`.
+**Saved:** ~30 lines of boilerplate trait definition + dynamic dispatch/trait mental overhead.

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -625,8 +625,6 @@ impl CheckpointManager {
         &self,
         snapshot: &crate::storage::snapshot::CurrentStorageSnapshot,
     ) -> Result<GraphIndexData> {
-        use crate::storage::snapshot::StorageSnapshot;
-
         let mut nodes = Vec::new();
         let mut edges = Vec::new();
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,7 +42,7 @@ pub use redb_cold_storage::{
     RedbColdStorage, RedbConfig, decode_edge_version, decode_node_version, encode_edge_version,
     encode_node_version,
 };
-pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot, StorageSnapshot};
+pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot};
 pub use tiered_storage::{
     LatencyPercentiles, TieredStorage, TieredStorageConfig, TieredStorageMetrics,
 };

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -40,42 +40,6 @@ use crate::core::version::{EdgeVersion, NodeVersion};
 use crate::storage::wal::LSN;
 use std::sync::Arc;
 
-/// Snapshot isolation trait for storage layers.
-///
-/// Provides a consistent point-in-time view of storage that is isolated
-/// from concurrent modifications. Used primarily for checkpointing to
-/// ensure data consistency.
-///
-/// # Design
-///
-/// Snapshots use Arc-based COW:
-/// - Snapshot creation does ONE iteration over DashMap/structures
-/// - Collects `Arc<T>` references (cheap, just pointer + refcount)
-/// - Total memory: 8 bytes × num_entities (not full clones)
-/// - Iteration over snapshot is isolated from concurrent writes
-pub trait StorageSnapshot: Send + Sync {
-    /// Node iterator type (streaming, no Vec allocation)
-    type NodeIter: Iterator<Item = Node>;
-
-    /// Edge iterator type (streaming, no Vec allocation)
-    type EdgeIter: Iterator<Item = Edge>;
-
-    /// Get the LSN at which this snapshot was taken
-    fn lsn(&self) -> LSN;
-
-    /// Get the number of nodes in this snapshot
-    fn node_count(&self) -> usize;
-
-    /// Get the number of edges in this snapshot
-    fn edge_count(&self) -> usize;
-
-    /// Iterate over nodes in snapshot (streaming, isolated)
-    fn iter_nodes(&self) -> Self::NodeIter;
-
-    /// Iterate over edges in snapshot (streaming, isolated)
-    fn iter_edges(&self) -> Self::EdgeIter;
-}
-
 /// Snapshot of CurrentStorage at a specific LSN.
 ///
 /// Uses Arc-based COW to provide snapshot isolation without
@@ -121,30 +85,32 @@ impl CurrentStorageSnapshot {
     }
 }
 
-impl StorageSnapshot for CurrentStorageSnapshot {
-    type NodeIter = CurrentNodeIterator;
-    type EdgeIter = CurrentEdgeIterator;
-
-    fn lsn(&self) -> LSN {
+impl CurrentStorageSnapshot {
+    /// Get the LSN at which this snapshot was taken
+    pub fn lsn(&self) -> LSN {
         self.lsn
     }
 
-    fn node_count(&self) -> usize {
+    /// Get the number of nodes in this snapshot
+    pub fn node_count(&self) -> usize {
         self.nodes.len()
     }
 
-    fn edge_count(&self) -> usize {
+    /// Get the number of edges in this snapshot
+    pub fn edge_count(&self) -> usize {
         self.edges.len()
     }
 
-    fn iter_nodes(&self) -> Self::NodeIter {
+    /// Iterate over nodes in snapshot (streaming, isolated)
+    pub fn iter_nodes(&self) -> CurrentNodeIterator {
         CurrentNodeIterator {
             nodes: self.nodes.clone(),
             index: 0,
         }
     }
 
-    fn iter_edges(&self) -> Self::EdgeIter {
+    /// Iterate over edges in snapshot (streaming, isolated)
+    pub fn iter_edges(&self) -> CurrentEdgeIterator {
         CurrentEdgeIterator {
             edges: self.edges.clone(),
             index: 0,

--- a/tests/snapshot_race_condition.rs
+++ b/tests/snapshot_race_condition.rs
@@ -10,7 +10,6 @@ use aletheiadb::core::temporal::time;
 use aletheiadb::storage::checkpoint::{CheckpointConfig, CheckpointManager};
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
-use aletheiadb::storage::snapshot::StorageSnapshot;
 use aletheiadb::storage::wal::LSN;
 use std::sync::{Arc, Barrier};
 use std::thread;


### PR DESCRIPTION
Removes the speculative generality introduced by the `StorageSnapshot` trait, which only had a single implementor. Refactored the methods to be direct inherent methods on `CurrentStorageSnapshot` and updated the `mod.rs` and other calling files to clean up unnecessary imports. Also includes the `.jules/razor.md` log.

---
*PR created automatically by Jules for task [132472318404994078](https://jules.google.com/task/132472318404994078) started by @madmax983*