### PR TITLE
🤖 Sentinel: Strengthen HTTP API tests to kill surviving mutants

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -80,3 +80,9 @@
 **Summary:** Numerous mutants survived in `predicates_equal`, replacing boolean operators `&&` with `||` and equality operators `==` with `!=`.
 **Diagnosis:** WEAK_TEST - The existing tests only checked equality matching entirely (where both terms were exactly the same) or entirely differently (different variants). It lacked "partial mismatch" checks (same variant, different internal value).
 **Kill Shot:** Added `test_predicates_equal_exhaustive_mismatches` to explicitly check every `Predicate` variant with slightly mismatched keys or values to force the strict `&&` evaluations.
+
+**[Weak Test Coverage in HTTP API Handlers]**
+**Module:** `src/http/handlers.rs`
+**Summary:** Mutants survived regarding JSON payload type conversions (`json_to_predicate_value`), boundary condition checks for DoS protection (`> 10000` mutated to `>=` or `==`), and error code categorization logic (`||` mutated to `&&`).
+**Diagnosis:** MISSING_TEST / WEAK_TEST - The test suite didn't comprehensively cover the individual match arms of `json_to_predicate_value`, the edge cases of deep pagination limits (`offset + limit == 10000`), or explicit distinction between "syntax" and "parse" error handling branches. Also, an underlying `test_cors_headers_present` test failure masked overall mutant evaluation for `http_server` tasks.
+**Kill Shot:** Fixed the CORS test by supplying a `peer_addr`, and added `test_json_to_predicate_value`, `test_execute_query_parse_error`, and exact boundary condition payloads (9900 + 100 vs 9901 + 100) inside `test_warden_find_node_deep_pagination` and `test_warden_find_neighbors_overflow`.

--- a/run_mutants.sh
+++ b/run_mutants.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo mutants --features "http-server" --file src/http/handlers.rs --test-tool cargo --timeout 60 -- -q --test http_server

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -693,12 +693,47 @@ mod tests {
             "Error: {}",
             error
         );
+
+        // Boundary test: exactly 10_000 should be allowed
+        let exact_boundary_payload = json!({
+            "operation": "find_node",
+            "label": "Person",
+            "offset": 9_900,
+            "limit": 100
+        });
+        let req2 = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&exact_boundary_payload)
+            .to_request();
+        let resp2 = test::call_service(&app, req2).await;
+        assert!(resp2.status().is_success(), "Should allow exactly 10_000");
+
+        // Boundary test: exactly 10_001 should be rejected
+        let exceed_boundary_payload = json!({
+            "operation": "find_node",
+            "label": "Person",
+            "offset": 9_901,
+            "limit": 100
+        });
+        let req3 = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&exceed_boundary_payload)
+            .to_request();
+        let resp3 = test::call_service(&app, req3).await;
+        assert!(
+            resp3.status().is_client_error(),
+            "Should reject exactly 10_001"
+        );
     }
 
     // Warden: Check if FindNode allows deep pagination
     #[actix_rt::test]
     async fn test_warden_find_node_deep_pagination() {
         let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+        // Create dummy node so a valid ID exists if we get past the boundary
+        db.create_node("Node", crate::core::PropertyMap::new())
+            .unwrap();
+
         let state = web::Data::new(AppState::new(db));
 
         let app = test::init_service(
@@ -735,6 +770,37 @@ mod tests {
             error.contains("Pagination limit exceeded"),
             "Error: {}",
             error
+        );
+
+        // Boundary test: exactly 10_000 should be allowed
+        let exact_boundary_payload = json!({
+            "operation": "find_neighbors",
+            "node_id": 1,
+            "offset": 9_900,
+            "limit": 100
+        });
+        let req2 = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&exact_boundary_payload)
+            .to_request();
+        let resp2 = test::call_service(&app, req2).await;
+        assert!(resp2.status().is_success(), "Should allow exactly 10_000");
+
+        // Boundary test: exactly 10_001 should be rejected
+        let exceed_boundary_payload = json!({
+            "operation": "find_neighbors",
+            "node_id": 1,
+            "offset": 9_901,
+            "limit": 100
+        });
+        let req3 = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&exceed_boundary_payload)
+            .to_request();
+        let resp3 = test::call_service(&app, req3).await;
+        assert!(
+            resp3.status().is_client_error(),
+            "Should reject exactly 10_001"
         );
     }
 
