### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -357,6 +357,29 @@ impl Default for AnchorConfig {
 /// This stores only the changes from the previous version, enabling
 /// efficient storage of temporal data. For vector properties, uses
 /// sparse delta compression when beneficial (Issue #215).
+///
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::core::property::PropertyMapBuilder;
+/// use aletheiadb::core::version::PropertyDelta;
+///
+/// let old_props = PropertyMapBuilder::new()
+///     .insert("name", "Alice")
+///     .insert("age", 30i64)
+///     .build();
+///
+/// let new_props = PropertyMapBuilder::new()
+///     .insert("name", "Alice")
+///     .insert("age", 31i64) // age changed
+///     .build();
+///
+/// let delta = PropertyDelta::from_diff(&old_props, &new_props);
+/// assert!(!delta.is_empty());
+///
+/// let result = delta.apply(&old_props);
+/// assert_eq!(result.get("age").and_then(|v| v.as_int()), Some(31));
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct PropertyDelta {
     /// Properties that were added or modified (non-vector)
@@ -654,6 +677,10 @@ impl Default for PropertyDelta {
 }
 
 /// Version data - either a full snapshot (anchor) or a delta.
+///
+/// Represents the payload of a node or edge version. If the node or edge has not changed
+/// sufficiently to warrant a full snapshot, it may store a [`VersionData::Delta`] representing
+/// changes from the prior version. Otherwise, it stores a [`VersionData::Anchor`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum VersionData {
     /// Full snapshot of properties (anchor point)

--- a/src/index/temporal_adjacency.rs
+++ b/src/index/temporal_adjacency.rs
@@ -74,9 +74,9 @@ impl TemporalAdjacencyEntry {
 
 /// Temporal adjacency index for graph traversal at specific points in time.
 pub struct TemporalAdjacencyIndex {
-    /// Outgoing edges: source_node -> [entries]
+    /// Outgoing edges: source_node -> `[entries]`
     pub(crate) outgoing: DashMap<NodeId, Vec<TemporalAdjacencyEntry>>,
-    /// Incoming edges: target_node -> [entries]
+    /// Incoming edges: target_node -> `[entries]`
     pub(crate) incoming: DashMap<NodeId, Vec<TemporalAdjacencyEntry>>,
     /// Configuration
     config: TemporalAdjacencyConfig,

--- a/src/storage/current/iterators.rs
+++ b/src/storage/current/iterators.rs
@@ -10,7 +10,7 @@
 //! (100-500ns per traversal) in hot paths, especially for deep graph queries.
 //!
 //! AletheiaDB avoids this by returning lazy iterators. These iterators hold a lock-free reference
-//! ([`MergedAdjacencyGuard`](crate::index::incremental_adjacency::MergedAdjacencyGuard)) to the underlying
+//! ([`MergedAdjacencyGuard`]) to the underlying
 //! adjacency data (frozen CSR slice + delta map) and yield edge IDs on demand.
 //!
 //! This approach provides:

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -312,6 +312,21 @@ pub(crate) fn load_vector_indexes(
 ///
 /// This ensures that on restart, the graph structure can be reloaded 6-30x faster than
 /// replaying the Write-Ahead Log (WAL).
+///
+/// # Examples
+///
+/// ```ignore
+/// use aletheiadb::storage::index_persistence::operations::persist_graph_index;
+///
+/// // Example of persisting the graph (Internal API)
+/// let (nodes, edges) = persist_graph_index(
+///     &current_storage,
+///     &manager,
+///     Some(&tracker),
+///     current_lsn
+/// ).unwrap();
+/// println!("Persisted {} nodes and {} edges", nodes, edges);
+/// ```
 pub(crate) fn persist_graph_index(
     current: &Arc<CurrentStorage>,
     manager: &Arc<IndexPersistenceManager>,
@@ -396,6 +411,14 @@ pub(crate) fn persist_graph_index(
 }
 
 /// Persist temporal index to disk.
+///
+/// Converts the historical versions of nodes and edges into a disk-friendly format
+/// and writes them to `versions.idx`.
+///
+/// # Panics
+///
+/// This function does not panic under normal conditions, but relies on obtaining a read lock
+/// on the `HistoricalStorage`. If the lock is poisoned, it will panic.
 pub(crate) fn persist_temporal_index(
     historical: &Arc<RwLock<HistoricalStorage>>,
     _temporal_indexes: &Arc<TemporalIndexes>,
@@ -466,6 +489,9 @@ pub(crate) fn persist_temporal_index(
 }
 
 /// Persist string interner to disk.
+///
+/// Writes the global string interner state so that `InternedString` IDs can be accurately
+/// resolved across restarts. This must be the first index loaded on startup.
 pub(crate) fn persist_string_interner(
     manager: &Arc<IndexPersistenceManager>,
     tracker: &Arc<PersistenceTracker>,
@@ -489,6 +515,9 @@ pub(crate) fn persist_string_interner(
 }
 
 /// Persist temporal adjacency index to disk.
+///
+/// Saves the temporal adjacency index which allows fast temporal edge traversal.
+/// If the index is not enabled or empty, this does nothing.
 pub(crate) fn persist_temporal_adjacency_index(
     historical: &Arc<RwLock<HistoricalStorage>>,
     manager: &Arc<IndexPersistenceManager>,


### PR DESCRIPTION
*   Fixed `cargo doc` warnings in `src/index/temporal_adjacency.rs` and `src/storage/current/iterators.rs`.
*   Added comprehensive, narrative-driven documentation to `src/core/version.rs` (specifically `PropertyDelta` and `VersionData`) and `src/storage/index_persistence/operations.rs` (specifically `persist_graph_index`, `persist_temporal_index`, etc.).
*   Added an executable doc-test for `PropertyDelta`.
*   Explained the *why* for operations (e.g. why string interner is loaded first).

---
*PR created automatically by Jules for task [4985551508831291280](https://jules.google.com/task/4985551508831291280) started by @madmax983*