### PR TITLE
🦀 Core: Fix torn read snapshot isolation violation in Synergy Engine

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -5,3 +5,17 @@ No high-severity findings.
 
 ### Residual risks
 - A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that is explicitly suppressed with `#[allow(clippy::collapsible_if)]`. This prevents CI failures under strict linting (`-D warnings`) but leaves nested `if` statements in the codebase. However, it poses no correctness, regression, or concurrency risk, and correctly resolves the issue without relying on unstable Rust features like let chains.
+
+## 🦀 Core Review: Synergy Engine
+
+**Findings:**
+
+*   **Severity:** High
+*   **File:** `src/experimental/synergy.rs:74` and `src/experimental/synergy.rs:92`
+*   **What can break:** Torn Read / Snapshot Isolation Violation. A concurrent write (e.g., node properties updated or edges modified) between the two `self.db.read(|tx| { ... })` blocks will result in inconsistent state. For example, the first transaction reads `baseline_vector` from nodes at `T1`, but the second transaction reads the edges (and thus structure) at `T2`.
+*   **Why it breaks:** Using two separate transactions `db.read(...)` means that the graph state can change in the background between transactions. Since the engine relies on the interplay of both properties and structure to calculate "synergy," taking two separate snapshots breaks logical consistency and correctness, leading to non-deterministic or completely invalid synergy scores.
+*   **Minimal fix:** Unify the two `db.read(|tx| { ... })` calls into a single transaction so both node vectors and structural edges are read from the identical MVCC snapshot.
+*   **Required tests:** The existing tests cover basic functionality. Adding an explicit torn-read concurrency test is difficult without hooks, but unifying the transaction is mathematically necessary.
+
+**Test Gaps:**
+*   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.

--- a/src/experimental/synergy.rs
+++ b/src/experimental/synergy.rs
@@ -88,6 +88,8 @@ impl<'a> Synergy<'a> {
         let node_set: HashSet<NodeId> = nodes.iter().cloned().collect();
         let mut vectors = Vec::new();
         let mut valid_nodes = Vec::new();
+        let mut baseline_vector = Vec::new();
+        let mut emergent_components = Vec::new();
 
         // Use read closure
         self.db.read(|tx| {
@@ -101,22 +103,17 @@ impl<'a> Synergy<'a> {
                     }
                 }
             }
-            Ok::<(), Error>(())
-        })?;
 
-        if vectors.is_empty() {
-            return Err(Error::other(
-                "None of the provided nodes have the specified vector property",
-            ));
-        }
+            if vectors.is_empty() {
+                return Err(Error::other(
+                    "None of the provided nodes have the specified vector property",
+                ));
+            }
 
-        // 2. Calculate the Baseline Vector (simple average)
-        let baseline_vector = Self::average_vectors(&vectors)?;
+            // 2. Calculate the Baseline Vector (simple average)
+            baseline_vector = Self::average_vectors(&vectors)?;
 
-        // 3. Calculate the Emergent Vector
-        let mut emergent_components = Vec::new();
-
-        self.db.read(|tx| {
+            // 3. Calculate the Emergent Vector
             for (i, &node_id) in valid_nodes.iter().enumerate() {
                 let mut neighbor_vectors = Vec::new();
 


### PR DESCRIPTION
🦀 Core Review: Synergy Engine

**Findings:**

*   **Severity:** High
*   **File:** `src/experimental/synergy.rs:74` and `src/experimental/synergy.rs:92`
*   **What can break:** Torn Read / Snapshot Isolation Violation. A concurrent write (e.g., node properties updated or edges modified) between the two `self.db.read(|tx| { ... })` blocks will result in inconsistent state. For example, the first transaction reads `baseline_vector` from nodes at `T1`, but the second transaction reads the edges (and thus structure) at `T2`.
*   **Why it breaks:** Using two separate transactions `db.read(...)` means that the graph state can change in the background between transactions. Since the engine relies on the interplay of both properties and structure to calculate "synergy," taking two separate snapshots breaks logical consistency and correctness, leading to non-deterministic or completely invalid synergy scores.
*   **Minimal fix:** Unify the two `db.read(|tx| { ... })` calls into a single transaction so both node vectors and structural edges are read from the identical MVCC snapshot.
*   **Required tests:** The existing tests cover basic functionality. Adding an explicit torn-read concurrency test is difficult without hooks, but unifying the transaction is mathematically necessary.

**Test Gaps:**
*   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.

---
*PR created automatically by Jules for task [9223186112049507257](https://jules.google.com/task/9223186112049507257) started by @madmax983*