### PR TITLE
⏱️ Chronos: Benchmark Report for latest commit

### DIFF
--- a/benchmarks/history.json
+++ b/benchmarks/history.json
@@ -1729,5 +1729,757 @@
         "std_dev_ns": 27171.71107871942
       }
     }
+  },
+  {
+    "timestamp": "2026-03-03T06:54:27.366554+00:00",
+    "commit": "268e122",
+    "branch": "jules-10636708643017105327-54e0d64f",
+    "benchmarks": {
+      "aletheiadb_node_creation": {
+        "point_estimate_ns": 98575.83371273262,
+        "ci_lower_ns": 90689.89329348289,
+        "ci_upper_ns": 106151.5373996296,
+        "std_dev_ns": 313311.27280214935
+      },
+      "aletheiadb_3_hop_traversal": {
+        "point_estimate_ns": 480.9010423276334,
+        "ci_lower_ns": 480.5417492009717,
+        "ci_upper_ns": 481.33038051034123,
+        "std_dev_ns": 2.3207495941495586
+      },
+      "aletheiadb_labeled_traversal": {
+        "point_estimate_ns": 160.24901986729475,
+        "ci_lower_ns": 159.6384037539917,
+        "ci_upper_ns": 161.07461922316912,
+        "std_dev_ns": 4.260224459993823
+      },
+      "aletheiadb_historical_stats": {
+        "point_estimate_ns": 1060.9385541335994,
+        "ci_lower_ns": 1055.3493649473712,
+        "ci_upper_ns": 1068.5488874880652,
+        "std_dev_ns": 78.71544152976732
+      },
+      "aletheiadb_edge_creation": {
+        "point_estimate_ns": 97409.58886371578,
+        "ci_lower_ns": 87690.33032203034,
+        "ci_upper_ns": 106708.90030726204,
+        "std_dev_ns": 326797.8658355379
+      },
+      "aletheiadb_out_degree": {
+        "point_estimate_ns": 106.36308621172634,
+        "ci_lower_ns": 105.72122261233667,
+        "ci_upper_ns": 106.98264964274624,
+        "std_dev_ns": 3.0696262796013087
+      },
+      "aletheiadb_in_degree": {
+        "point_estimate_ns": 99.89096106417895,
+        "ci_lower_ns": 98.83983032997963,
+        "ci_upper_ns": 101.4890018508264,
+        "std_dev_ns": 27.3547178209705
+      },
+      "aletheiadb_batch/batch_node_creation/100": {
+        "point_estimate_ns": 325397029.9,
+        "ci_lower_ns": 322391117.113,
+        "ci_upper_ns": 328390227.99899995,
+        "std_dev_ns": 10922234.024783077
+      },
+      "aletheiadb_batch/batch_node_creation/1000": {
+        "point_estimate_ns": 3302576801.4,
+        "ci_lower_ns": 3236176307.5885,
+        "ci_upper_ns": 3373227124.0645,
+        "std_dev_ns": 249331436.2315026
+      },
+      "aletheiadb_batch/batch_node_creation/10": {
+        "point_estimate_ns": 30397243.23,
+        "ci_lower_ns": 30051096.527125,
+        "ci_upper_ns": 30747962.88375,
+        "std_dev_ns": 1269341.5382926315
+      },
+      "time_travel/with_deltas_v15": {
+        "point_estimate_ns": 161.36243855847692,
+        "ci_lower_ns": 156.47016604612344,
+        "ci_upper_ns": 165.73223148388587,
+        "std_dev_ns": 22.931786683062867
+      },
+      "time_travel/worst_case_v19": {
+        "point_estimate_ns": 137.57487343899757,
+        "ci_lower_ns": 131.7883346207547,
+        "ci_upper_ns": 146.19098668326038,
+        "std_dev_ns": 48.68351712191426
+      },
+      "time_travel/deep_history_v5": {
+        "point_estimate_ns": 124.62564110406889,
+        "ci_lower_ns": 122.39407835499408,
+        "ci_upper_ns": 128.9306329651325,
+        "std_dev_ns": 5.03493091920285
+      },
+      "time_travel/at_anchor_v20": {
+        "point_estimate_ns": 122.05285897715636,
+        "ci_lower_ns": 121.98299425647447,
+        "ci_upper_ns": 122.12011985861746,
+        "std_dev_ns": 0.25384779319637046
+      },
+      "aletheiadb_single_hop/10000_nodes": {
+        "point_estimate_ns": 114.83917503156874,
+        "ci_lower_ns": 114.5414440965101,
+        "ci_upper_ns": 115.13922059594763,
+        "std_dev_ns": 0.6616150284334525
+      },
+      "aletheiadb_single_hop/100_nodes": {
+        "point_estimate_ns": 115.74426168442875,
+        "ci_lower_ns": 115.13513394589454,
+        "ci_upper_ns": 116.48345208749221,
+        "std_dev_ns": 2.0866907558021475
+      },
+      "aletheiadb_single_hop/1000_nodes": {
+        "point_estimate_ns": 114.9620557771512,
+        "ci_lower_ns": 114.79420000440768,
+        "ci_upper_ns": 115.14732947728338,
+        "std_dev_ns": 0.4641603872973116
+      },
+      "aletheiadb_fast_path/node_lookup/100": {
+        "point_estimate_ns": 61.48525363744229,
+        "ci_lower_ns": 61.43927693780358,
+        "ci_upper_ns": 61.54274994360206,
+        "std_dev_ns": 0.19910211941728956
+      },
+      "aletheiadb_fast_path/node_lookup/1000": {
+        "point_estimate_ns": 61.37950341988233,
+        "ci_lower_ns": 61.3206202687698,
+        "ci_upper_ns": 61.43426717903051,
+        "std_dev_ns": 0.16573357778956238
+      },
+      "aletheiadb_fast_path/node_lookup/10000": {
+        "point_estimate_ns": 62.112032963927184,
+        "ci_lower_ns": 61.87530053683396,
+        "ci_upper_ns": 62.397294494807326,
+        "std_dev_ns": 0.8006162483220643
+      }
+    }
+  },
+  {
+    "timestamp": "2026-03-15T02:30:09.832082+00:00",
+    "commit": "268e122",
+    "branch": "jules-10636708643017105327-54e0d64f",
+    "benchmarks": {
+      "aletheiadb_node_creation": {
+        "point_estimate_ns": 98587.62970186095,
+        "ci_lower_ns": 90698.29442179702,
+        "ci_upper_ns": 106173.72371252635,
+        "std_dev_ns": 311649.85990371724
+      },
+      "node_lookup": {
+        "point_estimate_ns": 57.35913619722359,
+        "ci_lower_ns": 56.50455736977553,
+        "ci_upper_ns": 58.057577969288594,
+        "std_dev_ns": 2.478978909261774
+      },
+      "aletheiadb_3_hop_traversal": {
+        "point_estimate_ns": 490.9566824714146,
+        "ci_lower_ns": 486.0911210610184,
+        "ci_upper_ns": 496.89226252026714,
+        "std_dev_ns": 27.204349912522094
+      },
+      "mixed_read_write_80_20": {
+        "point_estimate_ns": 16000283.62,
+        "ci_lower_ns": 15809894.181,
+        "ci_upper_ns": 16190992.190750001,
+        "std_dev_ns": 694296.5083462258
+      },
+      "out_degree": {
+        "point_estimate_ns": 359.75132622830426,
+        "ci_lower_ns": 356.85372429311076,
+        "ci_upper_ns": 362.5014469368608,
+        "std_dev_ns": 7.889877530865651
+      },
+      "labeled_traversal": {
+        "point_estimate_ns": 425.64406262430873,
+        "ci_lower_ns": 420.622228504982,
+        "ci_upper_ns": 431.62721114393304,
+        "std_dev_ns": 23.8432888104791
+      },
+      "aletheiadb_labeled_traversal": {
+        "point_estimate_ns": 157.15374083604598,
+        "ci_lower_ns": 154.35412086249553,
+        "ci_upper_ns": 160.18810752329708,
+        "std_dev_ns": 6.34016989521742
+      },
+      "aletheiadb_historical_stats": {
+        "point_estimate_ns": 943.6866053089475,
+        "ci_lower_ns": 937.0550959101432,
+        "ci_upper_ns": 950.83425962732,
+        "std_dev_ns": 22.104610984163774
+      },
+      "aletheiadb_edge_creation": {
+        "point_estimate_ns": 97436.22900990098,
+        "ci_lower_ns": 87868.1728304804,
+        "ci_upper_ns": 106706.3525712044,
+        "std_dev_ns": 329736.7550253931
+      },
+      "edge_lookup": {
+        "point_estimate_ns": 54.688862384150916,
+        "ci_lower_ns": 54.53080204617688,
+        "ci_upper_ns": 54.85548877609847,
+        "std_dev_ns": 0.6577688944393374
+      },
+      "3_hop_traversal": {
+        "point_estimate_ns": 50499.76467860099,
+        "ci_lower_ns": 50195.45179808302,
+        "ci_upper_ns": 50859.43997623219,
+        "std_dev_ns": 1490.776446113358
+      },
+      "find_neighbors": {
+        "point_estimate_ns": 1138.7508130323538,
+        "ci_lower_ns": 1133.0010882738668,
+        "ci_upper_ns": 1144.9304650388685,
+        "std_dev_ns": 33.00068384786064
+      },
+      "in_degree": {
+        "point_estimate_ns": 353.85812896033354,
+        "ci_lower_ns": 351.1177751389412,
+        "ci_upper_ns": 357.44752522291805,
+        "std_dev_ns": 11.74043677802048
+      },
+      "read_latency_p50_p99": {
+        "point_estimate_ns": 9.255731818014869,
+        "ci_lower_ns": 8.472376505454749,
+        "ci_upper_ns": 10.397560480532274,
+        "std_dev_ns": 46.38946563780239
+      },
+      "aletheiadb_out_degree": {
+        "point_estimate_ns": 100.89695770641809,
+        "ci_lower_ns": 100.08986265539227,
+        "ci_upper_ns": 101.68178816864175,
+        "std_dev_ns": 2.14312779223662
+      },
+      "node_creation": {
+        "point_estimate_ns": 3424.896199580742,
+        "ci_lower_ns": 3265.7409935797023,
+        "ci_upper_ns": 3570.1669011700205,
+        "std_dev_ns": 5232.938710870045
+      },
+      "aletheiadb_in_degree": {
+        "point_estimate_ns": 93.74131073468745,
+        "ci_lower_ns": 92.17469766364088,
+        "ci_upper_ns": 95.18538433100804,
+        "std_dev_ns": 4.109423942380016
+      },
+      "edge_creation": {
+        "point_estimate_ns": 3440.5106951057096,
+        "ci_lower_ns": 3322.669368720461,
+        "ci_upper_ns": 3539.767837277622,
+        "std_dev_ns": 4612.91616683829
+      },
+      "aletheiadb_batch/batch_node_creation/100": {
+        "point_estimate_ns": 320779687.18,
+        "ci_lower_ns": 318032787.8545,
+        "ci_upper_ns": 323449664.4575,
+        "std_dev_ns": 9826482.332096051
+      },
+      "aletheiadb_batch/batch_node_creation/1000": {
+        "point_estimate_ns": 3242852639.9,
+        "ci_lower_ns": 3214890051.227,
+        "ci_upper_ns": 3273274384.0959997,
+        "std_dev_ns": 106175397.50162914
+      },
+      "aletheiadb_batch/batch_node_creation/10": {
+        "point_estimate_ns": 29939598.485,
+        "ci_lower_ns": 29743041.610375,
+        "ci_upper_ns": 30138036.486874998,
+        "std_dev_ns": 722614.5848965567
+      },
+      "cold_batch_write_throughput/zstd/100": {
+        "point_estimate_ns": 7984555.209230771,
+        "ci_lower_ns": 7938082.85973077,
+        "ci_upper_ns": 8035914.551730769,
+        "std_dev_ns": 176757.74135319245
+      },
+      "cold_batch_write_throughput/zstd/1000": {
+        "point_estimate_ns": 67057959.66,
+        "ci_lower_ns": 66660094.097,
+        "ci_upper_ns": 67483061.61999999,
+        "std_dev_ns": 1504887.2352253841
+      },
+      "cold_batch_write_throughput/zstd/10000": {
+        "point_estimate_ns": 183446030.5,
+        "ci_lower_ns": 182197288.48250002,
+        "ci_upper_ns": 184820715.5985,
+        "std_dev_ns": 4794514.962395135
+      },
+      "cold_batch_write_throughput/fast/100": {
+        "point_estimate_ns": 5315076.176726849,
+        "ci_lower_ns": 5278580.774147371,
+        "ci_upper_ns": 5360815.23508413,
+        "std_dev_ns": 166366.75442118396
+      },
+      "cold_batch_write_throughput/fast/1000": {
+        "point_estimate_ns": 47496730.08000001,
+        "ci_lower_ns": 47190056.528333336,
+        "ci_upper_ns": 47822298.563,
+        "std_dev_ns": 1146849.8502744287
+      },
+      "cold_batch_write_throughput/fast/10000": {
+        "point_estimate_ns": 457425994.88,
+        "ci_lower_ns": 455340097.58,
+        "ci_upper_ns": 459588424.4665,
+        "std_dev_ns": 7743969.269904092
+      },
+      "id_generation_current/read_current_approximate": {
+        "point_estimate_ns": 0.3391853652511247,
+        "ci_lower_ns": 0.3380311057358404,
+        "ci_upper_ns": 0.3405628788518511,
+        "std_dev_ns": 0.0054786215669653466
+      },
+      "id_generation_current/read_current": {
+        "point_estimate_ns": 0.33831643589648536,
+        "ci_lower_ns": 0.3371945946733663,
+        "ci_upper_ns": 0.3398494193620269,
+        "std_dev_ns": 0.00542802265524165
+      },
+      "serialization_simulation/resolve_with": {
+        "point_estimate_ns": 98287.18488410018,
+        "ci_lower_ns": 97919.88168313337,
+        "ci_upper_ns": 98634.33624391229,
+        "std_dev_ns": 1792.7067208014626
+      },
+      "serialization_simulation/resolve": {
+        "point_estimate_ns": 160238.28518578917,
+        "ci_lower_ns": 158939.2119208228,
+        "ci_upper_ns": 161410.04941458785,
+        "std_dev_ns": 3855.707324545374
+      },
+      "single_transaction_latency/async": {
+        "point_estimate_ns": 64900.051954701354,
+        "ci_lower_ns": 57170.80987311615,
+        "ci_upper_ns": 71961.69357918137,
+        "std_dev_ns": 36152.03227886931
+      },
+      "single_transaction_latency/synchronous": {
+        "point_estimate_ns": 738790.876715201,
+        "ci_lower_ns": 724415.2182177077,
+        "ci_upper_ns": 751570.2572508124,
+        "std_dev_ns": 62857.96577672319
+      },
+      "single_transaction_latency/group_commit_fast": {
+        "point_estimate_ns": 2005998.2242865462,
+        "ci_lower_ns": 1983871.007169227,
+        "ci_upper_ns": 2031190.052723856,
+        "std_dev_ns": 98480.73259396356
+      },
+      "single_transaction_latency/group_commit_default": {
+        "point_estimate_ns": 3202838.11062318,
+        "ci_lower_ns": 3167055.5776339755,
+        "ci_upper_ns": 3234592.4976296197,
+        "std_dev_ns": 206348.94605099864
+      },
+      "single_transaction_latency/async_batched_default": {
+        "point_estimate_ns": 9242505.828000002,
+        "ci_lower_ns": 9235120.238449996,
+        "ci_upper_ns": 9249805.207549999,
+        "std_dev_ns": 26842.586084467715
+      },
+      "single_transaction_latency/async_batched_aggressive": {
+        "point_estimate_ns": 5099493.626255096,
+        "ci_lower_ns": 5080978.541780118,
+        "ci_upper_ns": 5112408.729099465,
+        "std_dev_ns": 786485.0343885532
+      },
+      "hot_path/resolve_with/100": {
+        "point_estimate_ns": 1901.637951888068,
+        "ci_lower_ns": 1896.8598787370008,
+        "ci_upper_ns": 1907.0474461500407,
+        "std_dev_ns": 27.269522419156583
+      },
+      "hot_path/resolve_with/1000": {
+        "point_estimate_ns": 19530.006934736753,
+        "ci_lower_ns": 19398.531501352805,
+        "ci_upper_ns": 19697.45570992577,
+        "std_dev_ns": 851.7532529460259
+      },
+      "hot_path/resolve_with/10000": {
+        "point_estimate_ns": 193731.4561655157,
+        "ci_lower_ns": 191585.70712623544,
+        "ci_upper_ns": 196210.6015574444,
+        "std_dev_ns": 8895.807252286559
+      },
+      "hot_path/resolve/100": {
+        "point_estimate_ns": 3138.833386011678,
+        "ci_lower_ns": 3126.6970180313406,
+        "ci_upper_ns": 3152.9034587083343,
+        "std_dev_ns": 43.21022831163168
+      },
+      "hot_path/resolve/1000": {
+        "point_estimate_ns": 32127.303872708213,
+        "ci_lower_ns": 31636.61093267416,
+        "ci_upper_ns": 32600.41746161481,
+        "std_dev_ns": 868.9917992627544
+      },
+      "hot_path/resolve/10000": {
+        "point_estimate_ns": 315141.9923336768,
+        "ci_lower_ns": 312444.316501659,
+        "ci_upper_ns": 318045.347875309,
+        "std_dev_ns": 7589.250250671464
+      },
+      "id_generation_concurrent/threads/16": {
+        "point_estimate_ns": 709674.309256455,
+        "ci_lower_ns": 698247.643976185,
+        "ci_upper_ns": 722907.0409910163,
+        "std_dev_ns": 96789.67068012431
+      },
+      "id_generation_concurrent/threads/8": {
+        "point_estimate_ns": 328334.9012302316,
+        "ci_lower_ns": 324672.35345762194,
+        "ci_upper_ns": 332917.9937756368,
+        "std_dev_ns": 43371.33913632645
+      },
+      "id_generation_concurrent/threads/2": {
+        "point_estimate_ns": 111903.96722326904,
+        "ci_lower_ns": 109037.79148129158,
+        "ci_upper_ns": 114817.83265767172,
+        "std_dev_ns": 9270.484902539687
+      },
+      "id_generation_concurrent/threads/4": {
+        "point_estimate_ns": 184963.6136146556,
+        "ci_lower_ns": 183189.95861651443,
+        "ci_upper_ns": 187391.1175102174,
+        "std_dev_ns": 18212.611552273596
+      },
+      "get_outgoing_allocation/degree_100": {
+        "point_estimate_ns": 29.400045193928044,
+        "ci_lower_ns": 29.17944490468543,
+        "ci_upper_ns": 29.636421767818533,
+        "std_dev_ns": 0.6432608744548489
+      },
+      "get_outgoing_allocation/degree_1": {
+        "point_estimate_ns": 29.784490945350733,
+        "ci_lower_ns": 29.588192875573903,
+        "ci_upper_ns": 29.980640318112773,
+        "std_dev_ns": 0.6170122433388732
+      },
+      "get_outgoing_allocation/degree_10": {
+        "point_estimate_ns": 29.358700065504095,
+        "ci_lower_ns": 28.995499444619938,
+        "ci_upper_ns": 29.781735401787035,
+        "std_dev_ns": 0.7077294288663304
+      },
+      "arc_overhead/arc_clone_drop": {
+        "point_estimate_ns": 32.328183794413654,
+        "ci_lower_ns": 32.13436874000657,
+        "ci_upper_ns": 32.5263148522814,
+        "std_dev_ns": 0.6491062414822107
+      },
+      "arc_overhead/direct_access": {
+        "point_estimate_ns": 19.396578117291092,
+        "ci_lower_ns": 19.28828427424887,
+        "ci_upper_ns": 19.4986934367019,
+        "std_dev_ns": 0.48519869061310433
+      },
+      "time_travel/with_deltas_v15": {
+        "point_estimate_ns": 191.21739630911577,
+        "ci_lower_ns": 189.69653850993413,
+        "ci_upper_ns": 192.8624011233218,
+        "std_dev_ns": 5.503763104297013
+      },
+      "time_travel/worst_case_v19": {
+        "point_estimate_ns": 237.05254708231317,
+        "ci_lower_ns": 212.2969783676878,
+        "ci_upper_ns": 260.4385802490558,
+        "std_dev_ns": 38.83559599343729
+      },
+      "time_travel/deep_history_v5": {
+        "point_estimate_ns": 194.3435393463451,
+        "ci_lower_ns": 192.4565934899717,
+        "ci_upper_ns": 196.46573050706243,
+        "std_dev_ns": 5.648887299233414
+      },
+      "time_travel/at_anchor_v20": {
+        "point_estimate_ns": 196.70861146689114,
+        "ci_lower_ns": 193.2373649461988,
+        "ci_upper_ns": 200.0624776112326,
+        "std_dev_ns": 7.500842832237022
+      },
+      "cold_read_latency/single_read/fast_compression": {
+        "point_estimate_ns": 38472.0112284308,
+        "ci_lower_ns": 37829.46620484481,
+        "ci_upper_ns": 39358.866969005845,
+        "std_dev_ns": 3124.3447372824576
+      },
+      "cold_read_latency/single_read/no_compression": {
+        "point_estimate_ns": 3250.170524141374,
+        "ci_lower_ns": 3220.342873230004,
+        "ci_upper_ns": 3281.8449079685233,
+        "std_dev_ns": 99.07774910095385
+      },
+      "cold_read_latency/single_read/zstd_compression": {
+        "point_estimate_ns": 37930.24439795406,
+        "ci_lower_ns": 37432.55855761133,
+        "ci_upper_ns": 38486.62110422454,
+        "std_dev_ns": 3918.78040791088
+      },
+      "compression_ratio/compress/zstd": {
+        "point_estimate_ns": 40949194.79333333,
+        "ci_lower_ns": 40346152.9465,
+        "ci_upper_ns": 41634001.899333335,
+        "std_dev_ns": 2352491.0408831113
+      },
+      "compression_ratio/compress/fast": {
+        "point_estimate_ns": 37084809.88666666,
+        "ci_lower_ns": 36794899.11633332,
+        "ci_upper_ns": 37418278.28533333,
+        "std_dev_ns": 1135964.342782694
+      },
+      "compression_ratio/compress/no_compression": {
+        "point_estimate_ns": 27364011.215,
+        "ci_lower_ns": 27139303.981374998,
+        "ci_upper_ns": 27620779.145375002,
+        "std_dev_ns": 876828.4296574201
+      },
+      "id_generation_lifecycle/create_and_generate_1000": {
+        "point_estimate_ns": 8769.325187039713,
+        "ci_lower_ns": 8735.95246584717,
+        "ci_upper_ns": 8805.331804503474,
+        "std_dev_ns": 182.8318873571135
+      },
+      "checkpoint_load/100": {
+        "point_estimate_ns": 312875.5959213297,
+        "ci_lower_ns": 310506.8141760678,
+        "ci_upper_ns": 315588.33877747087,
+        "std_dev_ns": 6729.39472399416
+      },
+      "checkpoint_load/1000": {
+        "point_estimate_ns": 1490437.5406794797,
+        "ci_lower_ns": 1480874.2774808742,
+        "ci_upper_ns": 1503107.755379563,
+        "std_dev_ns": 35749.571050188126
+      },
+      "checkpoint_load/10000": {
+        "point_estimate_ns": 13147422.8175,
+        "ci_lower_ns": 13079969.189875001,
+        "ci_upper_ns": 13219135.1781875,
+        "std_dev_ns": 254189.1447241819
+      },
+      "recovery/100": {
+        "point_estimate_ns": 412587.27487245196,
+        "ci_lower_ns": 410517.92285266606,
+        "ci_upper_ns": 414941.2544204464,
+        "std_dev_ns": 11160.749810130703
+      },
+      "recovery/1000": {
+        "point_estimate_ns": 612701.4945037025,
+        "ci_lower_ns": 608041.8312649337,
+        "ci_upper_ns": 618572.4958030456,
+        "std_dev_ns": 20692.280031135237
+      },
+      "recovery/10": {
+        "point_estimate_ns": 401830.28163498704,
+        "ci_lower_ns": 392801.88623950374,
+        "ci_upper_ns": 410170.5133658444,
+        "std_dev_ns": 19206.754309456024
+      },
+      "multiple_accesses/resolve_100": {
+        "point_estimate_ns": 3136.695789647006,
+        "ci_lower_ns": 3130.643805816805,
+        "ci_upper_ns": 3143.391174481948,
+        "std_dev_ns": 53.65959967565472
+      },
+      "multiple_accesses/resolve_with_100": {
+        "point_estimate_ns": 1904.1517451492764,
+        "ci_lower_ns": 1897.0812662795802,
+        "ci_upper_ns": 1912.5808409852677,
+        "std_dev_ns": 22.867557705221117
+      },
+      "cold_write_latency/single_write/fast_compression": {
+        "point_estimate_ns": 341138.2491237359,
+        "ci_lower_ns": 337331.9055420343,
+        "ci_upper_ns": 346286.51798405213,
+        "std_dev_ns": 17713.154628067343
+      },
+      "cold_write_latency/single_write/no_compression": {
+        "point_estimate_ns": 288700.7208153757,
+        "ci_lower_ns": 283352.63924269116,
+        "ci_upper_ns": 294103.9113354154,
+        "std_dev_ns": 16063.512086707882
+      },
+      "cold_write_latency/single_write/zstd_compression": {
+        "point_estimate_ns": 450067.5095114217,
+        "ci_lower_ns": 439010.85784309707,
+        "ci_upper_ns": 461751.9020033441,
+        "std_dev_ns": 34555.17363775895
+      },
+      "aletheiadb_single_hop/10000_nodes": {
+        "point_estimate_ns": 104.56842069062493,
+        "ci_lower_ns": 102.9563665718424,
+        "ci_upper_ns": 106.41729698635747,
+        "std_dev_ns": 4.259298809003289
+      },
+      "aletheiadb_single_hop/100_nodes": {
+        "point_estimate_ns": 113.29739403731448,
+        "ci_lower_ns": 110.54215051293805,
+        "ci_upper_ns": 117.00478719681355,
+        "std_dev_ns": 10.915015610403742
+      },
+      "aletheiadb_single_hop/1000_nodes": {
+        "point_estimate_ns": 103.33543710414426,
+        "ci_lower_ns": 102.4425302112672,
+        "ci_upper_ns": 104.37148380507527,
+        "std_dev_ns": 2.370412817889779
+      },
+      "checkpoint_creation/100": {
+        "point_estimate_ns": 4050172.636668608,
+        "ci_lower_ns": 3949305.4544337266,
+        "ci_upper_ns": 4153974.1178758186,
+        "std_dev_ns": 501342.0921502577
+      },
+      "checkpoint_creation/1000": {
+        "point_estimate_ns": 4503956.974327315,
+        "ci_lower_ns": 4308249.538246574,
+        "ci_upper_ns": 4779138.332539268,
+        "std_dev_ns": 1036249.1865353642
+      },
+      "checkpoint_creation/10000": {
+        "point_estimate_ns": 8782351.653846152,
+        "ci_lower_ns": 8644668.41973077,
+        "ci_upper_ns": 8929586.26573077,
+        "std_dev_ns": 518924.9909319285
+      },
+      "aletheiadb_fast_path/node_lookup/100": {
+        "point_estimate_ns": 55.7091008492787,
+        "ci_lower_ns": 55.42447172264897,
+        "ci_upper_ns": 56.02559826085742,
+        "std_dev_ns": 1.3125043284570264
+      },
+      "aletheiadb_fast_path/node_lookup/1000": {
+        "point_estimate_ns": 62.21701260240902,
+        "ci_lower_ns": 61.69015469174057,
+        "ci_upper_ns": 62.87366149923121,
+        "std_dev_ns": 4.688050292788612
+      },
+      "aletheiadb_fast_path/node_lookup/10000": {
+        "point_estimate_ns": 61.496291652368335,
+        "ci_lower_ns": 60.745021414428756,
+        "ci_upper_ns": 62.19819330997648,
+        "std_dev_ns": 2.420109159211571
+      },
+      "string_length/resolve_with": {
+        "point_estimate_ns": 19.255809393842565,
+        "ci_lower_ns": 19.152395186325602,
+        "ci_upper_ns": 19.383044607637057,
+        "std_dev_ns": 0.3150626111918453
+      },
+      "string_length/resolve": {
+        "point_estimate_ns": 31.90334249184791,
+        "ci_lower_ns": 31.69429490883091,
+        "ci_upper_ns": 32.14330715230428,
+        "std_dev_ns": 0.6172536006340448
+      },
+      "string_access_single/resolve_with": {
+        "point_estimate_ns": 20.35724248819866,
+        "ci_lower_ns": 20.27236814837408,
+        "ci_upper_ns": 20.453807889796284,
+        "std_dev_ns": 0.3822012946057436
+      },
+      "string_access_single/resolve": {
+        "point_estimate_ns": 32.818241884097105,
+        "ci_lower_ns": 32.645380020704096,
+        "ci_upper_ns": 32.98610340843367,
+        "std_dev_ns": 0.6434443187760562
+      },
+      "find_nodes_by_property/10000_nodes": {
+        "point_estimate_ns": 636240.7677227723,
+        "ci_lower_ns": 633251.7897069725,
+        "ci_upper_ns": 639761.8916203626,
+        "std_dev_ns": 15768.126485917852
+      },
+      "find_nodes_by_property/100_nodes": {
+        "point_estimate_ns": 4402.218632743769,
+        "ci_lower_ns": 4318.948439429574,
+        "ci_upper_ns": 4475.116267502731,
+        "std_dev_ns": 221.7327757959944
+      },
+      "find_nodes_by_property/1000_nodes": {
+        "point_estimate_ns": 36142.20156129338,
+        "ci_lower_ns": 35785.173598829075,
+        "ci_upper_ns": 36489.693447741134,
+        "std_dev_ns": 974.1706384497136
+      },
+      "batch_throughput/async": {
+        "point_estimate_ns": 52369763.22,
+        "ci_lower_ns": 52319985.3155,
+        "ci_upper_ns": 52420980.13025,
+        "std_dev_ns": 184188.66343654934
+      },
+      "batch_throughput/synchronous": {
+        "point_estimate_ns": 758780473.84,
+        "ci_lower_ns": 736164581.748,
+        "ci_upper_ns": 782289756.237,
+        "std_dev_ns": 83825985.85566933
+      },
+      "property_lookup_vs_scan/manual_label_scan_filter": {
+        "point_estimate_ns": 123678.92628721696,
+        "ci_lower_ns": 121011.41059538366,
+        "ci_upper_ns": 126741.9659046191,
+        "std_dev_ns": 4543.055201351237
+      },
+      "property_lookup_vs_scan/find_nodes_by_property": {
+        "point_estimate_ns": 34448.08784599822,
+        "ci_lower_ns": 34239.84849226928,
+        "ci_upper_ns": 34711.34199670512,
+        "std_dev_ns": 598.10185069911
+      },
+      "sustained_write_throughput/sustained_write_10k_versions_fast_reference": {
+        "point_estimate_ns": 458794148.95,
+        "ci_lower_ns": 456505203.7854167,
+        "ci_upper_ns": 461358424.9558334,
+        "std_dev_ns": 5706069.508446738
+      },
+      "sustained_write_throughput/sustained_write_10k_versions": {
+        "point_estimate_ns": 188724560.78333333,
+        "ci_lower_ns": 187325765.16979167,
+        "ci_upper_ns": 190176897.50479165,
+        "std_dev_ns": 3347370.1890176446
+      },
+      "id_generation_single_thread/sequential_10000": {
+        "point_estimate_ns": 63473.55253348864,
+        "ci_lower_ns": 63171.719199662795,
+        "ci_upper_ns": 63790.83584480766,
+        "std_dev_ns": 2620.243169220623
+      },
+      "id_generation_single_thread/sequential_1000": {
+        "point_estimate_ns": 6257.837940631038,
+        "ci_lower_ns": 6224.98239430881,
+        "ci_upper_ns": 6291.19886309539,
+        "std_dev_ns": 220.03936315799098
+      },
+      "single_hop_traversal/10000_nodes": {
+        "point_estimate_ns": 393.8347018356106,
+        "ci_lower_ns": 391.6432289532886,
+        "ci_upper_ns": 396.43115827687944,
+        "std_dev_ns": 9.855025669911928
+      },
+      "single_hop_traversal/100_nodes": {
+        "point_estimate_ns": 398.9846451310958,
+        "ci_lower_ns": 393.92418528622085,
+        "ci_upper_ns": 404.95239220421456,
+        "std_dev_ns": 19.63077225862747
+      },
+      "single_hop_traversal/1000_nodes": {
+        "point_estimate_ns": 412.45091885429673,
+        "ci_lower_ns": 408.7035430090078,
+        "ci_upper_ns": 416.7949170507843,
+        "std_dev_ns": 22.108862576618293
+      },
+      "string_comparison/resolve_with": {
+        "point_estimate_ns": 20.227907610077125,
+        "ci_lower_ns": 20.027186316174348,
+        "ci_upper_ns": 20.436556302310265,
+        "std_dev_ns": 0.4849035243422935
+      },
+      "string_comparison/resolve": {
+        "point_estimate_ns": 31.086784872762486,
+        "ci_lower_ns": 30.912788961032273,
+        "ci_upper_ns": 31.290283474344655,
+        "std_dev_ns": 1.1676686002666379
+      }
+    }
   }
 ]

--- a/benchmarks/report.html
+++ b/benchmarks/report.html
@@ -305,29 +305,29 @@
       <h1>CHRONOS</h1>
     </div>
     <div class="meta">
-      <span><span class="meta-label">commit</span> 198c57d</span>
-      <span><span class="meta-label">branch</span> jules-3069904928789557752-7bfd23b2</span>
-      <span><span class="meta-label">generated</span> 2026-02-21 20:43 UTC</span>
-      <span><span class="meta-label">history</span> 3 runs</span>
+      <span><span class="meta-label">commit</span> dc19c58</span>
+      <span><span class="meta-label">branch</span> jules-10636708643017105327-54e0d64f</span>
+      <span><span class="meta-label">generated</span> 2026-03-15 02:35 UTC</span>
+      <span><span class="meta-label">history</span> 6 runs</span>
     </div>
   </header>
 
-  <div class="verdict verdict-good">
-    <h2>✅ Performance Improved</h2>
-    <p>5 benchmarks got faster.</p>
+  <div class="verdict verdict-neutral">
+    <h2>➖ No Significant Changes</h2>
+    <p>All benchmarks within noise threshold.</p>
   </div>
 
   <div class="stats-row">
     <div class="stat-card stat-total">
-      <div class="stat-value">232</div>
+      <div class="stat-value">103</div>
       <div class="stat-label">Total</div>
     </div>
     <div class="stat-card stat-improved">
-      <div class="stat-value">5</div>
+      <div class="stat-value">0</div>
       <div class="stat-label">Improved</div>
     </div>
     <div class="stat-card stat-stable">
-      <div class="stat-value">42</div>
+      <div class="stat-value">103</div>
       <div class="stat-label">Stable</div>
     </div>
     <div class="stat-card stat-regressed">
@@ -335,7 +335,7 @@
       <div class="stat-label">Regressed</div>
     </div>
     <div class="stat-card stat-new">
-      <div class="stat-value">185</div>
+      <div class="stat-value">0</div>
       <div class="stat-label">New</div>
     </div>
   </div>
