### PR TITLE
🤖 Sentinel: eliminate mutants in query planner rules

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -68,3 +68,15 @@
 **Summary:** Potential regression in floating point equality semantics (NaN).
 **Diagnosis:** WEAK_TEST - Explicit verification of `NaN != NaN` (PartialEq) vs `NaN == NaN` (semantically_equal) was needed to prevent regressions.
 **Kill Shot:** Added `test_property_value_partial_eq_nan_semantics` in `src/core/property.rs`.
+
+**[Weak Test Coverage in Query Planner Reordering]**
+**Module:** `aletheiadb::query::planner::rules::operation_reordering`
+**Summary:** Numerous mutants survived in selectivity estimation formulas (replacing `-` with `+`), `estimate_cardinality` (replacing `*` with `/` for join cardinality), and in equality checks (`filters_equal` logic using `||` instead of `&&`, and missing match arms in `predicates_equal`).
+**Diagnosis:** WEAK_TEST / MISSING_COVERAGE - The test suite verified overall query plans but lacked explicit unit tests for the exact values and bounds used inside the query planner's selectivity equations, and it lacked exhaustive equality match checks.
+**Kill Shot:** Added `test_sentry_filters_equal_logic`, `test_sentry_estimate_cardinality_binary_op_formula`, `test_sentry_predicates_equal_variants`, and `test_sentry_reorder_filters_exact_selectivity` in `src/query/planner/rules/operation_reordering.rs`.
+
+**[Weak Test Coverage in Query Planner Pushdown]**
+**Module:** `aletheiadb::query::planner::rules::predicate_pushdown`
+**Summary:** Mutants survived that deleted the match arms preventing pushdown for `Scan`, `Traverse`, and `VectorRank(with limit)`. Another mutant replaced `||` with `&&` when returning `changed` status for binary operators.
+**Diagnosis:** WEAK_TEST / MISSING_COVERAGE - While integration tests verified general pushdown, specific tests checking the boundaries of where pushdown *stops* (or checking partial binary tree pushdown flags) were missing.
+**Kill Shot:** Added `test_sentry_push_down_scan`, `test_sentry_push_down_traverse`, `test_sentry_push_down_vector_rank_with_limit`, `test_sentry_push_down_sort`, and `test_sentry_push_down_binary_op_changed_flag` in `src/query/planner/rules/predicate_pushdown.rs`.

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -1065,3 +1065,284 @@ mod tests {
         assert_eq!(sel, NULL_CHECK_SELECTIVITY);
     }
 }
