### PR TITLE
🎻 Bard: Prophet Link Prediction Documentation Update

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -70,3 +70,11 @@
 ## 2025-03-02 - Logical vs Physical Plan Clarification
 **Confusion:** The `src/query/planner/physical.rs` module lacked documentation detailing the distinction between logical query plans (what data to fetch) and physical query plans (the execution strategy used to fetch it). This is a core concept that makes the query planner opaque.
 **Clarification:** Added module-level documentation describing the optimizer's role in creating a `PhysicalPlan` and providing an example of how to view the underlying structure via `.explain()`.
+
+## 2025-03-05 - Prophet Algorithm Clarification
+**Confusion:** The `Prophet` link prediction engine was vaguely documented as "predicting the future". Users could easily assume it was a standard ML model or purely topological (like mutual friends). The interplay between the Adamic-Adar index (topology) and cosine similarity (semantics) was buried in the source code.
+**Clarification:** Added comprehensive module-level documentation and struct-level examples detailing the specific algorithm (`Score = AdamicAdar * (1.0 + VectorSimilarity)`), explaining exactly how it bridges structural positioning with conceptual alignment.
+
+## 2025-03-05 - Doctests with Feature Flags
+**Confusion:** When writing doctests for modules behind a feature flag (like `nova`), wrapping the test block in `# #[cfg(feature = "nova")] \n # { ... }` causes `rustdoc` to generate invalid syntax when the test is extracted. It creates an anonymous block at the root level which is an expression, not an item, breaking `cargo test`. If the feature flag is disabled, it leaves an empty file causing a `main function not found` error.
+**Clarification:** To properly feature-gate doctests, conditionally compile the imports and the `main` function itself: `# #[cfg(feature = "nova")] \n fn main() { ... }`, and crucially, provide an empty fallback `main` function for when the feature is disabled: `# #[cfg(not(feature = "nova"))] \n # fn main() {}`.

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -162,7 +162,6 @@ pub mod kaleidoscope;
 /// Prism: Semantic Spectroscopy for Vectors.
 pub mod prism;
 #[cfg(feature = "nova")]
-/// Prophet Link Prediction Engine.
 pub mod prophet;
 #[cfg(feature = "nova")]
 /// Ripple: Semantic Causality Detector.

--- a/src/experimental/prophet.rs
+++ b/src/experimental/prophet.rs
@@ -1,17 +1,101 @@
 //! Prophet: Link Prediction Engine.
 //!
-//! This module implements a link prediction engine that suggests missing connections
-//! in the graph based on topological structure (Adamic-Adar) and semantic similarity.
+//! Why do some nodes connect while others remain isolated? The [`Prophet`] engine attempts to
+//! answer this by predicting missing links in the graph. Unlike traditional link prediction
+//! that relies solely on graph topology (like mutual friends), `Prophet` bridges the gap
+//! between **structural topology** and **semantic vector similarity**.
+//!
+//! It combines the Adamic-Adar index (which measures topological closeness) with cosine
+//! similarity of the nodes' vector embeddings. This means it recommends connections not just
+//! because nodes share a neighborhood, but because they are structurally positioned *and*
+//! conceptually aligned to connect.
 //!
 //! # The Algorithm
