### PR TITLE
⚡ Bolt: Use FastHashMap (IdentityHasher) internally in Oracle PageRank

### DIFF
--- a/src/experimental/oracle.rs
+++ b/src/experimental/oracle.rs
@@ -13,9 +13,11 @@
 
 use crate::AletheiaDB;
 use crate::core::error::{Result, StorageError};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use rand::prelude::*;
 use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
 
 /// The Oracle Engine.
 pub struct Oracle<'a> {
@@ -50,7 +52,12 @@ impl<'a> Oracle<'a> {
         num_walks: usize,
         max_steps: usize,
     ) -> Result<HashMap<NodeId, f32>> {
-        let mut visits: HashMap<NodeId, usize> = HashMap::new();
+        // PERFORMANCE: Use IdentityHasher instead of the default SipHash for the `visits` map.
+        // `NodeId` is a wrapper around a unique `u64`. In a Monte Carlo simulation (random walks),
+        // we perform millions of map insertions and lookups. Bypassing SipHash eliminates
+        // unnecessary hashing overhead on already-unique integer keys, significantly improving throughput.
+        let mut visits: HashMap<NodeId, usize, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
         let mut rng = rand::thread_rng();
 
         // Ensure seed exists


### PR DESCRIPTION
* 💡 What: Replaced internal `HashMap` with `HashMap<..., BuildHasherDefault<IdentityHasher>>` for tracking visits in `Oracle::personalized_page_rank` and added internal documentation explaining the optimization.
* 🎯 Why: `NodeId` is a wrapper around a unique `u64`. The default `SipHash` in `HashMap` introduces unnecessary hashing overhead in the hot path of the Monte Carlo simulation where millions of map insertions and lookups occur.
* 📊 Impact: Expected to reduce CPU time spent on hashing and improve the throughput of random walks in `personalized_page_rank` while fully preserving the public API (returning a standard `HashMap`).
* 🔬 Measurement: Run `cargo test --features="nova" --lib experimental::oracle` to verify correctness.

---
*PR created automatically by Jules for task [13343252523061899657](https://jules.google.com/task/13343252523061899657) started by @madmax983*