### PR TITLE
🪒 Razor: [simplification] De-abstract PropagationModel trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+
+## [Reduction]
+**Bloat:** `PropagationModel` trait (Single-implementation abstraction used only by `LinearPropagation`).
+**Cut:** Deleted the `PropagationModel` trait. Refactored `Sybil::simulate` to use the concrete `LinearPropagation` struct directly.
+**Saved:** ~20 lines of boilerplate + removed generic overhead.

--- a/src/experimental/sybil.rs
+++ b/src/experimental/sybil.rs
@@ -45,24 +45,6 @@ use std::collections::HashMap;
 pub type PropagationState = HashMap<NodeId, Vec<f32>>;
 
 /// Defines how a node updates its state based on its neighbors.
-pub trait PropagationModel {
-    /// Calculate the next state for a node.
-    ///
-    /// # Arguments
-    /// * `node_id` - The node being updated.
-    /// * `current_self` - The node's current vector (if any).
-    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
-    ///
-    /// # Returns
-    /// The new vector state for the node.
-    fn next_state(
-        &self,
-        node_id: NodeId,
-        current_self: Option<&[f32]>,
-        neighbors: &[(NodeId, &[f32])],
-    ) -> Option<Vec<f32>>;
-}
-
 /// A simple linear propagation model.
 /// New State = (1 - alpha) * Old State + alpha * Average(Neighbor States)
 pub struct LinearPropagation {
@@ -79,10 +61,17 @@ impl LinearPropagation {
             alpha: alpha.clamp(0.0, 1.0),
         }
     }
-}
 
-impl PropagationModel for LinearPropagation {
-    fn next_state(
+    /// Calculate the next state for a node.
+    ///
+    /// # Arguments
+    /// * `node_id` - The node being updated.
+    /// * `current_self` - The node's current vector (if any).
+    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
+    ///
+    /// # Returns
+    /// The new vector state for the node.
+    pub fn next_state(
         &self,
         _node_id: NodeId,
         current_self: Option<&[f32]>,
@@ -156,10 +145,10 @@ impl<'a> Sybil<'a> {
     /// * `property_name` - The vector property to use as the "meme".
     /// * `model` - The propagation logic.
     /// * `steps` - Number of iterations.
-    pub fn simulate<M: PropagationModel>(
+    pub fn simulate(
         &self,
         property_name: &str,
-        model: &M,
+        model: &LinearPropagation,
         steps: usize,
     ) -> Result<PropagationState> {
         // Step 1: Load Initial State
@@ -231,7 +220,7 @@ impl<'a> Sybil<'a> {
                 // Iterate A (with state). For each neighbor B, accumulate A's influence on B.
                 // Then finalize B.
 
-                // BUT, the `PropagationModel` trait is designed as "Pull" (`next_state` takes `neighbors`).
+                // BUT, the `LinearPropagation` model is designed as "Pull" (`next_state` takes `neighbors`).
                 // Let's try to find neighbors.
 
                 let incoming_edges = self.db.get_incoming_edges(node_id);


### PR DESCRIPTION
## [Reduction] 
**Bloat:** `PropagationModel` trait was a single-implementation abstraction used only by `LinearPropagation`, which forced consumers of `simulate` to deal with unnecessary generic parameters.
**Cut:** Deleted the `PropagationModel` trait entirely. Refactored `Sybil::simulate` to use the concrete `LinearPropagation` struct directly, and moved the `next_state` method implementation directly into the `LinearPropagation` impl block.
**Saved:** ~20 lines of boilerplate, plus removed dynamic dispatch and generic overhead, increasing readability according to the KISS principle.

---
*PR created automatically by Jules for task [14327054564883780573](https://jules.google.com/task/14327054564883780573) started by @madmax983*