### PR TITLE
⚡ Bolt: [performance improvement] Optimize temporal parser whitespace cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,9 @@
 ## 2026-11-20 - Avoid `min_by` on DashMap
 **Learning:** `DashMap::iter().min_by(...)` and `max_by(...)` hold onto `RefMulti` read guards across loop iterations, which can cause deadlocks if a concurrent writer is waiting for a lock on the same shard.
 **Action:** Use `.fold(None, |min, current| ...)` to extract and clone only the necessary minimum/maximum value while immediately dropping the reference guard for each element. This prevents deadlocks and improves concurrency performance.
+**[Avoid unused doc comments on statements]
+**Learning:** Adding doc comments (///) to local statements inside functions triggers the  lint under .
+**Action:** Use plain comments (//) instead of doc comments for inline logic optimization explanations.
+**[Avoid unused doc comments on statements]
+**Learning:** Adding doc comments (///) to local statements inside functions triggers the `clippy::unused_doc_comments` lint under `-D warnings`.
+**Action:** Use plain comments (//) instead of doc comments for inline logic optimization explanations.

--- a/src/sql/temporal_parser.rs
+++ b/src/sql/temporal_parser.rs
@@ -588,7 +588,19 @@ pub fn extract_temporal_clauses(sql: &str) -> Result<ExtractedTemporal, SqlError
     }
 
     // Clean up extra whitespace
-    cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    // OPTIMIZATION: Replaced `.split_whitespace().collect::<Vec<_>>().join(" ")` with an allocation-free loop
+    // that pushes directly into a pre-allocated `String`. This avoids an intermediate `Vec` allocation and
+    // improves performance on the hot path of SQL parsing.
+    let mut optimized_cleaned = String::with_capacity(cleaned.len());
+    let mut first = true;
+    for word in cleaned.split_whitespace() {
+        if !first {
+            optimized_cleaned.push(' ');
+        }
+        optimized_cleaned.push_str(word);
+        first = false;
+    }
+    cleaned = optimized_cleaned;
 
     Ok(ExtractedTemporal {
         cleaned_sql: cleaned,


### PR DESCRIPTION
💡 What: Switched `cleaned.split_whitespace().collect::<Vec<_>>().join(" ")` to an allocation-free loop pushing to a pre-allocated `String`.
🎯 Why: Avoiding intermediate `Vec` allocations on the hot path of SQL parsing.
📊 Impact: Removes one heap allocation per temporal clause parsed.
🔬 Measurement: Run `cargo bench` or `cargo test -p aletheiadb --lib sql::temporal_parser`.

---
*PR created automatically by Jules for task [8155350624006027767](https://jules.google.com/task/8155350624006027767) started by @madmax983*