-//! Score(A, B) = AdamicAdar(A, B) * (1.0 + VectorSimilarity(A, B))
+//! The prediction score between two unconnected nodes $A$ and $B$ is calculated as:
+//!
+//! `Score(A, B) = AdamicAdar(A, B) * (1.0 + VectorSimilarity(A, B))`
+//!
+//! - **Adamic-Adar:** Sum of $\frac{1}{\log(degree(z))}$ for all shared neighbors $z$.
+//! - **Vector Similarity:** Cosine similarity of the vector embeddings between $A$ and $B$.
+//!
+//! If vectors are perfectly orthogonal, the score reverts to standard Adamic-Adar. If they
+//! are similar, the topological score is boosted, surfacing structurally valid but semantically
+//! richer recommendations.
+//!
+//! # Examples
+//!
+//! > ⚠️ **REQUIRES FEATURE: nova**
+//!
+//! ```rust
+//! // [dependencies]
+//! // aletheiadb = { version = "0.1", features = ["nova"] }
+//!
+//! # #[cfg(feature = "nova")]
+//! use aletheiadb::AletheiaDB;
+//! # #[cfg(feature = "nova")]
+//! use aletheiadb::experimental::prophet::Prophet;
+//! # #[cfg(feature = "nova")]
+//! use aletheiadb::core::property::PropertyMapBuilder;
+//!
+//! # #[cfg(feature = "nova")]
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = AletheiaDB::new()?;
+//!
+//! // Assume we have a graph of users and their interests.
+//! // We want to recommend new connections for User A.
+//! # let props = PropertyMapBuilder::new().build();
+//! # let node_a = db.create_node("User", props.clone())?;
+//! # let node_b = db.create_node("User", props.clone())?;
+//! # let node_c = db.create_node("User", props.clone())?;
+//! # db.create_edge(node_a, node_b, "KNOWS", props.clone())?;
+//! # db.create_edge(node_b, node_c, "KNOWS", props)?;
+//!
+//! let prophet = Prophet::new(&db);
+//!
+//! // Predict the top 5 most likely future connections for node_a
+//! let predictions = prophet.predict_links(node_a, 5)?;
+//!
+//! for (target_node, score) in predictions {
+//!     println!("Predicted connection to node {} with confidence score {}", target_node, score);
+//! }
+//! # Ok(())
+//! # }
+//! # #[cfg(not(feature = "nova"))]
+//! # fn main() {}
+//! ```
 
 use crate::AletheiaDB;
 use crate::core::error::Result;
 use crate::core::id::NodeId;
 use std::collections::HashSet;
 
-/// The Prophet predicts the future (connections).
+/// The engine for predicting missing or future connections in the graph.
+///
+/// `Prophet` operates by combining topological network structure with vector semantics.
+/// It uses the Adamic-Adar index to find structurally likely connections, and then scales
+/// that probability by the cosine similarity of the nodes' vector embeddings.
+///
+/// This requires a [`AletheiaDB`] instance to query both the graph topology and the
+/// vector properties. By default, it will use the first registered vector index it finds.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// use aletheiadb::AletheiaDB;
+/// # #[cfg(feature = "nova")]
+/// use aletheiadb::experimental::prophet::Prophet;
+///
+/// # #[cfg(feature = "nova")]
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let db = AletheiaDB::new()?;
+/// // Initialize the prophet engine attached to the database
+/// let prophet = Prophet::new(&db);
+/// # Ok(())
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 pub struct Prophet<'a> {
     db: &'a AletheiaDB,
     /// Optional vector property override.
@@ -19,7 +103,29 @@ pub struct Prophet<'a> {
 }
 
 impl<'a> Prophet<'a> {
-    /// Create a new Prophet.
+    /// Initializes a new link prediction engine bound to the given database.
+    ///
+    /// By default, the engine will attempt to automatically discover the primary vector property
+    /// by querying the database's registered vector indexes. If you have multiple vector indexes
+    /// and need to target a specific one, use [`Prophet::with_property`] after initialization.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::AletheiaDB;
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::experimental::prophet::Prophet;
+    ///
+    /// # #[cfg(feature = "nova")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let prophet = Prophet::new(&db);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "nova"))]
+    /// # fn main() {}
+    /// ```
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
@@ -27,7 +133,29 @@ impl<'a> Prophet<'a> {
         }
     }
 
-    /// Set the property name to use for vector operations.
+    /// Specifies the exact vector property name to use for calculating semantic similarity.
+    ///
+    /// This is required if the database contains multiple vector properties (e.g., "title_embedding"
+    /// and "body_embedding") and you want to base predictions on a specific semantic domain.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::AletheiaDB;
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::experimental::prophet::Prophet;
+    ///
+    /// # #[cfg(feature = "nova")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// // Force the prophet to only consider the "bio_embedding" property for similarity
+    /// let prophet = Prophet::new(&db).with_property("bio_embedding");
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "nova"))]
+    /// # fn main() {}
+    /// ```
     pub fn with_property(mut self, name: impl Into<String>) -> Self {
         self.property_name = Some(name.into());
         self
@@ -125,7 +253,62 @@ impl<'a> Prophet<'a> {
         }
     }
 
