### PR TITLE
⚡ Bolt: Avoid Vec allocation when cleaning up whitespace

### DIFF
--- a/src/sql/temporal_parser.rs
+++ b/src/sql/temporal_parser.rs
@@ -588,7 +588,19 @@ pub fn extract_temporal_clauses(sql: &str) -> Result<ExtractedTemporal, SqlError
     }
 
     // Clean up extra whitespace
-    cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    // PERF: Avoid intermediate Vec allocation when cleaning up whitespace.
+    // By pre-allocating a String with the capacity of the original string and
+    // pushing directly, we avoid allocating and populating a Vec for the joined words.
+    let mut new_cleaned = String::with_capacity(cleaned.len());
+    let mut first = true;
+    for word in cleaned.split_whitespace() {
+        if !first {
+            new_cleaned.push(' ');
+        }
+        new_cleaned.push_str(word);
+        first = false;
+    }
+    cleaned = new_cleaned;
 
     Ok(ExtractedTemporal {
         cleaned_sql: cleaned,


### PR DESCRIPTION
**💡 What:** Switched from `.collect::<Vec<_>>().join(" ")` to an iterative loop using a `String` pre-allocated with `String::with_capacity()` when trimming excess whitespace in the temporal SQL parser.
**🎯 Why:** The previous code caused an unnecessary intermediate `Vec` allocation simply to join strings with a space delimiter.
**📊 Impact:** Completely removes the intermediate `Vec` heap allocation, saving cycles and memory on parsing queries with temporal clauses.
**🔬 Measurement:** Verified with `cargo test` that the parser functionality remains exactly identical.

---
*PR created automatically by Jules for task [11348698097648198286](https://jules.google.com/task/11348698097648198286) started by @madmax983*