### PR TITLE
🎻 Bard: [documentation update] Clarify Result shadowing in prelude

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -82,3 +82,7 @@
 ## 2025-03-05 - Logical vs Physical Plans and Iterator Performance
 **Confusion:** The difference between logical plans (`LogicalOp`) and physical plans (`PhysicalOp`) in the query engine was unclear. Additionally, the iterators used for execution (`ResultIterator` implementations) lacked clarity on their streaming architecture.
 **Clarification:** Documented `PhysicalOp` to explain its 1:1 mapping with iterators. Added struct-level documentation to `ResultIterator` implementations to clarify the pull-based, lazy execution model used during query processing.
+
+## 2025-05-24 - Result Shadowing in Prelude
+**Confusion:** The `aletheiadb::prelude` module exports `Result` which maps to `Result<T, aletheiadb::Error>`. When users copy-paste examples into their own `fn main() -> Result<(), Box<dyn std::error::Error>>`, they encounter compiler errors because the prelude's `Result` shadows `std::result::Result` and expects only 1 type argument.
+**Clarification:** Documented the shadowing behavior directly on `pub use crate::core::error::{Error, Result};` in `src/prelude.rs` with an executable doctest demonstrating the explicit `std::result::Result` usage. Also updated all `fn main()` examples in `README.md` to use the explicit path and added an inline comment explaining why.

--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ See **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for complete architecture d
 ```rust
 use aletheiadb::prelude::*;
 
+// Note: `aletheiadb::prelude::Result` shadows `std::result::Result`.
+// When returning a result from `main()`, explicitly specify `std::result::Result`.
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Create a new database
     let db = AletheiaDB::new().unwrap();
@@ -805,7 +807,7 @@ use std::sync::Arc;
 
 // Note: Requires `tokio` dependency in Cargo.toml
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Enable in Cargo.toml: features = ["embedding-openai"]
 
     // 1. Create embedding service

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,29 @@
 
 pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};
+
+/// The database error and result types.
+///
+/// **⚠️ Warning:** Importing `Result` from the prelude shadows the standard library's `std::result::Result`.
+/// If you are writing a `main` function that returns a result, you must explicitly use `std::result::Result`:
+///
+/// ```rust
+/// use aletheiadb::prelude::*;
+///
+/// // Notice the explicit std::result::Result here:
+/// fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+///     let db = AletheiaDB::new()?;
+///
+///     // Database methods return aletheiadb::Result
+///     let id: NodeId = db.write(|tx| {
+///         tx.create_node("Test", PropertyMap::new())
+///     })?;
+///
+///     Ok(())
+/// }
+/// ```
 pub use crate::core::error::{Error, Result};
+
 pub use crate::core::id::{EdgeId, NodeId, VersionId};
 pub use crate::core::interning::InternedString;
 pub use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};


### PR DESCRIPTION
📖 Chapter: The Prelude module
🔦 Insight: Clarified that `aletheiadb::prelude::Result` shadows `std::result::Result`, causing confusion for users copying examples.
🧪 Example: Updated documentation with an executable doctest showing the correct usage.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [13449674911957752803](https://jules.google.com/task/13449674911957752803) started by @madmax983*