@@ -859,5 +925,85 @@ mod tests {
 
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_client_error()); // 400 Bad Request
+    }
+
+    #[actix_rt::test]
+    async fn test_execute_query_parse_error() {
+        let db = std::sync::Arc::new(crate::AletheiaDB::new().unwrap());
+        let state = web::Data::new(AppState::new(db));
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/query", web::post().to(handle_query)),
+        )
+        .await;
+
+        // Invalid syntax using an unsupported token (like a stray # symbol)
+        // or a query we know generates a parser error starting with "Parse"
+        let payload = json!({
+            "operation": "execute_query",
+            "query": "MATCH # INVALID"
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/query")
+            .set_json(&payload)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+
+        // This causes the error string to contain "parse", resulting in 400 Bad Request
+        // If the error handling logic replacing || with && was present, this would be a 500 error
+        assert_eq!(resp.status().as_u16(), 400);
+    }
+
+    // Warden: Kill json_to_predicate_value mutants
+    #[actix_rt::test]
+    async fn test_json_to_predicate_value() {
+        // Test Null
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Null),
+            Some(PredicateValue::Null)
+        );
+
+        // Test Bool
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Bool(true)),
+            Some(PredicateValue::Bool(true))
+        );
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Bool(false)),
+            Some(PredicateValue::Bool(false))
+        );
+
+        // Test Number (i64)
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Number(42.into())),
+            Some(PredicateValue::Int(42))
+        );
+
+        // Test Number (f64)
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Number(
+                serde_json::Number::from_f64(42.5).unwrap()
+            )),
+            Some(PredicateValue::Float(42.5))
+        );
+
+        // Test String
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::String("hello".to_string())),
+            Some(PredicateValue::String("hello".to_string()))
+        );
+
+        // Test Unsupported Types (Array, Object) return None
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Array(vec![])),
+            None
+        );
+        assert_eq!(
+            json_to_predicate_value(&serde_json::Value::Object(serde_json::Map::new())),
+            None
+        );
     }
 }

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -21,7 +21,10 @@ async fn test_health_endpoint_returns_healthy_status() {
     let app = test::init_service(App::new().configure(configure_app)).await;
 
     // Make request to health endpoint
-    let req = test::TestRequest::get().uri("/status").to_request();
+    let req = test::TestRequest::get()
+        .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+        .uri("/status")
+        .to_request();
     let resp = test::call_service(&app, req).await;
 
     // Assert response status is 200 OK
@@ -48,7 +51,10 @@ async fn test_health_endpoint_returns_healthy_status() {
 async fn test_health_endpoint_returns_json_content_type() {
     let app = test::init_service(App::new().configure(configure_app)).await;
 
-    let req = test::TestRequest::get().uri("/status").to_request();
+    let req = test::TestRequest::get()
+        .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+        .uri("/status")
+        .to_request();
     let resp = test::call_service(&app, req).await;
 
     let content_type = resp
@@ -73,6 +79,7 @@ async fn test_cors_headers_present() {
 
     // Send OPTIONS preflight request
     let req = test::TestRequest::default()
+        .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
         .method(actix_web::http::Method::OPTIONS)
         .uri("/status")
         .insert_header(("Origin", "http://example.com"))
@@ -156,7 +163,10 @@ async fn test_request_logging_middleware_configured() {
 
     // Make multiple requests to ensure logging middleware doesn't break anything
     for _ in 0..3 {
-        let req = test::TestRequest::get().uri("/status").to_request();
+        let req = test::TestRequest::get()
+            .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
+            .uri("/status")
+            .to_request();
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
     }
@@ -168,6 +178,7 @@ async fn test_unknown_route_returns_404() {
     let app = test::init_service(App::new().configure(configure_app)).await;
 
     let req = test::TestRequest::get()
+        .peer_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 12345)))
         .uri("/nonexistent-route")
         .to_request();
     let resp = test::call_service(&app, req).await;


### PR DESCRIPTION
**🤖 Sentinel Analysis Report**

**Module Targeting**: `src/http/handlers.rs`

**Issues Found**: 
*   A widespread test failure in `tests/http_server.rs` (`test_cors_headers_present`) due to a `RateLimit` IP extraction panic was masking mutant detection. 
*   `json_to_predicate_value` was functionally un-tested for specific data types (`Null`, `Bool`, `String`, `Number`).
*   Deep pagination DoS protection limits (10,000 threshold) were only generally tested (e.g. 100,000 + 10), leaving `>` to `>=` or `==` mutants surviving. 
*   Parser error branch fallback wasn't exercised because tests exclusively hit "syntax" errors in the boolean logical `||` statement. 

**Resolutions**:
*   Patched `tests/http_server.rs` explicitly providing `peer_addr()` data. 
*   Added comprehensive data type conversion tests in `src/http/handlers.rs`.
*   Added strict boundary bounds testing at precisely `10_000` (success) and `10_001` (failure).
*   Added explicit Parse failure tests. 
*   Updated the internal Sentinel journal.

---
*PR created automatically by Jules for task [7118958925983705867](https://jules.google.com/task/7118958925983705867) started by @madmax983*