### PR TITLE
🦀 Core: Fix Aura engine dimension mismatch bug

### DIFF
--- a/src/experimental/aura.rs
+++ b/src/experimental/aura.rs
@@ -164,9 +164,14 @@ impl<'a> AuraEngine<'a> {
                     let mut curr_normalized = current.clone();
                     ops::normalize_in_place(&mut curr_normalized);
 
-                    let sim = ops::cosine_similarity(&sum, &curr_normalized)?;
-                    // Divergence is distance: 1.0 - similarity
-                    divergence_score = (1.0 - sim).max(0.0);
+                    if sum.len() == curr_normalized.len() {
+                        let sim = ops::cosine_similarity(&sum, &curr_normalized)?;
+                        // Divergence is distance: 1.0 - similarity
+                        divergence_score = (1.0 - sim).max(0.0);
+                    } else {
+                        // Dimension mismatch implies total semantic shift
+                        divergence_score = 1.0;
+                    }
                 }
 
                 aura_vector = Some(sum);
@@ -289,5 +294,51 @@ mod tests {
             "Expected significant divergence, got {}",
             result.divergence_score
         );
+    }
+
+    #[test]
+    fn test_aura_dimension_mismatch() {
+        let db = AletheiaDB::new().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        let mut n1 = crate::core::id::NodeId::new(0).unwrap();
+
+        // State 1: Established Aura with dimension 2
+        db.write(|tx| {
+            n1 = tx
+                .create_node(
+                    "Concept",
+                    PropertyMapBuilder::new()
+                        .insert_vector("vec", &[1.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
+            Ok::<(), crate::core::error::Error>(())
+        })
+        .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // State 2: Sudden shift to dimension 3
+        db.write(|tx| {
+            tx.update_node(
+                n1,
+                PropertyMapBuilder::new()
+                    .insert_vector("vec", &[0.0, 1.0, 0.0])
+                    .build(),
+            )
+            .unwrap();
+            Ok::<(), crate::core::error::Error>(())
+        })
+        .unwrap();
+
+        let engine = AuraEngine::new(&db);
+
+        // This should not panic or return a DimensionMismatch error, but handle it gracefully
+        let result = engine.calculate_aura(n1, "vec", 1_000_000).unwrap();
+
+        // When dimensions mismatch, divergence should default to total shift (1.0)
+        assert_eq!(result.divergence_score, 1.0);
     }
 }


### PR DESCRIPTION
🦀 Core: Fix Aura engine dimension mismatch bug

Findings:
- Severity: high
- File reference: src/experimental/aura.rs:167
- What can break: The `AuraEngine::calculate_aura` function would panic if a node's vector dimensionality changed over its history. `ops::cosine_similarity` returns a `DimensionMismatch` error which was being bubbled up via `?`, causing legitimate temporal aggregation queries to fail.
- Why it breaks: `AuraEngine` aggregated historical vectors with exponential decay. If a node was updated with a vector of a different length, the historical `sum` vector would mismatch the `current_vector` length when passed to `cosine_similarity`.
- Minimal fix: Before calculating cosine similarity, check if `sum.len() == curr_normalized.len()`. If they mismatch, skip similarity calculation and default to a complete semantic shift (`divergence_score = 1.0`).
- Required tests: Added `test_aura_dimension_mismatch` to explicitly verify safe handling of vector dimension changes over time without panicking.

Test gaps:
- No residual test gaps found for this specific failure mode.

---
*PR created automatically by Jules for task [7015531929300324939](https://jules.google.com/task/7015531929300324939) started by @madmax983*