### PR TITLE
🦀 Core Review: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None identified. No scope or diff was provided to evaluate test coverage.
+
+### Residual risks
+- None identified. No code was provided for review.


### PR DESCRIPTION
Since no code or diff was provided for review, the `Core` persona instructions dictated logging an "Empty Scope Review" explicitly stating "No high-severity findings." alongside residual risks and test gaps. This was appended successfully to `.jules/core_review.md` and pre-commit checks (`cargo fmt`, `clippy`, and `test`) passed.

---
*PR created automatically by Jules for task [2412153062448569870](https://jules.google.com/task/2412153062448569870) started by @madmax983*