### PR TITLE
🛡️ Sentry: Add test coverage for core deserialization bounds checking

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,6 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+## Auditability and Defensive Deserialization
+**Learning:** Calls to `unwrap()` during `try_into()` conversions from byte slices in core deserialization paths (`property.rs` and `vector/serialization.rs`) were technically safe because the slice lengths were validated immediately prior to the conversion. However, using `unwrap()` triggers tools (and human reviewers) searching for panic risks, degrading confidence in safety and masking real panic risks.
+**Action:** Always replace `unwrap()` with `expect("descriptive message about prior length checks")` when converting slices with proven sizes to ensure the code is auditable and correctly demonstrates defensive programming in the face of potentially corrupt disk data.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -73,3 +73,5 @@ pub use vector::{
     validate_vector_with_bounds,
 };
 pub mod version;
+#[cfg(test)]
+pub(crate) mod sentry_property_error_tests;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -72,6 +72,6 @@ pub use vector::{
     validate_vector,
     validate_vector_with_bounds,
 };
-pub mod version;
 #[cfg(test)]
 pub(crate) mod sentry_property_error_tests;
+pub mod version;

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -685,7 +685,11 @@ impl PropertyValue {
             );
         }
         // SAFETY: Length check above guarantees slice has 8 bytes
-        let value = i64::from_le_bytes(bytes[1..9].try_into().unwrap());
+        let value = i64::from_le_bytes(
+            bytes[1..9]
+                .try_into()
+                .expect("Slice length guaranteed by prior checks"),
+        );
         Ok((PropertyValue::Int(value), 9))
     }
 
@@ -697,7 +701,11 @@ impl PropertyValue {
             .into());
         }
         // SAFETY: Length check above guarantees slice has 8 bytes
-        let value = f64::from_le_bytes(bytes[1..9].try_into().unwrap());
+        let value = f64::from_le_bytes(
+            bytes[1..9]
+                .try_into()
+                .expect("Slice length guaranteed by prior checks"),
+        );
         Ok((PropertyValue::Float(value), 9))
     }
 
@@ -709,7 +717,11 @@ impl PropertyValue {
             )
             .into());
         }
-        let len = u32::from_le_bytes(bytes[1..5].try_into().unwrap()) as usize;
+        let len = u32::from_le_bytes(
+            bytes[1..5]
+                .try_into()
+                .expect("Slice length guaranteed by prior checks"),
+        ) as usize;
         let offset = 5usize;
 
         let required_len = offset
@@ -739,7 +751,11 @@ impl PropertyValue {
             )
             .into());
         }
-        let len = u32::from_le_bytes(bytes[1..5].try_into().unwrap()) as usize;
+        let len = u32::from_le_bytes(
+            bytes[1..5]
+                .try_into()
+                .expect("Slice length guaranteed by prior checks"),
+        ) as usize;
         let offset = 5usize;
 
         let required_len = offset
@@ -766,7 +782,11 @@ impl PropertyValue {
             )
             .into());
         }
-        let count = u32::from_le_bytes(bytes[1..5].try_into().unwrap()) as usize;
+        let count = u32::from_le_bytes(
+            bytes[1..5]
+                .try_into()
+                .expect("Slice length guaranteed by prior checks"),
+        ) as usize;
         let mut offset: usize = 5;
 
         // Prevent DoS via memory exhaustion from malicious input
@@ -1354,7 +1374,11 @@ impl PropertyMap {
             .into());
         }
 
-        let count = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
+        let count = u32::from_le_bytes(
+            bytes[0..4]
+                .try_into()
+                .expect("Slice length guaranteed by prior checks"),
+        ) as usize;
 
         // Prevent DoS via memory exhaustion from malicious input
         if count > MAX_PROPERTY_MAP_CAPACITY {
@@ -1394,8 +1418,11 @@ impl PropertyMap {
                 .into());
             }
             // SAFETY: Length check above guarantees 4 bytes available
-            let key_len =
-                u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+            let key_len = u32::from_le_bytes(
+                bytes[offset..offset + 4]
+                    .try_into()
+                    .expect("Slice length guaranteed by prior checks"),
+            ) as usize;
             offset += 4;
 
             // Read key

