### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -19,3 +19,8 @@ No high-severity findings.
 
 **Test Gaps:**
 *   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.
+
+No high-severity findings.
+
+### Residual Risks / Test Gaps
+- **Empty Review Scope:** No code changes were provided in the diff or working tree. The residual risk is that potentially intended changes were not reviewed.


### PR DESCRIPTION
This PR contains the output of the "Core" 🦀 code review agent. 

Because no specific diff or scope was provided in the original request, and the working tree was clean, the review fell back to the explicitly instructed "no findings" behavior.

It appends the required string `No high-severity findings.` to `.jules/core_review.md` and lists the residual risk of un-reviewed code due to the lack of an input scope. Pre-closure checks (`cargo fmt`, `cargo clippy`, and `cargo test -- --skip havoc`) were successfully executed.

---
*PR created automatically by Jules for task [4951352417130466040](https://jules.google.com/task/4951352417130466040) started by @madmax983*