### PR TITLE
🎻 Bard: [query planner documentation update]

### DIFF
--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -13,6 +13,33 @@ use super::super::plan::{SortKey, TemporalContext};
 use super::cost::Cost;
 
 /// A physical query plan ready for execution.
+///
+/// This structure represents a compiled, optimized query plan that maps
+/// directly to execution operators. It contains the root operator tree,
+/// cost estimates, and execution context.
+///
+/// ## Examples
+///
+/// ```rust
+/// # use aletheiadb::core::NodeId;
+/// # use aletheiadb::query::planner::physical::{PhysicalPlan, PhysicalOp};
+/// # use aletheiadb::query::planner::cost::Cost;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Create a simple plan that looks up a node by ID
+/// let plan = PhysicalPlan {
+///     root: PhysicalOp::NodeLookup { node_ids: vec![NodeId::new(1)?] },
+///     estimated_cost: Cost { cpu: 0.5, io: 1.0, memory: 1024, network: 0.0 },
+///     temporal_context: None,
+///     parallel: false,
+///     include_provenance: false,
+/// };
+///
+/// assert!(!plan.is_temporal());
+/// assert_eq!(plan.cpu_cost(), 0.5);
+/// assert_eq!(plan.memory_cost(), 1024);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct PhysicalPlan {
     /// Root physical operator

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -26,6 +26,44 @@ use super::{OptimizationRule, Statistics};
 /// ```
 ///
 /// Non-Eq predicates and scans without a label are left unchanged.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::rules::{OptimizationRule, FilterScanFusion};
