### PR TITLE
🔒 Warden: [security fix] Fix DoS vulnerability in CSR parsing

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,7 @@
 2024-XX-XX - [Warden: CSR Adjacency Index Vulnerability]
 **Threat:** `AdjacencyIndex::import_csr` did not validate that `node_ids` is sorted, and did not validate that `offsets` is monotonically increasing. It also didn't validate that the first offset is `0`. This allows a maliciously constructed CSR payload to cause OOB reads (Denial of Service) when `get_adjacency` is called, due to `start > end` or `end > edges.len()` when slicing the `edges` array.
 **Defense:** Added rigorous validation in `validate_csr_invariants` to ensure `node_ids` is strictly sorted (no duplicates), `offsets` begins with `0`, and is monotonically increasing.
+
+2025-02-28 - [DoS in CSR Data Parsing]
+**Threat:** A Denial of Service (DoS) vulnerability existed in `AdjacencyIndex::import_csr` where invalid Compressed Sparse Row (CSR) invariant validation caused an intentional panic via `.unwrap()`, leading to server crash on malformed or malicious CSR data during index restoration/import.
+**Defense:** Changed the function signature to return a `Result<Self, String>` and propagated the error upstream. Handled the error in `restore_index_impl` to gracefully fallback to `current.compact_adjacency()` instead of panicking.

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -94,13 +94,13 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Self {
+    ) -> Result<Self, String> {
         if offsets.is_empty() || edge_ids.is_empty() {
-            return Self::new();
+            return Ok(Self::new());
         }
 
         // Validate CSR invariants
-        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids).unwrap();
+        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids)?;
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -128,12 +128,12 @@ impl AdjacencyIndex {
             }
         }
 
-        Self {
+        Ok(Self {
             node_ids: node_ids_typed,
             offsets: offsets_usize,
             edges: adjacency_entries,
             max_node_id,
-        }
+        })
     }
 }
 
@@ -814,7 +814,7 @@ mod tests {
         edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
         edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
@@ -879,14 +879,15 @@ mod sentry_tests {
     }
 
     #[test]
-    #[should_panic(expected = "CSR offsets length mismatch")]
-    fn test_import_csr_panics_on_invalid() {
-        // Integration check: ensure import_csr actually calls validate and panics
+    fn test_import_csr_returns_err_on_invalid() {
+        // Integration check: ensure import_csr actually calls validate and returns err
         let node_ids = vec![10];
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
-        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let res = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("CSR offsets length mismatch"));
     }
 
     #[test]
@@ -905,7 +906,7 @@ mod sentry_tests {
         edges_map.insert(EdgeId::new(101).unwrap(), (target, label));
 
         // Should not panic
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
 
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -781,7 +781,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> Result<(), String> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -812,7 +812,7 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -828,7 +828,7 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====
@@ -858,6 +858,7 @@ impl CurrentIndexes {
                 );
             }
         }