+
+#[cfg(test)]
+mod sentry_operation_reordering_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::ir::{Predicate, PredicateValue};
+    use crate::query::plan::{BinaryOp, LogicalOp, ScanOp, UnaryOp};
+
+    fn test_stats() -> Statistics {
+        Statistics::default()
+    }
+
+    #[test]
+    fn test_sentry_filters_equal_logic() {
+        // 🛡️ Sentry Test: Verify strict matching in `filters_equal`
+        // Targets mutants changing `&&` to `||` when combining predicates_equal and filters_equal.
+        let rule = OperationReordering;
+
+        let base_scan = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+        let base_empty = LogicalOp::Empty;
+
+        let filter_a = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            base_scan.clone(),
+        );
+
+        // Same predicate, different input type (Scan vs Empty) so discriminant differs
+        let filter_b = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            base_empty.clone(),
+        );
+
+        // Different predicate, same input
+        let filter_c = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Bob")),
+            base_scan.clone(),
+        );
+
+        // Same predicate, same input
+        let filter_d = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            base_scan.clone(),
+        );
+
+        assert!(
+            !rule.filters_equal(&filter_a, &filter_b),
+            "Should be false when inputs differ in discriminant"
+        );
+        assert!(
+            !rule.filters_equal(&filter_a, &filter_c),
+            "Should be false when predicates differ"
+        );
+        assert!(
+            rule.filters_equal(&filter_a, &filter_d),
+            "Should be true when both match"
+        );
+    }
+
+    #[test]
+    fn test_sentry_estimate_cardinality_binary_op_formula() {
+        // 🛡️ Sentry Test: Verify exact cardinality estimation formula for BinaryOp (Join)
+        // Targets mutants changing * to / or + or omitting the 0.1 factor.
+        let rule = OperationReordering;
+
+        // Left card = 1000
+        let left = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(1000),
+        });
+
+        // Right card = 200
+        let right = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(200),
+        });
+
+        let binary_op = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "k1".to_string(),
+                right_key: "k2".to_string(),
+            },
+            left,
+            right,
+        );
+
+        // Formula: (left_card * right_card * 0.1) as usize
+        // (1000 * 200 * 0.1) = 200000 * 0.1 = 20000
+        assert_eq!(rule.estimate_cardinality(&binary_op), 20000);
+    }
+
+    #[test]
+    fn test_sentry_predicates_equal_variants() {
+        // 🛡️ Sentry Test: Verify all Predicate variants are correctly matched in predicates_equal.
+        // Targets mutants that delete match arms or replace `&&` with `||` / `==` with `!=` in the comparisons.
+        let rule = OperationReordering;
+
+        let eq1 = Predicate::Eq {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        let eq2 = Predicate::Eq {
+            key: "k".to_string(),
+            value: PredicateValue::Int(2),
+        };
+        assert!(rule.predicates_equal(&eq1, &eq1));
+        assert!(!rule.predicates_equal(&eq1, &eq2));
+
+        let ne1 = Predicate::Ne {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        let ne2 = Predicate::Ne {
+            key: "k".to_string(),
+            value: PredicateValue::Int(2),
+        };
+        assert!(rule.predicates_equal(&ne1, &ne1));
+        assert!(!rule.predicates_equal(&ne1, &ne2));
+
+        let gt1 = Predicate::Gt {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        let gt2 = Predicate::Gt {
+            key: "k".to_string(),
+            value: PredicateValue::Int(2),
+        };
+        assert!(rule.predicates_equal(&gt1, &gt1));
+        assert!(!rule.predicates_equal(&gt1, &gt2));
+
+        let gte1 = Predicate::Gte {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        let gte2 = Predicate::Gte {
+            key: "k".to_string(),
+            value: PredicateValue::Int(2),
+        };
+        assert!(rule.predicates_equal(&gte1, &gte1));
+        assert!(!rule.predicates_equal(&gte1, &gte2));
+
+        let lt1 = Predicate::Lt {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        let lt2 = Predicate::Lt {
+            key: "k".to_string(),
+            value: PredicateValue::Int(2),
+        };
+        assert!(rule.predicates_equal(&lt1, &lt1));
+        assert!(!rule.predicates_equal(&lt1, &lt2));
+
+        let lte1 = Predicate::Lte {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        let lte2 = Predicate::Lte {
+            key: "k".to_string(),
+            value: PredicateValue::Int(2),
+        };
+        assert!(rule.predicates_equal(&lte1, &lte1));
+        assert!(!rule.predicates_equal(&lte1, &lte2));
+
+        let in1 = Predicate::In {
+            key: "k".to_string(),
+            values: vec![PredicateValue::Int(1)],
+        };
+        let in2 = Predicate::In {
+            key: "k".to_string(),
+            values: vec![PredicateValue::Int(2)],
+        };
+        assert!(rule.predicates_equal(&in1, &in1));
+        assert!(!rule.predicates_equal(&in1, &in2));
+
+        let c1 = Predicate::Contains {
+            key: "k".to_string(),
+            substring: "a".to_string(),
+        };
+        let c2 = Predicate::Contains {
+            key: "k".to_string(),
+            substring: "b".to_string(),
+        };
+        assert!(rule.predicates_equal(&c1, &c1));
+        assert!(!rule.predicates_equal(&c1, &c2));
+
+        let s1 = Predicate::StartsWith {
+            key: "k".to_string(),
+            prefix: "a".to_string(),
+        };
+        let s2 = Predicate::StartsWith {
+            key: "k".to_string(),
+            prefix: "b".to_string(),
+        };
+        assert!(rule.predicates_equal(&s1, &s1));
+        assert!(!rule.predicates_equal(&s1, &s2));
+
+        let e1 = Predicate::EndsWith {
+            key: "k".to_string(),
+            suffix: "a".to_string(),
+        };
+        let e2 = Predicate::EndsWith {
+            key: "k".to_string(),
+            suffix: "b".to_string(),
+        };
+        assert!(rule.predicates_equal(&e1, &e1));
+        assert!(!rule.predicates_equal(&e1, &e2));
+
+        let ex1 = Predicate::Exists("k1".to_string());
+        let ex2 = Predicate::Exists("k2".to_string());
+        assert!(rule.predicates_equal(&ex1, &ex1));
+        assert!(!rule.predicates_equal(&ex1, &ex2));
+
+        let nex1 = Predicate::NotExists("k1".to_string());
+        let nex2 = Predicate::NotExists("k2".to_string());
+        assert!(rule.predicates_equal(&nex1, &nex1));
+        assert!(!rule.predicates_equal(&nex1, &nex2));
+
+        let and1 = Predicate::And(vec![Predicate::True, Predicate::False]);
+        let and2 = Predicate::And(vec![Predicate::True, Predicate::True]);
+        assert!(rule.predicates_equal(&and1, &and1));
+        assert!(!rule.predicates_equal(&and1, &and2));
+
+        let or1 = Predicate::Or(vec![Predicate::True, Predicate::False]);
+        let or2 = Predicate::Or(vec![Predicate::True, Predicate::True]);
+        assert!(rule.predicates_equal(&or1, &or1));
+        assert!(!rule.predicates_equal(&or1, &or2));
+
+        let not1 = Predicate::Not(Box::new(Predicate::True));
+        let not2 = Predicate::Not(Box::new(Predicate::False));
+        assert!(rule.predicates_equal(&not1, &not1));
+        assert!(!rule.predicates_equal(&not1, &not2));
+    }
+
+    #[test]
+    fn test_sentry_reorder_filters_exact_selectivity() {
+        // 🛡️ Sentry Test: Verify exact selectivity values inside `estimate_filter_selectivity`
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        let p_gt = Predicate::Gt {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        assert_eq!(
+            rule.estimate_filter_selectivity(&p_gt, &stats),
+            RANGE_PREDICATE_SELECTIVITY
+        );
+
+        let p_contains = Predicate::Contains {
+            key: "k".to_string(),
+            substring: "a".to_string(),
+        };
+        assert_eq!(
+            rule.estimate_filter_selectivity(&p_contains, &stats),
+            STRING_PREDICATE_SELECTIVITY
+        );
+
+        let p_ne = Predicate::Ne {
+            key: "k".to_string(),
+            value: PredicateValue::Int(1),
+        };
+        assert_eq!(
+            rule.estimate_filter_selectivity(&p_ne, &stats),
+            NOT_EQUALS_SELECTIVITY
+        );
+
+        let p_in = Predicate::In {
+            key: "k".to_string(),
+            values: vec![],
+        };
+        assert_eq!(
+            rule.estimate_filter_selectivity(&p_in, &stats),
+            IN_PREDICATE_SELECTIVITY
+        );
+
+        let p_exists = Predicate::Exists("k".to_string());
+        assert_eq!(
+            rule.estimate_filter_selectivity(&p_exists, &stats),
+            EXISTENCE_CHECK_SELECTIVITY
+        );
+    }
+}

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -557,3 +557,137 @@ mod sentry_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod sentry_predicate_pushdown_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::ir::Predicate;
+    use crate::query::plan::{BinaryOp, LogicalOp, ScanOp, SortKey, UnaryOp};
+    use std::sync::Arc;
+
+    fn test_stats() -> Statistics {
+        Statistics::default()
+    }
+
+    #[test]
+    fn test_sentry_push_down_scan() {
+        // 🛡️ Sentry Test: Verify that push_down stops at LogicalOp::Scan
+        // Targets mutant deleting match arm `LogicalOp::Scan(_)`.
+        let rule = PredicatePushdown;
+        let stats = test_stats();
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none(), "Should return None for Scan (no change)");
+    }
+
+    #[test]
+    fn test_sentry_push_down_traverse() {
+        // 🛡️ Sentry Test: Verify that push_down stops at Traverse
+        // Targets mutant deleting match arm `LogicalOp::Unary{op:UnaryOp::Traverse{..}, ..}`.
+        let rule = PredicatePushdown;
+        let stats = test_stats();
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::unary(
+                UnaryOp::Traverse {
+                    label: None,
+                    direction: crate::query::ir::Direction::Outgoing,
+                    depth: crate::query::ir::TraversalDepth::default(),
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(
+            result.is_none(),
+            "Should return None for Traverse (no change)"
+        );
+    }
+
+    #[test]
+    fn test_sentry_push_down_vector_rank_with_limit() {
+        // 🛡️ Sentry Test: Verify that push_down stops at VectorRank with limit
+        // Targets mutant deleting match arm for VectorRank.
+        let rule = PredicatePushdown;
+        let stats = test_stats();
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::unary(
+                UnaryOp::VectorRank {
+                    embedding: Arc::from([0.1f32; 4].as_slice()),
+                    top_k: Some(10),
+                    property_key: None,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(
+            result.is_none(),
+            "Should not push down through VectorRank with limit"
+        );
+    }
+
+    #[test]
+    fn test_sentry_push_down_sort() {
+        // 🛡️ Sentry Test: Verify that push_down succeeds through Sort
+        // Targets mutant deleting match arm for Sort.
+        let rule = PredicatePushdown;
+        let stats = test_stats();
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: SortKey::Property("name".to_string()),
+                    descending: false,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should push down through Sort");
+    }
+
+    #[test]
+    fn test_sentry_push_down_binary_op_changed_flag() {
+        // 🛡️ Sentry Test: Verify || logic in BinaryOp changed flag
+        // Targets replacing || with && for left_changed || right_changed
+        let rule = PredicatePushdown;
+
+        // Right side will change: Filter -> Sort
+        let right_op = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("active", true)),
+            LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: SortKey::Property("created".to_string()),
+                    descending: true,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        );
+
+        // Left side will NOT change: Scan
+        let left_op = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+
+        // Binary Op: Union(Left, Right)
+        let binary_op = LogicalOp::binary(BinaryOp::Union, left_op, right_op);
+
+        let (_, changed) = rule.push_down(&binary_op).unwrap();
+        assert!(
+            changed,
+            "Should return changed=true when ONLY the right side changes"
+        );
+    }
+}


### PR DESCRIPTION
**🧬 Mutants Found:** Dozens of surviving mutants in `operation_reordering.rs` (especially in equality checking and mathematical formulas) and `predicate_pushdown.rs` (in deleted match arms and binary operator changed status).
**🎯 Tests Added/Strengthened:**
*   Added `test_sentry_filters_equal_logic` and `test_sentry_predicates_equal_variants` to ensure structural equality ignores no properties.
*   Added `test_sentry_estimate_cardinality_binary_op_formula` and `test_sentry_reorder_filters_exact_selectivity` to test specific math formulas directly.
*   Added `test_sentry_push_down_scan`, `test_sentry_push_down_traverse`, `test_sentry_push_down_vector_rank_with_limit`, and `test_sentry_push_down_sort` to confirm exactly when pushdown continues or halts.
*   Added `test_sentry_push_down_binary_op_changed_flag` to verify logical flag propagation.
**⚠️ Suspected Bugs:** None.
**📊 Kill Rate:** Mutants successfully killed. No code changes required, purely tests added.

---
*PR created automatically by Jules for task [10599452165454522256](https://jules.google.com/task/10599452165454522256) started by @madmax983*