### PR TITLE
🤖 Sentinel: Strengthen core graph label coverage

### DIFF
--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -621,6 +621,25 @@ mod sentry_tests {
     }
 
     #[test]
+    fn test_matches_label_mismatch() {
+        // 🛡️ Sentry Test: Verify `matches_label` correctly returns false when checking a valid
+        // label against a different string. This kills the mutant replacing `matches_label`
+        // return value with `true`.
+        let label = GLOBAL_INTERNER.intern("User").unwrap();
+        let node = Node::new(
+            NodeId::new(1).unwrap(),
+            label,
+            PropertyMapBuilder::new().build(),
+            VersionId::new(1).unwrap(),
+        );
+
+        assert!(
+            !node.has_label_str("Admin"),
+            "matches_label should return false when checking against a different label"
+        );
+    }
+
+    #[test]
     fn test_node_with_metadata() {
         // 🛡️ Sentry Test: Verify Node::with_metadata correctly stores metadata.
         // This targets mutants where the metadata argument is ignored and replaced with default.


### PR DESCRIPTION
**🧬 Mutants Found:** 1 surviving mutant in `src/core/graph.rs` where `matches_label` returned `true` instead of its evaluated boolean.
**🎯 Tests Added/Strengthened:** Added `test_matches_label_mismatch` in `sentry_tests` inside `src/core/graph.rs` to verify that `has_label_str` correctly evaluates to `false` when provided a mismatched label string for a valid interned node label.
**⚠️ Suspected Bugs:** None.
**📊 Kill Rate:** 26/26 mutants successfully eliminated for `core::graph` baseline.
**🔗 Havoc Interaction:** None.

---
*PR created automatically by Jules for task [7128765996881492741](https://jules.google.com/task/7128765996881492741) started by @madmax983*