### PR TITLE
chore: remove resolved FIX comment in havoc_wal_notifier

### DIFF
--- a/tests/havoc_wal_notifier.rs
+++ b/tests/havoc_wal_notifier.rs
@@ -36,7 +36,7 @@ mod loom_tests {
         }
 
         fn notify_success(&self) {
-            // FIX: Acquire mutex before updating state and notifying
+            // Acquire mutex before updating state and notifying
             // This prevents the "lost wakeup" scenario where a waiter checks the state (Pending),
             // then the notifier updates state and signals (Lost), then the waiter sleeps forever.
             let _guard = self.wait_mutex.lock().unwrap();


### PR DESCRIPTION
The issue "Acquire Mutex Before State Update" described by the `// FIX:` comment was already implemented correctly directly below the comment (`let _guard = self.wait_mutex.lock().unwrap();`).
Removing the `FIX:` prefix to resolve the tracked task since no further logic changes are required.

---
*PR created automatically by Jules for task [16820907027557016544](https://jules.google.com/task/16820907027557016544) started by @madmax983*