### PR TITLE
🎻 Bard: [documentation update] Fix experimental feature leaks and doctest warnings

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -89,3 +89,6 @@
 ## 2025-03-05 - The Spark and Details Format
 **Confusion:** Basic documentation comments like "Creates a new ID" don't help tired developers understand *why* strong types exist or *when* checkpoints trigger.
 **Clarification:** Added `# The Spark` and `# The Details` narrative structures to `NodeId`, `EdgeId`, `VersionId`, and `CheckpointManager` methods to explain the context of use, plus concrete `# Examples`.
+## 2025-03-05 - Experimental Feature Leaks II & Doctest Conditionals
+**Confusion:** Several experimental modules (`chronos`, `echo`, `sherlock`, and `temporal_narrative`) in `src/experimental/mod.rs` were missing their `#[cfg(feature = "nova")]` gating attributes. This allowed them to leak into the public API without the required feature flag enabled. Furthermore, the doctests for `sherlock` (in `mod.rs`) and `kairos` used an anonymous block (`# { ... }`) for feature gating, which generated `main function not found` or `expressions at the top level` warnings in `cargo test --doc`.
+**Clarification:** Added the missing `#[cfg(feature = "nova")]` attributes to the exposed experimental modules. Fixed the doctests to use conditional compilation on the `main` function and imports themselves (`# #[cfg(feature = "nova")] \n fn main() { ... }`), and added an empty fallback `main` function for when the feature is disabled.

--- a/src/experimental/kairos.rs
+++ b/src/experimental/kairos.rs
@@ -17,9 +17,12 @@
 //! # Example
 //!
 //! ```rust,no_run
+//! # #[cfg(feature = "nova")]
 //! use aletheiadb::AletheiaDB;
+//! # #[cfg(feature = "nova")]
 //! use aletheiadb::experimental::kairos::Kairos;
 //!
+//! # #[cfg(feature = "nova")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let db = AletheiaDB::new()?;
 //! let kairos = Kairos::new(&db);
@@ -33,6 +36,8 @@
 //! }
 //! # Ok(())
 //! # }
+//! # #[cfg(not(feature = "nova"))]
+//! # fn main() {}
 //! ```
 
 use crate::AletheiaDB;

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -62,12 +62,15 @@
 //! // aletheiadb = { version = "0.1", features = ["nova"] }
 //!
 //! # #[cfg(feature = "nova")]
-//! # {
 //! use aletheiadb::AletheiaDB;
+//! # #[cfg(feature = "nova")]
 //! use aletheiadb::experimental::sherlock::{Sherlock, Mystery, Clue};
+//! # #[cfg(feature = "nova")]
 //! use aletheiadb::core::property::PropertyValue;
+//! # #[cfg(feature = "nova")]
 //! use std::time::Duration;
 //!
+//! # #[cfg(feature = "nova")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let db = AletheiaDB::new()?;
 //! # let node_id = db.create_node("User", Default::default())?;
@@ -90,7 +93,6 @@
 //!     println!("🕵️ Sherlock found {} suspicious sequences!", detections.len());
 //! }
 //! # Ok(())
-//! # }
 //! # }
 //! # #[cfg(not(feature = "nova"))]
 //! # fn main() {}
@@ -117,6 +119,7 @@ pub mod chameleon;
 #[cfg(feature = "nova")]
 /// Chimera: Hybrid Entity Synthesis Engine.
 pub mod chimera;
+#[cfg(feature = "nova")]
 /// Chronos: Temporal Graph Analysis & Pathfinding.
 pub mod chronos;
 #[cfg(feature = "nova")]
@@ -128,6 +131,7 @@ pub mod dissonance;
 #[cfg(feature = "nova")]
 /// Semantic Trajectory Extrapolation ("Dreamer").
 pub mod dreamer;
+#[cfg(feature = "nova")]
 /// Temporal Resonance Engine ("Echo") for finding nodes with similar activity patterns.
 pub mod echo;
 #[cfg(feature = "nova")]
@@ -168,6 +172,7 @@ pub mod ripple;
 #[cfg(feature = "nova")]
 /// Semantic Navigator for vector-guided pathfinding.
 pub mod semantic_navigator;
+#[cfg(feature = "nova")]
 /// Sherlock: Temporal Pattern Matching Engine.
 pub mod sherlock;
 #[cfg(feature = "nova")]
@@ -184,6 +189,7 @@ pub mod telepathy;
 #[cfg(feature = "nova")]
 /// Temporal Diff Engine for computing snapshot differences.
 pub mod temporal_diff;
+#[cfg(feature = "nova")]
 /// Temporal narrative generator for natural language history logs.
 pub mod temporal_narrative;
 


### PR DESCRIPTION
📖 Chapter: The `experimental` module ("Nova" playground)
🔦 Insight: Several experimental features (`chronos`, `echo`, `sherlock`, and `temporal_narrative`) were missing their `#[cfg(feature = "nova")]` gating attributes in `src/experimental/mod.rs`, causing them to leak into the public API even when the feature was disabled. Additionally, the doctests for `sherlock` and `kairos` used improper feature-gating via anonymous blocks (`# { ... }`), which caused `cargo test --doc` to emit `main function not found` or `expressions at the top level` warnings. This PR adds the missing feature gates and properly structures the doctests with conditionally compiled `main` functions.
🧪 Example: Modified doctests now run correctly in `cargo test --doc` without warnings.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [13664170159611149878](https://jules.google.com/task/13664170159611149878) started by @madmax983*