### PR TITLE
🦀 Core: Empty Scope Review

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: Empty Scope Review
+
+No high-severity findings.
+
+### Test gaps
+- None identified due to empty scope.
+
+### Residual risks
+- None identified due to empty scope.


### PR DESCRIPTION
Performed a Core persona risk-first Rust code review on an empty scope. Logged the required 'No high-severity findings' alongside missing test gaps and residual risks to the `.jules/core_review.md` journal. No code changes were necessary or made.

---
*PR created automatically by Jules for task [17908141579893347049](https://jules.google.com/task/17908141579893347049) started by @madmax983*