--- a/src/core/sentry_property_error_tests.rs
+++ b/src/core/sentry_property_error_tests.rs
@@ -1,0 +1,127 @@
+#[cfg(test)]
+mod tests {
+    use crate::core::property::{PropertyValue, PropertyMap};
+    use crate::core::error::Error;
+    use crate::core::property::{TAG_INT, TAG_FLOAT, TAG_STRING, TAG_BYTES, TAG_ARRAY};
+
+    #[test]
+    fn test_deserialize_int_short_buffer() {
+        // Int requires 1 byte for tag and 8 bytes for value.
+        let bytes = [TAG_INT, 1, 2, 3]; // Only 4 bytes total
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for Int value"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_float_short_buffer() {
+        // Float requires 1 byte for tag and 8 bytes for value.
+        let bytes = [TAG_FLOAT, 1, 2, 3, 4, 5]; // Only 6 bytes total
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for Float value"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_string_short_length_buffer() {
+        // String requires 1 byte for tag, 4 for length
+        let bytes = [TAG_STRING, 1, 0]; // 3 bytes total, length is incomplete
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for String length"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_string_short_data_buffer() {
+        // String claims 10 bytes length, but data is missing
+        let mut bytes = vec![TAG_STRING];
+        bytes.extend_from_slice(&10u32.to_le_bytes()); // len = 10
+        bytes.extend_from_slice(&[65, 66, 67]); // Only 3 bytes of data
+
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for String data"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_bytes_short_length_buffer() {
+        let bytes = [TAG_BYTES, 1, 0];
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for Bytes length"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_bytes_short_data_buffer() {
+        let mut bytes = vec![TAG_BYTES];
+        bytes.extend_from_slice(&10u32.to_le_bytes()); // len = 10
+        bytes.extend_from_slice(&[1, 2, 3]);
+
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for Bytes data"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_array_short_count_buffer() {
+        let bytes = [TAG_ARRAY, 1, 0];
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for Array count"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_property_map_short_count_buffer() {
+        let bytes = [1, 0, 0]; // 3 bytes, short for 4 byte count
+        let result = PropertyMap::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for PropertyMap count"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_property_map_short_key_length_buffer() {
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // 1 entry
+        bytes.extend_from_slice(&[1, 0]); // only 2 bytes for key length
+        let result = PropertyMap::deserialize(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            // It could hit the min_required_bytes check first, or the key length check
+            assert!(msg.contains("Insufficient buffer size for PropertyMap entries") || msg.contains("Buffer too short for property key length"));
+        } else {
+            panic!("Expected CorruptedData error");
+        }
+    }
+}

--- a/src/core/sentry_property_error_tests.rs
+++ b/src/core/sentry_property_error_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use crate::core::property::{PropertyValue, PropertyMap};
     use crate::core::error::Error;
