### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,22 @@ let similar = db.find_similar(doc_id, 10)?;
 ### Hybrid Queries (Graph + Vector + Temporal)
 
 ```rust
+use aletheiadb::prelude::*;
+use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+use aletheiadb::index::vector::temporal::TemporalVectorConfig;
+
+let db = AletheiaDB::new().unwrap();
+
+// First, configure and enable the vector index
+db.vector_index("embedding")
+    .hnsw(HnswConfig::new(384, DistanceMetric::Cosine))
+    .temporal(TemporalVectorConfig::default())
+    .enable()?;
+
+let alice_id = db.create_node("Person", properties! { "name" => "Alice", "age" => 30 })?;
+let bob_id = db.create_node("Person", properties! { "name" => "Bob", "age" => 30 })?;
+db.create_edge(alice_id, bob_id, "KNOWS", properties! {})?;
+
 // Setup query parameters
 let query_embedding = vec![0.1f32; 384];
 let valid_time = aletheiadb::time::now();
@@ -845,6 +861,10 @@ features = [
 **Basic usage:**
 
 ```rust
+// ⚠️ REQUIRES FEATURE: observability
+// [dependencies]
+// aletheiadb = { version = "0.1", features = ["observability"] }
+
 use aletheiadb::observability;
 
 fn main() {


### PR DESCRIPTION
🤦 **The Confusion:** 
Tried to copy-paste the "Hybrid Queries" example and it failed with a weird `IndexNotFound` error. Also tried the "Production Observability" example and it completely failed to compile because `observability` isn't in scope by default.

🕵️ **The Reality:** 
The Hybrid Queries example assumed `AletheiaDB` was already initialized and a vector index named "embedding" was pre-configured from earlier examples. If a user runs it standalone, it breaks. 
The Production Observability example requires the `observability` cargo feature flag, but that isn't mentioned inside the code block where copy-pasters look.

💡 **The Fix:** 
- Updated the "Hybrid Queries" example to be fully self-contained by adding database initialization and vector index setup logic.
- Added a huge `// ⚠️ REQUIRES FEATURE: observability` banner and dependency comment in the "Production Observability" code block so copy-pasters know what to put in their `Cargo.toml`.

---
*PR created automatically by Jules for task [7226478824515090877](https://jules.google.com/task/7226478824515090877) started by @madmax983*