### PR TITLE
🎻 Bard: [documentation update] Document query executor architecture and pipeline model

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -82,3 +82,6 @@
 ## 2025-03-05 - Logical vs Physical Plans and Iterator Performance
 **Confusion:** The difference between logical plans (`LogicalOp`) and physical plans (`PhysicalOp`) in the query engine was unclear. Additionally, the iterators used for execution (`ResultIterator` implementations) lacked clarity on their streaming architecture.
 **Clarification:** Documented `PhysicalOp` to explain its 1:1 mapping with iterators. Added struct-level documentation to `ResultIterator` implementations to clarify the pull-based, lazy execution model used during query processing.
+## 2025-03-06 - Undocumented Query Executor
+**Confusion:** The `src/query/executor` modules lacked high-level architectural documentation, making it hard to understand how `PhysicalPlan`s map to iterators and how streaming vs structured results differ.
+**Clarification:** Added module-level documentation to `mod.rs`, `iterators.rs`, and `results.rs` explaining the pull-based Volcano execution model, the role of the `QueryExecutor`, and providing executable doctests for `ExecutionConfig` and result collection.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -2,6 +2,38 @@
 //!
 //! Pull-based iterators for query execution. Each physical operator
 //! has a corresponding iterator that lazily produces results.
+//!
+//! # Pull-Based Iteration
+//!
+//! AletheiaDB's execution engine leverages a Volcano-style (or pipeline) pull-based execution model.
+//! Instead of operators pushing chunks of data upwards, the root operator pulls individual rows by calling
+//! `next()` on its children. This lazy evaluation minimizes the active memory footprint, avoiding
+//! intermediate allocations during traversal or filtering operations, keeping overhead under ~100ns per hop.
+//!
+//! # Examples
+//!
+//! You typically compose these iterators into pipelines to execute queries:
+//!
+//! ```rust
+//! use std::sync::Arc;
+//! use aletheiadb::query::executor::{NodeScanIterator, FilterIterator, LimitIterator, ResultIterator};
+//! use aletheiadb::query::ir::Predicate;
+//! use aletheiadb::storage::current::CurrentStorage;
+//!
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let storage = Arc::new(CurrentStorage::new());
+//!
+//! // Pipeline: Scan "Person" -> Filter by name -> Limit 10
+//! let scan = Box::new(NodeScanIterator::new(Some("Person".to_string()), storage));
+//! let filter = Box::new(FilterIterator::new(scan, Predicate::eq("name", "Alice")));
+//! let mut limit = LimitIterator::new(filter, 0, 10);
+//!
+//! while let Some(row) = limit.next() {
+//!     println!("Result: {:?}", row?.entity.node_id());
+//! }
+//! # Ok(())
+//! # }
+//! ```
 
 use parking_lot::RwLock;
 use std::cmp::Reverse;

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -3,6 +3,50 @@
 //! Executes physical query plans using a pull-based iterator model.
 //! The executor transforms physical operators into iterators that
 //! lazily produce results.
+//!
+//! # Architecture
+//!
+//! The query executor ([`QueryExecutor`]) sits between the query planner and the storage engine.
+//! Its responsibility is to take a compiled [`PhysicalPlan`] and orchestrate its execution by translating
+//! the plan's [`PhysicalOp`] nodes into a chain of [`ResultIterator`] implementations.
+//!
+//! This pull-based (or Pipeline/Volcano) model means that data flows through the query engine
+//! lazily. A record is only pulled from the storage layer when `next()` is called on the outermost iterator,
+//! keeping memory usage low for operations like `LIMIT`.
+//!
+//! # Execution Flow
+//!
+//! 1. A client submits an AST or uses the Query Builder.
+//! 2. The Planner converts the intent into a [`PhysicalPlan`].
+//! 3. The [`QueryExecutor`] recursively translates the [`PhysicalPlan`]'s [`PhysicalOp`] root into a Boxed [`ResultIterator`].
+//! 4. The Executor wraps the iterator in [`QueryResults`] which the client iterates over.
+//!
+//! # Example: Execution Configuration
+//!
+//! You can fine-tune query execution using [`ExecutionConfig`]:
+//!
+//! ```rust
+//! use std::sync::Arc;
+//! use parking_lot::RwLock;
+//! use aletheiadb::query::executor::{QueryExecutor, ExecutionConfig};
+//! use aletheiadb::storage::current::CurrentStorage;
+//! use aletheiadb::storage::historical::HistoricalStorage;
+//! use aletheiadb::core::version::AnchorConfig;
+//!
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let current = Arc::new(CurrentStorage::new());
+//! let historical = Arc::new(RwLock::new(HistoricalStorage::with_config(AnchorConfig::default())));
+//!
+//! let config = ExecutionConfig {
+//!     max_buffer_size: 50_000,
+//!     parallel: true,
+//!     timeout_ms: 5000,
+//! };
+//!
+//! let executor = QueryExecutor::with_config(current, historical, config);
+//! # Ok(())
+//! # }
+//! ```
 
 mod iterators;
 mod results;

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -1,6 +1,83 @@
 //! Query Result Types
 //!
 //! Defines the result types returned by query execution.
