### PR TITLE
🧹 Simplify core/graph.rs: delegate constructors, remove duplicate MCP label matcher

### DIFF
--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -43,13 +43,13 @@ impl Node {
         properties: PropertyMap,
         current_version: VersionId,
     ) -> Self {
-        Node {
+        Self::with_metadata(
             id,
             label,
             properties,
             current_version,
-            metadata: VersionMetadata::default(),
-        }
+            VersionMetadata::default(),
+        )
     }
 
     /// Create a new node with explicit metadata (for transactions).
@@ -169,15 +169,15 @@ impl Edge {
         properties: PropertyMap,
         current_version: VersionId,
     ) -> Self {
-        Edge {
+        Self::with_metadata(
             id,
             label,
             source,
             target,
             properties,
             current_version,
-            metadata: VersionMetadata::default(),
-        }
+            VersionMetadata::default(),
+        )
     }
 
     /// Create a new edge with explicit metadata (for transactions).

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -751,12 +751,6 @@ impl AletheiaMcpServer {
         tx_time.unwrap_or_else(|| TRANSACTION_TIME_NOW.to_string())
     }
 
-    fn matches_label(&self, interned: crate::core::InternedString, label: &str) -> bool {
-        GLOBAL_INTERNER
-            .resolve_with(interned, |s| s == label)
-            .unwrap_or(false)
-    }
-
     /// Get the expected dimensions for a vector index property.
     /// Returns None if the index doesn't exist.
     fn get_vector_index_dimensions(&self, property_name: &str) -> Option<usize> {
@@ -1270,7 +1264,7 @@ impl AletheiaMcpServer {
             .filter(|e| {
                 req.label
                     .as_ref()
-                    .map(|l| self.matches_label(e.label, l))
+                    .map(|l| e.has_label_str(l))
                     .unwrap_or(true)
             })
             .map(|e| self.edge_to_response(&e))
@@ -1335,7 +1329,7 @@ impl AletheiaMcpServer {
                             .filter(|eid| {
                                 self.db
                                     .get_edge(*eid)
-                                    .map(|e| self.matches_label(e.label, &req.edge_label))
+                                    .map(|e| e.has_label_str(&req.edge_label))
                                     .unwrap_or(false)
                             })
                             .collect()
@@ -1351,7 +1345,7 @@ impl AletheiaMcpServer {
                             .filter(|eid| {
                                 self.db
                                     .get_edge(*eid)
-                                    .map(|e| self.matches_label(e.label, &req.edge_label))
+                                    .map(|e| e.has_label_str(&req.edge_label))
                                     .unwrap_or(false)
                             })
                             .collect();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -751,6 +751,24 @@ impl AletheiaMcpServer {
         tx_time.unwrap_or_else(|| TRANSACTION_TIME_NOW.to_string())
     }
 
+    /// Filter incoming edges by label. Mirrors `get_outgoing_edges_with_label` for the
+    /// incoming direction, which has no equivalent on the DB API.
+    fn incoming_edges_with_label<'a>(
+        &'a self,
+        node_id: NodeId,
+        edge_label: &'a str,
+    ) -> impl Iterator<Item = EdgeId> + 'a {
+        self.db
+            .get_incoming_edges(node_id)
+            .into_iter()
+            .filter(|eid| {
+                self.db
+                    .get_edge(*eid)
+                    .map(|e| e.has_label_str(edge_label))
+                    .unwrap_or(false)
+            })
+    }
+
     /// Get the expected dimensions for a vector index property.
     /// Returns None if the index doesn't exist.
     fn get_vector_index_dimensions(&self, property_name: &str) -> Option<usize> {
@@ -1321,35 +1339,14 @@ impl AletheiaMcpServer {
 
             if current_depth < depth {
                 let edge_ids: Vec<EdgeId> = match direction {
-                    "incoming" => {
-                        // Filter incoming edges by label manually
-                        self.db
-                            .get_incoming_edges(current_id)
-                            .into_iter()
-                            .filter(|eid| {
-                                self.db
-                                    .get_edge(*eid)
-                                    .map(|e| e.has_label_str(&req.edge_label))
-                                    .unwrap_or(false)
-                            })
-                            .collect()
-                    }
+                    "incoming" => self
+                        .incoming_edges_with_label(current_id, &req.edge_label)
+                        .collect(),
                     "both" => {
                         let mut edges = self
                             .db
                             .get_outgoing_edges_with_label(current_id, &req.edge_label);
-                        let incoming: Vec<EdgeId> = self
-                            .db
-                            .get_incoming_edges(current_id)
-                            .into_iter()
-                            .filter(|eid| {
-                                self.db
-                                    .get_edge(*eid)
-                                    .map(|e| e.has_label_str(&req.edge_label))
-                                    .unwrap_or(false)
-                            })
-                            .collect();
-                        edges.extend(incoming);
+                        edges.extend(self.incoming_edges_with_label(current_id, &req.edge_label));
                         edges
                     }
                     _ => self


### PR DESCRIPTION
## Summary

- **`Node::new` / `Edge::new`** now delegate to `with_metadata` instead of duplicating the struct literal — eliminates a maintenance trap where adding a new field would require two updates
- **Remove `AletheiaMcpServer::matches_label`** — this was a verbatim copy of the interner lookup already exposed as `Edge::has_label_str` / `Node::has_label_str` on the public API; three call sites updated to use `e.has_label_str(...)` directly

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all` applied
- [x] All 3029 lib tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)