### PR TITLE
👺 Havoc: Bypass NodeId invariants via unsafe transmute in AdjacencyIndex::import_csr

### DIFF
--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -585,6 +585,16 @@ impl AdjacencyIndex {
         }
 
         #[allow(clippy::collapsible_if)]
+        if let Some(&last_node_id) = node_ids.last() {
+            if last_node_id > crate::core::id::MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids exceed MAX_VALID_ID: {}",
+                    last_node_id
+                ));
+            }
+        }
+
+        #[allow(clippy::collapsible_if)]
         if let Some(&last_offset) = offsets.last() {
             if last_offset != edge_ids.len() as u64 {
                 return Err(format!(

--- a/tests/havoc_unsafe.rs
+++ b/tests/havoc_unsafe.rs
@@ -63,3 +63,35 @@ fn test_builder_dos_limits() {
         .build();
     assert!(res.is_err());
 }
+
+#[test]
+fn test_import_csr_invalid_id() {
+    let label = aletheiadb::core::interning::GLOBAL_INTERNER
+        .intern("KNOWS")
+        .unwrap();
+
+    // We create a node ID larger than MAX_VALID_ID
+    let invalid_id: u64 = aletheiadb::core::id::MAX_VALID_ID + 1;
+
+    let nodes = vec![invalid_id];
+    let offsets = vec![0, 1];
+    let edge_ids = vec![100];
+    let mut edge_map = std::collections::HashMap::default();
+    edge_map.insert(
+        aletheiadb::core::id::EdgeId::new(100).unwrap(),
+        (aletheiadb::core::id::NodeId::new(2).unwrap(), label),
+    );
+
+    // This should panic or return an error because it violates the MAX_VALID_ID invariant.
+    // If it succeeds, the unsafe transmute bypassed the checks, which is a bug.
+
+    // We expect a panic, since validate_csr_invariants returns a Result, and import_csr unwraps it.
+    let result = std::panic::catch_unwind(|| {
+        aletheiadb::index::AdjacencyIndex::import_csr(nodes, offsets, edge_ids, &edge_map)
+    });
+
+    assert!(
+        result.is_err(),
+        "Expected import_csr to panic due to invalid NodeId"
+    );
+}


### PR DESCRIPTION
🧨 **The Trigger:** Passing a valid CSR offset/edge structure but with an invalid node ID (e.g. `u64::MAX`) would bypass system invariant checks due to unsafe transmute from `Vec<u64>` to `Vec<NodeId>`.
📉 **The Stack Trace:** No crash initially, but memory corruption or invalid invariants downstream could cause undefined behavior.
🧪 **Reproduction:** Run `cargo test --test havoc_unsafe` to see it panic now that the check correctly fails.
😈 **Comment:** You assumed an external caller would respect your max limits before an unsafe transmute. You were wrong.

---
*PR created automatically by Jules for task [15997953110673444104](https://jules.google.com/task/15997953110673444104) started by @madmax983*