### PR TITLE
⚡ Bolt: optimize whitespace cleanup in temporal parser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 **Pre-allocate Vectors in collect_structured**
 **Learning:** `Vec::new()` without capacity hints inside a loop where the target size is known (via `iterator.size_hint()` or `Vec::len()`) causes unnecessary heap allocations. Using `Vec::with_capacity` based on iterator size bounds prevents these allocations.
 **Action:** Always check if the final collection size is known or estimable (e.g. from an iterator) and use `Vec::with_capacity` instead of `Vec::new()` to initialize collections.
+
+**[Optimize temporal parser whitespace clean up]**
+**Learning:** Chaining `.split_whitespace().collect::<Vec<_>>().join(" ")` creates an intermediate vector which can be costly on hot paths.
+**Action:** Replace `split_whitespace().collect::<Vec<_>>().join(" ")` with manual traversal over `split_whitespace()` where strings are pushed onto a pre-allocated buffer of length `String::with_capacity(string.len())`.

--- a/src/sql/temporal_parser.rs
+++ b/src/sql/temporal_parser.rs
@@ -588,7 +588,17 @@ pub fn extract_temporal_clauses(sql: &str) -> Result<ExtractedTemporal, SqlError
     }
 
     // Clean up extra whitespace
-    cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    // ⚡ Bolt: Eliminate intermediate Vec allocation when cleaning up whitespace
+    let mut optimized_cleaned = String::with_capacity(cleaned.len());
+    let mut first = true;
+    for word in cleaned.split_whitespace() {
+        if !first {
+            optimized_cleaned.push(' ');
+        }
+        optimized_cleaned.push_str(word);
+        first = false;
+    }
+    cleaned = optimized_cleaned;
 
     Ok(ExtractedTemporal {
         cleaned_sql: cleaned,


### PR DESCRIPTION
💡 **What:** Optimized whitespace cleanup in the SQL temporal parser by replacing `.split_whitespace().collect::<Vec<_>>().join(" ")` with manual string pushing and a pre-allocated buffer via `String::with_capacity(cleaned.len())`.

🎯 **Why:** The previous code chained `collect` into a `Vec` before calling `join`, unnecessarily allocating a heap array for tokens which can become costly on parsing hot paths.

📊 **Impact:** Eliminates 1 intermediate array allocation per parsed temporal SQL statement.

🔬 **Measurement:** Run `cargo test --lib sql::temporal_parser` to verify the parsed outputs have not changed.

---
*PR created automatically by Jules for task [15887918068240170618](https://jules.google.com/task/15887918068240170618) started by @madmax983*