### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -62,3 +62,11 @@
 ## 2025-03-01 - README Getting Started Examples
 **Confusion:** Users copying examples from the README encountered compilation errors due to missing `aletheiadb::prelude::*` imports and missing feature flags (like `sharding-rpc`). Furthermore, running multiple examples sequentially in the same directory caused runtime crashes (e.g., `InvalidTimeRange`) due to conflicting leftover state in the default `./aletheiadb` directory. Unused variables also caused compiler warnings.
 **Clarification:** Updated README examples to consistently include `use aletheiadb::prelude::*`, explicitly declare required feature flags for sharding, prefix unused variables with `_`, and added a prominent warning about database state persistence and cleanup between example runs.
+
+## 2025-03-02 - Opaque Iterator Implementation Details
+**Confusion:** The `src/storage/current/iterators.rs` module lacked documentation explaining why specific iterator types were generated via macros instead of just returning a standard `Vec<EdgeId>`. This obscured the "Zero-Allocation Traversal" performance philosophy.
+**Clarification:** Added module-level documentation explaining that these iterators avoid expensive memory allocations on hot paths by holding lock-free references to contiguous memory arrays, reducing traversal overhead by 100-500ns per hop.
+
+## 2025-03-02 - Logical vs Physical Plan Clarification
+**Confusion:** The `src/query/planner/physical.rs` module lacked documentation detailing the distinction between logical query plans (what data to fetch) and physical query plans (the execution strategy used to fetch it). This is a core concept that makes the query planner opaque.
+**Clarification:** Added module-level documentation describing the optimizer's role in creating a `PhysicalPlan` and providing an example of how to view the underlying structure via `.explain()`.

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -1,7 +1,29 @@
 //! Physical Query Plan
 //!
-//! Physical operators that directly map to execution primitives.
-//! These are the "instructions" that the query executor runs.
+//! The physical query plan represents the explicit strategy the query engine will use
+//! to fulfill a request. It maps directly to execution primitives.
+//!
+//! # Logical vs Physical
+//!
+//! While a *Logical Plan* describes **what** data to retrieve (e.g., "Join these two tables"),
+//! the *Physical Plan* describes **how** to execute it (e.g., "Use a HashJoin, building the table on the smaller side").
+//!
+//! The optimizer in the query planner converts a logical plan into a physical plan by:
+//! 1. Choosing the right algorithm (e.g., `NodeScan` vs `PropertyScan`).
+//! 2. Evaluating costs (`EstimatedCost`).
+//! 3. Utilizing indexes where available.
+//!
+//! Each `PhysicalOp` implementation typically defines an exact execution flow over the underlying
+//! graph data and indexes.
+//!
+//! # Examples
+//!
+//! To see how physical plans are structured, you can call `.explain()` on a plan:
+//!
+//! ```rust,ignore
+//! let plan = planner.plan(&db, query)?;
+//! println!("{}", plan.explain());
+//! ```
 
 use std::sync::Arc;
 

--- a/src/storage/current/iterators.rs
+++ b/src/storage/current/iterators.rs
@@ -1,3 +1,26 @@
+//! Zero-Allocation Traversal Iterators
+//!
+//! This module provides high-performance iterators for traversing graph edges
+//! without allocating intermediate memory.
+//!
+//! # The "Zero-Allocation Traversal" Philosophy
+//!
+//! Graph traversal often requires fetching the neighbors of a node. Naive implementations
+//! allocate a `Vec<EdgeId>` to return these neighbors, which introduces significant overhead
+//! (100-500ns per traversal) in hot paths, especially for deep graph queries.
+//!
+//! AletheiaDB avoids this by returning lazy iterators. These iterators hold a lock-free reference
+//! ([`MergedAdjacencyGuard`](crate::index::incremental_adjacency::MergedAdjacencyGuard)) to the underlying
+//! adjacency data (frozen CSR slice + delta map) and yield edge IDs on demand.
+//!
+//! This approach provides:
+//! - **Zero allocation**: No `Vec` is created during traversal.
+//! - **Lazy evaluation**: Only the necessary edges are processed, which is crucial for `LIMIT` queries.
+//! - **Cache-friendly**: Edge IDs are read sequentially from contiguous memory (the CSR frozen state).
+//!
+//! The iterators defined here are generated via macros to ensure consistent behavior
+//! across different traversal directions (outgoing vs. incoming) and filtering conditions (with/without labels).
+
 use crate::core::id::EdgeId;
 use crate::core::interning::InternedString;
 use crate::index::incremental_adjacency::MergedAdjacencyGuard;


### PR DESCRIPTION
This PR addresses the missing module-level documentation for `src/storage/current/iterators.rs` and `src/query/planner/physical.rs`, which were identified as having a low code-to-doc ratio by `find_undocumented.py`.

It adds narrative explanations for *why* the zero-allocation iterators exist (performance optimization) and clarifies the distinction between logical and physical plans in the query engine. It also adds an entry to `.jules/bard.md` documenting these clarifications.

---
*PR created automatically by Jules for task [15375989078662957774](https://jules.google.com/task/15375989078662957774) started by @madmax983*