### PR TITLE
🤖 Sentinel: TxIdGenerator Mutant Test Kill Shots

### DIFF
--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -1664,3 +1664,31 @@ mod sentinel_id_generator_tests {
         assert_ne!(unchecked.as_u64(), 0);
     }
 }
+
+#[cfg(test)]
+mod sentinel_id_generator_txid_tests {
+    use super::{TxId, TxIdGenerator};
+
+    #[test]
+    fn test_tx_id_generator_math_and_logic() {
+        let generator = TxIdGenerator::new(); // Starts at 1
+
+        let first = generator.next();
+        assert_eq!(first, TxId::new(1));
+
+        let second = generator.next();
+        assert_eq!(second, TxId::new(2));
+
+        let generator_current = generator.current();
+        assert_eq!(generator_current, TxId::new(2));
+
+        let third = generator.next();
+        assert_eq!(third, TxId::new(3));
+
+        let txid_as_u64 = third.as_u64();
+        assert_eq!(txid_as_u64, 3);
+
+        let txid_string = format!("{}", third);
+        assert_eq!(txid_string, "TxId(3)");
+    }
+}


### PR DESCRIPTION
🤖 **Sentinel**: Test Coverage Improvements

**🧬 Mutants Found:** Evaluated remaining mutant survivors targeting AletheiaDB `TxIdGenerator`, `TxId` types, Temporal interval queries, HTTP handlers, and custom Identity hashers. Most of the findings logged in `.jules/sentinel.md` had already been verified as killed by preceding iterations in `tests/`.

**🎯 Tests Added/Strengthened:**
Added a direct integration test block in `src/core/id.rs` named `sentinel_id_generator_txid_tests` to kill remaining mutant survivors that mutate underlying state transitions inside the `TxIdGenerator` (e.g. modifying `current + 1` to `- 1` or `* 1`, and returning default empty wrapper structures).

**⚠️ Suspected Bugs:** None.

**📊 Kill Rate:** Remaining mutants in `core::id::TxIdGenerator` correctly addressed.

**🔗 Havoc Interaction:** None.

---
*PR created automatically by Jules for task [13057918697422615572](https://jules.google.com/task/13057918697422615572) started by @madmax983*