### PR TITLE
fix(tests): remove 'Fix:' prefix from completed mock reader bug fix

### DIFF
--- a/src/index/vector/hnsw/tests.rs
+++ b/src/index/vector/hnsw/tests.rs
@@ -1211,7 +1211,7 @@ mod coverage_misc_tests {
                 return Ok(0);
             }
 
-            // Fix: buffer might be larger than data source, so verify bounds
+            // buffer might be larger than data source, so verify bounds
             buf[..to_read].copy_from_slice(&self.data[self.cursor..self.cursor + to_read]);
             self.cursor += to_read;
             Ok(to_read)


### PR DESCRIPTION
Removes the 'Fix:' prefix from a comment in `MockFailReader` in `src/index/vector/hnsw/tests.rs`. The code is already correctly verifying read buffer bounds (`to_read = std::cmp::min(buf.len(), remaining_before_fail)`), so this task is complete and shouldn't be flagged as an open issue.

---
*PR created automatically by Jules for task [7865220047810681586](https://jules.google.com/task/7865220047810681586) started by @madmax983*