### PR TITLE
🤖 Sentinel: Eliminate TimeRange mutant boundary weaknesses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -125,3 +125,9 @@
 **Summary:** Mutants regarding strict bounds on `MAX_VALID_TIMESTAMP` (`>` mutated to `>=` or `==`) within `TimeRange::from` and `TimeRange::at` survived, alongside strict math operators (`*`, `/`, `%`) inside `time::to_secs`, `time::to_millis`, and `time::to_iso8601` methods. Finally, specific bounding checks involving exclusive interval boundaries in `contains` and `overlaps` were weakly asserted allowing `>` to mutate into `>=`.
 **Diagnosis:** MISSING_TEST / WEAK_TEST - Existing tests tested positive path boundary logic well, but neglected specific maximum boundary exact values (`MAX_VALID_TIMESTAMP`), exact conversion validation that strictly broke if `/` turned into `%`, and exact exclusion of boundaries inside interval intersections.
 **Kill Shot:** Appended explicit exact boundary tests `test_timerange_from_at_exact_boundaries`, `test_time_to_secs_millis_exact_math`, `test_time_to_iso8601_exact_content`, and `test_timerange_contains_exact_boundary` directly to `tests/sentry_temporal.rs`.
+
+**[Weak Test Coverage in TimeRange Boundary Conditions]**
+**Module:** `src/core/temporal.rs`
+**Summary:** Mutants regarding strict boolean boundaries and inclusion inside `TimeRange::contains`, `TimeRange::contains_or_after` and `TimeRange::contains_range` survived. Specifically, mutants swapping `&&` to `||` and modifying bound exclusivity (`<` to `<=`, `==`, `>`) were allowed to persist due to non-exhaustive edge-case verification.
+**Diagnosis:** MISSING_TEST / WEAK_TEST - The test suite previously evaluated positive paths for logical temporal overlap but neglected exact tests on exact integer boundary overlap on the `[start, end)` boundary structures causing conditions to slip.
+**Kill Shot:** Appended explicitly constructed boundary tests `test_sentry_time_range_contains_boundaries`, `test_sentry_time_range_contains_or_after_boundaries`, and `test_sentry_time_range_contains_range_boundaries` directly to `tests/sentry_temporal.rs`.

--- a/tests/sentry_temporal.rs
+++ b/tests/sentry_temporal.rs
@@ -240,3 +240,104 @@ fn test_timerange_contains_exact_boundary() {
         "Touching ranges should NOT overlap (exact boundary check reverse)"
     );
 }
+
+#[test]
+fn test_sentry_time_range_contains_boundaries() {
+    use aletheiadb::core::hlc::HybridTimestamp;
+    use aletheiadb::core::temporal::TimeRange;
+
+    let start = HybridTimestamp::new(100, 0).unwrap();
+    let mid = HybridTimestamp::new(150, 0).unwrap();
+    let end = HybridTimestamp::new(200, 0).unwrap();
+    let before = HybridTimestamp::new(99, 0).unwrap();
+    let after = HybridTimestamp::new(201, 0).unwrap();
+
+    let range = TimeRange::new(start, end).unwrap();
+
+    // Kill mutants replacing `>=` with `<` or `>`, `<` with `<=`, `==`, etc.
+    assert!(range.contains(start), "Must contain exact start boundary");
+    assert!(!range.contains(before), "Must NOT contain before start");
+
+    assert!(range.contains(mid), "Must contain value inside range");
+
+    assert!(!range.contains(end), "Must NOT contain exact end boundary");
+    assert!(!range.contains(after), "Must NOT contain after end");
+}
+
+#[test]
+fn test_sentry_time_range_contains_or_after_boundaries() {
+    use aletheiadb::core::hlc::HybridTimestamp;
+    use aletheiadb::core::temporal::TimeRange;
+
+    let start = HybridTimestamp::new(100, 0).unwrap();
+    let end = HybridTimestamp::new(200, 0).unwrap();
+    let before = HybridTimestamp::new(99, 0).unwrap();
+    let after = HybridTimestamp::new(101, 0).unwrap();
+
+    let range = TimeRange::new(start, end).unwrap();
+
+    // Kill mutants replacing `>=` with `<` or `>`
+    assert!(
+        range.contains_or_after(start),
+        "Must contain exact start boundary"
+    );
+    assert!(
+        range.contains_or_after(after),
+        "Must contain after start boundary"
+    );
+    assert!(
+        !range.contains_or_after(before),
+        "Must NOT contain before start boundary"
+    );
+}
+
+#[test]
+fn test_sentry_time_range_contains_range_boundaries() {
+    use aletheiadb::core::hlc::HybridTimestamp;
+    use aletheiadb::core::temporal::TimeRange;
+
+    let start = HybridTimestamp::new(100, 0).unwrap();
+    let end = HybridTimestamp::new(200, 0).unwrap();
+
+    let range = TimeRange::new(start, end).unwrap();
+
+    // Exact match
+    let exact_range = TimeRange::new(start, end).unwrap();
+    assert!(
+        range.contains_range(&exact_range),
+        "Must contain exact range"
+    );
+
+    // Strictly inside
+    let inside_range = TimeRange::new(
+        HybridTimestamp::new(101, 0).unwrap(),
+        HybridTimestamp::new(199, 0).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        range.contains_range(&inside_range),
+        "Must contain strictly inner range"
+    );
+
+    // Spills before start
+    let earlier_start_range = TimeRange::new(
+        HybridTimestamp::new(99, 0).unwrap(),
+        HybridTimestamp::new(150, 0).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        !range.contains_range(&earlier_start_range),
+        "Must NOT contain range starting earlier"
+    );
+
+    // Spills after end
+    let later_end_range = TimeRange::new(
+        HybridTimestamp::new(150, 0).unwrap(),
+        HybridTimestamp::new(201, 0).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        !range.contains_range(&later_end_range),
+        "Must NOT contain range ending later"
+    );
+}


### PR DESCRIPTION
**🧬 Mutants Found:** Dozens of boolean mutations (`&&` to `||`) and threshold evaluation replacements (`<` to `<=`, `==`, `>`) across the `contains`, `contains_or_after`, and `contains_range` implementations inside `TimeRange`.

**🎯 Tests Added/Strengthened:** 
* Extensively appended explicitly bounded unit-tests targeting boundary boundaries exactly via `tests/sentry_temporal.rs`.
* Added `test_sentry_time_range_contains_boundaries`.
* Added `test_sentry_time_range_contains_or_after_boundaries`.
* Added `test_sentry_time_range_contains_range_boundaries`.

**⚠️ Suspected Bugs:** 0

**📊 Kill Rate:** Substantially raised the mutant execution stability and eliminated overlapping structural boundaries allowed via previously passing logical structures.

**🔗 Havoc Interaction:** None immediately; verified exact bound implementations strictly adhere to explicit boundary overlap checks.

---
*PR created automatically by Jules for task [15692447702876771328](https://jules.google.com/task/15692447702876771328) started by @madmax983*