### PR TITLE
⚡ Bolt: Optimize query result iteration to avoid intermediate heap allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-11-20 - Identity Hashing for WriteBuffer Lookups
 **Learning:** `WriteBuffer` used default `HashMap` (SipHash) for `modified_nodes` and `modified_edges` to track dirty state during transactions. Since keys are `NodeId` and `EdgeId` (wrappers around `u64`), hashing overhead was unnecessary and reduced throughput during bulk write operations.
 **Action:** Replaced `HashMap` with `FastHashMap` (`HashMap<..., BuildHasherDefault<IdentityHasher>>`) for `modified_nodes` and `modified_edges` in `WriteBuffer`. Using `IdentityHasher` for already-unique integer-like keys eliminates SipHash overhead and improves lookup/insertion speeds during transaction tracking.
+
+**[Removing Intermediate Collections in Iterators]**
+**Learning:** Chaining `.collect_all()?` on iterators to convert them to vectors before applying `.into_iter().filter_map(...)` incurs massive unnecessary allocations for large data sets. Also `.collect_all()?.len()` allocates a whole vector just to count elements.
+**Action:** When working with iterators, always loop through them directly with `while let Some(item) = iter.next()` to perform transformations and aggregations in a single pass without large intermediate allocations, thus minimizing heap allocations.

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -168,33 +168,32 @@ impl QueryResults {
     }
 
     /// Collect all nodes from results
-    pub fn collect_nodes(self) -> Result<Vec<Node>> {
-        let rows = self.collect_all()?;
-        Ok(rows
-            .into_iter()
-            .filter_map(|row| {
-                if let EntityResult::Node(n) = row.entity {
-                    Some(n)
-                } else {
-                    None
-                }
-            })
-            .collect())
+    ///
+    /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
+    /// a large intermediate `Vec` of all rows before extracting the nodes.
+    pub fn collect_nodes(mut self) -> Result<Vec<Node>> {
+        let mut nodes = Vec::new();
+        while let Some(row) = self.iterator.next() {
+            if let EntityResult::Node(n) = row?.entity {
+                nodes.push(n);
+            }
+        }
+        Ok(nodes)
     }
 
     /// Collect nodes with their scores
-    pub fn collect_nodes_with_scores(self) -> Result<Vec<(Node, f32)>> {
-        let rows = self.collect_all()?;
-        Ok(rows
-            .into_iter()
-            .filter_map(|row| {
-                if let (EntityResult::Node(n), Some(score)) = (row.entity, row.score) {
-                    Some((n, score))
-                } else {
-                    None
-                }
-            })
-            .collect())
+    ///
+    /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
+    /// a large intermediate `Vec` of all rows before extracting the nodes and scores.
+    pub fn collect_nodes_with_scores(mut self) -> Result<Vec<(Node, f32)>> {
+        let mut results = Vec::new();
+        while let Some(row) = self.iterator.next() {
+            let row = row?;
+            if let (EntityResult::Node(n), Some(score)) = (row.entity, row.score) {
+                results.push((n, score));
+            }
+        }
+        Ok(results)
     }
 
     /// Take at most n results
@@ -221,8 +220,17 @@ impl QueryResults {
     }
 
     /// Count the number of results
-    pub fn count_all(self) -> Result<usize> {
-        Ok(self.collect_all()?.len())
+    ///
+    /// ⚡ Bolt Optimization: Consumes the iterator and counts the items directly.
+    /// This avoids allocating a large `Vec` just to check its length, significantly
+    /// reducing memory overhead for large result sets.
+    pub fn count_all(mut self) -> Result<usize> {
+        let mut count = 0;
+        while let Some(row) = self.iterator.next() {
+            row?; // ensure no error
+            count += 1;
+        }
+        Ok(count)
     }
 
     /// Check if there are any results


### PR DESCRIPTION
💡 What: Rewrote `collect_nodes`, `collect_nodes_with_scores`, and `count_all` in `src/query/executor/results.rs` to consume the result iterator directly using `while let Some(row) = self.iterator.next()`. Added inline documentation for the optimization.

🎯 Why: Previously, these methods chained `.collect_all()?` (allocating a full vector of all query results) before using `.into_iter().filter_map(...)` or `.len()`. This incurred massive and unnecessary heap allocations and memory overhead for large query result sets.

📊 Impact: Reduces intermediate heap allocations to 0 for these operations. Memory consumption is directly proportional only to the final output vector (or O(1) in the case of `count_all`), avoiding significant spikes during query processing.

🔬 Measurement: Run `cargo test --features nova test_query_results` (or the full test suite). All tests related to result collection pass and verify correct extraction logic and error propagation.

---
*PR created automatically by Jules for task [7079719984089752688](https://jules.google.com/task/7079719984089752688) started by @madmax983*