### PR TITLE
🛡️ Sentry: [test coverage improvement] HTTP JSON converter edge cases

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,6 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+## JSON Array Converter Edge Cases
+**Learning:** In `src/http/converters.rs`, the recursive json to `PropertyValue` converter correctly implements limitations and type fallbacks, but some paths like `Value::Object` returning an error directly or mixed-type arrays falling back to generic `PropertyValue::Array` instead of numeric Vectors lacked explicit test coverage. Testing these edge cases ensures no regressions on unsupported types or boundary arrays like `[]`.
+**Action:** Always add explicit tests for `serde_json::Value` parsing edge cases, even if they seem trivial, to ensure the API boundary behaves predictably when confronted with malformed or unsupported JSON inputs.

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -473,6 +473,50 @@ mod tests {
     }
 
     #[test]
+    fn test_json_object_error() {
+        // 🎯 Target: json_to_property_value_recursive
+        // 💣 Risk: Missing test for unsupported Object variant
+        let value = json!({"key": "value"});
+        let result = json_to_property_value(&value);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Nested objects are not supported"));
+    }
+
+    #[test]
+    fn test_json_invalid_float_in_array() {
+        // 🎯 Target: json_to_property_value_recursive array processing
+        // 💣 Risk: Array values masquerading as numbers but failing f64 conversion.
+        // Actually, serde_json guarantees .is_number() corresponds to .as_f64() or similar,
+        // but we'll try to trigger the "Invalid float in array" error.
+        // We'll create an array of values where .is_number() is true but .as_f64() is false.
+        // `serde_json::Number` might not convert to f64 if it's too large for u64/i64/f64?
+        // It's hard to trigger .as_f64() returning None if .is_number() is true,
+        // but let's test a mixed array which falls back to generic PropertyValue::Array.
+        let value = json!([1.0, "string"]);
+        let result = json_to_property_value(&value);
+        assert!(result.is_ok());
+        if let PropertyValue::Array(ref arr) = result.unwrap() {
+            assert_eq!(arr.len(), 2);
+        } else {
+            panic!("Expected generic array");
+        }
+    }
+
+    #[test]
+    fn test_json_empty_array() {
+        // 🎯 Target: json_to_property_value_recursive empty array
+        // 💣 Risk: Should produce empty PropertyValue::Array, not panic
+        let value = json!([]);
+        let result = json_to_property_value(&value);
+        assert!(result.is_ok());
+        if let PropertyValue::Array(ref arr) = result.unwrap() {
+            assert_eq!(arr.len(), 0);
+        } else {
+            panic!("Expected generic array");
+        }
+    }
+
+    #[test]
     fn test_json_vector_pre_allocation_limit() {
         use crate::core::property::MAX_ARRAY_ELEMENTS;
         use crate::core::property::MAX_VECTOR_DIMENSIONS;

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -479,7 +479,11 @@ mod tests {
         let value = json!({"key": "value"});
         let result = json_to_property_value(&value);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Nested objects are not supported"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Nested objects are not supported")
+        );
     }
 
     #[test]


### PR DESCRIPTION
🎯 Target: `json_to_property_value` in `src/http/converters.rs`
💣 Risk: Edge cases around unsupported JSON objects or mixed-type arrays might have triggered unhandled logic panics or returned unexpected defaults across the HTTP API boundary.
🧪 Strategy: Wrote tests explicitly covering `serde_json::Value::Object` parsing failures, parsing of empty arrays, and mixed-type array fallback handling.
🔬 Verification: Run `cargo test --lib http::converters::tests`

---
*PR created automatically by Jules for task [10976005432934885552](https://jules.google.com/task/10976005432934885552) started by @madmax983*