### PR TITLE
⚡ Bolt: Optimize query result collection with vector pre-allocation

### DIFF
--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -159,8 +159,12 @@ impl QueryResults {
     }
 
     /// Collect all results into a vector, stopping on first error
+    ///
+    /// ⚡ Bolt Optimization: Pre-allocates vector based on iterator's lower size bound
+    /// to reduce heap allocations during collection.
     pub fn collect_all(mut self) -> Result<Vec<QueryRow>> {
-        let mut results = Vec::new();
+        let (lower, _) = self.iterator.size_hint();
+        let mut results = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             results.push(row?);
         }
@@ -171,8 +175,10 @@ impl QueryResults {
     ///
     /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
     /// a large intermediate `Vec` of all rows before extracting the nodes.
+    /// Pre-allocates vector based on iterator's lower size bound.
     pub fn collect_nodes(mut self) -> Result<Vec<Node>> {
-        let mut nodes = Vec::new();
+        let (lower, _) = self.iterator.size_hint();
+        let mut nodes = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             if let EntityResult::Node(n) = row?.entity {
                 nodes.push(n);
@@ -185,8 +191,10 @@ impl QueryResults {
     ///
     /// ⚡ Bolt Optimization: Consumes the iterator directly to avoid allocating
     /// a large intermediate `Vec` of all rows before extracting the nodes and scores.
+    /// Pre-allocates vector based on iterator's lower size bound.
     pub fn collect_nodes_with_scores(mut self) -> Result<Vec<(Node, f32)>> {
-        let mut results = Vec::new();
+        let (lower, _) = self.iterator.size_hint();
+        let mut results = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             let row = row?;
             if let (EntityResult::Node(n), Some(score)) = (row.entity, row.score) {

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1321,7 +1321,7 @@ fn test_recovery_after_concurrent_writes() {
                         let lsn = loop {
                             match wal_ref.append_async(operation.clone()) {
                                 Ok(lsn) => break lsn,
-                                Err(e) if retries < 10 => {
+                                Err(_e) if retries < 10 => {
                                     retries += 1;
                                     std::thread::sleep(std::time::Duration::from_millis(1));
                                 }


### PR DESCRIPTION
## 💡 What
The `collect_all`, `collect_nodes`, and `collect_nodes_with_scores` methods in `src/query/executor/results.rs` now pre-allocate their internal vectors using `Vec::with_capacity(lower)` derived from the iterator's lower size bound (`size_hint()`).

## 🎯 Why
Previously, these methods initialized vectors with `Vec::new()`, resulting in a capacity of 0. As elements were pushed during iteration over potentially large result sets, the vector had to repeatedly reallocate its memory buffer and copy elements. By knowing the lower bound in advance, we can allocate memory upfront.

## 📊 Impact
Reduces heap allocations and memory reallocations during query execution. For large graph queries returning thousands of nodes, this eliminates intermediate capacity expansions.

## 🔬 Measurement
Run standard benchmarks or `cargo test -p aletheiadb --lib query::executor::results`. The changes maintain exact logical parity with previous behavior but perform fewer memory operations under the hood.

---
*PR created automatically by Jules for task [9817257647600916861](https://jules.google.com/task/9817257647600916861) started by @madmax983*