### PR TITLE
🛡️ Sentry: [PredicatePushdown test coverage improvement]

### DIFF
--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -596,7 +596,7 @@ mod sentry_tests {
                     depth: crate::query::ir::TraversalDepth::Exact(1),
                 },
                 LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
-            )
+            ),
         ));
 
         let result = rule.apply(&plan, &stats).unwrap();

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -552,6 +552,96 @@ mod tests {
 #[cfg(test)]
 mod sentry_tests {
     use super::*;
+
+    #[test]
+    fn test_apply_unchanged() {
+        let rule = PredicatePushdown;
+        let stats = Statistics::default();
+        let plan = LogicalPlan::new(LogicalOp::Scan(ScanOp::NodeLookup(vec![
+            NodeId::new(1).unwrap(),
+        ])));
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_apply_changed() {
+        let rule = PredicatePushdown;
+        let stats = Statistics::default();
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("a", 1)),
+            LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: SortKey::Property("a".to_string()),
+                    descending: true,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_pushdown_traverse() {
+        let rule = PredicatePushdown;
+        let stats = Statistics::default();
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("a", 1)),
+            LogicalOp::unary(
+                UnaryOp::Traverse {
+                    label: None,
+                    direction: crate::query::ir::Direction::Outgoing,
+                    depth: crate::query::ir::TraversalDepth::Exact(1),
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            )
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        // Filter cannot push past Traverse
+        assert!(result.is_none());
+    }
+    #[test]
+    fn test_pushdown_unsupported_unary_op() {
+        let rule = PredicatePushdown;
+        let stats = Statistics::default();
+
+        // Filter inside an unsupported UnaryOp (like Limit) should be passed through
+        // but limit itself cannot be pushed down into.
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("a", 1)),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        // Since Filter is directly above Scan, it doesn't change.
+        // Limit -> Filter -> Scan
+        // push_down(Limit(Filter(Scan))) -> Limit(push_down(Filter(Scan))) -> Limit(Filter(Scan))
+        assert!(result.is_none());
+
+        let plan2 = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("a", 1)),
+            LogicalOp::unary(
+                UnaryOp::Limit(10),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+
+        let result2 = rule.apply(&plan2, &stats).unwrap();
+        // Filter cannot push past Limit
+        assert!(result2.is_none());
+    }
+    #[test]
+    fn test_pushdown_name() {
+        let rule = PredicatePushdown;
+        assert_eq!(rule.name(), "predicate-pushdown");
+    }
+
     use crate::core::NodeId;
     use crate::query::ir::Predicate;
     use crate::query::plan::{BinaryOp, ScanOp, SortKey};


### PR DESCRIPTION
🎯 Target: `src/query/planner/rules/predicate_pushdown.rs`

💣 Risk: Untested fallthrough behavior logic in pushdown rules, or undetected errors in `OptimizationRule::name()` or `OptimizationRule::apply()` method return values, could lead to silent bugs or regressions during future refactorings.

🧪 Strategy:
*   Added `test_pushdown_name` to explicitly test `OptimizationRule::name`.
*   Added `test_apply_changed` and `test_apply_unchanged` to directly verify logic branching in `OptimizationRule::apply`.
*   Added `test_pushdown_unsupported_unary_op` to test fallback `LogicalOp::Unary` pushdown mechanics through `Limit` and non-`Filter` UnaryOp nesting.
*   Added `test_pushdown_traverse` to explicitly catch and test the `Traverse` blocking match arm inside `push_down`.

🔬 Verification: Run `cargo test --features nova -p aletheiadb --lib query::planner::rules::predicate_pushdown` to verify all new tests run correctly and pass.

---
*PR created automatically by Jules for task [14411829792630117081](https://jules.google.com/task/14411829792630117081) started by @madmax983*