### PR TITLE
🦀 Core Review: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None.
+
+### Residual risks
+- None identified as the scope was empty.


### PR DESCRIPTION
Performed a Core review with an empty scope. As instructed, explicitly stated "No high-severity findings." and listed residual risks and test gaps. Appended findings to `.jules/core_review.md`.

---
*PR created automatically by Jules for task [14102651818432003406](https://jules.google.com/task/14102651818432003406) started by @madmax983*