### PR TITLE
🎻 Bard: [documentation update] Add struct docs for query engine and cold storage

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -78,3 +78,7 @@
 ## 2025-03-05 - Doctests with Feature Flags
 **Confusion:** When writing doctests for modules behind a feature flag (like `nova`), wrapping the test block in `# #[cfg(feature = "nova")] \n # { ... }` causes `rustdoc` to generate invalid syntax when the test is extracted. It creates an anonymous block at the root level which is an expression, not an item, breaking `cargo test`. If the feature flag is disabled, it leaves an empty file causing a `main function not found` error.
 **Clarification:** To properly feature-gate doctests, conditionally compile the imports and the `main` function itself: `# #[cfg(feature = "nova")] \n fn main() { ... }`, and crucially, provide an empty fallback `main` function for when the feature is disabled: `# #[cfg(not(feature = "nova"))] \n # fn main() {}`.
+
+## 2025-03-05 - Logical vs Physical Plans and Iterator Performance
+**Confusion:** The difference between logical plans (`LogicalOp`) and physical plans (`PhysicalOp`) in the query engine was unclear. Additionally, the iterators used for execution (`ResultIterator` implementations) lacked clarity on their streaming architecture.
+**Clarification:** Documented `PhysicalOp` to explain its 1:1 mapping with iterators. Added struct-level documentation to `ResultIterator` implementations to clarify the pull-based, lazy execution model used during query processing.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -24,6 +24,10 @@ use crate::storage::historical::HistoricalStorage;
 use super::results::{EntityId, EntityResult, QueryRow};
 
 /// Trait for result iteration (pull-based).
+///
+/// Query execution uses a pull-based iterator model, where each physical
+/// operator is implemented as an iterator. Calling `next()` pulls results
+/// sequentially through the pipeline.
 pub trait ResultIterator: Send {
     /// Get the next result row
     fn next(&mut self) -> Option<Result<QueryRow>>;
@@ -35,6 +39,8 @@ pub trait ResultIterator: Send {
 }
 
 /// Empty iterator that produces no results.
+///
+/// Used for query plans that evaluate to empty at planning time.
 pub struct EmptyIterator;
 
 impl ResultIterator for EmptyIterator {
@@ -47,7 +53,9 @@ impl ResultIterator for EmptyIterator {
     }
 }
 
-/// Iterator for direct node lookups.
+/// Direct node lookup iterator.
+///
+/// Yields nodes corresponding to a specific list of IDs. O(1) per node.
 pub struct NodeLookupIterator {
     node_ids: std::vec::IntoIter<NodeId>,
     current: Arc<CurrentStorage>,
@@ -104,6 +112,10 @@ impl ResultIterator for NodeLookupIterator {
 /// - Streaming iteration using channels (`std::sync::mpsc`)
 /// - Chunked iteration to limit memory per batch
 /// - Index-based iteration that doesn't require holding locks
+///
+/// Sequential node scan iterator.
+///
+/// Scans through nodes sequentially, optionally applying a label filter.
 pub struct NodeScanIterator {
     label: Option<String>,
     current: Arc<CurrentStorage>,
@@ -864,6 +876,10 @@ impl ResultIterator for TraversalIterator {
 /// // Iterate results
 /// // for row in filter_iter { ... }
 /// ```
+///
+/// Iterator that applies a predicate filter.
+///
+/// Pulls rows from the input and yields only those matching the predicate.
 pub struct FilterIterator {
     input: Box<dyn ResultIterator>,
     predicate: Predicate,

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -198,6 +198,18 @@ impl Default for OperationCosts {
 }
 
 /// Cost model for estimating query execution costs.
+///
+/// Contains weights and base costs for CPU, I/O, memory, and network operations.
+/// Different models can be used to optimize for different environments (e.g., low-latency vs high-throughput).
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::query::planner::cost::CostModel;
+///
+/// let model = CostModel::new();
+/// assert_eq!(model.weights.cpu_weight, 1.0);
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct CostModel {
     /// Cost weights for combining different factors

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -323,6 +323,27 @@ fn format_memory(bytes: usize) -> String {
 }
 
 /// Physical operators that execute against storage.
+///
+/// Unlike `LogicalOp`s which describe the intent of the query, `PhysicalOp`s
+/// specify exactly how the data will be accessed and processed. They map 1:1
+/// with the iterators in `src/query/executor/iterators.rs`.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::core::NodeId;
+/// use aletheiadb::query::planner::physical::PhysicalOp;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // A node lookup operator directly fetches specific nodes by ID.
+/// let op = PhysicalOp::NodeLookup {
+///     node_ids: vec![NodeId::new(42)?],
+/// };
+///
+/// assert_eq!(op.name(), "NodeLookup");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub enum PhysicalOp {
     // === Scan Operators ===

--- a/src/storage/redb_cold_storage.rs
+++ b/src/storage/redb_cold_storage.rs
@@ -142,6 +142,17 @@ impl CompressionAlgorithm {
 }
 
 /// Configuration for cold storage.
+///
+/// Configures behavior like compression, batch sizes, and durability.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::storage::redb_cold_storage::{ColdStorageConfig, CompressionAlgorithm};
+///
+/// let config = ColdStorageConfig::default();
+/// assert!(matches!(config.compression, CompressionAlgorithm::Zstd));
+/// ```
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "config-toml", serde(default))]
@@ -173,6 +184,19 @@ impl Default for ColdStorageConfig {
 }
 
 /// Statistics for cold storage operations.
+///
+/// Tracks bytes written, read, compression ratios, and error counts.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::storage::redb_cold_storage::ColdStorageStats;
+///
+/// let mut stats = ColdStorageStats::default();
+/// stats.bytes_written_raw = 1000;
+/// stats.bytes_written_compressed = 500;
+/// assert_eq!(stats.compression_ratio(), 2.0);
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct ColdStorageStats {
     /// Total number of node versions stored.
@@ -302,6 +326,20 @@ fn map_compaction_error(
 }
 
 /// Configuration for Redb cold storage.
+///
+/// Used to tune the internal Redb environment and setup cache sizes,
+/// compression, and checksumming.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::storage::redb_cold_storage::{RedbConfig, CompressionAlgorithm};
+///
+/// let config = RedbConfig::new()
+///     .compression(CompressionAlgorithm::Fast)
+///     .enable_checksums(true)
+///     .cache_size_bytes(1024 * 1024 * 64); // 64MB cache
+/// ```
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "config-toml", serde(default))]


### PR DESCRIPTION
📖 Chapter: Query Planner, Iterators & Redb Cold Storage
🔦 Insight: Documented `PhysicalOp` to explain its 1:1 mapping with iterators. Added struct-level documentation to `ResultIterator` implementations to clarify the pull-based, lazy execution model used during query processing. Added struct docs for `ColdStorageConfig`, `ColdStorageStats`, `RedbConfig` and `CostModel`.
🧪 Example: Added executable doctests for `PhysicalOp`, `ColdStorageConfig`, `ColdStorageStats`, `RedbConfig`, and `CostModel`.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [10185248107009170997](https://jules.google.com/task/10185248107009170997) started by @madmax983*