### PR TITLE
🛡️ Sentry: Fix to_iso8601 panic on pre-epoch timestamps

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,6 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+## ISO 8601 Format Panic Risk on Pre-Epoch Timestamps
+**Learning:** The `to_iso8601` function in `src/core/temporal.rs` used naive conversion casting `i64` wallclock microseconds to `u64` seconds and adding it to `UNIX_EPOCH`. This caused a `SystemTime` overflow panic when passing negative wallclocks (timestamps before 1970).
+**Action:** Always test temporal logic with negative wallclock values to ensure calculations correctly handle pre-epoch times, using `.abs()` and conditional subtraction (`UNIX_EPOCH - duration`) instead of unchecked casting.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -673,11 +673,16 @@ pub mod time {
 
         let wallclock = timestamp.wallclock();
         // Convert microseconds to seconds and nanoseconds
-        let secs = wallclock / 1_000_000;
-        let nanos = ((wallclock % 1_000_000) * 1000) as u32;
+        let secs = wallclock.abs() / 1_000_000;
+        let nanos = ((wallclock.abs() % 1_000_000) * 1000) as u32;
 
+        let duration = std::time::Duration::new(secs as u64, nanos);
         // This is a simplified conversion - for production use chrono crate
-        let datetime = UNIX_EPOCH + std::time::Duration::new(secs as u64, nanos);
+        let datetime = if wallclock >= 0 {
+            UNIX_EPOCH + duration
+        } else {
+            UNIX_EPOCH - duration
+        };
         format!("{:?}", datetime) // Simplified - use chrono for proper formatting
     }
 
@@ -1631,6 +1636,21 @@ mod sentry_tests {
             !interval.is_current(),
             "is_current() should be false if one dimension is closed"
         );
+    }
+
+    #[test]
+    fn test_sentry_iso8601_before_epoch() {
+        // 🛡️ Sentry Test: Verify time::to_iso8601 handles timestamps before 1970 without panicking.
+        // This targets the bug where casting negative seconds to u64 panics and adding to UNIX_EPOCH panics.
+
+        // 1969-12-31 23:59:59 UTC
+        let secs = -1;
+        let ts = time::from_secs(secs);
+        let output = time::to_iso8601(ts);
+
+        // Output format is platform dependent, but shouldn't panic.
+        // It should contain the 1 sec offset or a system time.
+        assert!(!output.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
🎯 Target: `src/core/temporal.rs` - `to_iso8601()` function
💣 Risk: Passing a negative wallclock value (time before UNIX_EPOCH, 1970) caused a `SystemTime` panic due to an unchecked cast to `u64` and invalid addition to the epoch.
🧪 Strategy: Updated the function to extract absolute values for calculation and conditionally subtracted the `Duration` from `UNIX_EPOCH` for negative wallclocks. Added the `test_sentry_iso8601_before_epoch` unit test.
🔬 Verification: `cargo test test_sentry_iso8601_before_epoch`

---
*PR created automatically by Jules for task [10299961742831472090](https://jules.google.com/task/10299961742831472090) started by @madmax983*