### PR TITLE
🛡️ Sentry: [test coverage improvement] Explicitly validate MAX_VALID_ID in CSR import

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,7 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+
+**MAX_VALID_ID Validation on Zero-Copy Imports**
+**Learning:** Raw arrays intended for zero-copy transmute into strongly typed wrappers (like `NodeId` or `EdgeId`) must be explicitly validated against `MAX_VALID_ID` before the `unsafe` block. Failure to do so bypasses the type system's bounds checking, leading to logic bugs or memory corruption downstream.
+**Action:** Always validate that no elements exceed `MAX_VALID_ID` in `Vec<u64>` imports before using `unsafe` zero-copy transmute.

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -14,6 +14,7 @@
 //! sequential access to a contiguous region of memory.
 
 use crate::core::hasher::IdentityHasher;
+use crate::core::id::MAX_VALID_ID;
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
 use rayon::prelude::*;
@@ -595,6 +596,23 @@ impl AdjacencyIndex {
             }
         }
 
+        #[allow(clippy::collapsible_if)]
+        if let Some(&last_node_id) = node_ids.last() {
+            if last_node_id > MAX_VALID_ID {
+                return Err(format!(
+                    "CSR node_ids exceed MAX_VALID_ID: {}",
+                    last_node_id
+                ));
+            }
+        }
+
+        if let Some(&invalid_edge) = edge_ids.iter().find(|&&id| id > MAX_VALID_ID) {
+            return Err(format!(
+                "CSR edge_ids exceed MAX_VALID_ID: {}",
+                invalid_edge
+            ));
+        }
+
         Ok(())
     }
 
@@ -1132,6 +1150,20 @@ mod sentry_tests {
             AdjacencyIndex::validate_csr_invariants(&duplicate_node_ids, &offsets, &edge_ids)
                 .unwrap_err();
         assert!(err_duplicate.contains("CSR node_ids are not strictly monotonically increasing"));
+
+        // 8. Node ID > MAX_VALID_ID
+        let invalid_node_ids = vec![10, MAX_VALID_ID + 1];
+        let err_invalid_node =
+            AdjacencyIndex::validate_csr_invariants(&invalid_node_ids, &offsets, &edge_ids)
+                .unwrap_err();
+        assert!(err_invalid_node.contains("CSR node_ids exceed MAX_VALID_ID"));
+
+        // 9. Edge ID > MAX_VALID_ID
+        let invalid_edge_ids = vec![100, MAX_VALID_ID + 1];
+        let err_invalid_edge =
+            AdjacencyIndex::validate_csr_invariants(&node_ids, &offsets, &invalid_edge_ids)
+                .unwrap_err();
+        assert!(err_invalid_edge.contains("CSR edge_ids exceed MAX_VALID_ID"));
     }
 
     #[test]


### PR DESCRIPTION
🎯 Target: AdjacencyIndex::validate_csr_invariants
💣 Risk: Zero-copy transmute without MAX_VALID_ID validation allows invalid IDs into the system
🧪 Strategy: Added checks for node_ids and edge_ids against MAX_VALID_ID in validate_csr_invariants
🔬 Verification: cargo test -p aletheiadb --lib index::adjacency

---
*PR created automatically by Jules for task [9446006476522595100](https://jules.google.com/task/9446006476522595100) started by @madmax983*