### PR TITLE
👺 Havoc: API Fuzzing & DoS Prevention

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1623,10 +1623,28 @@ impl PropertyMapBuilder {
     /// The key is automatically interned. If interning fails (capacity exceeded),
     /// returns self unchanged.
     ///
-    /// Panics if recursion depth limit is exceeded.
-    pub fn insert<V: Into<PropertyValue>>(self, key: &str, value: V) -> Self {
-        self.try_insert(key, value)
-            .expect("Property insertion failed (recursion depth limit exceeded)")
+    /// Instead of panicking if recursion depth limit is exceeded (which allows DoS),
+    /// it silently ignores the property and returns self.
+    pub fn insert<V: Into<PropertyValue>>(mut self, key: &str, value: V) -> Self {
+        // We replicate try_insert to avoid move semantics issues without panicking
+        if let Ok(interned_key) = GLOBAL_INTERNER.intern(key) {
+            let val = value.into();
+            if let Ok(val_size) = val.serialized_size() {
+                if let Some(old_val) = self.map.insert(interned_key, val) {
+                    self.current_size = self
+                        .current_size
+                        .saturating_sub(old_val.serialized_size().unwrap_or(0))
+                        .saturating_add(val_size);
+                } else {
+                    let key_size = 4 + key.len(); // Length prefix (4) + string bytes
+                    self.current_size = self
+                        .current_size
+                        .saturating_add(key_size)
+                        .saturating_add(val_size);
+                }
+            }
+        }
+        self
     }
 
     /// Insert a property (fallible).
@@ -1657,10 +1675,27 @@ impl PropertyMapBuilder {
 
     /// Insert a property with an already-interned key.
     ///
-    /// Panics if recursion depth limit is exceeded.
-    pub fn insert_by_key(self, key: PropertyKey, value: PropertyValue) -> Self {
-        self.try_insert_by_key(key, value)
-            .expect("Property insertion failed (recursion depth limit exceeded)")
+    /// Instead of panicking if recursion depth limit is exceeded (which allows DoS),
+    /// it silently ignores the property and returns self.
+    pub fn insert_by_key(mut self, key: PropertyKey, value: PropertyValue) -> Self {
+        if let Ok(val_size) = value.serialized_size() {
+            if let Some(old_val) = self.map.insert(key, value) {
+                self.current_size = self
+                    .current_size
+                    .saturating_sub(old_val.serialized_size().unwrap_or(0))
+                    .saturating_add(val_size);
+            } else {
+                let key_len = GLOBAL_INTERNER
+                    .resolve_with(key, |s| s.len())
+                    .unwrap_or(256);
+                let key_size = 4 + key_len;
+                self.current_size = self
+                    .current_size
+                    .saturating_add(key_size)
+                    .saturating_add(val_size);
+            }
+        }
+        self
     }
 
     /// Insert a property with an already-interned key (fallible).
@@ -3677,7 +3712,7 @@ mod sentry_tests {
         let invalid_key = InternedString::from_raw(u32::MAX);
         let builder = PropertyMapBuilder::new();
         // This should trigger debug_assert!(false) inside try_insert_by_key
-        builder.insert_by_key(invalid_key, PropertyValue::Int(1));
+        let _ = builder.try_insert_by_key(invalid_key, PropertyValue::Int(1));
     }
 
     /// 🎯 Target: PropertyValue equality with NaN
@@ -3728,18 +3763,22 @@ mod sentry_tests {
         );
     }
 
-    /// 🎯 Target: PropertyMapBuilder::insert panic
-    /// 💣 Risk: Incorrect panic message or behavior on recursion limit.
-    /// 🧪 Strategy: Trigger recursion limit and catch panic message.
+    /// 🎯 Target: PropertyMapBuilder::try_insert error
+    /// 💣 Risk: Incorrect error message or behavior on recursion limit.
+    /// 🧪 Strategy: Trigger recursion limit and catch error message.
     /// 🔬 Verification: expect specific string.
     #[test]
-    #[should_panic(expected = "recursion depth limit exceeded")]
-    fn test_property_map_builder_insert_panic_message() {
+    fn test_property_map_builder_try_insert_error_message() {
         let mut value = PropertyValue::Int(42);
         for _ in 0..MAX_RECURSION_DEPTH + 1 {
             value = PropertyValue::Array(Arc::new(vec![value]));
         }
-        PropertyMapBuilder::new().insert("deep", value);
+        let res = PropertyMapBuilder::new().try_insert("deep", value);
+        assert!(res.is_err());
+        if let Err(e) = res {
+            let err_msg = e.to_string();
+            assert!(err_msg.contains("recursion depth limit exceeded"));
+        }
     }
 
     /// 🎯 Target: PropertyMap::deserialize (MAX_PROPERTY_MAP_CAPACITY)

--- a/tests/havoc_interner_fuzz.proptest-regressions
+++ b/tests/havoc_interner_fuzz.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 697eeec1a33c4218c78017fdb8d3b36eafa7f1659d002ea29f3b6818f34edcd3 # shrinks to label = "", key = "", value = ""

--- a/tests/havoc_interner_fuzz.rs
+++ b/tests/havoc_interner_fuzz.rs
@@ -1,0 +1,22 @@
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::property::PropertyMapBuilder;
+use proptest::prelude::*;
+use std::sync::Arc;
+
+lazy_static::lazy_static! {
+    static ref DB: Arc<AletheiaDB> = Arc::new(AletheiaDB::new().unwrap());
+}
+
+proptest! {
+    #[test]
+    fn fuzz_create_node_label(label in "\\PC*", key in "\\PC*", value in "\\PC*") {
+        // The previous test instantiated a DB per iteration, which is too slow.
+        // We use a shared static DB now.
+        let db = &*DB;
+
+        // We use insert() (which internally used to panic on interner exhaustion)
+        // to verify that the application code safely swallows the error rather than crashing.
+        let props = PropertyMapBuilder::new().insert(&key, value).build();
+        let _ = db.create_node(&label, props);
+    }
+}

--- a/tests/havoc_property_fuzz.rs
+++ b/tests/havoc_property_fuzz.rs
@@ -1,0 +1,16 @@
+use aletheiadb::core::property::{PropertyMap, PropertyValue};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn fuzz_property_value_deserialize(data in any::<Vec<u8>>()) {
+        // We throw garbage at it. It should return Err, but it MUST NOT panic.
+        let _ = PropertyValue::deserialize(&data);
+    }
+
+    #[test]
+    fn fuzz_property_map_deserialize(data in any::<Vec<u8>>()) {
+        // Same here: garbage in, Err out. No panics allowed.
+        let _ = PropertyMap::deserialize(&data);
+    }
+}


### PR DESCRIPTION
* 🧨 **The Trigger:** Fuzzing the `AletheiaDB::create_node` API with massive amounts of randomly generated strings (or simply deeply nested arrays) causes a panic when `PropertyMapBuilder` encounters interner exhaustion or recursion limits. The public `insert()` method is infallible, but internally `.expect()` was used.
* 📉 **The Stack Trace:**
```rust
thread 'fuzz_create_node_label' panicked at /app/src/core/property.rs:1629:14:
Property insertion failed (recursion depth limit exceeded): Storage(CapacityExceeded { resource: "string interner", current: 100000, limit: 100000 })
```
* 🧪 **Reproduction:** Run `cargo test --test havoc_interner_fuzz`
* 😈 **Comment:** You thought `unwrap()` was safe because you controlled the inputs. But the API takes raw strings from the public. I fed your interner 100k random strings and brought the whole database crashing down. Never trust user input to be finite or sane. The infallible methods now swallow the error silently—protecting the process from crashing, while the underlying `try_insert` remains available for those who actually care about error propagation. I also proved your deserialization is robust against raw byte chaos, which is disappointing to me, but good for you.

---
*PR created automatically by Jules for task [16403072808811726039](https://jules.google.com/task/16403072808811726039) started by @madmax983*