### PR TITLE
⚒️ Forge: [Refactor lexer comment skipping]

### DIFF
--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -448,68 +448,72 @@ impl<'a> Lexer<'a> {
             }
 
             // Check for comments
-            if let Some(&(_, ch)) = self.chars.peek() {
-                if ch == '-' {
-                    // Check for -- comment
-                    let mut chars_clone = self.chars.clone();
-                    chars_clone.next();
-                    if let Some(&(_, '-')) = chars_clone.peek() {
-                        // Skip to end of line
-                        self.advance(); // first -
-                        self.advance(); // second -
-                        while let Some(&(_, ch)) = self.chars.peek() {
-                            if ch == '\n' {
-                                self.advance();
-                                break;
-                            }
-                            self.advance();
-                        }
+            let Some(&(_, ch)) = self.chars.peek() else {
+                break;
+            };
+
+            if ch == '-' {
+                let mut chars_clone = self.chars.clone();
+                chars_clone.next();
+                if let Some(&(_, '-')) = chars_clone.peek() {
+                    self.skip_single_line_comment();
+                    continue;
+                }
+            } else if ch == '/' {
+                let mut chars_clone = self.chars.clone();
+                chars_clone.next();
+                if let Some(&(_, next_ch)) = chars_clone.peek() {
+                    if next_ch == '/' {
+                        self.skip_single_line_comment();
                         continue;
-                    }
-                } else if ch == '/' {
-                    // Check for // or /* comment
-                    let mut chars_clone = self.chars.clone();
-                    chars_clone.next();
-                    if let Some(&(_, next_ch)) = chars_clone.peek() {
-                        if next_ch == '/' {
-                            // Skip to end of line
-                            self.advance(); // first /
-                            self.advance(); // second /
-                            while let Some(&(_, ch)) = self.chars.peek() {
-                                if ch == '\n' {
-                                    self.advance();
-                                    break;
-                                }
-                                self.advance();
-                            }
-                            continue;
-                        } else if next_ch == '*' {
-                            // Skip to */
-                            self.advance(); // /
-                            self.advance(); // *
-                            let mut found_end = false;
-                            loop {
-                                match self.advance() {
-                                    Some((_, '*')) => {
-                                        if let Some(&(_, '/')) = self.chars.peek() {
-                                            self.advance();
-                                            found_end = true;
-                                            break;
-                                        }
-                                    }
-                                    None => break,
-                                    _ => {}
-                                }
-                            }
-                            if !found_end {
-                                return Err(self.error("Unterminated block comment".to_string()));
-                            }
-                            continue;
-                        }
+                    } else if next_ch == '*' {
+                        self.skip_block_comment()?;
+                        continue;
                     }
                 }
             }
+
             break;
+        }
+        Ok(())
+    }
+
+    fn skip_single_line_comment(&mut self) {
+        // Advance past the two comment characters (e.g., '--' or '//')
+        self.advance();
+        self.advance();
+
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch == '\n' {
+                self.advance();
+                break;
+            }
+            self.advance();
+        }
+    }
+
+    fn skip_block_comment(&mut self) -> Result<(), LexerError> {
+        // Advance past '/*'
+        self.advance();
+        self.advance();
+
+        let mut found_end = false;
+        loop {
+            match self.advance() {
+                Some((_, '*')) => {
+                    if let Some(&(_, '/')) = self.chars.peek() {
+                        self.advance();
+                        found_end = true;
+                        break;
+                    }
+                }
+                None => break,
+                _ => {}
+            }
+        }
+
+        if !found_end {
+            return Err(self.error("Unterminated block comment".to_string()));
         }
         Ok(())
     }


### PR DESCRIPTION
🚮 **Smell:** `src/query/lexer.rs` contained a "Pyramid of Doom" in the `skip_whitespace_and_comments` function. It was deeply nested (up to 9 levels) with inline loops for handling `--`, `//`, and `/* */` comments, making it a "God Function" that was hard to read and mentally trace.

✨ **Solution:** Extracted the distinct comment handling logic into two private helper methods:
- `skip_single_line_comment(&mut self)`
- `skip_block_comment(&mut self) -> Result<(), LexerError>`
Refactored the main loop to use a guard clause (`let Some(...) = ... else { break; }`) and call these helper functions.

🧼 **Benefit:** Drastically flattens the indentation structure from 9 levels to a maximum of 5, shortens the original function, significantly reduces cognitive load, and modularizes the parsing rules.

🛡️ **Verification:** Tests passed. No logic changed. Verified via `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --lib query::lexer` (44/44 tests passed).

---
*PR created automatically by Jules for task [8006362270309845457](https://jules.google.com/task/8006362270309845457) started by @madmax983*