### PR TITLE
🤖 Sentinel: Strengthen core ID generation and conversion tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -91,3 +91,9 @@
 **Summary:** Mutants survived regarding JSON payload type conversions (`json_to_predicate_value`), boundary condition checks for DoS protection (`> 10000` mutated to `>=` or `==`), and error code categorization logic (`||` mutated to `&&`).
 **Diagnosis:** MISSING_TEST / WEAK_TEST - The test suite didn't comprehensively cover the individual match arms of `json_to_predicate_value`, the edge cases of deep pagination limits (`offset + limit == 10000`), or explicit distinction between "syntax" and "parse" error handling branches. Also, an underlying `test_cors_headers_present` test failure masked overall mutant evaluation for `http_server` tasks.
 **Kill Shot:** Fixed the CORS test by supplying a `peer_addr`, and added `test_json_to_predicate_value`, `test_execute_query_parse_error`, and exact boundary condition payloads (9900 + 100 vs 9901 + 100) inside `test_warden_find_node_deep_pagination` and `test_warden_find_neighbors_overflow`.
+
+**[Weak Test Coverage in ID Generator Boundaries and Entity Conversions]**
+**Module:** `src/core/id.rs`
+**Summary:** `cargo-mutants` indicated potential gaps where `IdGenerator::with_start`, `IdGenerator::next`, and `EntityId::from` traits could return default values or be altered without failing the test suite (e.g., replacing `From` implementations with `Default::default()`, or off-by-one errors near `MAX_VALID_ID`).
+**Diagnosis:** MISSING_TEST / WEAK_TEST - The existing `sentinel_id_tests.rs` covered basic properties but missed explicit tests ensuring `EntityId::from` implementations match the behavior of `into()`, verifying that `IdGenerator::with_start` correctly applies exactly 0 or 1, and confirming the exact `MAX_VALID_ID` boundary exhaustion logic for `IdGenerator::next`.
+**Kill Shot:** Added `test_entity_id_from_implementations`, `test_id_generator_with_start_boundary`, and `test_id_generator_next_boundary` to `tests/sentinel_id_tests.rs`.

--- a/tests/sentinel_id_tests.rs
+++ b/tests/sentinel_id_tests.rs
@@ -157,3 +157,36 @@ fn test_tx_id_display() {
     let id = TxId::new(5);
     assert_eq!(format!("{}", id), "TxId(5)");
 }
+
+#[test]
+fn test_entity_id_from_implementations() {
+    let node_id = NodeId::new(42).unwrap();
+    let entity_node = EntityId::from(node_id);
+    assert!(entity_node.is_node());
+    assert_eq!(entity_node.as_node(), Some(node_id));
+
+    let edge_id = EdgeId::new(42).unwrap();
+    let entity_edge = EntityId::from(edge_id);
+    assert!(entity_edge.is_edge());
+    assert_eq!(entity_edge.as_edge(), Some(edge_id));
+}
+
+#[test]
+fn test_id_generator_with_start_boundary() {
+    let generator_0 = IdGenerator::with_start(0);
+    assert_eq!(generator_0.current_approximate(), 0);
+    assert_eq!(generator_0.next().unwrap(), 0);
+
+    let generator_1 = IdGenerator::with_start(1);
+    assert_eq!(generator_1.current_approximate(), 1);
+    assert_eq!(generator_1.next().unwrap(), 1);
+}
+
+#[test]
+fn test_id_generator_next_boundary() {
+    let limit = u64::MAX - 1000; // MAX_VALID_ID
+    let generator = IdGenerator::with_start(limit);
+    assert_eq!(generator.next().unwrap(), limit);
+    // The next one should fail because it exceeds MAX_VALID_ID
+    assert!(generator.next().is_err());
+}


### PR DESCRIPTION
🤖 **Sentinel** identified weak test coverage in the `src/core/id.rs` module regarding `IdGenerator` boundaries and `EntityId::from` implementations. 

### 🧬 Mutants Found
`cargo-mutants` found several surviving mutants indicating gaps:
- Replacing `<impl From<NodeId> for EntityId>::from -> Self with Default::default()`
- Replacing `IdGenerator::with_start -> Self with Default::default()`
- Changing boundary operators `>` to `>=` or `==` inside `IdGenerator::next` near `MAX_VALID_ID`.

### 🎯 Tests Added/Strengthened
Targeted tests were added to `tests/sentinel_id_tests.rs`:
- `test_entity_id_from_implementations`: Verifies explicit conversions for `NodeId` and `EdgeId` into their respective `EntityId` enum variants.
- `test_id_generator_with_start_boundary`: Verifies exact initial value handling.
- `test_id_generator_next_boundary`: Verifies exhaustive boundary logic at `MAX_VALID_ID`.

### ⚠️ Suspected Bugs
None found. The logic was correct, but the tests were not asserting the bounds exhaustively.

### 🔗 Havoc Interaction
These edge cases were not heavily stressed by the current Havoc configuration.

Journal updated in `.jules/sentinel.md`. All verification checks (formatting, linting, tests) passed.

---
*PR created automatically by Jules for task [13082857745573665376](https://jules.google.com/task/13082857745573665376) started by @madmax983*