### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/run_overflow_test.sh
+++ b/run_overflow_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo test --lib core::property::tests::test_deserialize_string_overflow || true

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -4236,3 +4236,82 @@ mod sentry_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod sentry_overflow_tests {
+    use super::*;
+
+    #[test]
+    fn test_sentry_deserialize_string_length_overflow() {
+        // 🛡️ Sentry Test: Verify `deserialize_string` correctly handles length overflow
+        // which prevents DoS attacks via memory exhaustion or integer overflow panics.
+        // It specifically targets `offset.checked_add(len)` logic.
+
+        // TAG_STRING = 8
+        // [tag:1][len:4][data...]
+        let mut bytes = vec![TAG_STRING];
+
+        // len = u32::MAX, this causes offset (5) + len (4294967295) = 4294967300
+        // on 32-bit systems this would overflow usize, on 64-bit it's just very large
+        // But the check `if bytes.len() < required_len` will safely fail.
+
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Storage(StorageError::CorruptedData(msg))) => {
+                assert!(
+                    msg.contains("Buffer too short for String data"),
+                    "Error should mention buffer too short, got: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected CorruptedData error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_sentry_deserialize_bytes_length_overflow() {
+        // 🛡️ Sentry Test: Verify `deserialize_bytes` correctly handles length overflow.
+        let mut bytes = vec![TAG_BYTES];
+
+        // len = u32::MAX
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Storage(StorageError::CorruptedData(msg))) => {
+                assert!(
+                    msg.contains("Buffer too short for Bytes data"),
+                    "Error should mention buffer too short, got: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected CorruptedData error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_sentry_deserialize_array_length_overflow() {
+        // 🛡️ Sentry Test: Verify `deserialize_array` correctly protects against memory exhaustion DoS.
+        let mut bytes = vec![TAG_ARRAY];
+
+        // request count = u32::MAX elements, which far exceeds MAX_ARRAY_ELEMENTS
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        let result = PropertyValue::deserialize(&bytes);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Storage(StorageError::CorruptedData(msg))) => {
+                assert!(
+                    msg.contains("Array count"),
+                    "Error should mention Array count, got: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected CorruptedData error, got {:?}", result),
+        }
+    }
+}


### PR DESCRIPTION
🎯 Target: `src/core/property.rs` - `deserialize_string`, `deserialize_bytes`, and `deserialize_array`.
💣 Risk: Length parameters exceeding buffer bounds can lead to panics due to out-of-bounds indexing or `checked_add` errors.
🧪 Strategy: Added specific unit tests testing the limits of these lengths via u32::MAX.
🔬 Verification: `cargo test --lib core::property::sentry_overflow_tests`

---
*PR created automatically by Jules for task [18047059879853340569](https://jules.google.com/task/18047059879853340569) started by @madmax983*