### PR TITLE
🦀 Core: Review Report for DashMap min_by optimization

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,0 +1,13 @@
+# Core🦀 Review Report: Avoid O(N) heap allocations on DashMap minimum key lookup
+
+## Findings
+No high-severity findings.
+
+The recent change from `.map(|r| r.key().clone()).min()` to `.min_by(|a, b| a.key().cmp(b.key())).map(|r| r.key().clone())` in `src/storage/current/mod.rs` was thoroughly reviewed for deadlock and concurrency risks.
+
+While `.min_by` requires holding a `Ref` (read lock) for the currently discovered minimum element across subsequent shard inspections, this is entirely safe with `DashMap`. `DashMap` supports multiple concurrent read locks without deadlocking, and iterator references are not upgraded, thus precluding lock cycle conditions even under concurrent writes. We verified this by authoring and executing explicit multi-threaded contention tests.
+
+## Test Gaps & Residual Risk
+There is technically a residual performance edge case:
+- Because the `Ref` for the minimum item is held for the duration of the entire map iteration, concurrent writes *to the specific shard* of that minimum element will be blocked until the iteration completes.
+- Given that the `vector_indexes` map typically only contains a very small handful of items (often just one or two properties), the likelihood and duration of such a contention event are extremely minimal and practically imperceptible. No code change is warranted.

--- a/review_plan.md
+++ b/review_plan.md
@@ -1,0 +1,13 @@
+# 🦀 Core Review Plan
+
+## Findings
+- No high-severity findings.
+- The use of `.min_by(|a, b| a.key().cmp(b.key()))` correctly retains a `Ref` (read lock on the shard) for the currently discovered minimum while evaluating successive elements. This technically means that `min_by` will briefly hold *two* read locks simultaneously (one for the current minimum `a`, one for the candidate `b`) while comparing their keys.
+- However, since `DashMap` is sharded, taking two *read* locks concurrently is completely safe and won't cause deadlocks, even when interleaved with concurrent writes (which take write locks, but write locks only block readers on *that specific shard*). The iterators don't upgrade locks, so cycle deadlocks are avoided.
+
+## Residual Risk / Test Gaps
+- While `min_by` itself is safe and performant for finding the minimum key without `O(N)` heap allocations, it *does* mean that a read lock on the shard containing the current minimum will be held for the *entire remaining duration* of the iteration. If the `vector_indexes` map is large, holding a read lock for the entire iteration could block concurrent insertions/mutations to that specific shard for an extended period, leading to contention.
+- Given that `vector_indexes` is typically small (just the vector index properties enabled, usually << 10 elements), this contention risk is practically zero.
+
+## Actions
+- The current implementation is safe, highly performant, and resolves the prior `O(N)` allocation issue. I will submit the report.


### PR DESCRIPTION
This PR submits the "Core🦀" code review report evaluating the recent performance optimization in `src/storage/current/mod.rs` (avoiding O(N) heap allocations during DashMap iteration). 

The review confirmed there are no high-severity findings, and that holding multiple read locks across shards via `min_by` does not introduce deadlock vulnerabilities in `DashMap`.

Residual write-contention risk is negligible and explicitly documented.

---
*PR created automatically by Jules for task [1517303821241828398](https://jules.google.com/task/1517303821241828398) started by @madmax983*