### PR TITLE
👺 Havoc: Prevent panic when loading corrupted adjacency CSR with non-monotonic offsets

### DIFF
--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -94,13 +94,13 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Self {
+    ) -> Result<Self, String> {
         if offsets.is_empty() || edge_ids.is_empty() {
-            return Self::new();
+            return Ok(Self::new());
         }
 
         // Validate CSR invariants
-        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids).unwrap();
+        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids)?;
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -128,12 +128,12 @@ impl AdjacencyIndex {
             }
         }
 
-        Self {
+        Ok(Self {
             node_ids: node_ids_typed,
             offsets: offsets_usize,
             edges: adjacency_entries,
             max_node_id,
-        }
+        })
     }
 }
 
@@ -307,6 +307,17 @@ impl AdjacencyIndex {
                     "CSR last offset mismatch: expected {}, got {}",
                     edge_ids.len(),
                     last_offset
+                ));
+            }
+        }
+
+        for i in 0..offsets.len().saturating_sub(1) {
+            if offsets[i] > offsets[i + 1] {
+                return Err(format!(
+                    "CSR offsets not monotonically increasing at index {}: {} > {}",
+                    i,
+                    offsets[i],
+                    offsets[i + 1]
                 ));
             }
         }
@@ -786,7 +797,7 @@ mod tests {
         edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
         edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
@@ -829,7 +840,7 @@ mod sentry_tests {
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
-        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let _ = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
     }
 
     #[test]
@@ -848,7 +859,7 @@ mod sentry_tests {
         edges_map.insert(EdgeId::new(101).unwrap(), (target, label));
 
         // Should not panic
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
 
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -781,7 +781,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> Result<(), String> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -812,7 +812,7 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -828,7 +828,7 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====
@@ -858,6 +858,8 @@ impl CurrentIndexes {
                 );
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -985,7 +985,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> std::result::Result<(), String> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,
@@ -993,7 +993,7 @@ impl CurrentStorage {
             incoming_node_ids,
             incoming_offsets,
             incoming_edge_ids,
-        );
+        )
     }
 
     /// Get the number of nodes.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -850,7 +850,7 @@ pub(crate) fn load_indexes_startup(
                 if !graph_data.outgoing_offsets.is_empty()
                     && !graph_data.incoming_offsets.is_empty()
                 {
-                    current.import_csr(
+                    let import_result = current.import_csr(
                         graph_data.outgoing_node_ids,
                         graph_data.outgoing_offsets,
                         graph_data.outgoing_neighbors,
@@ -858,6 +858,14 @@ pub(crate) fn load_indexes_startup(
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
                     );
+
+                    if let Err(e) = import_result {
+                        eprintln!(
+                            "Warning: Failed to import CSR data ({}), falling back to compacting adjacency",
+                            e
+                        );
+                        current.compact_adjacency();
+                    }
                 } else {
                     // Fallback for older index files without CSR data
                     current.compact_adjacency();

--- a/tests/havoc_proptest_adjacency.proptest-regressions
+++ b/tests/havoc_proptest_adjacency.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 040ea1e1b787df694c4a44874fc3f6286b5ab007e4a68d65973d7c0b269ba168 # shrinks to node_ids = [0, 1], mut offsets = [0, 3, 0], edge_ids = [0, 0]

--- a/tests/havoc_proptest_adjacency.rs
+++ b/tests/havoc_proptest_adjacency.rs
@@ -1,0 +1,36 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::index::adjacency::AdjacencyIndex;
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+proptest! {
+    #[test]
+    fn test_adjacency_index_no_panic(
+        node_ids in proptest::collection::vec(0..100u64, 2..=2),
+        mut offsets in proptest::collection::vec(0..100u64, 3..=3),
+        edge_ids in proptest::collection::vec(0..100u64, 2..=2),
+    ) {
+        // force the invariant that the last offset matches edge_ids len
+        offsets[2] = 2;
+
+        let edges_map = HashMap::default();
+
+        // This shouldn't panic
+        let mut sorted_node_ids = node_ids.clone();
+        sorted_node_ids.sort_unstable();
+        sorted_node_ids.dedup();
+        if sorted_node_ids.len() < 2 {
+            return Ok(()); // skip if deduped is smaller
+        }
+
+        // It should gracefully return an error here, so we capture the result
+        let result = AdjacencyIndex::import_csr(sorted_node_ids.clone(), offsets, edge_ids, &edges_map);
+
+        if let Ok(index) = result {
+            // try to get adjacency
+            for &n in &sorted_node_ids {
+                let _ = index.get_adjacency(NodeId::new(n).unwrap());
+            }
+        }
+    }
+}

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1381,7 +1381,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1447,7 +1447,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1526,7 +1526,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1592,7 +1592,7 @@ mod phase7_persistence_integration {
             in_nodes,
             in_offsets,
             in_edges,
-        );
+        ).unwrap();
 
         // Delta should be empty
         assert_eq!(


### PR DESCRIPTION
👺 **Havoc: Chaos Engineering PR**

* 🧨 **The Trigger:** The `validate_csr_invariants` method in `AdjacencyIndex` checked the length of arrays but failed to verify that the CSR `offsets` vector is monotonically increasing (`offsets[i] <= offsets[i+1]`). A mutated/corrupted offsets array loaded from persistence could lead to `start > end` when fetching adjacency.
* 📉 **The Stack Trace:** `thread 'test_adjacency_index_no_panic' panicked at src/index/adjacency.rs:228:28: range end index 3 out of range for slice of length 2`
* 🧪 **Reproduction:** Run the newly added proptest `cargo test --test havoc_proptest_adjacency`. It generates semi-random lengths and offset configurations, exposing the missing validation.
* 😈 **Comment:** "You assumed index data would remain perfectly ordered on disk and never get corrupted. You were wrong. Now we validate and gracefully fall back to compacting the adjacency if the index is broken, instead of taking down the whole DB."

**Changes Made:**
1. Updated `validate_csr_invariants` to check for monotonically increasing offsets.
2. Refactored `import_csr` methods in `src/index/adjacency.rs`, `src/index/current.rs`, and `src/storage/current/mod.rs` to return `Result`s instead of panicking/unwrapping.
3. Updated `src/storage/index_persistence/operations.rs` to catch the `Err` and fallback to `current.compact_adjacency()`.
4. Add proptest in `tests/havoc_proptest_adjacency.rs`.

---
*PR created automatically by Jules for task [975293723247705325](https://jules.google.com/task/975293723247705325) started by @madmax983*