@@ -354,1627 +354,724 @@
       </thead>
       <tbody>
 
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">3_hop_traversal</td>
-            <td class="numeric">—</td>
-            <td class="numeric">56.71 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">50.50 µs</td>
+            <td class="numeric">50.50 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_3_hop_traversal</td>
-            <td class="numeric">—</td>
-            <td class="numeric">483.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">491.0 ns</td>
+            <td class="numeric">491.0 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_batch/batch_node_creation/10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">27.81 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">29.94 ms</td>
+            <td class="numeric">29.94 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_batch/batch_node_creation/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">289.83 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">320.78 ms</td>
+            <td class="numeric">320.78 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_batch/batch_node_creation/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">2.831 s</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.243 s</td>
+            <td class="numeric">3.243 s</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_edge_creation</td>
-            <td class="numeric">—</td>
-            <td class="numeric">97.35 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">97.44 µs</td>
+            <td class="numeric">97.44 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_fast_path/node_lookup/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">62.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">55.7 ns</td>
+            <td class="numeric">55.7 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_fast_path/node_lookup/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">62.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">62.2 ns</td>
+            <td class="numeric">62.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_fast_path/node_lookup/10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">61.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">61.5 ns</td>
+            <td class="numeric">61.5 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_historical_stats</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.06 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">943.7 ns</td>
+            <td class="numeric">943.7 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_in_degree</td>
-            <td class="numeric">—</td>
-            <td class="numeric">104.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">93.7 ns</td>
+            <td class="numeric">93.7 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_labeled_traversal</td>
-            <td class="numeric">—</td>
-            <td class="numeric">159.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">157.2 ns</td>
+            <td class="numeric">157.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_node_creation</td>
-            <td class="numeric">—</td>
-            <td class="numeric">105.59 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">98.59 µs</td>
+            <td class="numeric">98.59 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_out_degree</td>
-            <td class="numeric">—</td>
-            <td class="numeric">100.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">100.9 ns</td>
+            <td class="numeric">100.9 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_single_hop/10000_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">116.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">104.6 ns</td>
+            <td class="numeric">104.6 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_single_hop/1000_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">116.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">103.3 ns</td>
+            <td class="numeric">103.3 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">aletheiadb_single_hop/100_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">116.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">113.3 ns</td>
+            <td class="numeric">113.3 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
+            <td class="bench-name">arc_overhead/arc_clone_drop</td>
+            <td class="numeric">32.3 ns</td>
+            <td class="numeric">32.3 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">arc_overhead/direct_access</td>
+            <td class="numeric">19.4 ns</td>
+            <td class="numeric">19.4 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">batch_throughput/async</td>
-            <td class="numeric">—</td>
-            <td class="numeric">52.79 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">52.37 ms</td>
+            <td class="numeric">52.37 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">batch_throughput/synchronous</td>
-            <td class="numeric">—</td>
-            <td class="numeric">635.75 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">758.78 ms</td>
+            <td class="numeric">758.78 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">checkpoint_creation/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.89 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">4.05 ms</td>
+            <td class="numeric">4.05 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">checkpoint_creation/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.03 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">4.50 ms</td>
+            <td class="numeric">4.50 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">checkpoint_creation/10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">7.66 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">8.78 ms</td>
+            <td class="numeric">8.78 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">checkpoint_load/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">323.51 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">312.88 µs</td>
+            <td class="numeric">312.88 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">checkpoint_load/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.63 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">1.49 ms</td>
+            <td class="numeric">1.49 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">checkpoint_load/10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">15.18 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">closure_write_single_node</td>
-            <td class="numeric">2.81 ms</td>
-            <td class="numeric">2.81 ms</td>
+            <td class="numeric">13.15 ms</td>
+            <td class="numeric">13.15 ms</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_batch_write_throughput/fast/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.93 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">5.32 ms</td>
+            <td class="numeric">5.32 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_batch_write_throughput/fast/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">45.81 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">47.50 ms</td>
+            <td class="numeric">47.50 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_batch_write_throughput/fast/10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">454.83 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">457.43 ms</td>
+            <td class="numeric">457.43 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_batch_write_throughput/zstd/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">7.45 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">7.98 ms</td>
+            <td class="numeric">7.98 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_batch_write_throughput/zstd/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">66.78 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">67.06 ms</td>
+            <td class="numeric">67.06 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_batch_write_throughput/zstd/10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">189.51 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">183.45 ms</td>
+            <td class="numeric">183.45 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_read_latency/single_read/fast_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">34.54 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">38.47 µs</td>
+            <td class="numeric">38.47 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_read_latency/single_read/no_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">3.31 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.25 µs</td>
+            <td class="numeric">3.25 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_read_latency/single_read/zstd_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">34.41 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">37.93 µs</td>
+            <td class="numeric">37.93 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_write_latency/single_write/fast_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">340.43 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">341.14 µs</td>
+            <td class="numeric">341.14 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_write_latency/single_write/no_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">343.79 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">288.70 µs</td>
+            <td class="numeric">288.70 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">cold_write_latency/single_write/zstd_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">373.87 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">450.07 µs</td>
+            <td class="numeric">450.07 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
-            <td class="bench-name">comparison_csr/full_rebuild_insert_query</td>
-            <td class="numeric">—</td>
-            <td class="numeric">140.05 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">comparison_csr/incremental_csr_insert_query</td>
-            <td class="numeric">—</td>
-            <td class="numeric">16.60 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">compression_ratio/compress/fast</td>
-            <td class="numeric">—</td>
-            <td class="numeric">34.87 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">37.08 ms</td>
+            <td class="numeric">37.08 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">compression_ratio/compress/no_compression</td>
-            <td class="numeric">—</td>
-            <td class="numeric">31.26 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">27.36 ms</td>
+            <td class="numeric">27.36 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">compression_ratio/compress/zstd</td>
-            <td class="numeric">—</td>
-            <td class="numeric">36.22 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/10000_versions/2_readers</td>
-            <td class="numeric">133.88 µs</td>
-            <td class="numeric">133.88 µs</td>
+            <td class="numeric">40.95 ms</td>
+            <td class="numeric">40.95 ms</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/10000_versions/4_readers</td>
-            <td class="numeric">474.74 µs</td>
-            <td class="numeric">474.74 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/1000_versions/16_readers</td>
-            <td class="numeric">767.65 µs</td>
-            <td class="numeric">767.65 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/1000_versions/2_readers</td>
-            <td class="numeric">130.10 µs</td>
-            <td class="numeric">130.10 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/1000_versions/4_readers</td>
-            <td class="numeric">220.64 µs</td>
-            <td class="numeric">220.64 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/1000_versions/8_readers</td>
-            <td class="numeric">422.91 µs</td>
-            <td class="numeric">422.91 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/100_versions/16_readers</td>
-            <td class="numeric">696.72 µs</td>
-            <td class="numeric">696.72 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/100_versions/2_readers</td>
-            <td class="numeric">130.26 µs</td>
-            <td class="numeric">130.26 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/100_versions/4_readers</td>
-            <td class="numeric">203.70 µs</td>
-            <td class="numeric">203.70 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_reads_same_entity/100_versions/8_readers</td>
-            <td class="numeric">383.87 µs</td>
-            <td class="numeric">383.87 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_writes/different_entities/2</td>
-            <td class="numeric">139.71 µs</td>
-            <td class="numeric">139.71 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_writes/different_entities/4</td>
-            <td class="numeric">220.01 µs</td>
-            <td class="numeric">220.01 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_writes/different_entities/8</td>
-            <td class="numeric">417.36 µs</td>
-            <td class="numeric">417.36 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_writes/same_entity_contention/2</td>
-            <td class="numeric">214.57 µs</td>
-            <td class="numeric">214.57 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_writes/same_entity_contention/4</td>
-            <td class="numeric">1.23 ms</td>
-            <td class="numeric">1.23 ms</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">concurrent_writes/same_entity_contention/8</td>
-            <td class="numeric">9.48 ms</td>
-            <td class="numeric">9.48 ms</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/naive_3pass/1024</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.60 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/naive_3pass/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">6.95 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/naive_3pass/3072</td>
-            <td class="numeric">—</td>
-            <td class="numeric">14.03 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/naive_3pass/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.65 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/naive_3pass/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">3.44 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/optimized/1024</td>
-            <td class="numeric">—</td>
-            <td class="numeric">201.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/optimized/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">299.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/optimized/3072</td>
-            <td class="numeric">—</td>
-            <td class="numeric">592.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/optimized/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">77.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/optimized/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">151.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/scalar_1pass/1024</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.58 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/scalar_1pass/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">2.36 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/scalar_1pass/3072</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.73 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/scalar_1pass/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">636.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity/scalar_1pass/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.18 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_batch/find_most_similar/10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">811.3 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_batch/find_most_similar/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">8.28 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_batch/find_most_similar/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">90.46 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_normalized/general/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">300.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_normalized/general/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">78.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_normalized/specialized/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">284.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_normalized/specialized/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">56.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">cosine_similarity_openai_1536d</td>
-            <td class="numeric">—</td>
-            <td class="numeric">301.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
             <td class="bench-name">edge_creation</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.46 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.44 µs</td>
+            <td class="numeric">3.44 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">edge_lookup</td>
-            <td class="numeric">—</td>
-            <td class="numeric">62.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">54.7 ns</td>
+            <td class="numeric">54.7 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/optimized/1024</td>
-            <td class="numeric">—</td>
-            <td class="numeric">175.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/optimized/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">272.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/optimized/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">65.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/optimized/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">123.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/scalar/1024</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.55 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/scalar/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">2.33 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/scalar/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">566.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/scalar/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.16 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/squared_optimized/1024</td>
-            <td class="numeric">—</td>
-            <td class="numeric">173.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/squared_optimized/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">269.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/squared_optimized/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">56.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">euclidean_distance/squared_optimized/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">121.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">find_neighbors</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.24 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">1.14 µs</td>
+            <td class="numeric">1.14 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">find_nodes_by_property/10000_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">757.09 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">636.24 µs</td>
+            <td class="numeric">636.24 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">find_nodes_by_property/1000_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">50.79 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">36.14 µs</td>
+            <td class="numeric">36.14 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">find_nodes_by_property/100_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.67 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">4.40 µs</td>
+            <td class="numeric">4.40 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
-            <td class="bench-name">frozen_view_hot_path/frozen_view/100000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">40.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">frozen_view_hot_path/frozen_view/10000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">33.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">frozen_view_hot_path/frozen_view/1000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">20.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">frozen_view_hot_path/merged_guard/100000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">32.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">frozen_view_hot_path/merged_guard/10000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">32.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">frozen_view_hot_path/merged_guard/1000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">32.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">get_outgoing_allocation/degree_1</td>
-            <td class="numeric">—</td>
-            <td class="numeric">35.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">29.8 ns</td>
+            <td class="numeric">29.8 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">get_outgoing_allocation/degree_10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">35.3 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">29.4 ns</td>
+            <td class="numeric">29.4 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">get_outgoing_allocation/degree_100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">35.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">29.4 ns</td>
+            <td class="numeric">29.4 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
+            <td class="bench-name">hot_path/resolve/100</td>
+            <td class="numeric">3.14 µs</td>
+            <td class="numeric">3.14 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">hot_path/resolve/1000</td>
+            <td class="numeric">32.13 µs</td>
+            <td class="numeric">32.13 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">hot_path/resolve/10000</td>
+            <td class="numeric">315.14 µs</td>
+            <td class="numeric">315.14 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">hot_path/resolve_with/100</td>
+            <td class="numeric">1.90 µs</td>
+            <td class="numeric">1.90 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">hot_path/resolve_with/1000</td>
+            <td class="numeric">19.53 µs</td>
+            <td class="numeric">19.53 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">hot_path/resolve_with/10000</td>
+            <td class="numeric">193.73 µs</td>
+            <td class="numeric">193.73 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">id_generation_concurrent/threads/16</td>
-            <td class="numeric">—</td>
-            <td class="numeric">674.80 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">709.67 µs</td>
+            <td class="numeric">709.67 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_concurrent/threads/2</td>
-            <td class="numeric">—</td>
-            <td class="numeric">120.89 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">111.90 µs</td>
+            <td class="numeric">111.90 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_concurrent/threads/4</td>
-            <td class="numeric">—</td>
-            <td class="numeric">198.11 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">184.96 µs</td>
+            <td class="numeric">184.96 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_concurrent/threads/8</td>
-            <td class="numeric">—</td>
-            <td class="numeric">375.17 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">328.33 µs</td>
+            <td class="numeric">328.33 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_current/read_current</td>
-            <td class="numeric">—</td>
-            <td class="numeric">0.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">0.3 ns</td>
+            <td class="numeric">0.3 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_current/read_current_approximate</td>
-            <td class="numeric">—</td>
-            <td class="numeric">0.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">0.3 ns</td>
+            <td class="numeric">0.3 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_lifecycle/create_and_generate_1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">8.80 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">8.77 µs</td>
+            <td class="numeric">8.77 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_single_thread/sequential_1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">6.90 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">6.26 µs</td>
+            <td class="numeric">6.26 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">id_generation_single_thread/sequential_10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">69.02 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">63.47 µs</td>
+            <td class="numeric">63.47 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">in_degree</td>
-            <td class="numeric">—</td>
-            <td class="numeric">398.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_compaction/edges/1000+100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">60.28 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_compaction/edges/10000+1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">955.60 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_compaction/edges/100000+10000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">8.19 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_concurrent/threads/2</td>
-            <td class="numeric">—</td>
-            <td class="numeric">141.58 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_concurrent/threads/4</td>
-            <td class="numeric">—</td>
-            <td class="numeric">211.62 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_concurrent/threads/8</td>
-            <td class="numeric">—</td>
-            <td class="numeric">410.13 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_insert_latency/0existing</td>
-            <td class="numeric">—</td>
-            <td class="numeric">288.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_insert_latency/100000existing</td>
-            <td class="numeric">—</td>
-            <td class="numeric">289.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_insert_latency/10000existing</td>
-            <td class="numeric">—</td>
-            <td class="numeric">183.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_insert_latency/1000existing</td>
-            <td class="numeric">—</td>
-            <td class="numeric">226.3 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_read_no_delta/10000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">32.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_read_no_delta/1000edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">32.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_read_no_delta/100edges</td>
-            <td class="numeric">—</td>
-            <td class="numeric">32.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_read_with_delta/10pct_delta</td>
-            <td class="numeric">—</td>
-            <td class="numeric">67.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_read_with_delta/1pct_delta</td>
-            <td class="numeric">—</td>
-            <td class="numeric">64.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">incremental_read_with_delta/5pct_delta</td>
-            <td class="numeric">—</td>
-            <td class="numeric">64.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search/k/1</td>
-            <td class="numeric">126.51 µs</td>
-            <td class="numeric">126.51 µs</td>
+            <td class="numeric">353.9 ns</td>
+            <td class="numeric">353.9 ns</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">knn_search/k/10</td>
-            <td class="numeric">121.11 µs</td>
-            <td class="numeric">121.11 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search/k/20</td>
-            <td class="numeric">123.29 µs</td>
-            <td class="numeric">123.29 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search/k/5</td>
-            <td class="numeric">119.25 µs</td>
-            <td class="numeric">119.25 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search/k/50</td>
-            <td class="numeric">122.09 µs</td>
-            <td class="numeric">122.09 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search_index_size/index_size/100</td>
-            <td class="numeric">21.02 µs</td>
-            <td class="numeric">21.02 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search_index_size/index_size/1000</td>
-            <td class="numeric">120.52 µs</td>
-            <td class="numeric">120.52 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search_index_size/index_size/10000</td>
-            <td class="numeric">313.17 µs</td>
-            <td class="numeric">313.17 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search_index_size/index_size/500</td>
-            <td class="numeric">68.08 µs</td>
-            <td class="numeric">68.08 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">knn_search_index_size/index_size/5000</td>
-            <td class="numeric">242.32 µs</td>
-            <td class="numeric">242.32 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-new">
             <td class="bench-name">labeled_traversal</td>
-            <td class="numeric">—</td>
-            <td class="numeric">465.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">425.6 ns</td>
+            <td class="numeric">425.6 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">mixed_read_write_80_20</td>
-            <td class="numeric">—</td>
-            <td class="numeric">16.59 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">16.00 ms</td>
+            <td class="numeric">16.00 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">multiple_accesses/resolve_100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">3.57 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.14 µs</td>
+            <td class="numeric">3.14 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
+            <td class="bench-name">multiple_accesses/resolve_with_100</td>
+            <td class="numeric">1.90 µs</td>
+            <td class="numeric">1.90 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">node_creation</td>
-            <td class="numeric">—</td>
-            <td class="numeric">4.43 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.42 µs</td>
+            <td class="numeric">3.42 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">node_lookup</td>
-            <td class="numeric">—</td>
-            <td class="numeric">64.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">57.4 ns</td>
+            <td class="numeric">57.4 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">out_degree</td>
-            <td class="numeric">—</td>
-            <td class="numeric">406.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">359.8 ns</td>
+            <td class="numeric">359.8 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
-            <td class="bench-name">point_in_time_queries/1000vectors</td>
-            <td class="numeric">—</td>
-            <td class="numeric">30.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">point_in_time_queries/100vectors</td>
-            <td class="numeric">—</td>
-            <td class="numeric">27.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">property_lookup_vs_scan/find_nodes_by_property</td>
-            <td class="numeric">—</td>
-            <td class="numeric">39.03 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">34.45 µs</td>
+            <td class="numeric">34.45 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">property_lookup_vs_scan/manual_label_scan_filter</td>
-            <td class="numeric">—</td>
-            <td class="numeric">138.29 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">123.68 µs</td>
+            <td class="numeric">123.68 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">read_latency_p50_p99</td>
-            <td class="numeric">—</td>
-            <td class="numeric">8.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">read_transaction_creation</td>
-            <td class="numeric">339.2 ns</td>
-            <td class="numeric">339.2 ns</td>
+            <td class="numeric">9.3 ns</td>
+            <td class="numeric">9.3 ns</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">read_under_write_contention/concurrent_writers/0</td>
-            <td class="numeric">4.46 µs</td>
-            <td class="numeric">4.46 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">read_under_write_contention/concurrent_writers/2</td>
-            <td class="numeric">56.66 ms</td>
-            <td class="numeric">56.66 ms</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">read_under_write_contention/concurrent_writers/4</td>
-            <td class="numeric">114.75 ms</td>
-            <td class="numeric">114.75 ms</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-new">
             <td class="bench-name">recovery/10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">500.06 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">401.83 µs</td>
+            <td class="numeric">401.83 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">recovery/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">457.03 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">412.59 µs</td>
+            <td class="numeric">412.59 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">recovery/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">647.92 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">612.70 µs</td>
+            <td class="numeric">612.70 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
+            <td class="bench-name">serialization_simulation/resolve</td>
+            <td class="numeric">160.24 µs</td>
+            <td class="numeric">160.24 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
+            <td class="bench-name">serialization_simulation/resolve_with</td>
+            <td class="numeric">98.29 µs</td>
+            <td class="numeric">98.29 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
+        </tr>
+        <tr class="row-stable">
             <td class="bench-name">single_hop_traversal/10000_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">431.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">393.8 ns</td>
+            <td class="numeric">393.8 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_hop_traversal/1000_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">431.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">412.5 ns</td>
+            <td class="numeric">412.5 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_hop_traversal/100_nodes</td>
-            <td class="numeric">—</td>
-            <td class="numeric">431.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">399.0 ns</td>
+            <td class="numeric">399.0 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_transaction_latency/async</td>
-            <td class="numeric">—</td>
-            <td class="numeric">65.06 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">64.90 µs</td>
+            <td class="numeric">64.90 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_transaction_latency/async_batched_aggressive</td>
-            <td class="numeric">—</td>
-            <td class="numeric">5.02 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">5.10 ms</td>
+            <td class="numeric">5.10 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_transaction_latency/async_batched_default</td>
-            <td class="numeric">—</td>
-            <td class="numeric">9.19 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">9.24 ms</td>
+            <td class="numeric">9.24 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_transaction_latency/group_commit_default</td>
-            <td class="numeric">—</td>
-            <td class="numeric">2.76 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">3.20 ms</td>
+            <td class="numeric">3.20 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_transaction_latency/group_commit_fast</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.80 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">2.01 ms</td>
+            <td class="numeric">2.01 ms</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">single_transaction_latency/synchronous</td>
-            <td class="numeric">—</td>
-            <td class="numeric">571.98 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">738.79 µs</td>
+            <td class="numeric">738.79 µs</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
-            <td class="bench-name">snapshot_creation/time_interval_1s</td>
-            <td class="numeric">—</td>
-            <td class="numeric">77.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">snapshot_creation/transaction_interval_10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">24.16 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">snapshot_creation/transaction_interval_100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">2.50 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">string_access_single/resolve</td>
-            <td class="numeric">—</td>
-            <td class="numeric">35.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">32.8 ns</td>
+            <td class="numeric">32.8 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">string_access_single/resolve_with</td>
-            <td class="numeric">—</td>
-            <td class="numeric">21.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">20.4 ns</td>
+            <td class="numeric">20.4 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">string_comparison/resolve</td>
-            <td class="numeric">—</td>
-            <td class="numeric">36.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">31.1 ns</td>
+            <td class="numeric">31.1 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">string_comparison/resolve_with</td>
-            <td class="numeric">—</td>
-            <td class="numeric">22.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">20.2 ns</td>
+            <td class="numeric">20.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">string_length/resolve</td>
-            <td class="numeric">—</td>
-            <td class="numeric">36.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">31.9 ns</td>
+            <td class="numeric">31.9 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">string_length/resolve_with</td>
-            <td class="numeric">—</td>
-            <td class="numeric">22.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">sustained_write_10k_versions</td>
-            <td class="numeric">—</td>
-            <td class="numeric">181.74 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">sustained_write_10k_versions_fast_reference</td>
-            <td class="numeric">—</td>
-            <td class="numeric">455.09 ms</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-improved">
-            <td class="bench-name">target_3_hop/traverse_three_hops</td>
-            <td class="numeric">282.2 ns</td>
-            <td class="numeric">269.4 ns</td>
-            <td class="change">-4.5%</td>
-            <td class="status-cell">🟢</td>
-        </tr>
-        <tr class="row-improved">
-            <td class="bench-name">target_batch_insertion/insert_1000_edges</td>
-            <td class="numeric">781.38 µs</td>
-            <td class="numeric">630.49 µs</td>
-            <td class="change">-19.3%</td>
-            <td class="status-cell">🟢</td>
-        </tr>
-        <tr class="row-improved">
-            <td class="bench-name">target_single_hop/traverse_one_hop</td>
-            <td class="numeric">42.6 ns</td>
-            <td class="numeric">39.5 ns</td>
-            <td class="change">-7.3%</td>
-            <td class="status-cell">🟢</td>
-        </tr>
-        <tr class="row-improved">
-            <td class="bench-name">target_time_travel/at_anchor</td>
-            <td class="numeric">282.6 ns</td>
-            <td class="numeric">272.3 ns</td>
-            <td class="change">-3.6%</td>
-            <td class="status-cell">🟢</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">target_time_travel/with_5_deltas</td>
-            <td class="numeric">275.1 ns</td>
-            <td class="numeric">279.3 ns</td>
-            <td class="change">+1.5%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-improved">
-            <td class="bench-name">target_time_travel/worst_case_9_deltas</td>
-            <td class="numeric">286.2 ns</td>
-            <td class="numeric">274.5 ns</td>
-            <td class="change">-4.1%</td>
-            <td class="status-cell">🟢</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">temporal_insert/append_only/100</td>
-            <td class="numeric">20.52 µs</td>
-            <td class="numeric">20.52 µs</td>
+            <td class="numeric">19.3 ns</td>
+            <td class="numeric">19.3 ns</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">temporal_insert/append_only/1000</td>
-            <td class="numeric">210.75 µs</td>
-            <td class="numeric">210.75 µs</td>
+            <td class="bench-name">sustained_write_throughput/sustained_write_10k_versions</td>
+            <td class="numeric">188.72 ms</td>
+            <td class="numeric">188.72 ms</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">temporal_insert/append_only/10000</td>
-            <td class="numeric">2.17 ms</td>
-            <td class="numeric">2.17 ms</td>
+            <td class="bench-name">sustained_write_throughput/sustained_write_10k_versions_fast_reference</td>
+            <td class="numeric">458.79 ms</td>
+            <td class="numeric">458.79 ms</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
         <tr class="row-stable">
-            <td class="bench-name">temporal_insert/retroactive/100</td>
-            <td class="numeric">147.47 µs</td>
-            <td class="numeric">147.47 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">temporal_insert/retroactive/1000</td>
-            <td class="numeric">12.55 ms</td>
-            <td class="numeric">12.55 ms</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">temporal_insert/retroactive/10000</td>
-            <td class="numeric">1.287 s</td>
-            <td class="numeric">1.287 s</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-new">
             <td class="bench-name">time_travel/at_anchor_v20</td>
-            <td class="numeric">—</td>
-            <td class="numeric">124.0 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">196.7 ns</td>
+            <td class="numeric">196.7 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">time_travel/deep_history_v5</td>
-            <td class="numeric">—</td>
-            <td class="numeric">124.3 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">194.3 ns</td>
+            <td class="numeric">194.3 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">time_travel/with_deltas_v15</td>
-            <td class="numeric">—</td>
-            <td class="numeric">123.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
+            <td class="numeric">191.2 ns</td>
+            <td class="numeric">191.2 ns</td>
+            <td class="change">+0.0%</td>
+            <td class="status-cell">🟡</td>
         </tr>
-        <tr class="row-new">
+        <tr class="row-stable">
             <td class="bench-name">time_travel/worst_case_v19</td>
-            <td class="numeric">—</td>
-            <td class="numeric">124.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">traverse_and_rank_basic/100_power_law/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">40.65 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">traverse_and_rank_basic/100_sparse/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.29 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">traverse_and_rank_basic/100_uniform/100</td>
-            <td class="numeric">—</td>
-            <td class="numeric">7.89 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">traverse_and_rank_basic/1K_power_law/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">47.54 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">traverse_and_rank_basic/1K_sparse/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.28 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">traverse_and_rank_basic/1K_uniform/1000</td>
-            <td class="numeric">—</td>
-            <td class="numeric">8.12 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">valid_at_query/10000_versions</td>
-            <td class="numeric">22.36 µs</td>
-            <td class="numeric">22.36 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">valid_at_query/1000_versions</td>
-            <td class="numeric">3.90 µs</td>
-            <td class="numeric">3.90 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">valid_at_query/100_versions</td>
-            <td class="numeric">1.53 µs</td>
-            <td class="numeric">1.53 µs</td>
-            <td class="change">+0.0%</td>
-            <td class="status-cell">🟡</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_batch_deserialize/retrieval_workload/100x1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">36.64 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_batch_serialize/rag_workload/100x1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">22.99 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/1</td>
-            <td class="numeric">—</td>
-            <td class="numeric">54.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">55.4 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/128</td>
-            <td class="numeric">—</td>
-            <td class="numeric">67.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">376.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/3072</td>
-            <td class="numeric">—</td>
-            <td class="numeric">751.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">240.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_deserialize/deserialize/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">281.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_round_trip/round_trip/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">613.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_round_trip/round_trip/3072</td>
-            <td class="numeric">—</td>
-            <td class="numeric">1.43 µs</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_round_trip/round_trip/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">384.9 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_round_trip/round_trip/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">427.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/1</td>
-            <td class="numeric">—</td>
-            <td class="numeric">27.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/10</td>
-            <td class="numeric">—</td>
-            <td class="numeric">27.1 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/128</td>
-            <td class="numeric">—</td>
-            <td class="numeric">34.8 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">173.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/3072</td>
-            <td class="numeric">—</td>
-            <td class="numeric">219.2 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">134.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize/serialize/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">133.6 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize_into/serialize_into/1536</td>
-            <td class="numeric">—</td>
-            <td class="numeric">181.3 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize_into/serialize_into/384</td>
-            <td class="numeric">—</td>
-            <td class="numeric">119.7 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-new">
-            <td class="bench-name">vector_serialize_into/serialize_into/768</td>
-            <td class="numeric">—</td>
-            <td class="numeric">141.5 ns</td>
-            <td class="change">NEW</td>
-            <td class="status-cell">🆕</td>
-        </tr>
-        <tr class="row-stable">
-            <td class="bench-name">write_transaction_creation</td>
-            <td class="numeric">462.4 ns</td>
-            <td class="numeric">462.4 ns</td>
+            <td class="numeric">237.1 ns</td>
+            <td class="numeric">237.1 ns</td>
             <td class="change">+0.0%</td>
             <td class="status-cell">🟡</td>
         </tr>
@@ -1995,7 +1092,7 @@
 </div>
 
 <script>
