### PR TITLE
⚒️ Forge: Extract negative number parsing in `parse_value`

### DIFF
--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -793,26 +793,28 @@ impl Parser {
                 self.advance();
                 Ok(v)
             }
-            Some(Token::Dash) => {
-                self.advance();
-                match self.current() {
-                    Some(Token::IntegerLiteral(n)) => {
-                        let v = PropertyValue::Int(-*n);
-                        self.advance();
-                        Ok(v)
-                    }
-                    Some(Token::FloatLiteral(f)) => {
-                        let v = PropertyValue::Float(-*f);
-                        self.advance();
-                        Ok(v)
-                    }
-                    _ => Err(self.error(
-                        "Expected number after '-'".to_string(),
-                        Some("number".to_string()),
-                    )),
-                }
-            }
+            Some(Token::Dash) => self.parse_negative_number(),
             _ => Err(self.error("Expected value".to_string(), Some("value".to_string()))),
+        }
+    }
+
+    fn parse_negative_number(&mut self) -> Result<PropertyValue, ParseError> {
+        self.advance(); // consume Dash
+        match self.current() {
+            Some(Token::IntegerLiteral(n)) => {
+                let v = PropertyValue::Int(-*n);
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::FloatLiteral(f)) => {
+                let v = PropertyValue::Float(-*f);
+                self.advance();
+                Ok(v)
+            }
+            _ => Err(self.error(
+                "Expected number after '-'".to_string(),
+                Some("number".to_string()),
+            )),
         }
     }
 


### PR DESCRIPTION
* 🚮 Smell: `parse_value` contained a deeply nested `match` block specifically for handling negative numbers, which reduced readability and increased complexity of the primary function.
* ✨ Solution: Extracted the nested match statement handling `Token::Dash` into a named helper function `parse_negative_number()`.
* 🧼 Benefit: Flattens the function logic, making `parse_value` easier to read and maintain, adhering to single responsibility.
* 🛡️ Verification: Ran `cargo clippy`, `cargo fmt`, and `cargo test --features nova query::parser`, all of which passed cleanly without changing runtime behavior.

---
*PR created automatically by Jules for task [16250497337178269821](https://jules.google.com/task/16250497337178269821) started by @madmax983*