### PR TITLE
🛡️ Sentry: [test coverage improvement] sparse euclidean distance dimension mismatch

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,7 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+
+## Sparse Euclidean Distance Dimension Mismatch Coverage Gap
+**Learning:** `sparse_euclidean_distance` acts as a wrapper around `sparse_squared_euclidean_distance`, but didn't have an explicit test checking if `DimensionMismatch` errors properly propagated from the squared variant up through the square root mapping operation.
+**Action:** Always ensure that when one metric function wraps another and propagates its errors (e.g. via `?` or `.map()`), there is an explicit test verifying the error pathway in the wrapper, guaranteeing it handles the `Result` type correctly.

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2870,6 +2870,19 @@ fn test_sparse_euclidean_distance_pythagorean() {
 }
 
 #[test]
+fn test_sparse_euclidean_distance_dimension_mismatch() {
+    let a = SparseVec::new(vec![0], vec![1.0], 5).unwrap();
+    let b = SparseVec::new(vec![0], vec![1.0], 10).unwrap();
+
+    let result = sparse_euclidean_distance(&a, &b);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        Error::Vector(VectorError::DimensionMismatch { .. })
+    ));
+}
+
+#[test]
 fn test_sparse_similarity_with_bm25_like_vectors() {
     // Simulate BM25 document vectors
     let doc1 = SparseVec::new(vec![10, 42, 100, 257], vec![2.5, 1.8, 3.2, 1.2], 10000).unwrap();


### PR DESCRIPTION
🎯 Target: `sparse_euclidean_distance` in `src/core/vector/sparse.rs`
💣 Risk: The `DimensionMismatch` error path from `sparse_squared_euclidean_distance` was not explicitly covered when mapped through the square root operation.
🧪 Strategy: Added a new test `test_sparse_euclidean_distance_dimension_mismatch` to explicitly check the error propagation.
🔬 Verification: `cargo test --lib core::vector::tests::test_sparse_euclidean_distance_dimension_mismatch`

---
*PR created automatically by Jules for task [10746282245656473035](https://jules.google.com/task/10746282245656473035) started by @madmax983*