### PR TITLE
🔒 Warden: [security fix] Update quinn-proto to resolve RUSTSEC-2026-0037

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,7 @@
 2024-XX-XX - [Warden: CSR Adjacency Index Vulnerability]
 **Threat:** `AdjacencyIndex::import_csr` did not validate that `node_ids` is sorted, and did not validate that `offsets` is monotonically increasing. It also didn't validate that the first offset is `0`. This allows a maliciously constructed CSR payload to cause OOB reads (Denial of Service) when `get_adjacency` is called, due to `start > end` or `end > edges.len()` when slicing the `edges` array.
 **Defense:** Added rigorous validation in `validate_csr_invariants` to ensure `node_ids` is strictly sorted (no duplicates), `offsets` begins with `0`, and is monotonically increasing.
+
+**2026-03-09 - [Denial of Service in Quinn endpoints]**
+**Threat:** A high severity vulnerability (RUSTSEC-2026-0037) was discovered in `quinn-proto` v0.11.13, which could allow a Denial of Service attack against Quinn endpoints.
+**Defense:** Updated `quinn-proto` to `>=0.11.14` via `cargo update -p quinn-proto` to resolve the vulnerability.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
**🦠 Threat:** 
A high severity Denial of Service vulnerability (RUSTSEC-2026-0037) was discovered in `quinn-proto` v0.11.13, which could allow a DoS attack against Quinn endpoints.

**🛡️ Defense:** 
Updated `quinn-proto` to `>=0.11.14` via `cargo update -p quinn-proto` to resolve the vulnerability.

**💥 Severity:**
High (8.7).

**🧪 Verification:** 
Ran `cargo audit` to confirm the vulnerability is no longer present. Ran `cargo test --all-targets --all-features` to ensure no regressions were introduced. Added an entry to `.jules/warden.md` logging the findings.

---
*PR created automatically by Jules for task [1136674536909463205](https://jules.google.com/task/1136674536909463205) started by @madmax983*