### PR TITLE
🛡️ Sentry: [test coverage improvement] for index_persistence

### DIFF
--- a/src/storage/index_persistence/error.rs
+++ b/src/storage/index_persistence/error.rs
@@ -86,3 +86,48 @@ impl IndexPersistenceError {
 
 /// Result type for index persistence operations.
 pub type Result<T> = std::result::Result<T, IndexPersistenceError>;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn should_return_true_when_error_is_not_found() {
+        // Test with NotFound error
+        let err =
+            IndexPersistenceError::Io(io::Error::new(io::ErrorKind::NotFound, "file missing"));
+        assert!(
+            err.is_not_found(),
+            "is_not_found() should return true for ErrorKind::NotFound"
+        );
+
+        // Test with other IO error
+        let err2 =
+            IndexPersistenceError::Io(io::Error::new(io::ErrorKind::PermissionDenied, "denied"));
+        assert!(
+            !err2.is_not_found(),
+            "is_not_found() should return false for other IO errors"
+        );
+
+        // Test with non-IO error
+        let err3 = IndexPersistenceError::MissingIndex {
+            name: "test".to_string(),
+        };
+        assert!(
+            !err3.is_not_found(),
+            "is_not_found() should return false for non-IO errors"
+        );
+    }
+
+    #[test]
+    fn should_convert_from_bitcode_error() {
+        let bad_data = vec![0xFF, 0xFF, 0xFF];
+        let bitcode_err = bitcode::decode::<u32>(&bad_data).unwrap_err();
+
+        let err: IndexPersistenceError = bitcode_err.into();
+        assert!(
+            matches!(err, IndexPersistenceError::Serialization(_)),
+            "Should wrap bitcode::Error in Serialization variant"
+        );
+    }
+}

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -636,3 +636,61 @@ impl Default for StringPersistencePolicy {
         }
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_have_default_vector_policy() {
+        let policy = VectorPersistencePolicy::default();
+        assert_eq!(policy.mutation_threshold, 1000);
+        assert_eq!(policy.time_interval_secs, 300);
+    }
+
+    #[test]
+    fn should_have_default_graph_policy() {
+        let policy = GraphPersistencePolicy::default();
+        assert!(policy.on_adjacency_rebuild);
+        assert_eq!(policy.mutation_threshold, 5000);
+        assert_eq!(policy.time_interval_secs, 600);
+    }
+
+    #[test]
+    fn should_have_default_temporal_policy() {
+        let policy = TemporalPersistencePolicy::default();
+        assert_eq!(policy.version_threshold, 1000);
+        assert_eq!(policy.anchor_threshold, 100);
+        assert_eq!(policy.time_interval_secs, 300);
+    }
+
+    #[test]
+    fn should_have_default_string_policy() {
+        let policy = StringPersistencePolicy::default();
+        assert_eq!(policy.new_strings_threshold, 500);
+        assert_eq!(policy.time_interval_secs, 600);
+    }
+
+    #[test]
+    fn should_have_default_persistence_policies() {
+        let policy = PersistencePolicies::default();
+        assert_eq!(policy.vector, VectorPersistencePolicy::default());
+        assert_eq!(policy.graph, GraphPersistencePolicy::default());
+        assert_eq!(policy.temporal, TemporalPersistencePolicy::default());
+        assert_eq!(policy.strings, StringPersistencePolicy::default());
+    }
+
+    #[test]
+    fn should_serialize_and_deserialize_persistence_policies() {
+        let policy = PersistencePolicies {
+            vector: VectorPersistencePolicy { mutation_threshold: 42, time_interval_secs: 43 },
+            graph: GraphPersistencePolicy { on_adjacency_rebuild: false, mutation_threshold: 44, time_interval_secs: 45 },
+            temporal: TemporalPersistencePolicy { version_threshold: 46, anchor_threshold: 47, time_interval_secs: 48 },
+            strings: StringPersistencePolicy { new_strings_threshold: 49, time_interval_secs: 50 },
+        };
+
+        let encoded = bitcode::encode(&policy);
+        let decoded: PersistencePolicies = bitcode::decode(&encoded).unwrap();
+
+        assert_eq!(policy, decoded);
+    }
+}

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -682,10 +682,24 @@ mod tests {
     #[test]
     fn should_serialize_and_deserialize_persistence_policies() {
         let policy = PersistencePolicies {
-            vector: VectorPersistencePolicy { mutation_threshold: 42, time_interval_secs: 43 },
-            graph: GraphPersistencePolicy { on_adjacency_rebuild: false, mutation_threshold: 44, time_interval_secs: 45 },
-            temporal: TemporalPersistencePolicy { version_threshold: 46, anchor_threshold: 47, time_interval_secs: 48 },
-            strings: StringPersistencePolicy { new_strings_threshold: 49, time_interval_secs: 50 },
+            vector: VectorPersistencePolicy {
+                mutation_threshold: 42,
+                time_interval_secs: 43,
+            },
+            graph: GraphPersistencePolicy {
+                on_adjacency_rebuild: false,
+                mutation_threshold: 44,
+                time_interval_secs: 45,
+            },
+            temporal: TemporalPersistencePolicy {
+                version_threshold: 46,
+                anchor_threshold: 47,
+                time_interval_secs: 48,
+            },
+            strings: StringPersistencePolicy {
+                new_strings_threshold: 49,
+                time_interval_secs: 50,
+            },
         };
 
         let encoded = bitcode::encode(&policy);

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -355,3 +355,51 @@ pub fn load_indexes_parallel(
 
     Ok((graph_data, temporal_data, vector_data))
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn should_atomically_write_file() {
+        let dir = tempdir().unwrap();
+        let target_path = dir.path().join("test.txt");
+
+        // Write initial data
+        let data1 = b"hello world";
+        atomic_write(&target_path, data1).unwrap();
+
+        // Verify it was written
+        assert_eq!(fs::read(&target_path).unwrap(), data1);
+
+        // Overwrite
+        let data2 = b"new data";
+        atomic_write(&target_path, data2).unwrap();
+
+        // Verify it was overwritten correctly
+        assert_eq!(fs::read(&target_path).unwrap(), data2);
+
+        // Check no temp files left behind
+        let mut count = 0;
+        for entry in fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            assert_eq!(
+                entry.file_name(),
+                "test.txt",
+                "Should not have temporary files left"
+            );
+            count += 1;
+        }
+        assert_eq!(count, 1, "Should exactly have 1 file");
+    }
+
+    #[test]
+    fn should_fail_atomic_write_on_invalid_path() {
+        // Use a path that definitely doesn't exist to cause IO error
+        let path = std::path::PathBuf::from("/does/not/exist/anywhere/test.txt");
+        let result = atomic_write(&path, b"test");
+        assert!(result.is_err(), "Should return error for invalid directory");
+        assert!(matches!(result.unwrap_err(), IndexPersistenceError::Io(_)));
+    }
+}


### PR DESCRIPTION
🎯 **Target:**
`src/storage/index_persistence/error.rs`
`src/storage/index_persistence/formats.rs`
`src/storage/index_persistence/mod.rs`

💣 **Risk:**
- `error.rs`: If `IndexPersistenceError::is_not_found()` incorrectly flagged other IO errors as `NotFound`, the persistence manager might attempt to create indexes in directories without permissions rather than just handling initialization properly.
- `mod.rs`: `atomic_write` failure handling logic and temp file left-overs inside the index persistence loop could corrupt indices or exhaust disk space without alerting standard tests.
- `formats.rs`: Silent regressions to default index persistence policies (e.g., temporal or string persist intervals) could impact database performance silently.

🧪 **Strategy:**
- Added robust snapshot tests to verify `IndexPersistenceError::is_not_found` only matches `io::ErrorKind::NotFound`.
- Verified round-trip encoding logic via `bitcode::Error` mapping implementations.
- Leveraged `tempfile` inside `mod.rs` test module to simulate a full `atomic_write` lifecycle and assert zero temporary files were orphaned during atomic renames.
- Explicitly asserted default policy values in `formats.rs`.

🔬 **Verification:**
```bash
cargo test --lib index_persistence
```

---
*PR created automatically by Jules for task [970212360176023028](https://jules.google.com/task/970212360176023028) started by @madmax983*