+        Ok(())
     }
 }
 

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -1244,6 +1244,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_import_csr_error_propagation() {
+        let indexes = CurrentIndexes::new();
+
+        // 1. Invalid outgoing CSR data (e.g., offsets length mismatch)
+        let invalid_out_offsets = vec![0, 1]; // too short for 2 nodes
+        let res_out = indexes.import_csr(
+            vec![1, 2],
+            invalid_out_offsets,
+            vec![100, 101],
+            vec![1, 2],
+            vec![0, 1, 2],
+            vec![100, 101],
+        );
+        assert!(res_out.is_err());
+        assert!(res_out.unwrap_err().contains("CSR offsets length mismatch"));
+
+        // 2. Valid outgoing, invalid incoming CSR data (e.g., non-monotonic offsets)
+        let invalid_in_offsets = vec![0, 2, 1];
+        let res_in = indexes.import_csr(
+            vec![1, 2],
+            vec![0, 1, 2],
+            vec![100, 101],
+            vec![1, 2],
+            invalid_in_offsets,
+            vec![100], // length matched to last offset is tricky, but non-monotonic fails early
+        );
+        assert!(res_in.is_err());
+        assert!(
+            res_in
+                .unwrap_err()
+                .contains("CSR offsets are not monotonically increasing")
+        );
+    }
+
     /// Test AdjacencyGuard Debug implementation for coverage.
     #[test]
     fn test_adjacency_guard_debug() {

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -985,7 +985,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> std::result::Result<(), String> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,
@@ -993,7 +993,7 @@ impl CurrentStorage {
             incoming_node_ids,
             incoming_offsets,
             incoming_edge_ids,
-        );
+        )
     }
 
     /// Get the number of nodes.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -850,14 +850,20 @@ pub(crate) fn load_indexes_startup(
                 if !graph_data.outgoing_offsets.is_empty()
                     && !graph_data.incoming_offsets.is_empty()
                 {
-                    current.import_csr(
+                    if let Err(e) = current.import_csr(
                         graph_data.outgoing_node_ids,
                         graph_data.outgoing_offsets,
                         graph_data.outgoing_neighbors,
                         graph_data.incoming_node_ids,
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
-                    );
+                    ) {
+                        eprintln!(
+                            "Warning: Failed to import CSR adjacency structures ({}). Rebuilding instead...",
+                            e
+                        );
+                        current.compact_adjacency();
+                    }
                 } else {
                     // Fallback for older index files without CSR data
                     current.compact_adjacency();

--- a/src/storage/index_persistence/operations_tests.rs
+++ b/src/storage/index_persistence/operations_tests.rs
@@ -118,6 +118,60 @@ fn test_graph_persist_keeps_interner_consistent_with_graph_string_ids() {
 }
 
 #[test]
+fn test_restore_index_impl_with_invalid_csr_data() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));
+    let current = Arc::new(CurrentStorage::new());
+
+    // 1. Create a minimal valid graph
+    current
+        .create_node("TestNode", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Persist to get basic structures
+    persist_graph_index(&current, &manager, None, 0).unwrap();
+
+    // Now, intentionally corrupt the graph file's CSR arrays
+    let graph_path = manager.graph_path().join("adjacency.idx");
+    let mut graph_data =
+        crate::storage::index_persistence::graph::load_graph_index(&graph_path).unwrap();
+
+    // Add invalid CSR data (non-matching lengths, missing offsets)
+    graph_data.outgoing_node_ids = vec![1, 2, 3];
+    graph_data.outgoing_offsets = vec![0, 1]; // invalid: should be len 4
+    graph_data.outgoing_neighbors = vec![100];
+
+    graph_data.incoming_node_ids = vec![1, 2];
+    graph_data.incoming_offsets = vec![0, 1, 2];
+    graph_data.incoming_neighbors = vec![200, 201];
+
+    // Save corrupted graph data
+    use crate::storage::index_persistence::graph::save_graph_index;
+    save_graph_index(&graph_data, &graph_path).unwrap();
+
+    // The load process shouldn't panic, it should gracefully fall back
+    // to rebuilding adjacency via `compact_adjacency`.
+    let historical = Arc::new(parking_lot::RwLock::new(
+        crate::storage::historical::HistoricalStorage::new(),
+    ));
+    let node_id_gen = Arc::new(crate::core::id::IdGenerator::new());
+    let edge_id_gen = Arc::new(crate::core::id::IdGenerator::new());
+    let version_id_gen = Arc::new(crate::core::id::IdGenerator::new());
+    crate::storage::index_persistence::operations::load_indexes_startup(
+        &manager,
+        &current,
+        &historical,
+        &node_id_gen,
+        &edge_id_gen,
+        &version_id_gen,
+    );
+
+    // Verification: if it panics, the test fails. If we get here, the Err path in
+    // `restore_index_impl` was successfully triggered and swallowed.
+    assert_eq!(current.node_count(), 1);
+}
+
+#[test]
 fn test_persist_all_indexes_creates_manifest() {
     let temp_dir = tempfile::tempdir().unwrap();
     let manager = Arc::new(IndexPersistenceManager::new(temp_dir.path()));

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1374,14 +1374,16 @@ mod phase7_persistence_integration {
         }
 
         // Import CSR - should reconstruct delta from diff
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1440,14 +1442,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1519,14 +1523,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1585,14 +1591,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Delta should be empty
         assert_eq!(


### PR DESCRIPTION
### 🦠 Threat
A Denial of Service (DoS) vulnerability existed in `AdjacencyIndex::import_csr`. The function performed invariant validation on Compressed Sparse Row (CSR) inputs (e.g. `node_ids`, `offsets`, `edge_ids`) but intentionally panicked via `.unwrap()` when validation failed. This could lead to a server crash if malformed or malicious CSR data was provided during index restoration or import.

### 🛡️ Defense
Modified `AdjacencyIndex::import_csr` to return a `Result<Self, String>` and propagated the error up the call stack through `CurrentIndexes` and `CurrentStorage`. In `restore_index_impl` (where the initial index load happens), if `import_csr` returns an `Err`, it now prints a warning and gracefully falls back to `current.compact_adjacency()`, preventing the server from crashing.

### 💥 Severity
High - could panic server on startup or during specific operations depending on the ingestion path.

### 🧪 Verification
- Updated `sentry_tests::test_import_csr_panics_on_invalid` to `test_import_csr_returns_err_on_invalid` which explicitly asserts the return value is an `Err` containing the appropriate message.
- Passed `cargo check`, `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.

---
*PR created automatically by Jules for task [9981635243789496161](https://jules.google.com/task/9981635243789496161) started by @madmax983*