### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -15,3 +15,7 @@
 **IdentityHasher Coverage Gap**
 **Learning:** `IdentityHasher` provides optimizations for pre-hashed unique integer keys. However, large portions of `Hasher::write` branches, state mutability paths, and trait implementations (like bitwise operations in `update_state`) were not comprehensively tested, leaving them vulnerable to subtle regressions if tampered with (e.g., via mutation testing).
 **Action:** Wrote exhaustive tests covering every match arm in `write`, explicitly tested the `else` branch of `update_state` (which involves a XOR mix and multiply), and checked each integer specific method (`write_u8`, `write_u16`, etc.) individually and sequentially to eliminate any remaining `cargo mutants` escapees.
+
+## Import CSR Invariant Unwrapping
+**Learning:** `AdjacencyIndex::import_csr` used `.unwrap()` directly on the result of `validate_csr_invariants`. If the persisted graph data was corrupted on disk (e.g., offsets were wrong or lengths mismatched), the database startup would panic and crash the entire process.
+**Action:** Changed the function to return a `Result<Self, String>` and use the `?` operator. Propagated this error up through `CurrentIndexes` and `CurrentStorage` so that the `IndexPersistenceManager` could safely catch it during startup. Now, if corrupted data is loaded, it gracefully logs an error and falls back to `compact_adjacency()` to rebuild the index. Verified by converting the existing `#[should_panic]` test to expect an `Err`.

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-git diff
+git diff tests/sentry_coverage_tests.rs

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-git diff HEAD~1..HEAD --name-only
+git diff

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -94,13 +94,13 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Self {
+    ) -> Result<Self, String> {
         if offsets.is_empty() || edge_ids.is_empty() {
-            return Self::new();
+            return Ok(Self::new());
         }
 
         // Validate CSR invariants
-        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids).unwrap();
+        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids)?;
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -128,12 +128,12 @@ impl AdjacencyIndex {
             }
         }
 
-        Self {
+        Ok(Self {
             node_ids: node_ids_typed,
             offsets: offsets_usize,
             edges: adjacency_entries,
             max_node_id,
-        }
+        })
     }
 }
 
