### PR TITLE
🪒 Razor: Clean up experimental abstractions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,12 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+## [Reduction]
+**Bloat:** Unnecessary traits (`Resonator`, `PropagationModel`) in `src/experimental/` that only had a single implementation (`ActivityDensityResonator`, `LinearPropagation`).
+**Cut:** Flattened the traits into concrete structs, replacing dynamic dispatch and generic bounds with direct type usage in `EchoChamber` and `Sybil`.
+**Saved:** ~30 lines of code + cognitive load of navigating traits.
+
+## [Reduction]
+**Bloat:** Verbose `GraphContextBuilder` in `src/experimental/graph_context.rs` that only acted as a data holder for a few arguments before calling `build()`.
+**Cut:** Removed the builder struct and replaced it with a simple `build_graph_context` function.
+**Saved:** ~50 lines of boilerplate code + cognitive load of instantiating a builder for a simple function call.

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -259,6 +259,16 @@ mod tests {
         assert!(fp1.similarity(&fp3) > 0.6 && fp1.similarity(&fp3) < 0.8); // 45 deg
     }
 
+
+    #[test]
+    fn test_activity_density_resonator_standalone() {
+        let resonator = ActivityDensityResonator::default();
+        let history = EntityHistory {
+            versions: vec![],
+        };
+        let fp = resonator.resonate(&history);
+        assert_eq!(fp.bins.len(), 60);
+    }
     #[test]
     fn test_echo_chamber_integration() {
         let db = AletheiaDB::new().unwrap();

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -55,12 +55,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// It looks at the "Last N" microseconds of history and bins updates into
@@ -81,7 +75,7 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
+impl ActivityDensityResonator {
     fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
@@ -128,7 +122,7 @@ impl Resonator for ActivityDensityResonator {
 /// The Echo Chamber finds resonant nodes.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -146,13 +140,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -213,7 +207,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -228,7 +228,6 @@ impl<'a> EchoChamber<'a> {
     }
 }
 
-
 #[cfg(test)]
 mod base_tests {
     use super::*;
@@ -237,9 +236,7 @@ mod base_tests {
     #[test]
     fn test_activity_density_resonator_standalone() {
         let resonator = ActivityDensityResonator::default();
-        let history = EntityHistory {
-            versions: vec![],
-        };
+        let history = EntityHistory { versions: vec![] };
         let fp = resonator.resonate(&history);
         assert_eq!(fp.bins.len(), 60);
     }
@@ -275,8 +272,6 @@ mod tests {
         assert!(fp1.similarity(&fp2) < 0.01); // Orthogonal
         assert!(fp1.similarity(&fp3) > 0.6 && fp1.similarity(&fp3) < 0.8); // 45 deg
     }
-
-
 
     #[test]
     fn test_echo_chamber_integration() {

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -76,7 +76,8 @@ impl Default for ActivityDensityResonator {
 }
 
 impl ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -228,6 +228,23 @@ impl<'a> EchoChamber<'a> {
     }
 }
 
+
+#[cfg(test)]
+mod base_tests {
+    use super::*;
+    use crate::core::history::EntityHistory;
+
+    #[test]
+    fn test_activity_density_resonator_standalone() {
+        let resonator = ActivityDensityResonator::default();
+        let history = EntityHistory {
+            versions: vec![],
+        };
+        let fp = resonator.resonate(&history);
+        assert_eq!(fp.bins.len(), 60);
+    }
+}
+
 #[cfg(all(test, feature = "nova"))]
 mod tests {
     use super::*;
@@ -260,16 +277,7 @@ mod tests {
     }
 
 
-    #[test]
-    #[cfg(feature = "nova")]
-    fn test_activity_density_resonator_standalone() {
-        let resonator = ActivityDensityResonator::default();
-        let history = EntityHistory {
-            versions: vec![],
-        };
-        let fp = resonator.resonate(&history);
-        assert_eq!(fp.bins.len(), 60);
-    }
+
     #[test]
     fn test_echo_chamber_integration() {
         let db = AletheiaDB::new().unwrap();

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -261,6 +261,7 @@ mod tests {
 
 
     #[test]
+    #[cfg(feature = "nova")]
     fn test_activity_density_resonator_standalone() {
         let resonator = ActivityDensityResonator::default();
         let history = EntityHistory {

--- a/src/experimental/graph_context.rs
+++ b/src/experimental/graph_context.rs
@@ -19,7 +19,6 @@
 //!
 //! ```rust
 //! use aletheiadb::AletheiaDB;
-//! use aletheiadb::experimental::graph_context::GraphContextBuilder;
 //! use aletheiadb::core::id::NodeId;
 //!
 //! # fn example(db: &AletheiaDB, node_id: NodeId) -> aletheiadb::core::error::Result<()> {
@@ -71,193 +70,144 @@ use std::fmt::Write;
 ///
 /// ```rust
 /// # use aletheiadb::AletheiaDB;
-/// # use aletheiadb::experimental::graph_context::GraphContextBuilder;
 /// # fn example(db: &AletheiaDB, node_id: aletheiadb::core::id::NodeId) -> aletheiadb::core::error::Result<()> {
-/// let context = GraphContextBuilder::new(db, node_id)
-///     .with_history_limit(5)
-///     .with_neighbor_limit(10)
-///     .build()?;
+/// let context = aletheiadb::experimental::graph_context::build_graph_context(db, node_id, 5, 10)?;
 /// # Ok(())
 /// # }
 /// ```
-pub struct GraphContextBuilder<'a> {
-    db: &'a AletheiaDB,
+fn resolve_interned(s: InternedString) -> String {
+    GLOBAL_INTERNER
+        .resolve_with(s, |s| s.to_string())
+        .unwrap_or_else(|| format!("<interned:{}>", s.as_u32()))
+}
+
+/// Build the context string (Markdown).
+///
+/// # Returns
+///
+/// A formatted Markdown string containing the node's context.
+///
+/// # Errors
+///
+/// Returns an error if the `center_node` does not exist in the database.
+pub fn build_graph_context(
+    db: &AletheiaDB,
     center_node: NodeId,
     history_limit: usize,
     neighbor_limit: usize,
-}
+) -> Result<String> {
+    let mut output = String::new();
+    let node = db.get_node(center_node)?;
+    let label = resolve_interned(node.label);
 
-impl<'a> GraphContextBuilder<'a> {
-    /// Create a new builder for the given node.
-    ///
-    /// # Arguments
-    ///
-    /// * `db` - Reference to the database instance.
-    /// * `center_node` - The ID of the node to generate context for.
-    pub fn new(db: &'a AletheiaDB, center_node: NodeId) -> Self {
-        Self {
-            db,
-            center_node,
-            history_limit: 5,
-            neighbor_limit: 10,
+    // 1. Header
+    writeln!(
+        &mut output,
+        "# Node Context: {} ({})",
+        center_node.as_u64(),
+        label
+    )
+    .unwrap();
+
+    // 2. Properties
+    writeln!(&mut output, "\n## Properties").unwrap();
+    if node.properties.is_empty() {
+        writeln!(&mut output, "- (No properties)").unwrap();
+    } else {
+        // Sort keys for deterministic output
+        let mut props: Vec<_> = node.properties.iter().collect();
+        props.sort_by_key(|(k, _)| *k);
+
+        for (key_id, val) in props {
+            let key = resolve_interned(*key_id);
+            writeln!(&mut output, "- {}: {}", key, val).unwrap();
         }
     }
 
-    /// Set the maximum number of history events to include.
-    ///
-    /// # Trade-offs
-    ///
-    /// *   **Higher limit**: Provides more context on how the node evolved, useful for understanding causality.
-    /// *   **Lower limit**: Saves tokens in the LLM prompt window.
-    ///
-    /// Defaults to 5.
-    pub fn with_history_limit(mut self, limit: usize) -> Self {
-        self.history_limit = limit;
-        self
+    // 3. Evolution (History)
+    writeln!(&mut output, "\n## Evolution").unwrap();
+    let generator = NarrativeGenerator::new(db);
+    match generator.generate_node_narrative(center_node) {
+        Ok(events) => {
+            if events.is_empty() {
+                writeln!(&mut output, "- No history available.").unwrap();
+            } else {
+                for event in events.iter().rev().take(history_limit) {
+                    writeln!(
+                        &mut output,
+                        "- {} (v{}): {}",
+                        event.timestamp, event.version_number, event.description
+                    )
+                    .unwrap();
+                    for change in &event.changes {
+                        writeln!(&mut output, "  - {}", change).unwrap();
+                    }
+                }
+                if events.len() > history_limit {
+                    writeln!(
+                        &mut output,
+                        "- ... ({} more versions)",
+                        events.len() - history_limit
+                    )
+                    .unwrap();
+                }
+            }
+        }
+        Err(e) => {
+            writeln!(&mut output, "- Error retrieving history: {}", e).unwrap();
+        }
     }
 
-    /// Set the maximum number of neighbors to include.
-    ///
-    /// # Trade-offs
-    ///
-    /// *   **Higher limit**: Provides a broader view of the node's connections.
-    /// *   **Lower limit**: Saves tokens and prevents "context pollution" from irrelevant neighbors.
-    ///
-    /// Defaults to 10.
-    pub fn with_neighbor_limit(mut self, limit: usize) -> Self {
-        self.neighbor_limit = limit;
-        self
-    }
-
-    fn resolve(s: InternedString) -> String {
-        GLOBAL_INTERNER
-            .resolve_with(s, |s| s.to_string())
-            .unwrap_or_else(|| format!("<interned:{}>", s.as_u32()))
-    }
-
-    /// Build the context string (Markdown).
-    ///
-    /// # Returns
-    ///
-    /// A formatted Markdown string containing the node's context.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the `center_node` does not exist in the database.
-    pub fn build(&self) -> Result<String> {
-        let mut output = String::new();
-        let node = self.db.get_node(self.center_node)?;
-        let label = Self::resolve(node.label);
-
-        // 1. Header
+    // 4. Neighborhood
+    writeln!(&mut output, "\n## Neighborhood").unwrap();
+    let edges = db.get_outgoing_edges(center_node);
+    if edges.is_empty() {
+        writeln!(&mut output, "- (No outgoing edges)").unwrap();
+    } else {
         writeln!(
             &mut output,
-            "# Node Context: {} ({})",
-            self.center_node.as_u64(),
-            label
+            "{} outgoing edges (showing max {}):",
+            edges.len(),
+            neighbor_limit
         )
         .unwrap();
-
-        // 2. Properties
-        writeln!(&mut output, "\n## Properties").unwrap();
-        if node.properties.is_empty() {
-            writeln!(&mut output, "- (No properties)").unwrap();
-        } else {
-            // Sort keys for deterministic output
-            let mut props: Vec<_> = node.properties.iter().collect();
-            props.sort_by_key(|(k, _)| *k);
-
-            for (key_id, val) in props {
-                let key = Self::resolve(*key_id);
-                writeln!(&mut output, "- {}: {}", key, val).unwrap();
-            }
-        }
-
-        // 3. Evolution (History)
-        writeln!(&mut output, "\n## Evolution").unwrap();
-        let generator = NarrativeGenerator::new(self.db);
-        match generator.generate_node_narrative(self.center_node) {
-            Ok(events) => {
-                if events.is_empty() {
-                    writeln!(&mut output, "- No history available.").unwrap();
+        for edge_id in edges.iter().take(neighbor_limit) {
+            if let Ok(edge) = db.get_edge(*edge_id) {
+                let edge_label = resolve_interned(edge.label);
+                // Try to get target node label if possible, otherwise just ID
+                let target_desc = if let Ok(target_node) = db.get_node(edge.target) {
+                    format!(
+                        "{} ({})",
+                        resolve_interned(target_node.label),
+                        edge.target.as_u64()
+                    )
                 } else {
-                    for event in events.iter().rev().take(self.history_limit) {
-                        writeln!(
-                            &mut output,
-                            "- {} (v{}): {}",
-                            event.timestamp, event.version_number, event.description
-                        )
-                        .unwrap();
-                        for change in &event.changes {
-                            writeln!(&mut output, "  - {}", change).unwrap();
-                        }
-                    }
-                    if events.len() > self.history_limit {
-                        writeln!(
-                            &mut output,
-                            "- ... ({} more versions)",
-                            events.len() - self.history_limit
-                        )
-                        .unwrap();
-                    }
-                }
-            }
-            Err(e) => {
-                writeln!(&mut output, "- Error retrieving history: {}", e).unwrap();
-            }
-        }
+                    format!("Node {}", edge.target.as_u64())
+                };
 
-        // 4. Neighborhood
-        writeln!(&mut output, "\n## Neighborhood").unwrap();
-        let edges = self.db.get_outgoing_edges(self.center_node);
-        if edges.is_empty() {
-            writeln!(&mut output, "- (No outgoing edges)").unwrap();
-        } else {
-            writeln!(
-                &mut output,
-                "{} outgoing edges (showing max {}):",
-                edges.len(),
-                self.neighbor_limit
-            )
-            .unwrap();
-            for edge_id in edges.iter().take(self.neighbor_limit) {
-                if let Ok(edge) = self.db.get_edge(*edge_id) {
-                    let edge_label = Self::resolve(edge.label);
-                    // Try to get target node label if possible, otherwise just ID
-                    let target_desc = if let Ok(target_node) = self.db.get_node(edge.target) {
-                        format!(
-                            "{} ({})",
-                            Self::resolve(target_node.label),
-                            edge.target.as_u64()
-                        )
-                    } else {
-                        format!("Node {}", edge.target.as_u64())
-                    };
+                writeln!(&mut output, "- {} -> {}", edge_label, target_desc).unwrap();
 
-                    writeln!(&mut output, "- {} -> {}", edge_label, target_desc).unwrap();
-
-                    // Edge properties (compact)
-                    if !edge.properties.is_empty() {
-                        let mut props_str: Vec<String> = edge
-                            .properties
-                            .iter()
-                            .map(|(k, v)| format!("{}: {}", Self::resolve(*k), v))
-                            .collect();
-                        // Sort for deterministic output
-                        props_str.sort();
-                        writeln!(
-                            &mut output,
-                            "  - Properties: {{ {} }}",
-                            props_str.join(", ")
-                        )
-                        .unwrap();
-                    }
+                // Edge properties (compact)
+                if !edge.properties.is_empty() {
+                    let mut props_str: Vec<String> = edge
+                        .properties
+                        .iter()
+                        .map(|(k, v)| format!("{}: {}", resolve_interned(*k), v))
+                        .collect();
+                    // Sort for deterministic output
+                    props_str.sort();
+                    writeln!(
+                        &mut output,
+                        "  - Properties: {{ {} }}",
+                        props_str.join(", ")
+                    )
+                    .unwrap();
                 }
             }
         }
-
-        Ok(output)
     }
+
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -299,10 +249,7 @@ mod tests {
             .unwrap();
 
         // 5. Build Context
-        let context = GraphContextBuilder::new(&db, node_a)
-            .with_history_limit(5)
-            .build()
-            .unwrap();
+        let context = build_graph_context(&db, node_a, 5, 10).unwrap();
 
         println!("{}", context);
 

--- a/src/experimental/sybil.rs
+++ b/src/experimental/sybil.rs
@@ -44,25 +44,6 @@ use std::collections::HashMap;
 /// Maps NodeId -> Vector (state).
 pub type PropagationState = HashMap<NodeId, Vec<f32>>;
 
-/// Defines how a node updates its state based on its neighbors.
-pub trait PropagationModel {
-    /// Calculate the next state for a node.
-    ///
-    /// # Arguments
-    /// * `node_id` - The node being updated.
-    /// * `current_self` - The node's current vector (if any).
-    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
-    ///
-    /// # Returns
-    /// The new vector state for the node.
-    fn next_state(
-        &self,
-        node_id: NodeId,
-        current_self: Option<&[f32]>,
-        neighbors: &[(NodeId, &[f32])],
-    ) -> Option<Vec<f32>>;
-}
-
 /// A simple linear propagation model.
 /// New State = (1 - alpha) * Old State + alpha * Average(Neighbor States)
 pub struct LinearPropagation {
@@ -81,8 +62,17 @@ impl LinearPropagation {
     }
 }
 
-impl PropagationModel for LinearPropagation {
-    fn next_state(
+impl LinearPropagation {
+    /// Calculate the next state for a node.
+    ///
+    /// # Arguments
+    /// * `_node_id` - The node being updated.
+    /// * `current_self` - The node's current vector (if any).
+    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
+    ///
+    /// # Returns
+    /// The new vector state for the node.
+    pub fn next_state(
         &self,
         _node_id: NodeId,
         current_self: Option<&[f32]>,
@@ -156,10 +146,10 @@ impl<'a> Sybil<'a> {
     /// * `property_name` - The vector property to use as the "meme".
     /// * `model` - The propagation logic.
     /// * `steps` - Number of iterations.
-    pub fn simulate<M: PropagationModel>(
+    pub fn simulate(
         &self,
         property_name: &str,
-        model: &M,
+        model: &LinearPropagation,
         steps: usize,
     ) -> Result<PropagationState> {
         // Step 1: Load Initial State


### PR DESCRIPTION
## [Reduction]
**Bloat:** Unnecessary traits (`Resonator`, `PropagationModel`) and Builders (`GraphContextBuilder`) in `src/experimental/`.
**Cut:** Flattened traits into concrete structs, removed Builder.
**Saved:** Lines of code and cognitive load.

---
*PR created automatically by Jules for task [3823053497092513222](https://jules.google.com/task/3823053497092513222) started by @madmax983*