### PR TITLE
⚡ Bolt: Optimize WriteBuffer HashMaps with IdentityHasher

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-27 - Identity Hashing for PropertyMap
 **Learning:** `PropertyMap` uses `InternedString` (u32) as keys but was using default `HashMap` hashing (SipHash), incurring ~15-30ns overhead per lookup. Switching to `IdentityHasher` eliminated this, yielding a 3.6x speedup on interned lookups.
 **Action:** Audit all usages of `HashMap<InternedString, ...>` or `HashMap<u32, ...>` and replace with `HashMap<..., BuildHasherDefault<IdentityHasher>>` where keys are already high-quality IDs.
+
+**[IdentityHasher for Integer Keys]**
+**Learning:** Using `HashMap` with default hasher for small integer-wrapper keys like `NodeId` or `EdgeId` causes unnecessary hashing overhead. `FastHashMap` (using `IdentityHasher`) should be used to avoid this overhead and improve lookup/insertion speeds.
+**Action:** Replace `HashMap` with `FastHashMap` for integer keys when hashing overhead is a bottleneck, especially in hot paths like `WriteBuffer` tracking modified entities.

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -1,11 +1,13 @@
 //! Write buffering for uncommitted transaction changes
 
 use crate::core::error::{Result, StorageError};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
 use crate::core::temporal::Timestamp;
 use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
 
 /// Buffered write operation
 ///
@@ -166,12 +168,14 @@ pub struct WriteBuffer {
     operations: Vec<BufferedWrite>,
 
     /// Quick lookup: which nodes have been written to
-    /// Maps NodeId → index in operations vector
-    modified_nodes: HashMap<NodeId, usize>,
+    /// Maps NodeId → index in operations vector.
+    /// Uses IdentityHasher because NodeId is an integer wrapper, avoiding expensive SipHash overhead.
+    modified_nodes: HashMap<NodeId, usize, BuildHasherDefault<IdentityHasher>>,
 
     /// Quick lookup: which edges have been written to
-    /// Maps EdgeId → index in operations vector
-    modified_edges: HashMap<EdgeId, usize>,
+    /// Maps EdgeId → index in operations vector.
+    /// Uses IdentityHasher because EdgeId is an integer wrapper, avoiding expensive SipHash overhead.
+    modified_edges: HashMap<EdgeId, usize, BuildHasherDefault<IdentityHasher>>,
 
     /// Maximum number of operations allowed (DoS protection)
     max_operations: usize,
@@ -199,8 +203,8 @@ impl WriteBuffer {
     pub fn with_max_operations(max_operations: usize) -> Self {
         WriteBuffer {
             operations: Vec::new(),
-            modified_nodes: HashMap::new(),
-            modified_edges: HashMap::new(),
+            modified_nodes: HashMap::with_hasher(BuildHasherDefault::default()),
+            modified_edges: HashMap::with_hasher(BuildHasherDefault::default()),
             max_operations,
             has_vector_operations: false,
             has_edge_operations: false,
@@ -214,8 +218,14 @@ impl WriteBuffer {
     pub fn with_capacity(capacity: usize) -> Self {
         WriteBuffer {
             operations: Vec::with_capacity(capacity),
-            modified_nodes: HashMap::with_capacity(capacity / 2),
-            modified_edges: HashMap::with_capacity(capacity / 2),
+            modified_nodes: HashMap::with_capacity_and_hasher(
+                capacity / 2,
+                BuildHasherDefault::default(),
+            ),
+            modified_edges: HashMap::with_capacity_and_hasher(
+                capacity / 2,
+                BuildHasherDefault::default(),
+            ),
             max_operations: capacity,
             has_vector_operations: false,
             has_edge_operations: false,


### PR DESCRIPTION
💡 What: The optimization implemented: switched the default hasher for `modified_nodes` and `modified_edges` HashMaps in `WriteBuffer` to `BuildHasherDefault<IdentityHasher>`.
🎯 Why: The bottleneck: default `HashMap` uses `SipHash`, which adds unnecessary cryptographic hashing overhead for keys that are small integer wrappers (like `NodeId` and `EdgeId`). 
📊 Impact: Expected gain: Reduces hashing overhead and improves lookup/insertion speeds in hot paths tracking modified entities.
🔬 Measurement: Run bench `process_data` or standard `cargo test` to observe the improvement in transaction processing overhead.

---
*PR created automatically by Jules for task [18267045839770044028](https://jules.google.com/task/18267045839770044028) started by @madmax983*