### PR TITLE
🦀 Core Review: Add risk-first analysis for Warden tests

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -19,3 +19,15 @@ No high-severity findings.
 
 **Test Gaps:**
 *   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.
+
+## 🦀 Core Review: Warden Vulnerability Tests
+
+**Findings:**
+
+No high-severity findings. The provided patch adds standalone test files (`tests/warden_hnsw_exploit.rs`, `tests/warden_http_panic.rs`, `tests/warden_property_safety.rs`) that effectively assert the integrity of existing security boundaries (HNSW dimension mismatch handling, HTTP JSON payload validation, and PropertyValue DoS amplification via oversized array declarations). Because no application logic is modified and the tests are isolated, no correctness or regression risk is introduced to the core system.
+
+### Test gaps
+- No missing tests were identified for correctness/regression risks within the context of these specific security assertions. The added tests cover the intended vectors successfully.
+
+### Residual risks
+- In `tests/warden_http_panic.rs`, the test `test_invalid_json_body` expects a `400 Bad Request` but does not assert on the error message body to guarantee the precise failure mode (e.g., distinguishing between a serde syntax error vs. an actix payload size limit error). This is a minor DX risk.


### PR DESCRIPTION
Added an isolated "Core🦀" risk-first code review for the latest Warden vulnerability testing additions.

The review explicitly confirms that adding standalone tests for:
- HNSW dimension mismatch exploits (`tests/warden_hnsw_exploit.rs`)
- HTTP JSON syntax/field panics (`tests/warden_http_panic.rs`)
- PropertyValue DoS length amplification (`tests/warden_property_safety.rs`)
... poses no correctness or regression risks to existing production logic, as they do not modify any core operations.

Also documented a minor DX (Developer Experience) risk related to the opaqueness of 400 Bad Request serde mapping, per the residual risks directive. All format, clippy, and cargo test invocations passed.

---
*PR created automatically by Jules for task [5917150945357562524](https://jules.google.com/task/5917150945357562524) started by @madmax983*