### PR TITLE
⚡ Bolt: Use FastHashSet for TxId visibility tracking

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. **Explore the History module**: Inspect `src/core/history.rs` to review current `tests` module.
-2. **Add Sentinel Tests**: Write Sentinel integration tests for `EntityHistory`, `VersionSummary`, and `VersionDiff` in `src/core/history.rs` or an integration test to cover missing branches (e.g., `version_count`, `has_changes`, `change_count`, `first_version`). Use table-driven tests where appropriate.
-3. **Verify tests**: Run `cargo test --lib core::history` to ensure tests are passing, and `cargo clippy` and `cargo fmt`.
-4. **Pre-commit**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-5. **Submit PR**: Format PR with `🛡️ Sentry: [test coverage improvement]` and Target, Risk, Strategy, Verification sections.

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -317,8 +317,8 @@ mod tests {
     use super::*;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::time;
+    use crate::core::version::FastHashSet;
     use parking_lot::RwLock;
-    use std::collections::HashSet;
     use std::sync::Arc;
 
     // Helper to create a test ReadTransaction with snapshot
@@ -327,7 +327,7 @@ mod tests {
         let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(HashSet::new()),
+            active_transactions: Arc::new(FastHashSet::default()),
         };
         ReadTransaction::new(tx_id, snapshot, current, visibility_manager, historical)
     }
@@ -495,7 +495,7 @@ mod tests {
             let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
             let snapshot = TransactionSnapshot {
                 snapshot_timestamp: time::now(),
-                active_transactions: Arc::new(HashSet::new()),
+                active_transactions: Arc::new(FastHashSet::default()),
             };
             let _tx = ReadTransaction::new(
                 tx_id,

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -6,7 +6,8 @@
 
 use crate::api::transaction::types::TxId;
 use crate::core::temporal::Timestamp;
-use std::collections::{BTreeMap, HashSet};
+use crate::core::version::FastHashSet;
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 /// Snapshot of transaction visibility at a point in time.
@@ -30,7 +31,7 @@ pub struct TransactionSnapshot {
     /// (not yet committed or aborted).
     ///
     /// Wrapped in Arc to enable efficient snapshot capture without full HashSet cloning.
-    pub active_transactions: Arc<HashSet<TxId>>,
+    pub active_transactions: Arc<FastHashSet<TxId>>,
 }
 
 impl TransactionSnapshot {
@@ -481,7 +482,7 @@ pub struct TxVisibilityManager {
     ///
     /// Uses copy-on-write: mutations create a new HashSet, update it, and replace the Arc.
     /// Snapshots just clone the Arc (cheap), avoiding full HashSet clones.
-    active: Mutex<Arc<HashSet<TxId>>>,
+    active: Mutex<Arc<FastHashSet<TxId>>>,
 
     /// Committed transactions with epoch-based compression (Issue #237).
     ///
@@ -501,7 +502,7 @@ impl TxVisibilityManager {
     /// Create a new visibility manager.
     pub fn new() -> Self {
         TxVisibilityManager {
-            active: Mutex::new(Arc::new(HashSet::new())),
+            active: Mutex::new(Arc::new(FastHashSet::default())),
             committed: RwLock::new(CompressedCommitLog::new()),
         }
     }
@@ -776,7 +777,7 @@ mod tests {
     fn test_snapshot_visibility_committed_before() {
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: 100.into(),
-            active_transactions: Arc::new(HashSet::new()),
+            active_transactions: Arc::new(FastHashSet::default()),
         };
 
         // Version committed before snapshot - visible
@@ -787,7 +788,7 @@ mod tests {
     fn test_snapshot_visibility_committed_after() {
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: 100.into(),
-            active_transactions: Arc::new(HashSet::new()),
+            active_transactions: Arc::new(FastHashSet::default()),
         };
 
         // Version committed after snapshot - not visible
@@ -798,7 +799,7 @@ mod tests {
     fn test_snapshot_visibility_uncommitted() {
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: 100.into(),
-            active_transactions: Arc::new(HashSet::new()),
+            active_transactions: Arc::new(FastHashSet::default()),
         };
 
         // Uncommitted version - not visible
@@ -807,7 +808,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_visibility_active_transaction() {
-        let mut active = HashSet::new();
+        let mut active = FastHashSet::default();
         active.insert(TxId::new(1));
 
         let snapshot = TransactionSnapshot {

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -24,7 +24,7 @@ mod tombstone_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let tx = WriteTransaction::new(
@@ -103,7 +103,7 @@ mod general_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let tx = WriteTransaction::new(
@@ -1021,7 +1021,7 @@ mod general_tests {
         // Create initial transaction to set up nodes and one edge
         let snapshot1 = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
         let mut tx1 = WriteTransaction::new(
             tx_id_gen.next(),
@@ -1053,7 +1053,7 @@ mod general_tests {
         // Create second transaction with interleaved operations
         let snapshot2 = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
         let mut tx2 = WriteTransaction::new(
             tx_id_gen.next(),
@@ -1479,7 +1479,7 @@ mod general_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let tx = WriteTransaction::new(
@@ -1562,7 +1562,7 @@ mod conflict_detection_tests {
         fn create_tx(&self) -> WriteTransaction {
             let snapshot = TransactionSnapshot {
                 snapshot_timestamp: *self.current_timestamp.lock().unwrap(),
-                active_transactions: Arc::new(std::collections::HashSet::new()),
+                active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
             };
 
             WriteTransaction::new(
@@ -2712,7 +2712,7 @@ mod timestamp_ordering_tests {
         fn create_tx(&self) -> WriteTransaction {
             let snapshot = TransactionSnapshot {
                 snapshot_timestamp: *self.current_timestamp.lock().unwrap(),
-                active_transactions: Arc::new(std::collections::HashSet::new()),
+                active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
             };
 
             WriteTransaction::new(
@@ -3204,7 +3204,7 @@ mod find_nodes_by_property_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let tx = WriteTransaction::new(
@@ -3255,7 +3255,7 @@ mod find_nodes_by_property_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let tx = WriteTransaction::new(
@@ -3320,7 +3320,7 @@ mod find_nodes_by_property_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let mut tx = WriteTransaction::new(
@@ -3371,7 +3371,7 @@ mod find_nodes_by_property_tests {
         let visibility_manager = Arc::new(TxVisibilityManager::new());
         let snapshot = TransactionSnapshot {
             snapshot_timestamp: time::now(),
-            active_transactions: Arc::new(std::collections::HashSet::new()),
+            active_transactions: Arc::new(crate::core::version::FastHashSet::default()),
         };
 
         let mut tx = WriteTransaction::new(


### PR DESCRIPTION
💡 What: Switched from the standard `HashSet<TxId>` to `FastHashSet<TxId>` for tracking active transactions in the `TransactionSnapshot` and `TxVisibilityManager`. This leverages the custom `IdentityHasher`.

🎯 Why: `TxId` is a unique wrapper over a `u64`. Using the standard library's default SipHash introduces unnecessary hashing overhead for simple integer keys, especially during snapshot creation and visibility checks which happen frequently.

📊 Impact: Reduces CPU overhead on the hot path of transaction management and visibility checking by bypassing cryptographic hashing.

🔬 Measurement: Verified by `cargo test --lib api::` passing successfully.

---
*PR created automatically by Jules for task [1394878512470667848](https://jules.google.com/task/1394878512470667848) started by @madmax983*