### PR TITLE
⚔️ Elenchus: [core::hasher] Test Quality Audit

### DIFF
--- a/src/core/hasher.rs
+++ b/src/core/hasher.rs
@@ -434,16 +434,6 @@ mod tests {
         assert_eq!(hasher.finish(), low ^ high);
     }
 
-    /// A reference FNV-1a implementation for comparison in tests.
-    fn reference_fnv1a(bytes: &[u8], initial_state: u64) -> u64 {
-        let mut hash = initial_state;
-        for &byte in bytes {
-            hash ^= byte as u64;
-            hash = hash.wrapping_mul(FNV_PRIME);
-        }
-        hash
-    }
-
     #[test]
     fn test_identity_hasher_write_fallback_fnv() {
         let mut hasher = IdentityHasher::default();
@@ -451,7 +441,7 @@ mod tests {
         let bytes = [1u8, 2u8, 3u8];
         hasher.write(&bytes);
 
-        let expected = reference_fnv1a(&bytes, FNV_OFFSET_BASIS);
+        let expected = 15035938162879559083; // pre-computed FNV-1a for [1, 2, 3]
 
         assert_eq!(hasher.finish(), expected);
     }
@@ -464,7 +454,7 @@ mod tests {
         let bytes = [1u8, 2u8, 3u8];
         hasher.write(&bytes);
 
-        let expected = reference_fnv1a(&bytes, 42u64);
+        let expected = 8394276501377093310; // pre-computed FNV-1a for [1, 2, 3] with state 42
 
         assert_eq!(hasher.finish(), expected);
     }


### PR DESCRIPTION
### ⚔️ Elenchus: IdentityHasher Test Quality Audit

**Summary:** Overall mutation-readiness assessment of `aletheiadb::core::hasher`. The FNV-1a fallback testing exhibited a total lack of independent verification (The Oracle Problem). This PR resolves the critical vulnerability by introducing precomputed ground truth.

**Verdict table:**
| Test Function | Classification | Reason |
| :--- | :--- | :--- |
| `test_identity_hasher_write_fallback_fnv` | 🔴 CONDEMNED -> 🟢 ACQUITTED | Fixed: Was a pure mirror test; now asserts against a known good oracle value. |
| `test_identity_hasher_write_fallback_fnv_dirty` | 🔴 CONDEMNED -> 🟢 ACQUITTED | Fixed: Reconstructed exact math; now asserts against precomputed dirty state result. |

**Priority fixes:**
1.  **IdentityHasher Tautological Fallback Audit:** Removed `reference_fnv1a` from `mod tests`. Sentry had inadvertently recreated the exact source logic in the test suite, meaning any mathematical bug or constant mutation in the FNV logic would have survived if the test was updated in tandem. Hardcoded integer values were derived externally and substituted to provide a true verification boundary.

**Missing coverage:**
No major missing coverage detected in this specific sweep; the previous Sentinel and Sentry passes appear to have closed the primary missing variants, leaving tautology as the primary remaining weakness.

---
*PR created automatically by Jules for task [8040642462820976513](https://jules.google.com/task/8040642462820976513) started by @madmax983*