### PR TITLE
🎻 Bard: Fix rustdoc warnings and broken links

### DIFF
--- a/src/embeddings/providers/huggingface.rs
+++ b/src/embeddings/providers/huggingface.rs
@@ -40,7 +40,7 @@ pub struct HuggingFaceConfig {
     pub model_id: String,
     /// Expected dimensions (must match model)
     pub dimensions: usize,
-    /// API URL (default: https://api-inference.huggingface.co)
+    /// API URL (default: <https://api-inference.huggingface.co>)
     pub base_url: Option<String>,
     /// Request timeout
     pub timeout_secs: u64,

--- a/src/embeddings/providers/ollama.rs
+++ b/src/embeddings/providers/ollama.rs
@@ -13,7 +13,7 @@
 //! # Prerequisites
 //!
 //! Ollama must be installed and running:
-//! 1. Install: https://ollama.ai
+//! 1. Install: <https://ollama.ai>
 //! 2. Pull a model: `ollama pull nomic-embed-text`
 //! 3. Ollama server runs on `localhost:11434` by default
 //!

--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -69,7 +69,7 @@ pub struct OpenAIConfig {
     api_key: String,
     /// Model to use
     pub model: OpenAIModel,
-    /// API base URL (default: https://api.openai.com/v1)
+    /// API base URL (default: <https://api.openai.com/v1>)
     pub base_url: Option<String>,
     /// Request timeout in seconds
     pub timeout_secs: u64,

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -45,7 +45,7 @@ impl ShutdownHandle {
 /// - Health check endpoint at `/status`
 ///
 /// Note: This function only configures routes, not middleware.
-/// Middleware (CORS, logging) is configured in [`create_app`] or [`create_app_with_config`].
+/// Middleware (CORS, logging) is configured in [`create_app`] or [`create_server`].
 ///
 /// # Example
 ///
@@ -127,7 +127,7 @@ fn build_rate_limit(
 /// Create a configured Actix-web application factory with all middleware.
 ///
 /// This creates an app with **permissive CORS** suitable for development/testing.
-/// For production use, prefer [`create_app_with_config`] with proper CORS settings.
+/// For production use, prefer [`create_server`] with proper CORS settings.
 ///
 /// This includes:
 /// - Request logging middleware
@@ -137,7 +137,7 @@ fn build_rate_limit(
 /// # Security Warning
 ///
 /// This function uses permissive CORS settings. For production deployments,
-/// use [`create_app_with_config`] with a properly configured [`ServerConfig`].
+/// use [`create_server`] with a properly configured [`ServerConfig`].
 pub fn create_app() -> App<
     impl actix_web::dev::ServiceFactory<
         actix_web::dev::ServiceRequest,

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -92,7 +92,7 @@ impl AppState {
         &self.db
     }
 
-    /// Get the Arc<AletheiaDB> directly
+    /// Get the `Arc<AletheiaDB>` directly
     ///
     /// Useful when you need to clone the Arc or pass it to other components.
     pub fn db_arc(&self) -> Arc<AletheiaDB> {

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -361,7 +361,7 @@ pub fn init(config: Config) {
 
 /// Get a snapshot of current metrics.
 ///
-/// This is a convenience function that delegates to [`METRICS.snapshot()`].
+/// This is a convenience function that delegates to [`METRICS`]'s `snapshot()` method.
 ///
 /// # Example
 ///

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1321,7 +1321,7 @@ fn test_recovery_after_concurrent_writes() {
                         let lsn = loop {
                             match wal_ref.append_async(operation.clone()) {
                                 Ok(lsn) => break lsn,
-                                Err(e) if retries < 10 => {
+                                Err(_e) if retries < 10 => {
                                     retries += 1;
                                     std::thread::sleep(std::time::Duration::from_millis(1));
                                 }


### PR DESCRIPTION
📖 Chapter: General API Documentation
🔦 Insight: Cleaned up numerous `cargo doc` warnings including unresolved links, bare URLs, and unclosed HTML tags to ensure a smooth, warning-free generation experience.
🧪 Example: Formatted raw URLs with `<...>` in the embedding provider docs.
🖼️ Preview: Documentation generation is now warning-free with `--all-features`.

---
*PR created automatically by Jules for task [6305872860026930794](https://jules.google.com/task/6305872860026930794) started by @madmax983*