### PR TITLE
🤖 Sentinel: Eliminate logic gap in OperationReordering binary ops

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -68,3 +68,9 @@
 **Summary:** Potential regression in floating point equality semantics (NaN).
 **Diagnosis:** WEAK_TEST - Explicit verification of `NaN != NaN` (PartialEq) vs `NaN == NaN` (semantically_equal) was needed to prevent regressions.
 **Kill Shot:** Added `test_property_value_partial_eq_nan_semantics` in `src/core/property.rs`.
+
+**[Weak Test Coverage in Partial Optimization Logic]**
+**Module:** src/query/planner/rules/operation_reordering.rs
+**Summary:** The mutant `replace || with && in OperationReordering::reorder` survived for binary operators. This means existing tests don't adequately check that the rule triggers correctly when only one branch of a binary operator (e.g., Union) is changed.
+**Diagnosis:** WEAK_TEST - No test covers a binary operator (like Union) where one branch gets optimized and the other remains unchanged, causing the `changed` flag to incorrectly be `false` if `&&` is used instead of `||`.
+**Kill Shot:** Added `test_binary_op_recursion_logic` which creates a `BinaryOp::Union` with an optimizable left branch and an unchanged right branch, asserting that the rule applies correctly.

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -1064,4 +1064,39 @@ mod tests {
         let sel = rule.estimate_filter_selectivity(&pred, &stats);
         assert_eq!(sel, NULL_CHECK_SELECTIVITY);
     }
+
+    #[test]
+    fn test_binary_op_recursion_logic() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        // Use a binary op like Union (anything but Join to hit the default Binary case)
+        let left_op = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("common_property", "value")),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("rare_property", "value")),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(1000),
+                }),
+            ),
+        );
+
+        let right_op = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(1000),
+        });
+
+        // Binary(Union, Left, Right)
+        // Left side will be optimized (Filter reordered) -> changed = true
+        // Right side is Scan -> changed = false
+        // Total changed = true || false = true
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left_op, right_op));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(
+            result.is_some(),
+            "Binary op with one changed branch should return Some"
+        );
+    }
 }


### PR DESCRIPTION
**🧬 Mutants Found:** 1 surviving mutant (`replace || with && in OperationReordering::reorder` for binary operators).
**🎯 Tests Added/Strengthened:** Added `test_binary_op_recursion_logic` in `src/query/planner/rules/operation_reordering.rs` to ensure partial optimization sets `changed=true`.
**⚠️ Suspected Bugs:** None.
**📊 Kill Rate:** Improved mutant kill rate by ensuring boolean flags on binary operations are handled correctly.
**🔗 Havoc Interaction:** N/A.

---
*PR created automatically by Jules for task [3027995728288016572](https://jules.google.com/task/3027995728288016572) started by @madmax983*