### PR TITLE
🎻 Bard: [documentation update] The Query Planner module

### DIFF
--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -1,13 +1,26 @@
 //! Query Planner
 //!
-//! Transforms logical plans into optimized physical plans for execution.
-//! The planner applies optimization rules and uses a cost model to choose
-//! the best execution strategy.
+//! The Query Planner acts as the brains of AletheiaDB's query engine. It translates
+//! user-facing queries into highly optimized execution strategies, bridging the gap
+//! between "what the user wants" and "how the database fetches it."
+//!
+//! # Logical vs. Physical Plans
+//!
+//! The planner operates in two distinct phases, dealing with two types of plans:
+//!
+//! - **Logical Plans**: The *what*. These represent the intent of the query independently
+//!   of the database's internal state. For example, "Find all `Person` nodes with `age > 30`."
+//!   The logical plan does not know if there is an index on `age`.
+//!
+//! - **Physical Plans**: The *how*. These represent the exact execution operations
+//!   (`PhysicalOp`) the database will perform. The planner looks at the logical plan,
+//!   consults `Statistics` and available indexes, and produces a physical plan like:
+//!   "Perform an `IndexScan` on the `age` property, then yield the resulting node IDs."
 //!
 //! # Life of a Query
 //!
-//! 1. **Logical Planning**: The `Query` struct (IR) is converted into a `LogicalPlan`.
-//!    This represents *what* to compute without specifying *how*.
+//! 1. **Logical Planning**: The `Query` struct (Intermediate Representation) is converted
+//!    into a `LogicalPlan`.
 //!    - Example: `Scan(Person) -> Filter(age > 30)`
 //!
 //! 2. **Optimization**: The planner applies a series of `OptimizationRule`s to the logical plan.
@@ -16,7 +29,6 @@
 //!    - **Cost-Based Decisions**: Uses `Statistics` and a `CostModel` to estimate the cost of different plans.
 //!
 //! 3. **Physical Planning**: The optimized logical plan is converted into a `PhysicalPlan`.
-//!    This represents the actual execution strategy (e.g., "Index Scan" vs "Full Scan").
 //!    - Example: `IndexScan(Person, age > 30)`
 //!
 //! 4. **Execution**: The `PhysicalPlan` is handed off to the `Executor` (not part of this module).

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -103,6 +103,32 @@ impl PhysicalPlan {
     /// - Estimated cardinalities (row counts)
     /// - Temporal context if applicable
     ///
+    /// # Panics
+    ///
+    /// This method will never panic.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use aletheiadb::core::NodeId;
+    /// # use aletheiadb::query::planner::physical::{PhysicalPlan, PhysicalOp};
+    /// # use aletheiadb::query::planner::cost::Cost;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let plan = PhysicalPlan {
+    ///     root: PhysicalOp::NodeLookup { node_ids: vec![NodeId::new(1)?] },
+    ///     estimated_cost: Cost { cpu: 0.5, io: 1.0, memory: 1024, network: 0.0 },
+    ///     temporal_context: None,
+    ///     parallel: false,
+    ///     include_provenance: false,
+    /// };
+    ///
+    /// let explanation = plan.explain();
+    /// assert!(explanation.contains("Physical Plan"));
+    /// assert!(explanation.contains("NodeLookup"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # Example Output
     ///
     /// ```text
@@ -617,7 +643,28 @@ impl PhysicalOp {
         }
     }
 
-    /// Format the plan tree as a string for debugging
+    /// Format the plan tree as a string for debugging.
+    ///
+    /// This will recursively format the `PhysicalOp` into a multiline string
+    /// detailing its type and parameters.
+    ///
+    /// # Panics
+    ///
+    /// This method does not panic.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use aletheiadb::core::NodeId;
+    /// # use aletheiadb::query::planner::physical::PhysicalOp;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let op = PhysicalOp::NodeLookup { node_ids: vec![NodeId::new(42)?] };
+    /// let output = op.explain();
+    /// assert!(output.contains("NodeLookup"));
+    /// assert!(output.contains("ids: [42]"));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn explain(&self) -> String {
         self.explain_indent(0)

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -661,7 +661,7 @@ impl PhysicalOp {
     /// let op = PhysicalOp::NodeLookup { node_ids: vec![NodeId::new(42)?] };
     /// let output = op.explain();
     /// assert!(output.contains("NodeLookup"));
-    /// assert!(output.contains("ids: [42]"));
+    /// assert!(output.contains("ids: [NodeId(42)]"));
     /// # Ok(())
     /// # }
     /// ```

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1321,7 +1321,7 @@ fn test_recovery_after_concurrent_writes() {
                         let lsn = loop {
                             match wal_ref.append_async(operation.clone()) {
                                 Ok(lsn) => break lsn,
-                                Err(e) if retries < 10 => {
+                                Err(_e) if retries < 10 => {
                                     retries += 1;
                                     std::thread::sleep(std::time::Duration::from_millis(1));
                                 }


### PR DESCRIPTION
📖 Chapter: The `Query Planner` module (`src/query/planner`)
🔦 Insight: Clarified the distinction between Logical Plans (the *what*) and Physical Plans (the *how*).
🧪 Example: Added executable doctests with examples for `PhysicalPlan::explain` and `PhysicalOp::explain`. Explicitly documented that `explain` does not panic.

---
*PR created automatically by Jules for task [8223965660731362063](https://jules.google.com/task/8223965660731362063) started by @madmax983*