### PR TITLE
🎻 Bard: [documentation update] Add detailed module-level docs to Query Executor

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -85,3 +85,7 @@
 ## 2025-03-05 - Opaque Persistence Architecture
 **Confusion:** The `src/index/vector/hnsw/persistence.rs` module lacked documentation explaining the two-file architecture (the usearch `.bin` file vs the AletheiaDB `.idx` file), making it difficult to understand how and why index mapping was persisted. Furthermore, the DoS protections (like `MAX_MAPPINGS_COUNT`) were not clearly highlighted at the module level.
 **Clarification:** Added a module-level `//!` documentation block detailing the architecture and security protections. Additionally, documented the `IndexMetadata` struct to explain why exact configuration matching is required.
+
+## 2025-03-05 - Query Executor Iterator Architecture
+**Confusion:** The `src/query/executor/mod.rs` module lacked detailed documentation explaining its "pull-based iterator model", leaving the concepts of lazy execution and memory backpressure (via `ExecutionConfig::max_buffer_size`) undocumented at the high level.
+**Clarification:** Added a detailed `//!` module-level "Tale" to `src/query/executor/mod.rs` that explicitly explains the streaming architecture, lazy execution without full-graph buffering, and how the config provides backpressure. Added an example of using a custom execution configuration.

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -1,8 +1,48 @@
 //! Query Executor
 //!
 //! Executes physical query plans using a pull-based iterator model.
-//! The executor transforms physical operators into iterators that
-//! lazily produce results.
+//!
+//! # Architecture
+//!
+//! The executor transforms physical operators (`PhysicalOp`) into iterators (`ResultIterator`) that
+//! lazily produce results. Instead of buffering entire graph traversals into memory, AletheiaDB
+//! uses a streaming architecture where each node in the query plan requests the next row from its child
+//! only when needed.
+//!
+//! # Lazy Execution & Backpressure
+//!
+//! - **Lazy Execution:** No data is fetched from storage until the `QueryResults` iterator is consumed.
+//! - **Backpressure:** The executor respects `ExecutionConfig::max_buffer_size`, applying backpressure to
+//!   prevent out-of-memory crashes on massive queries.
+//!
+//! # Example
+//!
+//! ```rust
+//! # use aletheiadb::core::error::Result;
+//! # fn main() -> Result<()> {
+//! # let current = std::sync::Arc::new(aletheiadb::storage::current::CurrentStorage::new());
+//! # let historical = std::sync::Arc::new(parking_lot::RwLock::new(aletheiadb::storage::historical::HistoricalStorage::new()));
+//! # let plan = PhysicalPlan { root: PhysicalOp::NodeScan { label: None, estimated_rows: 0 }, estimated_cost: Default::default(), temporal_context: None, parallel: false, include_provenance: false };
+//! use std::sync::Arc;
+//! use parking_lot::RwLock;
+//! use aletheiadb::storage::current::CurrentStorage;
+//! use aletheiadb::storage::historical::HistoricalStorage;
+//! use aletheiadb::query::{QueryExecutor, PhysicalPlan};
+//! use aletheiadb::query::planner::PhysicalOp;
+//!
+//! // Create executor with custom config
+//! let mut config = aletheiadb::query::executor::ExecutionConfig::default();
+//! config.max_buffer_size = 1000;
+//! let executor = QueryExecutor::with_config(current, historical, config);
+//!
+//! // Execute physical plan lazily
+//! let results = executor.execute(plan)?;
+//! for row in results {
+//!     println!("Row: {:?}", row?);
+//! }
+//! # Ok(())
+//! # }
+//! ```
 
 mod iterators;
 mod results;


### PR DESCRIPTION
📖 **Chapter:** The `Query Executor` module (`src/query/executor/mod.rs`)
🔦 **Insight:** Explained the "pull-based iterator model" and the streaming architecture that avoids full-graph buffering. Detailed how `ExecutionConfig::max_buffer_size` acts as backpressure to prevent out-of-memory crashes on massive queries, and how execution is lazy until the iterator is consumed.
🧪 **Example:** Added an executable `# use` setup doctest block showing how to instantiate and use a custom `ExecutionConfig` with the executor.
🖼️ **Preview:** N/A

---
*PR created automatically by Jules for task [13860199960816908131](https://jules.google.com/task/13860199960816908131) started by @madmax983*