### PR TITLE
⚡ Bolt: Replace .min_by with .fold on DashMap iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,7 @@
 **Avoid `.map(|r| r.key().clone()).min()`**
 **Learning:** `.map(...).min()` allocates a new string (via clone) for *every* element in a `DashMap` (or any iterator of refs) before it computes the minimum. This means `O(N)` heap allocations instead of O(1).
 **Action:** Use `.min_by(|a, b| a.key().cmp(b.key()))` first to find the ref to the minimal element, and *then* call `.map(|r| r.key().clone())` to allocate exactly once!
+
+## 2026-11-20 - Avoid `min_by` on DashMap
+**Learning:** `DashMap::iter().min_by(...)` and `max_by(...)` hold onto `RefMulti` read guards across loop iterations, which can cause deadlocks if a concurrent writer is waiting for a lock on the same shard.
+**Action:** Use `.fold(None, |min, current| ...)` to extract and clone only the necessary minimum/maximum value while immediately dropping the reference guard for each element. This prevents deadlocks and improves concurrency performance.

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1039,10 +1039,19 @@ impl CurrentStorage {
 
         // Find min key alphabetically
         // Note: DashMap iteration order is not guaranteed, so we must scan all keys
+        // We use `.fold` instead of `.min_by` to prevent deadlocks. `.min_by` holds
+        // multiple `RefMulti` read guards across iteration steps, which can block
+        // concurrent writers indefinitely. `.fold` immediately drops the guard for
+        // each element after extracting the necessary data.
         self.vector_indexes
             .iter()
-            .min_by(|a, b| a.key().cmp(b.key()))
-            .map(|r| r.key().clone())
+            .fold(None, |min: Option<String>, current| {
+                let key = current.key();
+                match min {
+                    Some(m) if m.as_str() <= key.as_str() => Some(m),
+                    _ => Some(key.clone()),
+                }
+            })
     }
 
     /// Get or create filter statistics for a label (Issue #334).


### PR DESCRIPTION
⚡ Bolt: Replace `.min_by` with `.fold` on DashMap iteration

* 💡 What: Replaced `.iter().min_by(...)` with `.fold(None, ...)` when finding the default vector property name in `CurrentStorage`.
* 🎯 Why: Using `.min_by` on a `DashMap` iterator holds the `RefMulti` read guard of the "current minimum" element across loop iterations. This blocks concurrent writers to that shard for the duration of the entire O(N) iteration, causing heavy lock contention and potential deadlocks.
* 📊 Impact: Significantly reduces lock contention duration on `DashMap` shards from O(N) to O(1) per element, preventing deadlocks and improving concurrent write throughput.
* 🔬 Measurement: Run `cargo bench` or concurrent read/write tests on `enable_vector_index` and `get_default_vector_property_name`.

---
*PR created automatically by Jules for task [16319707068560716107](https://jules.google.com/task/16319707068560716107) started by @madmax983*