### PR TITLE
🦀 Core: Fix `clippy::collapsible_if` in `src/experimental/omen.rs`

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -4,4 +4,5 @@ No high-severity findings.
 - No missing tests were identified for correctness/regression risks. The core logic of finding the valid history version correctly maintains bounds checks and type validations.
 
 ### Residual risks
-- A known `clippy::collapsible_if` warning exists in `src/experimental/omen.rs` that is explicitly suppressed with `#[allow(clippy::collapsible_if)]`. This prevents CI failures under strict linting (`-D warnings`) but leaves nested `if` statements in the codebase. However, it poses no correctness, regression, or concurrency risk, and correctly resolves the issue without relying on unstable Rust features like let chains.
+- Fixed a known `clippy::collapsible_if` warning in `src/experimental/omen.rs` that was previously explicitly suppressed with `#[allow(clippy::collapsible_if)]`. The nested conditions inside `find_vector_at` were refactored using an early return (`continue` loop keyword) to properly flatten the conditional logic without using the unstable `let_chains` feature.
+- No correctness, data loss, concurrency, security, or API behavior regressions were found in `src/experimental/omen.rs`'s logical paths.

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -207,16 +207,12 @@ impl<'a> Omen<'a> {
 
         for v in &history.versions {
             let vt_start = v.temporal.valid_time().start().wallclock();
-            #[allow(clippy::collapsible_if)]
-            if vt_start <= time.wallclock() {
-                if vt_start >= best_time {
-                    if let Some(val) = v.properties.get(property) {
-                        if let Some(vec) = val.as_vector() {
-                            best_vec = Some(vec.to_vec());
-                            best_time = vt_start;
-                        }
-                    }
-                }
+            if vt_start > time.wallclock() || vt_start < best_time {
+                continue;
+            }
+            if let Some(vec) = v.properties.get(property).and_then(|val| val.as_vector()) {
+                best_vec = Some(vec.to_vec());
+                best_time = vt_start;
             }
         }
         best_vec


### PR DESCRIPTION
🦀 **Core Persona Review & Fix**

I performed a risk-first code review on the recent changes to `src/experimental/omen.rs`.

**Findings:**
*   No high-severity correctness, concurrency, or performance regression risks were identified in the vector prediction or historical scanning logic.
*   **Residual Risk Mitigated:** The explicit `#[allow(clippy::collapsible_if)]` suppression was removed and cleanly refactored. By using an early `continue` if the temporal bounds aren't met, the logic remains semantically identical but flat enough to satisfy the `clippy` lint natively without using the nightly/unstable `let_chains` feature.

**Changes:**
1.  Refactored nested `if` statements inside `Omen::find_vector_at()`.
2.  Updated `.jules/core_review.md` to document the lack of high-severity findings and explicitly note the handled residual risk.

**Verification:**
*   `cargo clippy --all-targets --all-features -- -D warnings` passes.
*   `cargo fmt --all` passes.
*   `cargo test -p aletheiadb --lib experimental::omen --features nova` passes.

---
*PR created automatically by Jules for task [1140785268063377136](https://jules.google.com/task/1140785268063377136) started by @madmax983*