### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -1,3 +1,13 @@
+## 🦀 Core Review: Empty Scope
+
+No high-severity findings.
+
+### Test gaps
+- No missing tests were identified because no specific diff or scope was provided for review.
+
+### Residual risks
+- Unknown risks exist outside the boundaries of this review since no explicit scope was specified. Ensure all modifications follow standard review procedures when actual diffs are provided.
+
 No high-severity findings.
 
 ### Test gaps


### PR DESCRIPTION
Appended 'No high-severity findings.' to `.jules/core_review.md` and noted residual risks, as no specific code diff or scope was provided for review.

---
*PR created automatically by Jules for task [10143061668323365420](https://jules.google.com/task/10143061668323365420) started by @madmax983*