@@ -814,7 +814,7 @@ mod tests {
         edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
         edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
@@ -879,14 +879,14 @@ mod sentry_tests {
     }
 
     #[test]
-    #[should_panic(expected = "CSR offsets length mismatch")]
     fn test_import_csr_panics_on_invalid() {
-        // Integration check: ensure import_csr actually calls validate and panics
+        // Integration check: ensure import_csr actually calls validate and returns Err
         let node_ids = vec![10];
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
-        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let err = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap_err();
+        assert!(err.contains("CSR offsets length mismatch"));
     }
 
     #[test]
@@ -905,7 +905,7 @@ mod sentry_tests {
         edges_map.insert(EdgeId::new(101).unwrap(), (target, label));
 
         // Should not panic
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
 
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -781,7 +781,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> Result<(), String> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -812,7 +812,7 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -828,7 +828,7 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====
@@ -858,6 +858,8 @@ impl CurrentIndexes {
                 );
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -985,7 +985,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> std::result::Result<(), String> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,
@@ -993,7 +993,7 @@ impl CurrentStorage {
             incoming_node_ids,
             incoming_offsets,
             incoming_edge_ids,
-        );
+        )
     }
 
     /// Get the number of nodes.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -850,14 +850,20 @@ pub(crate) fn load_indexes_startup(
                 if !graph_data.outgoing_offsets.is_empty()
                     && !graph_data.incoming_offsets.is_empty()
                 {
-                    current.import_csr(
+                    if let Err(e) = current.import_csr(
                         graph_data.outgoing_node_ids,
                         graph_data.outgoing_offsets,
                         graph_data.outgoing_neighbors,
                         graph_data.incoming_node_ids,
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
-                    );
+                    ) {
+                        eprintln!(
+                            "Failed to import CSR data, falling back to compact_adjacency: {}",
+                            e
+                        );
+                        current.compact_adjacency();
+                    }
                 } else {
                     // Fallback for older index files without CSR data
                     current.compact_adjacency();

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1374,14 +1374,16 @@ mod phase7_persistence_integration {
         }
 
         // Import CSR - should reconstruct delta from diff
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1440,14 +1442,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1519,14 +1523,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1585,14 +1591,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Delta should be empty
         assert_eq!(

--- a/tests/sentry_coverage_tests.rs
+++ b/tests/sentry_coverage_tests.rs
@@ -56,6 +56,12 @@ fn test_load_indexes_startup_corrupt_csr_fallback() {
     let target = db.create_node("Company", Default::default()).unwrap();
     db.create_edge(source, target, "WORKS_AT", Default::default())
         .unwrap();
+
+    // Instead of `db.compact_adjacency()` which doesn't exist, we will use the test-only
+    // internal api or auto-trigger it. Since I cannot access pub(crate) from `tests/`,
+    // I can make a fake `GraphIndexData` entirely manually and write it to `adjacency.idx`!
+    // But since `AletheiaDB` was created, I can just let it persist nodes and edges,
+    // and I'll modify the `graph_data` manually after loading it.
     db.persist_indexes().unwrap();
     drop(db);
 
@@ -65,11 +71,19 @@ fn test_load_indexes_startup_corrupt_csr_fallback() {
 
     let mut data = load_graph_index(&graph_path).unwrap();
 
-    // Corrupt the CSR offsets! (Make lengths mismatch to trigger import_csr error)
-    if !data.outgoing_offsets.is_empty() {
-        let last = data.outgoing_offsets.len() - 1;
-        data.outgoing_offsets[last] = 9999;
-    }
+    // Because the DB didn't compact, outgoing_offsets is likely empty!
+    // We can manually fake a CSR structure that fails validation to force it down the error path.
+    data.outgoing_node_ids = vec![0];
+    data.outgoing_offsets = vec![0, 1]; // Length 2
+    data.outgoing_neighbors = vec![1];  // Length 1 (valid so far)
+
+    // Also need incoming to bypass the `!is_empty()` checks
+    data.incoming_node_ids = vec![1];
+    data.incoming_offsets = vec![0, 1];
+    data.incoming_neighbors = vec![0];
+
+    // Corrupt the CSR offsets! (Make length of offsets wrong compared to neighbors)
+    data.outgoing_offsets.push(2); // Now length 3, neighbors length 1 -> Mismatch!
 
     // Save back to disk
     save_graph_index(&data, &graph_path).unwrap();
@@ -87,7 +101,20 @@ fn test_load_indexes_startup_corrupt_csr_fallback() {
     let db2 = db2.unwrap();
 
     // Graph should still be queryable (since compact_adjacency rebuilds it from the base nodes/edges)
-    // We do a simple node count / degree check instead of SQL to avoid parsing
     assert_eq!(db2.node_count(), 2);
     assert_eq!(db2.edge_count(), 1);
 }
+// I noticed db.persist_indexes() is saving `outgoing_neighbors` as empty,
+// which causes `import_csr` to hit the `if offsets.is_empty() || edge_ids.is_empty() { return Ok(...) }` early return.
+// Why is `outgoing_neighbors` empty? `current.export_outgoing_csr()` must be returning empty?
+// Wait, `db.persist_indexes()` persists `current.all_edges()`, but CSR is exported from `current.export_outgoing_csr()`.
+// `CurrentIndexes` only moves items to CSR via `compact_adjacency()`.
+// `db.persist_indexes()` does not automatically compact before exporting!
+// Ah, `current.export_outgoing_csr()` exports the frozen CSR. But my new edge is still in the delta buffer!
+// Let's add `db.compact_adjacency()` before `db.persist_indexes()`!
+// I see that db.persist_indexes() does NOT compact the adjacency!
+// So it just saves the frozen CSR (which is empty) and the delta buffer is saved somewhere else?
+// Wait, `persist_graph_index` calls `current.export_outgoing_csr()`.
+// Let's check what `persist_graph_index` does.
+// I'll call `db.current_storage().compact_adjacency();` directly, if I can.
+// But AletheiaDB struct has no current_storage() method publicly available.

--- a/tests/sentry_coverage_tests.rs
+++ b/tests/sentry_coverage_tests.rs
@@ -1,0 +1,90 @@
+use aletheiadb::AletheiaDB;
+use aletheiadb::AletheiaDBConfig;
+use aletheiadb::index::current::CurrentIndexes;
+use aletheiadb::storage::index_persistence::IndexPersistenceManager;
+use aletheiadb::storage::index_persistence::graph::{load_graph_index, save_graph_index};
+
+#[test]
+fn test_current_indexes_import_csr_propagates_error() {
+    let indexes = CurrentIndexes::new();
+
+    let out_node_ids = vec![10];
+    let out_offsets = vec![0];
+    let out_edge_ids = vec![100];
+    let in_node_ids = vec![10];
+    let in_offsets = vec![0, 1];
+    let in_edge_ids = vec![100];
+
+    let res = indexes.import_csr(
+        out_node_ids.clone(),
+        out_offsets.clone(),
+        out_edge_ids.clone(),
+        in_node_ids.clone(),
+        in_offsets.clone(),
+        in_edge_ids.clone(),
+    );
+
+    assert!(res.is_err());
+    assert!(res.unwrap_err().contains("CSR offsets length mismatch"));
+
+    let out_offsets_valid = vec![0, 1];
+    let in_offsets_invalid = vec![0];
+
+    let res2 = indexes.import_csr(
+        out_node_ids,
+        out_offsets_valid,
+        out_edge_ids,
+        in_node_ids,
+        in_offsets_invalid,
+        in_edge_ids,
+    );
+
+    assert!(res2.is_err());
+    assert!(res2.unwrap_err().contains("CSR offsets length mismatch"));
+}
+
+#[test]
+fn test_load_indexes_startup_corrupt_csr_fallback() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut config = AletheiaDBConfig::default();
+    config.wal.wal_dir = temp_dir.path().join("wal");
+    config.persistence.data_dir = temp_dir.path().join("data");
+
+    // Create DB to write valid data
+    let db = AletheiaDB::with_unified_config(config.clone()).unwrap();
+    let source = db.create_node("Person", Default::default()).unwrap();
+    let target = db.create_node("Company", Default::default()).unwrap();
+    db.create_edge(source, target, "WORKS_AT", Default::default())
+        .unwrap();
+    db.persist_indexes().unwrap();
+    drop(db);
+
+    // Read the graph data
+    let manager = IndexPersistenceManager::new(&config.persistence.data_dir);
+    let graph_path = manager.graph_path().join("adjacency.idx");
+
+    let mut data = load_graph_index(&graph_path).unwrap();
+
+    // Corrupt the CSR offsets! (Make lengths mismatch to trigger import_csr error)
+    data.outgoing_offsets.pop();
+
+    // Save back to disk
+    save_graph_index(&data, &graph_path).unwrap();
+
+    // Re-initialize DB from this corrupted state
+    // It should hit the fallback `compact_adjacency()` logic!
+    let db2 = AletheiaDB::with_unified_config(config);
+
+    // The DB should successfully load without panicking
+    assert!(
+        db2.is_ok(),
+        "Database should gracefully recover from corrupted CSR offsets"
+    );
+
+    let db2 = db2.unwrap();
+
+    // Graph should still be queryable (since compact_adjacency rebuilds it from the base nodes/edges)
+    // We do a simple node count / degree check instead of SQL to avoid parsing
+    assert_eq!(db2.node_count(), 2);
+    assert_eq!(db2.edge_count(), 1);
+}

--- a/tests/sentry_coverage_tests.rs
+++ b/tests/sentry_coverage_tests.rs
@@ -66,7 +66,10 @@ fn test_load_indexes_startup_corrupt_csr_fallback() {
     let mut data = load_graph_index(&graph_path).unwrap();
 
     // Corrupt the CSR offsets! (Make lengths mismatch to trigger import_csr error)
-    data.outgoing_offsets.pop();
+    if !data.outgoing_offsets.is_empty() {
+        let last = data.outgoing_offsets.len() - 1;
+        data.outgoing_offsets[last] = 9999;
+    }
 
     // Save back to disk
     save_graph_index(&data, &graph_path).unwrap();

--- a/tests/sentry_coverage_tests.rs
+++ b/tests/sentry_coverage_tests.rs
@@ -75,7 +75,7 @@ fn test_load_indexes_startup_corrupt_csr_fallback() {
     // We can manually fake a CSR structure that fails validation to force it down the error path.
     data.outgoing_node_ids = vec![0];
     data.outgoing_offsets = vec![0, 1]; // Length 2
-    data.outgoing_neighbors = vec![1];  // Length 1 (valid so far)
+    data.outgoing_neighbors = vec![1]; // Length 1 (valid so far)
 
     // Also need incoming to bypass the `!is_empty()` checks
     data.incoming_node_ids = vec![1];


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `AdjacencyIndex::import_csr` and its callers up to `CurrentStorage`.
💣 Risk: Loading corrupted `adjacency.idx` from disk would cause an immediate, unrecoverable panic during startup due to an `.unwrap()` on `validate_csr_invariants`.
🧪 Strategy: Refactored `import_csr` to return a `Result<Self, String>`. Bubbled the error up to `storage/index_persistence/operations.rs` where the `load_indexes_startup` now catches it, logs the corruption, and triggers a safe fallback index rebuild via `current.compact_adjacency()`. Removed `#[should_panic]` test and replaced it with a proper `Err` assertion.
🔬 Verification: `cargo test --lib index::adjacency::sentry_tests::test_import_csr_panics_on_invalid`

---
*PR created automatically by Jules for task [17277692524010134084](https://jules.google.com/task/17277692524010134084) started by @madmax983*