### PR TITLE
🪒 Razor: Remove unused StorageSnapshot trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,9 +1,4 @@
 ## [Reduction]
-**Bloat:** `FileColdStorage` (Redundant, inferior implementation of `ColdStorage` trait).
-**Cut:** Deleted `FileColdStorage` struct, implementation, and tests.
-**Saved:** ~200 lines of code + cognitive load of maintaining two cold storage backends.
-
-## [Reduction]
-**Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
-**Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
-**Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+**Bloat:** The `StorageSnapshot` trait in `src/storage/snapshot.rs`. It was implemented by exactly one struct (`CurrentStorageSnapshot`). `HistoricalStorageSnapshot` did not implement it. All callers explicitly took `&CurrentStorageSnapshot`.
+**Cut:** Deleted the `StorageSnapshot` trait, merged its methods directly into `CurrentStorageSnapshot`, and updated `src/storage/checkpoint.rs` to stop importing and using it.
+**Saved:** Unnecessary indirection and a useless trait definition. Code is more explicit and easier to read.

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,16 @@
-1. **Explore the History module**: Inspect `src/core/history.rs` to review current `tests` module.
-2. **Add Sentinel Tests**: Write Sentinel integration tests for `EntityHistory`, `VersionSummary`, and `VersionDiff` in `src/core/history.rs` or an integration test to cover missing branches (e.g., `version_count`, `has_changes`, `change_count`, `first_version`). Use table-driven tests where appropriate.
-3. **Verify tests**: Run `cargo test --lib core::history` to ensure tests are passing, and `cargo clippy` and `cargo fmt`.
-4. **Pre-commit**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-5. **Submit PR**: Format PR with `🛡️ Sentry: [test coverage improvement]` and Target, Risk, Strategy, Verification sections.
+1. **Goal**: Remove the `StorageSnapshot` trait.
+   - **Reason**: It's a "One-Time" trait. Only `CurrentStorageSnapshot` implements it. `HistoricalStorageSnapshot` does not implement it, but has similar methods. The `StorageSnapshot` trait isn't actually being used polymorphically anywhere; callers (like `extract_graph_data_from_snapshot` in `src/storage/checkpoint.rs`) just take a concrete `&CurrentStorageSnapshot` anyway.
+2. **Steps**:
+   - `src/storage/snapshot.rs`:
+     - Delete `pub trait StorageSnapshot { ... }`.
+     - Change `impl StorageSnapshot for CurrentStorageSnapshot` to just `impl CurrentStorageSnapshot`.
+     - Remove `type NodeIter = CurrentNodeIterator;` and `type EdgeIter = CurrentEdgeIterator;` and return the concrete types instead of `Self::NodeIter`.
+     - Wait, `iter_nodes` and `iter_edges` return `CurrentNodeIterator` and `CurrentEdgeIterator`. Make sure they return these explicitly.
+   - `src/storage/mod.rs`:
+     - Remove `StorageSnapshot` from the `pub use snapshot::{...};` exports.
+   - `src/storage/checkpoint.rs`:
+     - Remove `use crate::storage::snapshot::StorageSnapshot;`
+3. **Write Tests Check**:
+   - Verify with `cargo test`.
+4. **Pre-commit checks**:
+   - Run clippy, formatting, and `cargo doc --all-features`.

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -625,8 +625,6 @@ impl CheckpointManager {
         &self,
         snapshot: &crate::storage::snapshot::CurrentStorageSnapshot,
     ) -> Result<GraphIndexData> {
-        use crate::storage::snapshot::StorageSnapshot;
-
         let mut nodes = Vec::new();
         let mut edges = Vec::new();
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,7 +42,7 @@ pub use redb_cold_storage::{
     RedbColdStorage, RedbConfig, decode_edge_version, decode_node_version, encode_edge_version,
     encode_node_version,
 };
-pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot, StorageSnapshot};
+pub use snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot};
 pub use tiered_storage::{
     LatencyPercentiles, TieredStorage, TieredStorageConfig, TieredStorageMetrics,
 };

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -23,7 +23,7 @@
 //! # Usage
 //!
 //! ```ignore
-//! use aletheiadb::storage::snapshot::StorageSnapshot;
+//! use aletheiadb::storage::snapshot::CurrentStorageSnapshot;
 //!
 //! // Create snapshot at specific LSN
 //! let snapshot = current.create_snapshot(lsn);
@@ -53,29 +53,7 @@ use std::sync::Arc;
 /// - Collects `Arc<T>` references (cheap, just pointer + refcount)
 /// - Total memory: 8 bytes × num_entities (not full clones)
 /// - Iteration over snapshot is isolated from concurrent writes
