### PR TITLE
⚖️ Elenchus: `src/core/temporal.rs` Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -339,3 +339,17 @@
 **Finding:** The FNV-1a fallback tests for `IdentityHasher` (`test_identity_hasher_write_fallback_fnv` and `test_identity_hasher_write_fallback_fnv_dirty`) were tautological. They exactly mirrored the source implementation by reconstructing the FNV-1a multiplication and XOR sequence to generate their `expected` values. This meant they only asserted that "the code is the code" and provided no independent verification that the hashing logic was correct or consistent with standard FNV-1a.
 **Evidence:** The original tests explicitly copied the sequence `expected ^= 1; expected = expected.wrapping_mul(FNV_PRIME);` which exactly mirrors the `write` loop. Any mutation altering `FNV_PRIME` or the operation order would survive if the same change was incorrectly made to the test or if it was inherently flawed.
 **Recommendation:** Refactored the tests to use independently pre-computed integer constants as the `expected` values (the Oracle Problem solution). This ensures the implementation matches the ground truth rather than itself.
+
+**[Temporal Time Conversions Coverage Gap]**
+**Module:** `src/core/temporal.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The `time::from_secs`, `time::from_millis`, `time::to_secs`, `time::to_millis`, and `time::to_iso8601` methods lacked dedicated strict tests. As a result, many basic mathematical operations (`/` mutated to `*`, etc) within them could be mutated without failing any test cases.
+**Evidence:** Missing explicit test boundaries for internal maths.
+**Recommendation:** Added `test_time_conversions_mutants_strict` which covers exact values for integer conversions and ensures `to_iso8601` doesn't output blank or identical constant outputs.
+
+**[Temporal `to_iso8601` Bug and Weak Test Avoidance]**
+**Module:** `src/core/temporal.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The function `time::to_iso8601` is actively hiding a bug where it outputs a raw `SystemTime` debug string (`SystemTime { tv_sec: ... }`) instead of a valid ISO-8601 string. The initial strict test attempt highlighted this brittle behavior.
+**Evidence:** The output string format depends entirely on the OS implementation of `Debug` for `std::time::SystemTime`.
+**Recommendation:** Documented this bug. In `test_time_conversions_mutants_strict`, we opted for an `assert_ne` check using distinct inputs to catch arithmetic mutations without codifying and asserting against the currently broken, non-ISO-8601 `Debug` output format. The production code should be fixed to output true ISO-8601 (e.g., using `chrono`) as the comments inside the function suggest.

--- a/tests/sentry_temporal.rs
+++ b/tests/sentry_temporal.rs
@@ -1092,3 +1092,71 @@ fn test_timerange_from_at_mutants_strict() {
     });
     assert!(res.is_ok(), "Mutant test: != -> == in at");
 }
+
+#[test]
+fn test_time_conversions_mutants_strict() {
+    use aletheiadb::core::hlc::HybridTimestamp;
+    use aletheiadb::core::temporal::TIMESTAMP_MAX;
+    use aletheiadb::core::temporal::time;
+
+    // Test to_iso8601
+    assert_eq!(
+        time::to_iso8601(TIMESTAMP_MAX),
+        "current",
+        "Mutant test: to_iso8601 TIMESTAMP_MAX"
+    );
+
+    // We test that `to_iso8601` performs its internal calculations without hardcoding the
+    // platform-specific `Debug` format of `SystemTime` it currently returns.
+    // The current implementation is known to return `SystemTime` debug strings, not actual ISO8601.
+    // We assert that the output changes when the input timestamp changes, which kills arithmetic mutants.
+
+    let ts_base = HybridTimestamp::new(2_500_000, 0).unwrap();
+    let ts_diff = HybridTimestamp::new(3_500_000, 0).unwrap();
+
+    let iso_base = time::to_iso8601(ts_base);
+    let iso_diff = time::to_iso8601(ts_diff);
+
+    assert_ne!(
+        iso_base, iso_diff,
+        "Mutant test: arithmetic operations in to_iso8601 must affect the final output string"
+    );
+
+    // Let's test from_secs
+    assert_eq!(
+        time::from_secs(2),
+        HybridTimestamp::new(2_000_000, 0).unwrap(),
+        "Mutant test: from_secs * -> +/etc"
+    );
+
+    // Test from_millis
+    assert_eq!(
+        time::from_millis(2000),
+        HybridTimestamp::new(2_000_000, 0).unwrap(),
+        "Mutant test: from_millis * -> +/etc"
+    );
+
+    // Test to_secs
+    assert_eq!(
+        time::to_secs(HybridTimestamp::new(2_000_000, 0).unwrap()),
+        2,
+        "Mutant test: to_secs / -> *"
+    );
+    assert_eq!(
+        time::to_secs(HybridTimestamp::new(3_000_000, 0).unwrap()),
+        3,
+        "Mutant test: to_secs 0 or 1"
+    );
+
+    // Test to_millis
+    assert_eq!(
+        time::to_millis(HybridTimestamp::new(2_000_000, 0).unwrap()),
+        2000,
+        "Mutant test: to_millis / -> *"
+    );
+    assert_eq!(
+        time::to_millis(HybridTimestamp::new(3_000_000, 0).unwrap()),
+        3000,
+        "Mutant test: to_millis 0 or 1"
+    );
+}


### PR DESCRIPTION
Overall mutation-readiness assessment of the module.

- **`test_time_conversions_mutants_strict`:** added strict tests for internal conversion logic. Found the tests lacking in boundaries causing basic math operators like replacing `/` with `%` surviving. Adding fixed expected tests to prevent tautological testing.
- **`to_iso8601`:** explicitly tracked as 🟡 Suspect since the internal return result string depends on the debug formatted implementation representation for Rust. We avoided fixing it explicitly in the codebase according to strict boundaries instead, we caught this mutation bug using an assert to see if the string actually differs.
- The `time::to_iso8601` returning platform-specific formatting strings was explicitly documented.

---
*PR created automatically by Jules for task [11290406110383035103](https://jules.google.com/task/11290406110383035103) started by @madmax983*