### PR TITLE
🪒 Razor: Eliminate single-implementation StorageSnapshot trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+
+## [Reduction]
+**Bloat:** `StorageSnapshot` trait (Single-implementation abstraction used only by `CurrentStorageSnapshot`).
+**Cut:** Deleted the `StorageSnapshot` trait entirely and moved its required methods (`lsn`, `node_count`, `edge_count`, `iter_nodes`, `iter_edges`) to be inherent `pub` methods directly on `CurrentStorageSnapshot`.
+**Saved:** ~30 lines of boilerplate (trait definition, empty implementation blocks, redundant imports) + removed an unnecessary layer of abstraction.

--- a/patch_snapshot.sh
+++ b/patch_snapshot.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sed -i 's/use aletheiadb::storage::snapshot::StorageSnapshot;//g' src/storage/snapshot.rs
+sed -i 's/impl StorageSnapshot for CurrentStorageSnapshot {/impl CurrentStorageSnapshot {/g' src/storage/snapshot.rs

--- a/plan.md
+++ b/plan.md
@@ -1,12 +1,16 @@
-1. *The Spark:* Create `entanglement.rs` in `src/experimental/` to detect Quantum Entanglement in the graph! It identifies pairs of nodes whose semantic vectors change synchronously over time, even without direct edges (or to find hidden correlations).
-2. *The Scaffold:* Implement `EntanglementDetector`.
-   - `struct EntanglementDetector`
-   - It will take a list of node IDs and analyze their histories over a specific `TimeRange` or simply across versions.
-   - For each node, compute a sequence of vector *deltas* (changes between consecutive versions).
-   - Compute the correlation (cosine similarity between the delta vectors) between pairs of nodes.
-   - High correlation = High Entanglement.
-3. *Unslop:* Add tests that create two nodes, mutate them together synchronously with the same delta, and one node with different mutations. The test will assert that the entangled pair has a higher entanglement score.
-   - Refactor the code to ensure it's DRY and minimal. Use exact match on node IDs, and proper error handling.
-4. *Add module:* Add `#[cfg(feature = "nova")] \n pub mod entanglement;` to `src/experimental/mod.rs`
-5. *Check:* Run `cargo clippy`, `cargo test`, `cargo fmt --all`. (Pre-commit steps).
-6. *Present:* PR Title "🌟 Nova: Entanglement Detector". Include Spark, Feature, Potential, Risk in description.
+1. **The Target:** We are removing the single-implementation trait `StorageSnapshot` in `src/storage/snapshot.rs`.
+   - The trait `StorageSnapshot` has exactly one full implementation, `CurrentStorageSnapshot` (note that `HistoricalStorageSnapshot` doesn't even implement it currently but exists in the same file).
+   - This fits perfectly with Razor's philosophy of "De-Abstract: Replace single-implementation Traits with concrete Structs" and "The One-Time Trait: A trait that is implemented by exactly one struct. (Delete the trait)."
+
+2. **The Execution:**
+   - Remove the `StorageSnapshot` trait definition from `src/storage/snapshot.rs`.
+   - Remove the `impl StorageSnapshot for CurrentStorageSnapshot` block. Instead, implement those methods directly on `CurrentStorageSnapshot`.
+   - Update usages. In `src/storage/checkpoint.rs`, there's a function `extract_graph_data_from_snapshot` that imports and uses `StorageSnapshot` methods on `CurrentStorageSnapshot`. After the change, it will just call the methods directly on the struct without needing the trait.
+   - Update `src/storage/mod.rs` to remove the re-export of `StorageSnapshot`.
+
+3. **Verification (Razor's Check):**
+   - Run `cargo test` to ensure tests still pass.
+   - Run `cargo clippy` to check for lints.
+   - Write critical learnings to `.jules/razor.md` following Razor's journal format.
+
+4. **Pre-commit:** Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -625,8 +625,6 @@ impl CheckpointManager {
         &self,
         snapshot: &crate::storage::snapshot::CurrentStorageSnapshot,
     ) -> Result<GraphIndexData> {
-        use crate::storage::snapshot::StorageSnapshot;
-
         let mut nodes = Vec::new();
         let mut edges = Vec::new();
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,7 +42,7 @@ pub use redb_cold_storage::{
     RedbColdStorage, RedbConfig, decode_edge_version, decode_node_version, encode_edge_version,
     encode_node_version,
 };
-pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot, StorageSnapshot};
+pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot};
 pub use tiered_storage::{
     LatencyPercentiles, TieredStorage, TieredStorageConfig, TieredStorageMetrics,
 };

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -23,7 +23,7 @@
 //! # Usage
 //!
 //! ```ignore
-//! use aletheiadb::storage::snapshot::StorageSnapshot;
+//!
 //!
 //! // Create snapshot at specific LSN
 //! let snapshot = current.create_snapshot(lsn);
@@ -46,6 +46,11 @@ use std::sync::Arc;
 /// from concurrent modifications. Used primarily for checkpointing to
 /// ensure data consistency.
 ///
+/// Snapshot of CurrentStorage at a specific LSN.
+///
+/// Uses Arc-based COW to provide snapshot isolation without
+/// full data clones. Memory overhead is ~8 bytes per entity.
+///
 /// # Design
 ///
 /// Snapshots use Arc-based COW:
@@ -53,33 +58,6 @@ use std::sync::Arc;
 /// - Collects `Arc<T>` references (cheap, just pointer + refcount)
 /// - Total memory: 8 bytes × num_entities (not full clones)
 /// - Iteration over snapshot is isolated from concurrent writes
-pub trait StorageSnapshot: Send + Sync {
-    /// Node iterator type (streaming, no Vec allocation)
-    type NodeIter: Iterator<Item = Node>;
-
-    /// Edge iterator type (streaming, no Vec allocation)
-    type EdgeIter: Iterator<Item = Edge>;
-
-    /// Get the LSN at which this snapshot was taken
-    fn lsn(&self) -> LSN;
-
-    /// Get the number of nodes in this snapshot
-    fn node_count(&self) -> usize;
-
-    /// Get the number of edges in this snapshot
-    fn edge_count(&self) -> usize;
-
-    /// Iterate over nodes in snapshot (streaming, isolated)
-    fn iter_nodes(&self) -> Self::NodeIter;
-
-    /// Iterate over edges in snapshot (streaming, isolated)
-    fn iter_edges(&self) -> Self::EdgeIter;
-}
-
-/// Snapshot of CurrentStorage at a specific LSN.
-///
-/// Uses Arc-based COW to provide snapshot isolation without
-/// full data clones. Memory overhead is ~8 bytes per entity.
 ///
 /// # Isolation Guarantee
 ///
@@ -119,32 +97,32 @@ impl CurrentStorageSnapshot {
     pub fn edges(&self) -> &[Arc<Edge>] {
         &self.edges
     }
-}
 
-impl StorageSnapshot for CurrentStorageSnapshot {
-    type NodeIter = CurrentNodeIterator;
-    type EdgeIter = CurrentEdgeIterator;
-
-    fn lsn(&self) -> LSN {
+    /// Get the LSN at which this snapshot was taken
+    pub fn lsn(&self) -> LSN {
         self.lsn
     }
 
-    fn node_count(&self) -> usize {
+    /// Get the number of nodes in this snapshot
+    pub fn node_count(&self) -> usize {
         self.nodes.len()
     }
 
-    fn edge_count(&self) -> usize {
+    /// Get the number of edges in this snapshot
+    pub fn edge_count(&self) -> usize {
         self.edges.len()
     }
 
-    fn iter_nodes(&self) -> Self::NodeIter {
+    /// Iterate over nodes in snapshot (streaming, isolated)
+    pub fn iter_nodes(&self) -> CurrentNodeIterator {
         CurrentNodeIterator {
             nodes: self.nodes.clone(),
             index: 0,
         }
     }
 
-    fn iter_edges(&self) -> Self::EdgeIter {
+    /// Iterate over edges in snapshot (streaming, isolated)
+    pub fn iter_edges(&self) -> CurrentEdgeIterator {
         CurrentEdgeIterator {
             edges: self.edges.clone(),
             index: 0,

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1321,7 +1321,7 @@ fn test_recovery_after_concurrent_writes() {
                         let lsn = loop {
                             match wal_ref.append_async(operation.clone()) {
                                 Ok(lsn) => break lsn,
-                                Err(e) if retries < 10 => {
+                                Err(_e) if retries < 10 => {
                                     retries += 1;
                                     std::thread::sleep(std::time::Duration::from_millis(1));
                                 }

--- a/tests/mvcc_snapshot.rs
+++ b/tests/mvcc_snapshot.rs
@@ -13,7 +13,7 @@ use aletheiadb::core::version::VersionData;
 use aletheiadb::storage::checkpoint::{CheckpointConfig, CheckpointManager};
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
-use aletheiadb::storage::snapshot::StorageSnapshot;
+
 use aletheiadb::storage::wal::LSN;
 use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
 use std::collections::HashMap;

--- a/tests/snapshot_race_condition.rs
+++ b/tests/snapshot_race_condition.rs
@@ -10,7 +10,7 @@ use aletheiadb::core::temporal::time;
 use aletheiadb::storage::checkpoint::{CheckpointConfig, CheckpointManager};
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
-use aletheiadb::storage::snapshot::StorageSnapshot;
+
 use aletheiadb::storage::wal::LSN;
 use std::sync::{Arc, Barrier};
 use std::thread;


### PR DESCRIPTION
The user requested, under the 'Razor' persona, to simplify the code by de-abstracting single-implementation traits. I removed the `StorageSnapshot` trait from `src/storage/snapshot.rs`, which was solely implemented by `CurrentStorageSnapshot`, by rolling its required methods into the concrete struct implementation. Updated usages and cleaned up imports, reducing boilerplate.

---
*PR created automatically by Jules for task [10301110853537539983](https://jules.google.com/task/10301110853537539983) started by @madmax983*