### PR TITLE
👺 Havoc: Fix WalRingBuffer::len_approx underflow on u64 wraparound

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -1415,7 +1415,8 @@ mod tests {
 
         // Append 3 items. write_pos will wrap around.
         for i in 0..3 {
-            buf.try_append(PendingEntry::new_async(LSN(i), vec![])).unwrap();
+            buf.try_append(PendingEntry::new_async(LSN(i), vec![]))
+                .unwrap();
         }
 
         // At this point:
@@ -1426,7 +1427,11 @@ mod tests {
         // BUT there are 3 items in the buffer!
 
         let len = buf.len_approx();
-        assert_eq!(len, 3, "👺 HAVOC SUCCESS: len_approx() failed on wraparound! Expected 3, got {}", len);
+        assert_eq!(
+            len, 3,
+            "👺 HAVOC SUCCESS: len_approx() failed on wraparound! Expected 3, got {}",
+            len
+        );
     }
 
     #[test]

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -775,7 +775,7 @@ impl WalRingBuffer {
     pub fn len_approx(&self) -> usize {
         let write = self.write_pos.load(Ordering::Relaxed);
         let read = self.read_pos.load(Ordering::Relaxed);
-        write.saturating_sub(read) as usize
+        write.wrapping_sub(read) as usize
     }
 
     /// Check if the buffer is approximately empty.
@@ -1401,6 +1401,32 @@ mod tests {
         let final_drained = buf.drain();
         assert_eq!(final_drained.len(), 1);
         assert_eq!(final_drained[0].data, vec![100]);
+    }
+
+    #[test]
+    fn test_havoc_ring_buffer_len_approx_wraparound() {
+        // 👺 HAVOC: Trigger u64 wraparound to prove len_approx underflows and breaks.
+        let capacity = 4;
+        let mut buf = WalRingBuffer::new(capacity);
+
+        // Simulate being near u64::MAX
+        let start_pos = u64::MAX - 2;
+        buf.set_state_for_wraparound_test(start_pos, start_pos);
+
+        // Append 3 items. write_pos will wrap around.
+        for i in 0..3 {
+            buf.try_append(PendingEntry::new_async(LSN(i), vec![])).unwrap();
+        }
+
+        // At this point:
+        // read_pos = u64::MAX - 2
+        // write_pos = (u64::MAX - 2) + 3 = u64::MAX + 1 = 0
+        //
+        // Using saturating_sub: 0.saturating_sub(u64::MAX - 2) == 0
+        // BUT there are 3 items in the buffer!
+
+        let len = buf.len_approx();
+        assert_eq!(len, 3, "👺 HAVOC SUCCESS: len_approx() failed on wraparound! Expected 3, got {}", len);
     }
 
     #[test]


### PR DESCRIPTION
🧨 **The Trigger:** The absolute counters `write_pos` and `read_pos` in `WalRingBuffer` naturally wrap around `u64::MAX`. When calculating the approximate length using `write.saturating_sub(read)`, the value underflows to `0` instead of correctly calculating the distance across the wraparound boundary.

📉 **The Stack Trace:**
```
thread 'storage::wal::ring_buffer::tests::test_havoc_ring_buffer_len_approx_wraparound' panicked at src/storage/wal/ring_buffer.rs:1429:9:
assertion `left == right` failed: 👺 HAVOC SUCCESS: len_approx() failed on wraparound! Expected 3, got 0
  left: 0
 right: 3
```

🧪 **Reproduction:** Run `cargo test --lib test_havoc_ring_buffer_len_approx_wraparound`

😈 **Comment:** You assumed `write_pos` would always be strictly greater than `read_pos` using saturating arithmetic. But a circle has no beginning. You were wrong. Using `wrapping_sub` properly honors the modulus of `u64::MAX`.

---
*PR created automatically by Jules for task [18343369132487789920](https://jules.google.com/task/18343369132487789920) started by @madmax983*