### PR TITLE
🤖 Sentinel: [hlc test coverage improvement]

### DIFF
--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -1226,3 +1226,42 @@ mod sentinel_evaluate_clock_skew_tests {
         assert_eq!(err_f.direction, ClockSkewDirection::Forward);
     }
 }
+#[test]
+fn test_max_backward_drift_us_exact() {
+    // Assert exactly 5 minutes in microseconds
+    assert_eq!(MAX_BACKWARD_DRIFT_US, 300_000_000);
+}
+
+#[test]
+fn test_max_forward_jump_us_exact() {
+    // Assert exactly 1 hour in microseconds
+    assert_eq!(MAX_FORWARD_JUMP_US, 3_600_000_000);
+}
+
+#[test]
+fn test_send_max_valid_timestamp_boundary() {
+    let current = HybridTimestamp::new(MAX_VALID_TIMESTAMP, 0).unwrap();
+    // Valid update to the exact boundary
+    let next = current.send(MAX_VALID_TIMESTAMP).unwrap();
+    assert_eq!(next.wallclock(), MAX_VALID_TIMESTAMP);
+    assert_eq!(next.logical(), 1);
+
+    // Invalid update beyond boundary
+    let err = current.send(MAX_VALID_TIMESTAMP + 1).unwrap_err();
+    assert!(matches!(err, TemporalError::InvalidTimestamp { .. }));
+}
+
+#[test]
+fn test_receive_max_valid_timestamp_boundary() {
+    let local = HybridTimestamp::new(MAX_VALID_TIMESTAMP, 0).unwrap();
+    let msg = HybridTimestamp::new(MAX_VALID_TIMESTAMP, 10).unwrap();
+
+    // Valid receive exactly at boundary
+    let next = local.receive(msg, MAX_VALID_TIMESTAMP).unwrap();
+    assert_eq!(next.wallclock(), MAX_VALID_TIMESTAMP);
+    assert_eq!(next.logical(), 11);
+
+    // Invalid receive where physical clock > MAX_VALID_TIMESTAMP
+    let err = local.receive(msg, MAX_VALID_TIMESTAMP + 1).unwrap_err();
+    assert!(matches!(err, TemporalError::InvalidTimestamp { .. }));
+}

--- a/test_hlc.rs
+++ b/test_hlc.rs
@@ -1,0 +1,36 @@
+#[test]
+fn test_max_backward_drift_us_exact() {
+    // Assert exactly 5 minutes in microseconds
+    assert_eq!(aletheiadb::core::hlc::MAX_BACKWARD_DRIFT_US, 300_000_000);
+}
+#[test]
+fn test_max_forward_jump_us_exact() {
+    // Assert exactly 1 hour in microseconds
+    assert_eq!(aletheiadb::core::hlc::MAX_FORWARD_JUMP_US, 3_600_000_000);
+}
+#[test]
+fn test_send_max_valid_timestamp_boundary() {
+    let current = aletheiadb::core::hlc::HybridTimestamp::new(aletheiadb::core::temporal::MAX_VALID_TIMESTAMP, 0).unwrap();
+    // Valid update to the exact boundary
+    let next = current.send(aletheiadb::core::temporal::MAX_VALID_TIMESTAMP).unwrap();
+    assert_eq!(next.wallclock(), aletheiadb::core::temporal::MAX_VALID_TIMESTAMP);
+    assert_eq!(next.logical(), 1);
+
+    // Invalid update beyond boundary
+    let err = current.send(aletheiadb::core::temporal::MAX_VALID_TIMESTAMP + 1).unwrap_err();
+    assert!(matches!(err, aletheiadb::core::error::TemporalError::InvalidTimestamp { .. }));
+}
+#[test]
+fn test_receive_max_valid_timestamp_boundary() {
+    let local = aletheiadb::core::hlc::HybridTimestamp::new(aletheiadb::core::temporal::MAX_VALID_TIMESTAMP, 0).unwrap();
+    let msg = aletheiadb::core::hlc::HybridTimestamp::new(aletheiadb::core::temporal::MAX_VALID_TIMESTAMP, 10).unwrap();
+
+    // Valid receive exactly at boundary
+    let next = local.receive(msg, aletheiadb::core::temporal::MAX_VALID_TIMESTAMP).unwrap();
+    assert_eq!(next.wallclock(), aletheiadb::core::temporal::MAX_VALID_TIMESTAMP);
+    assert_eq!(next.logical(), 11);
+
+    // Invalid receive where physical clock > MAX_VALID_TIMESTAMP
+    let err = local.receive(msg, aletheiadb::core::temporal::MAX_VALID_TIMESTAMP + 1).unwrap_err();
+    assert!(matches!(err, aletheiadb::core::error::TemporalError::InvalidTimestamp { .. }));
+}


### PR DESCRIPTION
Addresses weak test coverage in `src/core/hlc.rs` as identified in `.jules/sentinel.md`.

*   **`MAX_BACKWARD_DRIFT_US` / `MAX_FORWARD_JUMP_US` Bounds**: Added exact match assertions (`test_max_backward_drift_us_exact`, `test_max_forward_jump_us_exact`) to prevent mutations that change arithmetic operators (e.g. `*` to `/`).
*   **`HybridTimestamp` Receive/Send Boundary Protection**: Added specific tests (`test_send_max_valid_timestamp_boundary`, `test_receive_max_valid_timestamp_boundary`) to verify the strict adherence to the `MAX_VALID_TIMESTAMP` boundary limits, catching mutations where operators like `>` are transformed to `>=`.

---
*PR created automatically by Jules for task [10920439088210178938](https://jules.google.com/task/10920439088210178938) started by @madmax983*