### PR TITLE
🛡️ Sentry: Strengthen assertions in predicate pushdown tests

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -304,3 +304,23 @@
 **Recommendation:**
 1.  **Add Traversal Tests:** Create `tests/sentry_traversal.rs` to permanently test `TraversalIterator` cycle suppression and input isolation.
 2.  **Optimize VectorRerank:** Future optimization should use a bounded Min-Heap during iteration to keep memory O(K) instead of O(N).
+
+## [Predicate Pushdown Weak Assertions]
+**Module:** `src/query/planner/rules/predicate_pushdown.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Tests such as `test_push_filter_below_vector_rank_no_limit`, `test_push_filter_below_sort`, `test_binary_op_recursion_logic`, and `test_binary_op_partial_optimization` use weak assertions. They verify `result.is_some()` but only use generic `matches!` on the top level or a few levels of the resulting tree.
+**Evidence:** In `test_push_filter_below_sort`:
+```rust
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some());
+        let new_plan = result.unwrap();
+        assert!(matches!(
+            new_plan.root,
+            LogicalOp::Unary {
+                op: UnaryOp::Sort { .. },
+                ..
+            }
+        ));
+```
+This asserts only that the root became a `Sort`. It doesn't verify that the *child* of `Sort` actually became the `Filter`, or that the parameters of the `Sort` operator remain correct, or that the `Filter` actually wrapped the original `Scan`.
+**Recommendation:** Replace weak `matches!` tests with exact tree matching (using `assert_eq!`) if `LogicalOp` implements `Eq`, or exhaustively destructure the AST down to the leaf nodes and assert all fields are correct.

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -242,7 +242,7 @@ pub enum SortKey {
 /// Property predicates for filtering nodes and edges.
 ///
 /// Predicates can be combined using logical operators (And, Or, Not).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Predicate {
     /// Property equals a value
     Eq {

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -277,14 +277,29 @@ mod tests {
         assert!(result.is_some());
 
         let new_plan = result.unwrap();
-        // Check that VectorRank is now on top
-        assert!(matches!(
-            new_plan.root,
-            LogicalOp::Unary {
-                op: UnaryOp::VectorRank { .. },
-                ..
+        // Check full AST: VectorRank -> Filter -> Scan
+        if let LogicalOp::Unary {
+            op: UnaryOp::VectorRank { top_k, .. },
+            input: rank_input,
+        } = new_plan.root
+        {
+            assert_eq!(top_k, None);
+            if let LogicalOp::Unary {
+                op: UnaryOp::Filter(pred),
+                input: filter_input,
+            } = rank_input.as_ref()
+            {
+                assert_eq!(pred, &Predicate::eq("name", "Alice"));
+                assert!(matches!(
+                    filter_input.as_ref(),
+                    LogicalOp::Scan(ScanOp::NodeLookup(_))
+                ));
+            } else {
+                panic!("Expected Filter below VectorRank");
             }
-        ));
+        } else {
+            panic!("Expected VectorRank at root");
+        }
     }
 
     #[test]
@@ -356,14 +371,30 @@ mod tests {
         assert!(result.is_some());
 
         let new_plan = result.unwrap();
-        // Check that Sort is now on top
-        assert!(matches!(
-            new_plan.root,
-            LogicalOp::Unary {
-                op: UnaryOp::Sort { .. },
-                ..
+        // Check full AST: Sort -> Filter -> Scan
+        if let LogicalOp::Unary {
+            op: UnaryOp::Sort {
+                descending: true, ..
+            },
+            input: sort_input,
+        } = new_plan.root
+        {
+            if let LogicalOp::Unary {
+                op: UnaryOp::Filter(pred),
+                input: filter_input,
+            } = sort_input.as_ref()
+            {
+                assert_eq!(pred, &Predicate::eq("active", true));
+                assert!(matches!(
+                    filter_input.as_ref(),
+                    LogicalOp::Scan(ScanOp::NodeLookup(_))
+                ));
+            } else {
+                panic!("Expected Filter below Sort");
             }
-        ));
+        } else {
+            panic!("Expected Sort at root");
+        }
     }
 
     #[test]
@@ -477,20 +508,25 @@ mod tests {
         if let LogicalOp::Binary { left, .. } = new_plan.root {
             // Verify left side is optimized: Sort -> Filter -> Scan
             if let LogicalOp::Unary {
-                op: UnaryOp::Sort { .. },
+                op: UnaryOp::Sort {
+                    descending: true, ..
+                },
                 input: sort_input,
             } = *left
             {
-                assert!(
-                    matches!(
-                        sort_input.as_ref(),
-                        LogicalOp::Unary {
-                            op: UnaryOp::Filter(_),
-                            ..
-                        }
-                    ),
-                    "Left branch should have Filter pushed down below Sort"
-                );
+                if let LogicalOp::Unary {
+                    op: UnaryOp::Filter(pred),
+                    input: filter_input,
+                } = sort_input.as_ref()
+                {
+                    assert_eq!(pred, &Predicate::eq("active", true));
+                    assert!(matches!(
+                        filter_input.as_ref(),
+                        LogicalOp::Scan(ScanOp::NodeLookup(_))
+                    ));
+                } else {
+                    panic!("Expected Filter below Sort on left branch");
+                }
             } else {
                 panic!("Expected Sort at top of left branch, got {:?}", left);
             }
@@ -551,28 +587,37 @@ mod sentry_tests {
         if let LogicalOp::Binary { left, right, .. } = new_plan.root {
             // Left should be Sort(Filter...)
             if let LogicalOp::Unary {
-                op: UnaryOp::Sort { .. },
-                input,
+                op: UnaryOp::Sort {
+                    descending: true, ..
+                },
+                input: sort_input,
             } = *left
             {
-                assert!(matches!(
-                    *input,
-                    LogicalOp::Unary {
-                        op: UnaryOp::Filter(_),
-                        ..
-                    }
-                ));
+                if let LogicalOp::Unary {
+                    op: UnaryOp::Filter(pred),
+                    input: filter_input,
+                } = sort_input.as_ref()
+                {
+                    assert_eq!(pred, &Predicate::eq("a", 1));
+                    assert!(matches!(
+                        filter_input.as_ref(),
+                        LogicalOp::Scan(ScanOp::NodeLookup(_))
+                    ));
+                } else {
+                    panic!("Expected Filter below Sort on left branch");
+                }
             } else {
                 panic!("Left branch was not optimized");
             }
 
             // Right should still be Filter(Scan)
             if let LogicalOp::Unary {
-                op: UnaryOp::Filter(_),
+                op: UnaryOp::Filter(pred),
                 input,
             } = *right
             {
-                assert!(matches!(*input, LogicalOp::Scan(_)));
+                assert_eq!(pred, Predicate::eq("b", 2));
+                assert!(matches!(*input, LogicalOp::Scan(ScanOp::NodeLookup(_))));
             } else {
                 panic!("Right branch was unexpectedly modified or corrupted");
             }


### PR DESCRIPTION
Audited and strengthened test assertions in `src/query/planner/rules/predicate_pushdown.rs`.

Replaced superficial `matches!` checks that only asserted the presence of the top-level AST node with exhaustive nested `if let` destructuring to verify the full AST tree down to the leaf `Scan` node (e.g. `VectorRank -> Filter -> Scan` or `Sort -> Filter -> Scan`).
Also added `PartialEq` derive to `Predicate` to enable strict equality checks on the filter parameters inside the unit tests.

---
*PR created automatically by Jules for task [10974786586563217377](https://jules.google.com/task/10974786586563217377) started by @madmax983*