### PR TITLE
⚡ Bolt: zero-copy vector allocation optimization in PropertyDelta

### DIFF
--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -551,7 +551,7 @@ impl PropertyDelta {
                         && let Some(base_vec) = base_value.as_vector()
                     {
                         let new_vec = vec_delta.apply(base_vec);
-                        result.insert(*key, PropertyValue::vector(&new_vec));
+                        result.insert(*key, new_vec.into());
                     }
                 }
             }
@@ -626,7 +626,7 @@ impl PropertyDelta {
 
                         // Apply sparse delta to get full vector
                         let new_vec = vec_delta.apply(base_vec);
-                        self.changed.insert(key, PropertyValue::vector(&new_vec));
+                        self.changed.insert(key, new_vec.into());
                     }
                 }
             }


### PR DESCRIPTION
💡 What: Optimized `PropertyDelta::apply` and `PropertyDelta::materialize_vector_deltas` to use `.into()` when materializing new vectors from `VectorDelta`.
🎯 Why: Previous implementation `PropertyValue::vector(&new_vec)` was taking a reference to the `new_vec` slice and allocating a new `Arc<[f32]>` with copied data, even though `new_vec` is already an owned `Vec<f32>` allocation. Using `.into()` reuses the `Vec`'s buffer directly.
📊 Impact: Eliminates unnecessary `O(N)` heap allocations and data copies per modified vector property during snapshot materialization and delta application in the query path.
🔬 Measurement: Run bench `process_data` (or verify via `cargo test` which ensures correctness of the `apply` mechanism).

---
*PR created automatically by Jules for task [13498532645507643316](https://jules.google.com/task/13498532645507643316) started by @madmax983*