+//!
+//! # Streaming vs. Structured Results
+//!
+//! The query executor returns a [`QueryResults`] instance, which acts as a wrapper around the
+//! underlying execution iterators. This provides a streaming, lazy mechanism to consume data as
+//! it is fetched from the storage layers.
+//!
+//! Alternatively, if you need the entire result set in memory simultaneously (e.g. for JSON
+//! serialization in an HTTP API or for batch processing), you can materialize the results into
+//! a structured format using [`QueryResults::collect_structured()`]. This yields a [`QueryResult`]
+//! struct containing parallel arrays of nodes, scores, and temporal metadata.
+//!
+//! # Examples
+//!
+//! Using the streaming iterator:
+//!
+//! ```rust
+//! # use std::sync::Arc;
+//! # use parking_lot::RwLock;
+//! # use aletheiadb::storage::current::CurrentStorage;
+//! # use aletheiadb::storage::historical::HistoricalStorage;
+//! # use aletheiadb::query::{QueryExecutor, PhysicalPlan};
+//! # use aletheiadb::query::planner::PhysicalOp;
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # let current = Arc::new(CurrentStorage::new());
+//! # let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+//! # let executor = QueryExecutor::new(current, historical);
+//! # let plan = PhysicalPlan {
+//! #     root: PhysicalOp::Empty,
+//! #     estimated_cost: Default::default(),
+//! #     temporal_context: None,
+//! #     parallel: false,
+//! #     include_provenance: true,
+//! # };
+//! let results = executor.execute(plan)?;
+//!
+//! // Process rows one at a time without allocating the full dataset
+//! for row in results {
+//!     let row = row?;
+//!     println!("Found node: {:?}", row.entity.node_id());
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Using structured collection:
+//!
+//! ```rust
+//! # use std::sync::Arc;
+//! # use parking_lot::RwLock;
+//! # use aletheiadb::storage::current::CurrentStorage;
+//! # use aletheiadb::storage::historical::HistoricalStorage;
+//! # use aletheiadb::query::{QueryExecutor, PhysicalPlan};
+//! # use aletheiadb::query::planner::PhysicalOp;
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # let current = Arc::new(CurrentStorage::new());
+//! # let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+//! # let executor = QueryExecutor::new(current, historical);
+//! # let plan = PhysicalPlan {
+//! #     root: PhysicalOp::Empty,
+//! #     estimated_cost: Default::default(),
+//! #     temporal_context: None,
+//! #     parallel: false,
+//! #     include_provenance: true,
+//! # };
+//! let results = executor.execute(plan)?;
+//!
+//! // Materialize all rows into memory simultaneously
+//! let structured = results.collect_structured()?;
+//!
+//! println!("Found {} nodes", structured.nodes.len());
+//! if let Some(scores) = structured.scores {
+//!     println!("Highest score: {}", scores[0]);
+//! }
+//! # Ok(())
+//! # }
+//! ```
 
 use crate::core::error::Result;
 use crate::core::graph::{Edge, Node};


### PR DESCRIPTION
📖 Chapter: The `QueryExecutor` module
🔦 Insight: Clarified the Volcano-style pull-based execution model, explaining how `PhysicalPlan`s translate to lazy `ResultIterator`s to minimize memory allocation. Detailed the difference between streaming iterators and structured collection.
🧪 Example: Added 3 executable doctests demonstrating `ExecutionConfig`, streaming iteration, and `collect_structured()`.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [9188017104714130548](https://jules.google.com/task/9188017104714130548) started by @madmax983*