### PR TITLE
🛡️ Sentry: [test coverage improvement] PropertyMapBuilder::try_insert_by_key

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -3585,6 +3585,32 @@ mod sentry_tests {
         );
     }
 
+    /// 🎯 Target: PropertyMapBuilder::try_insert_by_key
+    /// 💣 Risk: Should fail gracefully (return Err) instead of panicking on deep recursion when using an interned key.
+    /// 🧪 Strategy: Try to insert a deeply nested structure using try_insert_by_key.
+    /// 🔬 Verification: Check that Result is Err and contains the recursion limit message.
+    #[test]
+    fn test_property_map_builder_try_insert_by_key_returns_error_on_deep_recursion() {
+        let mut value = PropertyValue::Int(42);
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            value = PropertyValue::Array(Arc::new(vec![value]));
+        }
+
+        let key = GLOBAL_INTERNER.intern("deep").unwrap();
+
+        // try_insert_by_key should return an error, not panic
+        let result = PropertyMapBuilder::new().try_insert_by_key(key, value);
+
+        assert!(result.is_err(), "Expected error, got Ok");
+        let err = result.err().unwrap();
+        let err_msg = format!("{}", err);
+        assert!(
+            err_msg.contains("recursion depth limit exceeded"),
+            "Unexpected error message: {}",
+            err_msg
+        );
+    }
+
     /// 🎯 Target: PropertyValue::estimated_heap_size
     /// 💣 Risk: Calculation failure should default to a "penalty" size to prevent cache monopolization by malicious inputs.
     /// 🧪 Strategy: Call estimated_heap_size on a deeply nested structure.


### PR DESCRIPTION
🎯 **Target:** `PropertyMapBuilder::try_insert_by_key`
💣 **Risk:** Should fail gracefully (return `Err`) instead of panicking on deep recursion when using an interned key.
🧪 **Strategy:** Try to insert a deeply nested structure using `try_insert_by_key`.
🔬 **Verification:** Check that `Result` is `Err` and contains the recursion limit message by running `cargo test test_property_map_builder_try_insert_by_key_returns_error_on_deep_recursion`.

---
*PR created automatically by Jules for task [9219763324194639089](https://jules.google.com/task/9219763324194639089) started by @madmax983*