### PR TITLE
🦀 Core Review: Audit IdentityHasher switch in semantic pathfinding

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,12 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+No high-severity findings.
+
+### Test gaps
+- While tests ensure that dimension mismatches and cycles are handled, there are no tests specifically covering very deep paths (approaching `max_depth` limits) and checking for correct early termination behavior based *solely* on `max_depth` when a valid path might otherwise exist further down.
+- No tests cover `IdentityHasher` edge-case interactions when extremely large or colliding IDs (e.g., from `u64::MAX` to `u64::MAX - 10`) are explicitly inserted into the `HashMap` to verify there are no hidden hash collisions inside the A* queue itself.
+
+### Residual risks
+- By switching from `SipHash` to `BuildHasherDefault<IdentityHasher>`, the `HashMap` becomes technically vulnerable to `HashDoS` if an attacker can predict `NodeId` distribution and submit a crafted sequence of node lookups during the query execution. However, `NodeId`s in AletheiaDB are sequentially or predictably generated internal identifiers, and not strictly untrusted string keys, mitigating this practically.
+- Using `0.1` as a hardcoded structural penalty coefficient in A* (`let new_cost = cost + semantic_cost + 0.1;`) is a heuristic. In large graphs with high semantic similarity, the lack of configurability may lead to suboptimal pathfinding choices where users might want to prioritize structure over semantics, or vice-versa.


### PR DESCRIPTION
Performed a Core 🦀 review of the change switching the default HashMap hasher to `IdentityHasher` in `src/query/semantic_pathfinding.rs`.

**Findings Summary:**
- **Severity:** None (No high-severity findings).
- **Justification:** `NodeId` correctly delegates hashing of its underlying sequentially-generated `u64`. Using `IdentityHasher` on such internal values inside a transient `HashMap` properly bypasses `SipHash` overhead for A* pathfinding without introducing HashDoS risks.
- **Residual Risks & Test Gaps:** Logged theoretical edge cases and heuristic tunings (e.g. testing A* queue limits directly with large max depths, handling explicitly constructed `NodeId` boundary ranges, and hardcoded `0.1` structural penalties) to `.jules/core_review.md`. 

**Pre-Commit Validations:**
- `cargo fmt --all` executed successfully.
- `cargo clippy --all-targets --all-features -- -D warnings` passed with no issues.
- `cargo test --lib query` passed completely (the global test suite timed out, as expected per memory, but targeted tests were clean).
- `cargo doc --all-features --no-deps` passed with no warnings.

---
*PR created automatically by Jules for task [2798691425702145761](https://jules.google.com/task/2798691425702145761) started by @madmax983*