### PR TITLE
🦀 Core: Fix AuraEngine dimension mismatch vulnerability

### DIFF
--- a/src/experimental/aura.rs
+++ b/src/experimental/aura.rs
@@ -164,9 +164,13 @@ impl<'a> AuraEngine<'a> {
                     let mut curr_normalized = current.clone();
                     ops::normalize_in_place(&mut curr_normalized);
 
-                    let sim = ops::cosine_similarity(&sum, &curr_normalized)?;
-                    // Divergence is distance: 1.0 - similarity
-                    divergence_score = (1.0 - sim).max(0.0);
+                    if sum.len() == curr_normalized.len() {
+                        let sim = ops::cosine_similarity(&sum, &curr_normalized)?;
+                        // Divergence is distance: 1.0 - similarity
+                        divergence_score = (1.0 - sim).max(0.0);
+                    } else {
+                        divergence_score = 1.0;
+                    }
                 }
 
                 aura_vector = Some(sum);

--- a/tests/aura_dimension_mismatch.rs
+++ b/tests/aura_dimension_mismatch.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "nova")]
 mod tests {
     use aletheiadb::AletheiaDB;
-    use aletheiadb::experimental::aura::AuraEngine;
-    use aletheiadb::core::property::PropertyMapBuilder;
     use aletheiadb::api::transaction::WriteOps;
+    use aletheiadb::core::property::PropertyMapBuilder;
+    use aletheiadb::experimental::aura::AuraEngine;
 
     #[test]
     fn test_aura_dimension_mismatch() {
@@ -43,8 +43,14 @@ mod tests {
 
         let engine = AuraEngine::new(&db);
         let result = engine.calculate_aura(n1, "vec", 1_000_000);
-        assert!(result.is_ok(), "Should not return an error due to dimension mismatch");
+        assert!(
+            result.is_ok(),
+            "Should not return an error due to dimension mismatch"
+        );
         let result = result.unwrap();
-        assert_eq!(result.divergence_score, 1.0, "Divergence should be 1.0 on dimension mismatch");
+        assert_eq!(
+            result.divergence_score, 1.0,
+            "Divergence should be 1.0 on dimension mismatch"
+        );
     }
 }

--- a/tests/aura_dimension_mismatch.rs
+++ b/tests/aura_dimension_mismatch.rs
@@ -1,0 +1,50 @@
+#[cfg(feature = "nova")]
+mod tests {
+    use aletheiadb::AletheiaDB;
+    use aletheiadb::experimental::aura::AuraEngine;
+    use aletheiadb::core::property::PropertyMapBuilder;
+    use aletheiadb::api::transaction::WriteOps;
+
+    #[test]
+    fn test_aura_dimension_mismatch() {
+        let db = AletheiaDB::new().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        let mut n1 = aletheiadb::core::id::NodeId::new(0).unwrap();
+
+        // State 1: vector dim 2
+        db.write(|tx| {
+            n1 = tx
+                .create_node(
+                    "Concept",
+                    PropertyMapBuilder::new()
+                        .insert_vector("vec", &[1.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
+            Ok::<(), aletheiadb::core::error::Error>(())
+        })
+        .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        // State 2: vector dim 4
+        db.write(|tx| {
+            tx.update_node(
+                n1,
+                PropertyMapBuilder::new()
+                    .insert_vector("vec", &[0.0, 1.0, 0.5, 0.5])
+                    .build(),
+            )
+            .unwrap();
+            Ok::<(), aletheiadb::core::error::Error>(())
+        })
+        .unwrap();
+
+        let engine = AuraEngine::new(&db);
+        let result = engine.calculate_aura(n1, "vec", 1_000_000);
+        assert!(result.is_ok(), "Should not return an error due to dimension mismatch");
+        let result = result.unwrap();
+        assert_eq!(result.divergence_score, 1.0, "Divergence should be 1.0 on dimension mismatch");
+    }
+}


### PR DESCRIPTION
**Findings:**
- **Severity:** High
- **File Reference:** `src/experimental/aura.rs:168`
- **What can break:** `AuraEngine::calculate_aura` can panic or return an error due to a `DimensionMismatch` from `ops::cosine_similarity` when a node's vector dimensionality changes over time (e.g. migrating to a new embedding model).
- **Why it breaks:** The exponential decay weighted sum requires aggregating historical vectors. Even if `weighted_sum` dimension validation prevents appending mismatched past vectors during accumulation, the final divergence comparison uses `ops::cosine_similarity(&sum, &curr_normalized)?` directly against the current vector. If the historical aura (`sum`) size differs from the current vector's size, it throws a `DimensionMismatch` error.
- **Minimal fix:** Added a dimension length check before computing `cosine_similarity`. If lengths do not match, default the `divergence_score` to `1.0` (total semantic shift).
- **Required tests:** Added `tests/aura_dimension_mismatch.rs` to verify that updating a node with a new vector dimension correctly yields a divergence of `1.0` instead of propagating an error.

---
*PR created automatically by Jules for task [3341736246495843862](https://jules.google.com/task/3341736246495843862) started by @madmax983*