### PR TITLE
⚖️ Elenchus: Strengthen predicate_pushdown assertions

### DIFF
--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -13,7 +13,7 @@ use crate::index::vector::DistanceMetric;
 use super::ir::{Direction, Predicate, TraversalDepth};
 
 /// A logical query plan represented as a tree of operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LogicalPlan {
     /// Root operation of the plan tree
     pub root: LogicalOp,
@@ -68,7 +68,7 @@ impl LogicalPlan {
 }
 
 /// Logical operation nodes in the query plan tree.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LogicalOp {
     /// Leaf operation: data source (scan, lookup, search)
     Scan(ScanOp),
@@ -147,7 +147,7 @@ impl LogicalOp {
 /// Scan operations (leaf nodes in the plan tree).
 ///
 /// These represent data sources - the starting points for query execution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ScanOp {
     /// Direct node lookup by ID(s) - O(1) per node
     NodeLookup(Vec<NodeId>),
@@ -225,7 +225,7 @@ pub enum ScanOp {
 }
 
 /// Unary operations that transform a single input.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UnaryOp {
     /// Filter rows by predicate
     Filter(Predicate),
@@ -281,7 +281,7 @@ pub enum UnaryOp {
 }
 
 /// Binary operations that combine two inputs.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BinaryOp {
     /// Set union of results
     Union,
@@ -302,7 +302,7 @@ pub enum BinaryOp {
 }
 
 /// Key for sorting results.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SortKey {
     /// Sort by a property value
     Property(String),
@@ -502,7 +502,7 @@ impl TemporalContext {
 }
 
 /// Hints for query optimization.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct QueryHints {
     /// User-provided cardinality estimate
     pub estimated_cardinality: Option<usize>,

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -279,21 +279,28 @@ mod tests {
         let new_plan = result.unwrap();
         // Check full AST: VectorRank -> Filter -> Scan
         if let LogicalOp::Unary {
-            op: UnaryOp::VectorRank { top_k, .. },
+            op:
+                UnaryOp::VectorRank {
+                    embedding,
+                    top_k,
+                    property_key,
+                },
             input: rank_input,
         } = new_plan.root
         {
+            assert_eq!(embedding, Arc::from([0.1f32; 4].as_slice()));
             assert_eq!(top_k, None);
+            assert_eq!(property_key, None);
             if let LogicalOp::Unary {
                 op: UnaryOp::Filter(pred),
                 input: filter_input,
             } = rank_input.as_ref()
             {
                 assert_eq!(pred, &Predicate::eq("name", "Alice"));
-                assert!(matches!(
+                assert_eq!(
                     filter_input.as_ref(),
-                    LogicalOp::Scan(ScanOp::NodeLookup(_))
-                ));
+                    &LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]))
+                );
             } else {
                 panic!("Expected Filter below VectorRank");
             }
@@ -373,22 +380,22 @@ mod tests {
         let new_plan = result.unwrap();
         // Check full AST: Sort -> Filter -> Scan
         if let LogicalOp::Unary {
-            op: UnaryOp::Sort {
-                descending: true, ..
-            },
+            op: UnaryOp::Sort { key, descending },
             input: sort_input,
         } = new_plan.root
         {
+            assert_eq!(key, SortKey::Property("created".to_string()));
+            assert!(descending);
             if let LogicalOp::Unary {
                 op: UnaryOp::Filter(pred),
                 input: filter_input,
             } = sort_input.as_ref()
             {
                 assert_eq!(pred, &Predicate::eq("active", true));
-                assert!(matches!(
+                assert_eq!(
                     filter_input.as_ref(),
-                    LogicalOp::Scan(ScanOp::NodeLookup(_))
-                ));
+                    &LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]))
+                );
             } else {
                 panic!("Expected Filter below Sort");
             }
