### PR TITLE
🎻 Bard: [documentation update] Fix README compilation and expand core docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ use aletheiadb::storage::wal::DurabilityMode;
 
 // Load from TOML file (requires file to exist)
 // let config = AletheiaDBConfig::from_toml_file("config/production.toml")?;
-// let db = AletheiaDB::with_unified_config(config);
+// let _db = AletheiaDB::with_unified_config(config);
 
 // Programmatic configuration
 let config = AletheiaDBConfig::builder()
@@ -799,6 +799,7 @@ db.write(|tx| {
 AletheiaDB includes an optional embedding generation system for semantic search:
 
 ```rust
+use aletheiadb::prelude::*;
 use aletheiadb::{AletheiaDB, properties};
 use aletheiadb::embeddings::{EmbeddingService, providers::openai::*};
 use std::sync::Arc;
@@ -861,6 +862,7 @@ features = [
 **Basic usage:**
 
 ```rust
+use aletheiadb::prelude::*;
 // ⚠️ REQUIRES FEATURE: observability
 // [dependencies]
 // aletheiadb = { version = "0.1", features = ["observability"] }

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -203,13 +203,44 @@ pub trait ReadOps {
 
     /// Find nodes by label and property value.
     ///
-    /// Returns the IDs of all nodes with the given label whose specified property
-    /// equals the given value. Only nodes visible in the current snapshot are returned.
+    /// This method is a targeted scan that retrieves the [`NodeId`]s of all nodes
+    /// matching the given label whose specified property strictly equals the given value.
+    /// It respects the snapshot isolation of the current transaction, meaning it only
+    /// returns nodes that were visible when this read transaction began.
     ///
     /// # Performance
     ///
     /// - **Time**: O(N) where N = nodes with the given label
-    /// - **Space**: O(M) where M = number of matching nodes
+    /// - **Space**: O(M) where M = matching nodes (allocates a Vec for results)
+    ///
+    /// *Note:* This operation currently performs a linear scan over all nodes with the
+    /// specified label. For highly selective queries on large datasets, this may be slow.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use aletheiadb::{AletheiaDB, properties};
+    /// # use aletheiadb::api::transaction::{ReadOps, WriteOps};
+    /// # use aletheiadb::core::property::PropertyValue;
+    /// # use aletheiadb::core::error::Error;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// db.write(|tx| -> Result<(), Error> {
+    ///     tx.create_node("User", properties!{"status" => "active", "tier" => "pro"})?;
+    ///     tx.create_node("User", properties!{"status" => "inactive", "tier" => "free"})?;
+    ///     Ok(())
+    /// })?;
+    ///
+    /// db.read(|tx| -> Result<(), Error> {
+    ///     // Find all users who are currently active
+    ///     let active_val = PropertyValue::String("active".into());
+    ///     let active_users = tx.find_nodes_by_property("User", "status", &active_val);
+    ///     assert_eq!(active_users.len(), 1);
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())
+    /// # }
+    /// ```
     fn find_nodes_by_property(
         &self,
         label: &str,

--- a/src/index/adjacency.rs
+++ b/src/index/adjacency.rs
@@ -439,8 +439,11 @@ impl AdjacencyIndex {
 
     /// Get total number of edges in the index.
     ///
-    /// Returns the exact size of the underlying flat CSR edges array.
-    /// Because the array is flat, this is an O(1) operation.
+    /// Retrieves the exact size of the underlying flat CSR edges array.
+    /// Because the index stores edges sequentially in a single contiguous block
+    /// of memory (the Compressed Sparse Row architecture), determining the total
+    /// edge count avoids any iteration or pointer chasing. This makes it an
+    /// extremely cheap `O(1)` operation.
     ///
     /// ## Examples
     ///
@@ -515,9 +518,13 @@ impl AdjacencyIndex {
 
     /// Get the number of nodes with outgoing edges.
     ///
-    /// Returns the exact size of the underlying CSR `node_ids` array.
-    /// Because the array only stores source nodes, this reflects the number
-    /// of unique nodes with an out-degree > 0. This is an O(1) operation.
+    /// Retrieves the exact size of the underlying CSR `node_ids` array.
+    ///
+    /// In a CSR graph, nodes that do not possess any outgoing edges are not allocated
+    /// a dedicated index slot in the sparse array structure in order to save memory.
+    /// Therefore, this method specifically reflects the number of unique nodes acting
+    /// as "sources" (out-degree > 0), rather than the total number of nodes in the database.
+    /// This is an `O(1)` operation.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
📖 **Chapter**: Getting Started & Core Storage Documentation
🔦 **Insight**: The README examples were failing to compile due to missing prelude imports and unused variables. The `IndexNotFound` hint still directed developers to an outdated vector index API. Several `ReadOps` and `AdjacencyIndex` methods had sparse, tautological "Gets the X" doc comments that didn't explain *why* they were performant or how they worked in the context of snapshot isolation.
🧪 **Example**: Added executable doctests with explicit database setup blocks to `find_nodes_by_property`. Updated the Adjacency Index docstrings to explain the `O(1)` complexity derived from the underlying flat CSR arrays.
🖼️ **Preview**: N/A

---
*PR created automatically by Jules for task [2725732429676946491](https://jules.google.com/task/2725732429676946491) started by @madmax983*