### PR TITLE
🔒 Warden: CSR Validation Fix

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -30,3 +30,6 @@
 1.  **Update `tokenizers`:** Updated `tokenizers` to version `0.22` in `Cargo.toml`. This version drops the dependency on `number_prefix` and includes fixes for known vulnerabilities.
 2.  **Update Dependencies:** Ran `cargo update` to pull in the latest compatible versions of all dependencies, resolving the yanked `bumpalo` issue in `wasm-bindgen`.
 3.  **Verification:** Ran `cargo audit` to confirm the vulnerabilities are resolved. Ran tests (`cargo test --features embedding-onnx`) to ensure no regressions.
+2024-XX-XX - [Warden: CSR Adjacency Index Vulnerability]
+**Threat:** `AdjacencyIndex::import_csr` did not validate that `node_ids` is sorted, and did not validate that `offsets` is monotonically increasing. It also didn't validate that the first offset is `0`. This allows a maliciously constructed CSR payload to cause OOB reads (Denial of Service) when `get_adjacency` is called, due to `start > end` or `end > edges.len()` when slicing the `edges` array.
+**Defense:** Added rigorous validation in `validate_csr_invariants` to ensure `node_ids` is strictly sorted (no duplicates), `offsets` begins with `0`, and is monotonically increasing.

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -301,6 +301,34 @@ impl AdjacencyIndex {
         }
 
         #[allow(clippy::collapsible_if)]
+        if let Some(&first_offset) = offsets.first() {
+            if first_offset != 0 {
+                return Err(format!(
+                    "CSR first offset mismatch: expected 0, got {}",
+                    first_offset
+                ));
+            }
+        }
+
+        for window in offsets.windows(2) {
+            if window[0] > window[1] {
+                return Err(format!(
+                    "CSR offsets are not monotonically increasing: {} > {}",
+                    window[0], window[1]
+                ));
+            }
+        }
+
+        for window in node_ids.windows(2) {
+            if window[0] >= window[1] {
+                return Err(format!(
+                    "CSR node_ids are not strictly monotonically increasing: {} >= {}",
+                    window[0], window[1]
+                ));
+            }
+        }
+
+        #[allow(clippy::collapsible_if)]
         if let Some(&last_offset) = offsets.last() {
             if last_offset != edge_ids.len() as u64 {
                 return Err(format!(
@@ -819,6 +847,35 @@ mod sentry_tests {
             AdjacencyIndex::validate_csr_invariants(&node_ids, &invalid_offsets_val, &edge_ids)
                 .unwrap_err();
         assert!(err_val.contains("CSR last offset mismatch"));
+
+        // 4. Invalid first offset
+        let invalid_first_offset = vec![1, 1, 2];
+        let err_first =
+            AdjacencyIndex::validate_csr_invariants(&node_ids, &invalid_first_offset, &edge_ids)
+                .unwrap_err();
+        assert!(err_first.contains("CSR first offset mismatch"));
+
+        // 5. Non-monotonic offsets
+        let non_monotonic_offsets = vec![0, 2, 1]; // 2 > 1
+        // We need 3 edge ids to match the last offset 1, or wait, last offset is 1, so edge len = 1
+        let err_monotonic =
+            AdjacencyIndex::validate_csr_invariants(&node_ids, &non_monotonic_offsets, &[100])
+                .unwrap_err();
+        assert!(err_monotonic.contains("CSR offsets are not monotonically increasing"));
+
+        // 6. Unsorted node ids
+        let unsorted_node_ids = vec![20, 10]; // unsorted
+        let err_unsorted =
+            AdjacencyIndex::validate_csr_invariants(&unsorted_node_ids, &offsets, &edge_ids)
+                .unwrap_err();
+        assert!(err_unsorted.contains("CSR node_ids are not strictly monotonically increasing"));
+
+        // 7. Duplicate node ids
+        let duplicate_node_ids = vec![10, 10]; // duplicate
+        let err_duplicate =
+            AdjacencyIndex::validate_csr_invariants(&duplicate_node_ids, &offsets, &edge_ids)
+                .unwrap_err();
+        assert!(err_duplicate.contains("CSR node_ids are not strictly monotonically increasing"));
     }
 
     #[test]


### PR DESCRIPTION
### 🦠 Threat
The `AdjacencyIndex::import_csr` function accepted externally-provided CSR arrays without validating that `node_ids` was sorted and that `offsets` started at 0 and was monotonically increasing. Due to unsafe transmutations and unchecked slices during `get_adjacency` lookups, this could cause out-of-bounds reads and panics resulting in Denial of Service (DoS).

### 🛡️ Defense
Added comprehensive validation in `validate_csr_invariants` to verify:
1. `node_ids` is strictly monotonically increasing (sorted, no duplicates).
2. `offsets` starts at `0`.
3. `offsets` is monotonically increasing.

### 💥 Severity
High - Maliciously crafted storage files could cause out-of-bounds panics resulting in a Denial of Service.

### 🧪 Verification
Added 4 new validation sub-tests in `test_validate_csr_invariants_logic` to ensure proper bounds checking and invariant enforcement. Ran `cargo test` and `cargo clippy` successfully. Also recorded findings to `.jules/warden.md` via `>>` append correctly preserving history.

---
*PR created automatically by Jules for task [12728895940120858340](https://jules.google.com/task/12728895940120858340) started by @madmax983*