### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 **Pre-allocated vector sizes based on strategy**
 **Learning:** When pre-allocating vectors based on multiple inputs, be mindful of the aggregation strategy. Concatenating requires `.sum()`, but merging or returning the first/best requires `.max()`. Using `.sum()` for a merge strategy causes severe O(N) memory over-allocation.
 **Action:** Always map the pre-allocation math directly to the behavior of the loop that populates it.
+
+**[Optimize TraversalIterator Vec Pre-allocation]**
+**Learning:** When using `.size_hint()` to pre-allocate `Vec::with_capacity()`, initializing iterators solely for their size hint and then discarding them causes redundant graph/database lookups, introducing a severe performance regression. Additionally, refactoring closures to take mutable references rather than mutably capturing from the environment means the closures themselves no longer need to be bound with `let mut`, which prevents `clippy::unused_mut` warnings.
+**Action:** Always instantiate iterators once, bind them to variables, calculate capacity using their size hints, and then consume those exact bindings. Carefully review closure bindings for unnecessary `mut` keywords when their captures change.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -771,57 +771,65 @@ impl TraversalIterator {
                 }
             }
             Direction::Both => {
-                let mut neighbors = Vec::new();
-
                 // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
                 // Helper closure to process edges and add to neighbors
                 // Zero-copy: only get target NodeId, not full Edge (Issue #190)
-                let mut process_outgoing = |edge_id| {
-                    if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                        return;
-                    }
-                    if let Ok(target) = self.current.get_edge_target(edge_id) {
-                        neighbors.push((target, edge_id));
-                    }
-                };
-
-                if let Some(ref label) = self.label {
-                    for edge_id in self
-                        .current
-                        .get_outgoing_edges_with_label_iter(node_id, label)
-                    {
-                        process_outgoing(edge_id);
-                    }
-                } else {
-                    for edge_id in self.current.get_outgoing_edges_iter(node_id) {
-                        process_outgoing(edge_id);
-                    }
-                }
+                let process_outgoing =
+                    |edge_id, neighbors: &mut Vec<(NodeId, crate::core::EdgeId)>| {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            return;
+                        }
+                        if let Ok(target) = self.current.get_edge_target(edge_id) {
+                            neighbors.push((target, edge_id));
+                        }
+                    };
 
                 // Zero-copy: only get source NodeId, not full Edge (Issue #190)
-                let mut process_incoming = |edge_id| {
-                    if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                        return;
-                    }
-                    if let Ok(source) = self.current.get_edge_source(edge_id) {
-                        neighbors.push((source, edge_id));
-                    }
-                };
+                let process_incoming =
+                    |edge_id, neighbors: &mut Vec<(NodeId, crate::core::EdgeId)>| {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            return;
+                        }
+                        if let Ok(source) = self.current.get_edge_source(edge_id) {
+                            neighbors.push((source, edge_id));
+                        }
+                    };
 
                 if let Some(ref label) = self.label {
-                    for edge_id in self
+                    // ⚡ Bolt Optimization: Instantiate iterators once to avoid duplicate lookups,
+                    // calculate required capacity, and pre-allocate to prevent heap reallocations.
+                    let out_iter = self
                         .current
-                        .get_incoming_edges_with_label_iter(node_id, label)
-                    {
-                        process_incoming(edge_id);
-                    }
-                } else {
-                    for edge_id in self.current.get_incoming_edges_iter(node_id) {
-                        process_incoming(edge_id);
-                    }
-                }
+                        .get_outgoing_edges_with_label_iter(node_id, label);
+                    let in_iter = self
+                        .current
+                        .get_incoming_edges_with_label_iter(node_id, label);
+                    let capacity = out_iter.size_hint().0 + in_iter.size_hint().0;
 
-                neighbors
+                    let mut neighbors = Vec::with_capacity(capacity);
+                    for edge_id in out_iter {
+                        process_outgoing(edge_id, &mut neighbors);
+                    }
+                    for edge_id in in_iter {
+                        process_incoming(edge_id, &mut neighbors);
+                    }
+                    neighbors
+                } else {
+                    // ⚡ Bolt Optimization: Instantiate iterators once to avoid duplicate lookups,
+                    // calculate required capacity, and pre-allocate to prevent heap reallocations.
+                    let out_iter = self.current.get_outgoing_edges_iter(node_id);
+                    let in_iter = self.current.get_incoming_edges_iter(node_id);
+                    let capacity = out_iter.size_hint().0 + in_iter.size_hint().0;
+
+                    let mut neighbors = Vec::with_capacity(capacity);
+                    for edge_id in out_iter {
+                        process_outgoing(edge_id, &mut neighbors);
+                    }
+                    for edge_id in in_iter {
+                        process_incoming(edge_id, &mut neighbors);
+                    }
+                    neighbors
+                }
             }
         }
     }


### PR DESCRIPTION
💡 What: Refactored `TraversalIterator::get_neighbors` (specifically `Direction::Both`) in `src/query/executor/iterators.rs` to read the `size_hint()` of the outgoing and incoming iterators. It calculates the necessary capacity, pre-allocates the `neighbors` vector with `Vec::with_capacity()`, and correctly reuses the initialized iterators for iteration without redundant graph lookups. It also correctly removes `mut` bindings on the closures.
🎯 Why: `TraversalIterator` collects all connected edge/target pairs during query execution. Prior to this patch, it relied on a zero-capacity `Vec::new()` vector that continually reallocated as the traversal expanded. Graph traversals frequently encounter highly-connected nodes (super nodes) leading to substantial and predictable allocation overhead on the hot path.
📊 Impact: Expected to reduce heap reallocation by allocating the exact capacity required upfront for bidirectional queries.
🔬 Measurement: Run `cargo test` on query iterators, or monitor peak heap allocations per query against heavily connected bidirectional nodes.

---
*PR created automatically by Jules for task [14856304385659219777](https://jules.google.com/task/14856304385659219777) started by @madmax983*