### PR TITLE
⚡ Bolt: Replace map/filter/collect with in-place retain

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 **[Optimize TraversalIterator Vec Pre-allocation]**
 **Learning:** When using `.size_hint()` to pre-allocate `Vec::with_capacity()`, initializing iterators solely for their size hint and then discarding them causes redundant graph/database lookups, introducing a severe performance regression. Additionally, refactoring closures to take mutable references rather than mutably capturing from the environment means the closures themselves no longer need to be bound with `let mut`, which prevents `clippy::unused_mut` warnings.
 **Action:** Always instantiate iterators once, bind them to variables, calculate capacity using their size hints, and then consume those exact bindings. Carefully review closure bindings for unnecessary `mut` keywords when their captures change.
+
+**[Optimize Filtering with `Vec::retain`]**
+**Learning:** When retrieving a `Vec` from a lower-level API and immediately filtering it, chaining `.into_iter().filter(...).collect()` forces the allocation of a completely new `Vec` on the heap, which is an unnecessary allocation.
+**Action:** Use `.retain(...)` on the existing `Vec` to filter the elements in-place. This preserves the original allocation and prevents unnecessary memory allocations in hot paths like querying the graph structure.

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -179,20 +179,21 @@ impl ReadTransaction {
     ///
     /// This prevents phantom reads by checking each edge's visibility.
     /// Edges that don't exist or aren't visible are filtered out.
-    fn filter_visible_edges(&self, edge_ids: Vec<EdgeId>) -> Vec<EdgeId> {
+    ///
+    /// ⚡ Bolt Optimization: Uses `.retain()` instead of `.into_iter().filter(...).collect()`
+    /// to filter in-place and avoid allocating a new `Vec`.
+    fn filter_visible_edges(&self, mut edge_ids: Vec<EdgeId>) -> Vec<EdgeId> {
+        edge_ids.retain(|&edge_id| {
+            // Check if edge is visible in our snapshot
+            if let Ok(edge) = self.current.get_edge(edge_id) {
+                self.visibility_manager
+                    .is_visible(&self.snapshot, edge.metadata.created_by_tx)
+            } else {
+                // Edge doesn't exist or was deleted - not visible
+                false
+            }
+        });
         edge_ids
-            .into_iter()
-            .filter(|&edge_id| {
-                // Check if edge is visible in our snapshot
-                if let Ok(edge) = self.current.get_edge(edge_id) {
-                    self.visibility_manager
-                        .is_visible(&self.snapshot, edge.metadata.created_by_tx)
-                } else {
-                    // Edge doesn't exist or was deleted - not visible
-                    false
-                }
-            })
-            .collect()
     }
 
     /// Query historical storage for an edge version visible at snapshot time.
@@ -324,19 +325,21 @@ impl ReadOps for ReadTransaction {
         property_key: &str,
         property_value: &PropertyValue,
     ) -> Vec<NodeId> {
-        self.current
-            .find_nodes_by_property(label, property_key, property_value)
-            .into_iter()
-            .filter(|node_id| {
-                self.current
-                    .get_node(*node_id)
-                    .map(|node| {
-                        self.visibility_manager
-                            .is_visible(&self.snapshot, node.metadata.created_by_tx)
-                    })
-                    .unwrap_or(false)
-            })
-            .collect()
+        // ⚡ Bolt Optimization: Uses `.retain()` to filter in-place and avoid allocating a new `Vec`.
+        let mut node_ids = self.current
+            .find_nodes_by_property(label, property_key, property_value);
+
+        node_ids.retain(|node_id| {
+            self.current
+                .get_node(*node_id)
+                .map(|node| {
+                    self.visibility_manager
+                        .is_visible(&self.snapshot, node.metadata.created_by_tx)
+                })
+                .unwrap_or(false)
+        });
+
+        node_ids
     }
 }
 

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -326,7 +326,8 @@ impl ReadOps for ReadTransaction {
         property_value: &PropertyValue,
     ) -> Vec<NodeId> {
         // ⚡ Bolt Optimization: Uses `.retain()` to filter in-place and avoid allocating a new `Vec`.
-        let mut node_ids = self.current
+        let mut node_ids = self
+            .current
             .find_nodes_by_property(label, property_key, property_value);
 
         node_ids.retain(|node_id| {

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -834,12 +834,13 @@ impl ReadOps for WriteTransaction {
         use crate::core::interning::GLOBAL_INTERNER;
 
         // 1. Get committed matches, excluding nodes modified in the buffer
-        let mut results: Vec<NodeId> = self
+        // ⚡ Bolt Optimization: Uses `.retain()` to filter in-place and avoid allocating a new `Vec`.
+        let mut results = self
             .current
-            .find_nodes_by_property(label, property_key, property_value)
-            .into_iter()
-            .filter(|node_id| !self.buffer.has_modified_node(*node_id))
-            .filter(|node_id| {
+            .find_nodes_by_property(label, property_key, property_value);
+
+        results.retain(|node_id| {
+            !self.buffer.has_modified_node(*node_id) && {
                 self.current
                     .get_node(*node_id)
                     .map(|node| {
@@ -847,8 +848,8 @@ impl ReadOps for WriteTransaction {
                             .is_visible(&self.snapshot, node.metadata.created_by_tx)
                     })
                     .unwrap_or(false)
-            })
-            .collect();
+            }
+        });
 
         // 2. Scan buffered writes for matching CreateNode/UpdateNode
         let label_id = GLOBAL_INTERNER.get_id(label);


### PR DESCRIPTION
💡 What: Replaced `.into_iter().filter(...).collect()` chains with `.retain(...)` when filtering `NodeId` and `EdgeId` vectors in `ReadTransaction` and `WriteTransaction` methods.
🎯 Why: Extracting a `Vec` from lower-level APIs (`CurrentStorage`) and immediately filtering it via a new iterator chain forces a complete reallocation of the filtered items into a new `Vec` on the heap.
📊 Impact: Eliminates one heap allocation per call to `filter_visible_edges` and `find_nodes_by_property`, reducing memory churn and improving cache locality during property and edge resolution queries.
🔬 Measurement: Run `cargo bench` on query operations and `cargo test --lib api::transaction`.

---
*PR created automatically by Jules for task [763563375191866430](https://jules.google.com/task/763563375191866430) started by @madmax983*