### PR TITLE
🔒 Warden: [security fix] Fix panic in `import_csr` by propagating validation errors

### DIFF
--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -94,13 +94,13 @@ impl AdjacencyIndex {
             (NodeId, InternedString),
             BuildHasherDefault<IdentityHasher>,
         >,
-    ) -> Self {
+    ) -> Result<Self, String> {
         if offsets.is_empty() || edge_ids.is_empty() {
-            return Self::new();
+            return Ok(Self::new());
         }
 
         // Validate CSR invariants
-        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids).unwrap();
+        Self::validate_csr_invariants(&node_ids, &offsets, &edge_ids)?;
 
         let max_node_id = node_ids.iter().max().copied().unwrap_or(0);
 
@@ -128,12 +128,12 @@ impl AdjacencyIndex {
             }
         }
 
-        Self {
+        Ok(Self {
             node_ids: node_ids_typed,
             offsets: offsets_usize,
             edges: adjacency_entries,
             max_node_id,
-        }
+        })
     }
 }
 
@@ -814,7 +814,7 @@ mod tests {
         edges_map.insert(EdgeId::new(10).unwrap(), (NodeId::new(2).unwrap(), label));
         edges_map.insert(EdgeId::new(20).unwrap(), (NodeId::new(1).unwrap(), label));
 
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.edge_count(), 2);
     }
@@ -879,14 +879,15 @@ mod sentry_tests {
     }
 
     #[test]
-    #[should_panic(expected = "CSR offsets length mismatch")]
-    fn test_import_csr_panics_on_invalid() {
-        // Integration check: ensure import_csr actually calls validate and panics
+    fn test_import_csr_returns_err_on_invalid() {
+        // Integration check: ensure import_csr actually calls validate and returns err
         let node_ids = vec![10];
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
-        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let result = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("CSR offsets length mismatch"));
     }
 
     #[test]
