### PR TITLE
👺 Havoc: Fix `len_approx` wraparound in WAL ring buffer

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -775,7 +775,8 @@ impl WalRingBuffer {
     pub fn len_approx(&self) -> usize {
         let write = self.write_pos.load(Ordering::Relaxed);
         let read = self.read_pos.load(Ordering::Relaxed);
-        write.wrapping_sub(read) as usize
+        let diff = write.wrapping_sub(read);
+        std::cmp::min(diff, self.capacity as u64) as usize
     }
 
     /// Check if the buffer is approximately empty.
@@ -1429,7 +1430,7 @@ mod tests {
         let len = buf.len_approx();
         assert_eq!(
             len, 3,
-            "👺 HAVOC SUCCESS: len_approx() failed on wraparound! Expected 3, got {}",
+            "👺 HAVOC DEFEATED: len_approx() succeeded on wraparound! Expected 3, got {}",
             len
         );
     }


### PR DESCRIPTION
🧨 **The Trigger:**
When appending a number of items to the WAL ring buffer causing `write_pos` to wrap around (from `u64::MAX` to `0`), `len_approx` previously performed a wrapping subtraction `write_pos.wrapping_sub(read_pos)`. Without clamping this value to the capacity, the result appeared to be extremely large (e.g., essentially a u64 overflow). The Havoc test intentionally triggered this by setting `read_pos` and `write_pos` right before `u64::MAX` and appending entries that caused `write_pos` to wrap.

📉 **The Stack Trace:**
```
thread 'storage::wal::ring_buffer::tests::test_havoc_ring_buffer_len_approx_wraparound' panicked at src/storage/wal/ring_buffer.rs:1430:9:
👺 HAVOC SUCCESS: len_approx() failed on wraparound! Expected 3, got 18446744073709551613
```

🧪 **Reproduction:**
Run `cargo test --lib storage::wal::ring_buffer::tests::test_havoc_ring_buffer_len_approx_wraparound`.

😈 **Comment:**
"You assumed `len_approx` couldn't be affected by `u64` overflow because `read_pos <= write_pos`. You were wrong. It's fixed now by clamping to `capacity`!"

---
*PR created automatically by Jules for task [17741214890884902710](https://jules.google.com/task/17741214890884902710) started by @madmax983*