### PR TITLE
🗣️ Echo: Getting Started example is broken (NarrativeGenerator DX)

### DIFF
--- a/DX_AUDIT_REPORT_ECHO.md
+++ b/DX_AUDIT_REPORT_ECHO.md
@@ -34,3 +34,8 @@ The library is in good shape. The `Debug` implementation for the main struct sig
 
 Signed,
 **Echo** 🗣️
+
+#### 4. NarrativeGenerator Fake Implementation (Major)
+**Scenario:** "Tried to run the `story_demo`. The documentation said it needed `nova` feature. When I created a new project and didn't enable it, the error message I got wasn't helpful in a compiler way, it was just a warning, and it let me compile my code, then crashed at runtime!"
+**Result:** The feature gate `#[cfg(feature = "nova")]` for `NarrativeGenerator` was implemented by providing a deprecated stub that panics at runtime. This compiles successfully but crashes at runtime.
+**Fix:** Removed the `#[cfg(not(feature = "nova"))]` stub implementations and feature gated the module in `src/experimental/mod.rs` so that attempting to use it without the `nova` feature results in a clear compile-time error like `unresolved import` or `struct not found`, which is exactly what the `README.md` says would happen. By having a runtime panic, we violate the documentation's premise and the Rust expectation of failing at compile time for missing features.

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -185,6 +185,7 @@ pub mod telepathy;
 #[cfg(feature = "nova")]
 /// Temporal Diff Engine for computing snapshot differences.
 pub mod temporal_diff;
+#[cfg(feature = "nova")]
 /// Temporal narrative generator for natural language history logs.
 pub mod temporal_narrative;
 

--- a/src/experimental/temporal_narrative.rs
+++ b/src/experimental/temporal_narrative.rs
@@ -1,13 +1,9 @@
 use crate::AletheiaDB;
-#[cfg(feature = "nova")]
 use crate::core::GLOBAL_INTERNER;
 use crate::core::error::Result;
-#[cfg(feature = "nova")]
 use crate::core::history::{VersionDiff, VersionInfo};
 use crate::core::id::NodeId;
-#[cfg(feature = "nova")]
 use crate::core::interning::InternedString;
-#[cfg(feature = "nova")]
 use crate::core::temporal::time;
 
 /// A single event in the narrative history of an entity.
@@ -24,21 +20,10 @@ pub struct NarrativeEvent {
 }
 
 /// Generator for creating natural language narratives from temporal history.
-#[cfg(feature = "nova")]
 pub struct NarrativeGenerator<'a> {
     db: &'a AletheiaDB,
 }
 
-#[cfg(not(feature = "nova"))]
-/// Generator for creating natural language narratives from temporal history.
-#[deprecated(
-    note = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-)]
-pub struct NarrativeGenerator<'a> {
-    _marker: std::marker::PhantomData<&'a AletheiaDB>,
-}
-
-#[cfg(feature = "nova")]
 impl<'a> NarrativeGenerator<'a> {
     /// Create a new narrative generator.
     pub fn new(db: &'a AletheiaDB) -> Self {
@@ -140,37 +125,7 @@ impl<'a> NarrativeGenerator<'a> {
     }
 }
 
-#[cfg(not(feature = "nova"))]
-#[allow(deprecated)]
-impl<'a> NarrativeGenerator<'a> {
-    /// Create a new narrative generator.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-
-    /// Generate a narrative for a specific node.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-}
-
-#[cfg(all(test, feature = "nova"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::transaction::WriteOps;
@@ -285,36 +240,5 @@ mod tests {
                 .any(|s| s.contains("was '\"delete_me\"'")),
             "Expected original value in removal message"
         );
-    }
-}
-
-#[cfg(all(test, not(feature = "nova")))]
-#[allow(deprecated)]
-mod stub_tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
-        let db = AletheiaDB::new().unwrap();
-        // This should panic
-        let _ = NarrativeGenerator::new(&db);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
-        // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
-            _marker: std::marker::PhantomData,
-        };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
     }
 }


### PR DESCRIPTION
🗣️ Echo: Fix misleading runtime panics for NarrativeGenerator

### 🤦 The Confusion:
"Tried to run the `story_demo`. The documentation said it needed the `nova` feature. When I created a new project and didn't enable it, the error message I got wasn't helpful in a compiler way, it was just a warning, and it let me compile my code, then crashed at runtime!"

### 🕵️ The Reality:
The feature gate `#[cfg(feature = "nova")]` for `NarrativeGenerator` was implemented by providing a deprecated stub that panics at runtime. This compiles successfully but crashes at runtime, contradicting standard Rust DX and explicit documentation that promises an unresolved import.

### 💡 The Fix:
The stub implementation (`#[cfg(not(feature = "nova"))]`) for `NarrativeGenerator` has been removed. The module itself (`src/experimental/temporal_narrative.rs`) is now correctly feature-gated directly in `src/experimental/mod.rs`. Attempting to use it without the `nova` feature now correctly results in a clear compile-time error (`unresolved import`), matching expectations. Update included in `DX_AUDIT_REPORT_ECHO.md`.

---
*PR created automatically by Jules for task [8168410715698006824](https://jules.google.com/task/8168410715698006824) started by @madmax983*