### PR TITLE
🎻 Bard: Documentation Update for Experimental Modules

### DIFF
--- a/src/experimental/hindsight.rs
+++ b/src/experimental/hindsight.rs
@@ -82,6 +82,51 @@ pub struct HindsightDiff {
 }
 
 /// The Hindsight engine wrapping the database and a scenario.
+///
+/// Hindsight is designed to let you safely "play in the sandbox" without affecting
+/// production data. By layering a virtual `Scenario` on top of a read-only view
+/// of the database, you can freely mutate the graph—adding nodes, deleting edges,
+/// and patching properties—and then run standard queries (like BFS or vector search)
+/// to see how the graph behaves under those conditions.
+///
+/// This is particularly useful for impact analysis ("If I sever this link, is the
+/// network disconnected?") and LLM reasoning ("Assume this new fact is true, does
+/// it change the path to the objective?").
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::AletheiaDB;
+/// use aletheiadb::experimental::hindsight::Hindsight;
+/// use aletheiadb::core::property::PropertyMapBuilder;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let db = AletheiaDB::new()?;
+///
+/// // Create a real node in the database
+/// let props = PropertyMapBuilder::new().insert("name", "Real Node").build();
+/// let real_node_id = db.create_node("Node", props)?;
+///
+/// // Start a simulation
+/// let mut hindsight = Hindsight::new(&db);
+///
+/// // Add a purely hypothetical node to the simulation
+/// let ghost_props = PropertyMapBuilder::new().insert("name", "Ghost Node").build();
+/// let ghost_id = hindsight.add_node("Hypothetical", ghost_props)?;
+///
+/// // You can retrieve the real node...
+/// let real = hindsight.get_node(real_node_id)?;
+/// assert_eq!(real.get_property("name").unwrap().as_str().unwrap(), "Real Node");
+///
+/// // ...and the ghost node!
+/// let ghost = hindsight.get_node(ghost_id)?;
+/// assert_eq!(ghost.get_property("name").unwrap().as_str().unwrap(), "Ghost Node");
+///
+/// // But the ghost node doesn't exist in the actual database
+/// assert!(db.get_node(ghost_id).is_err());
+/// # Ok(())
+/// # }
+/// ```
 pub struct Hindsight<'a> {
     db: &'a AletheiaDB,
     scenario: Scenario,
