### PR TITLE
🔒 Warden: Mitigate DoS bombs and remove generic unsafe vector transmutations

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,11 @@
 2024-XX-XX - [Warden: CSR Adjacency Index Vulnerability]
 **Threat:** `AdjacencyIndex::import_csr` did not validate that `node_ids` is sorted, and did not validate that `offsets` is monotonically increasing. It also didn't validate that the first offset is `0`. This allows a maliciously constructed CSR payload to cause OOB reads (Denial of Service) when `get_adjacency` is called, due to `start > end` or `end > edges.len()` when slicing the `edges` array.
 **Defense:** Added rigorous validation in `validate_csr_invariants` to ensure `node_ids` is strictly sorted (no duplicates), `offsets` begins with `0`, and is monotonically increasing.
+
+**2024-05-18 - Unbounded Actix-Web JSON Deserialization**
+**Threat:** The Actix-Web server did not enforce a strict payload limit for JSON deserialization on its API endpoints. This is a potential Denial of Service (DoS) vector where an attacker could send massive JSON payloads, exhausting memory and crashing the service (Deserialization Bombs).
+**Defense:** Explicitly configured `web::JsonConfig::default().limit(2 * 1024 * 1024)` in `src/http/server.rs` via `cfg.app_data` to limit incoming JSON payloads to a safe size (2MB).
+
+**2024-05-18 - Unsafe Vector Transmutation**
+**Threat:** A generic homegrown `unsafe fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U>` in `src/index/adjacency.rs` was used for zero-copy conversions. Although correctly asserting size and alignment, it lacked compile-time guarantees (like `AnyBitPattern`) to ensure that arbitrary bit patterns from `T` are actually valid for `U`. This allowed potential Undefined Behavior (UB) if misused elsewhere in the codebase.
+**Defense:** Replaced the unsafe block and generic implementation with `bytemuck::cast_vec`, enforcing `bytemuck::AnyBitPattern` and `bytemuck::NoUninit` trait bounds. Derived `Pod` and `Zeroable` for `NodeId` so it can be safely cast to/from integer arrays at zero cost, entirely removing the `unsafe` block.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitcode",
+ "bytemuck",
  "chrono",
  "comfy-table",
  "crc32fast",
@@ -517,6 +518,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ rayon = "1.8"
 comfy-table = "7.2.2"
 crossterm = "0.29.0"
 rand = "0.8"
+bytemuck = { version = "1.25.0", features = ["derive", "extern_crate_alloc"] }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -21,7 +21,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub const MAX_VALID_ID: u64 = u64::MAX - 1000;
 
 /// Unique identifier for a node in the graph.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, bytemuck::Pod, bytemuck::Zeroable,
+)]
 #[repr(transparent)]
 pub struct NodeId(u64);
 

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -56,6 +56,9 @@ impl ShutdownHandle {
 /// let app = App::new().configure(configure_app);
 /// ```
 pub fn configure_app(cfg: &mut web::ServiceConfig) {
+    // Defense in depth against deserialization DoS bombs
+    cfg.app_data(web::JsonConfig::default().limit(2 * 1024 * 1024)); // 2MB limit
+
     configure_health_routes(cfg);
     cfg.route("/query", web::post().to(handle_query));
 }

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -106,7 +106,7 @@ impl AdjacencyIndex {
 
         // Zero-copy conversion: NodeId(u64) has same layout as u64
         // SAFETY: NodeId is #[repr(transparent)] wrapper around u64.
-        let node_ids_typed: Vec<NodeId> = unsafe { Self::transmute_vec(node_ids) };
+        let node_ids_typed: Vec<NodeId> = Self::transmute_vec(node_ids);
 
         // Convert offsets (zero-copy on 64-bit, allocating on 32-bit)
         let offsets_usize = Self::convert_offsets(offsets);
@@ -350,7 +350,7 @@ impl AdjacencyIndex {
         #[cfg(target_pointer_width = "64")]
         {
             // SAFETY: usize == u64 on 64-bit platforms, so layout is compatible.
-            unsafe { Self::transmute_vec(offsets) }
+            Self::transmute_vec(offsets)
         }
 
         #[cfg(not(target_pointer_width = "64"))]
@@ -359,20 +359,17 @@ impl AdjacencyIndex {
         }
     }
 
-    /// Helper for zero-copy Vec conversion
+    /// Helper for zero-copy Vec conversion using bytemuck.
     ///
-    /// # Safety
-    /// T and U must have same layout, size, and alignment.
-    unsafe fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U> {
-        // Enforce safety invariants at compile time/runtime
-        assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<U>());
-        assert_eq!(std::mem::align_of::<T>(), std::mem::align_of::<U>());
-
-        let mut v = std::mem::ManuallyDrop::new(v);
-        // SAFETY: Caller ensures T and U layout compatibility.
-        // from_raw_parts is unsafe, but we are inside an unsafe function.
-        // In Rust 2024 (and newer editions), unsafe blocks are required inside unsafe functions.
-        unsafe { Vec::from_raw_parts(v.as_mut_ptr() as *mut U, v.len(), v.capacity()) }
+    /// Uses `bytemuck::cast_vec` which strictly enforces that both T and U
+    /// implement `AnyBitPattern` and `NoUninit`, guaranteeing memory safety
+    /// and preventing undefined behavior from invalid bit patterns.
+    fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U>
+    where
+        T: bytemuck::AnyBitPattern + bytemuck::NoUninit,
+        U: bytemuck::AnyBitPattern + bytemuck::NoUninit,
+    {
+        bytemuck::cast_vec(v)
     }
 }
 
@@ -785,7 +782,7 @@ mod tests {
 
         // Use NodeId which is transparent wrapper around u64
         // SAFETY: NodeId is repr(transparent) and same size/align as u64
-        let transmuted: Vec<NodeId> = unsafe { AdjacencyIndex::transmute_vec(original) };
+        let transmuted: Vec<NodeId> = AdjacencyIndex::transmute_vec(original);
 
         assert_eq!(transmuted.len(), 3);
         assert_eq!(transmuted.capacity(), cap);


### PR DESCRIPTION
*   **🦠 Threat:** Actix-Web endpoints accepted arbitrarily large JSON payloads, potentially allowing an attacker to cause memory exhaustion (OOM) via deserialization DoS bombs. Concurrently, a generic `unsafe fn transmute_vec` function lacked compiler constraints to ensure the bitwise validity of types being zero-copy converted, posing an Undefined Behavior (UB) risk if misused.
*   **🛡️ Defense:** Enforced a strict 2MB JSON limit (`web::JsonConfig::default().limit(2 * 1024 * 1024)`) in the Actix-Web `configure_app`. Added the `bytemuck` crate with `extern_crate_alloc` and `derive` features, replacing the generic unsafe block with `bytemuck::cast_vec` and explicitly deriving `Pod` and `Zeroable` on `NodeId`.
*   **💥 Severity:** High - Unbounded payload consumption could easily crash the system under public exposure. The unsafe transmute created a broad technical attack surface.
*   **🧪 Verification:** Ran the full index and HTTP test suites, verified compilation without `unsafe` warnings, and confirmed dependencies.

---
*PR created automatically by Jules for task [13980022792420225352](https://jules.google.com/task/13980022792420225352) started by @madmax983*