@@ -443,24 +450,40 @@ mod tests {
 
         // Root should be Sort
         if let LogicalOp::Unary {
-            op: UnaryOp::Sort { .. },
+            op: UnaryOp::Sort { key, descending },
             input: sort_input,
         } = root
         {
+            assert_eq!(key, &SortKey::Property("created".to_string()));
+            assert!(descending);
             // Next should be VectorRank
             if let LogicalOp::Unary {
-                op: UnaryOp::VectorRank { .. },
+                op:
+                    UnaryOp::VectorRank {
+                        embedding,
+                        top_k,
+                        property_key,
+                    },
                 input: rank_input,
             } = sort_input.as_ref()
             {
+                assert_eq!(embedding, &Arc::from([0.1f32; 4].as_slice()));
+                assert_eq!(top_k, &None);
+                assert_eq!(property_key, &None);
                 // Next should be Filter
-                assert!(matches!(
-                    rank_input.as_ref(),
-                    LogicalOp::Unary {
-                        op: UnaryOp::Filter(_),
-                        ..
-                    }
-                ));
+                if let LogicalOp::Unary {
+                    op: UnaryOp::Filter(pred),
+                    input: filter_input,
+                } = rank_input.as_ref()
+                {
+                    assert_eq!(pred, &Predicate::eq("active", true));
+                    assert_eq!(
+                        filter_input.as_ref(),
+                        &LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]))
+                    );
+                } else {
+                    panic!("Expected Filter below VectorRank");
+                }
             } else {
                 // If it failed here, print what we got
                 panic!("Expected VectorRank below Sort, got {:?}", sort_input);
@@ -508,22 +531,22 @@ mod tests {
         if let LogicalOp::Binary { left, .. } = new_plan.root {
             // Verify left side is optimized: Sort -> Filter -> Scan
             if let LogicalOp::Unary {
-                op: UnaryOp::Sort {
-                    descending: true, ..
-                },
+                op: UnaryOp::Sort { key, descending },
                 input: sort_input,
             } = *left
             {
+                assert_eq!(key, SortKey::Property("created".to_string()));
+                assert!(descending);
                 if let LogicalOp::Unary {
                     op: UnaryOp::Filter(pred),
                     input: filter_input,
                 } = sort_input.as_ref()
                 {
                     assert_eq!(pred, &Predicate::eq("active", true));
-                    assert!(matches!(
+                    assert_eq!(
                         filter_input.as_ref(),
-                        LogicalOp::Scan(ScanOp::NodeLookup(_))
-                    ));
+                        &LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]))
+                    );
                 } else {
                     panic!("Expected Filter below Sort on left branch");
                 }
@@ -587,22 +610,22 @@ mod sentry_tests {
         if let LogicalOp::Binary { left, right, .. } = new_plan.root {
             // Left should be Sort(Filter...)
             if let LogicalOp::Unary {
-                op: UnaryOp::Sort {
-                    descending: true, ..
-                },
+                op: UnaryOp::Sort { key, descending },
                 input: sort_input,
             } = *left
             {
+                assert_eq!(key, SortKey::Property("a".to_string()));
+                assert!(descending);
                 if let LogicalOp::Unary {
                     op: UnaryOp::Filter(pred),
                     input: filter_input,
                 } = sort_input.as_ref()
                 {
                     assert_eq!(pred, &Predicate::eq("a", 1));
-                    assert!(matches!(
+                    assert_eq!(
                         filter_input.as_ref(),
-                        LogicalOp::Scan(ScanOp::NodeLookup(_))
-                    ));
+                        &LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]))
+                    );
                 } else {
                     panic!("Expected Filter below Sort on left branch");
                 }
@@ -617,7 +640,10 @@ mod sentry_tests {
             } = *right
             {
                 assert_eq!(pred, Predicate::eq("b", 2));
-                assert!(matches!(*input, LogicalOp::Scan(ScanOp::NodeLookup(_))));
+                assert_eq!(
+                    *input,
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()]))
+                );
             } else {
                 panic!("Right branch was unexpectedly modified or corrupted");
             }


### PR DESCRIPTION
This PR addresses weak test assertions in `src/query/planner/rules/predicate_pushdown.rs` as identified in the `Elenchus Journal`. Tests that previously used `matches!(...)` macros with wildcards (`_`) provided false confidence because they verified only the presence of a target AST node without checking its internal configuration or properties.

**Changes:**
- Added `#[derive(PartialEq)]` to all logical plan AST nodes (`LogicalPlan`, `LogicalOp`, `ScanOp`, `UnaryOp`, `BinaryOp`, `SortKey`, `QueryHints`) in `src/query/plan.rs` to support exact equality assertions.
- Modified tests in `predicate_pushdown.rs` (`test_push_filter_below_vector_rank_no_limit`, `test_push_filter_below_sort`, `test_multi_level_pushdown`, `test_binary_op_recursion_logic`, and `sentry_tests::test_binary_op_partial_optimization`) to exhaustively destructure output subtrees and strictly assert all nested properties (like `embedding`, `top_k`, `SortKey`, `Predicate`, and `ScanOp::NodeLookup` vectors) using `assert_eq!`.

These exact match assertions eliminate the "Ceremony Test" and "Alibi Test" blindspots where optimization logic could corrupt operator arguments or discard nodes silently while still passing the test suite.

---
*PR created automatically by Jules for task [5742963571264136242](https://jules.google.com/task/5742963571264136242) started by @madmax983*