### PR TITLE
bench: stabilize id_generation_concurrent benchmark signal

### DIFF
--- a/benches/current_state.rs
+++ b/benches/current_state.rs
@@ -20,7 +20,8 @@ use aletheiadb::core::interning::StringInterner;
 use aletheiadb::{CurrentStorage, PropertyMapBuilder};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
 use std::thread;
 
 /// Create a test graph with a specified number of nodes and edges.
@@ -282,25 +283,49 @@ fn bench_id_concurrent(c: &mut Criterion) {
             BenchmarkId::new("threads", thread_count),
             &thread_count,
             |b, &thread_count| {
-                b.iter(|| {
-                    let generator = Arc::new(IdGenerator::new());
-                    let ids_per_thread = 1000;
+                let generator = Arc::new(IdGenerator::new());
+                // Keep enough work per iteration to amortize synchronization jitter.
+                let ids_per_thread = 1000;
+                let start_barrier = Arc::new(Barrier::new(thread_count + 1));
+                let done_barrier = Arc::new(Barrier::new(thread_count + 1));
+                let stop = Arc::new(AtomicBool::new(false));
 
-                    let handles: Vec<_> = (0..thread_count)
-                        .map(|_| {
-                            let gen_clone = Arc::clone(&generator);
-                            thread::spawn(move || {
+                // Keep worker threads alive across iterations to avoid measuring
+                // thread spawn/join overhead and OS scheduler noise.
+                let handles: Vec<_> = (0..thread_count)
+                    .map(|_| {
+                        let gen_clone = Arc::clone(&generator);
+                        let start_clone = Arc::clone(&start_barrier);
+                        let done_clone = Arc::clone(&done_barrier);
+                        let stop_clone = Arc::clone(&stop);
+                        thread::spawn(move || {
+                            loop {
+                                start_clone.wait();
+                                if stop_clone.load(Ordering::Acquire) {
+                                    break;
+                                }
+
                                 for _ in 0..ids_per_thread {
                                     black_box(gen_clone.next().unwrap());
                                 }
-                            })
-                        })
-                        .collect();
 
-                    for handle in handles {
-                        handle.join().unwrap();
-                    }
+                                done_clone.wait();
+                            }
+                        })
+                    })
+                    .collect();
+
+                b.iter(|| {
+                    start_barrier.wait();
+                    done_barrier.wait();
                 });
+
+                stop.store(true, Ordering::Release);
+                // Wake workers so they can observe the stop flag and exit.
+                start_barrier.wait();
+                for handle in handles {
+                    handle.join().unwrap();
+                }
             },
         );
     }

--- a/tests/regression_flush_corruption.rs
+++ b/tests/regression_flush_corruption.rs
@@ -1,6 +1,10 @@
+#[cfg(unix)]
 use aletheiadb::storage::wal::LSN;
+#[cfg(unix)]
 use aletheiadb::storage::wal::flush_coordinator::{FlushCoordinator, FlushCoordinatorConfig};
+#[cfg(unix)]
 use aletheiadb::storage::wal::ring_buffer::PendingEntry;
+#[cfg(unix)]
 use tempfile::tempdir;
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- stabilize id_generation_concurrent benchmark by keeping worker threads alive across Criterion iterations
- replace per-iteration thread spawn/join with barrier-synchronized workers so timing focuses on concurrent IdGenerator::next() contention
- fix pre-existing clippy failure on Windows by gating unix-only imports in 	ests/regression_flush_corruption.rs

## Why
The concurrent ID benchmark previously measured OS thread lifecycle/scheduler jitter in each iteration, causing large variance and false regression/improvement signals.

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all
- cargo test
- cargo bench --bench current_state -- id_generation_concurrent --noplot
- repeated cargo bench --bench current_state -- id_generation_concurrent/threads/4 --noplot runs show substantially tighter behavior than pre-fix
