### PR TITLE
👺 Havoc: Prevent invalid IDs during CSR import

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,22 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+1. **Understand the problem:**
+   - I need to hunt for an issue and show it crashing, as the "Havoc" persona.
+   - The user provided the memory instruction: "In AletheiaDB, when importing raw integer arrays (e.g., `Vec<u64>`) that will be zero-copy transmuted into strongly typed wrappers (like `Vec<NodeId>` or `Vec<EdgeId>`), explicitly validate that no elements exceed `MAX_VALID_ID` before the `unsafe` block to maintain system invariants and prevent logic bugs or memory corruption downstream."
+   - The method `AdjacencyIndex::import_csr` takes `node_ids: Vec<u64>` and `edge_ids: Vec<u64>`, transmuting them directly without ensuring elements are `<= MAX_VALID_ID`.
+   - I will modify `src/index/adjacency.rs` to validate that `node_ids` and `edge_ids` are less than or equal to `MAX_VALID_ID` inside `validate_csr_invariants`.
+   - Before fixing, I'll ensure I have a test (which I just wrote and failed).
+   - I will fix the vulnerability in `validate_csr_invariants`.
+
+2. **Fix `validate_csr_invariants`**:
+   - I will update `AdjacencyIndex::validate_csr_invariants` to iterate through `node_ids` and `edge_ids` and ensure they are all `<= crate::core::id::MAX_VALID_ID`.
+   - If any ID exceeds `MAX_VALID_ID`, return an `Err`.
+
+3. **Verify Fix**:
+   - Re-run `cargo test -p aletheiadb --lib index::havoc_tests` to verify the panic is now caught, returning an error (which `unwrap()`s inside `import_csr`, meaning it correctly panics on invalid input).
+
+4. **Complete Pre-Commit Steps**:
+   - Ensure `cargo test` passes.
+   - Run `cargo fmt --all`.
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`.
+
+5. **Submit PR**:
+   - Create a pull request titled "👺 Havoc: Prevent invalid IDs during CSR import".

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -548,6 +548,22 @@ impl AdjacencyIndex {
         offsets: &[u64],
         edge_ids: &[u64],
     ) -> Result<(), String> {
+        for &id in node_ids {
+            if id > crate::core::id::MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids contains invalid ID exceeding MAX_VALID_ID: {}",
+                    id
+                ));
+            }
+        }
+        for &id in edge_ids {
+            if id > crate::core::id::MAX_VALID_ID {
+                return Err(format!(
+                    "CSR edge_ids contains invalid ID exceeding MAX_VALID_ID: {}",
+                    id
+                ));
+            }
+        }
         if offsets.len() != node_ids.len() + 1 {
             return Err(format!(
                 "CSR offsets length mismatch: expected {}, got {}",

--- a/src/index/havoc_tests.rs
+++ b/src/index/havoc_tests.rs
@@ -1,0 +1,23 @@
+use crate::core::id::MAX_VALID_ID;
+use crate::index::AdjacencyIndex;
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+proptest! {
+    #[test]
+    fn test_import_csr_havoc_node_id(
+        invalid_id in (MAX_VALID_ID + 1)..=u64::MAX
+    ) {
+        let node_ids = vec![invalid_id];
+        let offsets = vec![0, 1];
+        let edge_ids = vec![100];
+        let edge_map = HashMap::default();
+
+        let result = std::panic::catch_unwind(|| {
+            AdjacencyIndex::import_csr(node_ids, offsets, edge_ids, &edge_map)
+        });
+
+        // We expect it to panic because the ID is invalid.
+        assert!(result.is_err(), "import_csr accepted an invalid NodeId > MAX_VALID_ID without panicking");
+    }
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -24,3 +24,6 @@ pub use temporal::TemporalIndexes;
 pub use temporal_adjacency::{TemporalAdjacencyConfig, TemporalAdjacencyIndex};
 pub use vector::{DistanceMetric, VectorIndex};
 pub use vector::{HnswIndex, HnswIndexBuilder};
+#[cfg(test)]
+/// Havoc test cases
+pub mod havoc_tests;


### PR DESCRIPTION
👺 **Havoc: Prevent Invalid IDs During CSR Import**

### 🧨 The Trigger:
The `AdjacencyIndex::import_csr` function imported raw `node_ids` and `edge_ids` arrays from persistence and transmuted them using zero-copy zero-allocation `unsafe` blocks into `NodeId` and `EdgeId` structures. The raw values inside these arrays were never validated to ensure they conformed to the required `<= MAX_VALID_ID` system invariants. 

If persistence or memory became corrupted, the system easily swallowed `u64::MAX` values as valid node IDs.

### 📉 The Stack Trace / Crash
While testing with `proptest`, passing `invalid_id in (MAX_VALID_ID + 1)..=u64::MAX` to `import_csr` successfully returned a completely invalid dataset, poisoning system memory invariants quietly, triggering down-the-line assertions or logic errors when mathematical boundary operations hit. The unwrap inside `import_csr` was completely sidestepped for invariant breakage.

### 🧪 Reproduction
Run the new proptest harness via:
```sh
cargo test -p aletheiadb --lib index::havoc_tests
```

### 😈 Comment
You assumed the bytes loaded off the disk would strictly abide by your compile-time invariants. You were wrong. Validate before you Transmute.

### 🛠️ The Fix
Modified `AdjacencyIndex::validate_csr_invariants` to explicitly iterate and assert that no underlying IDs loaded into the arrays ever exceed `crate::core::id::MAX_VALID_ID`. Any violation produces an `Err` which safely panics within the expected bounds of `import_csr`.

---
*PR created automatically by Jules for task [17122419390417817286](https://jules.google.com/task/17122419390417817286) started by @madmax983*