### PR TITLE
🔒 Warden: Replaced unsafe Vec transmutation with bytemuck

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,7 @@
 2024-XX-XX - [Warden: CSR Adjacency Index Vulnerability]
 **Threat:** `AdjacencyIndex::import_csr` did not validate that `node_ids` is sorted, and did not validate that `offsets` is monotonically increasing. It also didn't validate that the first offset is `0`. This allows a maliciously constructed CSR payload to cause OOB reads (Denial of Service) when `get_adjacency` is called, due to `start > end` or `end > edges.len()` when slicing the `edges` array.
 **Defense:** Added rigorous validation in `validate_csr_invariants` to ensure `node_ids` is strictly sorted (no duplicates), `offsets` begins with `0`, and is monotonically increasing.
+
+**2026-03-09 - Replaced unsafe Vec transmutation with bytemuck**
+**Threat:** `AdjacencyIndex::transmute_vec` used `unsafe` `Vec::from_raw_parts` for zero-copy conversions between `u64` and `NodeId`/`usize`. Incorrect usage or type changes could lead to severe memory safety issues like Undefined Behavior (UB), dangling pointers, or buffer overflows.
+**Defense:** Added `bytemuck::Pod` and `bytemuck::Zeroable` to `NodeId`, replacing the custom `unsafe fn transmute_vec` with the community-standard `bytemuck::cast_vec`. This guarantees memory-safe zero-copy transmutations at compile time/runtime and removes unnecessary `unsafe` code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitcode",
+ "bytemuck",
  "chrono",
  "comfy-table",
  "crc32fast",
@@ -517,6 +518,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ rayon = "1.8"
 comfy-table = "7.2.2"
 crossterm = "0.29.0"
 rand = "0.8"
+bytemuck = { version = "1.25.0", features = ["derive", "extern_crate_alloc"] }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -21,7 +21,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub const MAX_VALID_ID: u64 = u64::MAX - 1000;
 
 /// Unique identifier for a node in the graph.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, bytemuck::Pod, bytemuck::Zeroable,
+)]
 #[repr(transparent)]
 pub struct NodeId(u64);
 

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -106,7 +106,7 @@ impl AdjacencyIndex {
 
         // Zero-copy conversion: NodeId(u64) has same layout as u64
         // SAFETY: NodeId is #[repr(transparent)] wrapper around u64.
-        let node_ids_typed: Vec<NodeId> = unsafe { Self::transmute_vec(node_ids) };
+        let node_ids_typed: Vec<NodeId> = bytemuck::cast_vec(node_ids);
 
         // Convert offsets (zero-copy on 64-bit, allocating on 32-bit)
         let offsets_usize = Self::convert_offsets(offsets);
@@ -350,29 +350,13 @@ impl AdjacencyIndex {
         #[cfg(target_pointer_width = "64")]
         {
             // SAFETY: usize == u64 on 64-bit platforms, so layout is compatible.
-            unsafe { Self::transmute_vec(offsets) }
+            bytemuck::cast_vec(offsets)
         }
 
         #[cfg(not(target_pointer_width = "64"))]
         {
             offsets.iter().map(|&x| x as usize).collect()
         }
-    }
-
-    /// Helper for zero-copy Vec conversion
-    ///
-    /// # Safety
-    /// T and U must have same layout, size, and alignment.
-    unsafe fn transmute_vec<T, U>(v: Vec<T>) -> Vec<U> {
-        // Enforce safety invariants at compile time/runtime
-        assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<U>());
-        assert_eq!(std::mem::align_of::<T>(), std::mem::align_of::<U>());
-
-        let mut v = std::mem::ManuallyDrop::new(v);
-        // SAFETY: Caller ensures T and U layout compatibility.
-        // from_raw_parts is unsafe, but we are inside an unsafe function.
-        // In Rust 2024 (and newer editions), unsafe blocks are required inside unsafe functions.
-        unsafe { Vec::from_raw_parts(v.as_mut_ptr() as *mut U, v.len(), v.capacity()) }
     }
 }
 
@@ -785,7 +769,7 @@ mod tests {
 
         // Use NodeId which is transparent wrapper around u64
         // SAFETY: NodeId is repr(transparent) and same size/align as u64
-        let transmuted: Vec<NodeId> = unsafe { AdjacencyIndex::transmute_vec(original) };
+        let transmuted: Vec<NodeId> = bytemuck::cast_vec(original);
 
         assert_eq!(transmuted.len(), 3);
         assert_eq!(transmuted.capacity(), cap);


### PR DESCRIPTION
- **Threat:** `AdjacencyIndex::transmute_vec` used `unsafe` `Vec::from_raw_parts` for zero-copy conversions between `u64` and `NodeId`/`usize`. Incorrect usage or type changes could lead to severe memory safety issues like Undefined Behavior (UB), dangling pointers, or buffer overflows.
- **Defense:** Added `bytemuck::Pod` and `bytemuck::Zeroable` to `NodeId`, replacing the custom `unsafe fn transmute_vec` with the community-standard `bytemuck::cast_vec`. This guarantees memory-safe zero-copy transmutations at compile time/runtime and removes unnecessary `unsafe` code.
- **Severity:** High - potential for UB and buffer overflows.
- **Verification:** Ran `cargo audit`, global test suite, and verified compilation and `cargo doc` warnings. Added journal entry to `.jules/warden.md`.

---
*PR created automatically by Jules for task [11936542868344371271](https://jules.google.com/task/11936542868344371271) started by @madmax983*