### PR TITLE
🤖 Sentinel: [config.rs missing boundary tests]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1480,6 +1480,30 @@ wal_dir = "/custom/path/to/wal"
     }
 
     #[test]
+    #[should_panic(expected = "cold_storage_path must be set when enable_cold_storage is true")]
+    fn test_historical_config_build_panics_without_path() {
+        HistoricalConfigBuilder::new()
+            .enable_cold_storage(true)
+            .build();
+    }
+
+    #[test]
+    fn test_historical_config_enable_cold_storage() {
+        let builder = HistoricalConfigBuilder::new().enable_cold_storage(true);
+        assert!(builder.config.enable_cold_storage);
+
+        let builder = builder.enable_cold_storage(false);
+        assert!(!builder.config.enable_cold_storage);
+    }
+
+    #[test]
+    fn test_historical_config_cold_storage_path() {
+        let path = std::path::PathBuf::from("/test/path");
+        let builder = HistoricalConfigBuilder::new().cold_storage_path(path.clone());
+        assert_eq!(builder.config.cold_storage_path, Some(path));
+    }
+
+    #[test]
     fn test_vector_config_zero_max_k() {
         let result = VectorIndexConfigBuilder::new().max_k(0);
         assert!(result.is_err());


### PR DESCRIPTION
**🧬 Mutants Found:** Simulation based on missing builder assertions (baseline timeouts prevented exact count).
**🎯 Tests Added/Strengthened:** Added `test_historical_config_build_panics_without_path`, `test_historical_config_enable_cold_storage`, and `test_historical_config_cold_storage_path` to assert that boundary panics trigger cleanly and state variables are mutated correctly within the builder.
**⚠️ Suspected Bugs:** None.
**📊 Kill Rate:** Manually identified unverified logic covered and strengthened test footprint in `config.rs`.
**🔗 Havoc Interaction:** None, strictly tests pure Rust config structures.

---
*PR created automatically by Jules for task [18228683169557821767](https://jules.google.com/task/18228683169557821767) started by @madmax983*