### PR TITLE
🤖 Sentinel: Weak Test Coverage in Edge Logic & Formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -125,3 +125,9 @@
 **Summary:** Mutants regarding strict bounds on `MAX_VALID_TIMESTAMP` (`>` mutated to `>=` or `==`) within `TimeRange::from` and `TimeRange::at` survived, alongside strict math operators (`*`, `/`, `%`) inside `time::to_secs`, `time::to_millis`, and `time::to_iso8601` methods. Finally, specific bounding checks involving exclusive interval boundaries in `contains` and `overlaps` were weakly asserted allowing `>` to mutate into `>=`.
 **Diagnosis:** MISSING_TEST / WEAK_TEST - Existing tests tested positive path boundary logic well, but neglected specific maximum boundary exact values (`MAX_VALID_TIMESTAMP`), exact conversion validation that strictly broke if `/` turned into `%`, and exact exclusion of boundaries inside interval intersections.
 **Kill Shot:** Appended explicit exact boundary tests `test_timerange_from_at_exact_boundaries`, `test_time_to_secs_millis_exact_math`, `test_time_to_iso8601_exact_content`, and `test_timerange_contains_exact_boundary` directly to `tests/sentry_temporal.rs`.
+
+**[Weak Test Coverage in Edge Logic & Formatting]**
+**Module:** `src/core/graph.rs`
+**Summary:** Mutants returning default values or mutating exact operations survived in `Edge` logic (`connects` replaced with `true`, `false`, `||`, `!=`; `has_label_str` replaced with `false`, and `<impl std::fmt::Debug for Edge>::fmt` returning `Ok(Default::default())`).
+**Diagnosis:** WEAK_TEST / MISSING_TEST - Existing tests did not strictly verify `Edge::connects` behavior with mismatched inputs, did not check `Edge::has_label_str` against exact mismatches, and did not assert the content of the `Edge` debug string.
+**Kill Shot:** Added `tests/sentry_graph.rs` with `test_edge_connects_mutants`, `test_edge_has_label_str_mutants`, and `test_edge_fmt_mutants` to cover these exact gaps.

--- a/tests/sentry_graph.rs
+++ b/tests/sentry_graph.rs
@@ -1,0 +1,110 @@
+use aletheiadb::core::graph::Edge;
+use aletheiadb::core::id::{EdgeId, NodeId, VersionId};
+use aletheiadb::core::interning::GLOBAL_INTERNER;
+use aletheiadb::core::property::PropertyMap;
+
+#[test]
+fn test_edge_connects_mutants() {
+    let edge_id = EdgeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let source_id = NodeId::new(10).unwrap();
+    let target_id = NodeId::new(20).unwrap();
+    let version = VersionId::new(1).unwrap();
+
+    let edge = Edge::new(
+        edge_id,
+        label,
+        source_id,
+        target_id,
+        PropertyMap::new(),
+        version,
+    );
+
+    // Test exact match (returns true)
+    assert!(
+        edge.connects(source_id, target_id),
+        "Edge should connect exact source and target"
+    );
+
+    // Test mismatched source (returns false)
+    assert!(
+        !edge.connects(NodeId::new(99).unwrap(), target_id),
+        "Edge should NOT connect with wrong source"
+    );
+
+    // Test mismatched target (returns false)
+    assert!(
+        !edge.connects(source_id, NodeId::new(99).unwrap()),
+        "Edge should NOT connect with wrong target"
+    );
+
+    // Test both mismatched (returns false)
+    assert!(
+        !edge.connects(NodeId::new(99).unwrap(), NodeId::new(99).unwrap()),
+        "Edge should NOT connect with wrong source and target"
+    );
+}
+
+#[test]
+fn test_edge_has_label_str_mutants() {
+    let edge_id = EdgeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let source_id = NodeId::new(10).unwrap();
+    let target_id = NodeId::new(20).unwrap();
+    let version = VersionId::new(1).unwrap();
+
+    let edge = Edge::new(
+        edge_id,
+        label,
+        source_id,
+        target_id,
+        PropertyMap::new(),
+        version,
+    );
+
+    // Test exact match (returns true)
+    assert!(
+        edge.has_label_str("KNOWS"),
+        "Edge should match exact label string"
+    );
+
+    // Test mismatch (returns false)
+    assert!(
+        !edge.has_label_str("NOT_KNOWS"),
+        "Edge should NOT match incorrect label string"
+    );
+}
+
+#[test]
+fn test_edge_fmt_mutants() {
+    let edge_id = EdgeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let source_id = NodeId::new(10).unwrap();
+    let target_id = NodeId::new(20).unwrap();
+    let version = VersionId::new(1).unwrap();
+
+    let edge = Edge::new(
+        edge_id,
+        label,
+        source_id,
+        target_id,
+        PropertyMap::new(),
+        version,
+    );
+
+    let debug_str = format!("{:?}", edge);
+
+    // The mutant replaces the whole body with Ok(Default::default()) which returns ""
+    assert!(
+        !debug_str.is_empty(),
+        "Edge debug string should not be empty"
+    );
+    assert!(
+        debug_str.contains("Edge"),
+        "Edge debug string should contain 'Edge'"
+    );
+    assert!(
+        debug_str.contains("KNOWS"),
+        "Edge debug string should contain the label string"
+    );
+}


### PR DESCRIPTION
This PR introduces targeted tests to close test suite gaps identified by `cargo-mutants` within `src/core/graph.rs`, specifically for the `Edge` struct. 

### 🧬 Mutants Found:
Surviving mutants indicated that existing tests did not properly verify `Edge::connects` behavior with mismatched input IDs (e.g. converting `&&` to `||` or replacing equality checks with `!=`), did not check exact mismatches for `Edge::has_label_str`, and did not assert the output structure of `<impl std::fmt::Debug for Edge>::fmt`.

### 🎯 Tests Added:
- **`test_edge_connects_mutants`**: Tests all variations of matching and mismatching `NodeId` combinations for `Edge::connects`.
- **`test_edge_has_label_str_mutants`**: Evaluates correct boolean boundaries for `has_label_str`.
- **`test_edge_fmt_mutants`**: Verifies the formatting output contains expected type structure and interned string labels.

These exact boundary and behavioral assertions reliably kill the surviving mutants.

---
*PR created automatically by Jules for task [6164127222512517468](https://jules.google.com/task/6164127222512517468) started by @madmax983*