### PR TITLE
⚡ Bolt: Avoid O(N) heap allocations on DashMap minimum key lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2026-11-20 - Identity Hashing for Historical Storage
 **Learning:** `HistoricalStorage` and `MigrationService` used the default `HashMap` (SipHash) for integer wrapper keys like `NodeId`, `EdgeId`, and `VersionId`. Because these keys are unique internally-assigned high-quality IDs, SipHash incurs unnecessary hashing overhead.
 **Action:** Replaced `std::collections::HashMap` with `FastHashMap` (which uses `BuildHasherDefault<IdentityHasher>`) for tracking versions, heads, and stats. Using `IdentityHasher` speeds up tracking and lookups and is idiomatic across AletheiaDB for wrapper IDs.
+
+**Avoid `.map(|r| r.key().clone()).min()`**
+**Learning:** `.map(...).min()` allocates a new string (via clone) for *every* element in a `DashMap` (or any iterator of refs) before it computes the minimum. This means `O(N)` heap allocations instead of O(1).
+**Action:** Use `.min_by(|a, b| a.key().cmp(b.key()))` first to find the ref to the minimal element, and *then* call `.map(|r| r.key().clone())` to allocate exactly once!

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1039,7 +1039,10 @@ impl CurrentStorage {
 
         // Find min key alphabetically
         // Note: DashMap iteration order is not guaranteed, so we must scan all keys
-        self.vector_indexes.iter().map(|r| r.key().clone()).min()
+        self.vector_indexes
+            .iter()
+            .min_by(|a, b| a.key().cmp(b.key()))
+            .map(|r| r.key().clone())
     }
 
     /// Get or create filter statistics for a label (Issue #334).


### PR DESCRIPTION
💡 What: Changed `.map(|r| r.key().clone()).min()` to `.min_by(|a, b| a.key().cmp(b.key())).map(|r| r.key().clone())` for retrieving the default vector property from `DashMap` iterations in `src/storage/current/mod.rs`.

🎯 Why: Previously, `.map(|r| r.key().clone()).min()` allocated a new cloned String on the heap for every single property in the `DashMap` before making the minimum comparison. Now, we use `min_by` to strictly compare keys via string reference (`&String`) and only clone the final min element, resulting in exactly 1 heap allocation instead of N.

📊 Impact: Reduces heap allocations from `O(N)` to `O(1)` for getting the default vector property out of `vector_indexes` `DashMap`.

🔬 Measurement: Run bench tests on multiple vector indices to verify performance. Use `cargo test --lib storage::current::mod` to verify logic hasn't changed.

---
*PR created automatically by Jules for task [9254232074735873342](https://jules.google.com/task/9254232074735873342) started by @madmax983*