-    use crate::core::property::{TAG_INT, TAG_FLOAT, TAG_STRING, TAG_BYTES, TAG_ARRAY};
+    use crate::core::property::{PropertyMap, PropertyValue};
+    use crate::core::property::{TAG_ARRAY, TAG_BYTES, TAG_FLOAT, TAG_INT, TAG_STRING};
 
     #[test]
     fn test_deserialize_int_short_buffer() {
@@ -119,7 +119,10 @@ mod tests {
         assert!(result.is_err());
         if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
             // It could hit the min_required_bytes check first, or the key length check
-            assert!(msg.contains("Insufficient buffer size for PropertyMap entries") || msg.contains("Buffer too short for property key length"));
+            assert!(
+                msg.contains("Insufficient buffer size for PropertyMap entries")
+                    || msg.contains("Buffer too short for property key length")
+            );
         } else {
             panic!("Expected CorruptedData error");
         }

--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -122,3 +122,5 @@ pub use validation::*;
 
 #[cfg(test)]
 mod havoc_vector_math;
+#[cfg(test)]
+pub(crate) mod sentry_serialization_error_tests;

--- a/src/core/vector/sentry_serialization_error_tests.rs
+++ b/src/core/vector/sentry_serialization_error_tests.rs
@@ -1,0 +1,84 @@
+#[cfg(test)]
+mod tests {
+    use crate::core::vector::serialization::{deserialize_vector, deserialize_sparse_vector};
+    use crate::core::error::Error;
+
+    #[test]
+    fn test_deserialize_vector_short_buffer() {
+        // Vector with TAG_VECTOR (0x07) and valid dimension (2) but missing data
+        // TAG(1) + DIM(4) = 5 bytes total. We need 13 bytes total (5 + 2*4)
+        let bytes = [crate::core::property::TAG_VECTOR, 2, 0, 0, 0, 0, 0, 0]; // 8 bytes long
+
+        let result = deserialize_vector(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for vector data:"));
+        } else {
+            panic!("Expected CorruptedData error for short vector buffer");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_vector_missing_dimension() {
+        // Only TAG_VECTOR
+        let bytes = [crate::core::property::TAG_VECTOR, 1, 0];
+        let result = deserialize_vector(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for vector header"));
+        } else {
+            panic!("Expected CorruptedData error for missing dimension");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_sparse_vector_missing_metadata() {
+        // Missing nnz or dimension
+        let bytes = [crate::core::property::TAG_SPARSE_VECTOR, 5, 0, 0, 0, 1, 0]; // only 7 bytes, need 9 for meta
+        let result = deserialize_sparse_vector(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for sparse vector header"));
+        } else {
+            panic!("Expected CorruptedData error for missing metadata");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_sparse_vector_short_indices_buffer() {
+        // Dimension = 10, nnz = 2. Needs 9 + 2*4 + 2*4 = 25 bytes.
+        // Provide only 15 bytes (short on indices)
+        let mut bytes = vec![crate::core::property::TAG_SPARSE_VECTOR];
+        bytes.extend_from_slice(&10u32.to_le_bytes()); // dim
+        bytes.extend_from_slice(&2u32.to_le_bytes());  // nnz
+        bytes.extend_from_slice(&[0, 0, 0, 0]); // one index, missing second
+
+        let result = deserialize_sparse_vector(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for sparse vector data:"));
+        } else {
+            panic!("Expected CorruptedData error for short indices buffer");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_sparse_vector_short_values_buffer() {
+        // Dimension = 10, nnz = 2. Needs 9 + 2*4 + 2*4 = 25 bytes.
+        // Provide enough for indices, but short on values
+        let mut bytes = vec![crate::core::property::TAG_SPARSE_VECTOR];
+        bytes.extend_from_slice(&10u32.to_le_bytes()); // dim
+        bytes.extend_from_slice(&2u32.to_le_bytes());  // nnz
+        bytes.extend_from_slice(&0u32.to_le_bytes());  // index 1
+        bytes.extend_from_slice(&1u32.to_le_bytes());  // index 2
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());// value 1, missing value 2
+
+        let result = deserialize_sparse_vector(&bytes);
+        assert!(result.is_err());
+        if let Err(Error::Storage(crate::core::error::StorageError::CorruptedData(msg))) = result {
+            assert!(msg.contains("Buffer too short for sparse vector data:"));
+        } else {
+            panic!("Expected CorruptedData error for short values buffer");
+        }
+    }
+}

--- a/src/core/vector/sentry_serialization_error_tests.rs
+++ b/src/core/vector/sentry_serialization_error_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use crate::core::vector::serialization::{deserialize_vector, deserialize_sparse_vector};
     use crate::core::error::Error;
+    use crate::core::vector::serialization::{deserialize_sparse_vector, deserialize_vector};
 
     #[test]
     fn test_deserialize_vector_short_buffer() {
@@ -50,7 +50,7 @@ mod tests {
         // Provide only 15 bytes (short on indices)
         let mut bytes = vec![crate::core::property::TAG_SPARSE_VECTOR];
         bytes.extend_from_slice(&10u32.to_le_bytes()); // dim
-        bytes.extend_from_slice(&2u32.to_le_bytes());  // nnz
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // nnz
         bytes.extend_from_slice(&[0, 0, 0, 0]); // one index, missing second
 
         let result = deserialize_sparse_vector(&bytes);
@@ -68,10 +68,10 @@ mod tests {
         // Provide enough for indices, but short on values
         let mut bytes = vec![crate::core::property::TAG_SPARSE_VECTOR];
         bytes.extend_from_slice(&10u32.to_le_bytes()); // dim
-        bytes.extend_from_slice(&2u32.to_le_bytes());  // nnz
-        bytes.extend_from_slice(&0u32.to_le_bytes());  // index 1
-        bytes.extend_from_slice(&1u32.to_le_bytes());  // index 2
-        bytes.extend_from_slice(&1.0f32.to_le_bytes());// value 1, missing value 2
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // nnz
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // index 1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // index 2
+        bytes.extend_from_slice(&1.0f32.to_le_bytes()); // value 1, missing value 2
 
         let result = deserialize_sparse_vector(&bytes);
         assert!(result.is_err());

--- a/src/core/vector/serialization.rs
+++ b/src/core/vector/serialization.rs
@@ -173,7 +173,11 @@ pub fn deserialize_vector(bytes: &[u8]) -> Result<(Arc<[f32]>, usize)> {
         .into());
     }
 
-    let dimension = u32::from_le_bytes(bytes[1..5].try_into().unwrap()) as usize;
+    let dimension = u32::from_le_bytes(
+        bytes[1..5]
+            .try_into()
+            .expect("Slice length guaranteed by prior checks"),
+    ) as usize;
 
     // Prevent DoS via memory exhaustion from malicious input
     validate_vector_dimensions(dimension)?;
@@ -235,7 +239,11 @@ pub fn deserialize_vector(bytes: &[u8]) -> Result<(Arc<[f32]>, usize)> {
         let mut values = Vec::with_capacity(dimension);
         for chunk in data_slice.chunks_exact(4) {
             // SAFETY: chunks_exact guarantees exactly 4 bytes per chunk
-            values.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+            values.push(f32::from_le_bytes(
+                chunk
+                    .try_into()
+                    .expect("Slice length guaranteed by prior checks"),
+            ));
         }
         values
     };
@@ -331,8 +339,16 @@ pub fn deserialize_sparse_vector(bytes: &[u8]) -> Result<(Arc<SparseVec>, usize)
         .into());
     }
 
-    let dimension = u32::from_le_bytes(bytes[1..5].try_into().unwrap());
-    let nnz = u32::from_le_bytes(bytes[5..9].try_into().unwrap()) as usize;
+    let dimension = u32::from_le_bytes(
+        bytes[1..5]
+            .try_into()
+            .expect("Slice length guaranteed by prior checks"),
+    );
+    let nnz = u32::from_le_bytes(
+        bytes[5..9]
+            .try_into()
+            .expect("Slice length guaranteed by prior checks"),
+    ) as usize;
 
     // Validate nnz doesn't exceed dimension
     if nnz > dimension as usize {
@@ -401,7 +417,11 @@ pub fn deserialize_sparse_vector(bytes: &[u8]) -> Result<(Arc<SparseVec>, usize)
     let indices = {
         let mut indices = Vec::with_capacity(nnz);
         for chunk in indices_slice.chunks_exact(4) {
-            indices.push(u32::from_le_bytes(chunk.try_into().unwrap()));
+            indices.push(u32::from_le_bytes(
+                chunk
+                    .try_into()
+                    .expect("Slice length guaranteed by prior checks"),
+            ));
         }
         indices
     };
@@ -436,7 +456,11 @@ pub fn deserialize_sparse_vector(bytes: &[u8]) -> Result<(Arc<SparseVec>, usize)
     let values = {
         let mut values = Vec::with_capacity(nnz);
         for chunk in values_slice.chunks_exact(4) {
-            values.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+            values.push(f32::from_le_bytes(
+                chunk
+                    .try_into()
+                    .expect("Slice length guaranteed by prior checks"),
+            ));
         }
         values
     };
@@ -562,7 +586,11 @@ mod tests {
 
             // Validate header
             assert_eq!(bytes[0], TAG_VECTOR);
-            let dimension = u32::from_le_bytes(bytes[1..5].try_into().unwrap()) as usize;
+            let dimension = u32::from_le_bytes(
+                bytes[1..5]
+                    .try_into()
+                    .expect("Slice length guaranteed by prior checks"),
+            ) as usize;
             assert_eq!(dimension, test_vector.len());
             assert_eq!(bytes.len(), 1 + 4 + test_vector.len() * 4);
 


### PR DESCRIPTION
* 🎯 **Target:** Deserialization bounds checking and byte slice conversions in `src/core/property.rs` and `src/core/vector/serialization.rs`.
* 💣 **Risk:** Use of `.unwrap()` on dynamic byte conversions triggers panic alarms in security/audit reviews and could theoretically crash the database if earlier logic boundaries were breached. Without explicit tests for truncated data, it's unverified if the logic safely returns an error or eventually panics.
* 🧪 **Strategy:** 
  1. Replaced safe `.unwrap()` calls with `.expect("Slice length guaranteed by prior checks")` to explicitly document their safety for human reviewers and static analysis tools.
  2. Added dedicated test modules (`sentry_property_error_tests` and `sentry_serialization_error_tests`) that inject malformed and truncated byte buffers to ensure `StorageError::CorruptedData` is properly returned for `Int`, `Float`, `String`, `Bytes`, `Array`, `PropertyMap`, `Vector`, and `SparseVector` types.
* 🔬 **Verification:** `cargo test --lib core::`

---
*PR created automatically by Jules for task [8078368592380382656](https://jules.google.com/task/8078368592380382656) started by @madmax983*