-  const datasets = [{"label": "3_hop_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.709, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_3_hop_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.483, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27807.5, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289829.223, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2831177.141, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_edge_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.346, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.063, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.062, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.061, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_historical_stats", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.059, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_in_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.105, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_labeled_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.16, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_node_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.588, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_out_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.1, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.116, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.117, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.116, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "batch_throughput/async", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52792.62, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "batch_throughput/synchronous", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635748.426, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4892.959, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4029.267, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7663.185, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.505, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1627.958, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15179.93, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "closure_write_single_node", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2805.76, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2805.76, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4929.243, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45813.563, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454829.735, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7446.458, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66782.381, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189514.992, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/fast_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.306, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/zstd_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.409, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/fast_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.791, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/zstd_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.867, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "comparison_csr/full_rebuild_insert_query", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 140.053, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "comparison_csr/incremental_csr_insert_query", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.596, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/fast", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34868.528, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31258.892, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/zstd", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36219.494, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.878, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.878, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.741, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.741, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.646, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.646, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.103, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.103, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.644, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.644, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.905, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.905, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.718, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.718, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.264, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.264, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.703, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.703, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.868, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.868, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.707, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.707, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.015, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.015, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.36, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.36, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.574, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.574, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1225.713, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1225.713, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9476.39, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9476.39, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.952, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 14.034, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.652, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.435, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.201, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.3, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.592, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.077, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.152, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.581, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.36, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.728, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.636, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.182, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.811, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.281, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 90.459, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/general/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.3, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/general/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.078, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/specialized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.285, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/specialized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.057, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_openai_1536d", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.302, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "edge_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.461, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "edge_lookup", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.062, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.175, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.273, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.066, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.549, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.332, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.567, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.155, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.173, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.27, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.057, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.121, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_neighbors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.241, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.093, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.79, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.674, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/100000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.04, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.034, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.021, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/100000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/16", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.799, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/2", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.894, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/4", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.107, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/8", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.165, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_current/read_current", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.0, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_current/read_current_approximate", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.0, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_lifecycle/create_and_generate_1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.802, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_single_thread/sequential_1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.901, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_single_thread/sequential_10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.016, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "in_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.399, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/1000+100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 60.279, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/10000+1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 955.605, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/100000+10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8192.206, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/2", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.575, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/4", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 211.623, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/8", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 410.132, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/0existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.289, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/100000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.289, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/10000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.183, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/1000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.226, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/100edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/10pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.068, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/1pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.064, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/5pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.064, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/1", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.51, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.51, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/10", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.112, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.112, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/20", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.289, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.289, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/5", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.25, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.25, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/50", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.094, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.094, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.022, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.022, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.522, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.522, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.174, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.174, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/500", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.085, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.085, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/5000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.319, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.319, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "labeled_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.466, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "mixed_read_write_80_20", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16590.657, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "multiple_accesses/resolve_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.567, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "node_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.433, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "node_lookup", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.065, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "out_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.406, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "point_in_time_queries/1000vectors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.03, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "point_in_time_queries/100vectors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.027, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "property_lookup_vs_scan/find_nodes_by_property", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.031, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "property_lookup_vs_scan/manual_label_scan_filter", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.292, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_latency_p50_p99", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.009, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.339, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.339, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/0", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.455, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.455, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56660.317, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56660.317, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114751.007, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114751.007, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.064, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.033, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.917, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.432, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.432, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.431, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async_batched_aggressive", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5017.23, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async_batched_default", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9188.521, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/group_commit_default", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2755.249, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/group_commit_fast", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1799.046, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/synchronous", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.977, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/time_interval_1s", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.077, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/transaction_interval_10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 24.161, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/transaction_interval_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.504, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_access_single/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_access_single/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_comparison/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_comparison/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_length/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.037, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_length/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_10k_versions", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181743.777, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_10k_versions_fast_reference", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 455090.031, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.269, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 630.489, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.04, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.272, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.279, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.274, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.522, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.522, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.752, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.752, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2170.105, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2170.105, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.472, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.472, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12548.726, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12548.726, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1286764.102, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1286764.102, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/at_anchor_v20", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/deep_history_v5", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/with_deltas_v15", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/worst_case_v19", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_power_law/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.645, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_sparse/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.287, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_uniform/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.893, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_power_law/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 47.543, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_sparse/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.276, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_uniform/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.124, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/10000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.355, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.355, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/1000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.901, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.901, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/100_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.53, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.53, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_batch_deserialize/retrieval_workload/100x1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.638, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_batch_serialize/rag_workload/100x1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.986, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.055, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.055, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/128", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.067, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.377, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.752, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.241, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.614, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.433, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.385, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.428, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.028, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.027, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/128", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.173, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.219, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.135, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.134, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.181, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.12, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.142, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "write_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.462, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.462, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
+  const datasets = [{"label": "3_hop_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.709, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 50.5, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 50.5, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_3_hop_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.483, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.481, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.491, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.491, "commit": "dc19c58"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27807.5, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 30397.243, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29939.598, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 29939.598, "commit": "dc19c58"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289829.223, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 325397.03, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 320779.687, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 320779.687, "commit": "dc19c58"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_batch/batch_node_creation/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2831177.141, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 3302576.801, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3242852.64, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3242852.64, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_edge_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.346, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 97.41, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 97.436, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 97.436, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.063, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.061, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.056, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.056, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.062, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.061, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.062, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.062, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_fast_path/node_lookup/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.061, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.062, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.061, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.061, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_historical_stats", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.059, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 1.061, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.944, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.944, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_in_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.105, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.1, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.094, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.094, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_labeled_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.16, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.16, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.157, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.157, "commit": "dc19c58"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_node_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.588, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 98.576, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 98.588, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 98.588, "commit": "dc19c58"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_out_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.1, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.106, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.101, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.101, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.116, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.115, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.105, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.105, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.117, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.115, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.103, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.103, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "aletheiadb_single_hop/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.116, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.116, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.113, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.113, "commit": "dc19c58"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "arc_overhead/arc_clone_drop", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.032, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.032, "commit": "dc19c58"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "arc_overhead/direct_access", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.019, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.019, "commit": "dc19c58"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "batch_throughput/async", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52792.62, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 52369.763, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 52369.763, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "batch_throughput/synchronous", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635748.426, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 758780.474, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 758780.474, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4892.959, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4050.173, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 4050.173, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4029.267, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4503.957, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 4503.957, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_creation/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7663.185, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 8782.352, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 8782.352, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.505, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 312.876, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 312.876, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1627.958, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 1490.438, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 1490.438, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "checkpoint_load/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15179.93, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 13147.423, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 13147.423, "commit": "dc19c58"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "closure_write_single_node", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2805.76, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2805.76, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4929.243, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 5315.076, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 5315.076, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45813.563, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 47496.73, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 47496.73, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/fast/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454829.735, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 457425.995, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 457425.995, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7446.458, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 7984.555, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 7984.555, "commit": "dc19c58"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66782.381, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 67057.96, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 67057.96, "commit": "dc19c58"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_batch_write_throughput/zstd/10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189514.992, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 183446.03, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 183446.03, "commit": "dc19c58"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/fast_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 38.472, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 38.472, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.306, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.25, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3.25, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_read_latency/single_read/zstd_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.409, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 37.93, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 37.93, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/fast_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 341.138, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 341.138, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.791, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 288.701, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 288.701, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cold_write_latency/single_write/zstd_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.867, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 450.068, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 450.068, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "comparison_csr/full_rebuild_insert_query", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 140.053, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "comparison_csr/incremental_csr_insert_query", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.596, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/fast", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34868.528, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 37084.81, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 37084.81, "commit": "dc19c58"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/no_compression", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31258.892, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 27364.011, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 27364.011, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "compression_ratio/compress/zstd", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36219.494, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 40949.195, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 40949.195, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.878, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.878, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/10000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.741, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.741, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.646, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.646, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.103, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.103, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.644, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.644, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/1000_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.905, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.905, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/16_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.718, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.718, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/2_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.264, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.264, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/4_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.703, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.703, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_reads_same_entity/100_versions/8_readers", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.868, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.868, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.707, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.707, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.015, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.015, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/different_entities/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.36, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.36, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.574, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.574, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1225.713, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1225.713, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "concurrent_writes/same_entity_contention/8", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9476.39, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9476.39, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.952, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 14.034, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.652, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/naive_3pass/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.435, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.201, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.3, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.592, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.077, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.152, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.581, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.36, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.728, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.636, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity/scalar_1pass/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.182, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.811, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.281, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_batch/find_most_similar/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 90.459, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/general/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.3, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/general/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.078, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/specialized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.285, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_normalized/specialized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.057, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "cosine_similarity_openai_1536d", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.302, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "edge_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.461, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.441, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3.441, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "edge_lookup", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.062, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.055, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.055, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.175, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.273, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.066, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.549, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.332, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.567, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/scalar/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.155, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/1024", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.173, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.27, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.057, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "euclidean_distance/squared_optimized/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.121, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_neighbors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.241, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.139, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 1.139, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.093, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 636.241, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 636.241, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.79, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 36.142, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 36.142, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "find_nodes_by_property/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.674, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.402, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 4.402, "commit": "dc19c58"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/100000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.04, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.034, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/frozen_view/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.021, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/100000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "frozen_view_hot_path/merged_guard/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.03, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.03, "commit": "dc19c58"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.029, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.029, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "get_outgoing_allocation/degree_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.029, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.029, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "hot_path/resolve/100", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.139, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3.139, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "hot_path/resolve/1000", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 32.127, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 32.127, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "hot_path/resolve/10000", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 315.142, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 315.142, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "hot_path/resolve_with/100", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.902, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 1.902, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "hot_path/resolve_with/1000", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 19.53, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 19.53, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "hot_path/resolve_with/10000", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 193.731, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 193.731, "commit": "dc19c58"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/16", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.799, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 709.674, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 709.674, "commit": "dc19c58"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/2", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.894, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 111.904, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 111.904, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/4", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.107, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 184.964, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 184.964, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_concurrent/threads/8", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.165, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 328.335, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 328.335, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_current/read_current", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.0, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.0, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.0, "commit": "dc19c58"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_current/read_current_approximate", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.0, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.0, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.0, "commit": "dc19c58"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_lifecycle/create_and_generate_1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.802, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 8.769, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 8.769, "commit": "dc19c58"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_single_thread/sequential_1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.901, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 6.258, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 6.258, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "id_generation_single_thread/sequential_10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.016, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 63.474, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 63.474, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "in_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.399, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.354, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.354, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/1000+100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 60.279, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/10000+1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 955.605, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_compaction/edges/100000+10000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8192.206, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/2", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.575, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/4", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 211.623, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_concurrent/threads/8", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 410.132, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/0existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.289, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/100000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.289, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/10000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.183, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_insert_latency/1000existing", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.226, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/10000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/1000edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_no_delta/100edges", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.033, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/10pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.068, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/1pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.064, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "incremental_read_with_delta/5pct_delta", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.064, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/1", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.51, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.51, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/10", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.112, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.112, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/20", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.289, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.289, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/5", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.25, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.25, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search/k/50", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.094, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.094, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.022, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.022, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.522, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.522, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.174, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.174, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/500", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.085, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.085, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "knn_search_index_size/index_size/5000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.319, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.319, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "labeled_traversal", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.466, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.426, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.426, "commit": "dc19c58"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "mixed_read_write_80_20", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16590.657, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 16000.284, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 16000.284, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "multiple_accesses/resolve_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.567, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.137, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3.137, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "multiple_accesses/resolve_with_100", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.904, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 1.904, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "node_creation", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.433, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.425, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3.425, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "node_lookup", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.065, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.057, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.057, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "out_degree", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.406, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.36, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.36, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "point_in_time_queries/1000vectors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.03, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "point_in_time_queries/100vectors", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.027, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "property_lookup_vs_scan/find_nodes_by_property", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.031, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 34.448, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 34.448, "commit": "dc19c58"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "property_lookup_vs_scan/manual_label_scan_filter", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.292, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 123.679, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 123.679, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_latency_p50_p99", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.009, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.009, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.009, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.339, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.339, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/0", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.455, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.455, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/2", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56660.317, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56660.317, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "read_under_write_contention/concurrent_writers/4", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114751.007, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114751.007, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.064, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 401.83, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 401.83, "commit": "dc19c58"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.033, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 412.587, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 412.587, "commit": "dc19c58"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "recovery/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.917, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 612.701, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 612.701, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "serialization_simulation/resolve", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 160.238, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 160.238, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "serialization_simulation/resolve_with", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 98.287, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 98.287, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/10000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.432, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.394, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.394, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/1000_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.432, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.412, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.412, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_hop_traversal/100_nodes", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.431, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.399, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.399, "commit": "dc19c58"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 64.9, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 64.9, "commit": "dc19c58"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async_batched_aggressive", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5017.23, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 5099.494, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 5099.494, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/async_batched_default", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9188.521, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 9242.506, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 9242.506, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/group_commit_default", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2755.249, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3202.838, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 3202.838, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/group_commit_fast", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1799.046, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 2005.998, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 2005.998, "commit": "dc19c58"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "single_transaction_latency/synchronous", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.977, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 738.791, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 738.791, "commit": "dc19c58"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/time_interval_1s", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.077, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/transaction_interval_10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 24.161, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "snapshot_creation/transaction_interval_100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.504, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_access_single/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.033, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.033, "commit": "dc19c58"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_access_single/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.02, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.02, "commit": "dc19c58"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_comparison/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.036, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.031, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.031, "commit": "dc19c58"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_comparison/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.02, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.02, "commit": "dc19c58"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_length/resolve", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.037, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.032, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.032, "commit": "dc19c58"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "string_length/resolve_with", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.022, "commit": "198c57d"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.019, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.019, "commit": "dc19c58"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_10k_versions", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181743.777, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_10k_versions_fast_reference", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 455090.031, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_throughput/sustained_write_10k_versions", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 188724.561, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 188724.561, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "sustained_write_throughput/sustained_write_10k_versions_fast_reference", "data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 458794.149, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 458794.149, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_3_hop/traverse_three_hops", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.282, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.269, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_batch_insertion/insert_1000_edges", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 630.489, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_single_hop/traverse_one_hop", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.043, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.04, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/at_anchor", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.283, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.272, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/with_5_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.275, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.279, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "target_time_travel/worst_case_9_deltas", "data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.286, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.274, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.522, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.522, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.752, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.752, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/append_only/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2170.105, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2170.105, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/100", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.472, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.472, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/1000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12548.726, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12548.726, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "temporal_insert/retroactive/10000", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1286764.102, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1286764.102, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/at_anchor_v20", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.122, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.197, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.197, "commit": "dc19c58"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/deep_history_v5", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.125, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.194, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.194, "commit": "dc19c58"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/with_deltas_v15", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.161, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.191, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.191, "commit": "dc19c58"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "time_travel/worst_case_v19", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.124, "commit": "198c57d"}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 0.138, "commit": "268e122"}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.237, "commit": "268e122"}, {"x": "2026-03-15T02:35:36.460054+00:00", "y": 0.237, "commit": "dc19c58"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_power_law/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.645, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_sparse/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.287, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/100_uniform/100", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.893, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_power_law/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 47.543, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_sparse/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.276, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "traverse_and_rank_basic/1K_uniform/1000", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.124, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/10000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.355, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.355, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/1000_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.901, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.901, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "valid_at_query/100_versions", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.53, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.53, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_batch_deserialize/retrieval_workload/100x1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.638, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_batch_serialize/rag_workload/100x1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.986, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.055, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.055, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/128", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.067, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.377, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.752, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.241, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_deserialize/deserialize/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.282, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.614, "commit": "198c57d"}], "borderColor": "#f87171", "backgroundColor": "#f8717133", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.433, "commit": "198c57d"}], "borderColor": "#60a5fa", "backgroundColor": "#60a5fa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.385, "commit": "198c57d"}], "borderColor": "#c084fc", "backgroundColor": "#c084fc33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_round_trip/round_trip/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.428, "commit": "198c57d"}], "borderColor": "#fb923c", "backgroundColor": "#fb923c33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/1", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.028, "commit": "198c57d"}], "borderColor": "#4ade80", "backgroundColor": "#4ade8033", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/10", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.027, "commit": "198c57d"}], "borderColor": "#e879f9", "backgroundColor": "#e879f933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/128", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.035, "commit": "198c57d"}], "borderColor": "#38bdf8", "backgroundColor": "#38bdf833", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.173, "commit": "198c57d"}], "borderColor": "#a3e635", "backgroundColor": "#a3e63533", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/3072", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.219, "commit": "198c57d"}], "borderColor": "#f43f5e", "backgroundColor": "#f43f5e33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.135, "commit": "198c57d"}], "borderColor": "#14b8a6", "backgroundColor": "#14b8a633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize/serialize/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.134, "commit": "198c57d"}], "borderColor": "#22d3ee", "backgroundColor": "#22d3ee33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/1536", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.181, "commit": "198c57d"}], "borderColor": "#a78bfa", "backgroundColor": "#a78bfa33", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/384", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.12, "commit": "198c57d"}], "borderColor": "#f472b6", "backgroundColor": "#f472b633", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "vector_serialize_into/serialize_into/768", "data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.142, "commit": "198c57d"}], "borderColor": "#34d399", "backgroundColor": "#34d39933", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}, {"label": "write_transaction_creation", "data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 0.462, "commit": "198c57d"}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.462, "commit": "198c57d"}], "borderColor": "#fbbf24", "backgroundColor": "#fbbf2433", "fill": false, "tension": 0.3, "pointRadius": 4, "pointHoverRadius": 7}];
 
   const ctx = document.getElementById('timeseriesChart').getContext('2d');
   new Chart(ctx, {

--- a/benchmarks/timeseries.html
+++ b/benchmarks/timeseries.html
@@ -400,35 +400,35 @@
     <div class="nav-group-label">ungrouped</div>
 <a class="nav-item" href="#bench-3_hop_traversal" data-bench="3_hop_traversal">
   <span class="nav-bench-name">3_hop_traversal</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -10.9%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_3_hop_traversal" data-bench="aletheiadb_3_hop_traversal">
   <span class="nav-bench-name">aletheiadb_3_hop_traversal</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +1.6%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_edge_creation" data-bench="aletheiadb_edge_creation">
   <span class="nav-bench-name">aletheiadb_edge_creation</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.1%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_historical_stats" data-bench="aletheiadb_historical_stats">
   <span class="nav-bench-name">aletheiadb_historical_stats</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -10.9%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_in_degree" data-bench="aletheiadb_in_degree">
   <span class="nav-bench-name">aletheiadb_in_degree</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -10.6%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_labeled_traversal" data-bench="aletheiadb_labeled_traversal">
   <span class="nav-bench-name">aletheiadb_labeled_traversal</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ -1.7%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_node_creation" data-bench="aletheiadb_node_creation">
   <span class="nav-bench-name">aletheiadb_node_creation</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -6.6%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_out_degree" data-bench="aletheiadb_out_degree">
   <span class="nav-bench-name">aletheiadb_out_degree</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.5%</span>
 </a>
 <a class="nav-item" href="#bench-closure_write_single_node" data-bench="closure_write_single_node">
   <span class="nav-bench-name">closure_write_single_node</span>
@@ -440,43 +440,43 @@
 </a>
 <a class="nav-item" href="#bench-edge_creation" data-bench="edge_creation">
   <span class="nav-bench-name">edge_creation</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -22.9%</span>
 </a>
 <a class="nav-item" href="#bench-edge_lookup" data-bench="edge_lookup">
   <span class="nav-bench-name">edge_lookup</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -12.3%</span>
 </a>
 <a class="nav-item" href="#bench-find_neighbors" data-bench="find_neighbors">
   <span class="nav-bench-name">find_neighbors</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -8.2%</span>
 </a>
 <a class="nav-item" href="#bench-in_degree" data-bench="in_degree">
   <span class="nav-bench-name">in_degree</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.2%</span>
 </a>
 <a class="nav-item" href="#bench-labeled_traversal" data-bench="labeled_traversal">
   <span class="nav-bench-name">labeled_traversal</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -8.6%</span>
 </a>
 <a class="nav-item" href="#bench-mixed_read_write_80_20" data-bench="mixed_read_write_80_20">
   <span class="nav-bench-name">mixed_read_write_80_20</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -3.6%</span>
 </a>
 <a class="nav-item" href="#bench-node_creation" data-bench="node_creation">
   <span class="nav-bench-name">node_creation</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -22.7%</span>
 </a>
 <a class="nav-item" href="#bench-node_lookup" data-bench="node_lookup">
   <span class="nav-bench-name">node_lookup</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.2%</span>
 </a>
 <a class="nav-item" href="#bench-out_degree" data-bench="out_degree">
   <span class="nav-bench-name">out_degree</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.4%</span>
 </a>
 <a class="nav-item" href="#bench-read_latency_p50_p99" data-bench="read_latency_p50_p99">
   <span class="nav-bench-name">read_latency_p50_p99</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +5.5%</span>
 </a>
 <a class="nav-item" href="#bench-read_transaction_creation" data-bench="read_transaction_creation">
   <span class="nav-bench-name">read_transaction_creation</span>
@@ -497,127 +497,136 @@
 <div class="nav-group-label">aletheiadb_batch</div>
 <a class="nav-item" href="#bench-aletheiadb_batch--batch_node_creation--10" data-bench="aletheiadb_batch--batch_node_creation--10">
   <span class="nav-bench-name">10</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +7.7%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_batch--batch_node_creation--100" data-bench="aletheiadb_batch--batch_node_creation--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +10.7%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_batch--batch_node_creation--1000" data-bench="aletheiadb_batch--batch_node_creation--1000">
   <span class="nav-bench-name">1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +14.5%</span>
 </a>
 <div class="nav-group-label">aletheiadb_fast_path</div>
 <a class="nav-item" href="#bench-aletheiadb_fast_path--node_lookup--100" data-bench="aletheiadb_fast_path--node_lookup--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.2%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_fast_path--node_lookup--1000" data-bench="aletheiadb_fast_path--node_lookup--1000">
   <span class="nav-bench-name">1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.3%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_fast_path--node_lookup--10000" data-bench="aletheiadb_fast_path--node_lookup--10000">
   <span class="nav-bench-name">10000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.6%</span>
 </a>
 <div class="nav-group-label">aletheiadb_single_hop</div>
 <a class="nav-item" href="#bench-aletheiadb_single_hop--10000_nodes" data-bench="aletheiadb_single_hop--10000_nodes">
   <span class="nav-bench-name">10000_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -10.2%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_single_hop--1000_nodes" data-bench="aletheiadb_single_hop--1000_nodes">
   <span class="nav-bench-name">1000_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.3%</span>
 </a>
 <a class="nav-item" href="#bench-aletheiadb_single_hop--100_nodes" data-bench="aletheiadb_single_hop--100_nodes">
   <span class="nav-bench-name">100_nodes</span>
+  <span class="nav-trend trend-down">↓ -2.4%</span>
+</a>
+<div class="nav-group-label">arc_overhead</div>
+<a class="nav-item" href="#bench-arc_overhead--arc_clone_drop" data-bench="arc_overhead--arc_clone_drop">
+  <span class="nav-bench-name">arc_clone_drop</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-arc_overhead--direct_access" data-bench="arc_overhead--direct_access">
+  <span class="nav-bench-name">direct_access</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <div class="nav-group-label">batch_throughput</div>
 <a class="nav-item" href="#bench-batch_throughput--async" data-bench="batch_throughput--async">
   <span class="nav-bench-name">async</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ -0.8%</span>
 </a>
 <a class="nav-item" href="#bench-batch_throughput--synchronous" data-bench="batch_throughput--synchronous">
   <span class="nav-bench-name">synchronous</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +19.4%</span>
 </a>
 <div class="nav-group-label">checkpoint_creation</div>
 <a class="nav-item" href="#bench-checkpoint_creation--100" data-bench="checkpoint_creation--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -17.2%</span>
 </a>
 <a class="nav-item" href="#bench-checkpoint_creation--1000" data-bench="checkpoint_creation--1000">
   <span class="nav-bench-name">1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +11.8%</span>
 </a>
 <a class="nav-item" href="#bench-checkpoint_creation--10000" data-bench="checkpoint_creation--10000">
   <span class="nav-bench-name">10000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +14.6%</span>
 </a>
 <div class="nav-group-label">checkpoint_load</div>
 <a class="nav-item" href="#bench-checkpoint_load--100" data-bench="checkpoint_load--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -3.3%</span>
 </a>
 <a class="nav-item" href="#bench-checkpoint_load--1000" data-bench="checkpoint_load--1000">
   <span class="nav-bench-name">1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -8.4%</span>
 </a>
 <a class="nav-item" href="#bench-checkpoint_load--10000" data-bench="checkpoint_load--10000">
   <span class="nav-bench-name">10000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -13.4%</span>
 </a>
 <div class="nav-group-label">cold_batch_write_throughput</div>
 <a class="nav-item" href="#bench-cold_batch_write_throughput--fast--100" data-bench="cold_batch_write_throughput--fast--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +7.8%</span>
 </a>
 <a class="nav-item" href="#bench-cold_batch_write_throughput--fast--1000" data-bench="cold_batch_write_throughput--fast--1000">
   <span class="nav-bench-name">1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +3.7%</span>
 </a>
 <a class="nav-item" href="#bench-cold_batch_write_throughput--fast--10000" data-bench="cold_batch_write_throughput--fast--10000">
   <span class="nav-bench-name">10000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.6%</span>
 </a>
 <a class="nav-item" href="#bench-cold_batch_write_throughput--zstd--100" data-bench="cold_batch_write_throughput--zstd--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +7.2%</span>
 </a>
 <a class="nav-item" href="#bench-cold_batch_write_throughput--zstd--1000" data-bench="cold_batch_write_throughput--zstd--1000">
   <span class="nav-bench-name">1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.4%</span>
 </a>
 <a class="nav-item" href="#bench-cold_batch_write_throughput--zstd--10000" data-bench="cold_batch_write_throughput--zstd--10000">
   <span class="nav-bench-name">10000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -3.2%</span>
 </a>
 <div class="nav-group-label">cold_read_latency</div>
 <a class="nav-item" href="#bench-cold_read_latency--single_read--fast_compression" data-bench="cold_read_latency--single_read--fast_compression">
   <span class="nav-bench-name">fast_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +11.4%</span>
 </a>
 <a class="nav-item" href="#bench-cold_read_latency--single_read--no_compression" data-bench="cold_read_latency--single_read--no_compression">
   <span class="nav-bench-name">no_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ -1.7%</span>
 </a>
 <a class="nav-item" href="#bench-cold_read_latency--single_read--zstd_compression" data-bench="cold_read_latency--single_read--zstd_compression">
   <span class="nav-bench-name">zstd_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +10.2%</span>
 </a>
 <div class="nav-group-label">cold_write_latency</div>
 <a class="nav-item" href="#bench-cold_write_latency--single_write--fast_compression" data-bench="cold_write_latency--single_write--fast_compression">
   <span class="nav-bench-name">fast_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.2%</span>
 </a>
 <a class="nav-item" href="#bench-cold_write_latency--single_write--no_compression" data-bench="cold_write_latency--single_write--no_compression">
   <span class="nav-bench-name">no_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -16.0%</span>
 </a>
 <a class="nav-item" href="#bench-cold_write_latency--single_write--zstd_compression" data-bench="cold_write_latency--single_write--zstd_compression">
   <span class="nav-bench-name">zstd_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +20.4%</span>
 </a>
 <div class="nav-group-label">comparison_csr</div>
 <a class="nav-item" href="#bench-comparison_csr--full_rebuild_insert_query" data-bench="comparison_csr--full_rebuild_insert_query">
@@ -631,15 +640,15 @@
 <div class="nav-group-label">compression_ratio</div>
 <a class="nav-item" href="#bench-compression_ratio--compress--fast" data-bench="compression_ratio--compress--fast">
   <span class="nav-bench-name">fast</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +6.4%</span>
 </a>
 <a class="nav-item" href="#bench-compression_ratio--compress--no_compression" data-bench="compression_ratio--compress--no_compression">
   <span class="nav-bench-name">no_compression</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -12.5%</span>
 </a>
 <a class="nav-item" href="#bench-compression_ratio--compress--zstd" data-bench="compression_ratio--compress--zstd">
   <span class="nav-bench-name">zstd</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +13.1%</span>
 </a>
 <div class="nav-group-label">concurrent_reads_same_entity</div>
 <a class="nav-item" href="#bench-concurrent_reads_same_entity--10000_versions--2_readers" data-bench="concurrent_reads_same_entity--10000_versions--2_readers">
@@ -850,15 +859,15 @@
 <div class="nav-group-label">find_nodes_by_property</div>
 <a class="nav-item" href="#bench-find_nodes_by_property--10000_nodes" data-bench="find_nodes_by_property--10000_nodes">
   <span class="nav-bench-name">10000_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -16.0%</span>
 </a>
 <a class="nav-item" href="#bench-find_nodes_by_property--1000_nodes" data-bench="find_nodes_by_property--1000_nodes">
   <span class="nav-bench-name">1000_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -28.8%</span>
 </a>
 <a class="nav-item" href="#bench-find_nodes_by_property--100_nodes" data-bench="find_nodes_by_property--100_nodes">
   <span class="nav-bench-name">100_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -5.8%</span>
 </a>
 <div class="nav-group-label">frozen_view_hot_path</div>
 <a class="nav-item" href="#bench-frozen_view_hot_path--frozen_view--100000edges" data-bench="frozen_view_hot_path--frozen_view--100000edges">
@@ -888,55 +897,80 @@
 <div class="nav-group-label">get_outgoing_allocation</div>
 <a class="nav-item" href="#bench-get_outgoing_allocation--degree_1" data-bench="get_outgoing_allocation--degree_1">
   <span class="nav-bench-name">degree_1</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -16.4%</span>
 </a>
 <a class="nav-item" href="#bench-get_outgoing_allocation--degree_10" data-bench="get_outgoing_allocation--degree_10">
   <span class="nav-bench-name">degree_10</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -16.8%</span>
 </a>
 <a class="nav-item" href="#bench-get_outgoing_allocation--degree_100" data-bench="get_outgoing_allocation--degree_100">
   <span class="nav-bench-name">degree_100</span>
+  <span class="nav-trend trend-down">↓ -16.9%</span>
+</a>
+<div class="nav-group-label">hot_path</div>
+<a class="nav-item" href="#bench-hot_path--resolve--100" data-bench="hot_path--resolve--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-hot_path--resolve--1000" data-bench="hot_path--resolve--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-hot_path--resolve--10000" data-bench="hot_path--resolve--10000">
+  <span class="nav-bench-name">10000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-hot_path--resolve_with--100" data-bench="hot_path--resolve_with--100">
+  <span class="nav-bench-name">100</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-hot_path--resolve_with--1000" data-bench="hot_path--resolve_with--1000">
+  <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-hot_path--resolve_with--10000" data-bench="hot_path--resolve_with--10000">
+  <span class="nav-bench-name">10000</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <div class="nav-group-label">id_generation_concurrent</div>
 <a class="nav-item" href="#bench-id_generation_concurrent--threads--16" data-bench="id_generation_concurrent--threads--16">
   <span class="nav-bench-name">16</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +5.2%</span>
 </a>
 <a class="nav-item" href="#bench-id_generation_concurrent--threads--2" data-bench="id_generation_concurrent--threads--2">
   <span class="nav-bench-name">2</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -7.4%</span>
 </a>
 <a class="nav-item" href="#bench-id_generation_concurrent--threads--4" data-bench="id_generation_concurrent--threads--4">
   <span class="nav-bench-name">4</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -6.6%</span>
 </a>
 <a class="nav-item" href="#bench-id_generation_concurrent--threads--8" data-bench="id_generation_concurrent--threads--8">
   <span class="nav-bench-name">8</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -12.5%</span>
 </a>
 <div class="nav-group-label">id_generation_current</div>
 <a class="nav-item" href="#bench-id_generation_current--read_current" data-bench="id_generation_current--read_current">
   <span class="nav-bench-name">read_current</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.9%</span>
 </a>
 <a class="nav-item" href="#bench-id_generation_current--read_current_approximate" data-bench="id_generation_current--read_current_approximate">
   <span class="nav-bench-name">read_current_approximate</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.4%</span>
 </a>
 <div class="nav-group-label">id_generation_lifecycle</div>
 <a class="nav-item" href="#bench-id_generation_lifecycle--create_and_generate_1000" data-bench="id_generation_lifecycle--create_and_generate_1000">
   <span class="nav-bench-name">create_and_generate_1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ -0.4%</span>
 </a>
 <div class="nav-group-label">id_generation_single_thread</div>
 <a class="nav-item" href="#bench-id_generation_single_thread--sequential_1000" data-bench="id_generation_single_thread--sequential_1000">
   <span class="nav-bench-name">sequential_1000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -9.3%</span>
 </a>
 <a class="nav-item" href="#bench-id_generation_single_thread--sequential_10000" data-bench="id_generation_single_thread--sequential_10000">
   <span class="nav-bench-name">sequential_10000</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -8.0%</span>
 </a>
 <div class="nav-group-label">incremental_compaction</div>
 <a class="nav-item" href="#bench-incremental_compaction--edges--1000+100" data-bench="incremental_compaction--edges--1000+100">
@@ -1052,6 +1086,10 @@
 <div class="nav-group-label">multiple_accesses</div>
 <a class="nav-item" href="#bench-multiple_accesses--resolve_100" data-bench="multiple_accesses--resolve_100">
   <span class="nav-bench-name">resolve_100</span>
+  <span class="nav-trend trend-down">↓ -12.1%</span>
+</a>
+<a class="nav-item" href="#bench-multiple_accesses--resolve_with_100" data-bench="multiple_accesses--resolve_with_100">
+  <span class="nav-bench-name">resolve_with_100</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <div class="nav-group-label">point_in_time_queries</div>
@@ -1066,11 +1104,11 @@
 <div class="nav-group-label">property_lookup_vs_scan</div>
 <a class="nav-item" href="#bench-property_lookup_vs_scan--find_nodes_by_property" data-bench="property_lookup_vs_scan--find_nodes_by_property">
   <span class="nav-bench-name">find_nodes_by_property</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -11.7%</span>
 </a>
 <a class="nav-item" href="#bench-property_lookup_vs_scan--manual_label_scan_filter" data-bench="property_lookup_vs_scan--manual_label_scan_filter">
   <span class="nav-bench-name">manual_label_scan_filter</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -10.6%</span>
 </a>
 <div class="nav-group-label">read_under_write_contention</div>
 <a class="nav-item" href="#bench-read_under_write_contention--concurrent_writers--0" data-bench="read_under_write_contention--concurrent_writers--0">
@@ -1088,53 +1126,62 @@
 <div class="nav-group-label">recovery</div>
 <a class="nav-item" href="#bench-recovery--10" data-bench="recovery--10">
   <span class="nav-bench-name">10</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -19.6%</span>
 </a>
 <a class="nav-item" href="#bench-recovery--100" data-bench="recovery--100">
   <span class="nav-bench-name">100</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -9.7%</span>
 </a>
 <a class="nav-item" href="#bench-recovery--1000" data-bench="recovery--1000">
   <span class="nav-bench-name">1000</span>
+  <span class="nav-trend trend-down">↓ -5.4%</span>
+</a>
+<div class="nav-group-label">serialization_simulation</div>
+<a class="nav-item" href="#bench-serialization_simulation--resolve" data-bench="serialization_simulation--resolve">
+  <span class="nav-bench-name">resolve</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-serialization_simulation--resolve_with" data-bench="serialization_simulation--resolve_with">
+  <span class="nav-bench-name">resolve_with</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <div class="nav-group-label">single_hop_traversal</div>
 <a class="nav-item" href="#bench-single_hop_traversal--10000_nodes" data-bench="single_hop_traversal--10000_nodes">
   <span class="nav-bench-name">10000_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -8.8%</span>
 </a>
 <a class="nav-item" href="#bench-single_hop_traversal--1000_nodes" data-bench="single_hop_traversal--1000_nodes">
   <span class="nav-bench-name">1000_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -4.5%</span>
 </a>
 <a class="nav-item" href="#bench-single_hop_traversal--100_nodes" data-bench="single_hop_traversal--100_nodes">
   <span class="nav-bench-name">100_nodes</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -7.5%</span>
 </a>
 <div class="nav-group-label">single_transaction_latency</div>
 <a class="nav-item" href="#bench-single_transaction_latency--async" data-bench="single_transaction_latency--async">
   <span class="nav-bench-name">async</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ -0.3%</span>
 </a>
 <a class="nav-item" href="#bench-single_transaction_latency--async_batched_aggressive" data-bench="single_transaction_latency--async_batched_aggressive">
   <span class="nav-bench-name">async_batched_aggressive</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +1.6%</span>
 </a>
 <a class="nav-item" href="#bench-single_transaction_latency--async_batched_default" data-bench="single_transaction_latency--async_batched_default">
   <span class="nav-bench-name">async_batched_default</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-flat">→ +0.6%</span>
 </a>
 <a class="nav-item" href="#bench-single_transaction_latency--group_commit_default" data-bench="single_transaction_latency--group_commit_default">
   <span class="nav-bench-name">group_commit_default</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +16.2%</span>
 </a>
 <a class="nav-item" href="#bench-single_transaction_latency--group_commit_fast" data-bench="single_transaction_latency--group_commit_fast">
   <span class="nav-bench-name">group_commit_fast</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +11.5%</span>
 </a>
 <a class="nav-item" href="#bench-single_transaction_latency--synchronous" data-bench="single_transaction_latency--synchronous">
   <span class="nav-bench-name">synchronous</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +29.2%</span>
 </a>
 <div class="nav-group-label">snapshot_creation</div>
 <a class="nav-item" href="#bench-snapshot_creation--time_interval_1s" data-bench="snapshot_creation--time_interval_1s">
@@ -1152,28 +1199,37 @@
 <div class="nav-group-label">string_access_single</div>
 <a class="nav-item" href="#bench-string_access_single--resolve" data-bench="string_access_single--resolve">
   <span class="nav-bench-name">resolve</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -7.7%</span>
 </a>
 <a class="nav-item" href="#bench-string_access_single--resolve_with" data-bench="string_access_single--resolve_with">
   <span class="nav-bench-name">resolve_with</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -6.7%</span>
 </a>
 <div class="nav-group-label">string_comparison</div>
 <a class="nav-item" href="#bench-string_comparison--resolve" data-bench="string_comparison--resolve">
   <span class="nav-bench-name">resolve</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -14.0%</span>
 </a>
 <a class="nav-item" href="#bench-string_comparison--resolve_with" data-bench="string_comparison--resolve_with">
   <span class="nav-bench-name">resolve_with</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -8.8%</span>
 </a>
 <div class="nav-group-label">string_length</div>
 <a class="nav-item" href="#bench-string_length--resolve" data-bench="string_length--resolve">
   <span class="nav-bench-name">resolve</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-down">↓ -12.6%</span>
 </a>
 <a class="nav-item" href="#bench-string_length--resolve_with" data-bench="string_length--resolve_with">
   <span class="nav-bench-name">resolve_with</span>
+  <span class="nav-trend trend-down">↓ -12.5%</span>
+</a>
+<div class="nav-group-label">sustained_write_throughput</div>
+<a class="nav-item" href="#bench-sustained_write_throughput--sustained_write_10k_versions" data-bench="sustained_write_throughput--sustained_write_10k_versions">
+  <span class="nav-bench-name">sustained_write_10k_versions</span>
+  <span class="nav-trend trend-flat">→ +0.0%</span>
+</a>
+<a class="nav-item" href="#bench-sustained_write_throughput--sustained_write_10k_versions_fast_reference" data-bench="sustained_write_throughput--sustained_write_10k_versions_fast_reference">
+  <span class="nav-bench-name">sustained_write_10k_versions_fast_reference</span>
   <span class="nav-trend trend-flat">→ +0.0%</span>
 </a>
 <div class="nav-group-label">target_3_hop</div>
@@ -1232,19 +1288,19 @@
 <div class="nav-group-label">time_travel</div>
 <a class="nav-item" href="#bench-time_travel--at_anchor_v20" data-bench="time_travel--at_anchor_v20">
   <span class="nav-bench-name">at_anchor_v20</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +58.7%</span>
 </a>
 <a class="nav-item" href="#bench-time_travel--deep_history_v5" data-bench="time_travel--deep_history_v5">
   <span class="nav-bench-name">deep_history_v5</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +56.3%</span>
 </a>
 <a class="nav-item" href="#bench-time_travel--with_deltas_v15" data-bench="time_travel--with_deltas_v15">
   <span class="nav-bench-name">with_deltas_v15</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +54.3%</span>
 </a>
 <a class="nav-item" href="#bench-time_travel--worst_case_v19" data-bench="time_travel--worst_case_v19">
   <span class="nav-bench-name">worst_case_v19</span>
-  <span class="nav-trend trend-flat">→ +0.0%</span>
+  <span class="nav-trend trend-up">↑ +90.6%</span>
 </a>
 <div class="nav-group-label">traverse_and_rank_basic</div>
 <a class="nav-item" href="#bench-traverse_and_rank_basic--100_power_law--100" data-bench="traverse_and_rank_basic--100_power_law--100">
@@ -1391,19 +1447,19 @@
   <div class="page-header">
     <h1>Performance Timeseries</h1>
     <div class="page-meta">
-      <span><span class="label">runs</span> 3</span>
-      <span><span class="label">benchmarks</span> 232</span>
-      <span><span class="label">generated</span> 2026-02-21 20:44 UTC</span>
+      <span><span class="label">runs</span> 5</span>
+      <span><span class="label">benchmarks</span> 245</span>
+      <span><span class="label">generated</span> 2026-03-15 02:30 UTC</span>
     </div>
   </div>
 
   <div class="overview-row">
     <div class="overview-card">
-      <div class="overview-value">3</div>
+      <div class="overview-value">5</div>
       <div class="overview-label">Total Runs</div>
     </div>
     <div class="overview-card">
-      <div class="overview-value">232</div>
+      <div class="overview-value">245</div>
       <div class="overview-label">Benchmarks</div>
     </div>
     <div class="overview-card">
@@ -1411,13 +1467,13 @@
       <div class="overview-label">Trending Faster</div>
     </div>
     <div class="overview-card">
-      <div class="overview-value">0</div>
+      <div class="overview-value">5</div>
       <div class="overview-label">Trending Slower</div>
     </div>
   </div>
 
   <div class="movers">
-    <div class="movers-col"><h3 class="movers-label improved-label">⬇ Biggest Improvements</h3><div class="mover-item improved">target_batch_insertion/insert_1000_edges <span>-19.3%</span></div><div class="mover-item improved">target_single_hop/traverse_one_hop <span>-7.3%</span></div><div class="mover-item improved">target_3_hop/traverse_three_hops <span>-4.5%</span></div><div class="mover-item improved">target_time_travel/worst_case_9_deltas <span>-4.1%</span></div><div class="mover-item improved">target_time_travel/at_anchor <span>-3.6%</span></div></div>
+    <div class="movers-col"><h3 class="movers-label improved-label">⬇ Biggest Improvements</h3><div class="mover-item improved">find_nodes_by_property/1000_nodes <span>-28.8%</span></div><div class="mover-item improved">edge_creation <span>-22.9%</span></div><div class="mover-item improved">node_creation <span>-22.7%</span></div><div class="mover-item improved">recovery/10 <span>-19.6%</span></div><div class="mover-item improved">target_batch_insertion/insert_1000_edges <span>-19.3%</span></div></div><div class="movers-col"><h3 class="movers-label regressed-label">⬆ Biggest Regressions</h3><div class="mover-item regressed">time_travel/worst_case_v19 <span>+90.6%</span></div><div class="mover-item regressed">time_travel/at_anchor_v20 <span>+58.7%</span></div><div class="mover-item regressed">time_travel/deep_history_v5 <span>+56.3%</span></div><div class="mover-item regressed">time_travel/with_deltas_v15 <span>+54.3%</span></div><div class="mover-item regressed">single_transaction_latency/synchronous <span>+29.2%</span></div></div>
   </div>
 
   <div class="controls-bar">
@@ -1431,24 +1487,24 @@
 <section class="bench-section" id="bench-3_hop_traversal" data-bench-name="3_hop_traversal">
   <div class="bench-header">
     <h2 class="bench-title">3_hop_traversal</h2>
-    <div class="bench-latest">56.71 µs</div>
+    <div class="bench-latest">50.50 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">56.71 µs</span>
+      <span class="bench-stat-value">53.60 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.10 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">56.71 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">50.50 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1456,7 +1512,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-10.9%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1466,32 +1522,32 @@
 <section class="bench-section" id="bench-aletheiadb_3_hop_traversal" data-bench-name="aletheiadb_3_hop_traversal">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_3_hop_traversal</h2>
-    <div class="bench-latest">483.0 ns</div>
+    <div class="bench-latest">491.0 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">483.0 ns</span>
+      <span class="bench-stat-value">485.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">4.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">483.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">480.9 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">483.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">491.0 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+1.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1501,16 +1557,16 @@
 <section class="bench-section" id="bench-aletheiadb_edge_creation" data-bench-name="aletheiadb_edge_creation">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_edge_creation</h2>
-    <div class="bench-latest">97.35 µs</div>
+    <div class="bench-latest">97.44 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">97.35 µs</span>
+      <span class="bench-stat-value">97.40 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">37.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
@@ -1522,11 +1578,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">97.35 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">97.44 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.1%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1536,32 +1592,32 @@
 <section class="bench-section" id="bench-aletheiadb_historical_stats" data-bench-name="aletheiadb_historical_stats">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_historical_stats</h2>
-    <div class="bench-latest">1.06 µs</div>
+    <div class="bench-latest">943.7 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">1.06 µs</span>
+      <span class="bench-stat-value">1.02 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">54.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.4%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">1.06 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">943.7 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">1.06 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">1.06 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-10.9%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1571,24 +1627,24 @@
 <section class="bench-section" id="bench-aletheiadb_in_degree" data-bench-name="aletheiadb_in_degree">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_in_degree</h2>
-    <div class="bench-latest">104.9 ns</div>
+    <div class="bench-latest">93.7 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">104.9 ns</span>
+      <span class="bench-stat-value">99.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">4.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">104.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">93.7 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1596,7 +1652,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-10.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1606,32 +1662,32 @@
 <section class="bench-section" id="bench-aletheiadb_labeled_traversal" data-bench-name="aletheiadb_labeled_traversal">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_labeled_traversal</h2>
-    <div class="bench-latest">159.9 ns</div>
+    <div class="bench-latest">157.2 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">159.9 ns</span>
+      <span class="bench-stat-value">159.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.4 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">159.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">157.2 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">159.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">160.2 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">-1.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1641,24 +1697,24 @@
 <section class="bench-section" id="bench-aletheiadb_node_creation" data-bench-name="aletheiadb_node_creation">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_node_creation</h2>
-    <div class="bench-latest">105.59 µs</div>
+    <div class="bench-latest">98.59 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">105.59 µs</span>
+      <span class="bench-stat-value">100.92 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.30 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">105.59 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">98.58 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1666,7 +1722,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-6.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1676,20 +1732,20 @@
 <section class="bench-section" id="bench-aletheiadb_out_degree" data-bench-name="aletheiadb_out_degree">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_out_degree</h2>
-    <div class="bench-latest">100.4 ns</div>
+    <div class="bench-latest">100.9 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">100.4 ns</span>
+      <span class="bench-stat-value">102.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.7 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">2.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -1697,11 +1753,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">100.4 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">106.4 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1781,24 +1837,24 @@
 <section class="bench-section" id="bench-edge_creation" data-bench-name="edge_creation">
   <div class="bench-header">
     <h2 class="bench-title">edge_creation</h2>
-    <div class="bench-latest">4.46 µs</div>
+    <div class="bench-latest">3.44 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">4.46 µs</span>
+      <span class="bench-stat-value">3.95 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">510.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">12.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">4.46 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">3.44 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1806,7 +1862,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-22.9%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1816,24 +1872,24 @@
 <section class="bench-section" id="bench-edge_lookup" data-bench-name="edge_lookup">
   <div class="bench-header">
     <h2 class="bench-title">edge_lookup</h2>
-    <div class="bench-latest">62.4 ns</div>
+    <div class="bench-latest">54.7 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">62.4 ns</span>
+      <span class="bench-stat-value">58.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.8 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">62.4 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">54.7 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1841,7 +1897,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-12.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1851,24 +1907,24 @@
 <section class="bench-section" id="bench-find_neighbors" data-bench-name="find_neighbors">
   <div class="bench-header">
     <h2 class="bench-title">find_neighbors</h2>
-    <div class="bench-latest">1.24 µs</div>
+    <div class="bench-latest">1.14 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">1.24 µs</span>
+      <span class="bench-stat-value">1.19 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">51.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">1.24 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">1.14 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1876,7 +1932,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-8.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1886,24 +1942,24 @@
 <section class="bench-section" id="bench-in_degree" data-bench-name="in_degree">
   <div class="bench-header">
     <h2 class="bench-title">in_degree</h2>
-    <div class="bench-latest">398.6 ns</div>
+    <div class="bench-latest">353.9 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">398.6 ns</span>
+      <span class="bench-stat-value">376.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">22.4 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">398.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">353.9 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1911,7 +1967,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1921,24 +1977,24 @@
 <section class="bench-section" id="bench-labeled_traversal" data-bench-name="labeled_traversal">
   <div class="bench-header">
     <h2 class="bench-title">labeled_traversal</h2>
-    <div class="bench-latest">465.9 ns</div>
+    <div class="bench-latest">425.6 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">465.9 ns</span>
+      <span class="bench-stat-value">445.8 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">20.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.5%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">465.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">425.6 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1946,7 +2002,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-8.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1956,24 +2012,24 @@
 <section class="bench-section" id="bench-mixed_read_write_80_20" data-bench-name="mixed_read_write_80_20">
   <div class="bench-header">
     <h2 class="bench-title">mixed_read_write_80_20</h2>
-    <div class="bench-latest">16.59 ms</div>
+    <div class="bench-latest">16.00 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">16.59 ms</span>
+      <span class="bench-stat-value">16.30 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">295.19 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">1.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">16.59 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">16.00 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -1981,7 +2037,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-3.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -1991,24 +2047,24 @@
 <section class="bench-section" id="bench-node_creation" data-bench-name="node_creation">
   <div class="bench-header">
     <h2 class="bench-title">node_creation</h2>
-    <div class="bench-latest">4.43 µs</div>
+    <div class="bench-latest">3.42 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">4.43 µs</span>
+      <span class="bench-stat-value">3.93 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">504.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">12.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">4.43 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">3.42 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2016,7 +2072,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-22.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2026,24 +2082,24 @@
 <section class="bench-section" id="bench-node_lookup" data-bench-name="node_lookup">
   <div class="bench-header">
     <h2 class="bench-title">node_lookup</h2>
-    <div class="bench-latest">64.6 ns</div>
+    <div class="bench-latest">57.4 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">64.6 ns</span>
+      <span class="bench-stat-value">61.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">64.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">57.4 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2051,7 +2107,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2061,24 +2117,24 @@
 <section class="bench-section" id="bench-out_degree" data-bench-name="out_degree">
   <div class="bench-header">
     <h2 class="bench-title">out_degree</h2>
-    <div class="bench-latest">406.2 ns</div>
+    <div class="bench-latest">359.8 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">406.2 ns</span>
+      <span class="bench-stat-value">383.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">23.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">406.2 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">359.8 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2086,7 +2142,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2096,20 +2152,20 @@
 <section class="bench-section" id="bench-read_latency_p50_p99" data-bench-name="read_latency_p50_p99">
   <div class="bench-header">
     <h2 class="bench-title">read_latency_p50_p99</h2>
-    <div class="bench-latest">8.8 ns</div>
+    <div class="bench-latest">9.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">8.8 ns</span>
+      <span class="bench-stat-value">9.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">0.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">2.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2117,11 +2173,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">8.8 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">9.3 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+5.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2271,20 +2327,20 @@
 <section class="bench-section" id="bench-aletheiadb_batch--batch_node_creation--10" data-bench-name="aletheiadb_batch/batch_node_creation/10">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_batch/batch_node_creation/10</h2>
-    <div class="bench-latest">27.81 ms</div>
+    <div class="bench-latest">29.94 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">27.81 ms</span>
+      <span class="bench-stat-value">29.38 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.13 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2292,11 +2348,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">27.81 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">30.40 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+7.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2306,20 +2362,20 @@
 <section class="bench-section" id="bench-aletheiadb_batch--batch_node_creation--100" data-bench-name="aletheiadb_batch/batch_node_creation/100">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_batch/batch_node_creation/100</h2>
-    <div class="bench-latest">289.83 ms</div>
+    <div class="bench-latest">320.78 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">289.83 ms</span>
+      <span class="bench-stat-value">312.00 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">15.79 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2327,11 +2383,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">289.83 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">325.40 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+10.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2341,20 +2397,20 @@
 <section class="bench-section" id="bench-aletheiadb_batch--batch_node_creation--1000" data-bench-name="aletheiadb_batch/batch_node_creation/1000">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_batch/batch_node_creation/1000</h2>
-    <div class="bench-latest">2.831 s</div>
+    <div class="bench-latest">3.243 s</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">2.831 s</span>
+      <span class="bench-stat-value">3.126 s</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">209.57 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2362,11 +2418,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">2.831 s <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">3.303 s <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+14.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2376,24 +2432,24 @@
 <section class="bench-section" id="bench-aletheiadb_fast_path--node_lookup--100" data-bench-name="aletheiadb_fast_path/node_lookup/100">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_fast_path/node_lookup/100</h2>
-    <div class="bench-latest">62.7 ns</div>
+    <div class="bench-latest">55.7 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">62.7 ns</span>
+      <span class="bench-stat-value">60.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">62.7 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">55.7 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2401,7 +2457,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2411,32 +2467,32 @@
 <section class="bench-section" id="bench-aletheiadb_fast_path--node_lookup--1000" data-bench-name="aletheiadb_fast_path/node_lookup/1000">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_fast_path/node_lookup/1000</h2>
-    <div class="bench-latest">62.0 ns</div>
+    <div class="bench-latest">62.2 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">62.0 ns</span>
+      <span class="bench-stat-value">61.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">0.4 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">62.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">61.4 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">62.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">62.2 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2446,20 +2502,20 @@
 <section class="bench-section" id="bench-aletheiadb_fast_path--node_lookup--10000" data-bench-name="aletheiadb_fast_path/node_lookup/10000">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_fast_path/node_lookup/10000</h2>
-    <div class="bench-latest">61.2 ns</div>
+    <div class="bench-latest">61.5 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">61.2 ns</span>
+      <span class="bench-stat-value">61.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">0.4 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2467,11 +2523,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">61.2 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">62.1 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2481,24 +2537,24 @@
 <section class="bench-section" id="bench-aletheiadb_single_hop--10000_nodes" data-bench-name="aletheiadb_single_hop/10000_nodes">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_single_hop/10000_nodes</h2>
-    <div class="bench-latest">116.5 ns</div>
+    <div class="bench-latest">104.6 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">116.5 ns</span>
+      <span class="bench-stat-value">112.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">5.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">116.5 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">104.6 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2506,7 +2562,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-10.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2516,24 +2572,24 @@
 <section class="bench-section" id="bench-aletheiadb_single_hop--1000_nodes" data-bench-name="aletheiadb_single_hop/1000_nodes">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_single_hop/1000_nodes</h2>
-    <div class="bench-latest">116.6 ns</div>
+    <div class="bench-latest">103.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">116.6 ns</span>
+      <span class="bench-stat-value">111.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">5.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">116.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">103.3 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2541,7 +2597,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2551,24 +2607,24 @@
 <section class="bench-section" id="bench-aletheiadb_single_hop--100_nodes" data-bench-name="aletheiadb_single_hop/100_nodes">
   <div class="bench-header">
     <h2 class="bench-title">aletheiadb_single_hop/100_nodes</h2>
-    <div class="bench-latest">116.1 ns</div>
+    <div class="bench-latest">113.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">116.1 ns</span>
+      <span class="bench-stat-value">115.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">1.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">116.1 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">113.3 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2576,22 +2632,22 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-2.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
     <canvas id="chart-aletheiadb_single_hop--100_nodes" height="260"></canvas>
   </div>
 </section>
-<section class="bench-section" id="bench-batch_throughput--async" data-bench-name="batch_throughput/async">
+<section class="bench-section" id="bench-arc_overhead--arc_clone_drop" data-bench-name="arc_overhead/arc_clone_drop">
   <div class="bench-header">
-    <h2 class="bench-title">batch_throughput/async</h2>
-    <div class="bench-latest">52.79 ms</div>
+    <h2 class="bench-title">arc_overhead/arc_clone_drop</h2>
+    <div class="bench-latest">32.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">52.79 ms</span>
+      <span class="bench-stat-value">32.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
@@ -2603,7 +2659,77 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">52.79 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">32.3 ns <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.3 ns <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-arc_overhead--arc_clone_drop" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-arc_overhead--direct_access" data-bench-name="arc_overhead/direct_access">
+  <div class="bench-header">
+    <h2 class="bench-title">arc_overhead/direct_access</h2>
+    <div class="bench-latest">19.4 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">19.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">19.4 ns <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">19.4 ns <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-arc_overhead--direct_access" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-batch_throughput--async" data-bench-name="batch_throughput/async">
+  <div class="bench-header">
+    <h2 class="bench-title">batch_throughput/async</h2>
+    <div class="bench-latest">52.37 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">52.58 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">211.43 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.4%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">52.37 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2611,7 +2737,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">-0.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2621,20 +2747,20 @@
 <section class="bench-section" id="bench-batch_throughput--synchronous" data-bench-name="batch_throughput/synchronous">
   <div class="bench-header">
     <h2 class="bench-title">batch_throughput/synchronous</h2>
-    <div class="bench-latest">635.75 ms</div>
+    <div class="bench-latest">758.78 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">635.75 ms</span>
+      <span class="bench-stat-value">697.26 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">61.52 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">8.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2642,11 +2768,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">635.75 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">758.78 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+19.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2656,24 +2782,24 @@
 <section class="bench-section" id="bench-checkpoint_creation--100" data-bench-name="checkpoint_creation/100">
   <div class="bench-header">
     <h2 class="bench-title">checkpoint_creation/100</h2>
-    <div class="bench-latest">4.89 ms</div>
+    <div class="bench-latest">4.05 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">4.89 ms</span>
+      <span class="bench-stat-value">4.47 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">421.39 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">9.4%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">4.89 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">4.05 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2681,7 +2807,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-17.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2691,20 +2817,20 @@
 <section class="bench-section" id="bench-checkpoint_creation--1000" data-bench-name="checkpoint_creation/1000">
   <div class="bench-header">
     <h2 class="bench-title">checkpoint_creation/1000</h2>
-    <div class="bench-latest">4.03 ms</div>
+    <div class="bench-latest">4.50 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">4.03 ms</span>
+      <span class="bench-stat-value">4.27 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">237.34 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2712,11 +2838,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">4.03 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">4.50 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+11.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2726,20 +2852,20 @@
 <section class="bench-section" id="bench-checkpoint_creation--10000" data-bench-name="checkpoint_creation/10000">
   <div class="bench-header">
     <h2 class="bench-title">checkpoint_creation/10000</h2>
-    <div class="bench-latest">7.66 ms</div>
+    <div class="bench-latest">8.78 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">7.66 ms</span>
+      <span class="bench-stat-value">8.22 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">559.58 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2747,11 +2873,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">7.66 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">8.78 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+14.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2761,24 +2887,24 @@
 <section class="bench-section" id="bench-checkpoint_load--100" data-bench-name="checkpoint_load/100">
   <div class="bench-header">
     <h2 class="bench-title">checkpoint_load/100</h2>
-    <div class="bench-latest">323.51 µs</div>
+    <div class="bench-latest">312.88 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">323.51 µs</span>
+      <span class="bench-stat-value">318.19 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">5.31 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">1.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">323.51 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">312.88 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2786,7 +2912,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-3.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2796,24 +2922,24 @@
 <section class="bench-section" id="bench-checkpoint_load--1000" data-bench-name="checkpoint_load/1000">
   <div class="bench-header">
     <h2 class="bench-title">checkpoint_load/1000</h2>
-    <div class="bench-latest">1.63 ms</div>
+    <div class="bench-latest">1.49 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">1.63 ms</span>
+      <span class="bench-stat-value">1.56 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">68.76 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.4%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">1.63 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">1.49 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2821,7 +2947,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-8.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2831,24 +2957,24 @@
 <section class="bench-section" id="bench-checkpoint_load--10000" data-bench-name="checkpoint_load/10000">
   <div class="bench-header">
     <h2 class="bench-title">checkpoint_load/10000</h2>
-    <div class="bench-latest">15.18 ms</div>
+    <div class="bench-latest">13.15 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">15.18 ms</span>
+      <span class="bench-stat-value">14.16 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.02 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">7.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">15.18 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">13.15 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -2856,7 +2982,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-13.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2866,20 +2992,20 @@
 <section class="bench-section" id="bench-cold_batch_write_throughput--fast--100" data-bench-name="cold_batch_write_throughput/fast/100">
   <div class="bench-header">
     <h2 class="bench-title">cold_batch_write_throughput/fast/100</h2>
-    <div class="bench-latest">4.93 ms</div>
+    <div class="bench-latest">5.32 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">4.93 ms</span>
+      <span class="bench-stat-value">5.12 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">192.92 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2887,11 +3013,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">4.93 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">5.32 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+7.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2901,20 +3027,20 @@
 <section class="bench-section" id="bench-cold_batch_write_throughput--fast--1000" data-bench-name="cold_batch_write_throughput/fast/1000">
   <div class="bench-header">
     <h2 class="bench-title">cold_batch_write_throughput/fast/1000</h2>
-    <div class="bench-latest">45.81 ms</div>
+    <div class="bench-latest">47.50 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">45.81 ms</span>
+      <span class="bench-stat-value">46.66 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">841.58 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">1.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2922,11 +3048,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">45.81 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">47.50 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+3.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2936,20 +3062,20 @@
 <section class="bench-section" id="bench-cold_batch_write_throughput--fast--10000" data-bench-name="cold_batch_write_throughput/fast/10000">
   <div class="bench-header">
     <h2 class="bench-title">cold_batch_write_throughput/fast/10000</h2>
-    <div class="bench-latest">454.83 ms</div>
+    <div class="bench-latest">457.43 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">454.83 ms</span>
+      <span class="bench-stat-value">456.13 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.30 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2957,11 +3083,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">454.83 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">457.43 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -2971,20 +3097,20 @@
 <section class="bench-section" id="bench-cold_batch_write_throughput--zstd--100" data-bench-name="cold_batch_write_throughput/zstd/100">
   <div class="bench-header">
     <h2 class="bench-title">cold_batch_write_throughput/zstd/100</h2>
-    <div class="bench-latest">7.45 ms</div>
+    <div class="bench-latest">7.98 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">7.45 ms</span>
+      <span class="bench-stat-value">7.72 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">269.05 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.5%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -2992,11 +3118,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">7.45 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">7.98 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+7.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3006,20 +3132,20 @@
 <section class="bench-section" id="bench-cold_batch_write_throughput--zstd--1000" data-bench-name="cold_batch_write_throughput/zstd/1000">
   <div class="bench-header">
     <h2 class="bench-title">cold_batch_write_throughput/zstd/1000</h2>
-    <div class="bench-latest">66.78 ms</div>
+    <div class="bench-latest">67.06 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">66.78 ms</span>
+      <span class="bench-stat-value">66.92 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">137.79 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3027,11 +3153,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">66.78 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">67.06 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3041,24 +3167,24 @@
 <section class="bench-section" id="bench-cold_batch_write_throughput--zstd--10000" data-bench-name="cold_batch_write_throughput/zstd/10000">
   <div class="bench-header">
     <h2 class="bench-title">cold_batch_write_throughput/zstd/10000</h2>
-    <div class="bench-latest">189.51 ms</div>
+    <div class="bench-latest">183.45 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">189.51 ms</span>
+      <span class="bench-stat-value">186.48 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.03 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">1.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">189.51 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">183.45 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -3066,7 +3192,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-3.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3076,20 +3202,20 @@
 <section class="bench-section" id="bench-cold_read_latency--single_read--fast_compression" data-bench-name="cold_read_latency/single_read/fast_compression">
   <div class="bench-header">
     <h2 class="bench-title">cold_read_latency/single_read/fast_compression</h2>
-    <div class="bench-latest">34.54 µs</div>
+    <div class="bench-latest">38.47 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">34.54 µs</span>
+      <span class="bench-stat-value">36.51 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.97 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.4%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3097,11 +3223,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">34.54 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">38.47 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+11.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3111,24 +3237,24 @@
 <section class="bench-section" id="bench-cold_read_latency--single_read--no_compression" data-bench-name="cold_read_latency/single_read/no_compression">
   <div class="bench-header">
     <h2 class="bench-title">cold_read_latency/single_read/no_compression</h2>
-    <div class="bench-latest">3.31 µs</div>
+    <div class="bench-latest">3.25 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">3.31 µs</span>
+      <span class="bench-stat-value">3.28 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">27.7 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">3.31 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">3.25 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -3136,7 +3262,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">-1.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3146,20 +3272,20 @@
 <section class="bench-section" id="bench-cold_read_latency--single_read--zstd_compression" data-bench-name="cold_read_latency/single_read/zstd_compression">
   <div class="bench-header">
     <h2 class="bench-title">cold_read_latency/single_read/zstd_compression</h2>
-    <div class="bench-latest">34.41 µs</div>
+    <div class="bench-latest">37.93 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">34.41 µs</span>
+      <span class="bench-stat-value">36.17 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.76 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3167,11 +3293,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">34.41 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">37.93 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+10.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3181,20 +3307,20 @@
 <section class="bench-section" id="bench-cold_write_latency--single_write--fast_compression" data-bench-name="cold_write_latency/single_write/fast_compression">
   <div class="bench-header">
     <h2 class="bench-title">cold_write_latency/single_write/fast_compression</h2>
-    <div class="bench-latest">340.43 µs</div>
+    <div class="bench-latest">341.14 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">340.43 µs</span>
+      <span class="bench-stat-value">340.78 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">356.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3202,11 +3328,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">340.43 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">341.14 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3216,24 +3342,24 @@
 <section class="bench-section" id="bench-cold_write_latency--single_write--no_compression" data-bench-name="cold_write_latency/single_write/no_compression">
   <div class="bench-header">
     <h2 class="bench-title">cold_write_latency/single_write/no_compression</h2>
-    <div class="bench-latest">343.79 µs</div>
+    <div class="bench-latest">288.70 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">343.79 µs</span>
+      <span class="bench-stat-value">316.25 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">27.55 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">8.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">343.79 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">288.70 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -3241,7 +3367,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-16.0%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3251,20 +3377,20 @@
 <section class="bench-section" id="bench-cold_write_latency--single_write--zstd_compression" data-bench-name="cold_write_latency/single_write/zstd_compression">
   <div class="bench-header">
     <h2 class="bench-title">cold_write_latency/single_write/zstd_compression</h2>
-    <div class="bench-latest">373.87 µs</div>
+    <div class="bench-latest">450.07 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">373.87 µs</span>
+      <span class="bench-stat-value">411.97 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">38.10 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">9.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3272,11 +3398,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">373.87 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">450.07 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+20.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3356,20 +3482,20 @@
 <section class="bench-section" id="bench-compression_ratio--compress--fast" data-bench-name="compression_ratio/compress/fast">
   <div class="bench-header">
     <h2 class="bench-title">compression_ratio/compress/fast</h2>
-    <div class="bench-latest">34.87 ms</div>
+    <div class="bench-latest">37.08 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">34.87 ms</span>
+      <span class="bench-stat-value">35.98 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.11 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3377,11 +3503,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">34.87 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">37.08 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+6.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3391,24 +3517,24 @@
 <section class="bench-section" id="bench-compression_ratio--compress--no_compression" data-bench-name="compression_ratio/compress/no_compression">
   <div class="bench-header">
     <h2 class="bench-title">compression_ratio/compress/no_compression</h2>
-    <div class="bench-latest">31.26 ms</div>
+    <div class="bench-latest">27.36 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">31.26 ms</span>
+      <span class="bench-stat-value">29.31 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.95 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">31.26 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">27.36 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -3416,7 +3542,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-12.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -3426,20 +3552,20 @@
 <section class="bench-section" id="bench-compression_ratio--compress--zstd" data-bench-name="compression_ratio/compress/zstd">
   <div class="bench-header">
     <h2 class="bench-title">compression_ratio/compress/zstd</h2>
-    <div class="bench-latest">36.22 ms</div>
+    <div class="bench-latest">40.95 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">36.22 ms</span>
+      <span class="bench-stat-value">38.58 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.36 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -3447,11 +3573,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">36.22 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">40.95 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+13.1%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5211,24 +5337,24 @@
 <section class="bench-section" id="bench-find_nodes_by_property--10000_nodes" data-bench-name="find_nodes_by_property/10000_nodes">
   <div class="bench-header">
     <h2 class="bench-title">find_nodes_by_property/10000_nodes</h2>
-    <div class="bench-latest">757.09 µs</div>
+    <div class="bench-latest">636.24 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">757.09 µs</span>
+      <span class="bench-stat-value">696.67 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">60.43 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">8.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">757.09 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">636.24 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5236,7 +5362,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-16.0%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5246,24 +5372,24 @@
 <section class="bench-section" id="bench-find_nodes_by_property--1000_nodes" data-bench-name="find_nodes_by_property/1000_nodes">
   <div class="bench-header">
     <h2 class="bench-title">find_nodes_by_property/1000_nodes</h2>
-    <div class="bench-latest">50.79 µs</div>
+    <div class="bench-latest">36.14 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">50.79 µs</span>
+      <span class="bench-stat-value">43.47 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">7.32 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">16.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">50.79 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">36.14 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5271,7 +5397,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-28.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5281,24 +5407,24 @@
 <section class="bench-section" id="bench-find_nodes_by_property--100_nodes" data-bench-name="find_nodes_by_property/100_nodes">
   <div class="bench-header">
     <h2 class="bench-title">find_nodes_by_property/100_nodes</h2>
-    <div class="bench-latest">4.67 µs</div>
+    <div class="bench-latest">4.40 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">4.67 µs</span>
+      <span class="bench-stat-value">4.54 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">136.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.0%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">4.67 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">4.40 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5306,7 +5432,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-5.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5526,24 +5652,24 @@
 <section class="bench-section" id="bench-get_outgoing_allocation--degree_1" data-bench-name="get_outgoing_allocation/degree_1">
   <div class="bench-header">
     <h2 class="bench-title">get_outgoing_allocation/degree_1</h2>
-    <div class="bench-latest">35.6 ns</div>
+    <div class="bench-latest">29.8 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">35.6 ns</span>
+      <span class="bench-stat-value">32.7 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">9.0%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">35.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">29.8 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5551,7 +5677,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-16.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5561,24 +5687,24 @@
 <section class="bench-section" id="bench-get_outgoing_allocation--degree_10" data-bench-name="get_outgoing_allocation/degree_10">
   <div class="bench-header">
     <h2 class="bench-title">get_outgoing_allocation/degree_10</h2>
-    <div class="bench-latest">35.3 ns</div>
+    <div class="bench-latest">29.4 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">35.3 ns</span>
+      <span class="bench-stat-value">32.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">9.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">35.3 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">29.4 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5586,7 +5712,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-16.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5596,24 +5722,24 @@
 <section class="bench-section" id="bench-get_outgoing_allocation--degree_100" data-bench-name="get_outgoing_allocation/degree_100">
   <div class="bench-header">
     <h2 class="bench-title">get_outgoing_allocation/degree_100</h2>
-    <div class="bench-latest">35.4 ns</div>
+    <div class="bench-latest">29.4 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">35.4 ns</span>
+      <span class="bench-stat-value">32.4 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">3.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">9.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">35.4 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">29.4 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5621,22 +5747,22 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-16.9%</span>
     </div>
   </div>
   <div class="chart-wrap">
     <canvas id="chart-get_outgoing_allocation--degree_100" height="260"></canvas>
   </div>
 </section>
-<section class="bench-section" id="bench-id_generation_concurrent--threads--16" data-bench-name="id_generation_concurrent/threads/16">
+<section class="bench-section" id="bench-hot_path--resolve--100" data-bench-name="hot_path/resolve/100">
   <div class="bench-header">
-    <h2 class="bench-title">id_generation_concurrent/threads/16</h2>
-    <div class="bench-latest">674.80 µs</div>
+    <h2 class="bench-title">hot_path/resolve/100</h2>
+    <div class="bench-latest">3.14 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">674.80 µs</span>
+      <span class="bench-stat-value">3.14 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
@@ -5648,15 +5774,225 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">674.80 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">3.14 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">674.80 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">3.14 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
       <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-hot_path--resolve--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-hot_path--resolve--1000" data-bench-name="hot_path/resolve/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">hot_path/resolve/1000</h2>
+    <div class="bench-latest">32.13 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">32.13 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">32.13 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">32.13 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-hot_path--resolve--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-hot_path--resolve--10000" data-bench-name="hot_path/resolve/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">hot_path/resolve/10000</h2>
+    <div class="bench-latest">315.14 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">315.14 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">315.14 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">315.14 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-hot_path--resolve--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-hot_path--resolve_with--100" data-bench-name="hot_path/resolve_with/100">
+  <div class="bench-header">
+    <h2 class="bench-title">hot_path/resolve_with/100</h2>
+    <div class="bench-latest">1.90 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.90 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">1.90 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">1.90 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-hot_path--resolve_with--100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-hot_path--resolve_with--1000" data-bench-name="hot_path/resolve_with/1000">
+  <div class="bench-header">
+    <h2 class="bench-title">hot_path/resolve_with/1000</h2>
+    <div class="bench-latest">19.53 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">19.53 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">19.53 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">19.53 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-hot_path--resolve_with--1000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-hot_path--resolve_with--10000" data-bench-name="hot_path/resolve_with/10000">
+  <div class="bench-header">
+    <h2 class="bench-title">hot_path/resolve_with/10000</h2>
+    <div class="bench-latest">193.73 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">193.73 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">193.73 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">193.73 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-hot_path--resolve_with--10000" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-id_generation_concurrent--threads--16" data-bench-name="id_generation_concurrent/threads/16">
+  <div class="bench-header">
+    <h2 class="bench-title">id_generation_concurrent/threads/16</h2>
+    <div class="bench-latest">709.67 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">692.24 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">17.44 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">2.5%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">674.80 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">709.67 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-up">+5.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5666,24 +6002,24 @@
 <section class="bench-section" id="bench-id_generation_concurrent--threads--2" data-bench-name="id_generation_concurrent/threads/2">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_concurrent/threads/2</h2>
-    <div class="bench-latest">120.89 µs</div>
+    <div class="bench-latest">111.90 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">120.89 µs</span>
+      <span class="bench-stat-value">116.40 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">4.50 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">120.89 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">111.90 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5691,7 +6027,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-7.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5701,24 +6037,24 @@
 <section class="bench-section" id="bench-id_generation_concurrent--threads--4" data-bench-name="id_generation_concurrent/threads/4">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_concurrent/threads/4</h2>
-    <div class="bench-latest">198.11 µs</div>
+    <div class="bench-latest">184.96 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">198.11 µs</span>
+      <span class="bench-stat-value">191.54 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">6.57 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.4%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">198.11 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">184.96 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5726,7 +6062,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-6.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5736,24 +6072,24 @@
 <section class="bench-section" id="bench-id_generation_concurrent--threads--8" data-bench-name="id_generation_concurrent/threads/8">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_concurrent/threads/8</h2>
-    <div class="bench-latest">375.17 µs</div>
+    <div class="bench-latest">328.33 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">375.17 µs</span>
+      <span class="bench-stat-value">351.75 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">23.42 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">375.17 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">328.33 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5761,7 +6097,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-12.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5771,7 +6107,7 @@
 <section class="bench-section" id="bench-id_generation_current--read_current" data-bench-name="id_generation_current/read_current">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_current/read_current</h2>
-    <div class="bench-latest">0.4 ns</div>
+    <div class="bench-latest">0.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
@@ -5784,11 +6120,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">0.4 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">0.3 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5796,7 +6132,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.9%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5806,7 +6142,7 @@
 <section class="bench-section" id="bench-id_generation_current--read_current_approximate" data-bench-name="id_generation_current/read_current_approximate">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_current/read_current_approximate</h2>
-    <div class="bench-latest">0.4 ns</div>
+    <div class="bench-latest">0.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
@@ -5819,11 +6155,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">0.4 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">0.3 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5831,7 +6167,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5841,24 +6177,24 @@
 <section class="bench-section" id="bench-id_generation_lifecycle--create_and_generate_1000" data-bench-name="id_generation_lifecycle/create_and_generate_1000">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_lifecycle/create_and_generate_1000</h2>
-    <div class="bench-latest">8.80 µs</div>
+    <div class="bench-latest">8.77 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">8.80 µs</span>
+      <span class="bench-stat-value">8.79 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">16.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">8.80 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">8.77 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5866,7 +6202,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">-0.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5876,24 +6212,24 @@
 <section class="bench-section" id="bench-id_generation_single_thread--sequential_1000" data-bench-name="id_generation_single_thread/sequential_1000">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_single_thread/sequential_1000</h2>
-    <div class="bench-latest">6.90 µs</div>
+    <div class="bench-latest">6.26 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">6.90 µs</span>
+      <span class="bench-stat-value">6.58 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">321.8 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">6.90 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">6.26 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5901,7 +6237,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-9.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -5911,24 +6247,24 @@
 <section class="bench-section" id="bench-id_generation_single_thread--sequential_10000" data-bench-name="id_generation_single_thread/sequential_10000">
   <div class="bench-header">
     <h2 class="bench-title">id_generation_single_thread/sequential_10000</h2>
-    <div class="bench-latest">69.02 µs</div>
+    <div class="bench-latest">63.47 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">69.02 µs</span>
+      <span class="bench-stat-value">66.25 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.77 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">69.02 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">63.47 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -5936,7 +6272,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-8.0%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -6856,12 +7192,47 @@
 <section class="bench-section" id="bench-multiple_accesses--resolve_100" data-bench-name="multiple_accesses/resolve_100">
   <div class="bench-header">
     <h2 class="bench-title">multiple_accesses/resolve_100</h2>
-    <div class="bench-latest">3.57 µs</div>
+    <div class="bench-latest">3.14 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">3.57 µs</span>
+      <span class="bench-stat-value">3.35 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">215.3 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">6.4%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">3.14 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">3.57 µs <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-down">-12.1%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-multiple_accesses--resolve_100" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-multiple_accesses--resolve_with_100" data-bench-name="multiple_accesses/resolve_with_100">
+  <div class="bench-header">
+    <h2 class="bench-title">multiple_accesses/resolve_with_100</h2>
+    <div class="bench-latest">1.90 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">1.90 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
@@ -6873,11 +7244,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">3.57 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">1.90 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">3.57 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">1.90 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
@@ -6885,7 +7256,7 @@
     </div>
   </div>
   <div class="chart-wrap">
-    <canvas id="chart-multiple_accesses--resolve_100" height="260"></canvas>
+    <canvas id="chart-multiple_accesses--resolve_with_100" height="260"></canvas>
   </div>
 </section>
 <section class="bench-section" id="bench-point_in_time_queries--1000vectors" data-bench-name="point_in_time_queries/1000vectors">
@@ -6961,24 +7332,24 @@
 <section class="bench-section" id="bench-property_lookup_vs_scan--find_nodes_by_property" data-bench-name="property_lookup_vs_scan/find_nodes_by_property">
   <div class="bench-header">
     <h2 class="bench-title">property_lookup_vs_scan/find_nodes_by_property</h2>
-    <div class="bench-latest">39.03 µs</div>
+    <div class="bench-latest">34.45 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">39.03 µs</span>
+      <span class="bench-stat-value">36.74 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.29 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">39.03 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">34.45 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -6986,7 +7357,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-11.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -6996,24 +7367,24 @@
 <section class="bench-section" id="bench-property_lookup_vs_scan--manual_label_scan_filter" data-bench-name="property_lookup_vs_scan/manual_label_scan_filter">
   <div class="bench-header">
     <h2 class="bench-title">property_lookup_vs_scan/manual_label_scan_filter</h2>
-    <div class="bench-latest">138.29 µs</div>
+    <div class="bench-latest">123.68 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">138.29 µs</span>
+      <span class="bench-stat-value">130.99 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">7.31 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">138.29 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">123.68 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7021,7 +7392,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-10.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7136,24 +7507,24 @@
 <section class="bench-section" id="bench-recovery--10" data-bench-name="recovery/10">
   <div class="bench-header">
     <h2 class="bench-title">recovery/10</h2>
-    <div class="bench-latest">500.06 µs</div>
+    <div class="bench-latest">401.83 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">500.06 µs</span>
+      <span class="bench-stat-value">450.95 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">49.12 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">10.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">500.06 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">401.83 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7161,7 +7532,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-19.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7171,24 +7542,24 @@
 <section class="bench-section" id="bench-recovery--100" data-bench-name="recovery/100">
   <div class="bench-header">
     <h2 class="bench-title">recovery/100</h2>
-    <div class="bench-latest">457.03 µs</div>
+    <div class="bench-latest">412.59 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">457.03 µs</span>
+      <span class="bench-stat-value">434.81 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">22.22 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">457.03 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">412.59 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7196,7 +7567,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-9.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7206,24 +7577,24 @@
 <section class="bench-section" id="bench-recovery--1000" data-bench-name="recovery/1000">
   <div class="bench-header">
     <h2 class="bench-title">recovery/1000</h2>
-    <div class="bench-latest">647.92 µs</div>
+    <div class="bench-latest">612.70 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">647.92 µs</span>
+      <span class="bench-stat-value">630.31 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">17.61 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">2.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">647.92 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">612.70 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7231,22 +7602,22 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-5.4%</span>
     </div>
   </div>
   <div class="chart-wrap">
     <canvas id="chart-recovery--1000" height="260"></canvas>
   </div>
 </section>
-<section class="bench-section" id="bench-single_hop_traversal--10000_nodes" data-bench-name="single_hop_traversal/10000_nodes">
+<section class="bench-section" id="bench-serialization_simulation--resolve" data-bench-name="serialization_simulation/resolve">
   <div class="bench-header">
-    <h2 class="bench-title">single_hop_traversal/10000_nodes</h2>
-    <div class="bench-latest">431.9 ns</div>
+    <h2 class="bench-title">serialization_simulation/resolve</h2>
+    <div class="bench-latest">160.24 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">431.9 ns</span>
+      <span class="bench-stat-value">160.24 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
@@ -7258,7 +7629,77 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">431.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">160.24 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">160.24 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-serialization_simulation--resolve" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-serialization_simulation--resolve_with" data-bench-name="serialization_simulation/resolve_with">
+  <div class="bench-header">
+    <h2 class="bench-title">serialization_simulation/resolve_with</h2>
+    <div class="bench-latest">98.29 µs</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">98.29 µs</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">98.29 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">98.29 µs <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-serialization_simulation--resolve_with" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-single_hop_traversal--10000_nodes" data-bench-name="single_hop_traversal/10000_nodes">
+  <div class="bench-header">
+    <h2 class="bench-title">single_hop_traversal/10000_nodes</h2>
+    <div class="bench-latest">393.8 ns</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">412.9 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">19.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">4.6%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">393.8 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7266,7 +7707,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-8.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7276,24 +7717,24 @@
 <section class="bench-section" id="bench-single_hop_traversal--1000_nodes" data-bench-name="single_hop_traversal/1000_nodes">
   <div class="bench-header">
     <h2 class="bench-title">single_hop_traversal/1000_nodes</h2>
-    <div class="bench-latest">431.9 ns</div>
+    <div class="bench-latest">412.5 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">431.9 ns</span>
+      <span class="bench-stat-value">422.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">9.7 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">2.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">431.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">412.5 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7301,7 +7742,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-4.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7311,24 +7752,24 @@
 <section class="bench-section" id="bench-single_hop_traversal--100_nodes" data-bench-name="single_hop_traversal/100_nodes">
   <div class="bench-header">
     <h2 class="bench-title">single_hop_traversal/100_nodes</h2>
-    <div class="bench-latest">431.1 ns</div>
+    <div class="bench-latest">399.0 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">431.1 ns</span>
+      <span class="bench-stat-value">415.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">16.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.9%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">431.1 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">399.0 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7336,7 +7777,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-7.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7346,24 +7787,24 @@
 <section class="bench-section" id="bench-single_transaction_latency--async" data-bench-name="single_transaction_latency/async">
   <div class="bench-header">
     <h2 class="bench-title">single_transaction_latency/async</h2>
-    <div class="bench-latest">65.06 µs</div>
+    <div class="bench-latest">64.90 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">65.06 µs</span>
+      <span class="bench-stat-value">64.98 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">82.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.1%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">65.06 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">64.90 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7371,7 +7812,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">-0.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7381,20 +7822,20 @@
 <section class="bench-section" id="bench-single_transaction_latency--async_batched_aggressive" data-bench-name="single_transaction_latency/async_batched_aggressive">
   <div class="bench-header">
     <h2 class="bench-title">single_transaction_latency/async_batched_aggressive</h2>
-    <div class="bench-latest">5.02 ms</div>
+    <div class="bench-latest">5.10 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">5.02 ms</span>
+      <span class="bench-stat-value">5.06 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">41.13 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.8%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -7402,11 +7843,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">5.02 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">5.10 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+1.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7416,20 +7857,20 @@
 <section class="bench-section" id="bench-single_transaction_latency--async_batched_default" data-bench-name="single_transaction_latency/async_batched_default">
   <div class="bench-header">
     <h2 class="bench-title">single_transaction_latency/async_batched_default</h2>
-    <div class="bench-latest">9.19 ms</div>
+    <div class="bench-latest">9.24 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">9.19 ms</span>
+      <span class="bench-stat-value">9.22 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">26.99 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">0.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -7437,11 +7878,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">9.19 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">9.24 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-flat">+0.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7451,20 +7892,20 @@
 <section class="bench-section" id="bench-single_transaction_latency--group_commit_default" data-bench-name="single_transaction_latency/group_commit_default">
   <div class="bench-header">
     <h2 class="bench-title">single_transaction_latency/group_commit_default</h2>
-    <div class="bench-latest">2.76 ms</div>
+    <div class="bench-latest">3.20 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">2.76 ms</span>
+      <span class="bench-stat-value">2.98 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">223.79 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">7.5%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -7472,11 +7913,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">2.76 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">3.20 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+16.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7486,20 +7927,20 @@
 <section class="bench-section" id="bench-single_transaction_latency--group_commit_fast" data-bench-name="single_transaction_latency/group_commit_fast">
   <div class="bench-header">
     <h2 class="bench-title">single_transaction_latency/group_commit_fast</h2>
-    <div class="bench-latest">1.80 ms</div>
+    <div class="bench-latest">2.01 ms</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">1.80 ms</span>
+      <span class="bench-stat-value">1.90 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">103.48 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">5.4%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -7507,11 +7948,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">1.80 ms <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">2.01 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+11.5%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7521,20 +7962,20 @@
 <section class="bench-section" id="bench-single_transaction_latency--synchronous" data-bench-name="single_transaction_latency/synchronous">
   <div class="bench-header">
     <h2 class="bench-title">single_transaction_latency/synchronous</h2>
-    <div class="bench-latest">571.98 µs</div>
+    <div class="bench-latest">738.79 µs</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">571.98 µs</span>
+      <span class="bench-stat-value">655.38 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">83.41 µs</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">12.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -7542,11 +7983,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">571.98 µs <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">738.79 µs <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+29.2%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7661,24 +8102,24 @@
 <section class="bench-section" id="bench-string_access_single--resolve" data-bench-name="string_access_single/resolve">
   <div class="bench-header">
     <h2 class="bench-title">string_access_single/resolve</h2>
-    <div class="bench-latest">35.6 ns</div>
+    <div class="bench-latest">32.8 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">35.6 ns</span>
+      <span class="bench-stat-value">34.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.4 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.0%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">35.6 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">32.8 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7686,7 +8127,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-7.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7696,24 +8137,24 @@
 <section class="bench-section" id="bench-string_access_single--resolve_with" data-bench-name="string_access_single/resolve_with">
   <div class="bench-header">
     <h2 class="bench-title">string_access_single/resolve_with</h2>
-    <div class="bench-latest">21.8 ns</div>
+    <div class="bench-latest">20.4 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">21.8 ns</span>
+      <span class="bench-stat-value">21.1 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">0.7 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">3.5%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">21.8 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">20.4 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7721,7 +8162,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-6.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7731,24 +8172,24 @@
 <section class="bench-section" id="bench-string_comparison--resolve" data-bench-name="string_comparison/resolve">
   <div class="bench-header">
     <h2 class="bench-title">string_comparison/resolve</h2>
-    <div class="bench-latest">36.2 ns</div>
+    <div class="bench-latest">31.1 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">36.2 ns</span>
+      <span class="bench-stat-value">33.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">7.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">36.2 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">31.1 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7756,7 +8197,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-14.0%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7766,24 +8207,24 @@
 <section class="bench-section" id="bench-string_comparison--resolve_with" data-bench-name="string_comparison/resolve_with">
   <div class="bench-header">
     <h2 class="bench-title">string_comparison/resolve_with</h2>
-    <div class="bench-latest">22.2 ns</div>
+    <div class="bench-latest">20.2 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">22.2 ns</span>
+      <span class="bench-stat-value">21.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">1.0 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">4.6%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">22.2 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">20.2 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7791,7 +8232,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-8.8%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7801,24 +8242,24 @@
 <section class="bench-section" id="bench-string_length--resolve" data-bench-name="string_length/resolve">
   <div class="bench-header">
     <h2 class="bench-title">string_length/resolve</h2>
-    <div class="bench-latest">36.5 ns</div>
+    <div class="bench-latest">31.9 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">36.5 ns</span>
+      <span class="bench-stat-value">34.2 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">2.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">6.7%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">36.5 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">31.9 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
@@ -7826,7 +8267,7 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-down">-12.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -7836,12 +8277,47 @@
 <section class="bench-section" id="bench-string_length--resolve_with" data-bench-name="string_length/resolve_with">
   <div class="bench-header">
     <h2 class="bench-title">string_length/resolve_with</h2>
-    <div class="bench-latest">22.0 ns</div>
+    <div class="bench-latest">19.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">22.0 ns</span>
+      <span class="bench-stat-value">20.6 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">1.4 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">6.7%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">19.3 ns <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">22.0 ns <small>(198c57d)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-down">-12.5%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-string_length--resolve_with" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-sustained_write_throughput--sustained_write_10k_versions" data-bench-name="sustained_write_throughput/sustained_write_10k_versions">
+  <div class="bench-header">
+    <h2 class="bench-title">sustained_write_throughput/sustained_write_10k_versions</h2>
+    <div class="bench-latest">188.72 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">188.72 ms</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
@@ -7853,11 +8329,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">22.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">188.72 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">22.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">188.72 ms <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
@@ -7865,7 +8341,42 @@
     </div>
   </div>
   <div class="chart-wrap">
-    <canvas id="chart-string_length--resolve_with" height="260"></canvas>
+    <canvas id="chart-sustained_write_throughput--sustained_write_10k_versions" height="260"></canvas>
+  </div>
+</section>
+<section class="bench-section" id="bench-sustained_write_throughput--sustained_write_10k_versions_fast_reference" data-bench-name="sustained_write_throughput/sustained_write_10k_versions_fast_reference">
+  <div class="bench-header">
+    <h2 class="bench-title">sustained_write_throughput/sustained_write_10k_versions_fast_reference</h2>
+    <div class="bench-latest">458.79 ms</div>
+  </div>
+  <div class="bench-stats-bar">
+    <div class="bench-stat">
+      <span class="bench-stat-label">Mean</span>
+      <span class="bench-stat-value">458.79 ms</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Std Dev</span>
+      <span class="bench-stat-value">0.0 ns</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">CV</span>
+      <span class="bench-stat-value">0.0%</span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Best</span>
+      <span class="bench-stat-value best">458.79 ms <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Worst</span>
+      <span class="bench-stat-value worst">458.79 ms <small>(268e122)</small></span>
+    </div>
+    <div class="bench-stat">
+      <span class="bench-stat-label">Overall</span>
+      <span class="bench-stat-value trend-flat">+0.0%</span>
+    </div>
+  </div>
+  <div class="chart-wrap">
+    <canvas id="chart-sustained_write_throughput--sustained_write_10k_versions_fast_reference" height="260"></canvas>
   </div>
 </section>
 <section class="bench-section" id="bench-target_3_hop--traverse_three_hops" data-bench-name="target_3_hop/traverse_three_hops">
@@ -8291,32 +8802,32 @@
 <section class="bench-section" id="bench-time_travel--at_anchor_v20" data-bench-name="time_travel/at_anchor_v20">
   <div class="bench-header">
     <h2 class="bench-title">time_travel/at_anchor_v20</h2>
-    <div class="bench-latest">124.0 ns</div>
+    <div class="bench-latest">196.7 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">124.0 ns</span>
+      <span class="bench-stat-value">147.6 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">34.7 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">23.5%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
-      <span class="bench-stat-value best">124.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value best">122.1 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">124.0 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">196.7 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+58.7%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -8326,20 +8837,20 @@
 <section class="bench-section" id="bench-time_travel--deep_history_v5" data-bench-name="time_travel/deep_history_v5">
   <div class="bench-header">
     <h2 class="bench-title">time_travel/deep_history_v5</h2>
-    <div class="bench-latest">124.3 ns</div>
+    <div class="bench-latest">194.3 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">124.3 ns</span>
+      <span class="bench-stat-value">147.8 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">32.9 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">22.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -8347,11 +8858,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">124.3 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">194.3 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+56.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -8361,20 +8872,20 @@
 <section class="bench-section" id="bench-time_travel--with_deltas_v15" data-bench-name="time_travel/with_deltas_v15">
   <div class="bench-header">
     <h2 class="bench-title">time_travel/with_deltas_v15</h2>
-    <div class="bench-latest">123.9 ns</div>
+    <div class="bench-latest">191.2 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">123.9 ns</span>
+      <span class="bench-stat-value">158.8 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">27.5 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">17.3%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -8382,11 +8893,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">123.9 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">191.2 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+54.3%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -8396,20 +8907,20 @@
 <section class="bench-section" id="bench-time_travel--worst_case_v19" data-bench-name="time_travel/worst_case_v19">
   <div class="bench-header">
     <h2 class="bench-title">time_travel/worst_case_v19</h2>
-    <div class="bench-latest">124.4 ns</div>
+    <div class="bench-latest">237.1 ns</div>
   </div>
   <div class="bench-stats-bar">
     <div class="bench-stat">
       <span class="bench-stat-label">Mean</span>
-      <span class="bench-stat-value">124.4 ns</span>
+      <span class="bench-stat-value">166.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Std Dev</span>
-      <span class="bench-stat-value">0.0 ns</span>
+      <span class="bench-stat-value">50.3 ns</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">CV</span>
-      <span class="bench-stat-value">0.0%</span>
+      <span class="bench-stat-value">30.2%</span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Best</span>
@@ -8417,11 +8928,11 @@
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Worst</span>
-      <span class="bench-stat-value worst">124.4 ns <small>(198c57d)</small></span>
+      <span class="bench-stat-value worst">237.1 ns <small>(268e122)</small></span>
     </div>
     <div class="bench-stat">
       <span class="bench-stat-label">Overall</span>
-      <span class="bench-stat-value trend-flat">+0.0%</span>
+      <span class="bench-stat-value trend-up">+90.6%</span>
     </div>
   </div>
   <div class="chart-wrap">
@@ -9555,7 +10066,7 @@
 </main>
 
 <script>
-const CONFIGS = {"3_hop_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.7094, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.6255, "ci_upper": 56.8146}], "trend": [], "mean": 56.7094, "unit": "\u00b5s", "stats": {"mean": "56.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.71 \u00b5s", "max": "56.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_3_hop_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 483.0333, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 481.8018, "ci_upper": 484.841}], "trend": [], "mean": 483.0333, "unit": "ns", "stats": {"mean": "483.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "483.0 ns", "max": "483.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "483.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_batch/batch_node_creation/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.8075, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.675, "ci_upper": 27.9374}], "trend": [], "mean": 27.8075, "unit": "ms", "stats": {"mean": "27.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.81 ms", "max": "27.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_batch/batch_node_creation/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289.8292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 288.0868, "ci_upper": 291.5917}], "trend": [], "mean": 289.8292, "unit": "ms", "stats": {"mean": "289.83 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "289.83 ms", "max": "289.83 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "289.83 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_batch/batch_node_creation/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8312, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.8159, "ci_upper": 2.8495}], "trend": [], "mean": 2.8312, "unit": "s", "stats": {"mean": "2.831 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.831 s", "max": "2.831 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.831 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_edge_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.3458, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 87.5403, "ci_upper": 106.6907}], "trend": [], "mean": 97.3458, "unit": "\u00b5s", "stats": {"mean": "97.35 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "97.35 \u00b5s", "max": "97.35 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "97.35 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_fast_path/node_lookup/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.7337, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 62.6648, "ci_upper": 62.8097}], "trend": [], "mean": 62.7337, "unit": "ns", "stats": {"mean": "62.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "62.7 ns", "max": "62.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "62.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_fast_path/node_lookup/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.003, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 61.9509, "ci_upper": 62.0692}], "trend": [], "mean": 62.003, "unit": "ns", "stats": {"mean": "62.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "62.0 ns", "max": "62.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "62.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_fast_path/node_lookup/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 61.1577, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 61.1032, "ci_upper": 61.2266}], "trend": [], "mean": 61.1577, "unit": "ns", "stats": {"mean": "61.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "61.2 ns", "max": "61.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "61.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_historical_stats": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.0592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.057, "ci_upper": 1.0618}], "trend": [], "mean": 1.0592, "unit": "\u00b5s", "stats": {"mean": "1.06 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.06 \u00b5s", "max": "1.06 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.06 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_in_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 104.8917, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 104.81, "ci_upper": 104.9774}], "trend": [], "mean": 104.8917, "unit": "ns", "stats": {"mean": "104.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "104.9 ns", "max": "104.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "104.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_labeled_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 159.8682, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 159.7019, "ci_upper": 160.0694}], "trend": [], "mean": 159.8682, "unit": "ns", "stats": {"mean": "159.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "159.9 ns", "max": "159.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "159.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_node_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.588, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 95.5147, "ci_upper": 116.8485}], "trend": [], "mean": 105.588, "unit": "\u00b5s", "stats": {"mean": "105.59 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "105.59 \u00b5s", "max": "105.59 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "105.59 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_out_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 100.3947, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 100.3461, "ci_upper": 100.4534}], "trend": [], "mean": 100.3947, "unit": "ns", "stats": {"mean": "100.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "100.4 ns", "max": "100.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "100.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_single_hop/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.4999, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.3909, "ci_upper": 116.6086}], "trend": [], "mean": 116.4999, "unit": "ns", "stats": {"mean": "116.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "116.5 ns", "max": "116.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "116.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_single_hop/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.5517, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.4637, "ci_upper": 116.6516}], "trend": [], "mean": 116.5517, "unit": "ns", "stats": {"mean": "116.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "116.6 ns", "max": "116.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "116.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "aletheiadb_single_hop/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.1347, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.0577, "ci_upper": 116.2193}], "trend": [], "mean": 116.1347, "unit": "ns", "stats": {"mean": "116.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "116.1 ns", "max": "116.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "116.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "batch_throughput/async": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52.7926, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 52.7417, "ci_upper": 52.8425}], "trend": [], "mean": 52.7926, "unit": "ms", "stats": {"mean": "52.79 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "52.79 ms", "max": "52.79 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "52.79 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "batch_throughput/synchronous": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635.7484, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 625.9952, "ci_upper": 645.2215}], "trend": [], "mean": 635.7484, "unit": "ms", "stats": {"mean": "635.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "635.75 ms", "max": "635.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "635.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_creation/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.893, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.4531, "ci_upper": 5.316}], "trend": [], "mean": 4.893, "unit": "ms", "stats": {"mean": "4.89 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.89 ms", "max": "4.89 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.89 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_creation/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.0293, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.874, "ci_upper": 4.2611}], "trend": [], "mean": 4.0293, "unit": "ms", "stats": {"mean": "4.03 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.03 ms", "max": "4.03 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.03 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_creation/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.6632, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.568, "ci_upper": 7.7574}], "trend": [], "mean": 7.6632, "unit": "ms", "stats": {"mean": "7.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.66 ms", "max": "7.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_load/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.5051, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 317.3704, "ci_upper": 329.8024}], "trend": [], "mean": 323.5051, "unit": "\u00b5s", "stats": {"mean": "323.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "323.51 \u00b5s", "max": "323.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "323.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_load/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.628, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.614, "ci_upper": 1.6437}], "trend": [], "mean": 1.628, "unit": "ms", "stats": {"mean": "1.63 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.63 ms", "max": "1.63 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.63 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "checkpoint_load/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15.1799, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 15.0798, "ci_upper": 15.2868}], "trend": [], "mean": 15.1799, "unit": "ms", "stats": {"mean": "15.18 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "15.18 ms", "max": "15.18 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "15.18 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "closure_write_single_node": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8058}], "mean": 2.8058, "unit": "ms", "stats": {"mean": "2.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.81 ms", "max": "2.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "cold_batch_write_throughput/fast/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.9292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.9076, "ci_upper": 4.9539}], "trend": [], "mean": 4.9292, "unit": "ms", "stats": {"mean": "4.93 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.93 ms", "max": "4.93 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.93 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/fast/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45.8136, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 45.7461, "ci_upper": 45.8876}], "trend": [], "mean": 45.8136, "unit": "ms", "stats": {"mean": "45.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "45.81 ms", "max": "45.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "45.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/fast/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454.8297, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 454.2272, "ci_upper": 455.4686}], "trend": [], "mean": 454.8297, "unit": "ms", "stats": {"mean": "454.83 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "454.83 ms", "max": "454.83 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "454.83 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/zstd/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.4465, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.4201, "ci_upper": 7.4717}], "trend": [], "mean": 7.4465, "unit": "ms", "stats": {"mean": "7.45 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.45 ms", "max": "7.45 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.45 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/zstd/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66.7824, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.5764, "ci_upper": 67.0114}], "trend": [], "mean": 66.7824, "unit": "ms", "stats": {"mean": "66.78 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "66.78 ms", "max": "66.78 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "66.78 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_batch_write_throughput/zstd/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189.515, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 187.4879, "ci_upper": 191.7626}], "trend": [], "mean": 189.515, "unit": "ms", "stats": {"mean": "189.51 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "189.51 ms", "max": "189.51 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "189.51 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_read_latency/single_read/fast_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.4834, "ci_upper": 34.597}], "trend": [], "mean": 34.539, "unit": "\u00b5s", "stats": {"mean": "34.54 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.54 \u00b5s", "max": "34.54 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.54 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_read_latency/single_read/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.3055, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.2979, "ci_upper": 3.3147}], "trend": [], "mean": 3.3055, "unit": "\u00b5s", "stats": {"mean": "3.31 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.31 \u00b5s", "max": "3.31 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.31 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_read_latency/single_read/zstd_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.4087, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.3612, "ci_upper": 34.4647}], "trend": [], "mean": 34.4087, "unit": "\u00b5s", "stats": {"mean": "34.41 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.41 \u00b5s", "max": "34.41 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.41 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_write_latency/single_write/fast_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 338.7451, "ci_upper": 342.0878}], "trend": [], "mean": 340.426, "unit": "\u00b5s", "stats": {"mean": "340.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "340.43 \u00b5s", "max": "340.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "340.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_write_latency/single_write/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.7913, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 317.6596, "ci_upper": 379.6265}], "trend": [], "mean": 343.7913, "unit": "\u00b5s", "stats": {"mean": "343.79 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "343.79 \u00b5s", "max": "343.79 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "343.79 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cold_write_latency/single_write/zstd_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.8672, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 370.4404, "ci_upper": 377.8695}], "trend": [], "mean": 373.8672, "unit": "\u00b5s", "stats": {"mean": "373.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "373.87 \u00b5s", "max": "373.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "373.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "comparison_csr/full_rebuild_insert_query": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 140.053, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.986, "ci_upper": 141.1743}], "trend": [], "mean": 140.053, "unit": "\u00b5s", "stats": {"mean": "140.05 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "140.05 \u00b5s", "max": "140.05 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "140.05 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "comparison_csr/incremental_csr_insert_query": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5961, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 16.443, "ci_upper": 16.7372}], "trend": [], "mean": 16.5961, "unit": "\u00b5s", "stats": {"mean": "16.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "16.60 \u00b5s", "max": "16.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "16.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/fast": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.8685, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 33.5632, "ci_upper": 36.4003}], "trend": [], "mean": 34.8685, "unit": "ms", "stats": {"mean": "34.87 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.87 ms", "max": "34.87 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.87 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31.2589, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 31.0497, "ci_upper": 31.4758}], "trend": [], "mean": 31.2589, "unit": "ms", "stats": {"mean": "31.26 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "31.26 ms", "max": "31.26 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "31.26 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/zstd": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.2195, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.56, "ci_upper": 36.922}], "trend": [], "mean": 36.2195, "unit": "ms", "stats": {"mean": "36.22 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.22 ms", "max": "36.22 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.22 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "concurrent_reads_same_entity/10000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.8781}], "mean": 133.8781, "unit": "\u00b5s", "stats": {"mean": "133.88 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.88 \u00b5s", "max": "133.88 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.88 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/10000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.7407}], "mean": 474.7407, "unit": "\u00b5s", "stats": {"mean": "474.74 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "474.74 \u00b5s", "max": "474.74 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "474.74 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.6457}], "mean": 767.6457, "unit": "\u00b5s", "stats": {"mean": "767.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "767.65 \u00b5s", "max": "767.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "767.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.1031}], "mean": 130.1031, "unit": "\u00b5s", "stats": {"mean": "130.10 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.10 \u00b5s", "max": "130.10 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.10 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.6437}], "mean": 220.6437, "unit": "\u00b5s", "stats": {"mean": "220.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.64 \u00b5s", "max": "220.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.9052}], "mean": 422.9052, "unit": "\u00b5s", "stats": {"mean": "422.91 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "422.91 \u00b5s", "max": "422.91 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "422.91 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.7185}], "mean": 696.7185, "unit": "\u00b5s", "stats": {"mean": "696.72 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "696.72 \u00b5s", "max": "696.72 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "696.72 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.2643}], "mean": 130.2643, "unit": "\u00b5s", "stats": {"mean": "130.26 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.26 \u00b5s", "max": "130.26 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.26 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.7032}], "mean": 203.7032, "unit": "\u00b5s", "stats": {"mean": "203.70 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "203.70 \u00b5s", "max": "203.70 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "203.70 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.8675}], "mean": 383.8675, "unit": "\u00b5s", "stats": {"mean": "383.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "383.87 \u00b5s", "max": "383.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "383.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.7069}], "mean": 139.7069, "unit": "\u00b5s", "stats": {"mean": "139.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "139.71 \u00b5s", "max": "139.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "139.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.0149}], "mean": 220.0149, "unit": "\u00b5s", "stats": {"mean": "220.01 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.01 \u00b5s", "max": "220.01 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.01 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.3599}], "mean": 417.3599, "unit": "\u00b5s", "stats": {"mean": "417.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "417.36 \u00b5s", "max": "417.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "417.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.5742}], "mean": 214.5742, "unit": "\u00b5s", "stats": {"mean": "214.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "214.57 \u00b5s", "max": "214.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "214.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2257}], "mean": 1.2257, "unit": "ms", "stats": {"mean": "1.23 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.23 ms", "max": "1.23 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.23 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.4764}], "mean": 9.4764, "unit": "ms", "stats": {"mean": "9.48 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.48 ms", "max": "9.48 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.48 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "cosine_similarity/naive_3pass/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.5998, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.5964, "ci_upper": 4.6033}], "trend": [], "mean": 4.5998, "unit": "\u00b5s", "stats": {"mean": "4.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.60 \u00b5s", "max": "4.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9518, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 6.9487, "ci_upper": 6.9553}], "trend": [], "mean": 6.9518, "unit": "\u00b5s", "stats": {"mean": "6.95 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "6.95 \u00b5s", "max": "6.95 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "6.95 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 14.0339, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 14.0176, "ci_upper": 14.0553}], "trend": [], "mean": 14.0339, "unit": "\u00b5s", "stats": {"mean": "14.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "14.03 \u00b5s", "max": "14.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "14.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.6521, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.6509, "ci_upper": 1.6536}], "trend": [], "mean": 1.6521, "unit": "\u00b5s", "stats": {"mean": "1.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.65 \u00b5s", "max": "1.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.4352, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.415, "ci_upper": 3.4602}], "trend": [], "mean": 3.4352, "unit": "\u00b5s", "stats": {"mean": "3.44 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.44 \u00b5s", "max": "3.44 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.44 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 201.4877, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 200.8504, "ci_upper": 202.3099}], "trend": [], "mean": 201.4877, "unit": "ns", "stats": {"mean": "201.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "201.5 ns", "max": "201.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "201.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 299.6659, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.2803, "ci_upper": 300.0181}], "trend": [], "mean": 299.6659, "unit": "ns", "stats": {"mean": "299.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "299.7 ns", "max": "299.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "299.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 592.0544, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 591.7843, "ci_upper": 592.3525}], "trend": [], "mean": 592.0544, "unit": "ns", "stats": {"mean": "592.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "592.1 ns", "max": "592.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "592.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 77.1982, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.0254, "ci_upper": 77.3564}], "trend": [], "mean": 77.1982, "unit": "ns", "stats": {"mean": "77.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "77.2 ns", "max": "77.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "77.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 151.7529, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 151.6634, "ci_upper": 151.8528}], "trend": [], "mean": 151.7529, "unit": "ns", "stats": {"mean": "151.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "151.8 ns", "max": "151.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "151.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5811, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.5754, "ci_upper": 1.59}], "trend": [], "mean": 1.5811, "unit": "\u00b5s", "stats": {"mean": "1.58 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.58 \u00b5s", "max": "1.58 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.58 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.3602, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.3535, "ci_upper": 2.372}], "trend": [], "mean": 2.3602, "unit": "\u00b5s", "stats": {"mean": "2.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.36 \u00b5s", "max": "2.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.7282, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.7141, "ci_upper": 4.7443}], "trend": [], "mean": 4.7282, "unit": "\u00b5s", "stats": {"mean": "4.73 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.73 \u00b5s", "max": "4.73 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.73 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 636.1933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 603.1786, "ci_upper": 671.3907}], "trend": [], "mean": 636.1933, "unit": "ns", "stats": {"mean": "636.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "636.2 ns", "max": "636.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "636.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.182, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1815, "ci_upper": 1.1825}], "trend": [], "mean": 1.182, "unit": "\u00b5s", "stats": {"mean": "1.18 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.18 \u00b5s", "max": "1.18 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.18 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 811.3468, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 810.3818, "ci_upper": 812.3508}], "trend": [], "mean": 811.3468, "unit": "ns", "stats": {"mean": "811.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "811.3 ns", "max": "811.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "811.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.2806, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.2657, "ci_upper": 8.2983}], "trend": [], "mean": 8.2806, "unit": "\u00b5s", "stats": {"mean": "8.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.28 \u00b5s", "max": "8.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 90.4588, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 88.3046, "ci_upper": 92.9789}], "trend": [], "mean": 90.4588, "unit": "\u00b5s", "stats": {"mean": "90.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "90.46 \u00b5s", "max": "90.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "90.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/general/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 300.4556, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.9198, "ci_upper": 301.2823}], "trend": [], "mean": 300.4556, "unit": "ns", "stats": {"mean": "300.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "300.5 ns", "max": "300.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "300.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/general/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 78.0633, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.9841, "ci_upper": 78.1482}], "trend": [], "mean": 78.0633, "unit": "ns", "stats": {"mean": "78.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "78.1 ns", "max": "78.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "78.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/specialized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 284.7673, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 280.1321, "ci_upper": 290.0487}], "trend": [], "mean": 284.7673, "unit": "ns", "stats": {"mean": "284.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "284.8 ns", "max": "284.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "284.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/specialized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.5976, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.5608, "ci_upper": 56.6375}], "trend": [], "mean": 56.5976, "unit": "ns", "stats": {"mean": "56.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.6 ns", "max": "56.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_openai_1536d": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 301.5358, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.4368, "ci_upper": 304.2498}], "trend": [], "mean": 301.5358, "unit": "ns", "stats": {"mean": "301.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "301.5 ns", "max": "301.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "301.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "edge_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4612, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2203, "ci_upper": 4.6423}], "trend": [], "mean": 4.4612, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "edge_lookup": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.3798, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 62.3132, "ci_upper": 62.4333}], "trend": [], "mean": 62.3798, "unit": "ns", "stats": {"mean": "62.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "62.4 ns", "max": "62.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "62.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 174.9884, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 174.5683, "ci_upper": 175.509}], "trend": [], "mean": 174.9884, "unit": "ns", "stats": {"mean": "175.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "175.0 ns", "max": "175.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "175.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 272.6012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 272.4164, "ci_upper": 272.8048}], "trend": [], "mean": 272.6012, "unit": "ns", "stats": {"mean": "272.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "272.6 ns", "max": "272.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "272.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.5753, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 60.8333, "ci_upper": 69.9999}], "trend": [], "mean": 65.5753, "unit": "ns", "stats": {"mean": "65.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "65.6 ns", "max": "65.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "65.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.7884, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.6794, "ci_upper": 123.9155}], "trend": [], "mean": 123.7884, "unit": "ns", "stats": {"mean": "123.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.8 ns", "max": "123.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5486, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.5474, "ci_upper": 1.5499}], "trend": [], "mean": 1.5486, "unit": "\u00b5s", "stats": {"mean": "1.55 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.55 \u00b5s", "max": "1.55 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.55 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.3322, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.3308, "ci_upper": 2.334}], "trend": [], "mean": 2.3322, "unit": "\u00b5s", "stats": {"mean": "2.33 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.33 \u00b5s", "max": "2.33 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.33 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 566.6878, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 566.0427, "ci_upper": 567.318}], "trend": [], "mean": 566.6878, "unit": "ns", "stats": {"mean": "566.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "566.7 ns", "max": "566.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "566.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.1552, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1547, "ci_upper": 1.1559}], "trend": [], "mean": 1.1552, "unit": "\u00b5s", "stats": {"mean": "1.16 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.16 \u00b5s", "max": "1.16 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.16 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 173.0044, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 172.8747, "ci_upper": 173.158}], "trend": [], "mean": 173.0044, "unit": "ns", "stats": {"mean": "173.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "173.0 ns", "max": "173.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "173.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 269.6692, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 269.2292, "ci_upper": 270.1513}], "trend": [], "mean": 269.6692, "unit": "ns", "stats": {"mean": "269.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "269.7 ns", "max": "269.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "269.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.5494, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.4933, "ci_upper": 56.6058}], "trend": [], "mean": 56.5494, "unit": "ns", "stats": {"mean": "56.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.5 ns", "max": "56.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.2014, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.0685, "ci_upper": 121.3575}], "trend": [], "mean": 121.2014, "unit": "ns", "stats": {"mean": "121.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.2 ns", "max": "121.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_neighbors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2409, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2392, "ci_upper": 1.243}], "trend": [], "mean": 1.2409, "unit": "\u00b5s", "stats": {"mean": "1.24 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.24 \u00b5s", "max": "1.24 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.24 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_nodes_by_property/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.0933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 746.1684, "ci_upper": 766.5151}], "trend": [], "mean": 757.0933, "unit": "\u00b5s", "stats": {"mean": "757.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "757.09 \u00b5s", "max": "757.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "757.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_nodes_by_property/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.7901, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 47.4027, "ci_upper": 53.7229}], "trend": [], "mean": 50.7901, "unit": "\u00b5s", "stats": {"mean": "50.79 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "50.79 \u00b5s", "max": "50.79 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "50.79 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_nodes_by_property/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6744, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.6705, "ci_upper": 4.6789}], "trend": [], "mean": 4.6744, "unit": "\u00b5s", "stats": {"mean": "4.67 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.67 \u00b5s", "max": "4.67 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.67 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/100000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.9696, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 39.9448, "ci_upper": 39.9997}], "trend": [], "mean": 39.9696, "unit": "ns", "stats": {"mean": "40.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "40.0 ns", "max": "40.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "40.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 33.8967, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 33.4823, "ci_upper": 34.3487}], "trend": [], "mean": 33.8967, "unit": "ns", "stats": {"mean": "33.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "33.9 ns", "max": "33.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "33.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.7478, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.7342, "ci_upper": 20.7629}], "trend": [], "mean": 20.7478, "unit": "ns", "stats": {"mean": "20.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.7 ns", "max": "20.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/100000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.7605, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.7381, "ci_upper": 32.7867}], "trend": [], "mean": 32.7605, "unit": "ns", "stats": {"mean": "32.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.8 ns", "max": "32.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6491, "ci_upper": 32.7063}], "trend": [], "mean": 32.6752, "unit": "ns", "stats": {"mean": "32.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.7 ns", "max": "32.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6055, "ci_upper": 32.6551}], "trend": [], "mean": 32.6292, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.6438, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.6173, "ci_upper": 35.6692}], "trend": [], "mean": 35.6438, "unit": "ns", "stats": {"mean": "35.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.6 ns", "max": "35.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.2963, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.2689, "ci_upper": 35.3269}], "trend": [], "mean": 35.2963, "unit": "ns", "stats": {"mean": "35.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.3 ns", "max": "35.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.3701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.3296, "ci_upper": 35.4178}], "trend": [], "mean": 35.3701, "unit": "ns", "stats": {"mean": "35.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.4 ns", "max": "35.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/16": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.7988, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 668.2883, "ci_upper": 681.7834}], "trend": [], "mean": 674.7988, "unit": "\u00b5s", "stats": {"mean": "674.80 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "674.80 \u00b5s", "max": "674.80 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "674.80 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/2": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.8943, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.8132, "ci_upper": 122.2263}], "trend": [], "mean": 120.8943, "unit": "\u00b5s", "stats": {"mean": "120.89 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.89 \u00b5s", "max": "120.89 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.89 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/4": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.1065, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 195.2657, "ci_upper": 201.0119}], "trend": [], "mean": 198.1065, "unit": "\u00b5s", "stats": {"mean": "198.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "198.11 \u00b5s", "max": "198.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "198.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/8": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.1654, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 364.3727, "ci_upper": 389.8907}], "trend": [], "mean": 375.1654, "unit": "\u00b5s", "stats": {"mean": "375.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "375.17 \u00b5s", "max": "375.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "375.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_current/read_current": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.384, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 0.3835, "ci_upper": 0.3848}], "trend": [], "mean": 0.384, "unit": "ns", "stats": {"mean": "0.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "0.4 ns", "max": "0.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "0.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_current/read_current_approximate": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.383, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 0.3827, "ci_upper": 0.3833}], "trend": [], "mean": 0.383, "unit": "ns", "stats": {"mean": "0.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "0.4 ns", "max": "0.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "0.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_lifecycle/create_and_generate_1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.8024, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.3635, "ci_upper": 9.121}], "trend": [], "mean": 8.8024, "unit": "\u00b5s", "stats": {"mean": "8.80 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.80 \u00b5s", "max": "8.80 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.80 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_single_thread/sequential_1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9014, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 6.8972, "ci_upper": 6.906}], "trend": [], "mean": 6.9014, "unit": "\u00b5s", "stats": {"mean": "6.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "6.90 \u00b5s", "max": "6.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "6.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_single_thread/sequential_10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.0165, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 68.9682, "ci_upper": 69.0705}], "trend": [], "mean": 69.0165, "unit": "\u00b5s", "stats": {"mean": "69.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "69.02 \u00b5s", "max": "69.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "69.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "in_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 398.5843, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 398.2256, "ci_upper": 399.0399}], "trend": [], "mean": 398.5843, "unit": "ns", "stats": {"mean": "398.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "398.6 ns", "max": "398.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "398.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/1000+100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 60.2792, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 60.0174, "ci_upper": 60.5145}], "trend": [], "mean": 60.2792, "unit": "\u00b5s", "stats": {"mean": "60.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "60.28 \u00b5s", "max": "60.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "60.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/10000+1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 955.6045, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 949.4576, "ci_upper": 961.3519}], "trend": [], "mean": 955.6045, "unit": "\u00b5s", "stats": {"mean": "955.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "955.60 \u00b5s", "max": "955.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "955.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/100000+10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.1922, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.1618, "ci_upper": 8.2228}], "trend": [], "mean": 8.1922, "unit": "ms", "stats": {"mean": "8.19 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.19 ms", "max": "8.19 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.19 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/2": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.5752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 140.156, "ci_upper": 143.4946}], "trend": [], "mean": 141.5752, "unit": "\u00b5s", "stats": {"mean": "141.58 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "141.58 \u00b5s", "max": "141.58 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "141.58 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/4": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 211.6228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 210.6432, "ci_upper": 212.6665}], "trend": [], "mean": 211.6228, "unit": "\u00b5s", "stats": {"mean": "211.62 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "211.62 \u00b5s", "max": "211.62 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "211.62 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/8": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 410.1319, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.3735, "ci_upper": 411.8419}], "trend": [], "mean": 410.1319, "unit": "\u00b5s", "stats": {"mean": "410.13 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "410.13 \u00b5s", "max": "410.13 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "410.13 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/0existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 288.5947, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 238.623, "ci_upper": 340.8245}], "trend": [], "mean": 288.5947, "unit": "ns", "stats": {"mean": "288.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "288.6 ns", "max": "288.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "288.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/100000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289.1802, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 239.8888, "ci_upper": 340.0766}], "trend": [], "mean": 289.1802, "unit": "ns", "stats": {"mean": "289.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "289.2 ns", "max": "289.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "289.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/10000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 183.1639, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 173.8104, "ci_upper": 191.407}], "trend": [], "mean": 183.1639, "unit": "ns", "stats": {"mean": "183.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "183.2 ns", "max": "183.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "183.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/1000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 226.3477, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 217.2657, "ci_upper": 238.195}], "trend": [], "mean": 226.3477, "unit": "ns", "stats": {"mean": "226.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "226.3 ns", "max": "226.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "226.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6151, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.5984, "ci_upper": 32.6334}], "trend": [], "mean": 32.6151, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6383, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6172, "ci_upper": 32.6624}], "trend": [], "mean": 32.6383, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/100edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.65, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6283, "ci_upper": 32.6753}], "trend": [], "mean": 32.65, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/10pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 67.8572, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.551, "ci_upper": 69.5635}], "trend": [], "mean": 67.8572, "unit": "ns", "stats": {"mean": "67.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "67.9 ns", "max": "67.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "67.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/1pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 63.9781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 63.8033, "ci_upper": 64.2524}], "trend": [], "mean": 63.9781, "unit": "ns", "stats": {"mean": "64.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.0 ns", "max": "64.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/5pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.2054, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 63.8661, "ci_upper": 64.703}], "trend": [], "mean": 64.2054, "unit": "ns", "stats": {"mean": "64.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.2 ns", "max": "64.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/1": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.5096}], "mean": 126.5096, "unit": "\u00b5s", "stats": {"mean": "126.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "126.51 \u00b5s", "max": "126.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "126.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/10": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.1122}], "mean": 121.1122, "unit": "\u00b5s", "stats": {"mean": "121.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.11 \u00b5s", "max": "121.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/20": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.2891}], "mean": 123.2891, "unit": "\u00b5s", "stats": {"mean": "123.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.29 \u00b5s", "max": "123.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/5": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.2502}], "mean": 119.2502, "unit": "\u00b5s", "stats": {"mean": "119.25 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.25 \u00b5s", "max": "119.25 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.25 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/50": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.0939}], "mean": 122.0939, "unit": "\u00b5s", "stats": {"mean": "122.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "122.09 \u00b5s", "max": "122.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "122.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.0222}], "mean": 21.0222, "unit": "\u00b5s", "stats": {"mean": "21.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.02 \u00b5s", "max": "21.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.5215}], "mean": 120.5215, "unit": "\u00b5s", "stats": {"mean": "120.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.52 \u00b5s", "max": "120.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.1745}], "mean": 313.1745, "unit": "\u00b5s", "stats": {"mean": "313.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "313.17 \u00b5s", "max": "313.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "313.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/500": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.0848}], "mean": 68.0848, "unit": "\u00b5s", "stats": {"mean": "68.08 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "68.08 \u00b5s", "max": "68.08 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "68.08 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/5000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.3192}], "mean": 242.3192, "unit": "\u00b5s", "stats": {"mean": "242.32 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "242.32 \u00b5s", "max": "242.32 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "242.32 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "labeled_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 465.9282, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 465.3658, "ci_upper": 466.5311}], "trend": [], "mean": 465.9282, "unit": "ns", "stats": {"mean": "465.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "465.9 ns", "max": "465.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "465.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "mixed_read_write_80_20": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5907, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 16.2077, "ci_upper": 16.9809}], "trend": [], "mean": 16.5907, "unit": "ms", "stats": {"mean": "16.59 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "16.59 ms", "max": "16.59 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "16.59 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "multiple_accesses/resolve_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.5674, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.5566, "ci_upper": 3.5799}], "trend": [], "mean": 3.5674, "unit": "\u00b5s", "stats": {"mean": "3.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.57 \u00b5s", "max": "3.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "node_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4332, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.241, "ci_upper": 4.5807}], "trend": [], "mean": 4.4332, "unit": "\u00b5s", "stats": {"mean": "4.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.43 \u00b5s", "max": "4.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "node_lookup": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.5994, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 64.3196, "ci_upper": 64.78}], "trend": [], "mean": 64.5994, "unit": "ns", "stats": {"mean": "64.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.6 ns", "max": "64.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "out_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 406.1903, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 404.2937, "ci_upper": 407.7134}], "trend": [], "mean": 406.1903, "unit": "ns", "stats": {"mean": "406.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "406.2 ns", "max": "406.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "406.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "point_in_time_queries/1000vectors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 30.1798, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 30.0786, "ci_upper": 30.2899}], "trend": [], "mean": 30.1798, "unit": "ns", "stats": {"mean": "30.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "30.2 ns", "max": "30.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "30.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "point_in_time_queries/100vectors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.3891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.3452, "ci_upper": 27.4405}], "trend": [], "mean": 27.3891, "unit": "ns", "stats": {"mean": "27.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.4 ns", "max": "27.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "property_lookup_vs_scan/find_nodes_by_property": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.0306, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 38.9559, "ci_upper": 39.0986}], "trend": [], "mean": 39.0306, "unit": "\u00b5s", "stats": {"mean": "39.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "39.03 \u00b5s", "max": "39.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "39.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "property_lookup_vs_scan/manual_label_scan_filter": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.2924, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 137.9873, "ci_upper": 138.6328}], "trend": [], "mean": 138.2924, "unit": "\u00b5s", "stats": {"mean": "138.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "138.29 \u00b5s", "max": "138.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "138.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_latency_p50_p99": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.7752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.0249, "ci_upper": 9.8609}], "trend": [], "mean": 8.7752, "unit": "ns", "stats": {"mean": "8.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.8 ns", "max": "8.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "read_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 339.2398}], "mean": 339.2398, "unit": "ns", "stats": {"mean": "339.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "339.2 ns", "max": "339.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "339.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/0": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4554}], "mean": 4.4554, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.6603}], "mean": 56.6603, "unit": "ms", "stats": {"mean": "56.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.66 ms", "max": "56.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114.751}], "mean": 114.751, "unit": "ms", "stats": {"mean": "114.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "114.75 ms", "max": "114.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "114.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "recovery/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.0642, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 459.8291, "ci_upper": 536.5218}], "trend": [], "mean": 500.0642, "unit": "\u00b5s", "stats": {"mean": "500.06 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "500.06 \u00b5s", "max": "500.06 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "500.06 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "recovery/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.0332, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 438.4822, "ci_upper": 494.3068}], "trend": [], "mean": 457.0332, "unit": "\u00b5s", "stats": {"mean": "457.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "457.03 \u00b5s", "max": "457.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "457.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "recovery/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.9167, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 646.4979, "ci_upper": 649.5903}], "trend": [], "mean": 647.9167, "unit": "\u00b5s", "stats": {"mean": "647.92 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "647.92 \u00b5s", "max": "647.92 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "647.92 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9001, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.1618, "ci_upper": 435.2252}], "trend": [], "mean": 431.9001, "unit": "ns", "stats": {"mean": "431.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "431.9 ns", "max": "431.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "431.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9392, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.5473, "ci_upper": 434.3479}], "trend": [], "mean": 431.9392, "unit": "ns", "stats": {"mean": "431.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "431.9 ns", "max": "431.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "431.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.1358, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.5471, "ci_upper": 431.8251}], "trend": [], "mean": 431.1358, "unit": "ns", "stats": {"mean": "431.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "431.1 ns", "max": "431.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "431.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/async": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 57.2811, "ci_upper": 72.114}], "trend": [], "mean": 65.065, "unit": "\u00b5s", "stats": {"mean": "65.06 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "65.06 \u00b5s", "max": "65.06 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "65.06 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/async_batched_aggressive": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5.0172, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.9949, "ci_upper": 5.0335}], "trend": [], "mean": 5.0172, "unit": "ms", "stats": {"mean": "5.02 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "5.02 ms", "max": "5.02 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "5.02 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/async_batched_default": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.1885, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1837, "ci_upper": 9.1937}], "trend": [], "mean": 9.1885, "unit": "ms", "stats": {"mean": "9.19 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.19 ms", "max": "9.19 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.19 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/group_commit_default": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.7552, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7436, "ci_upper": 2.7678}], "trend": [], "mean": 2.7552, "unit": "ms", "stats": {"mean": "2.76 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.76 ms", "max": "2.76 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.76 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/group_commit_fast": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.799, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.7768, "ci_upper": 1.8225}], "trend": [], "mean": 1.799, "unit": "ms", "stats": {"mean": "1.80 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.80 ms", "max": "1.80 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.80 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_transaction_latency/synchronous": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.9769, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 563.8529, "ci_upper": 579.817}], "trend": [], "mean": 571.9769, "unit": "\u00b5s", "stats": {"mean": "571.98 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "571.98 \u00b5s", "max": "571.98 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "571.98 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/time_interval_1s": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 77.0748, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.0192, "ci_upper": 77.1398}], "trend": [], "mean": 77.0748, "unit": "ns", "stats": {"mean": "77.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "77.1 ns", "max": "77.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "77.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/transaction_interval_10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 24.1606, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 24.071, "ci_upper": 24.2429}], "trend": [], "mean": 24.1606, "unit": "\u00b5s", "stats": {"mean": "24.16 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "24.16 \u00b5s", "max": "24.16 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "24.16 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/transaction_interval_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.5038, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.4901, "ci_upper": 2.5173}], "trend": [], "mean": 2.5038, "unit": "\u00b5s", "stats": {"mean": "2.50 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.50 \u00b5s", "max": "2.50 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.50 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_access_single/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.5734, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.5592, "ci_upper": 35.59}], "trend": [], "mean": 35.5734, "unit": "ns", "stats": {"mean": "35.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "35.6 ns", "max": "35.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "35.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_access_single/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.8205, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.8061, "ci_upper": 21.8363}], "trend": [], "mean": 21.8205, "unit": "ns", "stats": {"mean": "21.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.8 ns", "max": "21.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_comparison/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.1669, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.7463, "ci_upper": 36.6306}], "trend": [], "mean": 36.1669, "unit": "ns", "stats": {"mean": "36.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.2 ns", "max": "36.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_comparison/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.1721, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 22.028, "ci_upper": 22.3815}], "trend": [], "mean": 22.1721, "unit": "ns", "stats": {"mean": "22.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.2 ns", "max": "22.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_length/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.5058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 36.2076, "ci_upper": 36.8017}], "trend": [], "mean": 36.5058, "unit": "ns", "stats": {"mean": "36.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.5 ns", "max": "36.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_length/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.0168, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.9521, "ci_upper": 22.09}], "trend": [], "mean": 22.0168, "unit": "ns", "stats": {"mean": "22.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.0 ns", "max": "22.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_10k_versions": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181.7438, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 180.8869, "ci_upper": 182.6944}], "trend": [], "mean": 181.7438, "unit": "ms", "stats": {"mean": "181.74 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "181.74 ms", "max": "181.74 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "181.74 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_10k_versions_fast_reference": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 455.09, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 454.13, "ci_upper": 456.0735}], "trend": [], "mean": 455.09, "unit": "ms", "stats": {"mean": "455.09 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "455.09 ms", "max": "455.09 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "455.09 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 269.4377, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 268.0299, "ci_upper": 271.0013}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 284.2773}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 271.5576}], "mean": 277.9174, "unit": "ns", "stats": {"mean": "277.9 ns", "std_dev": "6.0 ns", "cv": "2.2%", "min": "269.4 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "269.4 ns", "total_change": "-4.5%", "trend": "-4.5%", "count": 3}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 630.4888, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 627.7125, "ci_upper": 633.4295}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 806.5309}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 655.6376}], "mean": 731.0842, "unit": "\u00b5s", "stats": {"mean": "731.08 \u00b5s", "std_dev": "71.13 \u00b5s", "cv": "9.7%", "min": "630.49 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "630.49 \u00b5s", "total_change": "-19.3%", "trend": "-19.3%", "count": 3}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.5098, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 39.4579, "ci_upper": 39.5788}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 43.123}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.0259}], "mean": 41.5744, "unit": "ns", "stats": {"mean": "41.6 ns", "std_dev": "1.5 ns", "cv": "3.5%", "min": "39.5 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "39.5 ns", "total_change": "-7.3%", "trend": "-7.3%", "count": 3}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 272.3004, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 272.1219, "ci_upper": 272.4928}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 284.3073}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 274.0156}], "mean": 279.1614, "unit": "ns", "stats": {"mean": "279.2 ns", "std_dev": "4.9 ns", "cv": "1.7%", "min": "272.3 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "272.3 ns", "total_change": "-3.6%", "trend": "-3.6%", "count": 3}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 279.2666, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 270.6264, "ci_upper": 290.0937}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 274.4322}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 278.576}], "mean": 276.5041, "unit": "ns", "stats": {"mean": "276.5 ns", "std_dev": "2.0 ns", "cv": "0.7%", "min": "275.1 ns", "max": "279.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "279.3 ns", "total_change": "+1.5%", "trend": "+1.5%", "count": 3}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 274.4635, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 274.2626, "ci_upper": 274.6612}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 288.1864}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 276.424}], "mean": 282.3052, "unit": "ns", "stats": {"mean": "282.3 ns", "std_dev": "5.5 ns", "cv": "2.0%", "min": "274.5 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "274.5 ns", "total_change": "-4.1%", "trend": "-4.1%", "count": 3}}, "temporal_insert/append_only/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.5223}], "mean": 20.5223, "unit": "\u00b5s", "stats": {"mean": "20.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.52 \u00b5s", "max": "20.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.7516}], "mean": 210.7516, "unit": "\u00b5s", "stats": {"mean": "210.75 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "210.75 \u00b5s", "max": "210.75 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "210.75 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.1701}], "mean": 2.1701, "unit": "ms", "stats": {"mean": "2.17 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.17 ms", "max": "2.17 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.17 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.4722}], "mean": 147.4722, "unit": "\u00b5s", "stats": {"mean": "147.47 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "147.47 \u00b5s", "max": "147.47 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "147.47 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12.5487}], "mean": 12.5487, "unit": "ms", "stats": {"mean": "12.55 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "12.55 ms", "max": "12.55 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "12.55 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2868}], "mean": 1.2868, "unit": "s", "stats": {"mean": "1.287 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.287 s", "max": "1.287 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.287 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "time_travel/at_anchor_v20": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.9872, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.8817, "ci_upper": 124.109}], "trend": [], "mean": 123.9872, "unit": "ns", "stats": {"mean": "124.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "124.0 ns", "max": "124.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "124.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "time_travel/deep_history_v5": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 124.3222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 124.2538, "ci_upper": 124.4012}], "trend": [], "mean": 124.3222, "unit": "ns", "stats": {"mean": "124.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "124.3 ns", "max": "124.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "124.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "time_travel/with_deltas_v15": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.9411, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.8773, "ci_upper": 124.0033}], "trend": [], "mean": 123.9411, "unit": "ns", "stats": {"mean": "123.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.9 ns", "max": "123.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "time_travel/worst_case_v19": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 124.3814, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 124.3176, "ci_upper": 124.4393}], "trend": [], "mean": 124.3814, "unit": "ns", "stats": {"mean": "124.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "124.4 ns", "max": "124.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "124.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_power_law/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.6454, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 40.5756, "ci_upper": 40.7569}], "trend": [], "mean": 40.6454, "unit": "\u00b5s", "stats": {"mean": "40.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "40.65 \u00b5s", "max": "40.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "40.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_sparse/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2866, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2851, "ci_upper": 1.2882}], "trend": [], "mean": 1.2866, "unit": "\u00b5s", "stats": {"mean": "1.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.29 \u00b5s", "max": "1.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_uniform/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.8933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.8887, "ci_upper": 7.8985}], "trend": [], "mean": 7.8933, "unit": "\u00b5s", "stats": {"mean": "7.89 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.89 \u00b5s", "max": "7.89 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.89 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_power_law/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 47.5431, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 46.0216, "ci_upper": 48.9082}], "trend": [], "mean": 47.5431, "unit": "\u00b5s", "stats": {"mean": "47.54 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "47.54 \u00b5s", "max": "47.54 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "47.54 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_sparse/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2763, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2752, "ci_upper": 1.2775}], "trend": [], "mean": 1.2763, "unit": "\u00b5s", "stats": {"mean": "1.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.28 \u00b5s", "max": "1.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_uniform/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.124, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.1118, "ci_upper": 8.1406}], "trend": [], "mean": 8.124, "unit": "\u00b5s", "stats": {"mean": "8.12 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.12 \u00b5s", "max": "8.12 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.12 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/10000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.3551}], "mean": 22.3551, "unit": "\u00b5s", "stats": {"mean": "22.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.36 \u00b5s", "max": "22.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "valid_at_query/1000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.9012}], "mean": 3.9012, "unit": "\u00b5s", "stats": {"mean": "3.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.90 \u00b5s", "max": "3.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "valid_at_query/100_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5299}], "mean": 1.5299, "unit": "\u00b5s", "stats": {"mean": "1.53 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.53 \u00b5s", "max": "1.53 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.53 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "vector_batch_deserialize/retrieval_workload/100x1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.6376, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 36.5396, "ci_upper": 36.729}], "trend": [], "mean": 36.6376, "unit": "\u00b5s", "stats": {"mean": "36.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.64 \u00b5s", "max": "36.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_batch_serialize/rag_workload/100x1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.9863, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 22.8833, "ci_upper": 23.1147}], "trend": [], "mean": 22.9863, "unit": "\u00b5s", "stats": {"mean": "22.99 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.99 \u00b5s", "max": "22.99 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.99 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 54.6348, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 54.5623, "ci_upper": 54.718}], "trend": [], "mean": 54.6348, "unit": "ns", "stats": {"mean": "54.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "54.6 ns", "max": "54.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "54.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 55.4275, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 55.3586, "ci_upper": 55.5054}], "trend": [], "mean": 55.4275, "unit": "ns", "stats": {"mean": "55.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "55.4 ns", "max": "55.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "55.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/128": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 67.0515, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.955, "ci_upper": 67.1542}], "trend": [], "mean": 67.0515, "unit": "ns", "stats": {"mean": "67.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "67.1 ns", "max": "67.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "67.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 376.7175, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 373.5381, "ci_upper": 380.2115}], "trend": [], "mean": 376.7175, "unit": "ns", "stats": {"mean": "376.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "376.7 ns", "max": "376.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "376.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 751.7691, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 745.1252, "ci_upper": 758.7799}], "trend": [], "mean": 751.7691, "unit": "ns", "stats": {"mean": "751.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "751.8 ns", "max": "751.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "751.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 240.6619, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 239.0724, "ci_upper": 242.3761}], "trend": [], "mean": 240.6619, "unit": "ns", "stats": {"mean": "240.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "240.7 ns", "max": "240.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "240.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 281.7997, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 280.3144, "ci_upper": 283.402}], "trend": [], "mean": 281.7997, "unit": "ns", "stats": {"mean": "281.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "281.8 ns", "max": "281.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "281.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 613.6658, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 611.8239, "ci_upper": 615.3107}], "trend": [], "mean": 613.6658, "unit": "ns", "stats": {"mean": "613.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "613.7 ns", "max": "613.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "613.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.4334, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.4213, "ci_upper": 1.4449}], "trend": [], "mean": 1.4334, "unit": "\u00b5s", "stats": {"mean": "1.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.43 \u00b5s", "max": "1.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 384.864, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4977, "ci_upper": 386.9566}], "trend": [], "mean": 384.864, "unit": "ns", "stats": {"mean": "384.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "384.9 ns", "max": "384.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "384.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 427.7807, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 425.9115, "ci_upper": 429.4511}], "trend": [], "mean": 427.7807, "unit": "ns", "stats": {"mean": "427.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "427.8 ns", "max": "427.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "427.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.6736, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.6323, "ci_upper": 27.7247}], "trend": [], "mean": 27.6736, "unit": "ns", "stats": {"mean": "27.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.7 ns", "max": "27.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.1097, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.0881, "ci_upper": 27.132}], "trend": [], "mean": 27.1097, "unit": "ns", "stats": {"mean": "27.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.1 ns", "max": "27.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/128": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.7801, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.2233, "ci_upper": 35.393}], "trend": [], "mean": 34.7801, "unit": "ns", "stats": {"mean": "34.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.8 ns", "max": "34.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 173.4712, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 173.3446, "ci_upper": 173.6017}], "trend": [], "mean": 173.4712, "unit": "ns", "stats": {"mean": "173.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "173.5 ns", "max": "173.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "173.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 219.1664, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.124, "ci_upper": 220.383}], "trend": [], "mean": 219.1664, "unit": "ns", "stats": {"mean": "219.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "219.2 ns", "max": "219.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "219.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 134.5591, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 134.4308, "ci_upper": 134.7104}], "trend": [], "mean": 134.5591, "unit": "ns", "stats": {"mean": "134.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "134.6 ns", "max": "134.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "134.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.5553, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 128.5746, "ci_upper": 139.648}], "trend": [], "mean": 133.5553, "unit": "ns", "stats": {"mean": "133.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.6 ns", "max": "133.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181.317, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.2098, "ci_upper": 181.4454}], "trend": [], "mean": 181.317, "unit": "ns", "stats": {"mean": "181.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "181.3 ns", "max": "181.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "181.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.6943, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.4263, "ci_upper": 120.0107}], "trend": [], "mean": 119.6943, "unit": "ns", "stats": {"mean": "119.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.7 ns", "max": "119.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.5379, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 141.407, "ci_upper": 141.6805}], "trend": [], "mean": 141.5379, "unit": "ns", "stats": {"mean": "141.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "141.5 ns", "max": "141.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "141.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "write_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 462.4375}], "mean": 462.4375, "unit": "ns", "stats": {"mean": "462.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "462.4 ns", "max": "462.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "462.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}};
+const CONFIGS = {"3_hop_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.7094, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.6255, "ci_upper": 56.8146}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 50.4998, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 50.1955, "ci_upper": 50.8594}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.7094}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 50.4998}], "mean": 53.6046, "unit": "\u00b5s", "stats": {"mean": "53.60 \u00b5s", "std_dev": "3.10 \u00b5s", "cv": "5.8%", "min": "50.50 \u00b5s", "max": "56.71 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "50.50 \u00b5s", "total_change": "-10.9%", "trend": "-10.9%", "count": 2}}, "aletheiadb_3_hop_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 483.0333, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 481.8018, "ci_upper": 484.841}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 480.901, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 480.5417, "ci_upper": 481.3304}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 490.9567, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 486.0911, "ci_upper": 496.8923}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 481.002}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 488.9254}], "mean": 484.9637, "unit": "ns", "stats": {"mean": "485.0 ns", "std_dev": "4.3 ns", "cv": "0.9%", "min": "480.9 ns", "max": "491.0 ns", "min_commit": "268e122", "max_commit": "268e122", "latest": "491.0 ns", "total_change": "+1.6%", "trend": "+1.6%", "count": 3}}, "aletheiadb_batch/batch_node_creation/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.8075, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.675, "ci_upper": 27.9374}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 30.3972, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 30.0511, "ci_upper": 30.748}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.9396, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 29.743, "ci_upper": 30.138}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 28.3154}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 30.4475}], "mean": 29.3814, "unit": "ms", "stats": {"mean": "29.38 ms", "std_dev": "1.13 ms", "cv": "3.8%", "min": "27.81 ms", "max": "30.40 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "29.94 ms", "total_change": "+7.7%", "trend": "+7.7%", "count": 3}}, "aletheiadb_batch/batch_node_creation/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289.8292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 288.0868, "ci_upper": 291.5917}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 325.397, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 322.3911, "ci_upper": 328.3902}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 320.7797, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 318.0328, "ci_upper": 323.4497}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 296.5267}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 327.4772}], "mean": 312.002, "unit": "ms", "stats": {"mean": "312.00 ms", "std_dev": "15.79 ms", "cv": "5.1%", "min": "289.83 ms", "max": "325.40 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "320.78 ms", "total_change": "+10.7%", "trend": "+10.7%", "count": 3}}, "aletheiadb_batch/batch_node_creation/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8312, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.8159, "ci_upper": 2.8495}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 3.3026, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.2362, "ci_upper": 3.3732}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.2429, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.2149, "ci_upper": 3.2733}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.9197}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.3314}], "mean": 3.1255, "unit": "s", "stats": {"mean": "3.126 s", "std_dev": "209.57 ms", "cv": "6.7%", "min": "2.831 s", "max": "3.303 s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "3.243 s", "total_change": "+14.5%", "trend": "+14.5%", "count": 3}}, "aletheiadb_edge_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.3458, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 87.5403, "ci_upper": 106.6907}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 97.4096, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 87.6903, "ci_upper": 106.7089}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 97.4362, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 87.8682, "ci_upper": 106.7064}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 97.352}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 97.4424}], "mean": 97.3972, "unit": "\u00b5s", "stats": {"mean": "97.40 \u00b5s", "std_dev": "37.9 ns", "cv": "0.0%", "min": "97.35 \u00b5s", "max": "97.44 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "97.44 \u00b5s", "total_change": "+0.1%", "trend": "+0.1%", "count": 3}}, "aletheiadb_fast_path/node_lookup/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.7337, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 62.6648, "ci_upper": 62.8097}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 61.4853, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 61.4393, "ci_upper": 61.5427}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 55.7091, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 55.4245, "ci_upper": 56.0256}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 63.4884}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 56.4637}], "mean": 59.976, "unit": "ns", "stats": {"mean": "60.0 ns", "std_dev": "3.1 ns", "cv": "5.1%", "min": "55.7 ns", "max": "62.7 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "55.7 ns", "total_change": "-11.2%", "trend": "-11.2%", "count": 3}}, "aletheiadb_fast_path/node_lookup/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.003, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 61.9509, "ci_upper": 62.0692}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 61.3795, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 61.3206, "ci_upper": 61.4343}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 62.217, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 61.6902, "ci_upper": 62.8737}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 61.7595}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 61.9735}], "mean": 61.8665, "unit": "ns", "stats": {"mean": "61.9 ns", "std_dev": "0.4 ns", "cv": "0.6%", "min": "61.4 ns", "max": "62.2 ns", "min_commit": "268e122", "max_commit": "268e122", "latest": "62.2 ns", "total_change": "+0.3%", "trend": "+0.3%", "count": 3}}, "aletheiadb_fast_path/node_lookup/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 61.1577, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 61.1032, "ci_upper": 61.2266}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 62.112, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 61.8753, "ci_upper": 62.3973}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 61.4963, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 60.745, "ci_upper": 62.1982}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 61.4194}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 61.758}], "mean": 61.5887, "unit": "ns", "stats": {"mean": "61.6 ns", "std_dev": "0.4 ns", "cv": "0.6%", "min": "61.2 ns", "max": "62.1 ns", "min_commit": "198c57d", "max_commit": "268e122", "latest": "61.5 ns", "total_change": "+0.6%", "trend": "+0.6%", "count": 3}}, "aletheiadb_historical_stats": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.0592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.057, "ci_upper": 1.0618}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 1.0609, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 1.0553, "ci_upper": 1.0685}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.9437, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 0.9371, "ci_upper": 0.9508}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.079}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.9635}], "mean": 1.0213, "unit": "\u00b5s", "stats": {"mean": "1.02 \u00b5s", "std_dev": "54.9 ns", "cv": "5.4%", "min": "943.7 ns", "max": "1.06 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "943.7 ns", "total_change": "-10.9%", "trend": "-10.9%", "count": 3}}, "aletheiadb_in_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 104.8917, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 104.81, "ci_upper": 104.9774}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 99.891, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 98.8398, "ci_upper": 101.489}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 93.7413, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 92.1747, "ci_upper": 95.1854}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.0832}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 93.9328}], "mean": 99.508, "unit": "ns", "stats": {"mean": "99.5 ns", "std_dev": "4.6 ns", "cv": "4.6%", "min": "93.7 ns", "max": "104.9 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "93.7 ns", "total_change": "-10.6%", "trend": "-10.6%", "count": 3}}, "aletheiadb_labeled_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 159.8682, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 159.7019, "ci_upper": 160.0694}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 160.249, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 159.6384, "ci_upper": 161.0746}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 157.1537, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 154.3541, "ci_upper": 160.1881}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 160.4476}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 157.7331}], "mean": 159.0903, "unit": "ns", "stats": {"mean": "159.1 ns", "std_dev": "1.4 ns", "cv": "0.9%", "min": "157.2 ns", "max": "160.2 ns", "min_commit": "268e122", "max_commit": "268e122", "latest": "157.2 ns", "total_change": "-1.7%", "trend": "-1.7%", "count": 3}}, "aletheiadb_node_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 105.588, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 95.5147, "ci_upper": 116.8485}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 98.5758, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 90.6899, "ci_upper": 106.1515}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 98.5876, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 90.6983, "ci_upper": 106.1737}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 104.4173}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 97.417}], "mean": 100.9172, "unit": "\u00b5s", "stats": {"mean": "100.92 \u00b5s", "std_dev": "3.30 \u00b5s", "cv": "3.3%", "min": "98.58 \u00b5s", "max": "105.59 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "98.59 \u00b5s", "total_change": "-6.6%", "trend": "-6.6%", "count": 3}}, "aletheiadb_out_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 100.3947, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 100.3461, "ci_upper": 100.4534}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 106.3631, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 105.7212, "ci_upper": 106.9826}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 100.897, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 100.0899, "ci_upper": 101.6818}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 102.3005}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 102.8027}], "mean": 102.5516, "unit": "ns", "stats": {"mean": "102.6 ns", "std_dev": "2.7 ns", "cv": "2.6%", "min": "100.4 ns", "max": "106.4 ns", "min_commit": "198c57d", "max_commit": "268e122", "latest": "100.9 ns", "total_change": "+0.5%", "trend": "+0.5%", "count": 3}}, "aletheiadb_single_hop/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.4999, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.3909, "ci_upper": 116.6086}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 114.8392, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 114.5414, "ci_upper": 115.1392}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 104.5684, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 102.9564, "ci_upper": 106.4173}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 117.9349}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 106.0034}], "mean": 111.9691, "unit": "ns", "stats": {"mean": "112.0 ns", "std_dev": "5.3 ns", "cv": "4.7%", "min": "104.6 ns", "max": "116.5 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "104.6 ns", "total_change": "-10.2%", "trend": "-10.2%", "count": 3}}, "aletheiadb_single_hop/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.5517, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.4637, "ci_upper": 116.6516}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 114.9621, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 114.7942, "ci_upper": 115.1473}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 103.3354, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 102.4425, "ci_upper": 104.3715}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 118.2246}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 105.0083}], "mean": 111.6164, "unit": "ns", "stats": {"mean": "111.6 ns", "std_dev": "5.9 ns", "cv": "5.3%", "min": "103.3 ns", "max": "116.6 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "103.3 ns", "total_change": "-11.3%", "trend": "-11.3%", "count": 3}}, "aletheiadb_single_hop/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.1347, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 116.0577, "ci_upper": 116.2193}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 115.7443, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 115.1351, "ci_upper": 116.4835}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 113.2974, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 110.5422, "ci_upper": 117.0048}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 116.4775}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 113.6401}], "mean": 115.0588, "unit": "ns", "stats": {"mean": "115.1 ns", "std_dev": "1.3 ns", "cv": "1.1%", "min": "113.3 ns", "max": "116.1 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "113.3 ns", "total_change": "-2.4%", "trend": "-2.4%", "count": 3}}, "arc_overhead/arc_clone_drop": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 32.3282, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 32.1344, "ci_upper": 32.5263}], "trend": [], "mean": 32.3282, "unit": "ns", "stats": {"mean": "32.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.3 ns", "max": "32.3 ns", "min_commit": "268e122", "max_commit": "268e122", "latest": "32.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "arc_overhead/direct_access": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 19.3966, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 19.2883, "ci_upper": 19.4987}], "trend": [], "mean": 19.3966, "unit": "ns", "stats": {"mean": "19.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "19.4 ns", "max": "19.4 ns", "min_commit": "268e122", "max_commit": "268e122", "latest": "19.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "batch_throughput/async": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52.7926, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 52.7417, "ci_upper": 52.8425}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 52.3698, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 52.32, "ci_upper": 52.421}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 52.7926}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 52.3698}], "mean": 52.5812, "unit": "ms", "stats": {"mean": "52.58 ms", "std_dev": "211.43 \u00b5s", "cv": "0.4%", "min": "52.37 ms", "max": "52.79 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "52.37 ms", "total_change": "-0.8%", "trend": "-0.8%", "count": 2}}, "batch_throughput/synchronous": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635.7484, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 625.9952, "ci_upper": 645.2215}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 758.7805, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 736.1646, "ci_upper": 782.2898}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 635.7484}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 758.7805}], "mean": 697.2645, "unit": "ms", "stats": {"mean": "697.26 ms", "std_dev": "61.52 ms", "cv": "8.8%", "min": "635.75 ms", "max": "758.78 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "758.78 ms", "total_change": "+19.4%", "trend": "+19.4%", "count": 2}}, "checkpoint_creation/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.893, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.4531, "ci_upper": 5.316}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.0502, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.9493, "ci_upper": 4.154}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.893}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.0502}], "mean": 4.4716, "unit": "ms", "stats": {"mean": "4.47 ms", "std_dev": "421.39 \u00b5s", "cv": "9.4%", "min": "4.05 ms", "max": "4.89 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "4.05 ms", "total_change": "-17.2%", "trend": "-17.2%", "count": 2}}, "checkpoint_creation/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.0293, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.874, "ci_upper": 4.2611}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.504, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 4.3082, "ci_upper": 4.7791}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.0293}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.504}], "mean": 4.2666, "unit": "ms", "stats": {"mean": "4.27 ms", "std_dev": "237.34 \u00b5s", "cv": "5.6%", "min": "4.03 ms", "max": "4.50 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "4.50 ms", "total_change": "+11.8%", "trend": "+11.8%", "count": 2}}, "checkpoint_creation/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.6632, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.568, "ci_upper": 7.7574}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 8.7824, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 8.6447, "ci_upper": 8.9296}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.6632}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 8.7824}], "mean": 8.2228, "unit": "ms", "stats": {"mean": "8.22 ms", "std_dev": "559.58 \u00b5s", "cv": "6.8%", "min": "7.66 ms", "max": "8.78 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "8.78 ms", "total_change": "+14.6%", "trend": "+14.6%", "count": 2}}, "checkpoint_load/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.5051, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 317.3704, "ci_upper": 329.8024}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 312.8756, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 310.5068, "ci_upper": 315.5883}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 323.5051}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 312.8756}], "mean": 318.1904, "unit": "\u00b5s", "stats": {"mean": "318.19 \u00b5s", "std_dev": "5.31 \u00b5s", "cv": "1.7%", "min": "312.88 \u00b5s", "max": "323.51 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "312.88 \u00b5s", "total_change": "-3.3%", "trend": "-3.3%", "count": 2}}, "checkpoint_load/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.628, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.614, "ci_upper": 1.6437}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.4904, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 1.4809, "ci_upper": 1.5031}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.628}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.4904}], "mean": 1.5592, "unit": "ms", "stats": {"mean": "1.56 ms", "std_dev": "68.76 \u00b5s", "cv": "4.4%", "min": "1.49 ms", "max": "1.63 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "1.49 ms", "total_change": "-8.4%", "trend": "-8.4%", "count": 2}}, "checkpoint_load/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15.1799, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 15.0798, "ci_upper": 15.2868}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 13.1474, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 13.08, "ci_upper": 13.2191}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 15.1799}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 13.1474}], "mean": 14.1637, "unit": "ms", "stats": {"mean": "14.16 ms", "std_dev": "1.02 ms", "cv": "7.2%", "min": "13.15 ms", "max": "15.18 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "13.15 ms", "total_change": "-13.4%", "trend": "-13.4%", "count": 2}}, "closure_write_single_node": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7963, "ci_upper": 2.816}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.8058}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.8058}], "mean": 2.8058, "unit": "ms", "stats": {"mean": "2.81 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.81 ms", "max": "2.81 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.81 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "cold_batch_write_throughput/fast/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.9292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.9076, "ci_upper": 4.9539}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 5.3151, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 5.2786, "ci_upper": 5.3608}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.9292}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 5.3151}], "mean": 5.1222, "unit": "ms", "stats": {"mean": "5.12 ms", "std_dev": "192.92 \u00b5s", "cv": "3.8%", "min": "4.93 ms", "max": "5.32 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "5.32 ms", "total_change": "+7.8%", "trend": "+7.8%", "count": 2}}, "cold_batch_write_throughput/fast/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45.8136, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 45.7461, "ci_upper": 45.8876}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 47.4967, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 47.1901, "ci_upper": 47.8223}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 45.8136}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 47.4967}], "mean": 46.6551, "unit": "ms", "stats": {"mean": "46.66 ms", "std_dev": "841.58 \u00b5s", "cv": "1.8%", "min": "45.81 ms", "max": "47.50 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "47.50 ms", "total_change": "+3.7%", "trend": "+3.7%", "count": 2}}, "cold_batch_write_throughput/fast/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454.8297, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 454.2272, "ci_upper": 455.4686}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 457.426, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 455.3401, "ci_upper": 459.5884}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 454.8297}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 457.426}], "mean": 456.1279, "unit": "ms", "stats": {"mean": "456.13 ms", "std_dev": "1.30 ms", "cv": "0.3%", "min": "454.83 ms", "max": "457.43 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "457.43 ms", "total_change": "+0.6%", "trend": "+0.6%", "count": 2}}, "cold_batch_write_throughput/zstd/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.4465, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.4201, "ci_upper": 7.4717}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 7.9846, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 7.9381, "ci_upper": 8.0359}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.4465}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 7.9846}], "mean": 7.7155, "unit": "ms", "stats": {"mean": "7.72 ms", "std_dev": "269.05 \u00b5s", "cv": "3.5%", "min": "7.45 ms", "max": "7.98 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "7.98 ms", "total_change": "+7.2%", "trend": "+7.2%", "count": 2}}, "cold_batch_write_throughput/zstd/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66.7824, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.5764, "ci_upper": 67.0114}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 67.058, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 66.6601, "ci_upper": 67.4831}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 66.7824}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 67.058}], "mean": 66.9202, "unit": "ms", "stats": {"mean": "66.92 ms", "std_dev": "137.79 \u00b5s", "cv": "0.2%", "min": "66.78 ms", "max": "67.06 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "67.06 ms", "total_change": "+0.4%", "trend": "+0.4%", "count": 2}}, "cold_batch_write_throughput/zstd/10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189.515, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 187.4879, "ci_upper": 191.7626}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 183.446, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 182.1973, "ci_upper": 184.8207}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 189.515}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 183.446}], "mean": 186.4805, "unit": "ms", "stats": {"mean": "186.48 ms", "std_dev": "3.03 ms", "cv": "1.6%", "min": "183.45 ms", "max": "189.51 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "183.45 ms", "total_change": "-3.2%", "trend": "-3.2%", "count": 2}}, "cold_read_latency/single_read/fast_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.4834, "ci_upper": 34.597}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 38.472, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 37.8295, "ci_upper": 39.3589}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.539}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 38.472}], "mean": 36.5055, "unit": "\u00b5s", "stats": {"mean": "36.51 \u00b5s", "std_dev": "1.97 \u00b5s", "cv": "5.4%", "min": "34.54 \u00b5s", "max": "38.47 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "38.47 \u00b5s", "total_change": "+11.4%", "trend": "+11.4%", "count": 2}}, "cold_read_latency/single_read/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.3055, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.2979, "ci_upper": 3.3147}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.2502, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.2203, "ci_upper": 3.2818}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.3055}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.2502}], "mean": 3.2778, "unit": "\u00b5s", "stats": {"mean": "3.28 \u00b5s", "std_dev": "27.7 ns", "cv": "0.8%", "min": "3.25 \u00b5s", "max": "3.31 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "3.25 \u00b5s", "total_change": "-1.7%", "trend": "-1.7%", "count": 2}}, "cold_read_latency/single_read/zstd_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.4087, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.3612, "ci_upper": 34.4647}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 37.9302, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 37.4326, "ci_upper": 38.4866}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.4087}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 37.9302}], "mean": 36.1695, "unit": "\u00b5s", "stats": {"mean": "36.17 \u00b5s", "std_dev": "1.76 \u00b5s", "cv": "4.9%", "min": "34.41 \u00b5s", "max": "37.93 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "37.93 \u00b5s", "total_change": "+10.2%", "trend": "+10.2%", "count": 2}}, "cold_write_latency/single_write/fast_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 338.7451, "ci_upper": 342.0878}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 341.1382, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 337.3319, "ci_upper": 346.2865}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 340.426}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 341.1382}], "mean": 340.7821, "unit": "\u00b5s", "stats": {"mean": "340.78 \u00b5s", "std_dev": "356.1 ns", "cv": "0.1%", "min": "340.43 \u00b5s", "max": "341.14 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "341.14 \u00b5s", "total_change": "+0.2%", "trend": "+0.2%", "count": 2}}, "cold_write_latency/single_write/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.7913, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 317.6596, "ci_upper": 379.6265}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 288.7007, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 283.3526, "ci_upper": 294.1039}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 343.7913}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 288.7007}], "mean": 316.246, "unit": "\u00b5s", "stats": {"mean": "316.25 \u00b5s", "std_dev": "27.55 \u00b5s", "cv": "8.7%", "min": "288.70 \u00b5s", "max": "343.79 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "288.70 \u00b5s", "total_change": "-16.0%", "trend": "-16.0%", "count": 2}}, "cold_write_latency/single_write/zstd_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.8672, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 370.4404, "ci_upper": 377.8695}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 450.0675, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 439.0109, "ci_upper": 461.7519}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 373.8672}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 450.0675}], "mean": 411.9674, "unit": "\u00b5s", "stats": {"mean": "411.97 \u00b5s", "std_dev": "38.10 \u00b5s", "cv": "9.2%", "min": "373.87 \u00b5s", "max": "450.07 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "450.07 \u00b5s", "total_change": "+20.4%", "trend": "+20.4%", "count": 2}}, "comparison_csr/full_rebuild_insert_query": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 140.053, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.986, "ci_upper": 141.1743}], "trend": [], "mean": 140.053, "unit": "\u00b5s", "stats": {"mean": "140.05 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "140.05 \u00b5s", "max": "140.05 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "140.05 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "comparison_csr/incremental_csr_insert_query": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5961, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 16.443, "ci_upper": 16.7372}], "trend": [], "mean": 16.5961, "unit": "\u00b5s", "stats": {"mean": "16.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "16.60 \u00b5s", "max": "16.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "16.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "compression_ratio/compress/fast": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.8685, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 33.5632, "ci_upper": 36.4003}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 37.0848, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 36.7949, "ci_upper": 37.4183}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.8685}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 37.0848}], "mean": 35.9767, "unit": "ms", "stats": {"mean": "35.98 ms", "std_dev": "1.11 ms", "cv": "3.1%", "min": "34.87 ms", "max": "37.08 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "37.08 ms", "total_change": "+6.4%", "trend": "+6.4%", "count": 2}}, "compression_ratio/compress/no_compression": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31.2589, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 31.0497, "ci_upper": 31.4758}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 27.364, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 27.1393, "ci_upper": 27.6208}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 31.2589}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 27.364}], "mean": 29.3115, "unit": "ms", "stats": {"mean": "29.31 ms", "std_dev": "1.95 ms", "cv": "6.6%", "min": "27.36 ms", "max": "31.26 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "27.36 ms", "total_change": "-12.5%", "trend": "-12.5%", "count": 2}}, "compression_ratio/compress/zstd": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.2195, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.56, "ci_upper": 36.922}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 40.9492, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 40.3462, "ci_upper": 41.634}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.2195}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 40.9492}], "mean": 38.5843, "unit": "ms", "stats": {"mean": "38.58 ms", "std_dev": "2.36 ms", "cv": "6.1%", "min": "36.22 ms", "max": "40.95 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "40.95 ms", "total_change": "+13.1%", "trend": "+13.1%", "count": 2}}, "concurrent_reads_same_entity/10000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.8781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 133.4602, "ci_upper": 134.3459}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 133.8781}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.8781}], "mean": 133.8781, "unit": "\u00b5s", "stats": {"mean": "133.88 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.88 \u00b5s", "max": "133.88 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.88 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/10000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.7407, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 421.3448, "ci_upper": 528.9493}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 474.7407}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 474.7407}], "mean": 474.7407, "unit": "\u00b5s", "stats": {"mean": "474.74 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "474.74 \u00b5s", "max": "474.74 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "474.74 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.6457, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 764.5251, "ci_upper": 770.7783}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 767.6457}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 767.6457}], "mean": 767.6457, "unit": "\u00b5s", "stats": {"mean": "767.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "767.65 \u00b5s", "max": "767.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "767.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.1031, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.418, "ci_upper": 130.8036}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.1031}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.1031}], "mean": 130.1031, "unit": "\u00b5s", "stats": {"mean": "130.10 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.10 \u00b5s", "max": "130.10 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.10 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.6437, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.6511, "ci_upper": 222.6116}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.6437}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.6437}], "mean": 220.6437, "unit": "\u00b5s", "stats": {"mean": "220.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.64 \u00b5s", "max": "220.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/1000_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.9052, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 420.8548, "ci_upper": 424.9344}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 422.9052}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 422.9052}], "mean": 422.9052, "unit": "\u00b5s", "stats": {"mean": "422.91 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "422.91 \u00b5s", "max": "422.91 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "422.91 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/16_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.7185, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 693.915, "ci_upper": 699.7152}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 696.7185}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 696.7185}], "mean": 696.7185, "unit": "\u00b5s", "stats": {"mean": "696.72 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "696.72 \u00b5s", "max": "696.72 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "696.72 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/2_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.2643, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 129.5342, "ci_upper": 131.0283}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 130.2643}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 130.2643}], "mean": 130.2643, "unit": "\u00b5s", "stats": {"mean": "130.26 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "130.26 \u00b5s", "max": "130.26 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "130.26 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/4_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.7032, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 202.4409, "ci_upper": 205.1944}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 203.7032}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 203.7032}], "mean": 203.7032, "unit": "\u00b5s", "stats": {"mean": "203.70 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "203.70 \u00b5s", "max": "203.70 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "203.70 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_reads_same_entity/100_versions/8_readers": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.8675, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4974, "ci_upper": 385.1706}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 383.8675}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 383.8675}], "mean": 383.8675, "unit": "\u00b5s", "stats": {"mean": "383.87 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "383.87 \u00b5s", "max": "383.87 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "383.87 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.7069, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 138.8569, "ci_upper": 140.6295}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 139.7069}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 139.7069}], "mean": 139.7069, "unit": "\u00b5s", "stats": {"mean": "139.71 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "139.71 \u00b5s", "max": "139.71 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "139.71 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.0149, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.9372, "ci_upper": 220.928}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 220.0149}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 220.0149}], "mean": 220.0149, "unit": "\u00b5s", "stats": {"mean": "220.01 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "220.01 \u00b5s", "max": "220.01 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "220.01 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/different_entities/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.3599, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.2073, "ci_upper": 426.2143}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 417.3599}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 417.3599}], "mean": 417.3599, "unit": "\u00b5s", "stats": {"mean": "417.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "417.36 \u00b5s", "max": "417.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "417.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.5742, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.1854, "ci_upper": 248.6237}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 214.5742}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 214.5742}], "mean": 214.5742, "unit": "\u00b5s", "stats": {"mean": "214.57 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "214.57 \u00b5s", "max": "214.57 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "214.57 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2257, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1669, "ci_upper": 1.2951}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2257}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2257}], "mean": 1.2257, "unit": "ms", "stats": {"mean": "1.23 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.23 ms", "max": "1.23 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.23 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "concurrent_writes/same_entity_contention/8": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.4764, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1483, "ci_upper": 9.8449}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 9.4764}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.4764}], "mean": 9.4764, "unit": "ms", "stats": {"mean": "9.48 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "9.48 ms", "max": "9.48 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "9.48 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "cosine_similarity/naive_3pass/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.5998, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.5964, "ci_upper": 4.6033}], "trend": [], "mean": 4.5998, "unit": "\u00b5s", "stats": {"mean": "4.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.60 \u00b5s", "max": "4.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9518, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 6.9487, "ci_upper": 6.9553}], "trend": [], "mean": 6.9518, "unit": "\u00b5s", "stats": {"mean": "6.95 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "6.95 \u00b5s", "max": "6.95 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "6.95 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 14.0339, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 14.0176, "ci_upper": 14.0553}], "trend": [], "mean": 14.0339, "unit": "\u00b5s", "stats": {"mean": "14.03 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "14.03 \u00b5s", "max": "14.03 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "14.03 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.6521, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.6509, "ci_upper": 1.6536}], "trend": [], "mean": 1.6521, "unit": "\u00b5s", "stats": {"mean": "1.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.65 \u00b5s", "max": "1.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/naive_3pass/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.4352, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.415, "ci_upper": 3.4602}], "trend": [], "mean": 3.4352, "unit": "\u00b5s", "stats": {"mean": "3.44 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.44 \u00b5s", "max": "3.44 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.44 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 201.4877, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 200.8504, "ci_upper": 202.3099}], "trend": [], "mean": 201.4877, "unit": "ns", "stats": {"mean": "201.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "201.5 ns", "max": "201.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "201.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 299.6659, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.2803, "ci_upper": 300.0181}], "trend": [], "mean": 299.6659, "unit": "ns", "stats": {"mean": "299.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "299.7 ns", "max": "299.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "299.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 592.0544, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 591.7843, "ci_upper": 592.3525}], "trend": [], "mean": 592.0544, "unit": "ns", "stats": {"mean": "592.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "592.1 ns", "max": "592.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "592.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 77.1982, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.0254, "ci_upper": 77.3564}], "trend": [], "mean": 77.1982, "unit": "ns", "stats": {"mean": "77.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "77.2 ns", "max": "77.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "77.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 151.7529, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 151.6634, "ci_upper": 151.8528}], "trend": [], "mean": 151.7529, "unit": "ns", "stats": {"mean": "151.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "151.8 ns", "max": "151.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "151.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5811, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.5754, "ci_upper": 1.59}], "trend": [], "mean": 1.5811, "unit": "\u00b5s", "stats": {"mean": "1.58 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.58 \u00b5s", "max": "1.58 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.58 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.3602, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.3535, "ci_upper": 2.372}], "trend": [], "mean": 2.3602, "unit": "\u00b5s", "stats": {"mean": "2.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.36 \u00b5s", "max": "2.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.7282, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.7141, "ci_upper": 4.7443}], "trend": [], "mean": 4.7282, "unit": "\u00b5s", "stats": {"mean": "4.73 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.73 \u00b5s", "max": "4.73 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.73 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 636.1933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 603.1786, "ci_upper": 671.3907}], "trend": [], "mean": 636.1933, "unit": "ns", "stats": {"mean": "636.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "636.2 ns", "max": "636.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "636.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity/scalar_1pass/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.182, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1815, "ci_upper": 1.1825}], "trend": [], "mean": 1.182, "unit": "\u00b5s", "stats": {"mean": "1.18 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.18 \u00b5s", "max": "1.18 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.18 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 811.3468, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 810.3818, "ci_upper": 812.3508}], "trend": [], "mean": 811.3468, "unit": "ns", "stats": {"mean": "811.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "811.3 ns", "max": "811.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "811.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.2806, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.2657, "ci_upper": 8.2983}], "trend": [], "mean": 8.2806, "unit": "\u00b5s", "stats": {"mean": "8.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.28 \u00b5s", "max": "8.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_batch/find_most_similar/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 90.4588, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 88.3046, "ci_upper": 92.9789}], "trend": [], "mean": 90.4588, "unit": "\u00b5s", "stats": {"mean": "90.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "90.46 \u00b5s", "max": "90.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "90.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/general/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 300.4556, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.9198, "ci_upper": 301.2823}], "trend": [], "mean": 300.4556, "unit": "ns", "stats": {"mean": "300.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "300.5 ns", "max": "300.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "300.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/general/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 78.0633, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.9841, "ci_upper": 78.1482}], "trend": [], "mean": 78.0633, "unit": "ns", "stats": {"mean": "78.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "78.1 ns", "max": "78.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "78.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/specialized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 284.7673, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 280.1321, "ci_upper": 290.0487}], "trend": [], "mean": 284.7673, "unit": "ns", "stats": {"mean": "284.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "284.8 ns", "max": "284.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "284.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_normalized/specialized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.5976, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.5608, "ci_upper": 56.6375}], "trend": [], "mean": 56.5976, "unit": "ns", "stats": {"mean": "56.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.6 ns", "max": "56.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "cosine_similarity_openai_1536d": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 301.5358, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 299.4368, "ci_upper": 304.2498}], "trend": [], "mean": 301.5358, "unit": "ns", "stats": {"mean": "301.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "301.5 ns", "max": "301.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "301.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "edge_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4612, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2203, "ci_upper": 4.6423}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.4405, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.3227, "ci_upper": 3.5398}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4612}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.4405}], "mean": 3.9508, "unit": "\u00b5s", "stats": {"mean": "3.95 \u00b5s", "std_dev": "510.3 ns", "cv": "12.9%", "min": "3.44 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "3.44 \u00b5s", "total_change": "-22.9%", "trend": "-22.9%", "count": 2}}, "edge_lookup": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.3798, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 62.3132, "ci_upper": 62.4333}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 54.6889, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 54.5308, "ci_upper": 54.8555}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 62.3798}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 54.6889}], "mean": 58.5343, "unit": "ns", "stats": {"mean": "58.5 ns", "std_dev": "3.8 ns", "cv": "6.6%", "min": "54.7 ns", "max": "62.4 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "54.7 ns", "total_change": "-12.3%", "trend": "-12.3%", "count": 2}}, "euclidean_distance/optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 174.9884, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 174.5683, "ci_upper": 175.509}], "trend": [], "mean": 174.9884, "unit": "ns", "stats": {"mean": "175.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "175.0 ns", "max": "175.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "175.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 272.6012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 272.4164, "ci_upper": 272.8048}], "trend": [], "mean": 272.6012, "unit": "ns", "stats": {"mean": "272.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "272.6 ns", "max": "272.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "272.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.5753, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 60.8333, "ci_upper": 69.9999}], "trend": [], "mean": 65.5753, "unit": "ns", "stats": {"mean": "65.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "65.6 ns", "max": "65.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "65.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.7884, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.6794, "ci_upper": 123.9155}], "trend": [], "mean": 123.7884, "unit": "ns", "stats": {"mean": "123.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.8 ns", "max": "123.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5486, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.5474, "ci_upper": 1.5499}], "trend": [], "mean": 1.5486, "unit": "\u00b5s", "stats": {"mean": "1.55 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.55 \u00b5s", "max": "1.55 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.55 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.3322, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.3308, "ci_upper": 2.334}], "trend": [], "mean": 2.3322, "unit": "\u00b5s", "stats": {"mean": "2.33 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.33 \u00b5s", "max": "2.33 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.33 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 566.6878, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 566.0427, "ci_upper": 567.318}], "trend": [], "mean": 566.6878, "unit": "ns", "stats": {"mean": "566.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "566.7 ns", "max": "566.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "566.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/scalar/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.1552, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.1547, "ci_upper": 1.1559}], "trend": [], "mean": 1.1552, "unit": "\u00b5s", "stats": {"mean": "1.16 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.16 \u00b5s", "max": "1.16 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.16 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/1024": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 173.0044, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 172.8747, "ci_upper": 173.158}], "trend": [], "mean": 173.0044, "unit": "ns", "stats": {"mean": "173.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "173.0 ns", "max": "173.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "173.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 269.6692, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 269.2292, "ci_upper": 270.1513}], "trend": [], "mean": 269.6692, "unit": "ns", "stats": {"mean": "269.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "269.7 ns", "max": "269.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "269.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.5494, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.4933, "ci_upper": 56.6058}], "trend": [], "mean": 56.5494, "unit": "ns", "stats": {"mean": "56.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.5 ns", "max": "56.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "euclidean_distance/squared_optimized/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.2014, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.0685, "ci_upper": 121.3575}], "trend": [], "mean": 121.2014, "unit": "ns", "stats": {"mean": "121.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.2 ns", "max": "121.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "find_neighbors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2409, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2392, "ci_upper": 1.243}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.1388, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 1.133, "ci_upper": 1.1449}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2409}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.1388}], "mean": 1.1898, "unit": "\u00b5s", "stats": {"mean": "1.19 \u00b5s", "std_dev": "51.1 ns", "cv": "4.3%", "min": "1.14 \u00b5s", "max": "1.24 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "1.14 \u00b5s", "total_change": "-8.2%", "trend": "-8.2%", "count": 2}}, "find_nodes_by_property/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.0933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 746.1684, "ci_upper": 766.5151}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 636.2408, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 633.2518, "ci_upper": 639.7619}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 757.0933}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 636.2408}], "mean": 696.667, "unit": "\u00b5s", "stats": {"mean": "696.67 \u00b5s", "std_dev": "60.43 \u00b5s", "cv": "8.7%", "min": "636.24 \u00b5s", "max": "757.09 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "636.24 \u00b5s", "total_change": "-16.0%", "trend": "-16.0%", "count": 2}}, "find_nodes_by_property/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.7901, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 47.4027, "ci_upper": 53.7229}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 36.1422, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 35.7852, "ci_upper": 36.4897}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 50.7901}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 36.1422}], "mean": 43.4662, "unit": "\u00b5s", "stats": {"mean": "43.47 \u00b5s", "std_dev": "7.32 \u00b5s", "cv": "16.8%", "min": "36.14 \u00b5s", "max": "50.79 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "36.14 \u00b5s", "total_change": "-28.8%", "trend": "-28.8%", "count": 2}}, "find_nodes_by_property/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6744, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.6705, "ci_upper": 4.6789}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.4022, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 4.3189, "ci_upper": 4.4751}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.6744}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 4.4022}], "mean": 4.5383, "unit": "\u00b5s", "stats": {"mean": "4.54 \u00b5s", "std_dev": "136.1 ns", "cv": "3.0%", "min": "4.40 \u00b5s", "max": "4.67 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "4.40 \u00b5s", "total_change": "-5.8%", "trend": "-5.8%", "count": 2}}, "frozen_view_hot_path/frozen_view/100000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.9696, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 39.9448, "ci_upper": 39.9997}], "trend": [], "mean": 39.9696, "unit": "ns", "stats": {"mean": "40.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "40.0 ns", "max": "40.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "40.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 33.8967, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 33.4823, "ci_upper": 34.3487}], "trend": [], "mean": 33.8967, "unit": "ns", "stats": {"mean": "33.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "33.9 ns", "max": "33.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "33.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/frozen_view/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.7478, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.7342, "ci_upper": 20.7629}], "trend": [], "mean": 20.7478, "unit": "ns", "stats": {"mean": "20.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.7 ns", "max": "20.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/100000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.7605, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.7381, "ci_upper": 32.7867}], "trend": [], "mean": 32.7605, "unit": "ns", "stats": {"mean": "32.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.8 ns", "max": "32.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6491, "ci_upper": 32.7063}], "trend": [], "mean": 32.6752, "unit": "ns", "stats": {"mean": "32.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.7 ns", "max": "32.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "frozen_view_hot_path/merged_guard/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6292, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6055, "ci_upper": 32.6551}], "trend": [], "mean": 32.6292, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "get_outgoing_allocation/degree_1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.6438, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.6173, "ci_upper": 35.6692}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.7845, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 29.5882, "ci_upper": 29.9806}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.6438}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.7845}], "mean": 32.7142, "unit": "ns", "stats": {"mean": "32.7 ns", "std_dev": "2.9 ns", "cv": "9.0%", "min": "29.8 ns", "max": "35.6 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "29.8 ns", "total_change": "-16.4%", "trend": "-16.4%", "count": 2}}, "get_outgoing_allocation/degree_10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.2963, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.2689, "ci_upper": 35.3269}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.3587, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 28.9955, "ci_upper": 29.7817}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.2963}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.3587}], "mean": 32.3275, "unit": "ns", "stats": {"mean": "32.3 ns", "std_dev": "3.0 ns", "cv": "9.2%", "min": "29.4 ns", "max": "35.3 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "29.4 ns", "total_change": "-16.8%", "trend": "-16.8%", "count": 2}}, "get_outgoing_allocation/degree_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.3701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.3296, "ci_upper": 35.4178}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.4, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 29.1794, "ci_upper": 29.6364}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.3701}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 29.4}], "mean": 32.3851, "unit": "ns", "stats": {"mean": "32.4 ns", "std_dev": "3.0 ns", "cv": "9.2%", "min": "29.4 ns", "max": "35.4 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "29.4 ns", "total_change": "-16.9%", "trend": "-16.9%", "count": 2}}, "hot_path/resolve/100": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.1388, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.1267, "ci_upper": 3.1529}], "trend": [], "mean": 3.1388, "unit": "\u00b5s", "stats": {"mean": "3.14 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.14 \u00b5s", "max": "3.14 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "3.14 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "hot_path/resolve/1000": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 32.1273, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 31.6366, "ci_upper": 32.6004}], "trend": [], "mean": 32.1273, "unit": "\u00b5s", "stats": {"mean": "32.13 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.13 \u00b5s", "max": "32.13 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "32.13 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "hot_path/resolve/10000": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 315.142, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 312.4443, "ci_upper": 318.0453}], "trend": [], "mean": 315.142, "unit": "\u00b5s", "stats": {"mean": "315.14 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "315.14 \u00b5s", "max": "315.14 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "315.14 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "hot_path/resolve_with/100": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.9016, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 1.8969, "ci_upper": 1.907}], "trend": [], "mean": 1.9016, "unit": "\u00b5s", "stats": {"mean": "1.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.90 \u00b5s", "max": "1.90 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "1.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "hot_path/resolve_with/1000": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 19.53, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 19.3985, "ci_upper": 19.6975}], "trend": [], "mean": 19.53, "unit": "\u00b5s", "stats": {"mean": "19.53 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "19.53 \u00b5s", "max": "19.53 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "19.53 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "hot_path/resolve_with/10000": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 193.7315, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 191.5857, "ci_upper": 196.2106}], "trend": [], "mean": 193.7315, "unit": "\u00b5s", "stats": {"mean": "193.73 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "193.73 \u00b5s", "max": "193.73 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "193.73 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "id_generation_concurrent/threads/16": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.7988, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 668.2883, "ci_upper": 681.7834}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 709.6743, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 698.2476, "ci_upper": 722.907}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 674.7988}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 709.6743}], "mean": 692.2365, "unit": "\u00b5s", "stats": {"mean": "692.24 \u00b5s", "std_dev": "17.44 \u00b5s", "cv": "2.5%", "min": "674.80 \u00b5s", "max": "709.67 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "709.67 \u00b5s", "total_change": "+5.2%", "trend": "+5.2%", "count": 2}}, "id_generation_concurrent/threads/2": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.8943, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.8132, "ci_upper": 122.2263}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 111.904, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 109.0378, "ci_upper": 114.8178}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.8943}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 111.904}], "mean": 116.3991, "unit": "\u00b5s", "stats": {"mean": "116.40 \u00b5s", "std_dev": "4.50 \u00b5s", "cv": "3.9%", "min": "111.90 \u00b5s", "max": "120.89 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "111.90 \u00b5s", "total_change": "-7.4%", "trend": "-7.4%", "count": 2}}, "id_generation_concurrent/threads/4": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.1065, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 195.2657, "ci_upper": 201.0119}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 184.9636, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 183.19, "ci_upper": 187.3911}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 198.1065}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 184.9636}], "mean": 191.5351, "unit": "\u00b5s", "stats": {"mean": "191.54 \u00b5s", "std_dev": "6.57 \u00b5s", "cv": "3.4%", "min": "184.96 \u00b5s", "max": "198.11 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "184.96 \u00b5s", "total_change": "-6.6%", "trend": "-6.6%", "count": 2}}, "id_generation_concurrent/threads/8": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.1654, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 364.3727, "ci_upper": 389.8907}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 328.3349, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 324.6724, "ci_upper": 332.918}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 375.1654}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 328.3349}], "mean": 351.7501, "unit": "\u00b5s", "stats": {"mean": "351.75 \u00b5s", "std_dev": "23.42 \u00b5s", "cv": "6.7%", "min": "328.33 \u00b5s", "max": "375.17 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "328.33 \u00b5s", "total_change": "-12.5%", "trend": "-12.5%", "count": 2}}, "id_generation_current/read_current": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.384, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 0.3835, "ci_upper": 0.3848}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.3383, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 0.3372, "ci_upper": 0.3398}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.384}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.3383}], "mean": 0.3612, "unit": "ns", "stats": {"mean": "0.4 ns", "std_dev": "0.0 ns", "cv": "6.3%", "min": "0.3 ns", "max": "0.4 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "0.3 ns", "total_change": "-11.9%", "trend": "-11.9%", "count": 2}}, "id_generation_current/read_current_approximate": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.383, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 0.3827, "ci_upper": 0.3833}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.3392, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 0.338, "ci_upper": 0.3406}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 0.383}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 0.3392}], "mean": 0.3611, "unit": "ns", "stats": {"mean": "0.4 ns", "std_dev": "0.0 ns", "cv": "6.1%", "min": "0.3 ns", "max": "0.4 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "0.3 ns", "total_change": "-11.4%", "trend": "-11.4%", "count": 2}}, "id_generation_lifecycle/create_and_generate_1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.8024, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.3635, "ci_upper": 9.121}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 8.7693, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 8.736, "ci_upper": 8.8053}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.8024}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 8.7693}], "mean": 8.7859, "unit": "\u00b5s", "stats": {"mean": "8.79 \u00b5s", "std_dev": "16.5 ns", "cv": "0.2%", "min": "8.77 \u00b5s", "max": "8.80 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "8.77 \u00b5s", "total_change": "-0.4%", "trend": "-0.4%", "count": 2}}, "id_generation_single_thread/sequential_1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9014, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 6.8972, "ci_upper": 6.906}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 6.2578, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 6.225, "ci_upper": 6.2912}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 6.9014}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 6.2578}], "mean": 6.5796, "unit": "\u00b5s", "stats": {"mean": "6.58 \u00b5s", "std_dev": "321.8 ns", "cv": "4.9%", "min": "6.26 \u00b5s", "max": "6.90 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "6.26 \u00b5s", "total_change": "-9.3%", "trend": "-9.3%", "count": 2}}, "id_generation_single_thread/sequential_10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.0165, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 68.9682, "ci_upper": 69.0705}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 63.4736, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 63.1717, "ci_upper": 63.7908}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 69.0165}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 63.4736}], "mean": 66.245, "unit": "\u00b5s", "stats": {"mean": "66.25 \u00b5s", "std_dev": "2.77 \u00b5s", "cv": "4.2%", "min": "63.47 \u00b5s", "max": "69.02 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "63.47 \u00b5s", "total_change": "-8.0%", "trend": "-8.0%", "count": 2}}, "in_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 398.5843, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 398.2256, "ci_upper": 399.0399}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 353.8581, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 351.1178, "ci_upper": 357.4475}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 398.5843}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 353.8581}], "mean": 376.2212, "unit": "ns", "stats": {"mean": "376.2 ns", "std_dev": "22.4 ns", "cv": "5.9%", "min": "353.9 ns", "max": "398.6 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "353.9 ns", "total_change": "-11.2%", "trend": "-11.2%", "count": 2}}, "incremental_compaction/edges/1000+100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 60.2792, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 60.0174, "ci_upper": 60.5145}], "trend": [], "mean": 60.2792, "unit": "\u00b5s", "stats": {"mean": "60.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "60.28 \u00b5s", "max": "60.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "60.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/10000+1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 955.6045, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 949.4576, "ci_upper": 961.3519}], "trend": [], "mean": 955.6045, "unit": "\u00b5s", "stats": {"mean": "955.60 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "955.60 \u00b5s", "max": "955.60 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "955.60 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_compaction/edges/100000+10000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.1922, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.1618, "ci_upper": 8.2228}], "trend": [], "mean": 8.1922, "unit": "ms", "stats": {"mean": "8.19 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.19 ms", "max": "8.19 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.19 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/2": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.5752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 140.156, "ci_upper": 143.4946}], "trend": [], "mean": 141.5752, "unit": "\u00b5s", "stats": {"mean": "141.58 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "141.58 \u00b5s", "max": "141.58 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "141.58 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/4": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 211.6228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 210.6432, "ci_upper": 212.6665}], "trend": [], "mean": 211.6228, "unit": "\u00b5s", "stats": {"mean": "211.62 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "211.62 \u00b5s", "max": "211.62 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "211.62 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_concurrent/threads/8": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 410.1319, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 408.3735, "ci_upper": 411.8419}], "trend": [], "mean": 410.1319, "unit": "\u00b5s", "stats": {"mean": "410.13 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "410.13 \u00b5s", "max": "410.13 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "410.13 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/0existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 288.5947, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 238.623, "ci_upper": 340.8245}], "trend": [], "mean": 288.5947, "unit": "ns", "stats": {"mean": "288.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "288.6 ns", "max": "288.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "288.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/100000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 289.1802, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 239.8888, "ci_upper": 340.0766}], "trend": [], "mean": 289.1802, "unit": "ns", "stats": {"mean": "289.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "289.2 ns", "max": "289.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "289.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/10000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 183.1639, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 173.8104, "ci_upper": 191.407}], "trend": [], "mean": 183.1639, "unit": "ns", "stats": {"mean": "183.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "183.2 ns", "max": "183.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "183.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_insert_latency/1000existing": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 226.3477, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 217.2657, "ci_upper": 238.195}], "trend": [], "mean": 226.3477, "unit": "ns", "stats": {"mean": "226.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "226.3 ns", "max": "226.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "226.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/10000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6151, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.5984, "ci_upper": 32.6334}], "trend": [], "mean": 32.6151, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/1000edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.6383, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6172, "ci_upper": 32.6624}], "trend": [], "mean": 32.6383, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_no_delta/100edges": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 32.65, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 32.6283, "ci_upper": 32.6753}], "trend": [], "mean": 32.65, "unit": "ns", "stats": {"mean": "32.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "32.6 ns", "max": "32.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "32.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/10pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 67.8572, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.551, "ci_upper": 69.5635}], "trend": [], "mean": 67.8572, "unit": "ns", "stats": {"mean": "67.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "67.9 ns", "max": "67.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "67.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/1pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 63.9781, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 63.8033, "ci_upper": 64.2524}], "trend": [], "mean": 63.9781, "unit": "ns", "stats": {"mean": "64.0 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.0 ns", "max": "64.0 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.0 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "incremental_read_with_delta/5pct_delta": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.2054, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 63.8661, "ci_upper": 64.703}], "trend": [], "mean": 64.2054, "unit": "ns", "stats": {"mean": "64.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "64.2 ns", "max": "64.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "64.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "knn_search/k/1": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.5096, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0831, "ci_upper": 132.7899}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 126.5096}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 126.5096}], "mean": 126.5096, "unit": "\u00b5s", "stats": {"mean": "126.51 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "126.51 \u00b5s", "max": "126.51 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "126.51 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/10": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.1122, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.5678, "ci_upper": 123.3862}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 121.1122}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 121.1122}], "mean": 121.1122, "unit": "\u00b5s", "stats": {"mean": "121.11 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "121.11 \u00b5s", "max": "121.11 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "121.11 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/20": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.2891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 122.0981, "ci_upper": 124.4037}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 123.2891}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.2891}], "mean": 123.2891, "unit": "\u00b5s", "stats": {"mean": "123.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "123.29 \u00b5s", "max": "123.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "123.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/5": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.2502, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 118.8954, "ci_upper": 119.591}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 119.2502}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.2502}], "mean": 119.2502, "unit": "\u00b5s", "stats": {"mean": "119.25 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.25 \u00b5s", "max": "119.25 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.25 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search/k/50": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.0939, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 121.4923, "ci_upper": 122.9071}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 122.0939}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 122.0939}], "mean": 122.0939, "unit": "\u00b5s", "stats": {"mean": "122.09 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "122.09 \u00b5s", "max": "122.09 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "122.09 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.0222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.9822, "ci_upper": 21.0644}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 21.0222}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.0222}], "mean": 21.0222, "unit": "\u00b5s", "stats": {"mean": "21.02 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "21.02 \u00b5s", "max": "21.02 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "21.02 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.5215, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 120.1467, "ci_upper": 120.9898}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 120.5215}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 120.5215}], "mean": 120.5215, "unit": "\u00b5s", "stats": {"mean": "120.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "120.52 \u00b5s", "max": "120.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "120.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.1745, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 310.6567, "ci_upper": 316.8564}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 313.1745}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 313.1745}], "mean": 313.1745, "unit": "\u00b5s", "stats": {"mean": "313.17 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "313.17 \u00b5s", "max": "313.17 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "313.17 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/500": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.0848, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 67.887, "ci_upper": 68.3218}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 68.0848}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 68.0848}], "mean": 68.0848, "unit": "\u00b5s", "stats": {"mean": "68.08 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "68.08 \u00b5s", "max": "68.08 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "68.08 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "knn_search_index_size/index_size/5000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.3192, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 241.1474, "ci_upper": 243.4549}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 242.3192}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 242.3192}], "mean": 242.3192, "unit": "\u00b5s", "stats": {"mean": "242.32 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "242.32 \u00b5s", "max": "242.32 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "242.32 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "labeled_traversal": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 465.9282, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 465.3658, "ci_upper": 466.5311}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 425.6441, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 420.6222, "ci_upper": 431.6272}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 465.9282}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 425.6441}], "mean": 445.7861, "unit": "ns", "stats": {"mean": "445.8 ns", "std_dev": "20.1 ns", "cv": "4.5%", "min": "425.6 ns", "max": "465.9 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "425.6 ns", "total_change": "-8.6%", "trend": "-8.6%", "count": 2}}, "mixed_read_write_80_20": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5907, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 16.2077, "ci_upper": 16.9809}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 16.0003, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 15.8099, "ci_upper": 16.191}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 16.5907}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 16.0003}], "mean": 16.2955, "unit": "ms", "stats": {"mean": "16.30 ms", "std_dev": "295.19 \u00b5s", "cv": "1.8%", "min": "16.00 ms", "max": "16.59 ms", "min_commit": "268e122", "max_commit": "198c57d", "latest": "16.00 ms", "total_change": "-3.6%", "trend": "-3.6%", "count": 2}}, "multiple_accesses/resolve_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.5674, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.5566, "ci_upper": 3.5799}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.1367, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.1306, "ci_upper": 3.1434}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.5674}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.1367}], "mean": 3.352, "unit": "\u00b5s", "stats": {"mean": "3.35 \u00b5s", "std_dev": "215.3 ns", "cv": "6.4%", "min": "3.14 \u00b5s", "max": "3.57 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "3.14 \u00b5s", "total_change": "-12.1%", "trend": "-12.1%", "count": 2}}, "multiple_accesses/resolve_with_100": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 1.9042, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 1.8971, "ci_upper": 1.9126}], "trend": [], "mean": 1.9042, "unit": "\u00b5s", "stats": {"mean": "1.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.90 \u00b5s", "max": "1.90 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "1.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "node_creation": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4332, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.241, "ci_upper": 4.5807}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.4249, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.2657, "ci_upper": 3.5702}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4332}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.4249}], "mean": 3.9291, "unit": "\u00b5s", "stats": {"mean": "3.93 \u00b5s", "std_dev": "504.2 ns", "cv": "12.8%", "min": "3.42 \u00b5s", "max": "4.43 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "3.42 \u00b5s", "total_change": "-22.7%", "trend": "-22.7%", "count": 2}}, "node_lookup": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.5994, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 64.3196, "ci_upper": 64.78}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 57.3591, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 56.5046, "ci_upper": 58.0576}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 64.5994}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 57.3591}], "mean": 60.9793, "unit": "ns", "stats": {"mean": "61.0 ns", "std_dev": "3.6 ns", "cv": "5.9%", "min": "57.4 ns", "max": "64.6 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "57.4 ns", "total_change": "-11.2%", "trend": "-11.2%", "count": 2}}, "out_degree": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 406.1903, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 404.2937, "ci_upper": 407.7134}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 359.7513, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 356.8537, "ci_upper": 362.5014}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 406.1903}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 359.7513}], "mean": 382.9708, "unit": "ns", "stats": {"mean": "383.0 ns", "std_dev": "23.2 ns", "cv": "6.1%", "min": "359.8 ns", "max": "406.2 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "359.8 ns", "total_change": "-11.4%", "trend": "-11.4%", "count": 2}}, "point_in_time_queries/1000vectors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 30.1798, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 30.0786, "ci_upper": 30.2899}], "trend": [], "mean": 30.1798, "unit": "ns", "stats": {"mean": "30.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "30.2 ns", "max": "30.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "30.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "point_in_time_queries/100vectors": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.3891, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.3452, "ci_upper": 27.4405}], "trend": [], "mean": 27.3891, "unit": "ns", "stats": {"mean": "27.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.4 ns", "max": "27.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "property_lookup_vs_scan/find_nodes_by_property": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.0306, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 38.9559, "ci_upper": 39.0986}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 34.4481, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 34.2398, "ci_upper": 34.7113}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.0306}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 34.4481}], "mean": 36.7393, "unit": "\u00b5s", "stats": {"mean": "36.74 \u00b5s", "std_dev": "2.29 \u00b5s", "cv": "6.2%", "min": "34.45 \u00b5s", "max": "39.03 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "34.45 \u00b5s", "total_change": "-11.7%", "trend": "-11.7%", "count": 2}}, "property_lookup_vs_scan/manual_label_scan_filter": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.2924, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 137.9873, "ci_upper": 138.6328}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 123.6789, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 121.0114, "ci_upper": 126.742}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 138.2924}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 123.6789}], "mean": 130.9857, "unit": "\u00b5s", "stats": {"mean": "130.99 \u00b5s", "std_dev": "7.31 \u00b5s", "cv": "5.6%", "min": "123.68 \u00b5s", "max": "138.29 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "123.68 \u00b5s", "total_change": "-10.6%", "trend": "-10.6%", "count": 2}}, "read_latency_p50_p99": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.7752, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.0249, "ci_upper": 9.8609}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 9.2557, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 8.4724, "ci_upper": 10.3976}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.7752}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 9.2557}], "mean": 9.0155, "unit": "ns", "stats": {"mean": "9.0 ns", "std_dev": "0.2 ns", "cv": "2.7%", "min": "8.8 ns", "max": "9.3 ns", "min_commit": "198c57d", "max_commit": "268e122", "latest": "9.3 ns", "total_change": "+5.5%", "trend": "+5.5%", "count": 2}}, "read_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 339.2398, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 335.7964, "ci_upper": 343.7172}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 339.2398}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 339.2398}], "mean": 339.2398, "unit": "ns", "stats": {"mean": "339.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "339.2 ns", "max": "339.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "339.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/0": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4554, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.2289, "ci_upper": 4.747}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 4.4554}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 4.4554}], "mean": 4.4554, "unit": "\u00b5s", "stats": {"mean": "4.46 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "4.46 \u00b5s", "max": "4.46 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "4.46 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/2": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.6603, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 56.3429, "ci_upper": 57.0131}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 56.6603}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 56.6603}], "mean": 56.6603, "unit": "ms", "stats": {"mean": "56.66 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "56.66 ms", "max": "56.66 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "56.66 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "read_under_write_contention/concurrent_writers/4": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114.751, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 114.1859, "ci_upper": 115.3771}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 114.751}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 114.751}], "mean": 114.751, "unit": "ms", "stats": {"mean": "114.75 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "114.75 ms", "max": "114.75 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "114.75 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "recovery/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.0642, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 459.8291, "ci_upper": 536.5218}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 401.8303, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 392.8019, "ci_upper": 410.1705}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 500.0642}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 401.8303}], "mean": 450.9472, "unit": "\u00b5s", "stats": {"mean": "450.95 \u00b5s", "std_dev": "49.12 \u00b5s", "cv": "10.9%", "min": "401.83 \u00b5s", "max": "500.06 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "401.83 \u00b5s", "total_change": "-19.6%", "trend": "-19.6%", "count": 2}}, "recovery/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.0332, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 438.4822, "ci_upper": 494.3068}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 412.5873, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 410.5179, "ci_upper": 414.9413}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 457.0332}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 412.5873}], "mean": 434.8102, "unit": "\u00b5s", "stats": {"mean": "434.81 \u00b5s", "std_dev": "22.22 \u00b5s", "cv": "5.1%", "min": "412.59 \u00b5s", "max": "457.03 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "412.59 \u00b5s", "total_change": "-9.7%", "trend": "-9.7%", "count": 2}}, "recovery/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.9167, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 646.4979, "ci_upper": 649.5903}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 612.7015, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 608.0418, "ci_upper": 618.5725}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 647.9167}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 612.7015}], "mean": 630.3091, "unit": "\u00b5s", "stats": {"mean": "630.31 \u00b5s", "std_dev": "17.61 \u00b5s", "cv": "2.8%", "min": "612.70 \u00b5s", "max": "647.92 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "612.70 \u00b5s", "total_change": "-5.4%", "trend": "-5.4%", "count": 2}}, "serialization_simulation/resolve": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 160.2383, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 158.9392, "ci_upper": 161.41}], "trend": [], "mean": 160.2383, "unit": "\u00b5s", "stats": {"mean": "160.24 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "160.24 \u00b5s", "max": "160.24 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "160.24 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "serialization_simulation/resolve_with": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 98.2872, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 97.9199, "ci_upper": 98.6343}], "trend": [], "mean": 98.2872, "unit": "\u00b5s", "stats": {"mean": "98.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "98.29 \u00b5s", "max": "98.29 \u00b5s", "min_commit": "268e122", "max_commit": "268e122", "latest": "98.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "single_hop_traversal/10000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9001, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.1618, "ci_upper": 435.2252}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 393.8347, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 391.6432, "ci_upper": 396.4312}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9001}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 393.8347}], "mean": 412.8674, "unit": "ns", "stats": {"mean": "412.9 ns", "std_dev": "19.0 ns", "cv": "4.6%", "min": "393.8 ns", "max": "431.9 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "393.8 ns", "total_change": "-8.8%", "trend": "-8.8%", "count": 2}}, "single_hop_traversal/1000_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9392, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.5473, "ci_upper": 434.3479}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 412.4509, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 408.7035, "ci_upper": 416.7949}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.9392}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 412.4509}], "mean": 422.1951, "unit": "ns", "stats": {"mean": "422.2 ns", "std_dev": "9.7 ns", "cv": "2.3%", "min": "412.5 ns", "max": "431.9 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "412.5 ns", "total_change": "-4.5%", "trend": "-4.5%", "count": 2}}, "single_hop_traversal/100_nodes": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.1358, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 430.5471, "ci_upper": 431.8251}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 398.9846, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 393.9242, "ci_upper": 404.9524}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 431.1358}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 398.9846}], "mean": 415.0602, "unit": "ns", "stats": {"mean": "415.1 ns", "std_dev": "16.1 ns", "cv": "3.9%", "min": "399.0 ns", "max": "431.1 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "399.0 ns", "total_change": "-7.5%", "trend": "-7.5%", "count": 2}}, "single_transaction_latency/async": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 57.2811, "ci_upper": 72.114}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 64.9001, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 57.1708, "ci_upper": 71.9617}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 65.065}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 64.9001}], "mean": 64.9825, "unit": "\u00b5s", "stats": {"mean": "64.98 \u00b5s", "std_dev": "82.5 ns", "cv": "0.1%", "min": "64.90 \u00b5s", "max": "65.06 \u00b5s", "min_commit": "268e122", "max_commit": "198c57d", "latest": "64.90 \u00b5s", "total_change": "-0.3%", "trend": "-0.3%", "count": 2}}, "single_transaction_latency/async_batched_aggressive": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5.0172, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 4.9949, "ci_upper": 5.0335}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 5.0995, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 5.081, "ci_upper": 5.1124}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 5.0172}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 5.0995}], "mean": 5.0584, "unit": "ms", "stats": {"mean": "5.06 ms", "std_dev": "41.13 \u00b5s", "cv": "0.8%", "min": "5.02 ms", "max": "5.10 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "5.10 ms", "total_change": "+1.6%", "trend": "+1.6%", "count": 2}}, "single_transaction_latency/async_batched_default": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.1885, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 9.1837, "ci_upper": 9.1937}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 9.2425, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 9.2351, "ci_upper": 9.2498}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 9.1885}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 9.2425}], "mean": 9.2155, "unit": "ms", "stats": {"mean": "9.22 ms", "std_dev": "26.99 \u00b5s", "cv": "0.3%", "min": "9.19 ms", "max": "9.24 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "9.24 ms", "total_change": "+0.6%", "trend": "+0.6%", "count": 2}}, "single_transaction_latency/group_commit_default": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.7552, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.7436, "ci_upper": 2.7678}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.2028, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 3.1671, "ci_upper": 3.2346}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.7552}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 3.2028}], "mean": 2.979, "unit": "ms", "stats": {"mean": "2.98 ms", "std_dev": "223.79 \u00b5s", "cv": "7.5%", "min": "2.76 ms", "max": "3.20 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "3.20 ms", "total_change": "+16.2%", "trend": "+16.2%", "count": 2}}, "single_transaction_latency/group_commit_fast": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.799, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.7768, "ci_upper": 1.8225}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 2.006, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 1.9839, "ci_upper": 2.0312}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.799}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 2.006}], "mean": 1.9025, "unit": "ms", "stats": {"mean": "1.90 ms", "std_dev": "103.48 \u00b5s", "cv": "5.4%", "min": "1.80 ms", "max": "2.01 ms", "min_commit": "198c57d", "max_commit": "268e122", "latest": "2.01 ms", "total_change": "+11.5%", "trend": "+11.5%", "count": 2}}, "single_transaction_latency/synchronous": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.9769, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 563.8529, "ci_upper": 579.817}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 738.7909, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 724.4152, "ci_upper": 751.5703}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 571.9769}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 738.7909}], "mean": 655.3839, "unit": "\u00b5s", "stats": {"mean": "655.38 \u00b5s", "std_dev": "83.41 \u00b5s", "cv": "12.7%", "min": "571.98 \u00b5s", "max": "738.79 \u00b5s", "min_commit": "198c57d", "max_commit": "268e122", "latest": "738.79 \u00b5s", "total_change": "+29.2%", "trend": "+29.2%", "count": 2}}, "snapshot_creation/time_interval_1s": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 77.0748, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 77.0192, "ci_upper": 77.1398}], "trend": [], "mean": 77.0748, "unit": "ns", "stats": {"mean": "77.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "77.1 ns", "max": "77.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "77.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/transaction_interval_10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 24.1606, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 24.071, "ci_upper": 24.2429}], "trend": [], "mean": 24.1606, "unit": "\u00b5s", "stats": {"mean": "24.16 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "24.16 \u00b5s", "max": "24.16 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "24.16 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "snapshot_creation/transaction_interval_100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.5038, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.4901, "ci_upper": 2.5173}], "trend": [], "mean": 2.5038, "unit": "\u00b5s", "stats": {"mean": "2.50 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.50 \u00b5s", "max": "2.50 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.50 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "string_access_single/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.5734, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.5592, "ci_upper": 35.59}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 32.8182, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 32.6454, "ci_upper": 32.9861}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 35.5734}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 32.8182}], "mean": 34.1958, "unit": "ns", "stats": {"mean": "34.2 ns", "std_dev": "1.4 ns", "cv": "4.0%", "min": "32.8 ns", "max": "35.6 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "32.8 ns", "total_change": "-7.7%", "trend": "-7.7%", "count": 2}}, "string_access_single/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.8205, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.8061, "ci_upper": 21.8363}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 20.3572, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 20.2724, "ci_upper": 20.4538}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 21.8205}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 20.3572}], "mean": 21.0889, "unit": "ns", "stats": {"mean": "21.1 ns", "std_dev": "0.7 ns", "cv": "3.5%", "min": "20.4 ns", "max": "21.8 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "20.4 ns", "total_change": "-6.7%", "trend": "-6.7%", "count": 2}}, "string_comparison/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.1669, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 35.7463, "ci_upper": 36.6306}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 31.0868, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 30.9128, "ci_upper": 31.2903}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.1669}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 31.0868}], "mean": 33.6268, "unit": "ns", "stats": {"mean": "33.6 ns", "std_dev": "2.5 ns", "cv": "7.6%", "min": "31.1 ns", "max": "36.2 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "31.1 ns", "total_change": "-14.0%", "trend": "-14.0%", "count": 2}}, "string_comparison/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.1721, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 22.028, "ci_upper": 22.3815}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 20.2279, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 20.0272, "ci_upper": 20.4366}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.1721}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 20.2279}], "mean": 21.2, "unit": "ns", "stats": {"mean": "21.2 ns", "std_dev": "1.0 ns", "cv": "4.6%", "min": "20.2 ns", "max": "22.2 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "20.2 ns", "total_change": "-8.8%", "trend": "-8.8%", "count": 2}}, "string_length/resolve": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.5058, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 36.2076, "ci_upper": 36.8017}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 31.9033, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 31.6943, "ci_upper": 32.1433}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.5058}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 31.9033}], "mean": 34.2046, "unit": "ns", "stats": {"mean": "34.2 ns", "std_dev": "2.3 ns", "cv": "6.7%", "min": "31.9 ns", "max": "36.5 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "31.9 ns", "total_change": "-12.6%", "trend": "-12.6%", "count": 2}}, "string_length/resolve_with": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.0168, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.9521, "ci_upper": 22.09}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 19.2558, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 19.1524, "ci_upper": 19.383}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.0168}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 19.2558}], "mean": 20.6363, "unit": "ns", "stats": {"mean": "20.6 ns", "std_dev": "1.4 ns", "cv": "6.7%", "min": "19.3 ns", "max": "22.0 ns", "min_commit": "268e122", "max_commit": "198c57d", "latest": "19.3 ns", "total_change": "-12.5%", "trend": "-12.5%", "count": 2}}, "sustained_write_10k_versions": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181.7438, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 180.8869, "ci_upper": 182.6944}], "trend": [], "mean": 181.7438, "unit": "ms", "stats": {"mean": "181.74 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "181.74 ms", "max": "181.74 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "181.74 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_10k_versions_fast_reference": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 455.09, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 454.13, "ci_upper": 456.0735}], "trend": [], "mean": 455.09, "unit": "ms", "stats": {"mean": "455.09 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "455.09 ms", "max": "455.09 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "455.09 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_throughput/sustained_write_10k_versions": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 188.7246, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 187.3258, "ci_upper": 190.1769}], "trend": [], "mean": 188.7246, "unit": "ms", "stats": {"mean": "188.72 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "188.72 ms", "max": "188.72 ms", "min_commit": "268e122", "max_commit": "268e122", "latest": "188.72 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "sustained_write_throughput/sustained_write_10k_versions_fast_reference": {"data": [{"x": "2026-03-15T02:30:09.832082+00:00", "y": 458.7941, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 456.5052, "ci_upper": 461.3584}], "trend": [], "mean": 458.7941, "unit": "ms", "stats": {"mean": "458.79 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "458.79 ms", "max": "458.79 ms", "min_commit": "268e122", "max_commit": "268e122", "latest": "458.79 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "target_3_hop/traverse_three_hops": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.1573, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 279.7026, "ci_upper": 285.151}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 269.4377, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 268.0299, "ci_upper": 271.0013}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 284.2773}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 271.5576}], "mean": 277.9174, "unit": "ns", "stats": {"mean": "277.9 ns", "std_dev": "6.0 ns", "cv": "2.2%", "min": "269.4 ns", "max": "282.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "269.4 ns", "total_change": "-4.5%", "trend": "-4.5%", "count": 3}}, "target_batch_insertion/insert_1000_edges": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 781.382, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 676.9029, "ci_upper": 878.0733}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 630.4888, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 627.7125, "ci_upper": 633.4295}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 806.5309}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 655.6376}], "mean": 731.0842, "unit": "\u00b5s", "stats": {"mean": "731.08 \u00b5s", "std_dev": "71.13 \u00b5s", "cv": "9.7%", "min": "630.49 \u00b5s", "max": "781.38 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "630.49 \u00b5s", "total_change": "-19.3%", "trend": "-19.3%", "count": 3}}, "target_single_hop/traverse_one_hop": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 42.6068, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 42.3848, "ci_upper": 42.8318}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 39.5098, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 39.4579, "ci_upper": 39.5788}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 43.123}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.0259}], "mean": 41.5744, "unit": "ns", "stats": {"mean": "41.6 ns", "std_dev": "1.5 ns", "cv": "3.5%", "min": "39.5 ns", "max": "42.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "39.5 ns", "total_change": "-7.3%", "trend": "-7.3%", "count": 3}}, "target_time_travel/at_anchor": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 282.592, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 281.1667, "ci_upper": 284.0}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 272.3004, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 272.1219, "ci_upper": 272.4928}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 284.3073}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 274.0156}], "mean": 279.1614, "unit": "ns", "stats": {"mean": "279.2 ns", "std_dev": "4.9 ns", "cv": "1.7%", "min": "272.3 ns", "max": "282.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "272.3 ns", "total_change": "-3.6%", "trend": "-3.6%", "count": 3}}, "target_time_travel/with_5_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 275.1228, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 273.3902, "ci_upper": 276.6862}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 279.2666, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 270.6264, "ci_upper": 290.0937}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 274.4322}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 278.576}], "mean": 276.5041, "unit": "ns", "stats": {"mean": "276.5 ns", "std_dev": "2.0 ns", "cv": "0.7%", "min": "275.1 ns", "max": "279.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "279.3 ns", "total_change": "+1.5%", "trend": "+1.5%", "count": 3}}, "target_time_travel/worst_case_9_deltas": {"data": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T18:56:59.315967+00:00", "y": 286.226, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 285.2288, "ci_upper": 287.1851}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 274.4635, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 274.2626, "ci_upper": 274.6612}], "trend": [{"x": "2026-02-21T18:07:48.283497+00:00", "y": 288.1864}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 276.424}], "mean": 282.3052, "unit": "ns", "stats": {"mean": "282.3 ns", "std_dev": "5.5 ns", "cv": "2.0%", "min": "274.5 ns", "max": "286.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "274.5 ns", "total_change": "-4.1%", "trend": "-4.1%", "count": 3}}, "temporal_insert/append_only/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.5223, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 20.3853, "ci_upper": 20.6314}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 20.5223}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 20.5223}], "mean": 20.5223, "unit": "\u00b5s", "stats": {"mean": "20.52 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "20.52 \u00b5s", "max": "20.52 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "20.52 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.7516, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 209.3143, "ci_upper": 211.8738}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 210.7516}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 210.7516}], "mean": 210.7516, "unit": "\u00b5s", "stats": {"mean": "210.75 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "210.75 \u00b5s", "max": "210.75 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "210.75 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/append_only/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.1701, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 2.1621, "ci_upper": 2.1776}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 2.1701}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 2.1701}], "mean": 2.1701, "unit": "ms", "stats": {"mean": "2.17 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "2.17 ms", "max": "2.17 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "2.17 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/100": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.4722, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 146.592, "ci_upper": 149.2239}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 147.4722}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 147.4722}], "mean": 147.4722, "unit": "\u00b5s", "stats": {"mean": "147.47 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "147.47 \u00b5s", "max": "147.47 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "147.47 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/1000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12.5487, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 12.5267, "ci_upper": 12.5776}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 12.5487}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 12.5487}], "mean": 12.5487, "unit": "ms", "stats": {"mean": "12.55 ms", "std_dev": "0.0 ns", "cv": "0.0%", "min": "12.55 ms", "max": "12.55 ms", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "12.55 ms", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "temporal_insert/retroactive/10000": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2868, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2693, "ci_upper": 1.3096}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.2868}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2868}], "mean": 1.2868, "unit": "s", "stats": {"mean": "1.287 s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.287 s", "max": "1.287 s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.287 s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "time_travel/at_anchor_v20": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.9872, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.8817, "ci_upper": 124.109}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 122.0529, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 121.983, "ci_upper": 122.1201}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 196.7086, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 193.2374, "ci_upper": 200.0625}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 111.2222}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 183.9436}], "mean": 147.5829, "unit": "ns", "stats": {"mean": "147.6 ns", "std_dev": "34.7 ns", "cv": "23.5%", "min": "122.1 ns", "max": "196.7 ns", "min_commit": "268e122", "max_commit": "268e122", "latest": "196.7 ns", "total_change": "+58.7%", "trend": "+58.7%", "count": 3}}, "time_travel/deep_history_v5": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 124.3222, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 124.2538, "ci_upper": 124.4012}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 124.6256, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 122.3941, "ci_upper": 128.9306}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 194.3435, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 192.4566, "ci_upper": 196.4657}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 112.7531}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 182.7745}], "mean": 147.7638, "unit": "ns", "stats": {"mean": "147.8 ns", "std_dev": "32.9 ns", "cv": "22.3%", "min": "124.3 ns", "max": "194.3 ns", "min_commit": "198c57d", "max_commit": "268e122", "latest": "194.3 ns", "total_change": "+56.3%", "trend": "+56.3%", "count": 3}}, "time_travel/with_deltas_v15": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 123.9411, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 123.8773, "ci_upper": 124.0033}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 161.3624, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 156.4702, "ci_upper": 165.7322}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 191.2174, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 189.6965, "ci_upper": 192.8624}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 125.2022}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 192.4785}], "mean": 158.8403, "unit": "ns", "stats": {"mean": "158.8 ns", "std_dev": "27.5 ns", "cv": "17.3%", "min": "123.9 ns", "max": "191.2 ns", "min_commit": "198c57d", "max_commit": "268e122", "latest": "191.2 ns", "total_change": "+54.3%", "trend": "+54.3%", "count": 3}}, "time_travel/worst_case_v19": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 124.3814, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 124.3176, "ci_upper": 124.4393}, {"x": "2026-03-03T06:54:27.366554+00:00", "y": 137.5749, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 131.7883, "ci_upper": 146.191}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 237.0525, "commit": "268e122", "branch": "jules-10636708643017105327-54e0d64f", "ci_lower": 212.297, "ci_upper": 260.4386}], "trend": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 110.0007}, {"x": "2026-03-15T02:30:09.832082+00:00", "y": 222.6718}], "mean": 166.3363, "unit": "ns", "stats": {"mean": "166.3 ns", "std_dev": "50.3 ns", "cv": "30.2%", "min": "124.4 ns", "max": "237.1 ns", "min_commit": "198c57d", "max_commit": "268e122", "latest": "237.1 ns", "total_change": "+90.6%", "trend": "+90.6%", "count": 3}}, "traverse_and_rank_basic/100_power_law/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 40.6454, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 40.5756, "ci_upper": 40.7569}], "trend": [], "mean": 40.6454, "unit": "\u00b5s", "stats": {"mean": "40.65 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "40.65 \u00b5s", "max": "40.65 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "40.65 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_sparse/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2866, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2851, "ci_upper": 1.2882}], "trend": [], "mean": 1.2866, "unit": "\u00b5s", "stats": {"mean": "1.29 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.29 \u00b5s", "max": "1.29 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.29 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/100_uniform/100": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 7.8933, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 7.8887, "ci_upper": 7.8985}], "trend": [], "mean": 7.8933, "unit": "\u00b5s", "stats": {"mean": "7.89 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "7.89 \u00b5s", "max": "7.89 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "7.89 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_power_law/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 47.5431, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 46.0216, "ci_upper": 48.9082}], "trend": [], "mean": 47.5431, "unit": "\u00b5s", "stats": {"mean": "47.54 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "47.54 \u00b5s", "max": "47.54 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "47.54 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_sparse/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.2763, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.2752, "ci_upper": 1.2775}], "trend": [], "mean": 1.2763, "unit": "\u00b5s", "stats": {"mean": "1.28 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.28 \u00b5s", "max": "1.28 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.28 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "traverse_and_rank_basic/1K_uniform/1000": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 8.124, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 8.1118, "ci_upper": 8.1406}], "trend": [], "mean": 8.124, "unit": "\u00b5s", "stats": {"mean": "8.12 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "8.12 \u00b5s", "max": "8.12 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "8.12 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "valid_at_query/10000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.3551, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 21.4713, "ci_upper": 23.0909}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 22.3551}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.3551}], "mean": 22.3551, "unit": "\u00b5s", "stats": {"mean": "22.36 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.36 \u00b5s", "max": "22.36 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.36 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "valid_at_query/1000_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.9012, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 3.6979, "ci_upper": 4.0827}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 3.9012}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 3.9012}], "mean": 3.9012, "unit": "\u00b5s", "stats": {"mean": "3.90 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "3.90 \u00b5s", "max": "3.90 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "3.90 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "valid_at_query/100_versions": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5299, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.373, "ci_upper": 1.6545}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 1.5299}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.5299}], "mean": 1.5299, "unit": "\u00b5s", "stats": {"mean": "1.53 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.53 \u00b5s", "max": "1.53 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.53 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}, "vector_batch_deserialize/retrieval_workload/100x1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 36.6376, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 36.5396, "ci_upper": 36.729}], "trend": [], "mean": 36.6376, "unit": "\u00b5s", "stats": {"mean": "36.64 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "36.64 \u00b5s", "max": "36.64 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "36.64 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_batch_serialize/rag_workload/100x1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 22.9863, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 22.8833, "ci_upper": 23.1147}], "trend": [], "mean": 22.9863, "unit": "\u00b5s", "stats": {"mean": "22.99 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "22.99 \u00b5s", "max": "22.99 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "22.99 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 54.6348, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 54.5623, "ci_upper": 54.718}], "trend": [], "mean": 54.6348, "unit": "ns", "stats": {"mean": "54.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "54.6 ns", "max": "54.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "54.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 55.4275, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 55.3586, "ci_upper": 55.5054}], "trend": [], "mean": 55.4275, "unit": "ns", "stats": {"mean": "55.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "55.4 ns", "max": "55.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "55.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/128": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 67.0515, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 66.955, "ci_upper": 67.1542}], "trend": [], "mean": 67.0515, "unit": "ns", "stats": {"mean": "67.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "67.1 ns", "max": "67.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "67.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 376.7175, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 373.5381, "ci_upper": 380.2115}], "trend": [], "mean": 376.7175, "unit": "ns", "stats": {"mean": "376.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "376.7 ns", "max": "376.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "376.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 751.7691, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 745.1252, "ci_upper": 758.7799}], "trend": [], "mean": 751.7691, "unit": "ns", "stats": {"mean": "751.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "751.8 ns", "max": "751.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "751.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 240.6619, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 239.0724, "ci_upper": 242.3761}], "trend": [], "mean": 240.6619, "unit": "ns", "stats": {"mean": "240.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "240.7 ns", "max": "240.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "240.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_deserialize/deserialize/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 281.7997, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 280.3144, "ci_upper": 283.402}], "trend": [], "mean": 281.7997, "unit": "ns", "stats": {"mean": "281.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "281.8 ns", "max": "281.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "281.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 613.6658, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 611.8239, "ci_upper": 615.3107}], "trend": [], "mean": 613.6658, "unit": "ns", "stats": {"mean": "613.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "613.7 ns", "max": "613.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "613.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 1.4334, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 1.4213, "ci_upper": 1.4449}], "trend": [], "mean": 1.4334, "unit": "\u00b5s", "stats": {"mean": "1.43 \u00b5s", "std_dev": "0.0 ns", "cv": "0.0%", "min": "1.43 \u00b5s", "max": "1.43 \u00b5s", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "1.43 \u00b5s", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 384.864, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 382.4977, "ci_upper": 386.9566}], "trend": [], "mean": 384.864, "unit": "ns", "stats": {"mean": "384.9 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "384.9 ns", "max": "384.9 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "384.9 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_round_trip/round_trip/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 427.7807, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 425.9115, "ci_upper": 429.4511}], "trend": [], "mean": 427.7807, "unit": "ns", "stats": {"mean": "427.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "427.8 ns", "max": "427.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "427.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/1": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.6736, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.6323, "ci_upper": 27.7247}], "trend": [], "mean": 27.6736, "unit": "ns", "stats": {"mean": "27.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.7 ns", "max": "27.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/10": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 27.1097, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 27.0881, "ci_upper": 27.132}], "trend": [], "mean": 27.1097, "unit": "ns", "stats": {"mean": "27.1 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "27.1 ns", "max": "27.1 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "27.1 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/128": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 34.7801, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 34.2233, "ci_upper": 35.393}], "trend": [], "mean": 34.7801, "unit": "ns", "stats": {"mean": "34.8 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "34.8 ns", "max": "34.8 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "34.8 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 173.4712, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 173.3446, "ci_upper": 173.6017}], "trend": [], "mean": 173.4712, "unit": "ns", "stats": {"mean": "173.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "173.5 ns", "max": "173.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "173.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/3072": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 219.1664, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 218.124, "ci_upper": 220.383}], "trend": [], "mean": 219.1664, "unit": "ns", "stats": {"mean": "219.2 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "219.2 ns", "max": "219.2 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "219.2 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 134.5591, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 134.4308, "ci_upper": 134.7104}], "trend": [], "mean": 134.5591, "unit": "ns", "stats": {"mean": "134.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "134.6 ns", "max": "134.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "134.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize/serialize/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 133.5553, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 128.5746, "ci_upper": 139.648}], "trend": [], "mean": 133.5553, "unit": "ns", "stats": {"mean": "133.6 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "133.6 ns", "max": "133.6 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "133.6 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/1536": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 181.317, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 181.2098, "ci_upper": 181.4454}], "trend": [], "mean": 181.317, "unit": "ns", "stats": {"mean": "181.3 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "181.3 ns", "max": "181.3 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "181.3 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/384": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 119.6943, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 119.4263, "ci_upper": 120.0107}], "trend": [], "mean": 119.6943, "unit": "ns", "stats": {"mean": "119.7 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "119.7 ns", "max": "119.7 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "119.7 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "vector_serialize_into/serialize_into/768": {"data": [{"x": "2026-02-21T20:43:41.849269+00:00", "y": 141.5379, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 141.407, "ci_upper": 141.6805}], "trend": [], "mean": 141.5379, "unit": "ns", "stats": {"mean": "141.5 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "141.5 ns", "max": "141.5 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "141.5 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 1}}, "write_transaction_creation": {"data": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 462.4375, "commit": "198c57d", "branch": "jules-3069904928789557752-7bfd23b2", "ci_lower": 461.9952, "ci_upper": 462.9496}], "trend": [{"x": "2026-02-21T18:56:59.315967+00:00", "y": 462.4375}, {"x": "2026-02-21T20:43:41.849269+00:00", "y": 462.4375}], "mean": 462.4375, "unit": "ns", "stats": {"mean": "462.4 ns", "std_dev": "0.0 ns", "cv": "0.0%", "min": "462.4 ns", "max": "462.4 ns", "min_commit": "198c57d", "max_commit": "198c57d", "latest": "462.4 ns", "total_change": "+0.0%", "trend": "+0.0%", "count": 2}}};
 
 const overlays = { trend: true, mean: true, ci: false };
 const charts = {};


### PR DESCRIPTION
This PR executes the full benchmark suite for AletheiaDB, parses the Criterion results, updates the `benchmarks/history.json` ledger, and regenerates the HTML benchmark report and timeseries charts.

### Benchmark Results Summary

**🚨 Critical Regressions (>10% slower)**
- `time_travel/at_anchor_v20`: +61.2%
- `time_travel/deep_history_v5`: +55.9%
- `time_travel/with_deltas_v15`: +18.5%
- `time_travel/worst_case_v19`: +72.3%

**🔴 Regressions (>2% slower)**
- `aletheiadb_3_hop_traversal`: +2.1%
- `aletheiadb_edge_creation`: +2.4%
- `aletheiadb_fast_path/node_lookup/100`: +3.8%
- `aletheiadb_node_creation`: +4.6%
- `aletheiadb_single_hop/1000_nodes`: +3.4%

**🟢 Improvements (>2% faster)**
- `aletheiadb_fast_path/node_lookup/100`: -9.4%
- `aletheiadb_historical_stats`: -11.1%
- `aletheiadb_in_degree`: -6.2%
- `aletheiadb_out_degree`: -5.1%
- `aletheiadb_single_hop/10000_nodes`: -8.9%
- `aletheiadb_single_hop/1000_nodes`: -10.1%
- `aletheiadb_single_hop/100_nodes`: -2.1%
- `recovery_large_dataset/100k_nodes_500k_edges`: -4.6%
- `recovery_medium_dataset/10k_nodes_50k_edges`: -16.4%
- `recovery_small_dataset/100_nodes_500_edges`: -9.2%
- `recovery_vector_indexed/10k_nodes_384_dimensions`: -6.0%
- `recovery_wal_replay/100k_operations`: -5.6%

Please review the full report in `benchmarks/report.html`.

---
*PR created automatically by Jules for task [10636708643017105327](https://jules.google.com/task/10636708643017105327) started by @madmax983*