### PR TITLE
⚡ Bolt: Pre-allocate vectors in sharding executor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 **Pre-allocated vectors in sharding scatter logic**
 **Learning:** Found multiple vectors (`results`, `failures`, `aggregated`) in the critical path (`execute` and `aggregate_results`) being created without capacity, resulting in potentially multiple heap reallocations. `results` and `failures` size depends directly on `target_shards.len()`. The `aggregated` vector size depends on the sizes of all result data fragments.
 **Action:** Always pre-calculate the required vector capacity when creating `Vec`s in a collection loop, using methods like `.sum()` on `.map(|x| x.len())` for collection concatenation.
+
+**Pre-allocated vector sizes based on strategy**
+**Learning:** When pre-allocating vectors based on multiple inputs, be mindful of the aggregation strategy. Concatenating requires `.sum()`, but merging or returning the first/best requires `.max()`. Using `.sum()` for a merge strategy causes severe O(N) memory over-allocation.
+**Action:** Always map the pre-allocation math directly to the behavior of the loop that populates it.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 **Avoid intermediate Vec allocations when parsing queries**
 **Learning:** `cleaned.split_whitespace().collect::<Vec<_>>().join(" ");` creates an unnecessary `Vec` allocation on the heap, which isn't necessary for simple string transformations.
 **Action:** Use a pre-allocated string with `String::with_capacity(cleaned.len())` and a loop over the word iterator to concatenate spaces and words directly.
+
+**Pre-allocated vectors in sharding scatter logic**
+**Learning:** Found multiple vectors (`results`, `failures`, `aggregated`) in the critical path (`execute` and `aggregate_results`) being created without capacity, resulting in potentially multiple heap reallocations. `results` and `failures` size depends directly on `target_shards.len()`. The `aggregated` vector size depends on the sizes of all result data fragments.
+**Action:** Always pre-calculate the required vector capacity when creating `Vec`s in a collection loop, using methods like `.sum()` on `.map(|x| x.len())` for collection concatenation.

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -510,7 +510,8 @@ impl<C: ShardClient> QueryExecutor<C> {
             }
             AggregationStrategy::MergeNodes => {
                 // Merge and deduplicate (simplified - real impl would parse nodes)
-                let mut aggregated = Vec::with_capacity(results.iter().map(|r| r.data.len()).sum());
+                let mut aggregated =
+                    Vec::with_capacity(results.iter().map(|r| r.data.len()).max().unwrap_or(0));
                 let mut seen_len = 0;
                 for result in results {
                     if result.data.len() > seen_len {
@@ -852,6 +853,25 @@ mod tests {
         let query = DistributedQuery::new(1, vec![])
             .with_shards(vec![make_shard_id(0), make_shard_id(1)])
             .with_aggregation(AggregationStrategy::Concat);
+
+        let result = executor.execute(query).unwrap();
+        assert!(result.is_complete());
+    }
+
+    #[test]
+    fn test_aggregation_merge_nodes() {
+        let mut executor: QueryExecutor<MockShardClient> =
+            QueryExecutor::new(ExecutorConfig::default(), test_router());
+
+        let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
+        let client1 = Arc::new(MockShardClient::new(make_shard_id(1)));
+
+        executor.register_client(make_shard_id(0), client0);
+        executor.register_client(make_shard_id(1), client1);
+
+        let query = DistributedQuery::new(1, vec![])
+            .with_shards(vec![make_shard_id(0), make_shard_id(1)])
+            .with_aggregation(AggregationStrategy::MergeNodes);
 
         let result = executor.execute(query).unwrap();
         assert!(result.is_complete());

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -343,7 +343,7 @@ impl<C: ShardClient> QueryExecutor<C> {
         }
 
         // Scatter: Execute query on all target shards
-        let mut results: Vec<ShardResult> = Vec::new();
+        let mut results: Vec<ShardResult> = Vec::with_capacity(target_shards.len());
         let mut failures: Vec<(ShardId, NetworkError)> = Vec::new();
 
         for shard_id in &target_shards {
@@ -493,7 +493,7 @@ impl<C: ShardClient> QueryExecutor<C> {
         match query.aggregation {
             AggregationStrategy::Concat => {
                 // Simple concatenation
-                let mut aggregated = Vec::new();
+                let mut aggregated = Vec::with_capacity(results.iter().map(|r| r.data.len()).sum());
                 for result in results {
                     aggregated.extend(&result.data);
                 }
@@ -510,7 +510,7 @@ impl<C: ShardClient> QueryExecutor<C> {
             }
             AggregationStrategy::MergeNodes => {
                 // Merge and deduplicate (simplified - real impl would parse nodes)
-                let mut aggregated = Vec::new();
+                let mut aggregated = Vec::with_capacity(results.iter().map(|r| r.data.len()).sum());
                 let mut seen_len = 0;
                 for result in results {
                     if result.data.len() > seen_len {
@@ -547,7 +547,8 @@ impl<C: ShardClient> QueryExecutor<C> {
             }
             AggregationStrategy::ByShard => {
                 // Return results separately (serialize shard -> data mapping)
-                let mut aggregated = Vec::new();
+                let capacity: usize = results.iter().map(|r| r.data.len()).sum();
+                let mut aggregated = Vec::with_capacity(capacity + 4 + (results.len() * 6));
                 aggregated.extend_from_slice(&(results.len() as u32).to_le_bytes());
                 for result in results {
                     aggregated.extend_from_slice(&result.shard_id.as_u16().to_le_bytes());


### PR DESCRIPTION
* 💡 **What**: Replaced `Vec::new()` with `Vec::with_capacity()` for the `results` vector during query scatter, and correctly calculated `capacity` for the `aggregated` vector during query aggregation in the sharding executor.
* 🎯 **Why**: The scatter-gather phase of the distributed query execution is a very hot path. The default `Vec::new()` performs a series of reallocations (growing by 2x) as data is pushed into the `results` vector and the `aggregated` vectors. Since we already know the target size (the number of shards, or the lengths of the resulting data payloads), we can pre-allocate it perfectly to avoid heap fragmentation and time spent in the allocator.
* 📊 **Impact**: Removes up to `O(log(N))` intermediate allocations per query per aggregation loop, where N is the number of shards or total data length. The `failures` slice is explicitly kept as `Vec::new()` to ensure 0 allocations on the happy path.
* 🔬 **Measurement**: Run `cargo bench` against the `QueryExecutor` benchmarks or run `cargo test --lib storage::sharding`.

---
*PR created automatically by Jules for task [10027236130058458679](https://jules.google.com/task/10027236130058458679) started by @madmax983*