-    /// Predict missing links for a target node.
+    /// Predicts the most likely new connections for the given target node.
+    ///
+    /// This method performs a graph traversal to find "neighbors of neighbors" and evaluates them
+    /// as candidates. It calculates an Adamic-Adar score for topological closeness and then multiplies
+    /// it by `(1.0 + vector_similarity)`.
+    ///
+    /// The algorithm deliberately returns the top `k` candidates, ranked by this combined score.
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - The `NodeId` for which you want to predict new links.
+    /// * `k` - The maximum number of recommendations to return (e.g., "Top 5").
+    ///
+    /// # Returns
+    ///
+    /// A sorted vector of tuples containing `(CandidateNodeId, PredictionScore)`,
+    /// ordered descending from most likely to least likely.
+    ///
+    /// # Edge Cases
+    ///
+    /// - If `target` has no neighbors, it will have no "neighbors of neighbors" to evaluate, returning an empty list.
+    /// - If the database has no vector properties or missing vectors, the similarity score defaults to 0.0 (falling back to pure Adamic-Adar).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::AletheiaDB;
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::experimental::prophet::Prophet;
+    /// # #[cfg(feature = "nova")]
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    ///
+    /// # #[cfg(feature = "nova")]
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// # let props = PropertyMapBuilder::new().build();
+    /// # let user = db.create_node("User", props.clone())?;
+    /// # let intermediate = db.create_node("User", props.clone())?;
+    /// # let candidate = db.create_node("User", props.clone())?;
+    /// # db.create_edge(user, intermediate, "KNOWS", props.clone())?;
+    /// # db.create_edge(intermediate, candidate, "KNOWS", props)?;
+    ///
+    /// let prophet = Prophet::new(&db);
+    ///
+    /// // Recommend top 3 connections
+    /// let recommendations = prophet.predict_links(user, 3)?;
+    ///
+    /// if let Some((top_candidate, top_score)) = recommendations.first() {
+    ///     println!("Top recommendation: {} (score: {})", top_candidate, top_score);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "nova"))]
+    /// # fn main() {}
+    /// ```
     pub fn predict_links(&self, target: NodeId, k: usize) -> Result<Vec<(NodeId, f32)>> {
         let neighbors = self.get_neighbors(target)?;
 

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1321,7 +1321,7 @@ fn test_recovery_after_concurrent_writes() {
                         let lsn = loop {
                             match wal_ref.append_async(operation.clone()) {
                                 Ok(lsn) => break lsn,
-                                Err(e) if retries < 10 => {
+                                Err(_e) if retries < 10 => {
                                     retries += 1;
                                     std::thread::sleep(std::time::Duration::from_millis(1));
                                 }


### PR DESCRIPTION
📖 Chapter: The `Prophet` module (Experimental Link Prediction)

🔦 Insight: The `Prophet` engine was previously an opaque "black box" that "predicts the future". I clarified *how* it does this by bridging **structural topology** (Adamic-Adar index) with **semantic vector similarity** (`CosineSimilarity`). This explains why it recommends connections not just based on mutual friends, but on conceptual alignment. 

🧪 Example: Added 5 executable doctests demonstrating how to initialize the engine, target specific vector properties, and generate predictions. The doctests are carefully feature-gated using conditional `main` functions to prevent CI failures.

🖼️ Preview: The generated docs now have a rich mathematical explanation of the scoring algorithm and actionable code blocks for users to try out link prediction. Also resolved an outstanding `cargo doc` warning in the `experimental` module index.

---
*PR created automatically by Jules for task [10791462847177239335](https://jules.google.com/task/10791462847177239335) started by @madmax983*