### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None identified in this empty scope review.
+
+### Residual risks
+- No scope was provided, so no new residual risks have been evaluated.


### PR DESCRIPTION
Logs an empty scope review to the Core persona's journal as requested, noting the lack of scope provided.

---
*PR created automatically by Jules for task [14440411203574024593](https://jules.google.com/task/14440411203574024593) started by @madmax983*