### PR TITLE
🔒 Warden: Explicit payload limits for JSON deserialization bombs

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -56,6 +56,11 @@ impl ShutdownHandle {
 /// let app = App::new().configure(configure_app);
 /// ```
 pub fn configure_app(cfg: &mut web::ServiceConfig) {
+    // 🔒 Warden Defense: Prevent Deserialization DoS bombs
+    // Limit JSON payloads to 2MB (default is 2MB, but being explicit guarantees defense in depth)
+    let json_config = web::JsonConfig::default().limit(2 * 1024 * 1024);
+
+    cfg.app_data(json_config);
     configure_health_routes(cfg);
     cfg.route("/query", web::post().to(handle_query));
 }

--- a/tests/warden_json_bomb.rs
+++ b/tests/warden_json_bomb.rs
@@ -1,0 +1,35 @@
+use actix_web::http::StatusCode;
+use actix_web::{App, test};
+use aletheiadb::db::AletheiaDB;
+use aletheiadb::http::{AppState, configure_app};
+
+#[actix_rt::test]
+async fn test_json_payload_limit() {
+    let db = AletheiaDB::new().unwrap();
+    let app_state = actix_web::web::Data::new(AppState::new(std::sync::Arc::new(db)));
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_app),
+    )
+    .await;
+
+    // Create a JSON payload larger than 2MB
+    let large_string = "x".repeat(3 * 1024 * 1024); // 3MB string
+    let payload = format!(
+        r#"{{"operation": "find_node", "label": "{}"}}"#,
+        large_string
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/query")
+        .insert_header(("Content-Type", "application/json"))
+        .set_payload(payload)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+
+    // Should return 413 Payload Too Large
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}

--- a/tests/warden_json_bomb.rs
+++ b/tests/warden_json_bomb.rs
@@ -1,9 +1,11 @@
+#![cfg(feature = "http-server")]
+
 use actix_web::http::StatusCode;
 use actix_web::{App, test};
 use aletheiadb::db::AletheiaDB;
 use aletheiadb::http::{AppState, configure_app};
 
-#[actix_rt::test]
+#[actix_web::test]
 async fn test_json_payload_limit() {
     let db = AletheiaDB::new().unwrap();
     let app_state = actix_web::web::Data::new(AppState::new(std::sync::Arc::new(db)));
@@ -28,7 +30,7 @@ async fn test_json_payload_limit() {
         .set_payload(payload)
         .to_request();
 
-    let resp = test::call_service(&app, req).await;
+    let resp: actix_web::dev::ServiceResponse = test::call_service(&app, req).await;
 
     // Should return 413 Payload Too Large
     assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);


### PR DESCRIPTION
**🦠 Threat**: Actix-Web provides a default payload limit for `web::Json` extractors, but implicitly relying on framework defaults without explicit configuration represents a weak security posture. If the default changes or is accidentally overridden, the server becomes vulnerable to Deserialization Bombs (Denial of Service) where a user sends a massive JSON payload that consumes all available memory.

**🛡️ Defense**: Added explicit `web::JsonConfig::default().limit(2 * 1024 * 1024)` to the `configure_app` function in `src/http/server.rs` to guarantee defense-in-depth.

**💥 Severity**: Medium - A deserialization bomb could lead to memory exhaustion on nodes processing large unvalidated requests.

**🧪 Verification**: Added integration test `tests/warden_json_bomb.rs` which sends a 3MB string as a JSON property to the `/query` endpoint. Confirmed that the server rejects it with a `413 Payload Too Large` error rather than attempting to parse it.

---
*PR created automatically by Jules for task [7937547969440738759](https://jules.google.com/task/7937547969440738759) started by @madmax983*