+/// use aletheiadb::query::planner::stats::Statistics;
+/// use aletheiadb::query::plan::{LogicalPlan, LogicalOp, UnaryOp, ScanOp};
+/// use aletheiadb::query::ir::{Predicate, PredicateValue};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // 1. Construct a sub-optimal plan: Filter on Top of NodeScan
+/// let scan = LogicalOp::Scan(ScanOp::NodeScan {
+///     label: Some("Person".into()),
+///     estimated_rows: Some(100),
+/// });
+/// let filter = LogicalOp::unary(
+///     UnaryOp::Filter(Predicate::Eq {
+///         key: "name".into(),
+///         value: PredicateValue::String("Alice".into())
+///     }),
+///     scan
+/// );
+///
+/// let plan = LogicalPlan { root: filter, temporal_context: None, hints: Default::default() };
+///
+/// // 2. Apply the rule
+/// let rule = FilterScanFusion;
+/// let stats = Statistics::new();
+/// let optimized_plan = rule.apply(&plan, &stats)?.unwrap(); // unwraps if `changed == true`
+///
+/// // 3. The rule fuses them into a single PropertyScan
+/// assert!(matches!(
+///     optimized_plan.root,
+///     LogicalOp::Scan(ScanOp::PropertyScan { .. })
+/// ));
+/// # Ok(())
+/// # }
+/// ```
 pub struct FilterScanFusion;
 
 impl OptimizationRule for FilterScanFusion {

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -31,6 +31,49 @@ use super::{OptimizationRule, Statistics};
 ///     Traverse(KNOWS)
 ///       NodeLookup([1])
 /// ```
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::rules::{OptimizationRule, LimitPushdown};
+/// use aletheiadb::query::planner::stats::Statistics;
+/// use aletheiadb::query::plan::{LogicalPlan, LogicalOp, UnaryOp, ScanOp, SortKey};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // 1. Construct a plan where LIMIT is separated from VectorRank
+/// let scan = LogicalOp::Scan(ScanOp::NodeScan {
+///     label: Some("Person".into()),
+///     estimated_rows: Some(100),
+/// });
+/// let rank = LogicalOp::unary(
+///     UnaryOp::VectorRank {
+///         embedding: vec![0.1, 0.2].into(),
+///         top_k: None, // Missing limit!
+///         property_key: None,
+///     },
+///     scan
+/// );
+/// let limit = LogicalOp::unary(UnaryOp::Limit(10), rank);
+///
+/// let plan = LogicalPlan { root: limit, temporal_context: None, hints: Default::default() };
+///
+/// // 2. Apply the rule
+/// let rule = LimitPushdown;
+/// let stats = Statistics::new();
+/// let optimized_plan = rule.apply(&plan, &stats)?.unwrap(); // unwraps if `changed == true`
+///
+/// // 3. The rule preserves the outer Limit but ALSO pushes it down to VectorRank
+/// if let LogicalOp::Unary { op: UnaryOp::Limit(10), input } = optimized_plan.root {
+///     assert!(matches!(
+///         *input,
+///         LogicalOp::Unary { op: UnaryOp::VectorRank { top_k: Some(10), .. }, .. }
+///     ));
+/// } else {
+///     panic!("Expected Limit operator at root");
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub struct LimitPushdown;
 
 impl OptimizationRule for LimitPushdown {

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -73,6 +73,55 @@ const FALSE_SELECTIVITY: f64 = 0.0;
 /// Filter(A) -> Filter(B) -> Scan
 /// (Filter A is applied first, reducing rows for Filter B)
 /// ```
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::rules::{OptimizationRule, OperationReordering};
+/// use aletheiadb::query::planner::stats::Statistics;
+/// use aletheiadb::query::plan::{LogicalPlan, LogicalOp, UnaryOp, ScanOp};
+/// use aletheiadb::query::ir::{Predicate, PredicateValue};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // 1. Construct a sub-optimal plan: A very selective filter (Eq) is ABOVE a less selective one (NotEq)
+/// let scan = LogicalOp::Scan(ScanOp::NodeScan {
+///     label: Some("Person".into()),
+///     estimated_rows: Some(100),
+/// });
+/// let filter_bad = LogicalOp::unary(
+///     UnaryOp::Filter(Predicate::Ne {
+///         key: "status".into(),
+///         value: PredicateValue::String("deleted".into())
+///     }),
+///     scan
+/// );
+/// let filter_good = LogicalOp::unary(
+///     UnaryOp::Filter(Predicate::Eq {
+///         key: "id".into(),
+///         value: PredicateValue::Int(42)
+///     }),
+///     filter_bad
+/// );
+///
+/// let plan = LogicalPlan { root: filter_good, temporal_context: None, hints: Default::default() };
+///
+/// // 2. Apply the rule
+/// let rule = OperationReordering;
+/// let stats = Statistics::new();
+/// let optimized_plan = rule.apply(&plan, &stats)?.unwrap(); // unwraps if `changed == true`
+///
+/// // 3. The rule reorders them so the more selective Filter(Eq) is applied first (deeper in the tree)
+/// if let LogicalOp::Unary { op: UnaryOp::Filter(Predicate::Ne { .. }), input } = optimized_plan.root {
+///     assert!(matches!(
+///         *input,
+///         LogicalOp::Unary { op: UnaryOp::Filter(Predicate::Eq { .. }), .. }
+///     ));
+/// } else {
+///     panic!("Expected Ne filter at root after reordering");
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub struct OperationReordering;
 
 impl OptimizationRule for OperationReordering {

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -84,6 +84,48 @@ use super::{OptimizationRule, Statistics};
 ///     Filter(active = true)  <-- Pushed down
 ///       Scan(...)
 /// ```
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::rules::{OptimizationRule, PredicatePushdown};
+/// use aletheiadb::query::planner::stats::Statistics;
+/// use aletheiadb::query::plan::{LogicalPlan, LogicalOp, UnaryOp, ScanOp, SortKey};
+/// use aletheiadb::query::ir::{Predicate, PredicateValue};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // 1. Construct a sub-optimal plan: Filter is applied AFTER sorting
+/// let scan = LogicalOp::Scan(ScanOp::NodeScan {
+///     label: Some("Person".into()),
+///     estimated_rows: Some(100),
+/// });
+/// let sort = LogicalOp::unary(
+///     UnaryOp::Sort { key: SortKey::Score, descending: true },
+///     scan
+/// );
+/// let filter = LogicalOp::unary(
+///     UnaryOp::Filter(Predicate::Eq {
+///         key: "active".into(),
+///         value: PredicateValue::Bool(true)
+///     }),
+///     sort
+/// );
+///
+/// let plan = LogicalPlan { root: filter, temporal_context: None, hints: Default::default() };
+///
+/// // 2. Apply the rule
+/// let rule = PredicatePushdown;
+/// let stats = Statistics::new();
+/// let optimized_plan = rule.apply(&plan, &stats)?.unwrap();
+///
+/// // 3. The rule pushed the Filter BELOW the Sort
+/// assert!(matches!(
+///     optimized_plan.root,
+///     LogicalOp::Unary { op: UnaryOp::Sort { .. }, input: _ }
+/// ));
+/// # Ok(())
+/// # }
+/// ```
 pub struct PredicatePushdown;
 
 impl OptimizationRule for PredicatePushdown {

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -31,6 +31,22 @@ use parking_lot::RwLock;
 use crate::core::interning::InternedString;
 
 /// Atomic f64 for lock-free floating-point statistics.
+///
+/// Converts `f64` into its bit representation to be stored
+/// lock-free within an `AtomicU64`.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::stats::AtomicF64;
+/// use std::sync::atomic::Ordering;
+///
+/// let value = AtomicF64::new(42.5);
+/// assert_eq!(value.load(Ordering::Acquire), 42.5);
+///
+/// value.store(100.0, Ordering::Release);
+/// assert_eq!(value.load(Ordering::Acquire), 100.0);
+/// ```
 #[derive(Debug)]
 pub struct AtomicF64 {
     inner: std::sync::atomic::AtomicU64,


### PR DESCRIPTION
📖 **Chapter:** The `query::planner` rules and structures.
🔦 **Insight:** Explained *why* and *how* query optimization rules (`PredicatePushdown`, `LimitPushdown`, `FilterScanFusion`, `OperationReordering`) transform logical plans using explicit, executable AST constructions. Added usage examples for `PhysicalPlan` and lock-free `AtomicF64` statistics.
🧪 **Example:** Added 6 comprehensive, executable doc-tests.
🖼️ **Preview:** `cargo doc` now shows these examples in HTML form.

---
*PR created automatically by Jules for task [1164022379394710019](https://jules.google.com/task/1164022379394710019) started by @madmax983*