### PR TITLE
core: centralize error metrics and preserve error semantics

### DIFF
--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -7,7 +7,7 @@
 //! - No commit overhead
 
 use super::{ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager};
-use crate::core::error::{Result, StorageError};
+use crate::core::error::{Result, ResultExt, StorageError};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::property::PropertyValue;
@@ -204,43 +204,45 @@ impl ReadTransaction {
 
 impl ReadOps for ReadTransaction {
     fn get_node(&self, id: NodeId) -> Result<Node> {
-        // FAST PATH: Try current storage first
-        // Note: Use if-let to handle deletion case (when node was deleted after snapshot)
-        if let Ok(current_node) = self.current.get_node(id) {
+        let result = if let Ok(current_node) = self.current.get_node(id) {
             // Check if current version is visible in our snapshot
             if self
                 .visibility_manager
                 .is_visible(&self.snapshot, current_node.metadata.created_by_tx)
             {
-                return Ok(current_node);
+                Ok(current_node)
+            } else {
+                // If not visible, fall through to the slow path.
+                self.get_node_from_historical(id)
             }
-            // If not visible, fall through to the slow path
-        }
-        // If the node is not in current storage (e.g., it was deleted),
-        // we must still check historical storage
+        } else {
+            // If the node is not in current storage (e.g., it was deleted),
+            // we must still check historical storage.
+            self.get_node_from_historical(id)
+        };
 
-        // SLOW PATH: Query historical storage for version visible at snapshot time
-        self.get_node_from_historical(id)
+        result.record_error_metric()
     }
 
     fn get_edge(&self, id: EdgeId) -> Result<Edge> {
-        // FAST PATH: Try current storage first
-        // Note: Use if-let to handle deletion case (when edge was deleted after snapshot)
-        if let Ok(current_edge) = self.current.get_edge(id) {
+        let result = if let Ok(current_edge) = self.current.get_edge(id) {
             // Check if current version is visible in our snapshot
             if self
                 .visibility_manager
                 .is_visible(&self.snapshot, current_edge.metadata.created_by_tx)
             {
-                return Ok(current_edge);
+                Ok(current_edge)
+            } else {
+                // If not visible, fall through to the slow path.
+                self.get_edge_from_historical(id)
             }
-            // If not visible, fall through to the slow path
-        }
-        // If the edge is not in current storage (e.g., it was deleted),
-        // we must still check historical storage
+        } else {
+            // If the edge is not in current storage (e.g., it was deleted),
+            // we must still check historical storage.
+            self.get_edge_from_historical(id)
+        };
 
-        // SLOW PATH: Query historical storage for version visible at snapshot time
-        self.get_edge_from_historical(id)
+        result.record_error_metric()
     }
 
     fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -13,7 +13,7 @@ use super::{
     ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager, WriteBuffer,
     WriteOps,
 };
-use crate::core::error::{Result, StorageError, TransactionError};
+use crate::core::error::{Result, ResultExt, StorageError, TransactionError};
 use crate::core::graph::{Edge, Node};
 use crate::core::hlc::{
     SendWithSelfHealError, evaluate_clock_skew, is_clock_skew_self_heal_enabled,
@@ -332,6 +332,10 @@ impl WriteTransaction {
     /// - **GroupCommit**: Waits for batch fsync (ACID + high throughput)
     /// - **AsyncBatched**: Returns after flush to OS cache, batched fsync in background (<100µs latency)
     pub fn commit_with_timestamp(mut self) -> Result<Timestamp> {
+        self.commit_with_timestamp_inner().record_error_metric()
+    }
+
+    fn commit_with_timestamp_inner(&mut self) -> Result<Timestamp> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!(
             "transaction_commit",
@@ -490,7 +494,7 @@ impl WriteTransaction {
 
             // Log operations to WAL (lock-free striped append!)
             // This must happen BEFORE applying changes for durability.
-            wal::log_operations_to_wal(&self, commit)?;
+            wal::log_operations_to_wal(self, commit)?;
 
             #[cfg(feature = "observability")]
             let wal_logged = std::time::Instant::now();
@@ -546,7 +550,7 @@ impl WriteTransaction {
         };
 
         // Apply all changes atomically
-        apply::apply_changes(&self, commit_timestamp)?;
+        apply::apply_changes(self, commit_timestamp)?;
 
         // Notify temporal vector index of transaction completion (for snapshot creation)
         // Only call this if the transaction modified vector properties to avoid unnecessary overhead
@@ -660,74 +664,77 @@ impl WriteTransaction {
 
 impl ReadOps for WriteTransaction {
     fn get_node(&self, id: NodeId) -> Result<Node> {
-        // Read-your-writes: check write buffer first
-        if let Some(buffered) = self.buffer.get_node_write(id) {
-            match buffered {
+        let buffered_result = self
+            .buffer
+            .get_node_write(id)
+            .and_then(|buffered| match buffered {
                 super::BufferedWrite::CreateNode {
                     node_id,
                     label,
                     properties,
                     version_id,
                     ..
-                } => {
-                    // Return the buffered node
-                    return Ok(Node::with_metadata(
-                        *node_id,
-                        *label,
-                        properties.clone(),
-                        *version_id,
-                        VersionMetadata {
-                            created_by_tx: self.tx_id,
-                            commit_timestamp: None, // Not yet committed
-                        },
-                    ));
-                }
+                } => Some(Ok(Node::with_metadata(
+                    *node_id,
+                    *label,
+                    properties.clone(),
+                    *version_id,
+                    VersionMetadata {
+                        created_by_tx: self.tx_id,
+                        commit_timestamp: None, // Not yet committed
+                    },
+                ))),
                 super::BufferedWrite::UpdateNode {
                     node_id,
                     label,
                     properties,
                     version_id,
                     ..
-                } => {
-                    // Return the updated node
-                    return Ok(Node::with_metadata(
-                        *node_id,
-                        *label,
-                        properties.clone(),
-                        *version_id,
-                        VersionMetadata {
-                            created_by_tx: self.tx_id,
-                            commit_timestamp: None,
-                        },
-                    ));
-                }
+                } => Some(Ok(Node::with_metadata(
+                    *node_id,
+                    *label,
+                    properties.clone(),
+                    *version_id,
+                    VersionMetadata {
+                        created_by_tx: self.tx_id,
+                        commit_timestamp: None,
+                    },
+                ))),
                 super::BufferedWrite::DeleteNode { .. } => {
-                    // Node has been deleted in this transaction
-                    return Err(StorageError::NodeNotFound(id).into());
+                    Some(Err(StorageError::NodeNotFound(id).into()))
                 }
-                _ => {} // Not a node operation
+                _ => None, // Not a node operation
+            });
+
+        let result = if let Some(result) = buffered_result {
+            result
+        } else {
+            // Fall back to snapshot-isolated read from storage
+            match self.current.get_node(id) {
+                Ok(node) => {
+                    // Check if this version is visible in our snapshot
+                    if !self
+                        .visibility_manager
+                        .is_visible(&self.snapshot, node.metadata.created_by_tx)
+                    {
+                        // Version not visible - return NodeNotFound
+                        Err(StorageError::NodeNotFound(id).into())
+                    } else {
+                        Ok(node)
+                    }
+                }
+                Err(err) => Err(err),
             }
-        }
+        };
 
-        // Fall back to snapshot-isolated read from storage
-        let node = self.current.get_node(id)?;
-
-        // Check if this version is visible in our snapshot
-        if !self
-            .visibility_manager
-            .is_visible(&self.snapshot, node.metadata.created_by_tx)
-        {
-            // Version not visible - return NodeNotFound
-            return Err(StorageError::NodeNotFound(id).into());
-        }
-
-        Ok(node)
+        result.record_error_metric()
     }
 
     fn get_edge(&self, id: EdgeId) -> Result<Edge> {
-        // Read-your-writes: check write buffer first
-        if let Some(buffered) = self.buffer.get_edge_write(id) {
-            match buffered {
+        let buffered_result = self
+            .buffer
+            .get_edge_write(id)
+            .and_then(|buffered| match buffered {
                 super::BufferedWrite::CreateEdge {
                     edge_id,
                     source,
@@ -736,21 +743,18 @@ impl ReadOps for WriteTransaction {
                     properties,
                     version_id,
                     ..
-                } => {
-                    // Return the buffered edge
-                    return Ok(Edge::with_metadata(
-                        *edge_id,
-                        *label,
-                        *source,
-                        *target,
-                        properties.clone(),
-                        *version_id,
-                        VersionMetadata {
-                            created_by_tx: self.tx_id,
-                            commit_timestamp: None,
-                        },
-                    ));
-                }
+                } => Some(Ok(Edge::with_metadata(
+                    *edge_id,
+                    *label,
+                    *source,
+                    *target,
+                    properties.clone(),
+                    *version_id,
+                    VersionMetadata {
+                        created_by_tx: self.tx_id,
+                        commit_timestamp: None,
+                    },
+                ))),
                 super::BufferedWrite::UpdateEdge {
                     edge_id,
                     source,
@@ -759,42 +763,46 @@ impl ReadOps for WriteTransaction {
                     properties,
                     version_id,
                     ..
-                } => {
-                    // Return the updated edge
-                    return Ok(Edge::with_metadata(
-                        *edge_id,
-                        *label,
-                        *source,
-                        *target,
-                        properties.clone(),
-                        *version_id,
-                        VersionMetadata {
-                            created_by_tx: self.tx_id,
-                            commit_timestamp: None,
-                        },
-                    ));
-                }
+                } => Some(Ok(Edge::with_metadata(
+                    *edge_id,
+                    *label,
+                    *source,
+                    *target,
+                    properties.clone(),
+                    *version_id,
+                    VersionMetadata {
+                        created_by_tx: self.tx_id,
+                        commit_timestamp: None,
+                    },
+                ))),
                 super::BufferedWrite::DeleteEdge { .. } => {
-                    // Edge has been deleted in this transaction
-                    return Err(StorageError::EdgeNotFound(id).into());
+                    Some(Err(StorageError::EdgeNotFound(id).into()))
                 }
-                _ => {} // Not an edge operation
+                _ => None, // Not an edge operation
+            });
+
+        let result = if let Some(result) = buffered_result {
+            result
+        } else {
+            // Fall back to snapshot-isolated read from storage
+            match self.current.get_edge(id) {
+                Ok(edge) => {
+                    // Check if this version is visible in our snapshot
+                    if !self
+                        .visibility_manager
+                        .is_visible(&self.snapshot, edge.metadata.created_by_tx)
+                    {
+                        // Version not visible - return EdgeNotFound
+                        Err(StorageError::EdgeNotFound(id).into())
+                    } else {
+                        Ok(edge)
+                    }
+                }
+                Err(err) => Err(err),
             }
-        }
+        };
 
-        // Fall back to snapshot-isolated read from storage
-        let edge = self.current.get_edge(id)?;
-
-        // Check if this version is visible in our snapshot
-        if !self
-            .visibility_manager
-            .is_visible(&self.snapshot, edge.metadata.created_by_tx)
-        {
-            // Version not visible - return EdgeNotFound
-            return Err(StorageError::EdgeNotFound(id).into());
-        }
-
-        Ok(edge)
+        result.record_error_metric()
     }
 
     fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
@@ -885,37 +893,41 @@ impl WriteOps for WriteTransaction {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<NodeId> {
-        // Check transaction state
-        if self.state != TxState::Active {
-            return Err(TransactionError::InvalidState {
-                current: format!("{:?}", self.state),
-                expected: "Active".to_string(),
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
             }
-            .into());
-        }
 
-        // Generate IDs
-        let node_id = NodeId::new_unchecked(self.node_id_gen.next()?);
-        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
-        let label_interned = GLOBAL_INTERNER.intern(label)?;
+            // Generate IDs
+            let node_id = NodeId::new_unchecked(self.node_id_gen.next()?);
+            let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+            let label_interned = GLOBAL_INTERNER.intern(label)?;
 
-        // Get timestamp: use provided valid_from or default to transaction start time
-        let timestamp = self.start_timestamp;
-        let valid_from = valid_from.unwrap_or(timestamp);
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = valid_from.unwrap_or(timestamp);
 
-        // Validate valid_from is not too far in future
-        validation::validate_valid_from_future(valid_from)?;
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
 
-        // Buffer the write
-        self.buffer.add(super::BufferedWrite::CreateNode {
-            node_id,
-            version_id,
-            label: label_interned,
-            properties,
-            valid_from,
-        })?;
+            // Buffer the write
+            self.buffer.add(super::BufferedWrite::CreateNode {
+                node_id,
+                version_id,
+                label: label_interned,
+                properties,
+                valid_from,
+            })?;
 
-        Ok(node_id)
+            Ok(node_id)
+        })();
+
+        result.record_error_metric()
     }
 
     fn create_edge_with_valid_time(
@@ -926,36 +938,40 @@ impl WriteOps for WriteTransaction {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<EdgeId> {
-        // Check transaction state
-        if self.state != TxState::Active {
-            return Err(TransactionError::InvalidState {
-                current: format!("{:?}", self.state),
-                expected: "Active".to_string(),
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
             }
-            .into());
-        }
 
-        // Generate IDs
-        let edge_id = EdgeId::new_unchecked(self.edge_id_gen.next()?);
-        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
-        let label_interned = GLOBAL_INTERNER.intern(label)?;
+            // Generate IDs
+            let edge_id = EdgeId::new_unchecked(self.edge_id_gen.next()?);
+            let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+            let label_interned = GLOBAL_INTERNER.intern(label)?;
 
-        // Get timestamp: use provided valid_from or default to transaction start time
-        let timestamp = self.start_timestamp;
-        let valid_from = valid_from.unwrap_or(timestamp);
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = valid_from.unwrap_or(timestamp);
 
-        // Buffer the write
-        self.buffer.add(super::BufferedWrite::CreateEdge {
-            edge_id,
-            version_id,
-            source,
-            target,
-            label: label_interned,
-            properties,
-            valid_from,
-        })?;
+            // Buffer the write
+            self.buffer.add(super::BufferedWrite::CreateEdge {
+                edge_id,
+                version_id,
+                source,
+                target,
+                label: label_interned,
+                properties,
+                valid_from,
+            })?;
 
-        Ok(edge_id)
+            Ok(edge_id)
+        })();
+
+        result.record_error_metric()
     }
 
     fn update_node_with_valid_time(
@@ -964,62 +980,66 @@ impl WriteOps for WriteTransaction {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<()> {
-        // Check transaction state
-        if self.state != TxState::Active {
-            return Err(TransactionError::InvalidState {
-                current: format!("{:?}", self.state),
-                expected: "Active".to_string(),
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
             }
-            .into());
-        }
 
-        // Get current node to preserve label and existing properties
-        let node = self.current.get_node(node_id)?;
-        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+            // Get current node to preserve label and existing properties
+            let node = self.current.get_node(node_id)?;
+            let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
 
-        // PATCH semantics: Merge new properties with existing ones
-        // Start with existing properties
-        let mut builder = PropertyMapBuilder::from_map(node.properties.clone());
+            // PATCH semantics: Merge new properties with existing ones
+            // Start with existing properties
+            let mut builder = PropertyMapBuilder::from_map(node.properties.clone());
 
-        // Update/add properties from the incoming map
-        for (key, value) in properties.iter() {
-            builder = builder.insert_by_key(*key, value.clone());
-        }
+            // Update/add properties from the incoming map
+            for (key, value) in properties.iter() {
+                builder = builder.insert_by_key(*key, value.clone());
+            }
 
-        // Build the final merged property map
-        let merged_properties = builder.build();
+            // Build the final merged property map
+            let merged_properties = builder.build();
 
-        // Get timestamp: use provided valid_from or default to transaction start time
-        let timestamp = self.start_timestamp;
-        let valid_from = valid_from.unwrap_or(timestamp);
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = valid_from.unwrap_or(timestamp);
 
-        // Validate valid_from is not too far in future
-        validation::validate_valid_from_future(valid_from)?;
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
 
-        // Validate valid_from is not before entity creation
-        let historical = self.historical.read();
-        if let Some(current_version_id) = historical.get_current_node_version(node_id)
-            && let Some(current_version) = historical.get_node_version(current_version_id)
-        {
-            let creation_time = current_version.temporal.valid_time().start();
-            drop(historical); // Release lock before calling validation
-            validation::validate_valid_from_not_before_creation(
-                &format!("node:{}", node_id.as_u64()),
-                creation_time,
+            // Validate valid_from is not before entity creation
+            let historical = self.historical.read();
+            if let Some(current_version_id) = historical.get_current_node_version(node_id)
+                && let Some(current_version) = historical.get_node_version(current_version_id)
+            {
+                let creation_time = current_version.temporal.valid_time().start();
+                drop(historical); // Release lock before calling validation
+                validation::validate_valid_from_not_before_creation(
+                    &format!("node:{}", node_id.as_u64()),
+                    creation_time,
+                    valid_from,
+                )?;
+            }
+
+            // Buffer the write with merged properties
+            self.buffer.add(super::BufferedWrite::UpdateNode {
+                node_id,
+                version_id,
+                label: node.label,
+                properties: merged_properties,
                 valid_from,
-            )?;
-        }
+            })?;
 
-        // Buffer the write with merged properties
-        self.buffer.add(super::BufferedWrite::UpdateNode {
-            node_id,
-            version_id,
-            label: node.label,
-            properties: merged_properties,
-            valid_from,
-        })?;
+            Ok(())
+        })();
 
-        Ok(())
+        result.record_error_metric()
     }
 
     fn update_edge_with_valid_time(
@@ -1028,47 +1048,51 @@ impl WriteOps for WriteTransaction {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<()> {
-        // Check transaction state
-        if self.state != TxState::Active {
-            return Err(TransactionError::InvalidState {
-                current: format!("{:?}", self.state),
-                expected: "Active".to_string(),
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
             }
-            .into());
-        }
 
-        // Get current edge to preserve source, target, label and existing properties
-        let edge = self.current.get_edge(edge_id)?;
-        let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
+            // Get current edge to preserve source, target, label and existing properties
+            let edge = self.current.get_edge(edge_id)?;
+            let version_id = VersionId::new_unchecked(self.version_id_gen.next()?);
 
-        // PATCH semantics: Merge new properties with existing ones
-        // Start with existing properties
-        let mut builder = PropertyMapBuilder::from_map(edge.properties.clone());
+            // PATCH semantics: Merge new properties with existing ones
+            // Start with existing properties
+            let mut builder = PropertyMapBuilder::from_map(edge.properties.clone());
 
-        // Update/add properties from the incoming map
-        for (key, value) in properties.iter() {
-            builder = builder.insert_by_key(*key, value.clone());
-        }
+            // Update/add properties from the incoming map
+            for (key, value) in properties.iter() {
+                builder = builder.insert_by_key(*key, value.clone());
+            }
 
-        // Build the final merged property map
-        let merged_properties = builder.build();
+            // Build the final merged property map
+            let merged_properties = builder.build();
 
-        // Get timestamp: use provided valid_from or default to transaction start time
-        let timestamp = self.start_timestamp;
-        let valid_from = valid_from.unwrap_or(timestamp);
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = valid_from.unwrap_or(timestamp);
 
-        // Buffer the write with merged properties
-        self.buffer.add(super::BufferedWrite::UpdateEdge {
-            edge_id,
-            version_id,
-            source: edge.source,
-            target: edge.target,
-            label: edge.label,
-            properties: merged_properties,
-            valid_from,
-        })?;
+            // Buffer the write with merged properties
+            self.buffer.add(super::BufferedWrite::UpdateEdge {
+                edge_id,
+                version_id,
+                source: edge.source,
+                target: edge.target,
+                label: edge.label,
+                properties: merged_properties,
+                valid_from,
+            })?;
 
-        Ok(())
+            Ok(())
+        })();
+
+        result.record_error_metric()
     }
 
     fn delete_node_with_valid_time(
@@ -1076,52 +1100,56 @@ impl WriteOps for WriteTransaction {
         node_id: NodeId,
         valid_from: Option<Timestamp>,
     ) -> Result<()> {
-        // Check transaction state
-        if self.state != TxState::Active {
-            return Err(TransactionError::InvalidState {
-                current: format!("{:?}", self.state),
-                expected: "Active".to_string(),
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
             }
-            .into());
-        }
 
-        // Verify node exists and check for vector properties
-        let node = self.current.get_node(node_id)?;
+            // Verify node exists and check for vector properties
+            let node = self.current.get_node(node_id)?;
 
-        // If the node being deleted contains vector properties, mark the buffer
-        // to ensure the temporal vector index is notified on commit
-        if !self.buffer.has_vector_operations() && node.properties.contains_vector() {
-            self.buffer.mark_has_vector_operations();
-        }
+            // If the node being deleted contains vector properties, mark the buffer
+            // to ensure the temporal vector index is notified on commit
+            if !self.buffer.has_vector_operations() && node.properties.contains_vector() {
+                self.buffer.mark_has_vector_operations();
+            }
 
-        // Get timestamp: use provided valid_from or default to transaction start time
-        let timestamp = self.start_timestamp;
-        let valid_from = valid_from.unwrap_or(timestamp);
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = valid_from.unwrap_or(timestamp);
 
-        // Validate valid_from is not too far in future
-        validation::validate_valid_from_future(valid_from)?;
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
 
-        // Validate valid_from is not before entity creation
-        let historical = self.historical.read();
-        if let Some(current_version_id) = historical.get_current_node_version(node_id)
-            && let Some(current_version) = historical.get_node_version(current_version_id)
-        {
-            let creation_time = current_version.temporal.valid_time().start();
-            drop(historical); // Release lock before calling validation
-            validation::validate_valid_from_not_before_creation(
-                &format!("node:{}", node_id.as_u64()),
-                creation_time,
+            // Validate valid_from is not before entity creation
+            let historical = self.historical.read();
+            if let Some(current_version_id) = historical.get_current_node_version(node_id)
+                && let Some(current_version) = historical.get_node_version(current_version_id)
+            {
+                let creation_time = current_version.temporal.valid_time().start();
+                drop(historical); // Release lock before calling validation
+                validation::validate_valid_from_not_before_creation(
+                    &format!("node:{}", node_id.as_u64()),
+                    creation_time,
+                    valid_from,
+                )?;
+            }
+
+            // Buffer the write
+            self.buffer.add(super::BufferedWrite::DeleteNode {
+                node_id,
                 valid_from,
-            )?;
-        }
+            })?;
 
-        // Buffer the write
-        self.buffer.add(super::BufferedWrite::DeleteNode {
-            node_id,
-            valid_from,
-        })?;
+            Ok(())
+        })();
 
-        Ok(())
+        result.record_error_metric()
     }
 
     fn delete_node_cascade(&mut self, node_id: NodeId) -> Result<()> {
@@ -1167,35 +1195,39 @@ impl WriteOps for WriteTransaction {
         edge_id: EdgeId,
         valid_from: Option<Timestamp>,
     ) -> Result<()> {
-        // Check transaction state
-        if self.state != TxState::Active {
-            return Err(TransactionError::InvalidState {
-                current: format!("{:?}", self.state),
-                expected: "Active".to_string(),
+        let result = (|| {
+            // Check transaction state
+            if self.state != TxState::Active {
+                return Err(TransactionError::InvalidState {
+                    current: format!("{:?}", self.state),
+                    expected: "Active".to_string(),
+                }
+                .into());
             }
-            .into());
-        }
 
-        // Verify edge exists and check for vector properties
-        let edge = self.current.get_edge(edge_id)?;
+            // Verify edge exists and check for vector properties
+            let edge = self.current.get_edge(edge_id)?;
 
-        // If the edge being deleted contains vector properties, mark the buffer
-        // to ensure the temporal vector index is notified on commit
-        if !self.buffer.has_vector_operations() && edge.properties.contains_vector() {
-            self.buffer.mark_has_vector_operations();
-        }
+            // If the edge being deleted contains vector properties, mark the buffer
+            // to ensure the temporal vector index is notified on commit
+            if !self.buffer.has_vector_operations() && edge.properties.contains_vector() {
+                self.buffer.mark_has_vector_operations();
+            }
 
-        // Get timestamp: use provided valid_from or default to transaction start time
-        let timestamp = self.start_timestamp;
-        let valid_from = valid_from.unwrap_or(timestamp);
+            // Get timestamp: use provided valid_from or default to transaction start time
+            let timestamp = self.start_timestamp;
+            let valid_from = valid_from.unwrap_or(timestamp);
 
-        // Buffer the write
-        self.buffer.add(super::BufferedWrite::DeleteEdge {
-            edge_id,
-            valid_from,
-        })?;
+            // Buffer the write
+            self.buffer.add(super::BufferedWrite::DeleteEdge {
+                edge_id,
+                valid_from,
+            })?;
 
-        Ok(())
+            Ok(())
+        })();
+
+        result.record_error_metric()
     }
 }
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -11,6 +11,22 @@ use thiserror::Error;
 /// Result type alias using AletheiaDB's Error type.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Extension methods for [`Result`] values using AletheiaDB's error type.
+pub trait ResultExt<T> {
+    /// Record an error metric (if this is `Err`) and return the original result.
+    fn record_error_metric(self) -> Self;
+}
+
+impl<T> ResultExt<T> for Result<T> {
+    #[inline]
+    fn record_error_metric(self) -> Self {
+        if let Err(ref err) = self {
+            err.record_metric();
+        }
+        self
+    }
+}
+
 /// Main error type for all AletheiaDB operations.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -46,23 +62,36 @@ pub enum Error {
 }
 
 impl Error {
+    /// Record an error metric for this error's category.
+    ///
+    /// This is intentionally explicit and side-effect free for constructors and
+    /// conversions. Callers should record at API boundaries when returning errors.
+    #[inline]
+    pub fn record_metric(&self) {
+        #[cfg(feature = "observability")]
+        {
+            let counter = match self {
+                Error::Storage(_) => &crate::observability::METRICS.error_storage_total,
+                Error::Temporal(_) => &crate::observability::METRICS.error_temporal_total,
+                Error::Query(_) => &crate::observability::METRICS.error_query_total,
+                Error::Transaction(_) => &crate::observability::METRICS.error_transaction_total,
+                Error::Vector(_) => &crate::observability::METRICS.error_vector_total,
+                Error::Io(_) => &crate::observability::METRICS.error_io_total,
+                Error::NotImplemented { .. } | Error::Other(_) => {
+                    &crate::observability::METRICS.error_other_total
+                }
+            };
+            counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
     /// Create a new error from a message.
     pub fn other<S: Into<String>>(msg: S) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_other_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Other(msg.into())
     }
 
     /// Create a new NotImplemented error.
     pub fn not_implemented<S: Into<String>, R: Into<String>>(feature: S, reason: R) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_other_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::NotImplemented {
             feature: feature.into(),
             reason: reason.into(),
@@ -70,81 +99,46 @@ impl Error {
     }
 }
 
-// Manual From impls preserved because they have observability counter side effects.
+// Manual From impls are explicit to keep category conversions easy to audit.
 
 impl From<StorageError> for Error {
     fn from(e: StorageError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_storage_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Storage(e)
     }
 }
 
 impl From<TemporalError> for Error {
     fn from(e: TemporalError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_temporal_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Temporal(e)
     }
 }
 
 impl From<QueryError> for Error {
     fn from(e: QueryError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_query_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Query(e)
     }
 }
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_io_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Io(e)
     }
 }
 
 impl From<TransactionError> for Error {
     fn from(e: TransactionError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_transaction_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Transaction(e)
     }
 }
 
 impl From<VectorError> for Error {
     fn from(e: VectorError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_vector_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Vector(e)
     }
 }
 
 impl From<crate::config::ConfigError> for Error {
     fn from(e: crate::config::ConfigError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_other_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         Error::Other(e.to_string())
     }
 }
@@ -152,14 +146,113 @@ impl From<crate::config::ConfigError> for Error {
 #[cfg(feature = "sql")]
 impl From<crate::sql::SqlError> for Error {
     fn from(e: crate::sql::SqlError) -> Self {
-        #[cfg(feature = "observability")]
-        crate::observability::METRICS
-            .error_query_total
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let query_error = match e {
+            crate::sql::SqlError::ParseError(message) => QueryError::SyntaxError { message },
+            crate::sql::SqlError::UnsupportedFeature(feature) => {
+                QueryError::UnsupportedFeature { feature }
+            }
+            crate::sql::SqlError::InvalidTable(table) => QueryError::InvalidParameter {
+                parameter: "table".to_string(),
+                reason: format!("invalid table '{}': expected 'nodes' or 'edges'", table),
+            },
+            crate::sql::SqlError::InvalidColumn(column) => QueryError::InvalidParameter {
+                parameter: "column".to_string(),
+                reason: format!("invalid column reference: {}", column),
+            },
+            crate::sql::SqlError::InvalidTemporalClause(clause) => QueryError::InvalidParameter {
+                parameter: "temporal_clause".to_string(),
+                reason: format!("invalid temporal clause: {}", clause),
+            },
+            crate::sql::SqlError::InvalidTimestamp(timestamp) => QueryError::InvalidParameter {
+                parameter: "timestamp".to_string(),
+                reason: format!("invalid timestamp: {}", timestamp),
+            },
+            crate::sql::SqlError::MissingClause(clause) => QueryError::InvalidParameter {
+                parameter: "clause".to_string(),
+                reason: format!("missing required clause: {}", clause),
+            },
+            crate::sql::SqlError::TypeError(actual) => QueryError::TypeMismatch {
+                expected: "compatible SQL type".to_string(),
+                actual,
+            },
+            crate::sql::SqlError::ParameterError(reason) => QueryError::InvalidParameter {
+                parameter: "parameter".to_string(),
+                reason,
+            },
+        };
 
-        Error::Query(QueryError::SyntaxError {
-            message: e.to_string(),
-        })
+        Error::Query(query_error)
+    }
+}
+
+/// Structured categories for persistence failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistenceErrorKind {
+    /// Corrupted index data.
+    Corrupted,
+    /// String interner mismatch while restoring persisted state.
+    InternerMismatch,
+    /// Unsupported persisted manifest/index version.
+    UnsupportedVersion,
+    /// Required persisted index file is missing.
+    MissingIndex,
+    /// Invalid file magic bytes.
+    InvalidMagic,
+    /// Size-limit violation (DoS protection).
+    SizeLimitExceeded,
+    /// I/O failure while reading/writing persisted data.
+    Io,
+    /// Serialization/deserialization failure.
+    Serialization,
+    /// Unknown or unclassified persistence failure.
+    Unknown,
+}
+
+impl std::fmt::Display for PersistenceErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind = match self {
+            PersistenceErrorKind::Corrupted => "corrupted",
+            PersistenceErrorKind::InternerMismatch => "interner_mismatch",
+            PersistenceErrorKind::UnsupportedVersion => "unsupported_version",
+            PersistenceErrorKind::MissingIndex => "missing_index",
+            PersistenceErrorKind::InvalidMagic => "invalid_magic",
+            PersistenceErrorKind::SizeLimitExceeded => "size_limit_exceeded",
+            PersistenceErrorKind::Io => "io",
+            PersistenceErrorKind::Serialization => "serialization",
+            PersistenceErrorKind::Unknown => "unknown",
+        };
+        write!(f, "{}", kind)
+    }
+}
+
+impl From<&crate::storage::index_persistence::IndexPersistenceError> for PersistenceErrorKind {
+    fn from(e: &crate::storage::index_persistence::IndexPersistenceError) -> Self {
+        match e {
+            crate::storage::index_persistence::IndexPersistenceError::Corrupted { .. } => {
+                PersistenceErrorKind::Corrupted
+            }
+            crate::storage::index_persistence::IndexPersistenceError::InternerMismatch {
+                ..
+            } => PersistenceErrorKind::InternerMismatch,
+            crate::storage::index_persistence::IndexPersistenceError::UnsupportedVersion {
+                ..
+            } => PersistenceErrorKind::UnsupportedVersion,
+            crate::storage::index_persistence::IndexPersistenceError::MissingIndex { .. } => {
+                PersistenceErrorKind::MissingIndex
+            }
+            crate::storage::index_persistence::IndexPersistenceError::InvalidMagic { .. } => {
+                PersistenceErrorKind::InvalidMagic
+            }
+            crate::storage::index_persistence::IndexPersistenceError::SizeLimitExceeded {
+                ..
+            } => PersistenceErrorKind::SizeLimitExceeded,
+            crate::storage::index_persistence::IndexPersistenceError::Io(_) => {
+                PersistenceErrorKind::Io
+            }
+            crate::storage::index_persistence::IndexPersistenceError::Serialization(_) => {
+                PersistenceErrorKind::Serialization
+            }
+        }
     }
 }
 
@@ -215,10 +308,18 @@ pub enum StorageError {
     /// Corrupted data detected.
     #[error("Corrupted data: {0}")]
     CorruptedData(String),
-    /// Index persistence error.
+    /// Index persistence error with structured category information.
+    #[error("Persistence error [{kind}]: {message}")]
+    PersistenceErrorWithKind {
+        /// Persistence error category.
+        kind: PersistenceErrorKind,
+        /// Human-readable error message.
+        message: String,
+    },
+    /// Legacy index persistence error message.
     ///
-    /// This variant preserves the original IndexPersistenceError information
-    /// for better debugging and error handling of persistence operations.
+    /// This variant stores only a formatted message and does not retain structured
+    /// persistence error category information.
     #[error("Persistence error: {0}")]
     PersistenceError(String),
     /// Property with the given key was not found.
@@ -270,6 +371,24 @@ impl StorageError {
     /// Create a persistence error with a message.
     pub fn persistence<S: Into<String>>(msg: S) -> Self {
         StorageError::PersistenceError(msg.into())
+    }
+
+    /// Create a persistence error with explicit category information.
+    pub fn persistence_with_kind<S: Into<String>>(kind: PersistenceErrorKind, msg: S) -> Self {
+        StorageError::PersistenceErrorWithKind {
+            kind,
+            message: msg.into(),
+        }
+    }
+}
+
+impl From<crate::storage::index_persistence::IndexPersistenceError> for StorageError {
+    fn from(e: crate::storage::index_persistence::IndexPersistenceError) -> Self {
+        let kind = PersistenceErrorKind::from(&e);
+        StorageError::PersistenceErrorWithKind {
+            kind,
+            message: e.to_string(),
+        }
     }
 }
 
@@ -418,6 +537,12 @@ pub enum QueryError {
     SyntaxError {
         /// The error message
         message: String,
+    },
+    /// Query uses a feature that is not currently supported.
+    #[error("Unsupported query feature: {feature}")]
+    UnsupportedFeature {
+        /// The unsupported feature description.
+        feature: String,
     },
     /// Invalid query parameter.
     #[error("Invalid query parameter '{parameter}': {reason}")]
@@ -787,6 +912,14 @@ mod tests {
         assert!(format!("{}", err).contains("Persistence error"));
         assert!(format!("{}", err).contains("failed to save index"));
 
+        // Test PersistenceErrorWithKind
+        let err = StorageError::PersistenceErrorWithKind {
+            kind: PersistenceErrorKind::InvalidMagic,
+            message: "bad header".to_string(),
+        };
+        assert!(format!("{}", err).contains("invalid_magic"));
+        assert!(format!("{}", err).contains("bad header"));
+
         // Test PropertyNotFound
         let err = StorageError::PropertyNotFound("embedding".to_string());
         assert_eq!(format!("{}", err), "Property not found: embedding");
@@ -896,6 +1029,51 @@ mod tests {
         assert!(display.contains("vector index"));
         assert!(display.contains("embedding"));
         assert!(display.contains("vector_index(\"embedding\").hnsw"));
+    }
+
+    #[test]
+    fn test_index_persistence_error_conversion_preserves_kind() {
+        let io_err = crate::storage::index_persistence::IndexPersistenceError::Serialization(
+            "decode failed".to_string(),
+        );
+        let converted: StorageError = io_err.into();
+        match converted {
+            StorageError::PersistenceErrorWithKind { kind, message } => {
+                assert_eq!(kind, PersistenceErrorKind::Serialization);
+                assert!(message.contains("decode failed"));
+            }
+            other => panic!("expected PersistenceErrorWithKind, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "sql")]
+    #[test]
+    fn test_sql_error_conversion_preserves_semantics() {
+        let converted: Error = crate::sql::SqlError::UnsupportedFeature("MATCH".to_string()).into();
+        assert!(matches!(
+            converted,
+            Error::Query(QueryError::UnsupportedFeature { feature }) if feature == "MATCH"
+        ));
+
+        let converted: Error = crate::sql::SqlError::InvalidColumn("foo".to_string()).into();
+        assert!(matches!(
+            converted,
+            Error::Query(QueryError::InvalidParameter { parameter, .. }) if parameter == "column"
+        ));
+    }
+
+    #[cfg(feature = "observability")]
+    #[test]
+    fn test_result_ext_records_storage_metric_once() {
+        crate::observability::METRICS.reset();
+
+        let err: Result<()> = Err(StorageError::NodeNotFound(NodeId::new(1).unwrap()).into());
+        let snapshot = crate::observability::METRICS.snapshot();
+        assert_eq!(snapshot.error_storage_total, 0);
+
+        let _ = err.record_error_metric();
+        let snapshot = crate::observability::METRICS.snapshot();
+        assert_eq!(snapshot.error_storage_total, 1);
     }
 
     #[test]

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -1,5 +1,5 @@
 use crate::api::transaction::visibility::CompressionStats;
-use crate::core::error::{Result, StorageError};
+use crate::core::error::{PersistenceErrorKind, Result, ResultExt, StorageError};
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 use crate::index::temporal::TemporalIndexes;
@@ -39,85 +39,93 @@ impl AletheiaDB {
     /// db.persist_indexes()?; // Save indexes to disk
     /// ```
     pub fn persist_indexes(&self) -> Result<()> {
-        use crate::storage::index_persistence::formats::IndexManifest;
+        let result = (|| {
+            use crate::storage::index_persistence::formats::IndexManifest;
 
-        // Warn if background persistence thread has stopped
-        if self
-            .persistence_thread_stopped
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
-            eprintln!(
-                "Warning: Background persistence thread has stopped. \
-                 Automatic persistence is disabled. Manual persist_indexes() calls will still work."
-            );
-        }
+            // Warn if background persistence thread has stopped
+            if self
+                .persistence_thread_stopped
+                .load(std::sync::atomic::Ordering::Acquire)
+            {
+                eprintln!(
+                    "Warning: Background persistence thread has stopped. \
+                     Automatic persistence is disabled. Manual persist_indexes() calls will still work."
+                );
+            }
 
-        let manager =
-            self.persistence_manager
-                .as_ref()
-                .ok_or_else(|| StorageError::InconsistentState {
+            let manager = self.persistence_manager.as_ref().ok_or_else(|| {
+                StorageError::InconsistentState {
                     reason: "Index persistence not enabled".to_string(),
-                })?;
-
-        // Capture current LSN for all operations
-        let current_lsn = self.wal.current_lsn().0;
-
-        // 1. Save string interner first (dependency for all others)
-        if let Some(ref tracker) = self.persistence_tracker {
-            // Update the string LSN tracker to current_lsn BEFORE calculating safe LSN
-            // This ensures that even if no new strings were added, the tracker reflects
-            // that the interner is up-to-date with current_lsn.
-            crate::storage::index_persistence::operations::persist_string_interner(
-                manager,
-                tracker,
-                current_lsn,
-            )?;
-        } else {
-            manager.save_string_interner().map_err(|e| {
-                StorageError::PersistenceError(format!("Failed to save string interner: {}", e))
+                }
             })?;
-        }
 
-        // 2. Save graph index
-        crate::storage::index_persistence::operations::persist_graph_index(
-            &self.current,
-            manager,
-            self.persistence_tracker.as_ref(),
-            current_lsn,
-        )?;
+            // Capture current LSN for all operations
+            let current_lsn = self.wal.current_lsn().0;
 
-        // 3. Save vector indexes
-        if let Some(ref tracker) = self.persistence_tracker {
-            persist_vector_indexes(&self.current, manager, Some(tracker), current_lsn)?;
-        }
+            // 1. Save string interner first (dependency for all others)
+            if let Some(ref tracker) = self.persistence_tracker {
+                // Update the string LSN tracker to current_lsn BEFORE calculating safe LSN
+                // This ensures that even if no new strings were added, the tracker reflects
+                // that the interner is up-to-date with current_lsn.
+                crate::storage::index_persistence::operations::persist_string_interner(
+                    manager,
+                    tracker,
+                    current_lsn,
+                )?;
+            } else {
+                manager.save_string_interner().map_err(|e| {
+                    StorageError::persistence_with_kind(
+                        PersistenceErrorKind::from(&e),
+                        format!("Failed to save string interner: {}", e),
+                    )
+                })?;
+            }
 
-        // 4. Save temporal index (version history)
-        if let Some(ref tracker) = self.persistence_tracker {
-            persist_temporal_index(
-                &self.historical,
-                &self.temporal_indexes,
+            // 2. Save graph index
+            crate::storage::index_persistence::operations::persist_graph_index(
+                &self.current,
                 manager,
-                tracker,
+                self.persistence_tracker.as_ref(),
                 current_lsn,
             )?;
-        }
 
-        // 5. Save manifest last with SAFE LSN
-        // Note: This records the WAL position at persist time for future WAL replay coordination.
-        // We use the safe LSN (min of all components) if tracker is available, or current LSN if not.
-        // Since we just persisted everything successfully above, current_lsn is safe (and equal to min).
-        let safe_lsn = if let Some(ref tracker) = self.persistence_tracker {
-            tracker.get_safe_manifest_lsn()
-        } else {
-            current_lsn
-        };
+            // 3. Save vector indexes
+            if let Some(ref tracker) = self.persistence_tracker {
+                persist_vector_indexes(&self.current, manager, Some(tracker), current_lsn)?;
+            }
 
-        let manifest = IndexManifest::new(safe_lsn);
-        manager.save_manifest(&manifest).map_err(|e| {
-            StorageError::PersistenceError(format!("Failed to save manifest: {}", e))
-        })?;
+            // 4. Save temporal index (version history)
+            if let Some(ref tracker) = self.persistence_tracker {
+                persist_temporal_index(
+                    &self.historical,
+                    &self.temporal_indexes,
+                    manager,
+                    tracker,
+                    current_lsn,
+                )?;
+            }
 
-        Ok(())
+            // 5. Save manifest last with SAFE LSN
+            // Note: This records the WAL position at persist time for future WAL replay coordination.
+            // We use the safe LSN (min of all components) if tracker is available, or current LSN if not.
+            // Since we just persisted everything successfully above, current_lsn is safe (and equal to min).
+            let safe_lsn = if let Some(ref tracker) = self.persistence_tracker {
+                tracker.get_safe_manifest_lsn()
+            } else {
+                current_lsn
+            };
+
+            let manifest = IndexManifest::new(safe_lsn);
+            manager.save_manifest(&manifest).map_err(|e| {
+                StorageError::persistence_with_kind(
+                    PersistenceErrorKind::from(&e),
+                    format!("Failed to save manifest: {}", e),
+                )
+            })?;
+
+            Ok(())
+        })();
+        result.record_error_metric()
     }
 
     /// Get a reference to the current storage (test-only helper).

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -1,6 +1,6 @@
 use crate::api::transaction::{TxIdGenerator, TxVisibilityManager};
 use crate::config::AletheiaDBConfig;
-use crate::core::error::Result;
+use crate::core::error::{Result, ResultExt};
 use crate::core::id::IdGenerator;
 use crate::core::temporal::time;
 use crate::core::version::AnchorConfig;
@@ -150,207 +150,212 @@ impl AletheiaDB {
     /// let db = AletheiaDB::with_unified_config(config)?;
     /// ```
     pub fn with_unified_config(config: AletheiaDBConfig) -> Result<Self> {
-        let durability_mode = config.wal.durability_mode;
+        let result = (|| {
+            let durability_mode = config.wal.durability_mode;
 
-        // Create ConcurrentWalSystem config from unified WalConfig
-        let wal_system_config = ConcurrentWalSystemConfig {
-            wal_dir: config.wal.wal_dir,
-            num_stripes: config.wal.num_stripes,
-            stripe_capacity: config.wal.stripe_capacity,
-            segment_size: config.wal.segment_size,
-            segments_to_retain: config.wal.segments_to_retain,
-            flush_interval_ms: match durability_mode {
-                DurabilityMode::Async { flush_interval_ms } => flush_interval_ms,
-                DurabilityMode::GroupCommit { max_delay_ms, .. } => max_delay_ms,
-                DurabilityMode::AsyncBatched { max_delay_ms, .. } => max_delay_ms,
-                _ => config.wal.flush_interval_ms, // Use config default
-            },
-            durability_mode,
-            write_buffer_size: config.wal.write_buffer_size,
-        };
-
-        let wal = ConcurrentWalSystem::new(wal_system_config)?;
-        let wal = Arc::new(wal);
-
-        // Create persistence manager if enabled
-        let persistence_manager = if config.persistence.enabled {
-            Some(Arc::new(
-                crate::storage::index_persistence::IndexPersistenceManager::new(
-                    &config.persistence.data_dir,
-                ),
-            ))
-        } else {
-            None
-        };
-
-        // Create persistence tracker if persistence is enabled
-        let persistence_tracker = if config.persistence.enabled {
-            Some(Arc::new(PersistenceTracker::new()))
-        } else {
-            None
-        };
-
-        // Extract cold storage configuration before config.historical is moved
-        let enable_cold_storage = config.historical.enable_cold_storage;
-        let cold_storage_path = config.historical.cold_storage_path.clone();
-
-        let mut db = AletheiaDB {
-            current: Arc::new(CurrentStorage::new()),
-            historical: Arc::new(RwLock::new(HistoricalStorage::from_unified_config(
-                config.historical,
-            ))),
-            temporal_indexes: Arc::new(TemporalIndexes::new()),
-            wal,
-            current_timestamp: Arc::new(Mutex::new(time::now())),
-            commit_clock_observed_at: Arc::new(Mutex::new(Instant::now())),
-            tx_id_gen: Arc::new(TxIdGenerator::new()),
-            visibility_manager: Arc::new(TxVisibilityManager::new()),
-            node_id_gen: Arc::new(IdGenerator::new()),
-            edge_id_gen: Arc::new(IdGenerator::new()),
-            version_id_gen: Arc::new(IdGenerator::new()),
-            default_durability: durability_mode,
-            stats: Arc::new(Statistics::new()),
-            persistence_config: config.persistence.clone(),
-            persistence_manager: persistence_manager.clone(),
-            persistence_tracker: persistence_tracker.clone(),
-            persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            persistence_thread_handle: None,
-        };
-
-        // Load indexes on startup if enabled
-        if let Some(ref manager) = persistence_manager
-            && config.persistence.load_on_startup
-        {
-            let loaded_lsn = crate::storage::index_persistence::operations::load_indexes_startup(
-                manager,
-                &db.current,
-                &db.historical,
-                &db.node_id_gen,
-                &db.edge_id_gen,
-                &db.version_id_gen,
-            );
-
-            // Initialize tracker LSNs from the loaded manifest
-            if let Some(ref tracker) = persistence_tracker
-                && let Some(lsn) = loaded_lsn
-            {
-                tracker.set_start_lsn(lsn);
-                tracker.update_last_persisted_counts(
-                    db.current.node_count() as u64,
-                    db.current.edge_count() as u64,
-                );
-                // Also initialize string count from current state
-                tracker
-                    .update_last_persisted_string_count(crate::core::GLOBAL_INTERNER.len() as u64);
-            }
-
-            // Replay WAL entries that occurred after the persisted snapshot
-            // This ensures no data loss if the WAL is ahead of the indexes (e.g. crash before persist)
-            let start_lsn = match loaded_lsn {
-                Some(lsn) => crate::storage::wal::LSN(lsn).next(),
-                None => {
-                    // Safety check: if we have data but no LSN, replaying from initial is dangerous
-                    // as it might overwrite existing data with old WAL entries or duplicate IDs.
-                    if db.current.node_count() > 0 {
-                        #[cfg(feature = "observability")]
-                        tracing::error!(
-                            "Database contains data ({} nodes) but no persistence LSN found. \
-                             Skipping WAL replay to prevent potential data corruption. \
-                             This may indicate a missing or corrupted manifest file.",
-                            db.current.node_count()
-                        );
-                        #[cfg(not(feature = "observability"))]
-                        eprintln!(
-                            "ERROR: Database contains data ({} nodes) but no persistence LSN found. \
-                             Skipping WAL replay to prevent potential data corruption.",
-                            db.current.node_count()
-                        );
-                        // Skip replay by setting start_lsn to current WAL LSN (effectively no-op)
-                        db.wal.current_lsn()
-                    } else {
-                        crate::storage::wal::LSN::initial()
-                    }
-                }
+            // Create ConcurrentWalSystem config from unified WalConfig
+            let wal_system_config = ConcurrentWalSystemConfig {
+                wal_dir: config.wal.wal_dir,
+                num_stripes: config.wal.num_stripes,
+                stripe_capacity: config.wal.stripe_capacity,
+                segment_size: config.wal.segment_size,
+                segments_to_retain: config.wal.segments_to_retain,
+                flush_interval_ms: match durability_mode {
+                    DurabilityMode::Async { flush_interval_ms } => flush_interval_ms,
+                    DurabilityMode::GroupCommit { max_delay_ms, .. } => max_delay_ms,
+                    DurabilityMode::AsyncBatched { max_delay_ms, .. } => max_delay_ms,
+                    _ => config.wal.flush_interval_ms, // Use config default
+                },
+                durability_mode,
+                write_buffer_size: config.wal.write_buffer_size,
             };
 
-            // Capture initial version ID before replay
-            let initial_version_id = db.version_id_gen.current();
+            let wal = ConcurrentWalSystem::new(wal_system_config)?;
+            let wal = Arc::new(wal);
 
-            let mut historical_guard = db.historical.write();
-            let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
-                crate::storage::recovery::replay_wal_into_storage(
-                    &db.wal,
-                    &db.current,
-                    &mut historical_guard,
-                    start_lsn,
-                    initial_version_id,
-                )?;
-            drop(historical_guard);
+            // Create persistence manager if enabled
+            let persistence_manager = if config.persistence.enabled {
+                Some(Arc::new(
+                    crate::storage::index_persistence::IndexPersistenceManager::new(
+                        &config.persistence.data_dir,
+                    ),
+                ))
+            } else {
+                None
+            };
 
-            // Update ID generators to account for replayed entities.
-            // This ensures that subsequent writes use IDs that don't collide with replayed data.
-            if let Some(max_nid) = max_node_id {
-                db.node_id_gen.ensure_at_least(max_nid + 1);
+            // Create persistence tracker if persistence is enabled
+            let persistence_tracker = if config.persistence.enabled {
+                Some(Arc::new(PersistenceTracker::new()))
+            } else {
+                None
+            };
+
+            // Extract cold storage configuration before config.historical is moved
+            let enable_cold_storage = config.historical.enable_cold_storage;
+            let cold_storage_path = config.historical.cold_storage_path.clone();
+
+            let mut db = AletheiaDB {
+                current: Arc::new(CurrentStorage::new()),
+                historical: Arc::new(RwLock::new(HistoricalStorage::from_unified_config(
+                    config.historical,
+                ))),
+                temporal_indexes: Arc::new(TemporalIndexes::new()),
+                wal,
+                current_timestamp: Arc::new(Mutex::new(time::now())),
+                commit_clock_observed_at: Arc::new(Mutex::new(Instant::now())),
+                tx_id_gen: Arc::new(TxIdGenerator::new()),
+                visibility_manager: Arc::new(TxVisibilityManager::new()),
+                node_id_gen: Arc::new(IdGenerator::new()),
+                edge_id_gen: Arc::new(IdGenerator::new()),
+                version_id_gen: Arc::new(IdGenerator::new()),
+                default_durability: durability_mode,
+                stats: Arc::new(Statistics::new()),
+                persistence_config: config.persistence.clone(),
+                persistence_manager: persistence_manager.clone(),
+                persistence_tracker: persistence_tracker.clone(),
+                persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                persistence_thread_handle: None,
+            };
+
+            // Load indexes on startup if enabled
+            if let Some(ref manager) = persistence_manager
+                && config.persistence.load_on_startup
+            {
+                let loaded_lsn =
+                    crate::storage::index_persistence::operations::load_indexes_startup(
+                        manager,
+                        &db.current,
+                        &db.historical,
+                        &db.node_id_gen,
+                        &db.edge_id_gen,
+                        &db.version_id_gen,
+                    );
+
+                // Initialize tracker LSNs from the loaded manifest
+                if let Some(ref tracker) = persistence_tracker
+                    && let Some(lsn) = loaded_lsn
+                {
+                    tracker.set_start_lsn(lsn);
+                    tracker.update_last_persisted_counts(
+                        db.current.node_count() as u64,
+                        db.current.edge_count() as u64,
+                    );
+                    // Also initialize string count from current state
+                    tracker.update_last_persisted_string_count(
+                        crate::core::GLOBAL_INTERNER.len() as u64
+                    );
+                }
+
+                // Replay WAL entries that occurred after the persisted snapshot
+                // This ensures no data loss if the WAL is ahead of the indexes (e.g. crash before persist)
+                let start_lsn = match loaded_lsn {
+                    Some(lsn) => crate::storage::wal::LSN(lsn).next(),
+                    None => {
+                        // Safety check: if we have data but no LSN, replaying from initial is dangerous
+                        // as it might overwrite existing data with old WAL entries or duplicate IDs.
+                        if db.current.node_count() > 0 {
+                            #[cfg(feature = "observability")]
+                            tracing::error!(
+                                "Database contains data ({} nodes) but no persistence LSN found. \
+                             Skipping WAL replay to prevent potential data corruption. \
+                             This may indicate a missing or corrupted manifest file.",
+                                db.current.node_count()
+                            );
+                            #[cfg(not(feature = "observability"))]
+                            eprintln!(
+                                "ERROR: Database contains data ({} nodes) but no persistence LSN found. \
+                             Skipping WAL replay to prevent potential data corruption.",
+                                db.current.node_count()
+                            );
+                            // Skip replay by setting start_lsn to current WAL LSN (effectively no-op)
+                            db.wal.current_lsn()
+                        } else {
+                            crate::storage::wal::LSN::initial()
+                        }
+                    }
+                };
+
+                // Capture initial version ID before replay
+                let initial_version_id = db.version_id_gen.current();
+
+                let mut historical_guard = db.historical.write();
+                let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
+                    crate::storage::recovery::replay_wal_into_storage(
+                        &db.wal,
+                        &db.current,
+                        &mut historical_guard,
+                        start_lsn,
+                        initial_version_id,
+                    )?;
+                drop(historical_guard);
+
+                // Update ID generators to account for replayed entities.
+                // This ensures that subsequent writes use IDs that don't collide with replayed data.
+                if let Some(max_nid) = max_node_id {
+                    db.node_id_gen.ensure_at_least(max_nid + 1);
+                }
+                if let Some(max_eid) = max_edge_id {
+                    db.edge_id_gen.ensure_at_least(max_eid + 1);
+                }
+                db.version_id_gen.ensure_at_least(next_version_id);
             }
-            if let Some(max_eid) = max_edge_id {
-                db.edge_id_gen.ensure_at_least(max_eid + 1);
+
+            // Start background persistence thread if enabled
+            if let Some(ref tracker) = persistence_tracker
+                && let Some(ref manager) = persistence_manager
+            {
+                let handle = spawn_background_persistence_thread(
+                    Arc::clone(&db.current),
+                    Arc::clone(&db.historical),
+                    Arc::clone(&db.temporal_indexes),
+                    Arc::clone(&db.wal),
+                    Arc::clone(manager),
+                    Arc::clone(tracker),
+                    config.persistence.policies.clone(),
+                    Arc::clone(&db.persistence_thread_stopped),
+                );
+                db.persistence_thread_handle = Some(handle);
             }
-            db.version_id_gen.ensure_at_least(next_version_id);
-        }
 
-        // Start background persistence thread if enabled
-        if let Some(ref tracker) = persistence_tracker
-            && let Some(ref manager) = persistence_manager
-        {
-            let handle = spawn_background_persistence_thread(
-                Arc::clone(&db.current),
-                Arc::clone(&db.historical),
-                Arc::clone(&db.temporal_indexes),
-                Arc::clone(&db.wal),
-                Arc::clone(manager),
-                Arc::clone(tracker),
-                config.persistence.policies.clone(),
-                Arc::clone(&db.persistence_thread_stopped),
-            );
-            db.persistence_thread_handle = Some(handle);
-        }
-
-        // Wire temporal indexes to historical storage for O(log n) version lookups (Issue #209)
-        db.historical
-            .write()
-            .set_temporal_indexes(Arc::clone(&db.temporal_indexes));
-
-        // Initialize and enable temporal adjacency index for efficient temporal pathfinding
-        let temporal_adjacency_index = Arc::new(
-            crate::index::temporal_adjacency::TemporalAdjacencyIndex::new(
-                crate::index::temporal_adjacency::TemporalAdjacencyConfig::default(),
-            ),
-        );
-        db.historical
-            .write()
-            .set_temporal_adjacency_index(temporal_adjacency_index);
-
-        // Initialize cold storage if enabled
-        if enable_cold_storage && let Some(cold_storage_path) = cold_storage_path {
-            // Create Redb cold storage backend
-            let cold_storage =
-                Arc::new(RedbColdStorage::new(&cold_storage_path, RedbConfig::new())?);
-
-            // Create tiered storage with warm cache configuration
-            let tiered_config = TieredStorageConfig::default();
-            let tiered_storage = TieredStorage::new(tiered_config, cold_storage);
-
-            // Wire tiered storage to historical storage
-            // Note: migration_age_threshold and max_hot_versions from config.historical
-            // are used by HistoricalStorage's migration logic, not by TieredStorage
+            // Wire temporal indexes to historical storage for O(log n) version lookups (Issue #209)
             db.historical
                 .write()
-                .set_tiered_storage(Arc::new(tiered_storage));
-        }
+                .set_temporal_indexes(Arc::clone(&db.temporal_indexes));
 
-        seed_startup_current_timestamp(&db)?;
+            // Initialize and enable temporal adjacency index for efficient temporal pathfinding
+            let temporal_adjacency_index = Arc::new(
+                crate::index::temporal_adjacency::TemporalAdjacencyIndex::new(
+                    crate::index::temporal_adjacency::TemporalAdjacencyConfig::default(),
+                ),
+            );
+            db.historical
+                .write()
+                .set_temporal_adjacency_index(temporal_adjacency_index);
 
-        Ok(db)
+            // Initialize cold storage if enabled
+            if enable_cold_storage && let Some(cold_storage_path) = cold_storage_path {
+                // Create Redb cold storage backend
+                let cold_storage =
+                    Arc::new(RedbColdStorage::new(&cold_storage_path, RedbConfig::new())?);
+
+                // Create tiered storage with warm cache configuration
+                let tiered_config = TieredStorageConfig::default();
+                let tiered_storage = TieredStorage::new(tiered_config, cold_storage);
+
+                // Wire tiered storage to historical storage
+                // Note: migration_age_threshold and max_hot_versions from config.historical
+                // are used by HistoricalStorage's migration logic, not by TieredStorage
+                db.historical
+                    .write()
+                    .set_tiered_storage(Arc::new(tiered_storage));
+            }
+
+            seed_startup_current_timestamp(&db)?;
+
+            Ok(db)
+        })();
+        result.record_error_metric()
     }
 
     /// Create a new database with both anchor and WAL configuration.
@@ -365,66 +370,69 @@ impl AletheiaDB {
         anchor_config: AnchorConfig,
         wal_config: crate::config::WalConfig,
     ) -> Result<Self> {
-        let durability_mode = wal_config.durability_mode;
+        let result = (|| {
+            let durability_mode = wal_config.durability_mode;
 
-        // Create ConcurrentWalSystem config from unified WalConfig
-        let wal_system_config = ConcurrentWalSystemConfig {
-            wal_dir: wal_config.wal_dir,
-            num_stripes: wal_config.num_stripes,
-            stripe_capacity: wal_config.stripe_capacity,
-            segment_size: wal_config.segment_size,
-            segments_to_retain: wal_config.segments_to_retain,
-            flush_interval_ms: match durability_mode {
-                DurabilityMode::Async { flush_interval_ms } => flush_interval_ms,
-                DurabilityMode::GroupCommit { max_delay_ms, .. } => max_delay_ms,
-                DurabilityMode::AsyncBatched { max_delay_ms, .. } => max_delay_ms,
-                _ => wal_config.flush_interval_ms,
-            },
-            durability_mode,
-            write_buffer_size: wal_config.write_buffer_size,
-        };
+            // Create ConcurrentWalSystem config from unified WalConfig
+            let wal_system_config = ConcurrentWalSystemConfig {
+                wal_dir: wal_config.wal_dir,
+                num_stripes: wal_config.num_stripes,
+                stripe_capacity: wal_config.stripe_capacity,
+                segment_size: wal_config.segment_size,
+                segments_to_retain: wal_config.segments_to_retain,
+                flush_interval_ms: match durability_mode {
+                    DurabilityMode::Async { flush_interval_ms } => flush_interval_ms,
+                    DurabilityMode::GroupCommit { max_delay_ms, .. } => max_delay_ms,
+                    DurabilityMode::AsyncBatched { max_delay_ms, .. } => max_delay_ms,
+                    _ => wal_config.flush_interval_ms,
+                },
+                durability_mode,
+                write_buffer_size: wal_config.write_buffer_size,
+            };
 
-        let wal = ConcurrentWalSystem::new(wal_system_config)?;
-        let wal = Arc::new(wal);
+            let wal = ConcurrentWalSystem::new(wal_system_config)?;
+            let wal = Arc::new(wal);
 
-        let db = AletheiaDB {
-            current: Arc::new(CurrentStorage::new()),
-            historical: Arc::new(RwLock::new(HistoricalStorage::with_config(anchor_config))),
-            temporal_indexes: Arc::new(TemporalIndexes::new()),
-            wal,
-            current_timestamp: Arc::new(Mutex::new(time::now())),
-            commit_clock_observed_at: Arc::new(Mutex::new(Instant::now())),
-            tx_id_gen: Arc::new(TxIdGenerator::new()),
-            visibility_manager: Arc::new(TxVisibilityManager::new()),
-            node_id_gen: Arc::new(IdGenerator::new()),
-            edge_id_gen: Arc::new(IdGenerator::new()),
-            version_id_gen: Arc::new(IdGenerator::new()),
-            default_durability: durability_mode,
-            stats: Arc::new(Statistics::new()),
-            persistence_config: crate::storage::index_persistence::PersistenceConfig::default(),
-            persistence_manager: None,
-            persistence_tracker: None,
-            persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            persistence_thread_handle: None,
-        };
-        seed_startup_current_timestamp(&db)?;
+            let db = AletheiaDB {
+                current: Arc::new(CurrentStorage::new()),
+                historical: Arc::new(RwLock::new(HistoricalStorage::with_config(anchor_config))),
+                temporal_indexes: Arc::new(TemporalIndexes::new()),
+                wal,
+                current_timestamp: Arc::new(Mutex::new(time::now())),
+                commit_clock_observed_at: Arc::new(Mutex::new(Instant::now())),
+                tx_id_gen: Arc::new(TxIdGenerator::new()),
+                visibility_manager: Arc::new(TxVisibilityManager::new()),
+                node_id_gen: Arc::new(IdGenerator::new()),
+                edge_id_gen: Arc::new(IdGenerator::new()),
+                version_id_gen: Arc::new(IdGenerator::new()),
+                default_durability: durability_mode,
+                stats: Arc::new(Statistics::new()),
+                persistence_config: crate::storage::index_persistence::PersistenceConfig::default(),
+                persistence_manager: None,
+                persistence_tracker: None,
+                persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                persistence_thread_handle: None,
+            };
+            seed_startup_current_timestamp(&db)?;
 
-        // Wire temporal indexes to historical storage for O(log n) version lookups (Issue #209)
-        db.historical
-            .write()
-            .set_temporal_indexes(Arc::clone(&db.temporal_indexes));
+            // Wire temporal indexes to historical storage for O(log n) version lookups (Issue #209)
+            db.historical
+                .write()
+                .set_temporal_indexes(Arc::clone(&db.temporal_indexes));
 
-        // Initialize and enable temporal adjacency index for efficient temporal pathfinding
-        let temporal_adjacency_index = Arc::new(
-            crate::index::temporal_adjacency::TemporalAdjacencyIndex::new(
-                crate::index::temporal_adjacency::TemporalAdjacencyConfig::default(),
-            ),
-        );
-        db.historical
-            .write()
-            .set_temporal_adjacency_index(temporal_adjacency_index);
+            // Initialize and enable temporal adjacency index for efficient temporal pathfinding
+            let temporal_adjacency_index = Arc::new(
+                crate::index::temporal_adjacency::TemporalAdjacencyIndex::new(
+                    crate::index::temporal_adjacency::TemporalAdjacencyConfig::default(),
+                ),
+            );
+            db.historical
+                .write()
+                .set_temporal_adjacency_index(temporal_adjacency_index);
 
-        Ok(db)
+            Ok(db)
+        })();
+        result.record_error_metric()
     }
 
     /// Get the default durability mode for this database.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -1,5 +1,5 @@
 use crate::api::transaction::WriteOps;
-use crate::core::error::Result;
+use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::property::{PropertyMap, PropertyValue};
@@ -33,6 +33,7 @@ impl AletheiaDB {
     /// * [`write`](Self::write) - For batched write operations.
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         self.write(|tx| tx.create_node(label, properties))
+            .record_error_metric()
     }
 
     /// Create an edge between two nodes.
@@ -69,13 +70,14 @@ impl AletheiaDB {
         properties: PropertyMap,
     ) -> Result<EdgeId> {
         self.write(|tx| tx.create_edge(source, target, label, properties))
+            .record_error_metric()
     }
 
     /// Get the current state of a node.
     ///
     /// This uses the fast path (current storage) for O(1) lookup.
     pub fn get_node(&self, node_id: NodeId) -> Result<Node> {
-        self.current.get_node(node_id)
+        self.current.get_node(node_id).record_error_metric()
     }
 
     /// Access a node without cloning, executing a closure on the node data.
@@ -100,12 +102,12 @@ impl AletheiaDB {
     where
         F: FnOnce(&Node) -> R,
     {
-        self.current.with_node(id, f)
+        self.current.with_node(id, f).record_error_metric()
     }
 
     /// Get the current state of an edge.
     pub fn get_edge(&self, edge_id: EdgeId) -> Result<Edge> {
-        self.current.get_edge(edge_id)
+        self.current.get_edge(edge_id).record_error_metric()
     }
 
     /// Scan all nodes with a specific label, returning an iterator over node IDs.
@@ -166,7 +168,7 @@ impl AletheiaDB {
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
     pub fn get_edge_target(&self, edge_id: EdgeId) -> Result<NodeId> {
-        self.current.get_edge_target(edge_id)
+        self.current.get_edge_target(edge_id).record_error_metric()
     }
 
     /// Get the source node of an edge without cloning the entire edge.
@@ -177,7 +179,7 @@ impl AletheiaDB {
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
     pub fn get_edge_source(&self, edge_id: EdgeId) -> Result<NodeId> {
-        self.current.get_edge_source(edge_id)
+        self.current.get_edge_source(edge_id).record_error_metric()
     }
 
     /// Get outgoing edges from a node (current state).

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -33,7 +33,6 @@ impl AletheiaDB {
     /// * [`write`](Self::write) - For batched write operations.
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         self.write(|tx| tx.create_node(label, properties))
-            .record_error_metric()
     }
 
     /// Create an edge between two nodes.
@@ -70,7 +69,6 @@ impl AletheiaDB {
         properties: PropertyMap,
     ) -> Result<EdgeId> {
         self.write(|tx| tx.create_edge(source, target, label, properties))
-            .record_error_metric()
     }
 
     /// Get the current state of a node.

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -1,4 +1,4 @@
-use crate::core::error::Result;
+use crate::core::error::{Result, ResultExt};
 use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
@@ -60,18 +60,22 @@ impl AletheiaDB {
     /// }
     /// ```
     pub fn execute_query(&self, query: Query) -> Result<QueryResults> {
-        #[cfg(feature = "observability")]
-        let _span = tracing::info_span!("execute_query").entered();
+        let result = (|| {
+            #[cfg(feature = "observability")]
+            let _span = tracing::info_span!("execute_query").entered();
 
-        // Use cached statistics for cost-based optimization
-        // Statistics are shared across all queries for this database instance
-        let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));
-        let physical_plan = planner.plan(query)?;
+            // Use cached statistics for cost-based optimization
+            // Statistics are shared across all queries for this database instance
+            let planner = QueryPlanner::new(Arc::clone(&self.stats), Arc::clone(&self.current));
+            let physical_plan = planner.plan(query)?;
 
-        // Execute the plan
-        let executor = QueryExecutor::new(Arc::clone(&self.current), Arc::clone(&self.historical));
+            // Execute the plan
+            let executor =
+                QueryExecutor::new(Arc::clone(&self.current), Arc::clone(&self.historical));
 
-        executor.execute(physical_plan)
+            executor.execute(physical_plan)
+        })();
+        result.record_error_metric()
     }
 
     /// Traverse from a node and rank results by similarity to an embedding.

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -1,4 +1,4 @@
-use crate::core::error::Result;
+use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::temporal::{Timestamp, time};
@@ -98,6 +98,7 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_node_at_time(node_id, valid_time, transaction_time)
+            .record_error_metric()
     }
 
     /// Get an edge as it existed at a specific point in bi-temporal space.
@@ -116,6 +117,7 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_edge_at_time(edge_id, valid_time, transaction_time)
+            .record_error_metric()
     }
 
     /// Get multiple nodes as they existed at a specific point in bi-temporal space.
@@ -195,6 +197,7 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_nodes_at_time(node_ids, valid_time, transaction_time)
+            .record_error_metric()
     }
 
     /// Get multiple edges as they existed at a specific point in bi-temporal space.
@@ -269,6 +272,7 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_edges_at_time(edge_ids, valid_time, transaction_time)
+            .record_error_metric()
     }
 
     // ========================================================================
@@ -322,7 +326,10 @@ impl AletheiaDB {
     /// println!("Alice has {} versions", history.version_count());
     /// ```
     pub fn get_node_history(&self, node_id: NodeId) -> Result<EntityHistory> {
-        self.historical.read().get_node_history(node_id)
+        self.historical
+            .read()
+            .get_node_history(node_id)
+            .record_error_metric()
     }
 
     /// Get a node at a specific logical version number.
@@ -339,6 +346,7 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_node_at_version(node_id, version_number)
+            .record_error_metric()
     }
 
     /// Compute the difference between two versions of a node.
@@ -366,6 +374,7 @@ impl AletheiaDB {
         self.historical
             .read()
             .diff_node_versions(node_id, from_version, to_version)
+            .record_error_metric()
     }
 
     /// Get an edge at a specific valid time.
@@ -392,7 +401,10 @@ impl AletheiaDB {
     ///
     /// Returns all versions in chronological order (oldest first).
     pub fn get_edge_history(&self, edge_id: EdgeId) -> Result<EntityHistory> {
-        self.historical.read().get_edge_history(edge_id)
+        self.historical
+            .read()
+            .get_edge_history(edge_id)
+            .record_error_metric()
     }
 
     /// Compute the difference between two versions of an edge.
@@ -407,5 +419,6 @@ impl AletheiaDB {
         self.historical
             .read()
             .diff_edge_versions(edge_id, from_version, to_version)
+            .record_error_metric()
     }
 }

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2258,3 +2258,82 @@ fn test_debug_implementation() {
     assert!(debug_output.contains("persistence_enabled"));
     assert!(debug_output.contains("stats"));
 }
+
+#[cfg(feature = "observability")]
+fn poison_mutex<T>(mutex: &std::sync::Arc<std::sync::Mutex<T>>) {
+    let mutex = std::sync::Arc::clone(mutex);
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _guard = mutex.lock().expect("failed to lock mutex for poisoning");
+        panic!("intentional mutex poison for metrics test");
+    }));
+}
+
+#[cfg(feature = "observability")]
+#[test]
+fn test_create_node_transaction_error_counted_once_when_lock_poisoned() {
+    crate::observability::METRICS.reset();
+    let db = AletheiaDB::new().unwrap();
+
+    poison_mutex(&db.current_timestamp);
+
+    let result = db.create_node("Person", PropertyMapBuilder::new().build());
+    assert!(result.is_err());
+
+    let snapshot = crate::observability::METRICS.snapshot();
+    assert_eq!(snapshot.error_transaction_total, 1);
+}
+
+#[cfg(feature = "observability")]
+#[test]
+fn test_vector_builder_duplicate_enable_counts_error_once() {
+    use crate::index::vector::{DistanceMetric, HnswConfig};
+
+    let db = AletheiaDB::new().unwrap();
+    db.enable_vector_index("embedding", HnswConfig::new(4, DistanceMetric::Cosine))
+        .unwrap();
+
+    crate::observability::METRICS.reset();
+    let result = db
+        .vector_index("embedding")
+        .hnsw(HnswConfig::new(4, DistanceMetric::Cosine))
+        .enable();
+    assert!(result.is_err());
+
+    let snapshot = crate::observability::METRICS.snapshot();
+    assert_eq!(snapshot.error_vector_total, 1);
+}
+
+#[cfg(feature = "observability")]
+#[test]
+fn test_read_closure_db_error_counts_once() {
+    crate::observability::METRICS.reset();
+    let db = AletheiaDB::new().unwrap();
+
+    let missing_id = NodeId::new(999_999).unwrap();
+    let result: Result<()> = db.read(|tx| {
+        tx.get_node(missing_id)?;
+        Ok(())
+    });
+    assert!(result.is_err());
+
+    let snapshot = crate::observability::METRICS.snapshot();
+    assert_eq!(snapshot.error_storage_total, 1);
+}
+
+#[cfg(feature = "observability")]
+#[test]
+fn test_write_commit_error_counts_once() {
+    crate::observability::METRICS.reset();
+    let db = AletheiaDB::new().unwrap();
+
+    poison_mutex(&db.commit_clock_observed_at);
+
+    let result: Result<()> = db.write(|tx| {
+        tx.create_node("Person", PropertyMapBuilder::new().build())?;
+        Ok(())
+    });
+    assert!(result.is_err());
+
+    let snapshot = crate::observability::METRICS.snapshot();
+    assert_eq!(snapshot.error_transaction_total, 1);
+}

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -1,5 +1,5 @@
 use crate::api::transaction::{ReadTransaction, WriteTransaction};
-use crate::core::error::{Result, TransactionError};
+use crate::core::error::{Result, ResultExt, TransactionError};
 use crate::core::hlc::HybridTimestamp;
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
@@ -83,22 +83,25 @@ impl AletheiaDB {
     /// # }
     /// ```
     pub fn read_transaction(&self) -> Result<ReadTransaction> {
-        let tx_id = self.tx_id_gen.next();
-        let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
+        let result = (|| {
+            let tx_id = self.tx_id_gen.next();
+            let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
 
-        // Register as active
-        self.visibility_manager.register_active(tx_id);
+            // Register as active
+            self.visibility_manager.register_active(tx_id);
 
-        // Capture snapshot
-        let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
+            // Capture snapshot
+            let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-        Ok(ReadTransaction::new(
-            tx_id,
-            snapshot,
-            Arc::clone(&self.current),
-            Arc::clone(&self.visibility_manager),
-            Arc::clone(&self.historical),
-        ))
+            Ok(ReadTransaction::new(
+                tx_id,
+                snapshot,
+                Arc::clone(&self.current),
+                Arc::clone(&self.visibility_manager),
+                Arc::clone(&self.historical),
+            ))
+        })();
+        result.record_error_metric()
     }
 
     /// Execute a read-only operation in a transaction.
@@ -187,29 +190,32 @@ impl AletheiaDB {
     /// # }
     /// ```
     pub fn write_transaction(&self) -> Result<WriteTransaction> {
-        let tx_id = self.tx_id_gen.next();
-        let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
+        let result = (|| {
+            let tx_id = self.tx_id_gen.next();
+            let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
 
-        // Register as active
-        self.visibility_manager.register_active(tx_id);
+            // Register as active
+            self.visibility_manager.register_active(tx_id);
 
-        // Capture snapshot
-        let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
+            // Capture snapshot
+            let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-        Ok(WriteTransaction::new_with_clock_observed_at(
-            tx_id,
-            snapshot,
-            Arc::clone(&self.current),
-            Arc::clone(&self.historical),
-            Arc::clone(&self.temporal_indexes),
-            Arc::clone(&self.wal),
-            Arc::clone(&self.current_timestamp),
-            Arc::clone(&self.commit_clock_observed_at),
-            Arc::clone(&self.visibility_manager),
-            Arc::clone(&self.node_id_gen),
-            Arc::clone(&self.edge_id_gen),
-            Arc::clone(&self.version_id_gen),
-        ))
+            Ok(WriteTransaction::new_with_clock_observed_at(
+                tx_id,
+                snapshot,
+                Arc::clone(&self.current),
+                Arc::clone(&self.historical),
+                Arc::clone(&self.temporal_indexes),
+                Arc::clone(&self.wal),
+                Arc::clone(&self.current_timestamp),
+                Arc::clone(&self.commit_clock_observed_at),
+                Arc::clone(&self.visibility_manager),
+                Arc::clone(&self.node_id_gen),
+                Arc::clone(&self.edge_id_gen),
+                Arc::clone(&self.version_id_gen),
+            ))
+        })();
+        result.record_error_metric()
     }
 
     /// Execute a write operation in a transaction.
@@ -474,32 +480,35 @@ impl AletheiaDB {
         &self,
         options: WriteOptions,
     ) -> Result<WriteTransaction> {
-        let tx_id = self.tx_id_gen.next();
-        let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
+        let result = (|| {
+            let tx_id = self.tx_id_gen.next();
+            let snapshot_timestamp = self.snapshot_timestamp_for_read()?;
 
-        // Register as active
-        self.visibility_manager.register_active(tx_id);
+            // Register as active
+            self.visibility_manager.register_active(tx_id);
 
-        // Capture snapshot
-        let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
+            // Capture snapshot
+            let snapshot = self.visibility_manager.capture_snapshot(snapshot_timestamp);
 
-        // Determine effective durability mode
-        let durability = options.effective_durability(self.default_durability);
+            // Determine effective durability mode
+            let durability = options.effective_durability(self.default_durability);
 
-        Ok(WriteTransaction::new_with_durability_and_clock_observed_at(
-            tx_id,
-            snapshot,
-            Arc::clone(&self.current),
-            Arc::clone(&self.historical),
-            Arc::clone(&self.temporal_indexes),
-            Arc::clone(&self.wal),
-            Arc::clone(&self.current_timestamp),
-            Arc::clone(&self.commit_clock_observed_at),
-            Arc::clone(&self.visibility_manager),
-            Arc::clone(&self.node_id_gen),
-            Arc::clone(&self.edge_id_gen),
-            Arc::clone(&self.version_id_gen),
-            durability,
-        ))
+            Ok(WriteTransaction::new_with_durability_and_clock_observed_at(
+                tx_id,
+                snapshot,
+                Arc::clone(&self.current),
+                Arc::clone(&self.historical),
+                Arc::clone(&self.temporal_indexes),
+                Arc::clone(&self.wal),
+                Arc::clone(&self.current_timestamp),
+                Arc::clone(&self.commit_clock_observed_at),
+                Arc::clone(&self.visibility_manager),
+                Arc::clone(&self.node_id_gen),
+                Arc::clone(&self.edge_id_gen),
+                Arc::clone(&self.version_id_gen),
+                durability,
+            ))
+        })();
+        result.record_error_metric()
     }
 }

--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -110,7 +110,8 @@ impl AletheiaDB {
 
             // Enable vector index if it doesn't exist yet
             if !self.current.is_vector_index_enabled_for(property_name) {
-                self.enable_vector_index(property_name, resolved_hnsw_config.clone())?;
+                self.current
+                    .enable_vector_index(property_name, resolved_hnsw_config.clone())?;
             }
 
             #[cfg(feature = "observability")]

--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -1,4 +1,4 @@
-use crate::core::error::Result;
+use crate::core::error::{Result, ResultExt};
 use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
@@ -33,7 +33,9 @@ impl AletheiaDB {
     pub fn enable_vector_index(&self, property_name: &str, config: HnswConfig) -> Result<()> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!("enable_vector_index").entered();
-        self.current.enable_vector_index(property_name, config)
+        self.current
+            .enable_vector_index(property_name, config)
+            .record_error_metric()
     }
 
     /// Check if vector indexing is enabled.
@@ -79,21 +81,21 @@ impl AletheiaDB {
         property_name: &str,
         config: TemporalVectorConfig,
     ) -> Result<()> {
-        // Resolve hnsw_config: use provided config or get from existing vector index
-        let resolved_hnsw_config =
-            if let Some(hnsw_config) = config.hnsw_config.clone() {
+        let result = (|| {
+            // Resolve hnsw_config: use provided config or get from existing vector index
+            let resolved_hnsw_config = if let Some(hnsw_config) = config.hnsw_config.clone() {
                 // Config was provided explicitly
                 hnsw_config
             } else if self.current.is_vector_index_enabled_for(property_name) {
                 // No config provided, but vector index exists - use its config
                 self.current.get_hnsw_config_for(property_name).ok_or_else(|| {
-                crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
-                    format!(
-                        "Vector index exists for '{}' but could not retrieve its configuration",
-                        property_name
-                    ),
-                ))
-            })?
+                    crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
+                        format!(
+                            "Vector index exists for '{}' but could not retrieve its configuration",
+                            property_name
+                        ),
+                    ))
+                })?
             } else {
                 // No config provided and no vector index exists - error
                 return Err(crate::core::error::Error::Vector(
@@ -106,53 +108,55 @@ impl AletheiaDB {
                 ));
             };
 
-        // Enable vector index if it doesn't exist yet
-        if !self.current.is_vector_index_enabled_for(property_name) {
-            self.enable_vector_index(property_name, resolved_hnsw_config.clone())?;
-        }
+            // Enable vector index if it doesn't exist yet
+            if !self.current.is_vector_index_enabled_for(property_name) {
+                self.enable_vector_index(property_name, resolved_hnsw_config.clone())?;
+            }
 
-        #[cfg(feature = "observability")]
-        let _span = tracing::info_span!("enable_temporal_vector_index").entered();
+            #[cfg(feature = "observability")]
+            let _span = tracing::info_span!("enable_temporal_vector_index").entered();
 
-        // Create a resolved config with the hnsw_config set
-        let resolved_config = TemporalVectorConfig {
-            hnsw_config: Some(resolved_hnsw_config),
-            ..config
-        };
+            // Create a resolved config with the hnsw_config set
+            let resolved_config = TemporalVectorConfig {
+                hnsw_config: Some(resolved_hnsw_config),
+                ..config
+            };
 
-        // Enable temporal vector index in current storage
-        self.current
-            .enable_temporal_vector_index(property_name, resolved_config)?;
+            // Enable temporal vector index in current storage
+            self.current
+                .enable_temporal_vector_index(property_name, resolved_config)?;
 
-        // Get the temporal vector index from current storage
-        let temporal_index = self.current.get_temporal_vector_index().ok_or_else(|| {
-            crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
-                "Temporal vector index not found after enabling".to_string(),
-            ))
-        })?;
+            // Get the temporal vector index from current storage
+            let temporal_index = self.current.get_temporal_vector_index().ok_or_else(|| {
+                crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
+                    "Temporal vector index not found after enabling".to_string(),
+                ))
+            })?;
 
-        // Register pre-anchor hooks with historical storage (for strong consistency)
-        // Both node and edge hooks perform the same action, so we create one and clone it
-        let hook: crate::storage::historical::PreAnchorHook = {
-            let index = Arc::clone(&temporal_index);
-            Arc::new(move |_entity_type, _entity_id, timestamp, _properties| {
-                index.create_snapshot_for_anchor(timestamp)
-            })
-        };
+            // Register pre-anchor hooks with historical storage (for strong consistency)
+            // Both node and edge hooks perform the same action, so we create one and clone it
+            let hook: crate::storage::historical::PreAnchorHook = {
+                let index = Arc::clone(&temporal_index);
+                Arc::new(move |_entity_type, _entity_id, timestamp, _properties| {
+                    index.create_snapshot_for_anchor(timestamp)
+                })
+            };
 
-        let node_hook = Arc::clone(&hook);
-        let edge_hook = hook;
+            let node_hook = Arc::clone(&hook);
+            let edge_hook = hook;
 
-        let mut historical = self.historical.write();
+            let mut historical = self.historical.write();
 
-        historical.register_pre_node_anchor_hook(node_hook);
-        historical.register_pre_edge_anchor_hook(edge_hook);
+            historical.register_pre_node_anchor_hook(node_hook);
+            historical.register_pre_edge_anchor_hook(edge_hook);
 
-        // Create observer and register with historical storage (for extensibility)
-        let observer = VectorIndexObserver::new(temporal_index);
-        historical.add_observer(std::sync::Arc::new(observer));
+            // Create observer and register with historical storage (for extensibility)
+            let observer = VectorIndexObserver::new(temporal_index);
+            historical.add_observer(std::sync::Arc::new(observer));
 
-        Ok(())
+            Ok(())
+        })();
+        result.record_error_metric()
     }
 
     /// Check if temporal vector indexing is enabled.
@@ -291,6 +295,7 @@ impl AletheiaDB {
         let _span = tracing::info_span!("find_similar_in").entered();
         self.current
             .find_similar_in(property_name, query_node_id, k)
+            .record_error_metric()
     }
 
     /// Search a specific property's vector index with a raw embedding.
@@ -325,7 +330,9 @@ impl AletheiaDB {
     ) -> Result<Vec<(NodeId, f32)>> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!("search_vectors_in").entered();
-        self.current.search_vectors_in(property_name, embedding, k)
+        self.current
+            .search_vectors_in(property_name, embedding, k)
+            .record_error_metric()
     }
 
     /// Find k most similar nodes to a query node based on vector similarity.
@@ -357,7 +364,9 @@ impl AletheiaDB {
     pub fn find_similar(&self, query_node_id: NodeId, k: usize) -> Result<Vec<(NodeId, f32)>> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!("find_similar").entered();
-        self.current.find_similar(query_node_id, k)
+        self.current
+            .find_similar(query_node_id, k)
+            .record_error_metric()
     }
 
     /// Find k most similar nodes with a specific label.
@@ -387,6 +396,7 @@ impl AletheiaDB {
         let _span = tracing::info_span!("find_similar_with_label").entered();
         self.current
             .find_similar_with_label(query_node_id, label, k)
+            .record_error_metric()
     }
 
     /// Find k most similar nodes to a raw embedding vector.
@@ -427,7 +437,9 @@ impl AletheiaDB {
     ) -> Result<Vec<(NodeId, f32)>> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!("find_similar_by_embedding").entered();
-        self.current.find_similar_by_embedding(embedding, k)
+        self.current
+            .find_similar_by_embedding(embedding, k)
+            .record_error_metric()
     }
 
     /// Find k most similar nodes with a specific label to a raw embedding vector.
@@ -477,6 +489,7 @@ impl AletheiaDB {
         let _span = tracing::info_span!("find_similar").entered();
         self.current
             .find_similar_by_embedding_with_label(embedding, label, k)
+            .record_error_metric()
     }
 
     /// Find k most similar nodes using a custom predicate for filtering.
@@ -505,6 +518,7 @@ impl AletheiaDB {
         let _span = tracing::info_span!("find_similar_with_predicate").entered();
         self.current
             .find_similar_with_predicate(property_name, query_vector, k, predicate)
+            .record_error_metric()
     }
 
     /// Find k most similar nodes at a specific point in time.
@@ -543,7 +557,9 @@ impl AletheiaDB {
     ) -> Result<Vec<(NodeId, f32)>> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!("find_similar_as_of").entered();
-        self.current.find_similar_as_of(embedding, k, timestamp)
+        self.current
+            .find_similar_as_of(embedding, k, timestamp)
+            .record_error_metric()
     }
 
     /// Find similar vectors at a specific point in time for a specific property.
@@ -591,6 +607,7 @@ impl AletheiaDB {
             tracing::info_span!("find_similar_as_of_in", property = property_name).entered();
         self.current
             .find_similar_as_of_in(property_name, embedding, k, timestamp)
+            .record_error_metric()
     }
 
     /// Track semantic drift for a node over time in a specific property's temporal index.
@@ -649,6 +666,7 @@ impl AletheiaDB {
                 .entered();
         self.current
             .track_drift_in(property_name, node_id, reference_embedding, time_range)
+            .record_error_metric()
     }
 
     /// Get the semantic evolution of a node's embedding over time in a specific property.
@@ -697,6 +715,7 @@ impl AletheiaDB {
                 .entered();
         self.current
             .semantic_evolution_in(property_name, node_id, time_range)
+            .record_error_metric()
     }
 
     /// Find all nodes with semantic drift above a threshold in a specific property.
@@ -757,6 +776,7 @@ impl AletheiaDB {
         .entered();
         self.current
             .find_drift_in(property_name, threshold, time_range, metric)
+            .record_error_metric()
     }
 }
 

--- a/src/db/vector_builder.rs
+++ b/src/db/vector_builder.rs
@@ -1,4 +1,4 @@
-use crate::core::error::{Result, ResultExt};
+use crate::core::error::{Error, Result};
 use crate::db::AletheiaDB;
 use crate::index::vector::hnsw::HnswConfig;
 use crate::index::vector::temporal::TemporalVectorConfig;
@@ -144,29 +144,31 @@ impl<'a> VectorIndexBuilder<'a> {
     /// # }
     /// ```
     pub fn enable(self) -> Result<()> {
-        let result = (|| {
-            let hnsw_config = self.hnsw_config.ok_or_else(|| {
-                crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
+        let hnsw_config = self
+            .hnsw_config
+            .ok_or_else(|| {
+                Error::Vector(crate::core::error::VectorError::IndexError(
                     "HNSW configuration is required. Call .hnsw() before .enable()".to_string(),
                 ))
+            })
+            .inspect_err(|err| {
+                err.record_metric();
             })?;
 
-            // If temporal config is provided, use enable_temporal_vector_index which
-            // automatically enables the current index as well (fixing #386)
-            if let Some(temporal_config) = self.temporal_config {
-                // Merge HNSW config into temporal config
-                let temporal_config_with_hnsw = TemporalVectorConfig {
-                    hnsw_config: Some(hnsw_config),
-                    ..temporal_config
-                };
-                self.db
-                    .enable_temporal_vector_index(&self.property_name, temporal_config_with_hnsw)
-            } else {
-                // Just enable the current index
-                self.db
-                    .enable_vector_index(&self.property_name, hnsw_config)
-            }
-        })();
-        result.record_error_metric()
+        // If temporal config is provided, use enable_temporal_vector_index which
+        // automatically enables the current index as well (fixing #386)
+        if let Some(temporal_config) = self.temporal_config {
+            // Merge HNSW config into temporal config
+            let temporal_config_with_hnsw = TemporalVectorConfig {
+                hnsw_config: Some(hnsw_config),
+                ..temporal_config
+            };
+            self.db
+                .enable_temporal_vector_index(&self.property_name, temporal_config_with_hnsw)
+        } else {
+            // Just enable the current index
+            self.db
+                .enable_vector_index(&self.property_name, hnsw_config)
+        }
     }
 }

--- a/src/db/vector_builder.rs
+++ b/src/db/vector_builder.rs
@@ -1,4 +1,4 @@
-use crate::core::error::Result;
+use crate::core::error::{Result, ResultExt};
 use crate::db::AletheiaDB;
 use crate::index::vector::hnsw::HnswConfig;
 use crate::index::vector::temporal::TemporalVectorConfig;
@@ -144,26 +144,29 @@ impl<'a> VectorIndexBuilder<'a> {
     /// # }
     /// ```
     pub fn enable(self) -> Result<()> {
-        let hnsw_config = self.hnsw_config.ok_or_else(|| {
-            crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
-                "HNSW configuration is required. Call .hnsw() before .enable()".to_string(),
-            ))
-        })?;
+        let result = (|| {
+            let hnsw_config = self.hnsw_config.ok_or_else(|| {
+                crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
+                    "HNSW configuration is required. Call .hnsw() before .enable()".to_string(),
+                ))
+            })?;
 
-        // If temporal config is provided, use enable_temporal_vector_index which
-        // automatically enables the current index as well (fixing #386)
-        if let Some(temporal_config) = self.temporal_config {
-            // Merge HNSW config into temporal config
-            let temporal_config_with_hnsw = TemporalVectorConfig {
-                hnsw_config: Some(hnsw_config),
-                ..temporal_config
-            };
-            self.db
-                .enable_temporal_vector_index(&self.property_name, temporal_config_with_hnsw)
-        } else {
-            // Just enable the current index
-            self.db
-                .enable_vector_index(&self.property_name, hnsw_config)
-        }
+            // If temporal config is provided, use enable_temporal_vector_index which
+            // automatically enables the current index as well (fixing #386)
+            if let Some(temporal_config) = self.temporal_config {
+                // Merge HNSW config into temporal config
+                let temporal_config_with_hnsw = TemporalVectorConfig {
+                    hnsw_config: Some(hnsw_config),
+                    ..temporal_config
+                };
+                self.db
+                    .enable_temporal_vector_index(&self.property_name, temporal_config_with_hnsw)
+            } else {
+                // Just enable the current index
+                self.db
+                    .enable_vector_index(&self.property_name, hnsw_config)
+            }
+        })();
+        result.record_error_metric()
     }
 }


### PR DESCRIPTION
## Summary
- centralize core error metric accounting via Error::record_metric() and ResultExt::record_error_metric()
- remove metric side effects from constructors/conversions and record at DB API boundaries
- preserve SQL error semantics when converting SqlError to core Error
- add structured persistence error categories via PersistenceErrorKind and StorageError::PersistenceErrorWithKind
- update/extend tests for SQL mapping, persistence conversion fidelity, and metric recording behavior

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all
- cargo test
