### PR TITLE
🔒 Warden: Prevent MAX_VALID_ID bypass in AdjacencyIndex::import_csr

### DIFF
--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -14,7 +14,7 @@
 //! sequential access to a contiguous region of memory.
 
 use crate::core::hasher::IdentityHasher;
-use crate::core::id::{EdgeId, NodeId};
+use crate::core::id::{EdgeId, MAX_VALID_ID, NodeId};
 use crate::core::interning::InternedString;
 use rayon::prelude::*;
 use std::hash::BuildHasherDefault;
@@ -595,6 +595,26 @@ impl AdjacencyIndex {
             }
         }
 
+        #[allow(clippy::collapsible_if)]
+        if let Some(&max_node) = node_ids.last() {
+            if max_node > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids contains ID {} exceeding MAX_VALID_ID {}",
+                    max_node, MAX_VALID_ID
+                ));
+            }
+        }
+
+        #[allow(clippy::collapsible_if)]
+        if let Some(&max_edge) = edge_ids.iter().max() {
+            if max_edge > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR edge_ids contains ID {} exceeding MAX_VALID_ID {}",
+                    max_edge, MAX_VALID_ID
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -1166,5 +1186,33 @@ mod sentry_tests {
         assert_eq!(index.edge_count(), 2);
         assert_eq!(index.node_count(), 2);
         assert_eq!(index.max_node_id(), 20);
+    }
+}
+
+#[cfg(test)]
+mod additional_warden_tests {
+    use super::*;
+    use crate::core::id::MAX_VALID_ID;
+
+    #[test]
+    fn test_validate_csr_invariants_rejects_large_node_ids() {
+        let node_ids = vec![MAX_VALID_ID + 10];
+        let offsets = vec![0, 1];
+        let edge_ids = vec![100];
+
+        let result = AdjacencyIndex::validate_csr_invariants(&node_ids, &offsets, &edge_ids);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exceeding MAX_VALID_ID"));
+    }
+
+    #[test]
+    fn test_validate_csr_invariants_rejects_large_edge_ids() {
+        let node_ids = vec![10];
+        let offsets = vec![0, 1];
+        let edge_ids = vec![MAX_VALID_ID + 10];
+
+        let result = AdjacencyIndex::validate_csr_invariants(&node_ids, &offsets, &edge_ids);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exceeding MAX_VALID_ID"));
     }
 }


### PR DESCRIPTION
### 🦠 Threat
The `AdjacencyIndex::import_csr` function deserializes CSR arrays into zero-copy transmuted `Vec<NodeId>` and `Vec<EdgeId>`. However, it bypassed the explicit validation normally provided by `NodeId::new` and `EdgeId::new`. An attacker providing maliciously crafted or corrupted persistence data could instantiate `NodeId` or `EdgeId` structures containing inner values exceeding `MAX_VALID_ID` (such as `u64::MAX`). This bypass opens the door to logical bugs, integer overflow during allocations, and memory corruption downstream when the graph system relies on these invariants.

### 🛡️ Defense
Modified the `validate_csr_invariants` method to strictly enforce the `MAX_VALID_ID` boundary check for all imported node and edge IDs before the unsafe transmutation takes place. Because `node_ids` is already validated to be strictly monotonically increasing, we perform an `O(1)` check against `node_ids.last()`. For `edge_ids`, which can be unsorted, we perform an `O(E)` check over the array. 

### 💥 Severity
High - Without these checks, persistent storage reads or external data imports could inject malformed IDs that compromise the database's strict type invariants. This could lead to runtime panics or unpredictable execution states (UB) when dealing with downstream array allocations that assume a ceiling for `NodeId` sizes.

### 🧪 Verification
Added targeted unit tests in a new `additional_warden_tests` module within `src/index/adjacency.rs` that purposefully pass raw vectors exceeding `MAX_VALID_ID`. Verified that these attempts now return an appropriate error payload instead of allowing the transmutation. Cleanly passes `cargo test`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [10905044776339336114](https://jules.google.com/task/10905044776339336114) started by @madmax983*