### PR TITLE
⚡ Bolt: Optimize query result collection allocations

### DIFF
--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -160,7 +160,8 @@ impl QueryResults {
 
     /// Collect all results into a vector, stopping on first error
     pub fn collect_all(mut self) -> Result<Vec<QueryRow>> {
-        let mut results = Vec::new();
+        let (lower, _) = self.estimated_size();
+        let mut results = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             results.push(row?);
         }
@@ -172,7 +173,8 @@ impl QueryResults {
     /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
     /// a large intermediate `Vec` of all rows before extracting the nodes.
     pub fn collect_nodes(mut self) -> Result<Vec<Node>> {
-        let mut nodes = Vec::new();
+        let (lower, _) = self.estimated_size();
+        let mut nodes = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             if let EntityResult::Node(n) = row?.entity {
                 nodes.push(n);
@@ -186,7 +188,8 @@ impl QueryResults {
     /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
     /// a large intermediate `Vec` of all rows before extracting the nodes and scores.
     pub fn collect_nodes_with_scores(mut self) -> Result<Vec<(Node, f32)>> {
-        let mut results = Vec::new();
+        let (lower, _) = self.estimated_size();
+        let mut results = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             let row = row?;
             if let (EntityResult::Node(n), Some(score)) = (row.entity, row.score) {


### PR DESCRIPTION
💡 **What:** Modified `collect_all`, `collect_nodes`, and `collect_nodes_with_scores` methods in `QueryResults` (`src/query/executor/results.rs`) to use `Vec::with_capacity(lower)` based on the iterator's `self.estimated_size()`.
🎯 **Why:** Previously, these methods were using `Vec::new()`, which relies on dynamic reallocation as elements are added, potentially leading to unnecessary heap allocations and memory fragmentation. Pre-allocating the vector capacity based on the lower bound known from `size_hint()` significantly reduces reallocation costs. Using the lower bound over the upper bound prevents OOM panics in cases where `upper` is arbitrarily large or `usize::MAX`.
📊 **Impact:** Reduces heap allocations and memory reallocation overhead during query result collection, especially for large graph/vector queries.
🔬 **Measurement:** Run `cargo bench` or `cargo test -p aletheiadb --lib query::executor::results`. No logic or side-effects are introduced.

---
*PR created automatically by Jules for task [3117014746402291570](https://jules.google.com/task/3117014746402291570) started by @madmax983*