### PR TITLE
🦀 Core Review: Add risk-first analysis for Warden tests

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -19,3 +19,15 @@ No high-severity findings.
 
 **Test Gaps:**
 *   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.
+
+## 🦀 Core Review: Warden test coverage
+
+**Findings:**
+
+No high-severity findings. The PR correctly adds Warden coverage asserting existing security checks.
+
+### Test gaps
+- No missing tests were identified for correctness/regression risks within the scope of these test additions.
+
+### Residual risks
+- Relying on Serde variants to catch "wrong field types" (e.g. `12345` instead of `"label"`) returns an opaque 400 Bad Request to the user instead of descriptive field-level error. This is a DX (Developer Experience) risk, not a correctness risk.


### PR DESCRIPTION
🦀 **Core Review: Warden tests**

Evaluated test coverage additions for warden dos amplification, HTTP panics, and HNSW exploit dimensions.
- No high-severity functional correctness or security risks introduced. Tests assert correctly configured safety bounds.
- Documented Developer Experience (DX) gaps when returning opaque JSON validation 400 Bad Request HTTP errors in `.jules/core_review.md`.

---
*PR created automatically by Jules for task [9115873255377641676](https://jules.google.com/task/9115873255377641676) started by @madmax983*