@@ -905,7 +906,7 @@ mod sentry_tests {
         edges_map.insert(EdgeId::new(101).unwrap(), (target, label));
 
         // Should not panic
-        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+        let index = AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map).unwrap();
 
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -781,7 +781,7 @@ impl CurrentIndexes {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> Result<(), String> {
         use crate::core::hasher::IdentityHasher;
         use std::collections::{HashMap, HashSet};
         use std::hash::BuildHasherDefault;
@@ -812,7 +812,7 @@ impl CurrentIndexes {
             outgoing_offsets.clone(),
             outgoing_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.outgoing.import_frozen_csr(Arc::new(outgoing_csr));
 
         // Rebuild edges map for incoming (maps edge_id to source, not target)
@@ -828,7 +828,7 @@ impl CurrentIndexes {
             incoming_offsets,
             incoming_edge_ids.clone(),
             &edges_map,
-        );
+        )?;
         self.incoming.import_frozen_csr(Arc::new(incoming_csr));
 
         // ===== Phase 7: Reconstruct Delta Buffer =====
@@ -858,6 +858,8 @@ impl CurrentIndexes {
                 );
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -985,7 +985,7 @@ impl CurrentStorage {
         incoming_node_ids: Vec<u64>,
         incoming_offsets: Vec<u64>,
         incoming_edge_ids: Vec<u64>,
-    ) {
+    ) -> std::result::Result<(), String> {
         self.indexes.import_csr(
             outgoing_node_ids,
             outgoing_offsets,
@@ -993,7 +993,7 @@ impl CurrentStorage {
             incoming_node_ids,
             incoming_offsets,
             incoming_edge_ids,
-        );
+        )
     }
 
     /// Get the number of nodes.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -858,7 +858,10 @@ pub(crate) fn load_indexes_startup(
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
                     ) {
-                        log::error!("Failed to import CSR data: {}. Falling back to rebuilding adjacency...", e);
+                        eprintln!(
+                            "Failed to import CSR data: {}. Falling back to rebuilding adjacency...",
+                            e
+                        );
                         current.compact_adjacency();
                     }
                 } else {

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -858,10 +858,7 @@ pub(crate) fn load_indexes_startup(
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
                     ) {
-                        eprintln!(
-                            "Failed to import CSR data: {}. Falling back to rebuilding adjacency...",
-                            e
-                        );
+                        log::error!("Failed to import CSR data: {}. Falling back to rebuilding adjacency...", e);
                         current.compact_adjacency();
                     }
                 } else {

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -850,14 +850,20 @@ pub(crate) fn load_indexes_startup(
                 if !graph_data.outgoing_offsets.is_empty()
                     && !graph_data.incoming_offsets.is_empty()
                 {
-                    current.import_csr(
+                    if let Err(e) = current.import_csr(
                         graph_data.outgoing_node_ids,
                         graph_data.outgoing_offsets,
                         graph_data.outgoing_neighbors,
                         graph_data.incoming_node_ids,
                         graph_data.incoming_offsets,
                         graph_data.incoming_neighbors,
-                    );
+                    ) {
+                        eprintln!(
+                            "Failed to import CSR data: {}. Falling back to rebuilding adjacency...",
+                            e
+                        );
+                        current.compact_adjacency();
+                    }
                 } else {
                     // Fallback for older index files without CSR data
                     current.compact_adjacency();

--- a/tests/incremental_adjacency_tests.rs
+++ b/tests/incremental_adjacency_tests.rs
@@ -1374,14 +1374,16 @@ mod phase7_persistence_integration {
         }
 
         // Import CSR - should reconstruct delta from diff
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify all 13 edges are visible (10 in frozen + 3 in delta)
         {
@@ -1440,14 +1442,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify delta is empty
         assert_eq!(new_indexes.delta_edge_count(), 0, "Delta should be empty");
@@ -1519,14 +1523,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Verify each node has correct edge count
         for source in 0..3 {
@@ -1585,14 +1591,16 @@ mod phase7_persistence_integration {
             }
         }
 
-        new_indexes.import_csr(
-            out_nodes,
-            out_offsets,
-            out_edges,
-            in_nodes,
-            in_offsets,
-            in_edges,
-        );
+        new_indexes
+            .import_csr(
+                out_nodes,
+                out_offsets,
+                out_edges,
+                in_nodes,
+                in_offsets,
+                in_edges,
+            )
+            .unwrap();
 
         // Delta should be empty
         assert_eq!(

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -2841,3 +2841,110 @@ fn test_parallel_loading_graph_error() {
 
     println!("✓ Parallel loading graph error test passed");
 }
+
+#[test]
+fn test_malformed_csr_data_fallback() {
+    let _guard = INTERNER_TEST_MUTEX.lock().unwrap();
+
+    use aletheiadb::storage::index_persistence::PersistenceConfig;
+    use aletheiadb::{AletheiaDB, PropertyMapBuilder, config::AletheiaDBConfig};
+
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let wal_dir = dir.path().join("wal");
+
+    // Create database with data
+    {
+        let config = AletheiaDBConfig::builder()
+            .wal(WalConfigBuilder::new().wal_dir(wal_dir.clone()).build())
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: data_dir.clone(),
+                load_on_startup: false,
+                ..Default::default()
+            })
+            .build();
+
+        let db = AletheiaDB::with_unified_config(config).unwrap();
+
+        let n1 = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+
+        let n2 = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+
+        db.create_edge(
+            n1,
+            n2,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2020).build(),
+        )
+        .unwrap();
+
+        db.persist_indexes().unwrap();
+    }
+
+    // Now corrupt the graph persistence file directly to have an invalid CSR state
+    // We will do this by injecting corrupted CSR offsets in the serialized data.
+    use aletheiadb::storage::index_persistence::IndexPersistenceManager;
+    let manager = IndexPersistenceManager::new(&data_dir);
+    let graph_path = manager.graph_path().join("adjacency.idx");
+
+    // The best way to test this without manually messing with binary format is to replace the file with valid structure
+    // but invalid CSR invariants (e.g. non-monotonic offsets).
+    // Instead of raw byte hacking, we will just use a helper method to write malformed data.
+    use aletheiadb::storage::index_persistence::formats::GraphIndexData;
+
+    let corrupted_graph_data = GraphIndexData {
+        magic: *b"GGRP",
+        version: 1,
+        node_count: 2,
+        edge_count: 1,
+        nodes: vec![],
+        edges: vec![],
+        outgoing_node_ids: vec![1, 2],
+        outgoing_offsets: vec![0, 5, 2], // INVALID: non-monotonic offsets
+        outgoing_neighbors: vec![100, 101, 102],
+
+        // Valid incoming but outgoing is enough to fail the overall CSR import
+        incoming_node_ids: vec![1, 2],
+        incoming_offsets: vec![0, 1, 2],
+        incoming_neighbors: vec![100, 101],
+    };
+
+    let serialized_data = bitcode::encode(&corrupted_graph_data);
+
+    let mut file = std::fs::File::create(&graph_path).unwrap();
+
+    // We also need to add zstd compression because graph files are compressed
+    let mut encoder = zstd::stream::Encoder::new(&mut file, 0).unwrap();
+    std::io::Write::write_all(&mut encoder, &serialized_data).unwrap();
+    encoder.finish().unwrap();
+
+    // Try to load - should handle corrupted CSR gracefully by falling back to rebuilding adjacency
+    let config = AletheiaDBConfig::builder()
+        .wal(WalConfigBuilder::new().wal_dir(wal_dir.clone()).build())
+        .persistence(PersistenceConfig {
+            enabled: true,
+            data_dir: data_dir.clone(),
+            load_on_startup: true,
+            ..Default::default()
+        })
+        .build();
+
+    // Should not panic, but successfully start
+    let _db = AletheiaDB::with_unified_config(config).unwrap();
+
+    // The graph might be empty if it had to completely rebuild and no WAL/other data was there
+    // But importantly, it didn't panic!
+
+    println!("✓ Malformed CSR data fallback test passed");
+}


### PR DESCRIPTION
**Threat:** When loading graph data from disk, corrupted or malicious files with invalid Compressed Sparse Row (CSR) metadata could trigger an `.unwrap()` panic during `import_csr` validation, causing a Denial of Service (DoS) preventing the database from booting.

**Defense:** Safely propagated validation errors up the stack. `AdjacencyIndex::import_csr` and its callers now return `Result`. In `operations.rs`, failures in CSR loading are caught, logged, and trigger a graceful fallback to reconstructing the adjacency lists dynamically via `current.compact_adjacency()`.

**Severity:** Moderate/High - Local DoS via persistence file corruption.

**Verification:**
*   Updated unit tests to expect `Err` rather than a panic.
*   Added `test_malformed_csr_data_fallback` integration test in `index_persistence.rs` which explicitly corrupts CSR offsets (non-monotonic) and proves the database recovers successfully.
*   Fixed unused Result warnings in `incremental_adjacency_tests.rs`.

---
*PR created automatically by Jules for task [2425318835011998092](https://jules.google.com/task/2425318835011998092) started by @madmax983*