### PR TITLE
⚡ Bolt: Optimize `label_counts` HashMap hashing for `InternedString` keys

### DIFF
--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1910,8 +1910,19 @@ impl CurrentStorage {
     /// Returns an iterator of (interned_label, count) pairs.
     /// Used by the query planner for cost estimation and cardinality estimation.
     pub fn label_counts(&self) -> Vec<(crate::core::interning::InternedString, usize)> {
+        use crate::core::hasher::IdentityHasher;
         use std::collections::HashMap;
-        let mut counts: HashMap<crate::core::interning::InternedString, usize> = HashMap::new();
+        use std::hash::BuildHasherDefault;
+
+        // ⚡ Bolt: Use `IdentityHasher` instead of default SipHash.
+        // `InternedString` is already a high-quality unique integer ID (u32),
+        // so computing SipHash per node (potentially millions) is pure overhead.
+        // Bypassing hashing reduces cardinality estimation time significantly.
+        let mut counts: HashMap<
+            crate::core::interning::InternedString,
+            usize,
+            BuildHasherDefault<IdentityHasher>,
+        > = HashMap::default();
         for node in self.indexes.iter_nodes() {
             *counts.entry(node.label).or_insert(0) += 1;
         }


### PR DESCRIPTION
💡 What: Replaced the default `HashMap` in `CurrentStorage::label_counts` with a map using `IdentityHasher`.

🎯 Why: `InternedString` is already a unique wrapper around `u32`. The default hasher uses `SipHash`, which is slow and adds completely unnecessary overhead when hashing integers, slowing down cardinality estimation operations on millions of nodes. By using `IdentityHasher` we bypass this computational step.

📊 Impact: Significantly speeds up query planning and cardinality estimation where large numbers of nodes need to have their labels aggregated, by removing `O(N)` hashing steps.

🔬 Measurement: Measure CPU flamegraphs when executing large cardinality queries or `label_counts()` and look for reduced time spent inside hasher routines.

---
*PR created automatically by Jules for task [8445236913401353522](https://jules.google.com/task/8445236913401353522) started by @madmax983*