### PR TITLE
⚡ Bolt: Avoid target_shards cloning with Cow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 **[Optimize Filtering with `Vec::retain`]**
 **Learning:** When retrieving a `Vec` from a lower-level API and immediately filtering it, chaining `.into_iter().filter(...).collect()` forces the allocation of a completely new `Vec` on the heap, which is an unnecessary allocation.
 **Action:** Use `.retain(...)` on the existing `Vec` to filter the elements in-place. This preserves the original allocation and prevents unnecessary memory allocations in hot paths like querying the graph structure.
+
+**Optimize query target_shards Pre-allocation with Cow**
+**Learning:** In hot paths like distributed query execution (`execute` in `src/storage/sharding/executor.rs`), cloning `Vec` inputs (`shards.clone()`) creates unnecessary heap allocations and memory copies.
+**Action:** Use `std::borrow::Cow` to wrap inputs that may either be borrowed directly or constructed on the fly. `Cow<'_, [T]>` enables passing slice references without cloning when available (`Cow::Borrowed(slice)`), while retaining the ability to fall back to an owned collection (`Cow::Owned(vec)`) seamlessly. This removes a heap allocation for every query execution specifying `target_shards`.

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -39,6 +39,7 @@ use super::network::{NetworkError, NetworkResult, ShardClient};
 use super::router::{ShardRouter, TraversalPlan};
 use super::types::ShardId;
 use crate::core::id::NodeId;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -333,9 +334,11 @@ impl<C: ShardClient> QueryExecutor<C> {
         let timeout = query.timeout.unwrap_or(self.config.default_timeout);
 
         // Determine target shards
-        let target_shards = match &query.target_shards {
-            Some(shards) => shards.clone(),
-            None => self.clients.keys().copied().collect(),
+        // ⚡ Bolt Optimization: Avoid cloning target shards when provided in the query
+        // by using Cow to borrow the slice instead of allocating a new Vec.
+        let target_shards: Cow<'_, [ShardId]> = match &query.target_shards {
+            Some(shards) => Cow::Borrowed(shards),
+            None => Cow::Owned(self.clients.keys().copied().collect()),
         };
 
         if target_shards.is_empty() {
@@ -346,7 +349,7 @@ impl<C: ShardClient> QueryExecutor<C> {
         let mut results: Vec<ShardResult> = Vec::with_capacity(target_shards.len());
         let mut failures: Vec<(ShardId, NetworkError)> = Vec::new();
 
-        for shard_id in &target_shards {
+        for shard_id in target_shards.as_ref() {
             if start.elapsed() >= timeout {
                 // Timed out before sending to all shards
                 let pending: Vec<_> = target_shards


### PR DESCRIPTION
💡 What: Replaced `shards.clone()` with `Cow::Borrowed(shards)` and `Cow::Owned(clients.keys().copied().collect())` in `src/storage/sharding/executor.rs`.
🎯 Why: `execute()` is a hot path for every distributed query. Cloning the `target_shards` vector for every query with specified targets leads to unnecessary memory allocations on the heap and data copying.
📊 Impact: Eliminates a complete heap allocation and buffer copy (`Vec::clone`) on every query execution specifying `target_shards`, which improves overall distributed query latency and memory efficiency.
🔬 Measurement: Run bench on `execute` method under concurrent read pressure or verify the lack of `Vec::clone()` through memory profiling. No changes in tests are required to run them (verified via `cargo check` and `cargo test`).

---
*PR created automatically by Jules for task [8026655446954425951](https://jules.google.com/task/8026655446954425951) started by @madmax983*