### PR TITLE
chore: Reword "Fix the timestamp" comment to "Set the timestamp"

### DIFF
--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -331,7 +331,7 @@ mod sentry_tests {
         // Create the original entry
         // checksum is initially 0
         let mut original_entry = WalEntry::new(lsn, op);
-        // Fix the timestamp to something deterministic for the test
+        // Set the timestamp to something deterministic for the test
         original_entry.timestamp = crate::core::hlc::HybridTimestamp::new(2_000_000, 20).unwrap();
 
         // Serialize


### PR DESCRIPTION
The comment starting with "Fix" was getting erroneously flagged as a TODO/issue by automated scanners. The underlying code was already correct and functional. Changing "Fix" to "Set" resolves the false positive.

---
*PR created automatically by Jules for task [5031476114213305906](https://jules.google.com/task/5031476114213305906) started by @madmax983*