### PR TITLE
🦀 Core Review: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None identified; no specific codebase scope was provided for review.
+
+### Residual risks
+- Unspecified modules may harbor undocumented concurrency, memory safety, or correctness issues outside the currently established test boundaries.


### PR DESCRIPTION
Appended an "Empty Scope Review" entry to `.jules/core_review.md` explicitly stating "No high-severity findings" and detailing the residual risks and test gaps for a review task with no provided scope.

---
*PR created automatically by Jules for task [454552741503242315](https://jules.google.com/task/454552741503242315) started by @madmax983*