### PR TITLE
🤖 Sentinel: kill missing mutant coverage in predicate pushdown

### DIFF
--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -312,6 +312,23 @@ mod tests {
     }
 
     #[test]
+    fn test_stop_filter_at_scan() {
+        let rule = PredicatePushdown;
+        let stats = test_stats();
+
+        // Filter(Scan)
+        // Should NOT push down because we stop at scans
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        // Should return None because pushdown was blocked by Scan
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn test_stop_filter_at_vector_rank_with_limit() {
         let rule = PredicatePushdown;
         let stats = test_stats();


### PR DESCRIPTION
Added `test_stop_filter_at_scan` in `src/query/planner/rules/predicate_pushdown.rs` to address missing coverage where the test suite previously didn't verify that a `Filter` operator is properly blocked by a `Scan` operator during pushdown logic. Verified that other files flagged in `.jules/sentinel.md` (`src/core/version.rs` and `src/core/property.rs`) already have the required tests implemented from a prior commit.

---
*PR created automatically by Jules for task [7846554538324705471](https://jules.google.com/task/7846554538324705471) started by @madmax983*