### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/experimental/temporal_narrative.rs
+++ b/src/experimental/temporal_narrative.rs
@@ -145,28 +145,26 @@ impl<'a> NarrativeGenerator<'a> {
 impl<'a> NarrativeGenerator<'a> {
     /// Create a new narrative generator.
     ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
+    /// Without the `nova` feature enabled, this creates a stub generator that
+    /// will return errors when its methods are called.
     #[allow(unused_variables)]
-    #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
+        Self {
+            _marker: std::marker::PhantomData,
+        }
     }
 
     /// Generate a narrative for a specific node.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This method panics if the `nova` feature is not enabled.
+    /// This method returns a `NotImplemented` error if the `nova` feature is not enabled.
     #[allow(unused_variables)]
-    #[track_caller]
     pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
+        Err(crate::core::error::Error::NotImplemented {
+            feature: "nova".to_string(),
+            reason: "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml.".to_string()
+        })
     }
 }
 
@@ -294,27 +292,21 @@ mod stub_tests {
     use super::*;
 
     #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
+    fn test_stub_error_on_new() {
         let db = AletheiaDB::new().unwrap();
-        // This should panic
-        let _ = NarrativeGenerator::new(&db);
-    }
+        // This should no longer panic, but create the stub
+        let generator = NarrativeGenerator::new(&db);
 
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
-        // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
-            _marker: std::marker::PhantomData,
-        };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
+        // This should return an error
+        let result = generator.generate_node_narrative(NodeId::new(0).unwrap());
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            crate::core::error::Error::NotImplemented { feature, reason } => {
+                assert_eq!(feature, "nova");
+                assert!(reason.contains("features = [\"nova\"]"));
+            }
+            err => panic!("Expected NotImplemented error, got: {:?}", err),
+        }
     }
 }


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the `story_demo` example from the `README.md`. The compiler successfully parsed the code, but at runtime, the application crashed with a hard panic because the `nova` feature wasn't enabled. This provides a terrible Developer Experience (DX) because missing a feature flag shouldn't result in an unrecoverable crash, especially for experimental features.

🕵️ **The Reality:** In `src/experimental/temporal_narrative.rs`, the `#[cfg(not(feature = "nova"))]` implementation of `NarrativeGenerator` used `panic!()` in both its `new` constructor and its `generate_node_narrative` method. 

💡 **The Fix:** Removed the panics from the `nova`-disabled implementation. `NarrativeGenerator::new` now creates a safe, non-panicking stub (using `PhantomData`), and `generate_node_narrative` gracefully returns an `Err(crate::core::error::Error::NotImplemented)` detailing the exact feature (`nova`) that needs to be enabled in `Cargo.toml`. Also updated the tests in `stub_tests` to expect these proper error types instead of panics.

---
*PR created automatically by Jules for task [3591264619118870011](https://jules.google.com/task/3591264619118870011) started by @madmax983*