### PR TITLE
🛡️ Sentry: Error formatting and unwrap fallback coverage

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -8,3 +8,11 @@
 2.  When seeing duplicate implementations (in-memory vs persistent structs), check which one is used in production code vs tests.
 3.  Wired up `PersistentCommitLog` to `ShardCoordinator` via new `wal_path` config.
 4.  Updated `PersistentCommitLog` schema to include `commit_timestamp` (with backward compatibility logic for V1, though V2 enforced for new writes).
+
+## `unwrap_or_else` Fallbacks on Debug Implementations
+**Learning:** `std::fmt::Debug` implementations for entities using interned strings (`Node`, `Edge`) contained `unwrap_or_else(|| format!("{:?}", self.label))` blocks that were completely untested. Because the default behavior relies on `GLOBAL_INTERNER.resolve_with(...)` which almost always succeeds during normal execution, the fallback logic was invisible to the test suite and could silently mask initialization or interner corruption bugs.
+**Action:** Always create test cases using artificially injected, non-existent raw IDs (e.g., `InternedString::from_raw(u32::MAX - 10)`) when testing interner resolution fallbacks to ensure formatting and error handling behave correctly.
+
+## Vector Boundary Validation Fallbacks
+**Learning:** The public, panicking `PropertyValue::vector` wraps `PropertyValue::try_vector(...).unwrap_or_else(|e| panic!(...))`. While the panicking behavior was generally expected, the fallible `try_vector` component lacked direct coverage ensuring it correctly yielded a generic result over the dimension limits without panicking prematurely.
+**Action:** When APIs provide both panicking and fallible construction methods, ensure the fallible method receives explicit `Result::is_err()` boundary testing to prevent regressions that might turn it into a panicking method unintentionally.


### PR DESCRIPTION
🛡️ Sentry: Add tests for untracked error/formatting fallbacks

🎯 Target: `src/sql/error.rs`, `src/core/graph.rs`, `src/core/property.rs`.
💣 Risk: Formatting methods relying on `unwrap_or_else` closures could fail silently or return invalid output during corruption events. `try_vector` lacked boundary testing, relying on the panicking `vector` method coverage.
🧪 Strategy: Added explicit formatting checks for `SqlError` strings. Instantiated core `Node` and `Edge` structs with raw, fake `InternedString`s to trigger `unwrap_or_else` path in `fmt::Debug`. Sent vectors larger than `MAX_VECTOR_DIMENSIONS` to ensure `try_vector` correctly yields `is_err()` without panicking.
🔬 Verification: `cargo test --features "sql"`

---
*PR created automatically by Jules for task [2381798868786005012](https://jules.google.com/task/2381798868786005012) started by @madmax983*