### PR TITLE
🤖 Sentinel: Strengthen HybridTimestamp::new_unchecked test coverage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -125,3 +125,8 @@
 **Summary:** Mutants regarding strict bounds on `MAX_VALID_TIMESTAMP` (`>` mutated to `>=` or `==`) within `TimeRange::from` and `TimeRange::at` survived, alongside strict math operators (`*`, `/`, `%`) inside `time::to_secs`, `time::to_millis`, and `time::to_iso8601` methods. Finally, specific bounding checks involving exclusive interval boundaries in `contains` and `overlaps` were weakly asserted allowing `>` to mutate into `>=`.
 **Diagnosis:** MISSING_TEST / WEAK_TEST - Existing tests tested positive path boundary logic well, but neglected specific maximum boundary exact values (`MAX_VALID_TIMESTAMP`), exact conversion validation that strictly broke if `/` turned into `%`, and exact exclusion of boundaries inside interval intersections.
 **Kill Shot:** Appended explicit exact boundary tests `test_timerange_from_at_exact_boundaries`, `test_time_to_secs_millis_exact_math`, `test_time_to_iso8601_exact_content`, and `test_timerange_contains_exact_boundary` directly to `tests/sentry_temporal.rs`.
+**[Weak Test Coverage in HLC Unchecked Constructor]**
+**Module:** `aletheiadb::core::hlc`
+**Summary:** Mutation testing indicated a surviving mutant in `HybridTimestamp::new_unchecked` replacing its logic with a default return `Default::default()`.
+**Diagnosis:** MISSING_TEST - There were no direct exhaustive tests executing `HybridTimestamp::new_unchecked` ensuring internal struct layout is explicitly mapped from input bounds rather than failing softly via tests passing with empty defaults.
+**Kill Shot:** Appended targeted boundary test `test_hybrid_timestamp_new_unchecked_exhaustive` within `src/core/hlc.rs` directly explicitly validating field mappings from inputs.

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -1001,6 +1001,16 @@ mod tests {
     }
 
     #[test]
+    fn test_hybrid_timestamp_new_unchecked_exhaustive() {
+        // Kill `replace HybridTimestamp::new_unchecked -> Self with Default::default()` mutant
+        let ts = HybridTimestamp::new_unchecked(42, 10);
+        assert_eq!(ts.wallclock(), 42);
+        assert_eq!(ts.logical(), 10);
+        assert_ne!(ts.wallclock(), 0);
+        assert_ne!(ts.logical(), 0);
+    }
+
+    #[test]
     fn test_hybrid_timestamp_receive_exact_wallclock_logic() {
         // Targets the complex `receive` `if/else if` chain specifically `>` and `==` boundaries.
         // `if new_wallclock > self.wallclock && new_wallclock > msg.wallclock` -> reset to 0


### PR DESCRIPTION
**🧬 Mutants Found:** 1 surviving mutant in `src/core/hlc.rs` (replaced `HybridTimestamp::new_unchecked` body with `Default::default()`).
**🎯 Tests Added/Strengthened:** Added `test_hybrid_timestamp_new_unchecked_exhaustive` to `src/core/hlc.rs` which explicitly asserts all populated fields against exact structural mappings.
**⚠️ Suspected Bugs:** None. This was pure missing test coverage of internal struct mappings.
**📊 Kill Rate:** Killed the single targeted mutant, test suite passing.
**🔗 Havoc Interaction:** None strictly overlapping with Havoc's specific chaos testing, as this is low-level structural initialization testing.

---
*PR created automatically by Jules for task [7582232036743300877](https://jules.google.com/task/7582232036743300877) started by @madmax983*