### PR TITLE
⚡ Bolt: Use FastHashMap for integer keys in HistoricalStorage

### DIFF
--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -22,7 +22,7 @@ use crate::core::version::{
     AnchorConfig, EdgeVersion, EntityVersion, NodeVersion, TemporalVersion, VersionData,
 };
 use quick_cache::sync::Cache;
-use std::collections::HashMap;
+use crate::core::version::FastHashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -171,29 +171,29 @@ pub struct HistoricalStorage {
     /// Maximum depth for version reconstruction (DoS protection)
     max_reconstruction_depth: usize,
     /// All node versions, indexed by version ID
-    node_versions: HashMap<VersionId, NodeVersion>,
+    node_versions: FastHashMap<VersionId, NodeVersion>,
     /// All edge versions, indexed by version ID
-    edge_versions: HashMap<VersionId, EdgeVersion>,
+    edge_versions: FastHashMap<VersionId, EdgeVersion>,
     /// Head version ID for each node (most recent)
-    node_version_heads: HashMap<NodeId, VersionId>,
+    node_version_heads: FastHashMap<NodeId, VersionId>,
     /// Head version ID for each edge (most recent)
-    edge_version_heads: HashMap<EdgeId, VersionId>,
+    edge_version_heads: FastHashMap<EdgeId, VersionId>,
     /// Cached version counts per node (for O(1) capacity checks)
-    node_version_counts: HashMap<NodeId, usize>,
+    node_version_counts: FastHashMap<NodeId, usize>,
     /// Cached version counts per edge (for O(1) capacity checks)
-    edge_version_counts: HashMap<EdgeId, usize>,
+    edge_version_counts: FastHashMap<EdgeId, usize>,
     /// Versions since last anchor per node (for O(1) anchor interval checks)
     ///
     /// Issue #208: Cache the count of versions since the last anchor to avoid
     /// walking the version chain on every add operation. This improves write
     /// performance from O(anchor_interval) to O(1).
-    node_versions_since_anchor: HashMap<NodeId, usize>,
+    node_versions_since_anchor: FastHashMap<NodeId, usize>,
     /// Versions since last anchor per edge (for O(1) anchor interval checks)
     ///
     /// Issue #208: Cache the count of versions since the last anchor to avoid
     /// walking the version chain on every add operation. This improves write
     /// performance from O(anchor_interval) to O(1).
-    edge_versions_since_anchor: HashMap<EdgeId, usize>,
+    edge_versions_since_anchor: FastHashMap<EdgeId, usize>,
     /// Cached count of node anchor versions for O(1) stats() (Issue #212)
     ///
     /// This counter is incremented when node anchors are added and enables
@@ -375,14 +375,14 @@ impl HistoricalStorage {
             config,
             retention_policy,
             max_reconstruction_depth: MAX_RECONSTRUCTION_DEPTH,
-            node_versions: HashMap::new(),
-            edge_versions: HashMap::new(),
-            node_version_heads: HashMap::new(),
-            edge_version_heads: HashMap::new(),
-            node_version_counts: HashMap::new(),
-            edge_version_counts: HashMap::new(),
-            node_versions_since_anchor: HashMap::new(),
-            edge_versions_since_anchor: HashMap::new(),
+            node_versions: FastHashMap::default(),
+            edge_versions: FastHashMap::default(),
+            node_version_heads: FastHashMap::default(),
+            edge_version_heads: FastHashMap::default(),
+            node_version_counts: FastHashMap::default(),
+            edge_version_counts: FastHashMap::default(),
+            node_versions_since_anchor: FastHashMap::default(),
+            edge_versions_since_anchor: FastHashMap::default(),
             cached_node_anchor_count: 0,
             cached_node_delta_count: 0,
             cached_edge_anchor_count: 0,
@@ -1354,9 +1354,9 @@ impl HistoricalStorage {
     ///
     /// Returns a map of NodeId -> `Vec<NodeVersion>` for recovery property tests.
     /// This walks through all node versions and groups them by entity ID.
-    pub fn get_all_node_versions(&self) -> std::collections::HashMap<NodeId, Vec<&NodeVersion>> {
-        let mut result: std::collections::HashMap<NodeId, Vec<&NodeVersion>> =
-            std::collections::HashMap::new();
+    pub fn get_all_node_versions(&self) -> FastHashMap<NodeId, Vec<&NodeVersion>> {
+        let mut result: FastHashMap<NodeId, Vec<&NodeVersion>> =
+            FastHashMap::default();
 
         for version in self.node_versions.values() {
             result.entry(version.node_id).or_default().push(version);
@@ -1369,9 +1369,9 @@ impl HistoricalStorage {
     ///
     /// Returns a map of EdgeId -> `Vec<EdgeVersion>` for recovery property tests.
     /// This walks through all edge versions and groups them by entity ID.
-    pub fn get_all_edge_versions(&self) -> std::collections::HashMap<EdgeId, Vec<&EdgeVersion>> {
-        let mut result: std::collections::HashMap<EdgeId, Vec<&EdgeVersion>> =
-            std::collections::HashMap::new();
+    pub fn get_all_edge_versions(&self) -> FastHashMap<EdgeId, Vec<&EdgeVersion>> {
+        let mut result: FastHashMap<EdgeId, Vec<&EdgeVersion>> =
+            FastHashMap::default();
 
         for version in self.edge_versions.values() {
             result.entry(version.edge_id).or_default().push(version);
@@ -2668,14 +2668,14 @@ impl HistoricalStorage {
     /// Get all node versions for persistence.
     ///
     /// This is a crate-internal method used by the index persistence layer.
-    pub(crate) fn get_node_versions(&self) -> &HashMap<VersionId, NodeVersion> {
+    pub(crate) fn get_node_versions(&self) -> &FastHashMap<VersionId, NodeVersion> {
         &self.node_versions
     }
 
     /// Get all edge versions for persistence.
     ///
     /// This is a crate-internal method used by the index persistence layer.
-    pub(crate) fn get_edge_versions(&self) -> &HashMap<VersionId, EdgeVersion> {
+    pub(crate) fn get_edge_versions(&self) -> &FastHashMap<VersionId, EdgeVersion> {
         &self.edge_versions
     }
 
@@ -2787,7 +2787,7 @@ impl HistoricalStorage {
         // === Rebuild node version chains ===
 
         // Group versions by node ID
-        let mut node_versions_by_id: HashMap<NodeId, Vec<VersionId>> = HashMap::new();
+        let mut node_versions_by_id: FastHashMap<NodeId, Vec<VersionId>> = FastHashMap::default();
         for (vid, version) in &self.node_versions {
             node_versions_by_id
                 .entry(version.node_id)
@@ -2862,7 +2862,7 @@ impl HistoricalStorage {
         // === Rebuild edge version chains ===
 
         // Group versions by edge ID
-        let mut edge_versions_by_id: HashMap<EdgeId, Vec<VersionId>> = HashMap::new();
+        let mut edge_versions_by_id: FastHashMap<EdgeId, Vec<VersionId>> = FastHashMap::default();
         for (vid, version) in &self.edge_versions {
             edge_versions_by_id
                 .entry(version.edge_id)

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -69,6 +69,7 @@ use crate::storage::wal::LSN;
 use crate::storage::wal::flush_coordinator::FlushCoordinator;
 use quick_cache::sync::Cache;
 use std::collections::HashMap;
+use crate::core::version::FastHashMap;
 use std::panic;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1270,13 +1271,13 @@ impl MigrationService {
     /// * `_current_time` - Unused, kept for API compatibility (wallclock time is used internally)
     pub fn identify_node_candidates(
         &self,
-        versions: &HashMap<VersionId, NodeVersion>,
-        head_versions: &HashMap<NodeId, VersionId>,
-        version_counts: &HashMap<NodeId, usize>,
+        versions: &FastHashMap<VersionId, NodeVersion>,
+        head_versions: &FastHashMap<NodeId, VersionId>,
+        version_counts: &FastHashMap<NodeId, usize>,
         _current_time: Instant,
     ) -> Vec<MigrationCandidate> {
         // Track how many candidates we've selected per node
-        let mut candidates_per_node: HashMap<NodeId, usize> = HashMap::new();
+        let mut candidates_per_node: FastHashMap<NodeId, usize> = FastHashMap::default();
         let mut all_candidates = Vec::new();
 
         // Get current wallclock time in milliseconds since UNIX epoch
@@ -1352,13 +1353,13 @@ impl MigrationService {
     /// * `_current_time` - Unused, kept for API compatibility (wallclock time is used internally)
     pub fn identify_edge_candidates(
         &self,
-        versions: &HashMap<VersionId, EdgeVersion>,
-        head_versions: &HashMap<EdgeId, VersionId>,
-        version_counts: &HashMap<EdgeId, usize>,
+        versions: &FastHashMap<VersionId, EdgeVersion>,
+        head_versions: &FastHashMap<EdgeId, VersionId>,
+        version_counts: &FastHashMap<EdgeId, usize>,
         _current_time: Instant,
     ) -> Vec<MigrationCandidate> {
         // Track how many candidates we've selected per edge
-        let mut candidates_per_edge: HashMap<EdgeId, usize> = HashMap::new();
+        let mut candidates_per_edge: FastHashMap<EdgeId, usize> = FastHashMap::default();
         let mut all_candidates = Vec::new();
 
         // Get current wallclock time in milliseconds since UNIX epoch
@@ -1649,9 +1650,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         // Create 3 versions for node 100
         let node_id = NodeId::new(100).unwrap();
@@ -1679,9 +1680,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         let node_id = NodeId::new(100).unwrap();
         for i in 1..=3 {
@@ -1974,9 +1975,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         // Create versions for different nodes
         let node1 = NodeId::new(100).unwrap();
@@ -2243,9 +2244,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         // Create 3 versions for edge 200
         let edge_id = EdgeId::new(200).unwrap();
@@ -2273,9 +2274,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         let edge_id = EdgeId::new(200).unwrap();
         for i in 1..=3 {
@@ -2302,9 +2303,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         let edge_id = EdgeId::new(200).unwrap();
 
@@ -2510,9 +2511,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let empty_versions: HashMap<VersionId, EdgeVersion> = HashMap::new();
-        let empty_heads: HashMap<EdgeId, VersionId> = HashMap::new();
-        let empty_counts: HashMap<EdgeId, usize> = HashMap::new();
+        let empty_versions: FastHashMap<VersionId, EdgeVersion> = FastHashMap::default();
+        let empty_heads: FastHashMap<EdgeId, VersionId> = FastHashMap::default();
+        let empty_counts: FastHashMap<EdgeId, usize> = FastHashMap::default();
 
         let candidates = service.identify_edge_candidates(
             &empty_versions,
@@ -2532,9 +2533,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let counts: HashMap<NodeId, usize> = HashMap::new(); // Empty counts
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let counts: FastHashMap<NodeId, usize> = FastHashMap::default(); // Empty counts
 
         let node_id = NodeId::new(100).unwrap();
         for i in 1..=3 {
@@ -2630,9 +2631,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         // Create versions for multiple nodes
         for node_num in [100u64, 101, 102] {
@@ -2664,9 +2665,9 @@ mod tests {
             .build();
         let service = MigrationService::new(cold, policy);
 
-        let mut versions = HashMap::new();
-        let mut heads = HashMap::new();
-        let mut counts = HashMap::new();
+        let mut versions = FastHashMap::default();
+        let mut heads = FastHashMap::default();
+        let mut counts = FastHashMap::default();
 
         // Create versions for multiple edges
         for edge_num in [200u64, 201, 202] {


### PR DESCRIPTION
⚡ Bolt: Use FastHashMap for integer keys in HistoricalStorage

💡 What: Replaced standard `HashMap` with `FastHashMap` (using `IdentityHasher`) in `src/storage/historical/mod.rs` and `src/storage/migration.rs` for integer-wrapper keys like `NodeId`, `EdgeId`, and `VersionId`.
🎯 Why: Standard `HashMap` uses the cryptographically secure but slower `SipHash` algorithm. Since the keys are internal integer wrappers, a simple `IdentityHasher` avoids this hashing overhead entirely.
📊 Impact: Reduces CPU overhead during version chain lookups, iteration, and cache maintenance, slightly improving historical storage read/write performance.
🔬 Measurement: Run standard tests and benchmarks related to `HistoricalStorage`.

Pre-commit checks complete.

---
*PR created automatically by Jules for task [17281482448215498349](https://jules.google.com/task/17281482448215498349) started by @madmax983*