### PR TITLE
🦀 Core: Fix dimension mismatch panics in AuraEngine calculation

### DIFF
--- a/src/experimental/aura.rs
+++ b/src/experimental/aura.rs
@@ -161,12 +161,17 @@ impl<'a> AuraEngine<'a> {
                 ops::normalize_in_place(&mut sum);
 
                 if let Some(current) = &current_vector {
-                    let mut curr_normalized = current.clone();
-                    ops::normalize_in_place(&mut curr_normalized);
+                    if sum.len() == current.len() {
+                        let mut curr_normalized = current.clone();
+                        ops::normalize_in_place(&mut curr_normalized);
 
-                    let sim = ops::cosine_similarity(&sum, &curr_normalized)?;
-                    // Divergence is distance: 1.0 - similarity
-                    divergence_score = (1.0 - sim).max(0.0);
+                        let sim = ops::cosine_similarity(&sum, &curr_normalized)?;
+                        // Divergence is distance: 1.0 - similarity
+                        divergence_score = (1.0 - sim).max(0.0);
+                    } else {
+                        // Dimension mismatch implies a total semantic shift
+                        divergence_score = 1.0;
+                    }
                 }
 
                 aura_vector = Some(sum);

--- a/tests/warden_aura_dim_mismatch.rs
+++ b/tests/warden_aura_dim_mismatch.rs
@@ -1,0 +1,41 @@
+use aletheiadb::AletheiaDB;
+use aletheiadb::api::transaction::WriteOps;
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::experimental::aura::AuraEngine;
+
+#[test]
+fn test_aura_dim_mismatch() {
+    let db = AletheiaDB::new().unwrap();
+    let mut n1 = aletheiadb::core::id::NodeId::new(0).unwrap();
+
+    db.write(|tx| {
+        n1 = tx
+            .create_node(
+                "Concept",
+                PropertyMapBuilder::new()
+                    .insert_vector("vec", &[1.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+        Ok::<(), aletheiadb::core::error::Error>(())
+    })
+    .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    db.write(|tx| {
+        tx.update_node(
+            n1,
+            PropertyMapBuilder::new()
+                .insert_vector("vec", &[0.0, 1.0, 2.0]) // Different dimension!
+                .build(),
+        )
+        .unwrap();
+        Ok::<(), aletheiadb::core::error::Error>(())
+    })
+    .unwrap();
+
+    let engine = AuraEngine::new(&db);
+    let result = engine.calculate_aura(n1, "vec", 1_000_000).unwrap();
+    println!("Result: {:?}", result);
+}

--- a/tests/warden_aura_dim_mismatch.rs
+++ b/tests/warden_aura_dim_mismatch.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "nova")]
+
 use aletheiadb::AletheiaDB;
 use aletheiadb::api::transaction::WriteOps;
 use aletheiadb::core::property::PropertyMapBuilder;


### PR DESCRIPTION
**Findings:**
- **Severity**: High (can cause runtime panic or propagate unhandled errors failing queries).
- **File Reference**: `src/experimental/aura.rs:167`
- **What can break**: If an entity's vector property dimension changes, `ops::cosine_similarity` returns a `DimensionMismatch` error. If unhandled or blindly unwrapped elsewhere, this can panic.
- **Why it breaks**: AuraEngine attempts to calculate the cosine similarity between the current state vector and the historically-weighted "aura" vector. If the vectors have different dimensions (e.g., from an embedding model switch), `cosine_similarity` errors out.
- **Minimal fix**: Add a dimension check before calling `cosine_similarity`. If `sum.len() != current.len()`, bypass the similarity calculation and set `divergence_score` to `1.0` to indicate a complete semantic shift, keeping the engine robust against changing data shapes over time.
- **Required tests**: Added a test case simulating a node updating its vector property with a different dimension and verifying that `calculate_aura` completes gracefully.

**Test gaps**: Addressed via `tests/warden_aura_dim_mismatch.rs`.

---
*PR created automatically by Jules for task [3635617691175269770](https://jules.google.com/task/3635617691175269770) started by @madmax983*