### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None identified, as no specific code diff or scope was provided for review.
+
+### Residual risks
+- Since no code changes were evaluated, no specific architectural, concurrency, or correctness risks can be assessed for this request.


### PR DESCRIPTION
Addressed a prompt that didn't provide a codebase diff/scope to review by adding an empty scope entry in `.jules/core_review.md` according to the Core persona instructions.

---
*PR created automatically by Jules for task [4268599661476466261](https://jules.google.com/task/4268599661476466261) started by @madmax983*