### PR TITLE
🔒 Warden: [security fix] Add validation to import_csr for MAX_VALID_ID

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,7 @@
 2024-XX-XX - [Warden: CSR Adjacency Index Vulnerability]
 **Threat:** `AdjacencyIndex::import_csr` did not validate that `node_ids` is sorted, and did not validate that `offsets` is monotonically increasing. It also didn't validate that the first offset is `0`. This allows a maliciously constructed CSR payload to cause OOB reads (Denial of Service) when `get_adjacency` is called, due to `start > end` or `end > edges.len()` when slicing the `edges` array.
 **Defense:** Added rigorous validation in `validate_csr_invariants` to ensure `node_ids` is strictly sorted (no duplicates), `offsets` begins with `0`, and is monotonically increasing.
+
+**2024-05-19 - Untrusted CSR IDs Exceeding MAX_VALID_ID**
+**Threat:** Zero-copy transmute in `AdjacencyIndex::import_csr` did not validate that imported node or edge IDs were less than or equal to `MAX_VALID_ID`. This allowed arbitrarily large u64 values to bypass the `NodeId` / `EdgeId` boundary checks via the `transmute_vec` function, breaking the newtype invariants and introducing potential logic bugs or downstream memory corruption when those IDs are used in vectors.
+**Defense:** Added explicit bounds checks in `validate_csr_invariants` to ensure that no `node_ids` or `edge_ids` exceed `MAX_VALID_ID` before transmuting them from `Vec<u64>` to `Vec<NodeId>`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,50 @@
+import re
+
+def modify_file(filepath):
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    new_content = content.replace(
+        """        if let Some(&max_id) = node_ids.iter().max() {
+            if max_id > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids contains an invalid ID: {} > MAX_VALID_ID ({})",
+                    max_id, MAX_VALID_ID
+                ));
+            }
+        }""",
+        """        #[allow(clippy::collapsible_if)]
+        if let Some(&max_id) = node_ids.iter().max() {
+            if max_id > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids contains an invalid ID: {} > MAX_VALID_ID ({})",
+                    max_id, MAX_VALID_ID
+                ));
+            }
+        }"""
+    )
+
+    new_content = new_content.replace(
+        """        if let Some(&max_edge) = edge_ids.iter().max() {
+            if max_edge > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR edge_ids contains an invalid ID: {} > MAX_VALID_ID ({})",
+                    max_edge, MAX_VALID_ID
+                ));
+            }
+        }""",
+        """        #[allow(clippy::collapsible_if)]
+        if let Some(&max_edge) = edge_ids.iter().max() {
+            if max_edge > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR edge_ids contains an invalid ID: {} > MAX_VALID_ID ({})",
+                    max_edge, MAX_VALID_ID
+                ));
+            }
+        }"""
+    )
+
+    with open(filepath, 'w') as f:
+        f.write(new_content)
+
+modify_file('src/index/adjacency.rs')

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -548,6 +548,27 @@ impl AdjacencyIndex {
         offsets: &[u64],
         edge_ids: &[u64],
     ) -> Result<(), String> {
+        use crate::core::id::MAX_VALID_ID;
+
+        #[allow(clippy::collapsible_if)]
+        if let Some(&max_id) = node_ids.iter().max() {
+            if max_id > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids contains an invalid ID: {} > MAX_VALID_ID ({})",
+                    max_id, MAX_VALID_ID
+                ));
+            }
+        }
+
+        #[allow(clippy::collapsible_if)]
+        if let Some(&max_edge) = edge_ids.iter().max() {
+            if max_edge > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR edge_ids contains an invalid ID: {} > MAX_VALID_ID ({})",
+                    max_edge, MAX_VALID_ID
+                ));
+            }
+        }
         if offsets.len() != node_ids.len() + 1 {
             return Err(format!(
                 "CSR offsets length mismatch: expected {}, got {}",
@@ -1142,6 +1163,34 @@ mod sentry_tests {
         let offsets = vec![0]; // invalid len (should be 2)
         let edge_ids = vec![100]; // Non-empty to bypass early return
         let edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+    }
+
+    #[test]
+    #[should_panic(expected = "CSR node_ids contains an invalid ID")]
+    fn test_import_csr_panics_on_invalid_node_id() {
+        use crate::core::id::MAX_VALID_ID;
+        let node_ids = vec![MAX_VALID_ID + 1]; // invalid ID
+        let offsets = vec![0, 1];
+        let edge_ids = vec![100];
+        let mut edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+        let target = NodeId::new(99).unwrap();
+        let label = crate::core::interning::InternedString::from_raw(1);
+        edges_map.insert(EdgeId::new(100).unwrap(), (target, label));
+        AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
+    }
+
+    #[test]
+    #[should_panic(expected = "CSR edge_ids contains an invalid ID")]
+    fn test_import_csr_panics_on_invalid_edge_id() {
+        use crate::core::id::MAX_VALID_ID;
+        let node_ids = vec![10];
+        let offsets = vec![0, 1];
+        let edge_ids = vec![MAX_VALID_ID + 1]; // invalid ID
+        let mut edges_map = HashMap::with_hasher(BuildHasherDefault::<IdentityHasher>::default());
+        let target = NodeId::new(99).unwrap();
+        let label = crate::core::interning::InternedString::from_raw(1);
+        edges_map.insert(EdgeId::new(100).unwrap(), (target, label));
         AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edges_map);
     }
 


### PR DESCRIPTION
🦠 Threat: `AdjacencyIndex::import_csr` did not validate that imported node or edge IDs were less than or equal to `MAX_VALID_ID`. This allowed arbitrarily large `u64` values to bypass the `NodeId` / `EdgeId` boundary checks via the zero-copy `transmute_vec` function, breaking the newtype invariants and introducing potential logic bugs or downstream memory corruption when those IDs are used in vectors.
🛡️ Defense: Added explicit bounds checks in `validate_csr_invariants` to ensure that no `node_ids` or `edge_ids` exceed `MAX_VALID_ID` before transmuting them from `Vec<u64>` to `Vec<NodeId>`.
💥 Severity: High - could allow injection of invalid node and edge IDs into the graph, leading to data corruption and undefined behavior later in execution.
🧪 Verification: Added `test_import_csr_panics_on_invalid_node_id` and `test_import_csr_panics_on_invalid_edge_id` to demonstrate that `import_csr` properly catches inputs with invalid IDs. Checked that both tests pass.

---
*PR created automatically by Jules for task [1842808574723380911](https://jules.google.com/task/1842808574723380911) started by @madmax983*