### PR TITLE
👺 Havoc: NaN/Infinity Vector Injection

### DIFF
--- a/fix_property.py
+++ b/fix_property.py
@@ -1,0 +1,16 @@
+with open("src/core/property.rs", "r") as f:
+    c = f.read()
+
+c = c.replace('''    pub fn try_vector<V: AsRef<[f32]>>(v: V) -> Result<Self> {
+        let slice = v.as_ref();
+        validate_vector_dimensions(slice.len())?;
+        Ok(PropertyValue::Vector(Arc::from(slice)))
+    }''', '''    pub fn try_vector<V: AsRef<[f32]>>(v: V) -> Result<Self> {
+        let slice = v.as_ref();
+        validate_vector_dimensions(slice.len())?;
+        crate::core::vector::serialization::validate_vector_values(slice)?;
+        Ok(PropertyValue::Vector(Arc::from(slice)))
+    }''')
+
+with open("src/core/property.rs", "w") as f:
+    f.write(c)

--- a/fix_serialization.py
+++ b/fix_serialization.py
@@ -1,0 +1,93 @@
+with open("src/core/vector/serialization.rs", "r") as f:
+    c = f.read()
+
+c = c.replace('''pub(crate) fn validate_vector_dimensions(len: usize) -> Result<()> {
+    if len > MAX_VECTOR_DIMENSIONS {
+        return Err(Error::Vector(VectorError::DimensionTooLarge {
+            dimension: len,
+            max_allowed: MAX_VECTOR_DIMENSIONS,
+        }));
+    }
+    Ok(())
+}''', '''pub(crate) fn validate_vector_dimensions(len: usize) -> Result<()> {
+    if len > MAX_VECTOR_DIMENSIONS {
+        return Err(Error::Vector(VectorError::DimensionTooLarge {
+            dimension: len,
+            max_allowed: MAX_VECTOR_DIMENSIONS,
+        }));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_vector_values(v: &[f32]) -> Result<()> {
+    let mut nan_count = 0;
+    let mut inf_count = 0;
+
+    for &val in v {
+        if val.is_nan() {
+            nan_count += 1;
+        } else if val.is_infinite() {
+            inf_count += 1;
+        }
+    }
+
+    if nan_count > 0 {
+        return Err(Error::Vector(VectorError::ContainsNaN { count: nan_count }));
+    }
+    if inf_count > 0 {
+        return Err(Error::Vector(VectorError::ContainsInfinity { count: inf_count }));
+    }
+    Ok(())
+}''')
+
+c = c.replace('''pub fn try_serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) -> Result<()> {
+    // Defensive check: vectors should be validated at construction via PropertyValue::vector()
+    validate_vector_dimensions(v.len())?;''', '''pub fn try_serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) -> Result<()> {
+    // Defensive check: vectors should be validated at construction via PropertyValue::vector()
+    validate_vector_dimensions(v.len())?;
+    validate_vector_values(v)?;''')
+
+c = c.replace('''        // Big-endian fallback: convert each element individually
+        let mut values = Vec::with_capacity(dimension);
+        for chunk in data_slice.chunks_exact(4) {
+            values.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        }
+        values
+    };
+
+    Ok((Arc::from(values.into_boxed_slice()), total_len))''', '''        // Big-endian fallback: convert each element individually
+        let mut values = Vec::with_capacity(dimension);
+        for chunk in data_slice.chunks_exact(4) {
+            values.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        }
+        values
+    };
+
+    validate_vector_values(&values)?;
+
+    Ok((Arc::from(values.into_boxed_slice()), total_len))''')
+
+c = c.replace('''    #[cfg(not(target_endian = "little"))]
+    let values = {
+        let mut values = Vec::with_capacity(nnz);
+        for chunk in values_slice.chunks_exact(4) {
+            values.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        }
+        values
+    };
+
+    // Construct SparseVec (this will validate the data)''', '''    #[cfg(not(target_endian = "little"))]
+    let values = {
+        let mut values = Vec::with_capacity(nnz);
+        for chunk in values_slice.chunks_exact(4) {
+            values.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        }
+        values
+    };
+
+    validate_vector_values(&values)?;
+
+    // Construct SparseVec (this will validate the data)''')
+
+with open("src/core/vector/serialization.rs", "w") as f:
+    f.write(c)

--- a/test.rs
+++ b/test.rs
@@ -1,0 +1,7 @@
+use aletheiadb::core::property::PropertyValue;
+
+fn main() {
+    let vec_with_nan: Vec<f32> = vec![1.0f32, f32::NAN, 2.0f32];
+    let nan_vec_result = PropertyValue::try_vector(&vec_with_nan);
+    println!("{:?}", nan_vec_result);
+}


### PR DESCRIPTION
* 🧨 **The Trigger:** Passing `f32::NAN` or `f32::INFINITY` into `PropertyValue::vector` or raw serialized streams allows corrupted mathematical structures to pollute index graphs without explicitly failing.
* 📉 **The Stack Trace:** No explicit stack trace - this is a silent mathematical corruption vulnerability.
* 🧪 **Reproduction:** `cargo test --test havoc test_property_value_rejects_nan_and_infinity`
* 😈 **Comment:** "Math only works if the numbers are numbers."

---
*PR created automatically by Jules for task [7149526336574586456](https://jules.google.com/task/7149526336574586456) started by @madmax983*