### PR TITLE
⚡ Bolt: Pre-allocate vectors during sharding aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 **Avoid intermediate Vec allocations when parsing queries**
 **Learning:** `cleaned.split_whitespace().collect::<Vec<_>>().join(" ");` creates an unnecessary `Vec` allocation on the heap, which isn't necessary for simple string transformations.
 **Action:** Use a pre-allocated string with `String::with_capacity(cleaned.len())` and a loop over the word iterator to concatenate spaces and words directly.
+
+**[Unused Doc Comments in Function Bodies]
+**Learning:** Using `///` doc comments inside a function body that do not attach to an item (e.g., before a `let` statement or loop) triggers the `clippy::unused_doc_comments` warning.
+**Action:** Use standard `//` comments for internal inline explanations, saving `///` exclusively for struct, enum, trait, and function definitions.

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -493,7 +493,10 @@ impl<C: ShardClient> QueryExecutor<C> {
         match query.aggregation {
             AggregationStrategy::Concat => {
                 // Simple concatenation
-                let mut aggregated = Vec::new();
+                // ⚡ Bolt: Pre-allocate the vector to exactly match the sum of all result data lengths,
+                // avoiding multiple reallocations on this hot path.
+                let capacity: usize = results.iter().map(|r| r.data.len()).sum();
+                let mut aggregated = Vec::with_capacity(capacity);
                 for result in results {
                     aggregated.extend(&result.data);
                 }
@@ -547,7 +550,11 @@ impl<C: ShardClient> QueryExecutor<C> {
             }
             AggregationStrategy::ByShard => {
                 // Return results separately (serialize shard -> data mapping)
-                let mut aggregated = Vec::new();
+                // ⚡ Bolt: Pre-calculate the exact capacity needed for all shards:
+                // 4 bytes for count + per result (2 bytes shard_id + 4 bytes len + data.len()).
+                let capacity: usize =
+                    4 + results.iter().map(|r| 2 + 4 + r.data.len()).sum::<usize>();
+                let mut aggregated = Vec::with_capacity(capacity);
                 aggregated.extend_from_slice(&(results.len() as u32).to_le_bytes());
                 for result in results {
                     aggregated.extend_from_slice(&result.shard_id.as_u16().to_le_bytes());


### PR DESCRIPTION
💡 What: Switched from using `Vec::new()` to `Vec::with_capacity(capacity)` when aggregating results in `src/storage/sharding/executor.rs` for both `Concat` and `ByShard` strategies. The capacity is precisely pre-calculated by summing the `data.len()` fields across all incoming shard results.
🎯 Why: Aggregation is a critical hot path in distributed query execution. Continuously reallocating and copying a `Vec` as it grows via `.extend()` and `.extend_from_slice()` causes unnecessary heap churn, particularly for large result sets.
📊 Impact: Eliminates multiple heap allocations and potential `memcpy` operations during distributed query aggregation.
🔬 Measurement: Run `cargo test --all-targets` and benchmark `process_data` to verify consistent compile times and execution.

---
*PR created automatically by Jules for task [7668508454703718978](https://jules.google.com/task/7668508454703718978) started by @madmax983*