### PR TITLE
🎻 Bard: query planner documentation update

### DIFF
--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -28,12 +28,34 @@ pub struct Cost {
 
 impl Cost {
     /// Create a new cost with all zero values
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::Cost;
+    ///
+    /// let cost = Cost::zero();
+    /// assert_eq!(cost.cpu, 0.0);
+    /// assert_eq!(cost.io, 0.0);
+    /// ```
     #[must_use]
     pub fn zero() -> Self {
         Cost::default()
     }
 
     /// Calculate total weighted cost for comparison
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::{Cost, CostWeights};
+    ///
+    /// let cost = Cost { cpu: 10.0, io: 5.0, memory: 100, network: 0.0 };
+    /// let weights = CostWeights { cpu_weight: 1.0, io_weight: 10.0, memory_weight: 0.1, network_weight: 1.0 };
+    ///
+    /// // 10.0 * 1.0 + 5.0 * 10.0 + 100.0 * 0.1 = 10.0 + 50.0 + 10.0 = 70.0
+    /// assert_eq!(cost.total(&weights), 70.0);
+    /// ```
     #[must_use]
     pub fn total(&self, weights: &CostWeights) -> f64 {
         self.cpu * weights.cpu_weight
@@ -43,6 +65,20 @@ impl Cost {
     }
 
     /// Add two costs together
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::Cost;
+    ///
+    /// let c1 = Cost { cpu: 1.0, io: 2.0, memory: 100, network: 0.0 };
+    /// let c2 = Cost { cpu: 2.0, io: 3.0, memory: 50, network: 0.0 };
+    ///
+    /// let sum = c1.add(&c2);
+    /// assert_eq!(sum.cpu, 3.0);
+    /// assert_eq!(sum.io, 5.0);
+    /// assert_eq!(sum.memory, 150);
+    /// ```
     #[must_use]
     pub fn add(&self, other: &Cost) -> Cost {
         Cost {
@@ -54,6 +90,19 @@ impl Cost {
     }
 
     /// Scale cost by a factor
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::Cost;
+    ///
+    /// let cost = Cost { cpu: 2.0, io: 4.0, memory: 100, network: 0.0 };
+    /// let scaled = cost.scale(1.5);
+    ///
+    /// assert_eq!(scaled.cpu, 3.0);
+    /// assert_eq!(scaled.io, 6.0);
+    /// assert_eq!(scaled.memory, 150);
+    /// ```
     #[must_use]
     pub fn scale(&self, factor: f64) -> Cost {
         Cost {
@@ -159,12 +208,33 @@ pub struct CostModel {
 
 impl CostModel {
     /// Create a new cost model with default values
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::CostModel;
+    ///
+    /// let model = CostModel::new();
+    /// assert_eq!(model.weights.cpu_weight, 1.0);
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Create a cost model optimized for low-latency queries
+    ///
+    /// This model penalizes I/O and network operations more heavily to favor
+    /// fast, in-memory execution strategies.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::CostModel;
+    ///
+    /// let model = CostModel::low_latency();
+    /// assert!(model.weights.io_weight > 10.0); // Heavily penalizes IO
+    /// ```
     #[must_use]
     pub fn low_latency() -> Self {
         CostModel {
@@ -179,6 +249,18 @@ impl CostModel {
     }
 
     /// Create a cost model optimized for throughput
+    ///
+    /// This model is more tolerant of high memory usage and I/O if it means
+    /// processing more data efficiently in parallel.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::CostModel;
+    ///
+    /// let model = CostModel::high_throughput();
+    /// assert!(model.weights.cpu_weight < 1.0); // CPU is weighted less heavily
+    /// ```
     #[must_use]
     pub fn high_throughput() -> Self {
         CostModel {
@@ -198,12 +280,43 @@ impl CostModel {
     /// of per-node iteration exceeds the cost of holding the lock longer.
     ///
     /// Returns true if batch mode should be used.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::CostModel;
+    ///
+    /// let model = CostModel::new();
+    /// // Single lookup is cheaper with per-node lock
+    /// assert!(!model.should_use_batch_temporal_lookup(1));
+    /// // Large batches are cheaper holding the lock
+    /// assert!(model.should_use_batch_temporal_lookup(1000));
+    /// ```
     #[must_use]
     pub fn should_use_batch_temporal_lookup(&self, node_count: usize) -> bool {
         node_count >= self.operation_costs.batch_threshold
     }
 
     /// Estimate the cost of executing a physical operator
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::CostModel;
+    /// use aletheiadb::query::planner::stats::Statistics;
+    /// use aletheiadb::query::planner::physical::PhysicalOp;
+    /// use aletheiadb::core::NodeId;
+    ///
+    /// let model = CostModel::new();
+    /// let stats = Statistics::new();
+    /// let op = PhysicalOp::NodeLookup {
+    ///     node_ids: vec![NodeId::new(1).unwrap(), NodeId::new(2).unwrap()]
+    /// };
+    ///
+    /// let cost = model.estimate(&op, &stats);
+    /// assert!(cost.cpu > 0.0);
+    /// assert_eq!(cost.io, 0.0); // Simple lookups are assumed in-memory
+    /// ```
     #[must_use]
     pub fn estimate(&self, op: &PhysicalOp, stats: &Statistics) -> Cost {
         match op {
@@ -296,6 +409,23 @@ impl CostModel {
     }
 
     /// Estimate cardinality of a physical operator's output
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::cost::CostModel;
+    /// use aletheiadb::query::planner::stats::Statistics;
+    /// use aletheiadb::query::planner::physical::PhysicalOp;
+    /// use aletheiadb::core::NodeId;
+    ///
+    /// let model = CostModel::new();
+    /// let stats = Statistics::new();
+    /// let op = PhysicalOp::NodeLookup {
+    ///     node_ids: vec![NodeId::new(1).unwrap(), NodeId::new(2).unwrap()]
+    /// };
+    ///
+    /// assert_eq!(model.estimate_cardinality(&op, &stats), 2);
+    /// ```
     #[must_use]
     pub fn estimate_cardinality(&self, op: &PhysicalOp, stats: &Statistics) -> usize {
         match op {

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -239,7 +239,7 @@ impl Statistics {
     /// use aletheiadb::query::planner::Statistics;
     ///
     /// let stats = Statistics::new();
-    /// // Returns a non-zero default even when uninitialized to prevent divide-by-zero
+    /// // Returns a non-zero default estimate if statistics are uninitialized or the graph is empty.
     /// assert!(stats.average_out_degree() > 0.0);
     /// ```
     #[must_use]

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -284,7 +284,7 @@ impl Statistics {
     /// use aletheiadb::core::interning::InternedString;
     ///
     /// let stats = Statistics::new();
-    /// let label = InternedString::new("Person");
+    /// let label = InternedString::from_raw(1); // Assuming 1 represents "Person"
     /// assert_eq!(stats.label_cardinality(&label), None);
     /// ```
     #[must_use]

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -156,36 +156,92 @@ pub struct Statistics {
 
 impl Statistics {
     /// Create new empty statistics
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// assert_eq!(stats.node_count(), 0);
+    /// assert!(!stats.is_initialized());
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Check if statistics have been initialized
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// assert!(!stats.is_initialized()); // false by default
+    /// ```
     #[must_use]
     pub fn is_initialized(&self) -> bool {
         self.initialized.load(Ordering::Acquire)
     }
 
     /// Get the total node count
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// assert_eq!(stats.node_count(), 0);
+    /// ```
     #[must_use]
     pub fn node_count(&self) -> usize {
         self.node_count.load(Ordering::Relaxed)
     }
 
     /// Get the total edge count
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// assert_eq!(stats.edge_count(), 0);
+    /// ```
     #[must_use]
     pub fn edge_count(&self) -> usize {
         self.edge_count.load(Ordering::Relaxed)
     }
 
     /// Get the number of indexed vectors
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// assert_eq!(stats.vector_count(), 0);
+    /// ```
     #[must_use]
     pub fn vector_count(&self) -> usize {
         self.vector_count.load(Ordering::Relaxed)
     }
 
     /// Get the average out-degree
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// // Returns a non-zero default even when uninitialized to prevent divide-by-zero
+    /// assert!(stats.average_out_degree() > 0.0);
+    /// ```
     #[must_use]
     pub fn average_out_degree(&self) -> f64 {
         let avg = self.avg_out_degree.load(Ordering::Relaxed);
@@ -198,6 +254,16 @@ impl Statistics {
     }
 
     /// Get the average delta chain length
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// // Returns a non-zero default even when uninitialized
+    /// assert!(stats.average_delta_chain_length() > 0.0);
+    /// ```
     #[must_use]
     pub fn average_delta_chain_length(&self) -> f64 {
         let avg = self.avg_delta_chain.load(Ordering::Relaxed);
@@ -210,6 +276,17 @@ impl Statistics {
     }
 
     /// Get cardinality for a specific label
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    /// use aletheiadb::core::interning::InternedString;
+    ///
+    /// let stats = Statistics::new();
+    /// let label = InternedString::new("Person");
+    /// assert_eq!(stats.label_cardinality(&label), None);
+    /// ```
     #[must_use]
     pub fn label_cardinality(&self, label: &InternedString) -> Option<usize> {
         self.label_counts.get(label).map(|r| *r)
@@ -251,6 +328,16 @@ impl Statistics {
     ///
     /// This is called by [`AletheiaDB::refresh_statistics`](crate::db::AletheiaDB::refresh_statistics)
     /// to populate the cache with fresh values from the storage engine.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// stats.refresh(100, 50, 10, vec![], 2.0);
+    /// assert_eq!(stats.node_count(), 100);
+    /// ```
     pub fn refresh(
         &self,
         node_count: usize,
@@ -284,6 +371,19 @@ impl Statistics {
     /// Invalidate cached statistics.
     ///
     /// Forces the next query to trigger a refresh.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// stats.refresh(100, 50, 10, vec![], 2.0);
+    /// assert!(stats.is_initialized());
+    ///
+    /// stats.invalidate();
+    /// assert!(!stats.is_initialized());
+    /// ```
     pub fn invalidate(&self) {
         self.initialized.store(false, Ordering::Release);
     }
@@ -291,6 +391,16 @@ impl Statistics {
     /// Update property statistics.
     ///
     /// Used to feed distinct counts from background analysis jobs.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::query::planner::Statistics;
+    ///
+    /// let stats = Statistics::new();
+    /// stats.update_property_stats("status", 3);
+    /// assert_eq!(stats.estimate_selectivity("status", "active"), 1.0 / 3.0);
+    /// ```
     pub fn update_property_stats(&self, property: &str, distinct_count: usize) {
         let mut stats = self.property_stats.write();
         stats


### PR DESCRIPTION
📖 Chapter: The `query::planner` module (`cost.rs` and `stats.rs`).
🔦 Insight: Explained the *why* behind cost models (`low_latency` vs `high_throughput`) and added clear usage documentation for cost calculation and statistics accessors. Note: Did not remove basic getter descriptions but enhanced them with practical examples showing edge cases (like non-zero defaults).
🧪 Example: Added executable `## Examples` doctests to 10 methods in `cost.rs` and 11 methods in `stats.rs`.
🖼️ Preview: (Ran `cargo doc` locally and verified visual output for structs).

---
*PR created automatically by Jules for task [11612542066188827570](https://jules.google.com/task/11612542066188827570) started by @madmax983*