### PR TITLE
🤖 Sentinel: Strengthen `src/core/id.rs` tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -80,3 +80,9 @@
 **Summary:** Numerous mutants survived in `predicates_equal`, replacing boolean operators `&&` with `||` and equality operators `==` with `!=`.
 **Diagnosis:** WEAK_TEST - The existing tests only checked equality matching entirely (where both terms were exactly the same) or entirely differently (different variants). It lacked "partial mismatch" checks (same variant, different internal value).
 **Kill Shot:** Added `test_predicates_equal_exhaustive_mismatches` to explicitly check every `Predicate` variant with slightly mismatched keys or values to force the strict `&&` evaluations.
+
+**[Missing Test Coverage in TxIdGenerator & EntityId Creation]**
+**Module:** `src/core/id.rs`
+**Summary:** Mutants changing `TxIdGenerator::default()` behavior and `NodeId::new_unchecked(0)` survived.
+**Diagnosis:** MISSING_COVERAGE - The default implementation for `TxIdGenerator` wasn't explicitly verified to initialize starting ID to `1` (which acts as a current of `0`). Additionally, `new_unchecked` operations with ID `0` were untested, leaving edge cases surrounding empty/0-valued IDs uncovered.
+**Kill Shot:** Added `test_tx_id_generator_default` and `id_zero_*` tests inside `test_new_unchecked_bypasses_validation`.

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -1366,6 +1366,15 @@ mod proptests {
 
             let version = VersionId::new_unchecked(raw_id);
             prop_assert_eq!(version.as_u64(), raw_id);
+
+        let id_zero_node = NodeId::new_unchecked(0);
+        assert_eq!(id_zero_node.as_u64(), 0);
+
+        let id_zero_edge = EdgeId::new_unchecked(0);
+        assert_eq!(id_zero_edge.as_u64(), 0);
+
+        let id_zero_version = VersionId::new_unchecked(0);
+        assert_eq!(id_zero_version.as_u64(), 0);
         }
 
         /// Property: ID ordering is transitive: if a < b and b < c then a < c
@@ -1535,5 +1544,12 @@ mod warden_repro {
         generator.set_counter(u64::MAX);
         // This should panic to prevent wrapping to 0
         let _ = generator.next();
+    }
+
+    #[test]
+    fn test_tx_id_generator_default() {
+        let generator = TxIdGenerator::default();
+        assert_eq!(generator.current(), TxId(0));
+        assert_eq!(generator.next(), TxId(1));
     }
 }


### PR DESCRIPTION
🤖 Sentinel: Strengthen `src/core/id.rs` tests

🧬 Mutants Found: Surviving mutants in `TxIdGenerator::default` and `NodeId::new_unchecked` 0-value paths.
🎯 Tests Added/Strengthened: Added coverage for `TxIdGenerator::default()` returning a sequence starting essentially at `1` (`current=0`), and verified `new_unchecked` can successfully wrap value `0` directly without panics for all ID structs.
⚠️ Suspected Bugs: None
📊 Kill Rate: Stabilized coverage in `src/core/id.rs`.
🔗 Havoc Interaction: None.

---
*PR created automatically by Jules for task [17049076987258572492](https://jules.google.com/task/17049076987258572492) started by @madmax983*