### PR TITLE
⚡ Bolt: Pre-allocate Vec in collect_structured

### DIFF
--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -547,9 +547,13 @@ impl QueryResults {
     ///
     /// For very large result sets, this may consume significant memory. Consider using
     /// the streaming iterator directly for result sets exceeding 100K rows.
+    ///
+    /// ⚡ Bolt Optimization: Pre-allocates vector based on iterator's lower size bound
+    /// to reduce heap allocations during collection.
     pub fn collect_structured(mut self) -> Result<QueryResult> {
         // First pass: collect all rows
-        let mut rows = Vec::new();
+        let (lower, _) = self.iterator.size_hint();
+        let mut rows = Vec::with_capacity(lower);
         while let Some(row) = self.iterator.next() {
             rows.push(row?);
         }


### PR DESCRIPTION
💡 What: Switched from using `Vec::new()` to `Vec::with_capacity(lower)` in `QueryResults::collect_structured()`, using the lower bound from the iterator's `size_hint()`.
🎯 Why: `collect_structured` iterates over `self.iterator` and pushes rows into an initially empty `Vec`. For large result sets, this causes repeated heap reallocations. By pre-allocating using the known lower bound, we can avoid most of these allocations.
📊 Impact: Reduces heap allocations and reallocations when collecting structured query results.
🔬 Measurement: Run `cargo test --lib query -- executor::results::tests`.

---
*PR created automatically by Jules for task [7165805973312431792](https://jules.google.com/task/7165805973312431792) started by @madmax983*