@@ -93,6 +138,8 @@ pub struct Hindsight<'a> {
 
 impl<'a> Hindsight<'a> {
     /// Create a new Hindsight engine.
+    ///
+    /// Initializes an empty scenario layered on top of the current state of the database.
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
@@ -144,7 +191,32 @@ impl<'a> Hindsight<'a> {
 
     // ==================== Mutation Methods ====================
 
-    /// Simulate adding a node.
+    /// Simulate adding a node to the virtual graph.
+    ///
+    /// This generates a temporary `NodeId` that is valid *only* within this Hindsight instance.
+    /// The actual database remains completely unmodified.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::experimental::hindsight::Hindsight;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let mut hs = Hindsight::new(&db);
+    ///
+    /// let props = PropertyMapBuilder::new().insert("key", "value").build();
+    /// let temp_id = hs.add_node("Simulated", props)?;
+    ///
+    /// // The node exists in the simulation...
+    /// assert!(hs.get_node(temp_id).is_ok());
+    /// // ...but not in the real DB.
+    /// assert!(db.get_node(temp_id).is_err());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn add_node(&mut self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         let id = self.next_node_id();
         let interned_label = GLOBAL_INTERNER.intern(label)?;
@@ -158,7 +230,39 @@ impl<'a> Hindsight<'a> {
         Ok(id)
     }
 
-    /// Simulate adding an edge.
+    /// Simulate adding an edge to the virtual graph.
+    ///
+    /// This creates a temporary connection between two nodes. The endpoints can be either
+    /// real nodes in the database or temporary nodes created via [`Self::add_node`].
+    ///
+    /// The actual database remains completely unmodified.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::experimental::hindsight::Hindsight;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let mut hs = Hindsight::new(&db);
+    ///
+    /// // Create two simulated nodes
+    /// let props = PropertyMapBuilder::new().build();
+    /// let a = hs.add_node("Simulated", props.clone())?;
+    /// let b = hs.add_node("Simulated", props)?;
+    ///
+    /// // Connect them virtually
+    /// let edge_props = PropertyMapBuilder::new().insert("weight", 5.0).build();
+    /// let edge_id = hs.add_edge(a, b, "CONNECTED_TO", edge_props)?;
+    ///
+    /// // The edge is visible in Hindsight...
+    /// let retrieved_edge = hs.get_edge(edge_id)?;
+    /// assert_eq!(retrieved_edge.get_property("weight").unwrap().as_float().unwrap(), 5.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn add_edge(
         &mut self,
         source: NodeId,
@@ -261,6 +365,38 @@ impl<'a> Hindsight<'a> {
     // ==================== Read Methods ====================
 
     /// Get a node from the virtual graph.
+    ///
+    /// This method seamlessly merges the real database state with the simulated scenario.
+    /// It applies the following logic in order:
+    /// 1. If the node was virtually removed via [`Self::remove_node`], it returns a `NodeNotFound` error.
+    /// 2. If the node was virtually added via [`Self::add_node`], it returns the simulated node.
+    /// 3. Otherwise, it fetches the real node from the database and applies any virtual property patches from [`Self::update_node`].
+    ///
+    /// ## Errors
+    /// Returns `StorageError::NodeNotFound` if the node doesn't exist in the database *and* hasn't
+    /// been virtually added, or if it *was* in the database but has been virtually removed.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::experimental::hindsight::Hindsight;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let real_node_id = db.create_node("Node", PropertyMapBuilder::new().build())?;
+    ///
+    /// let mut hs = Hindsight::new(&db);
+    /// hs.remove_node(real_node_id); // Virtually remove the real node
+    ///
+    /// // Hindsight respects the virtual deletion
+    /// assert!(hs.get_node(real_node_id).is_err());
+    /// // But it remains in the actual DB
+    /// assert!(db.get_node(real_node_id).is_ok());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get_node(&self, id: NodeId) -> Result<Node> {
         // 1. Check if removed
         if self.scenario.removed_nodes.contains(&id) {
@@ -400,6 +536,44 @@ impl<'a> Hindsight<'a> {
     // ==================== Analysis Methods ====================
 
     /// Find a path between two nodes using Breadth-First Search on the virtual graph.
+    ///
+    /// This traversal respects all simulated changes: it will follow newly added virtual edges,
+    /// and it will ignore any real edges or nodes that have been virtually removed.
+    ///
+    /// This is ideal for "what-if" connectivity analysis (e.g., "If router X goes down,
+    /// can server A still reach server B?").
+    ///
+    /// ## Returns
+    /// Returns `Some(Vec<EdgeId>)` containing the shortest path of edges from `start` to `end`.
+    /// Returns `None` if no path exists in the *virtual* graph, or if either `start` or `end`
+    /// have been virtually removed.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::experimental::hindsight::Hindsight;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let a = db.create_node("A", PropertyMapBuilder::new().build())?;
+    /// let b = db.create_node("B", PropertyMapBuilder::new().build())?;
+    /// let c = db.create_node("C", PropertyMapBuilder::new().build())?;
+    ///
+    /// // Real graph: A -> B
+    /// db.create_edge(a, b, "LINK", PropertyMapBuilder::new().build())?;
+    ///
+    /// let mut hs = Hindsight::new(&db);
+    /// // What if B connects to C?
+    /// hs.add_edge(b, c, "VIRTUAL_LINK", PropertyMapBuilder::new().build())?;
+    ///
+    /// // Path A -> B -> C should now exist in Hindsight
+    /// let path = hs.find_path_bfs(a, c).unwrap();
+    /// assert_eq!(path.len(), 2);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn find_path_bfs(&self, start: NodeId, end: NodeId) -> Option<Vec<EdgeId>> {
         // Check if start or end are removed
         if self.scenario.removed_nodes.contains(&start)

--- a/src/experimental/metaphor.rs
+++ b/src/experimental/metaphor.rs
@@ -14,6 +14,40 @@
 //! - **Knowledge Migration**: Map concepts from one domain to another.
 //! - **Digital Twins**: Align a simulation graph with a real-world graph.
 //! - **Recommender Systems**: "You liked Movie A (Graph A). Movie B (Graph B) has a similar character dynamic."
+//!
+//! ## Examples
+//!
+//! ```rust
+//! // Requires features = ["nova"]
+//! use aletheiadb::AletheiaDB;
+//! use aletheiadb::experimental::metaphor::Metaphor;
+//! use aletheiadb::core::property::PropertyMapBuilder;
+//! use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = AletheiaDB::new()?;
+//! db.enable_vector_index("embedding", HnswConfig::new(2, DistanceMetric::Cosine))?;
+//!
+//! // Source Graph
+//! let props_a = PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0]).build();
+//! let a = db.create_node("Concept", props_a)?;
+//!
+//! // Target Graph
+//! let props_x = PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0]).build();
+//! let x = db.create_node("Analogue", props_x)?;
+//!
+//! let props_y = PropertyMapBuilder::new().insert_vector("embedding", &[0.0, 1.0]).build();
+//! let y = db.create_node("Analogue", props_y)?;
+//!
+//! let metaphor = Metaphor::new(&db);
+//! let alignment = metaphor.align(&[a], &[x, y], "embedding", 0.5)?;
+//!
+//! // A perfectly aligns with X based on semantic similarity
+//! assert_eq!(alignment.mappings[0].source, a);
+//! assert_eq!(alignment.mappings[0].target, x);
+//! # Ok(())
+//! # }
+//! ```
 
 #![allow(clippy::needless_range_loop, clippy::collapsible_if)]
 
@@ -60,11 +94,45 @@ impl<'a> Metaphor<'a> {
 
     /// Align a source subgraph to a target subgraph.
     ///
+    /// This method greedily matches nodes from the source graph to the target graph.
+    /// The algorithm first evaluates the purely semantic similarity using the specified `vector_property`.
+    /// When a match is finalized, the score of the remaining neighbors is artificially boosted
+    /// by the `structural_weight`. This ensures that if node `A` maps to node `X`, the algorithm
+    /// prefers mapping `A`'s neighbors to `X`'s neighbors over mapping them to isolated nodes
+    /// that might have a slightly higher baseline semantic score.
+    ///
     /// # Arguments
     /// * `source_nodes` - The nodes in the source graph to map.
     /// * `target_nodes` - The candidate nodes in the target graph.
     /// * `vector_property` - The property name containing vector embeddings.
     /// * `structural_weight` - How much structural consistency boosts the score (e.g., 0.5).
+    ///   A higher value prioritizes preserving the shape/topology of the graph over pure vector similarity.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// // Requires features = ["nova"]
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::experimental::metaphor::Metaphor;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// db.enable_vector_index("embedding", HnswConfig::new(2, DistanceMetric::Cosine))?;
+    ///
+    /// let a = db.create_node("A", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0]).build())?;
+    /// let x = db.create_node("X", PropertyMapBuilder::new().insert_vector("embedding", &[1.0, 0.0]).build())?;
+    ///
+    /// let metaphor = Metaphor::new(&db);
+    /// let alignment = metaphor.align(&[a], &[x], "embedding", 0.5)?;
+    ///
+    /// assert_eq!(alignment.mappings.len(), 1);
+    /// assert_eq!(alignment.mappings[0].source, a);
+    /// assert_eq!(alignment.mappings[0].target, x);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[allow(clippy::needless_range_loop, clippy::collapsible_if)]
     pub fn align(
         &self,

--- a/src/experimental/omen.rs
+++ b/src/experimental/omen.rs
@@ -72,6 +72,40 @@ impl<'a> Omen<'a> {
     }
 
     /// Predict the encounter between two nodes based on their trajectories in the given window.
+    ///
+    /// ## Returns
+    /// Returns `Some(Encounter)` if both nodes have valid trajectories (vectors defined at or before
+    /// the start and end of the window). Returns `None` if either node lacks the required vector data.
+    ///
+    /// ## Errors
+    /// Returns an error if fetching historical data for the nodes fails.
+    ///
+    /// ## Panics
+    /// This method is designed to be panic-free. Dimension mismatches between vectors will safely return `None`.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// // Requires features = ["nova"]
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::experimental::omen::Omen;
+    /// use aletheiadb::core::temporal::{TimeRange, time};
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let a = db.create_node("Node", PropertyMapBuilder::new().insert_vector("vec", &[0.0, 0.0]).build())?;
+    /// let b = db.create_node("Node", PropertyMapBuilder::new().insert_vector("vec", &[10.0, 0.0]).build())?;
+    ///
+    /// let omen = Omen::new(&db);
+    /// let window = TimeRange::new(time::now() - 1000, time::now())?;
+    ///
+    /// if let Some(encounter) = omen.predict_encounter(a, b, window, "vec")? {
+    ///     println!("Time to encounter: {:?}", encounter.time_to_encounter);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn predict_encounter(
         &self,
         node_a: NodeId,


### PR DESCRIPTION
📖 Chapter: Experimental Modules (`Hindsight`, `Metaphor`, `Omen`)
🔦 Insight: Explained the *why* behind the `Hindsight` sandbox, the structural weighting logic in `Metaphor::align`, and detailed panic/error conditions in `Omen::predict_encounter`.
🧪 Example: Added highly detailed, executable `## Examples` doc-tests to `Hindsight::add_edge`, `Hindsight::get_node`, `Hindsight::find_path_bfs`, `Metaphor::align`, and `Omen::predict_encounter`.
🖼️ Preview: Documentation is fully compiling via `cargo doc --all-features` without warnings.

---
*PR created automatically by Jules for task [8393581013009414604](https://jules.google.com/task/8393581013009414604) started by @madmax983*