### PR TITLE
⚡ Bolt: Replace HashMap with FastHashMap for NodeId keys in sparse index

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2026-11-20 - Identity Hashing for Historical Storage
 **Learning:** `HistoricalStorage` and `MigrationService` used the default `HashMap` (SipHash) for integer wrapper keys like `NodeId`, `EdgeId`, and `VersionId`. Because these keys are unique internally-assigned high-quality IDs, SipHash incurs unnecessary hashing overhead.
 **Action:** Replaced `std::collections::HashMap` with `FastHashMap` (which uses `BuildHasherDefault<IdentityHasher>`) for tracking versions, heads, and stats. Using `IdentityHasher` speeds up tracking and lookups and is idiomatic across AletheiaDB for wrapper IDs.
+
+## 2026-11-20 - Identity Hashing for Sparse Vector Search Index
+**Learning:** In `src/index/vector/sparse.rs`, the sparse vector search and reciprocal rank fusion implementations used the default `HashMap` (SipHash) for tracking scores across nodes (keys are `NodeId`). Given `NodeId` is a u64 wrapper, the default SipHash introduces unnecessary overhead in the hottest loops of the system where entries are constantly inserted and updated.
+**Action:** Replaced `HashMap<NodeId, f32>` with `FastHashMap<NodeId, f32>` (which uses `BuildHasherDefault<IdentityHasher>`). This optimization eliminates SipHash overhead during sparse vector search accumulation and score combination without changing the logic.

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -64,12 +64,13 @@ use crate::core::error::{Error, Result, VectorError};
 use crate::core::id::NodeId;
 use crate::core::property::MAX_VECTOR_DIMENSIONS;
 use crate::core::vector::SparseVec;
+use crate::core::version::FastHashMap;
 use bitcode::{Decode, Encode};
 use crc32fast::Hasher;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -453,11 +454,11 @@ impl SparseVectorIndex {
         // For cosine similarity, we track magnitudes to avoid second lookups
         // For BM25, we track document lengths to avoid second lookups
         let is_cosine = matches!(self.config.scoring, ScoringMethod::Cosine);
-        let mut scores: HashMap<NodeId, f32> = HashMap::new();
+        let mut scores: FastHashMap<NodeId, f32> = FastHashMap::default();
         // Magnitudes map is only used for cosine, but we always create it (cheap)
-        let mut magnitudes: HashMap<NodeId, f32> = HashMap::new();
+        let mut magnitudes: FastHashMap<NodeId, f32> = FastHashMap::default();
         // Document lengths map is only used for BM25, but we always create it (cheap)
-        let mut doc_lengths: HashMap<NodeId, f32> = HashMap::new();
+        let mut doc_lengths: FastHashMap<NodeId, f32> = FastHashMap::default();
         let query_magnitude = query.magnitude();
         // Use Acquire ordering to synchronize with Release stores, ensuring we see
         // all data modifications that happened before the count was updated
@@ -1072,7 +1073,7 @@ pub fn hybrid_fusion(
     let sparse_normalized = normalize_scores(sparse_results);
 
     // Combine scores
-    let mut combined: HashMap<NodeId, f32> = HashMap::new();
+    let mut combined: FastHashMap<NodeId, f32> = FastHashMap::default();
 
     for (id, score) in dense_normalized {
         *combined.entry(id).or_insert(0.0) += alpha * score;
@@ -1133,7 +1134,7 @@ pub fn reciprocal_rank_fusion(
     let k = k.min(MAX_K);
     let k_constant = k_constant.max(1.0);
 
-    let mut rrf_scores: HashMap<NodeId, f32> = HashMap::new();
+    let mut rrf_scores: FastHashMap<NodeId, f32> = FastHashMap::default();
 
     // Add RRF contribution from dense results
     for (rank, (id, _)) in dense_results.iter().enumerate() {


### PR DESCRIPTION
💡 What: Replaced `HashMap<NodeId, f32>` with `FastHashMap<NodeId, f32>` in the `src/index/vector/sparse.rs` module.
🎯 Why: `NodeId` is a wrapper around a `u64`. Using the default `SipHash` inside the tight loops of the sparse vector index (e.g., scoring loops, `reciprocal_rank_fusion`) is extremely slow and unnecessary. `FastHashMap` uses `IdentityHasher`, which passes the integer through without any expensive cryptographic hashing.
📊 Impact: Reduces CPU hashing overhead inside critical loop paths for vector scoring, increasing queries per second for sparse and hybrid queries.
🔬 Measurement: Verify tests run locally using `cargo test index::vector::sparse` or `cargo test --lib index::vector::sparse`.

---
*PR created automatically by Jules for task [16140154451738757259](https://jules.google.com/task/16140154451738757259) started by @madmax983*