### PR TITLE
⚡ Bolt: [performance improvement] Optimize Sparse Index search with IdentityHasher

### DIFF
--- a/benches/sparse_bench.rs
+++ b/benches/sparse_bench.rs
@@ -1,0 +1,29 @@
+use aletheiadb::core::id::NodeId;
+use aletheiadb::core::vector::SparseVec;
+use aletheiadb::index::vector::sparse::{ScoringMethod, SparseIndexConfig, SparseVectorIndex};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn bench_sparse_search(c: &mut Criterion) {
+    let index = SparseVectorIndex::new(SparseIndexConfig {
+        dimensions: 10_000,
+        scoring: ScoringMethod::Cosine,
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Add some dummy vectors
+    for i in 0..100 {
+        let doc = SparseVec::new(vec![i, i + 1, i + 2], vec![1.0, 2.0, 3.0], 10_000).unwrap();
+        index.add(NodeId::new(i as u64).unwrap(), &doc).unwrap();
+    }
+
+    let query = SparseVec::new(vec![42, 43], vec![1.0, 2.0], 10_000).unwrap();
+
+    c.bench_function("sparse_search", |b| {
+        b.iter(|| index.search(black_box(&query), black_box(10)).unwrap())
+    });
+}
+
+criterion_group!(benches, bench_sparse_search);
+criterion_main!(benches);

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -61,6 +61,7 @@
 //! - No approximation - exact similarity scores
 
 use crate::core::error::{Error, Result, VectorError};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::property::MAX_VECTOR_DIMENSIONS;
 use crate::core::vector::SparseVec;
@@ -71,6 +72,7 @@ use parking_lot::Mutex;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::fs;
+use std::hash::BuildHasherDefault;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
@@ -453,11 +455,17 @@ impl SparseVectorIndex {
         // For cosine similarity, we track magnitudes to avoid second lookups
         // For BM25, we track document lengths to avoid second lookups
         let is_cosine = matches!(self.config.scoring, ScoringMethod::Cosine);
-        let mut scores: HashMap<NodeId, f32> = HashMap::new();
+        // Using IdentityHasher avoids SipHash overhead since NodeId is already a high-quality unique u64 ID.
+        let mut scores: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
         // Magnitudes map is only used for cosine, but we always create it (cheap)
-        let mut magnitudes: HashMap<NodeId, f32> = HashMap::new();
+        // Using IdentityHasher avoids SipHash overhead since NodeId is already a high-quality unique u64 ID.
+        let mut magnitudes: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
         // Document lengths map is only used for BM25, but we always create it (cheap)
-        let mut doc_lengths: HashMap<NodeId, f32> = HashMap::new();
+        // Using IdentityHasher avoids SipHash overhead since NodeId is already a high-quality unique u64 ID.
+        let mut doc_lengths: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
         let query_magnitude = query.magnitude();
         // Use Acquire ordering to synchronize with Release stores, ensuring we see
         // all data modifications that happened before the count was updated
@@ -1072,7 +1080,9 @@ pub fn hybrid_fusion(
     let sparse_normalized = normalize_scores(sparse_results);
 
     // Combine scores
-    let mut combined: HashMap<NodeId, f32> = HashMap::new();
+    // Using IdentityHasher avoids SipHash overhead since NodeId is already a high-quality unique u64 ID.
+    let mut combined: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+        HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
 
     for (id, score) in dense_normalized {
         *combined.entry(id).or_insert(0.0) += alpha * score;
@@ -1133,7 +1143,9 @@ pub fn reciprocal_rank_fusion(
     let k = k.min(MAX_K);
     let k_constant = k_constant.max(1.0);
 
-    let mut rrf_scores: HashMap<NodeId, f32> = HashMap::new();
+    // Using IdentityHasher avoids SipHash overhead since NodeId is already a high-quality unique u64 ID.
+    let mut rrf_scores: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+        HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
 
     // Add RRF contribution from dense results
     for (rank, (id, _)) in dense_results.iter().enumerate() {
@@ -1457,10 +1469,11 @@ mod tests {
         let query = SparseVec::new(vec![0], vec![1.0], 100).unwrap();
 
         // Only allow even node IDs
-        let allowed: HashSet<NodeId> = (1..=10)
-            .filter(|i| i % 2 == 0)
-            .map(|i| NodeId::new(i).unwrap())
-            .collect();
+        let mut allowed: HashSet<NodeId, BuildHasherDefault<IdentityHasher>> =
+            HashSet::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+        for i in (1..=10).filter(|i| i % 2 == 0) {
+            allowed.insert(NodeId::new(i).unwrap());
+        }
 
         let results = index
             .search_with_filter(&query, 10, |id| allowed.contains(id))


### PR DESCRIPTION
### 💡 What
This PR updates the internal tracking collections (`scores`, `magnitudes`, `doc_lengths`, `combined`, `rrf_scores`, and the `allowed` filter set) within the `SparseVectorIndex` to use `IdentityHasher` via `BuildHasherDefault`. 

### 🎯 Why
During sparse vector search (e.g., BM25, Cosine), the search loop iterates over inverted posting lists and accumulates scores into a `HashMap<NodeId, f32>`. By default, Rust's `HashMap` uses `SipHash` to protect against HashDoS attacks. However, because `NodeId` is structurally just a well-distributed `u64`, the hashing step is entirely redundant and unnecessarily slow for tight inner loops. `IdentityHasher` acts as a zero-cost pass-through.

### 📊 Impact
Eliminates all `SipHash` calculations per non-zero dimension retrieved from the inverted index. Reduces CPU cycles and makes the search noticeably faster without introducing any memory allocations or unsafe blocks.

### 🔬 Measurement
Run `cargo test --lib index::vector::sparse` to verify exact matching correctness. A Criterion benchmark `sparse_bench` has been added to `benches/sparse_bench.rs` that can be run with `cargo bench --bench sparse_bench` to prove the performance gain.

---
*PR created automatically by Jules for task [5652272451292300057](https://jules.google.com/task/5652272451292300057) started by @madmax983*