### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- No missing tests were identified as no code was provided for review.
+
+### Residual risks
+- None identified in the empty scope.


### PR DESCRIPTION
Log empty scope review for Core persona

Since no specific diff or scope was provided for review, the `core_review.md` journal has been updated with an Empty Scope Review entry. This adheres strictly to the Core persona directives by explicitly noting the absence of findings, missing tests, and residual risks in this state.

---
*PR created automatically by Jules for task [6925842510262860532](https://jules.google.com/task/6925842510262860532) started by @madmax983*