### PR TITLE
⚔️ Elenchus: db Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -311,3 +311,10 @@
 **Finding:** The doc test example in `src/query/planner/rules/predicate_pushdown.rs` contained a weak assertion using `matches!`, which failed to verify the full AST structure after optimization. Furthermore, several unit tests (`test_push_filter_below_vector_rank_no_limit`, `test_push_filter_below_sort`, `test_binary_op_recursion_logic`, and `test_binary_op_partial_optimization`) included redundant and weak `assert!(result.is_some())` assertions.
 **Evidence:** The doc test used `assert!(matches!(optimized_plan.root, LogicalOp::Unary { op: UnaryOp::Sort { .. }, input: _ }));`, only verifying the root node type. The unit tests redundantly asserted `is_some()` before checking equality.
 **Recommendation:** Fixed the doc test to use an exact `expected_plan` and `assert_eq!(optimized_plan, expected_plan)` for complete structural verification (condensing the tree into single line structure to avoid Codecov issues). Updated the four unit tests to replace `assert!(result.is_some())` and `assert_eq!(result.unwrap(), expected_plan)` with a single robust `assert_eq!(result, Some(expected_plan))` check.
+
+**[Weak Assertions: Error Masking]**
+**Module:** `src/db/tests.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Multiple tests for non-existent entities (nodes, edges) and invalid relationships used the weak assertion `assert!(result.is_err())`. This asserts only that *some* error occurred, masking potential regressions where the operation fails for the wrong reason (e.g. a panic caught as an error, or a validation error instead of a not-found error).
+**Evidence:** Tests like `test_get_node_nonexistent`, `test_create_edge_invalid_target` simply asserted `is_err()` without checking the inner `StorageError` or `TransactionError` variants.
+**Recommendation:** Refactored these tests to use `assert!(matches!(result, Err(ExpectedVariant)))` to enforce strict error variant matching (e.g. `StorageError::NodeNotFound`, `StorageError::EdgeNotFound`, `TransactionError::ValidationFailed`).

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1002,7 +1002,12 @@ fn test_get_node_nonexistent() {
     let db = AletheiaDB::new().unwrap();
     let fake_id = NodeId::new(9999).unwrap();
     let result = db.get_node(fake_id);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Storage(
+            crate::core::error::StorageError::NodeNotFound(_)
+        ))
+    ));
 }
 
 #[test]
@@ -1010,7 +1015,12 @@ fn test_get_edge_nonexistent() {
     let db = AletheiaDB::new().unwrap();
     let fake_id = crate::core::id::EdgeId::new(9999).unwrap();
     let result = db.get_edge(fake_id);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Storage(
+            crate::core::error::StorageError::EdgeNotFound(_)
+        ))
+    ));
 }
 
 #[test]
@@ -1018,7 +1028,12 @@ fn test_get_edge_source_nonexistent() {
     let db = AletheiaDB::new().unwrap();
     let fake_id = crate::core::id::EdgeId::new(9999).unwrap();
     let result = db.get_edge_source(fake_id);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Storage(
+            crate::core::error::StorageError::EdgeNotFound(_)
+        ))
+    ));
 }
 
 #[test]
@@ -1026,7 +1041,12 @@ fn test_get_edge_target_nonexistent() {
     let db = AletheiaDB::new().unwrap();
     let fake_id = crate::core::id::EdgeId::new(9999).unwrap();
     let result = db.get_edge_target(fake_id);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Storage(
+            crate::core::error::StorageError::EdgeNotFound(_)
+        ))
+    ));
 }
 
 #[test]
@@ -1063,7 +1083,12 @@ fn test_create_edge_invalid_source() {
         "KNOWS",
         PropertyMapBuilder::new().build(),
     );
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Transaction(
+            crate::core::error::TransactionError::ValidationFailed { .. }
+        ))
+    ));
 }
 
 #[test]
@@ -1079,7 +1104,12 @@ fn test_create_edge_invalid_target() {
         "KNOWS",
         PropertyMapBuilder::new().build(),
     );
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Transaction(
+            crate::core::error::TransactionError::ValidationFailed { .. }
+        ))
+    ));
 }
 
 #[test]
@@ -1091,7 +1121,12 @@ fn test_create_edge_both_invalid() {
         "KNOWS",
         PropertyMapBuilder::new().build(),
     );
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::Transaction(
+            crate::core::error::TransactionError::ValidationFailed { .. }
+        ))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
**Summary**
This PR strengthens the test suite for the `db` module by replacing weak `is_err()` assertions with strict pattern matching on the exact expected error variants.

**Verdict table**
| Test | Verdict | Reason |
|---|---|---|
| `test_get_node_nonexistent` | 🟡 Suspect -> 🟢 Acquitted | Used `is_err()` masking wrong error types. Now explicitly checks for `NodeNotFound`. |
| `test_get_edge_nonexistent` | 🟡 Suspect -> 🟢 Acquitted | Used `is_err()`. Now explicitly checks for `EdgeNotFound`. |
| `test_get_edge_source_nonexistent` | 🟡 Suspect -> 🟢 Acquitted | Used `is_err()`. Now explicitly checks for `EdgeNotFound`. |
| `test_get_edge_target_nonexistent` | 🟡 Suspect -> 🟢 Acquitted | Used `is_err()`. Now explicitly checks for `EdgeNotFound`. |
| `test_create_edge_invalid_source` | 🔴 Condemned -> 🟢 Acquitted | Used `is_err()`. The assertion actually failed when strengthened to `NodeNotFound` because the underlying implementation returns `TransactionError::ValidationFailed`. Fixed to assert the correct error. |
| `test_create_edge_invalid_target` | 🔴 Condemned -> 🟢 Acquitted | Same issue as above. Fixed to assert `TransactionError::ValidationFailed`. |
| `test_create_edge_both_invalid` | 🔴 Condemned -> 🟢 Acquitted | Same issue as above. Fixed to assert `TransactionError::ValidationFailed`. |

**Priority fixes**
The `test_create_edge_invalid_*` tests were actively hiding the fact that they returned a `TransactionError::ValidationFailed` rather than a `StorageError::NodeNotFound`. This has been corrected.

**Missing coverage**
No new missing coverage was identified, but the existing coverage is now much more robust against regressions.

---
*PR created automatically by Jules for task [18072781028744847071](https://jules.google.com/task/18072781028744847071) started by @madmax983*