-pub trait StorageSnapshot: Send + Sync {
-    /// Node iterator type (streaming, no Vec allocation)
-    type NodeIter: Iterator<Item = Node>;
-
-    /// Edge iterator type (streaming, no Vec allocation)
-    type EdgeIter: Iterator<Item = Edge>;
-
-    /// Get the LSN at which this snapshot was taken
-    fn lsn(&self) -> LSN;
-
-    /// Get the number of nodes in this snapshot
-    fn node_count(&self) -> usize;
-
-    /// Get the number of edges in this snapshot
-    fn edge_count(&self) -> usize;
-
-    /// Iterate over nodes in snapshot (streaming, isolated)
-    fn iter_nodes(&self) -> Self::NodeIter;
-
-    /// Iterate over edges in snapshot (streaming, isolated)
-    fn iter_edges(&self) -> Self::EdgeIter;
-}
-
+///
 /// Snapshot of CurrentStorage at a specific LSN.
 ///
 /// Uses Arc-based COW to provide snapshot isolation without
@@ -119,32 +97,32 @@ impl CurrentStorageSnapshot {
     pub fn edges(&self) -> &[Arc<Edge>] {
         &self.edges
     }
-}
 
-impl StorageSnapshot for CurrentStorageSnapshot {
-    type NodeIter = CurrentNodeIterator;
-    type EdgeIter = CurrentEdgeIterator;
-
-    fn lsn(&self) -> LSN {
+    /// Get the LSN at which this snapshot was taken
+    pub fn lsn(&self) -> LSN {
         self.lsn
     }
 
-    fn node_count(&self) -> usize {
+    /// Get the number of nodes in this snapshot
+    pub fn node_count(&self) -> usize {
         self.nodes.len()
     }
 
-    fn edge_count(&self) -> usize {
+    /// Get the number of edges in this snapshot
+    pub fn edge_count(&self) -> usize {
         self.edges.len()
     }
 
-    fn iter_nodes(&self) -> Self::NodeIter {
+    /// Iterate over nodes in snapshot (streaming, isolated)
+    pub fn iter_nodes(&self) -> CurrentNodeIterator {
         CurrentNodeIterator {
             nodes: self.nodes.clone(),
             index: 0,
         }
     }
 
-    fn iter_edges(&self) -> Self::EdgeIter {
+    /// Iterate over edges in snapshot (streaming, isolated)
+    pub fn iter_edges(&self) -> CurrentEdgeIterator {
         CurrentEdgeIterator {
             edges: self.edges.clone(),
             index: 0,

--- a/tests/mvcc_snapshot.rs
+++ b/tests/mvcc_snapshot.rs
@@ -13,7 +13,6 @@ use aletheiadb::core::version::VersionData;
 use aletheiadb::storage::checkpoint::{CheckpointConfig, CheckpointManager};
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
-use aletheiadb::storage::snapshot::StorageSnapshot;
 use aletheiadb::storage::wal::LSN;
 use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
 use std::collections::HashMap;

--- a/tests/snapshot_race_condition.rs
+++ b/tests/snapshot_race_condition.rs
@@ -10,7 +10,6 @@ use aletheiadb::core::temporal::time;
 use aletheiadb::storage::checkpoint::{CheckpointConfig, CheckpointManager};
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
-use aletheiadb::storage::snapshot::StorageSnapshot;
 use aletheiadb::storage::wal::LSN;
 use std::sync::{Arc, Barrier};
 use std::thread;


### PR DESCRIPTION
## [Reduction]
**Bloat:** The `StorageSnapshot` trait in `src/storage/snapshot.rs` was a "One-Time" Trait. It was implemented by exactly one struct (`CurrentStorageSnapshot`), while another similar struct (`HistoricalStorageSnapshot`) existed but didn't implement it. No code in the repository relied on dynamic dispatch or polymorphic behavior for this trait; all callers explicitly referenced `&CurrentStorageSnapshot`.

**Cut:** 
- Deleted `pub trait StorageSnapshot`.
- Merged the methods previously under the trait `impl` directly into `impl CurrentStorageSnapshot`.
- Removed associated types and returned the concrete iterator types directly.
- Cleaned up unused imports in `src/storage/checkpoint.rs`, `tests/mvcc_snapshot.rs`, and `tests/snapshot_race_condition.rs`.
- Removed the trait from the exports in `src/storage/mod.rs`.

**Saved:** 
Removed an unnecessary layer of abstraction and boilerplate code, making the storage snapshot mechanism more explicit and straightforward to trace and understand.

---
*PR created automatically by Jules for task [666886202644766139](https://jules.google.com/task/666886202644766139) started by @madmax983*