### PR TITLE
🦀 Core Review: Empty Scope Log

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None identified in the empty scope.
+
+### Residual risks
+- Existing codebase residual risks apply as there was no diff to review.


### PR DESCRIPTION
### 🦀 Core Review
Performed an empty scope code review as requested by the Core persona directives.

Since no specific diff was provided, I have added an 'Empty Scope Review' log entry to `.jules/core_review.md` detailing:
- "No high-severity findings."
- Test gaps
- Residual risks

Pre-closure tasks ran: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and the global `cargo test` suite. All checks passed.

---
*PR created automatically by Jules for task [13100822405667647706](https://jules.google.com/task/13100822405667647706) started by @madmax983*