### PR TITLE
⚡ Bolt: Replace `.collect::<Vec<_>>().join(" ")` in SQL temporal parser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2026-11-20 - Avoid `min_by` on DashMap
 **Learning:** `DashMap::iter().min_by(...)` and `max_by(...)` hold onto `RefMulti` read guards across loop iterations, which can cause deadlocks if a concurrent writer is waiting for a lock on the same shard.
 **Action:** Use `.fold(None, |min, current| ...)` to extract and clone only the necessary minimum/maximum value while immediately dropping the reference guard for each element. This prevents deadlocks and improves concurrency performance.
+## 2026-11-20 - Eliminate collect::<Vec<_>>().join(" ")
+**Learning:** Chaining `split_whitespace().collect::<Vec<_>>().join(" ")` to remove redundant whitespace creates an unnecessary intermediate heap allocation for the `Vec` of string slices. In hot paths like the temporal SQL parser, this introduces needless allocator pressure.
+**Action:** Pre-allocate a `String::with_capacity(original.len())` and use a `for` loop to push words and spaces directly into the pre-allocated string, eliminating the intermediate vector allocation.

--- a/src/sql/temporal_parser.rs
+++ b/src/sql/temporal_parser.rs
@@ -588,7 +588,19 @@ pub fn extract_temporal_clauses(sql: &str) -> Result<ExtractedTemporal, SqlError
     }
 
     // Clean up extra whitespace
-    cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    // ⚡ Bolt: `split_whitespace().collect::<Vec<_>>().join(" ")` creates an unnecessary `Vec` allocation
+    // on the heap for every SQL string being parsed, which causes allocator pressure.
+    // Instead we build the string directly with pre-allocation to eliminate 1 heap allocation per temporal SQL query parsing operation.
+    let mut new_cleaned = String::with_capacity(cleaned.len());
+    let mut first = true;
+    for word in cleaned.split_whitespace() {
+        if !first {
+            new_cleaned.push(' ');
+        }
+        new_cleaned.push_str(word);
+        first = false;
+    }
+    cleaned = new_cleaned;
 
     Ok(ExtractedTemporal {
         cleaned_sql: cleaned,


### PR DESCRIPTION
💡 What: Replaced an intermediate `.collect::<Vec<_>>()` allocation when cleaning up SQL strings by building the string directly with pre-allocation.
🎯 Why: `split_whitespace().collect::<Vec<_>>().join(" ")` creates an unnecessary `Vec` allocation on the heap for every SQL string being parsed, which causes allocator pressure.
📊 Impact: Eliminates 1 heap allocation per temporal SQL query parsing operation.
🔬 Measurement: Run `cargo test --lib sql::temporal_parser`.

---
*PR created automatically by Jules for task [3437866535524153273](https://jules.google.com/task/3437866535524153273) started by @madmax983*