### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -19,3 +19,11 @@ No high-severity findings.
 
 **Test Gaps:**
 *   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.
+
+No high-severity findings.
+
+### Test gaps
+- None, as no scope was provided.
+
+### Residual risks
+- None, as no scope was provided.


### PR DESCRIPTION
Appended 'No high-severity findings.' to `.jules/core_review.md` and noted residual risks, as no specific code diff or scope was provided for review.

---
*PR created automatically by Jules for task [4635746910971681025](https://jules.google.com/task/4635746910971681025) started by @madmax983*