### PR TITLE
🦀 Core: Review Predicate Pushdown Tests Update

### DIFF
--- a/.jules/core_review.md
+++ b/.jules/core_review.md
@@ -29,3 +29,13 @@ No high-severity findings.
 
 ### Residual risks
 - `IdGenerator::current_approximate()` operates with `Ordering::Relaxed` memory synchronization to achieve extreme performance (~1ns). This makes it unsuitable for any critical snapshot isolation logic and strictly limits its safe usage to non-critical metrics and logging, which is well-documented but represents a slight structural misuse risk.
+
+## 🦀 Core Review: `src/query/planner/rules/predicate_pushdown.rs` Tests Update
+
+No high-severity findings.
+
+### Test gaps
+- None identified in the updated scope. The modifications explicitly strengthen test coverage by replacing weak `matches!` verifications with exact tree structural checks using `assert_eq!` across the doc test and relevant unit tests.
+
+### Residual risks
+- Minor stylistic risk of hardcoding AST structures inside the `assert_eq!` blocks in the tests, potentially causing maintenance overhead if the AST representation of `LogicalOp` or `UnaryOp` changes in the future, as tests will broadly fail and require verbose rewrites.


### PR DESCRIPTION
### 🦀 Core Review
Performed a risk-first code review on the latest commit (`fd21bdf4`) focusing on updates to `src/query/planner/rules/predicate_pushdown.rs` tests. 

No high-severity findings were identified. The changes tightened test verifications by replacing generic `matches!` assertions with strict `assert_eq!` validations of the `LogicalPlan` AST, closing previously flagged test coverage gaps without introducing concurrency, security, correctness, or performance risks.

**Findings & Risks:**
Documented in `.jules/core_review.md`. Added a minor note on the residual risk of hardcoded AST structures causing maintenance overhead if `LogicalOp` models change. 

**Assumption:**
Because no specific diff or scope was explicitly specified in the request, I assumed the target for review was the most recent `HEAD` commit (`fd21bdf42d9c88ec6f89faeba444799631a7b4e8`).

**Pre-commit Checks:**
- [x] Run `cargo fmt --all`
- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Run `cargo test`

---
*PR created automatically by Jules for task [7912590580989921677](https://jules.google.com/task/7912590580989921677) started by @madmax983*