### PR TITLE
🦀 Core: Code review for `try_insert_by_key` coverage

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -19,3 +19,13 @@ No high-severity findings.
 
 **Test Gaps:**
 *   No explicit concurrency tests checking for consistency between node properties and graph structure within a single `analyze` call.
+
+## 🦀 Core Review: PropertyMapBuilder::try_insert_by_key
+
+No high-severity findings.
+
+### Test gaps
+- The requested diff is inherently a test coverage improvement (`test_property_map_builder_try_insert_by_key_returns_error_on_deep_recursion`). No missing tests were identified for correctness/regression risks for this specific isolated change.
+
+### Residual risks
+- None identified for `PropertyMapBuilder::try_insert_by_key`. It correctly defers to `serialized_size()`, which performs cycle/depth checks and returns an explicit `Result` bounding deep recursion.


### PR DESCRIPTION
## 🦀 Core Review: PropertyMapBuilder::try_insert_by_key

This PR submits a code review for the recent improvements to test coverage around `PropertyMapBuilder::try_insert_by_key`.

**Assumptions Documented:**
Given no specific scope was provided, I have autonomously made the safe assumption to perform the review against the most recent isolated commit (`21bd436 🛡️ Sentry: [test coverage improvement] PropertyMapBuilder::try_insert_by_key (#1614)`).

**Findings:**
*   No high-severity findings. The implemented logic safely delegates to `serialized_size()`, properly bubbling up an `Err` limit when `MAX_RECURSION_DEPTH` is exceeded, protecting against stack overflow DoS attacks without panicking.
*   The review has been securely appended to `.jules/core_review.md`.

All pre-commit checks (`cargo fmt`, `cargo clippy`, `cargo test -- test_property_map_builder_try_insert_by_key_returns_error_on_deep_recursion`) pass successfully.

---
*PR created automatically by Jules for task [12703116691867048488](https://jules.google.com/task/12703116691867048488) started by @madmax983*