### PR TITLE
⚡ Bolt: Optimize TraversalIterator by eliminating intermediate Vec allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 **Avoid intermediate Vec allocations when parsing queries**
 **Learning:** `cleaned.split_whitespace().collect::<Vec<_>>().join(" ");` creates an unnecessary `Vec` allocation on the heap, which isn't necessary for simple string transformations.
 **Action:** Use a pre-allocated string with `String::with_capacity(cleaned.len())` and a loop over the word iterator to concatenate spaces and words directly.
+
+**Refactor BFS `TraversalIterator` to avoid intermediate Vec allocations**
+**Learning:** During graph traversals (like BFS), returning a `Vec` of neighbors from a helper method on each node evaluation can accumulate significant heap allocation overhead over time.
+**Action:** Replace `get_neighbors() -> Vec<T>` with a higher-order function like `process_neighbors<F>(mut f: F)` that lazily yields each neighbor directly to the required collection (like a `VecDeque` frontier), achieving a zero-cost abstraction without fighting the borrow checker (by defining it as an associated function instead of a method taking `&self`).

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -679,149 +679,115 @@ impl TraversalIterator {
         }
     }
 
-    /// Check if an edge existed at the specified temporal context using a pre-acquired lock guard.
-    /// Returns true if no temporal context is set (current state query).
-    #[inline]
-    fn edge_visible_at_time(
-        &self,
-        edge_id: crate::core::EdgeId,
-        historical_guard: &Option<parking_lot::RwLockReadGuard<'_, HistoricalStorage>>,
-    ) -> bool {
-        match self.temporal_context {
-            Some((valid_time, tx_time)) => {
-                // Use the pre-acquired guard to avoid per-edge lock acquisition
-                historical_guard
-                    .as_ref()
-                    .expect("historical_guard must be Some when temporal_context is Some")
-                    .find_edge_version_at_time(edge_id, valid_time, tx_time)
-                    .is_some()
-            }
-            None => true, // No temporal context, use current state
-        }
-    }
-
-    fn get_neighbors(&self, node_id: NodeId) -> Vec<(NodeId, crate::core::EdgeId)> {
+    fn process_neighbors<F>(
+        direction: &Direction,
+        label: Option<&String>,
+        current: &Arc<CurrentStorage>,
+        temporal_context: Option<(Timestamp, Timestamp)>,
+        historical: &Arc<RwLock<HistoricalStorage>>,
+        node_id: NodeId,
+        mut f: F,
+    ) where
+        F: FnMut(NodeId, crate::core::EdgeId),
+    {
         // Acquire historical lock ONCE for all edge checks in this call.
-        // This avoids the performance regression of acquiring per-edge locks.
-        let historical_guard = self.temporal_context.map(|_| self.historical.read());
+        let historical_guard = temporal_context.map(|_| historical.read());
 
-        match self.direction {
+        let edge_visible_at_time =
+            |edge_id: crate::core::EdgeId,
+             guard: &Option<parking_lot::RwLockReadGuard<'_, HistoricalStorage>>|
+             -> bool {
+                match temporal_context {
+                    Some((valid_time, tx_time)) => guard
+                        .as_ref()
+                        .expect("historical_guard must be Some when temporal_context is Some")
+                        .find_edge_version_at_time(edge_id, valid_time, tx_time)
+                        .is_some(),
+                    None => true,
+                }
+            };
+
+        match direction {
             Direction::Outgoing => {
-                // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
-                if let Some(ref label) = self.label {
-                    self.current
-                        .get_outgoing_edges_with_label_iter(node_id, label)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get target NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_target(edge_id)
-                                .ok()
-                                .map(|target| (target, edge_id))
-                        })
-                        .collect()
+                if let Some(lbl) = label {
+                    for edge_id in current.get_outgoing_edges_with_label_iter(node_id, lbl) {
+                        if !edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        if let Ok(target) = current.get_edge_target(edge_id) {
+                            f(target, edge_id);
+                        }
+                    }
                 } else {
-                    self.current
-                        .get_outgoing_edges_iter(node_id)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get target NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_target(edge_id)
-                                .ok()
-                                .map(|target| (target, edge_id))
-                        })
-                        .collect()
+                    for edge_id in current.get_outgoing_edges_iter(node_id) {
+                        if !edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        if let Ok(target) = current.get_edge_target(edge_id) {
+                            f(target, edge_id);
+                        }
+                    }
                 }
             }
             Direction::Incoming => {
-                // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
-                if let Some(ref label) = self.label {
-                    self.current
-                        .get_incoming_edges_with_label_iter(node_id, label)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get source NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_source(edge_id)
-                                .ok()
-                                .map(|source| (source, edge_id))
-                        })
-                        .collect()
+                if let Some(lbl) = label {
+                    for edge_id in current.get_incoming_edges_with_label_iter(node_id, lbl) {
+                        if !edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        if let Ok(source) = current.get_edge_source(edge_id) {
+                            f(source, edge_id);
+                        }
+                    }
                 } else {
-                    self.current
-                        .get_incoming_edges_iter(node_id)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get source NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_source(edge_id)
-                                .ok()
-                                .map(|source| (source, edge_id))
-                        })
-                        .collect()
+                    for edge_id in current.get_incoming_edges_iter(node_id) {
+                        if !edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        if let Ok(source) = current.get_edge_source(edge_id) {
+                            f(source, edge_id);
+                        }
+                    }
                 }
             }
             Direction::Both => {
-                let mut neighbors = Vec::new();
-
-                // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
-                // Helper closure to process edges and add to neighbors
-                // Zero-copy: only get target NodeId, not full Edge (Issue #190)
                 let mut process_outgoing = |edge_id| {
-                    if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                    if !edge_visible_at_time(edge_id, &historical_guard) {
                         return;
                     }
-                    if let Ok(target) = self.current.get_edge_target(edge_id) {
-                        neighbors.push((target, edge_id));
+                    if let Ok(target) = current.get_edge_target(edge_id) {
+                        f(target, edge_id);
                     }
                 };
 
-                if let Some(ref label) = self.label {
-                    for edge_id in self
-                        .current
-                        .get_outgoing_edges_with_label_iter(node_id, label)
-                    {
+                if let Some(lbl) = label {
+                    for edge_id in current.get_outgoing_edges_with_label_iter(node_id, lbl) {
                         process_outgoing(edge_id);
                     }
                 } else {
-                    for edge_id in self.current.get_outgoing_edges_iter(node_id) {
+                    for edge_id in current.get_outgoing_edges_iter(node_id) {
                         process_outgoing(edge_id);
                     }
                 }
 
-                // Zero-copy: only get source NodeId, not full Edge (Issue #190)
                 let mut process_incoming = |edge_id| {
-                    if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                    if !edge_visible_at_time(edge_id, &historical_guard) {
                         return;
                     }
-                    if let Ok(source) = self.current.get_edge_source(edge_id) {
-                        neighbors.push((source, edge_id));
+                    if let Ok(source) = current.get_edge_source(edge_id) {
+                        f(source, edge_id);
                     }
                 };
 
-                if let Some(ref label) = self.label {
-                    for edge_id in self
-                        .current
-                        .get_incoming_edges_with_label_iter(node_id, label)
-                    {
+                if let Some(lbl) = label {
+                    for edge_id in current.get_incoming_edges_with_label_iter(node_id, lbl) {
                         process_incoming(edge_id);
                     }
                 } else {
-                    for edge_id in self.current.get_incoming_edges_iter(node_id) {
+                    for edge_id in current.get_incoming_edges_iter(node_id) {
                         process_incoming(edge_id);
                     }
                 }
-
-                neighbors
             }
         }
     }
@@ -843,16 +809,23 @@ impl ResultIterator for TraversalIterator {
                 }
 
                 // Expand neighbors
-                let neighbors = self.get_neighbors(node_id);
-                for (target, edge_id) in neighbors {
-                    if self.visited.insert(target) {
-                        let mut new_path = path.clone();
-                        new_path.push(EntityId::Edge(edge_id));
-                        new_path.push(EntityId::Node(target));
-                        self.frontier
-                            .push_back((target, new_path, current_depth + 1));
-                    }
-                }
+                Self::process_neighbors(
+                    &self.direction,
+                    self.label.as_ref(),
+                    &self.current,
+                    self.temporal_context,
+                    &self.historical,
+                    node_id,
+                    |target, edge_id| {
+                        if self.visited.insert(target) {
+                            let mut new_path = path.clone();
+                            new_path.push(EntityId::Edge(edge_id));
+                            new_path.push(EntityId::Node(target));
+                            self.frontier
+                                .push_back((target, new_path, current_depth + 1));
+                        }
+                    },
+                );
                 continue;
             }
 

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -1485,3 +1485,4 @@ mod tests {
         assert!(node.properties.get("embedding").is_none());
     }
 }
+mod traversal_iterator_tests;

--- a/src/query/executor/traversal_iterator_tests.rs
+++ b/src/query/executor/traversal_iterator_tests.rs
@@ -1,0 +1,209 @@
+#[cfg(test)]
+mod traversal_tests {
+    use super::super::iterators::*;
+    use crate::core::id::NodeId;
+    use crate::core::property::PropertyMapBuilder;
+    use crate::query::ir::Direction;
+    use crate::storage::current::CurrentStorage;
+    use crate::storage::historical::HistoricalStorage;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn create_test_node(current: &Arc<CurrentStorage>, label: &str) -> NodeId {
+        current
+            .create_node(label, PropertyMapBuilder::new().build())
+            .unwrap()
+    }
+
+    fn create_test_edge(
+        current: &Arc<CurrentStorage>,
+        source: NodeId,
+        target: NodeId,
+        label: &str,
+    ) {
+        current
+            .create_edge(source, target, label, PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+
+    // Helper for setup
+    fn setup_storage() -> (Arc<CurrentStorage>, Arc<RwLock<HistoricalStorage>>) {
+        let current = Arc::new(CurrentStorage::new());
+        let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        (current, historical)
+    }
+
+    #[test]
+    fn test_traversal_outgoing() {
+        let (current, historical) = setup_storage();
+        let n1 = create_test_node(&current, "Person");
+        let n2 = create_test_node(&current, "Person");
+        let n3 = create_test_node(&current, "Person");
+
+        create_test_edge(&current, n1, n2, "KNOWS");
+        create_test_edge(&current, n1, n3, "LIKES");
+
+        let input = Box::new(NodeLookupIterator::new(vec![n1], current.clone()));
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Outgoing,
+            None,
+            1,
+            current.clone(),
+            historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+        results.sort();
+        assert_eq!(results, vec![n2, n3]);
+    }
+
+    #[test]
+    fn test_traversal_outgoing_with_label() {
+        let (current, historical) = setup_storage();
+        let n1 = create_test_node(&current, "Person");
+        let n2 = create_test_node(&current, "Person");
+        let n3 = create_test_node(&current, "Person");
+
+        create_test_edge(&current, n1, n2, "KNOWS");
+        create_test_edge(&current, n1, n3, "LIKES");
+
+        let input = Box::new(NodeLookupIterator::new(vec![n1], current.clone()));
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Outgoing,
+            Some("KNOWS".to_string()),
+            1,
+            current.clone(),
+            historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+        assert_eq!(results, vec![n2]);
+    }
+
+    #[test]
+    fn test_traversal_incoming() {
+        let (current, historical) = setup_storage();
+        let n1 = create_test_node(&current, "Person");
+        let n2 = create_test_node(&current, "Person");
+        let n3 = create_test_node(&current, "Person");
+
+        create_test_edge(&current, n2, n1, "KNOWS");
+        create_test_edge(&current, n3, n1, "LIKES");
+
+        let input = Box::new(NodeLookupIterator::new(vec![n1], current.clone()));
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Incoming,
+            None,
+            1,
+            current.clone(),
+            historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+        results.sort();
+        assert_eq!(results, vec![n2, n3]);
+    }
+
+    #[test]
+    fn test_traversal_incoming_with_label() {
+        let (current, historical) = setup_storage();
+        let n1 = create_test_node(&current, "Person");
+        let n2 = create_test_node(&current, "Person");
+        let n3 = create_test_node(&current, "Person");
+
+        create_test_edge(&current, n2, n1, "KNOWS");
+        create_test_edge(&current, n3, n1, "LIKES");
+
+        let input = Box::new(NodeLookupIterator::new(vec![n1], current.clone()));
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Incoming,
+            Some("KNOWS".to_string()),
+            1,
+            current.clone(),
+            historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+        assert_eq!(results, vec![n2]);
+    }
+
+    #[test]
+    fn test_traversal_both() {
+        let (current, historical) = setup_storage();
+        let n1 = create_test_node(&current, "Person");
+        let n2 = create_test_node(&current, "Person");
+        let n3 = create_test_node(&current, "Person");
+
+        create_test_edge(&current, n1, n2, "KNOWS");
+        create_test_edge(&current, n3, n1, "LIKES");
+
+        let input = Box::new(NodeLookupIterator::new(vec![n1], current.clone()));
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Both,
+            None,
+            1,
+            current.clone(),
+            historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+        results.sort();
+        assert_eq!(results, vec![n2, n3]);
+    }
+
+    #[test]
+    fn test_traversal_both_with_label() {
+        let (current, historical) = setup_storage();
+        let n1 = create_test_node(&current, "Person");
+        let n2 = create_test_node(&current, "Person");
+        let n3 = create_test_node(&current, "Person");
+        let n4 = create_test_node(&current, "Person");
+
+        create_test_edge(&current, n1, n2, "KNOWS");
+        create_test_edge(&current, n3, n1, "KNOWS");
+        create_test_edge(&current, n1, n4, "LIKES"); // Should be filtered out
+
+        let input = Box::new(NodeLookupIterator::new(vec![n1], current.clone()));
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Both,
+            Some("KNOWS".to_string()),
+            1,
+            current.clone(),
+            historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+        results.sort();
+        assert_eq!(results, vec![n2, n3]);
+    }
+}


### PR DESCRIPTION
💡 What: Refactored `TraversalIterator` to use `process_neighbors` with a closure (`FnMut`) instead of returning an intermediate `Vec<(NodeId, EdgeId)>`.
🎯 Why: `get_neighbors` allocated a new `Vec` to store the neighbor nodes and edge IDs on each step of a BFS graph traversal, resulting in unnecessary heap allocation overhead on a very hot path. 
📊 Impact: Eliminates `O(E)` dynamic memory allocations per visited node during query execution graph traversals.
🔬 Measurement: Verifiable by inspecting the memory allocations removed from the `TraversalIterator::next` hot loop. Checked with `cargo test --lib query::executor::iterators`.

---
*PR created automatically by Jules for task [7477346558178293236](https://jules.google.com/task/7477346558178293236) started by @madmax983*