### PR TITLE
⚡ Bolt: Use IdentityHasher for Semantic Pathfinding HashMaps

### DIFF
--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -60,12 +60,14 @@
 //! it treats the cost as infinite (effectively blocking the path) instead of panicking.
 
 use crate::core::error::Result;
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;
 use crate::core::vector::cosine_similarity;
 use crate::query::traits::GraphView;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
+use std::hash::BuildHasherDefault;
 
 /// State for priority queue (min-heap based on cost).
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -182,8 +184,9 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
         bidirectional: bool,
     ) -> Result<Option<Vec<NodeId>>> {
         let mut pq = BinaryHeap::new();
-        let mut dist = HashMap::new();
-        let mut came_from = HashMap::new();
+        let mut dist: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> = HashMap::default();
+        let mut came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
 
         // Initialize start node
         dist.insert(start, 0.0);
@@ -308,8 +311,9 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
         bidirectional: bool,
     ) -> Result<Option<Vec<NodeId>>> {
         let mut pq = BinaryHeap::new();
-        let mut dist = HashMap::new();
-        let mut came_from = HashMap::new();
+        let mut dist: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> = HashMap::default();
+        let mut came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
 
         // Verify start node existed
         if self.db.get_node_at_time(start, time, time).is_err() {
@@ -436,7 +440,11 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
         }
     }
 
-    fn reconstruct_path(&self, came_from: HashMap<NodeId, NodeId>, current: NodeId) -> Vec<NodeId> {
+    fn reconstruct_path(
+        &self,
+        came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>>,
+        current: NodeId,
+    ) -> Vec<NodeId> {
         let mut path = vec![current];
         let mut curr = current;
         while let Some(&prev) = came_from.get(&curr) {


### PR DESCRIPTION
💡 What: Replaced standard `HashMap` with `HashMap<NodeId, f32/NodeId, BuildHasherDefault<IdentityHasher>>` for `dist` and `came_from` in `SemanticPathfinder`.
🎯 Why: The default `HashMap` uses SipHash, which is unnecessarily expensive for `NodeId` keys (which are just unique `u64` wrappers). Semantic pathfinding algorithms like Dijkstra/A* do thousands of internal `HashMap` insertions and lookups per query. Using a pass-through hasher eliminates this CPU overhead.
📊 Impact: Expected to reduce pathfinding query latency measurably by eliminating cryptographic hashing on the hot path while maintaining exact algorithmic correctness. 
🔬 Measurement: Run `cargo test --lib query::` to verify correctness. Since this is an algorithmic hot path optimization, `cargo bench` (if available for queries) would show the impact.

---
*PR created automatically by Jules for task [3539182473051481895](https://jules.google.com/task/3539182473051481895) started by @madmax983*