### PR TITLE
⚒️ Forge: Extract operations from HTTP handle_query God Function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -5,3 +5,7 @@
 ## src/query/parser.rs God Function
 **Learning:** `parse_primary_predicate` in `src/query/parser.rs` was a 100+ line function mixing multiple predicate parsing logic (EXISTS, string ops, IN, comparison), making it hard to read and maintain.
 **Action:** Extracted specific predicate logic into helper functions (`parse_exists_predicate`, `parse_string_predicate`, etc.) to flatten the structure and improve readability.
+
+## src/http/handlers.rs God Function
+**Learning:** `handle_query` in `src/http/handlers.rs` was a single ~290-line function containing deeply nested logic for dispatching and handling five distinct `QueryRequest` operations (`CreateNode`, `GetNode`, `FindNode`, `FindNeighbors`, `ExecuteQuery`). This created a massive "Pyramid of Doom" that violated the single responsibility principle and made it hard to reason about each handler's resource limits and error responses.
+**Action:** Flattened the logic by extracting each `QueryRequest` match arm into private asynchronous helper functions (`handle_create_node`, `handle_get_node`, etc.), reducing `handle_query` to a concise routing dispatch function.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -277,6 +277,290 @@ fn json_to_predicate_value(v: &serde_json::Value) -> Option<PredicateValue> {
 ///
 /// * **Pagination**: `limit + offset` must not exceed 10,000 to prevent CPU exhaustion.
 /// * **Result Size**: `limit` is capped at 1000 for neighbor queries.
+async fn handle_create_node(
+    db: std::sync::Arc<crate::AletheiaDB>,
+    label: String,
+    properties: Option<HashMap<String, serde_json::Value>>,
+) -> HttpResponse {
+    let props = match properties {
+        Some(p) => match json_to_property_map(&p) {
+            Ok(map) => map,
+            Err(e) => return HttpResponse::BadRequest().json(ApiResponse::error(e)),
+        },
+        None => crate::core::PropertyMap::new(),
+    };
+
+    let result = web::block(move || match db.create_node(&label, props) {
+        Ok(node_id) => match db.get_node(node_id) {
+            Ok(node) => {
+                let props_json =
+                    property_map_to_json(&node.properties).map_err(|e| e.to_string())?;
+                let node_json = json!({
+                    "id": node.id.as_u64(),
+                    "label": interned_to_string(node.label),
+                    "properties": props_json
+                });
+                Ok(node_json)
+            }
+            Err(e) => Err(e.to_string()),
+        },
+        Err(e) => Err(e.to_string()),
+    })
+    .await;
+
+    match result {
+        Ok(Ok(node_json)) => HttpResponse::Ok().json(ApiResponse::success(node_json)),
+        Ok(Err(e)) => HttpResponse::BadRequest().json(ApiResponse::error(e)),
+        Err(e) => HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string())),
+    }
+}
+
+async fn handle_get_node(db: std::sync::Arc<crate::AletheiaDB>, node_id: u64) -> HttpResponse {
+    match NodeId::new(node_id) {
+        Ok(nid) => match db.get_node(nid) {
+            Ok(node) => {
+                let props_json = match property_map_to_json(&node.properties) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return HttpResponse::InternalServerError().json(ApiResponse::error(e));
+                    }
+                };
+                let node_json = json!({
+                    "id": node.id.as_u64(),
+                    "label": interned_to_string(node.label),
+                    "properties": props_json
+                });
+                HttpResponse::Ok().json(ApiResponse::success(node_json))
+            }
+            // Issue 1: Return 404 for node not found
+            Err(_) => HttpResponse::NotFound()
+                .json(ApiResponse::error(format!("Node {} not found", node_id))),
+        },
+        Err(e) => HttpResponse::BadRequest().json(ApiResponse::error(e.to_string())),
+    }
+}
+
+async fn handle_find_node(
+    db: std::sync::Arc<crate::AletheiaDB>,
+    label: Option<String>,
+    properties: Option<HashMap<String, serde_json::Value>>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> HttpResponse {
+    // Issue 4: Pagination
+    let limit_val = limit.unwrap_or(100);
+    let offset_val = offset.unwrap_or(0);
+
+    // Prevent deep pagination attacks (CPU DoS)
+    // Use saturating_add to prevent integer overflow bypass
+    let max_deep_pagination = 10_000;
+    if offset_val.saturating_add(limit_val) > max_deep_pagination {
+        return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+            "Pagination limit exceeded: offset + limit must be <= {}",
+            max_deep_pagination
+        )));
+    }
+
+    let result = web::block(move || {
+        let mut builder = if let Some(lbl) = label {
+            QueryBuilder::new().scan_label(&lbl)
+        } else {
+            QueryBuilder::new().scan(None)
+        };
+
+        if let Some(props) = properties {
+            for (key, value) in props {
+                if let Some(pred_value) = json_to_predicate_value(&value) {
+                    builder = builder.filter(Predicate::eq(key, pred_value));
+                }
+            }
+        }
+
+        if let Some(skip) = offset {
+            builder = builder.skip(skip);
+        }
+
+        match builder.limit(limit_val).execute(&db) {
+            Ok(results) => {
+                let mut nodes = Vec::new();
+                for row in results.flatten() {
+                    if let crate::query::executor::EntityResult::Node(node) = row.entity {
+                        let props_json =
+                            property_map_to_json(&node.properties).map_err(|e| e.to_string())?;
+                        nodes.push(json!({
+                            "id": node.id.as_u64(),
+                            "label": interned_to_string(node.label),
+                            "properties": props_json
+                        }));
+                    }
+                }
+                Ok(nodes)
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    })
+    .await;
+
+    match result {
+        Ok(Ok(nodes)) => HttpResponse::Ok().json(ApiResponse::success(json!(nodes))),
+        Ok(Err(e)) => HttpResponse::InternalServerError().json(ApiResponse::error(e)),
+        Err(e) => HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string())),
+    }
+}
+
+async fn handle_find_neighbors(
+    db: std::sync::Arc<crate::AletheiaDB>,
+    node_id: u64,
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> HttpResponse {
+    // Validation first
+    let nid = match NodeId::new(node_id) {
+        Ok(nid) => nid,
+        Err(e) => {
+            return HttpResponse::BadRequest().json(ApiResponse::error(e.to_string()));
+        }
+    };
+
+    // Safety limits to prevent DoS
+    let max_limit = 1000;
+    let max_deep_pagination = 10_000;
+
+    let limit_val = limit.unwrap_or(100).min(max_limit);
+    let offset_val = offset.unwrap_or(0);
+
+    // Prevent deep-pagination and overflow bypasses.
+    if offset_val.saturating_add(limit_val) > max_deep_pagination {
+        return HttpResponse::BadRequest().json(ApiResponse::error(format!(
+            "Pagination limit exceeded: offset + limit must be <= {}",
+            max_deep_pagination
+        )));
+    }
+
+    let result = web::block(move || {
+        // Deduplication
+        let mut seen_ids = HashSet::new();
+        let mut neighbors = Vec::with_capacity(limit_val);
+
+        // Use zero-allocation iterators
+        // Outgoing: edge -> target node
+        let outgoing_iter = db
+            .get_outgoing_edges_iter(nid)
+            .map(|edge_id| db.get_edge_target(edge_id).ok());
+
+        // Incoming: edge -> source node
+        let incoming_iter = db
+            .get_incoming_edges_iter(nid)
+            .map(|edge_id| db.get_edge_source(edge_id).ok());
+
+        // Chain iterators -> filter valid -> filter duplicates -> skip -> take
+        let combined_iter = outgoing_iter
+            .chain(incoming_iter)
+            .flatten() // remove None (failed lookups)
+            .filter(|&neighbor_id| seen_ids.insert(neighbor_id)) // deduplicate
+            .skip(offset_val)
+            .take(limit_val);
+
+        for neighbor_id in combined_iter {
+            match db.get_node(neighbor_id) {
+                Ok(node) => {
+                    let props_json =
+                        property_map_to_json(&node.properties).map_err(|e| e.to_string())?;
+                    neighbors.push(json!({
+                        "id": node.id.as_u64(),
+                        "label": interned_to_string(node.label),
+                        "properties": props_json
+                    }));
+                }
+                Err(e) => {
+                    // Node ID found in edge but not in node index? Should be impossible unless corrupted
+                    return Err(e.to_string());
+                }
+            }
+        }
+        Ok(neighbors)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(neighbors)) => HttpResponse::Ok().json(ApiResponse::success(json!(neighbors))),
+        Ok(Err(e)) => HttpResponse::InternalServerError().json(ApiResponse::error(e)),
+        Err(e) => HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string())),
+    }
+}
+
+async fn handle_execute_query(
+    db: std::sync::Arc<crate::AletheiaDB>,
+    query: String,
+    parameters: Option<HashMap<String, serde_json::Value>>,
+) -> HttpResponse {
+    // Move parsing + execution to blocking thread
+    // Parsing is CPU bound, execution involves DB IO/scans
+    let result = web::block(move || {
+        // 1. Parse the query
+        let parsed_query = if let Some(params_json) = parameters {
+            match json_to_parameter_map(&params_json) {
+                Ok(params) => match parse_query_with_params(&query, params) {
+                    Ok(q) => q,
+                    Err(e) => return Err(e.to_string()),
+                },
+                Err(e) => return Err(e),
+            }
+        } else {
+            match parse_query(&query) {
+                Ok(q) => q,
+                Err(e) => return Err(e.to_string()),
+            }
+        };
+
+        // 2. Execute the query
+        match db.execute_query(parsed_query) {
+            Ok(results) => {
+                // 3. Serialize results
+                let mut json_results = Vec::new();
+                for row_result in results {
+                    match row_result {
+                        Ok(row) => match query_row_to_json(row) {
+                            Ok(json) => json_results.push(json),
+                            Err(e) => return Err(e),
+                        },
+                        Err(e) => return Err(e.to_string()),
+                    }
+                }
+                Ok(json_results)
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    })
+    .await;
+
+    match result {
+        Ok(Ok(json_results)) => HttpResponse::Ok().json(ApiResponse::success(json!(json_results))),
+        Ok(Err(e)) => {
+            // Simple heuristic: parse errors (often starting with "Syntax error") are Bad Request,
+            // others (StorageError) are Internal Server Error.
+            // For now, mapping everything to Internal Error to be safe/consistent with previous behavior
+            // (though previous behavior had explicit BadRequest for parse errors).
+            // Let's improve this:
+            if e.to_lowercase().contains("syntax") || e.to_lowercase().contains("parse") {
+                HttpResponse::BadRequest().json(ApiResponse::error(e))
+            } else {
+                HttpResponse::InternalServerError().json(ApiResponse::error(e))
+            }
+        }
+        Err(e) => HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string())),
+    }
+}
+
+/// Query endpoint handler.
+///
+/// Accepts a JSON `QueryRequest` and executes the corresponding operation against the database.
+/// Returns an `ApiResponse` wrapped in an `HttpResponse`.
+///
+/// # Resource Limits
+///
+/// * **Pagination**: `limit + offset` must not exceed 10,000 to prevent CPU exhaustion.
+/// * **Result Size**: `limit` is capped at 1000 for neighbor queries.
 pub async fn handle_query(
     state: web::Data<AppState>,
     req: web::Json<QueryRequest>,
@@ -285,286 +569,22 @@ pub async fn handle_query(
 
     match req.into_inner() {
         QueryRequest::CreateNode { label, properties } => {
-            let props = match properties {
-                Some(p) => match json_to_property_map(&p) {
-                    Ok(map) => map,
-                    Err(e) => return HttpResponse::BadRequest().json(ApiResponse::error(e)),
-                },
-                None => crate::core::PropertyMap::new(),
-            };
-
-            let db = db.clone();
-            let label = label.clone();
-
-            let result = web::block(move || match db.create_node(&label, props) {
-                Ok(node_id) => match db.get_node(node_id) {
-                    Ok(node) => {
-                        let props_json =
-                            property_map_to_json(&node.properties).map_err(|e| e.to_string())?;
-                        let node_json = json!({
-                            "id": node.id.as_u64(),
-                            "label": interned_to_string(node.label),
-                            "properties": props_json
-                        });
-                        Ok(node_json)
-                    }
-                    Err(e) => Err(e.to_string()),
-                },
-                Err(e) => Err(e.to_string()),
-            })
-            .await;
-
-            match result {
-                Ok(Ok(node_json)) => HttpResponse::Ok().json(ApiResponse::success(node_json)),
-                Ok(Err(e)) => HttpResponse::BadRequest().json(ApiResponse::error(e)),
-                Err(e) => {
-                    HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string()))
-                }
-            }
+            handle_create_node(db, label, properties).await
         }
-        QueryRequest::GetNode { node_id } => {
-            match NodeId::new(node_id) {
-                Ok(nid) => match db.get_node(nid) {
-                    Ok(node) => {
-                        let props_json = match property_map_to_json(&node.properties) {
-                            Ok(p) => p,
-                            Err(e) => {
-                                return HttpResponse::InternalServerError()
-                                    .json(ApiResponse::error(e));
-                            }
-                        };
-                        let node_json = json!({
-                            "id": node.id.as_u64(),
-                            "label": interned_to_string(node.label),
-                            "properties": props_json
-                        });
-                        HttpResponse::Ok().json(ApiResponse::success(node_json))
-                    }
-                    // Issue 1: Return 404 for node not found
-                    Err(_) => HttpResponse::NotFound()
-                        .json(ApiResponse::error(format!("Node {} not found", node_id))),
-                },
-                Err(e) => HttpResponse::BadRequest().json(ApiResponse::error(e.to_string())),
-            }
-        }
+        QueryRequest::GetNode { node_id } => handle_get_node(db, node_id).await,
         QueryRequest::FindNode {
             label,
             properties,
             limit,
             offset,
-        } => {
-            // Issue 4: Pagination
-            let limit_val = limit.unwrap_or(100);
-            let offset_val = offset.unwrap_or(0);
-
-            // Prevent deep pagination attacks (CPU DoS)
-            // Use saturating_add to prevent integer overflow bypass
-            let max_deep_pagination = 10_000;
-            if offset_val.saturating_add(limit_val) > max_deep_pagination {
-                return HttpResponse::BadRequest().json(ApiResponse::error(format!(
-                    "Pagination limit exceeded: offset + limit must be <= {}",
-                    max_deep_pagination
-                )));
-            }
-
-            let db = db.clone();
-
-            let result = web::block(move || {
-                let mut builder = if let Some(lbl) = label {
-                    QueryBuilder::new().scan_label(&lbl)
-                } else {
-                    QueryBuilder::new().scan(None)
-                };
-
-                if let Some(props) = properties {
-                    for (key, value) in props {
-                        if let Some(pred_value) = json_to_predicate_value(&value) {
-                            builder = builder.filter(Predicate::eq(key, pred_value));
-                        }
-                    }
-                }
-
-                if let Some(skip) = offset {
-                    builder = builder.skip(skip);
-                }
-
-                match builder.limit(limit_val).execute(&db) {
-                    Ok(results) => {
-                        let mut nodes = Vec::new();
-                        for row in results.flatten() {
-                            if let crate::query::executor::EntityResult::Node(node) = row.entity {
-                                let props_json = property_map_to_json(&node.properties)
-                                    .map_err(|e| e.to_string())?;
-                                nodes.push(json!({
-                                    "id": node.id.as_u64(),
-                                    "label": interned_to_string(node.label),
-                                    "properties": props_json
-                                }));
-                            }
-                        }
-                        Ok(nodes)
-                    }
-                    Err(e) => Err(e.to_string()),
-                }
-            })
-            .await;
-
-            match result {
-                Ok(Ok(nodes)) => HttpResponse::Ok().json(ApiResponse::success(json!(nodes))),
-                Ok(Err(e)) => HttpResponse::InternalServerError().json(ApiResponse::error(e)),
-                Err(e) => {
-                    HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string()))
-                }
-            }
-        }
+        } => handle_find_node(db, label, properties, limit, offset).await,
         QueryRequest::FindNeighbors {
             node_id,
             limit,
             offset,
-        } => {
-            // Validation first
-            let nid = match NodeId::new(node_id) {
-                Ok(nid) => nid,
-                Err(e) => {
-                    return HttpResponse::BadRequest().json(ApiResponse::error(e.to_string()));
-                }
-            };
-
-            // Safety limits to prevent DoS
-            let max_limit = 1000;
-            let max_deep_pagination = 10_000;
-
-            let limit_val = limit.unwrap_or(100).min(max_limit);
-            let offset_val = offset.unwrap_or(0);
-
-            // Prevent deep-pagination and overflow bypasses.
-            if offset_val.saturating_add(limit_val) > max_deep_pagination {
-                return HttpResponse::BadRequest().json(ApiResponse::error(format!(
-                    "Pagination limit exceeded: offset + limit must be <= {}",
-                    max_deep_pagination
-                )));
-            }
-
-            let db = db.clone();
-
-            let result = web::block(move || {
-                // Deduplication
-                let mut seen_ids = HashSet::new();
-                let mut neighbors = Vec::with_capacity(limit_val);
-
-                // Use zero-allocation iterators
-                // Outgoing: edge -> target node
-                let outgoing_iter = db
-                    .get_outgoing_edges_iter(nid)
-                    .map(|edge_id| db.get_edge_target(edge_id).ok());
-
-                // Incoming: edge -> source node
-                let incoming_iter = db
-                    .get_incoming_edges_iter(nid)
-                    .map(|edge_id| db.get_edge_source(edge_id).ok());
-
-                // Chain iterators -> filter valid -> filter duplicates -> skip -> take
-                let combined_iter = outgoing_iter
-                    .chain(incoming_iter)
-                    .flatten() // remove None (failed lookups)
-                    .filter(|&neighbor_id| seen_ids.insert(neighbor_id)) // deduplicate
-                    .skip(offset_val)
-                    .take(limit_val);
-
-                for neighbor_id in combined_iter {
-                    match db.get_node(neighbor_id) {
-                        Ok(node) => {
-                            let props_json = property_map_to_json(&node.properties)
-                                .map_err(|e| e.to_string())?;
-                            neighbors.push(json!({
-                                "id": node.id.as_u64(),
-                                "label": interned_to_string(node.label),
-                                "properties": props_json
-                            }));
-                        }
-                        Err(e) => {
-                            // Node ID found in edge but not in node index? Should be impossible unless corrupted
-                            return Err(e.to_string());
-                        }
-                    }
-                }
-                Ok(neighbors)
-            })
-            .await;
-
-            match result {
-                Ok(Ok(neighbors)) => {
-                    HttpResponse::Ok().json(ApiResponse::success(json!(neighbors)))
-                }
-                Ok(Err(e)) => HttpResponse::InternalServerError().json(ApiResponse::error(e)),
-                Err(e) => {
-                    HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string()))
-                }
-            }
-        }
+        } => handle_find_neighbors(db, node_id, limit, offset).await,
         QueryRequest::ExecuteQuery { query, parameters } => {
-            let db = db.clone();
-
-            // Move parsing + execution to blocking thread
-            // Parsing is CPU bound, execution involves DB IO/scans
-            let result = web::block(move || {
-                // 1. Parse the query
-                let parsed_query = if let Some(params_json) = parameters {
-                    match json_to_parameter_map(&params_json) {
-                        Ok(params) => match parse_query_with_params(&query, params) {
-                            Ok(q) => q,
-                            Err(e) => return Err(e.to_string()),
-                        },
-                        Err(e) => return Err(e),
-                    }
-                } else {
-                    match parse_query(&query) {
-                        Ok(q) => q,
-                        Err(e) => return Err(e.to_string()),
-                    }
-                };
-
-                // 2. Execute the query
-                match db.execute_query(parsed_query) {
-                    Ok(results) => {
-                        // 3. Serialize results
-                        let mut json_results = Vec::new();
-                        for row_result in results {
-                            match row_result {
-                                Ok(row) => match query_row_to_json(row) {
-                                    Ok(json) => json_results.push(json),
-                                    Err(e) => return Err(e),
-                                },
-                                Err(e) => return Err(e.to_string()),
-                            }
-                        }
-                        Ok(json_results)
-                    }
-                    Err(e) => Err(e.to_string()),
-                }
-            })
-            .await;
-
-            match result {
-                Ok(Ok(json_results)) => {
-                    HttpResponse::Ok().json(ApiResponse::success(json!(json_results)))
-                }
-                Ok(Err(e)) => {
-                    // Simple heuristic: parse errors (often starting with "Syntax error") are Bad Request,
-                    // others (StorageError) are Internal Server Error.
-                    // For now, mapping everything to Internal Error to be safe/consistent with previous behavior
-                    // (though previous behavior had explicit BadRequest for parse errors).
-                    // Let's improve this:
-                    if e.to_lowercase().contains("syntax") || e.to_lowercase().contains("parse") {
-                        HttpResponse::BadRequest().json(ApiResponse::error(e))
-                    } else {
-                        HttpResponse::InternalServerError().json(ApiResponse::error(e))
-                    }
-                }
-                Err(e) => {
-                    HttpResponse::InternalServerError().json(ApiResponse::error(e.to_string()))
-                }
-            }
+            handle_execute_query(db, query, parameters).await
         }
     }
 }


### PR DESCRIPTION
- **🚮 Smell:** The `handle_query` function in `src/http/handlers.rs` was a sprawling ~290-line "God Function" containing deeply nested `match` statements for five different API operations (`CreateNode`, `GetNode`, `FindNode`, `FindNeighbors`, `ExecuteQuery`).
- **✨ Solution:** Extracted the logic for each `QueryRequest` variant into a separate, private asynchronous helper function. Modified `handle_query` to act purely as a simple dispatch function delegating to the appropriate helper based on the request type. Added the required module-level `///` docs to `handle_query`.
- **🧼 Benefit:** Adheres to the single responsibility principle, significantly flattens the file's structure, reduces nesting, and makes it drastically easier to understand, test, and maintain individual API operations.
- **🛡️ Verification:** Tests passed. No logic changed. Verified via `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --features="http-server" --lib http`.

Added learning to `.jules/forge.md`.

---
*PR created automatically by Jules for task [14632828960042020830](https://jules.google.com/task/14632828960042020830) started by @madmax983*