### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,11 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+
+## Missing Property Retrieval Coverage
+**Learning:** Checking for edge-cases during data structure manipulation should include cases explicitly testing property lookup behaviors for missing keys.
+**Action:** Enhance tests for Edge and Node getters.
+
+## Sparse Vector Distance Metric Verification
+**Learning:** `sparse_squared_euclidean_distance` needs explicit tests validating its logic against edge cases like disjoint vector components and comparing against zero vectors to ensure algorithm updates don't silently corrupt calculations.
+**Action:** Always add basic unit tests with hand-calculated math answers for sparse vector metrics alongside property or generative tests.

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -306,6 +306,7 @@ mod tests {
             Some("Alice")
         );
         assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(30));
+        assert_eq!(node.get_property("missing_prop"), None);
         assert_eq!(node.metadata, VersionMetadata::default());
     }
 
@@ -348,6 +349,7 @@ mod tests {
             edge.get_property("since").and_then(|v| v.as_int()),
             Some(2020)
         );
+        assert_eq!(edge.get_property("missing_prop"), None);
         assert_eq!(edge.metadata, VersionMetadata::default());
     }
 
@@ -464,6 +466,10 @@ mod tests {
             debug_str.contains("Alice"),
             "Debug output should contain property value"
         );
+        assert!(
+            debug_str.contains("current_version"),
+            "Debug output should contain current version"
+        );
     }
 
     #[test]
@@ -506,6 +512,10 @@ mod tests {
         assert!(
             debug_str.contains("2024"),
             "Debug output should contain property value"
+        );
+        assert!(
+            debug_str.contains("source") && debug_str.contains("target"),
+            "Debug output should contain source and target nodes"
         );
     }
 

--- a/src/core/vector/sparse.rs
+++ b/src/core/vector/sparse.rs
@@ -832,4 +832,26 @@ mod tests {
             "squared_euclidean_distance should fail on mismatched dimensions"
         );
     }
+
+    #[test]
+    fn test_sparse_squared_euclidean_distance_disjoint() {
+        let a = SparseVec::new(vec![0], vec![2.0], 5).unwrap();
+        let b = SparseVec::new(vec![1], vec![3.0], 5).unwrap();
+
+        // Distance from [2, 0, 0, 0, 0] to [0, 3, 0, 0, 0]
+        // Expected squared distance = (2-0)^2 + (0-3)^2 = 4 + 9 = 13.0
+        let dist_sq = sparse_squared_euclidean_distance(&a, &b).unwrap();
+        assert_eq!(dist_sq, 13.0);
+    }
+
+    #[test]
+    fn test_sparse_squared_euclidean_distance_zero_vector() {
+        let a = SparseVec::new(vec![0], vec![3.0], 5).unwrap();
+        let b = SparseVec::new(vec![], vec![], 5).unwrap();
+
+        // Distance from [3, 0, 0, 0, 0] to [0, 0, 0, 0, 0]
+        // Expected squared distance = (3-0)^2 = 9.0
+        let dist_sq = sparse_squared_euclidean_distance(&a, &b).unwrap();
+        assert_eq!(dist_sq, 9.0);
+    }
 }


### PR DESCRIPTION
Adds additional test coverage to `src/core/graph.rs` for `Node` and `Edge` implementations, covering missing property retrievals and stringification formatting. Also adds boundary condition test coverage to `src/core/vector/sparse.rs` for `sparse_squared_euclidean_distance`, covering disjoint vector components and comparing against an empty vector.

---
*PR created automatically by Jules for task [14137179892868317256](https://jules.google.com/task/14137179892868317256) started by @madmax983*