### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/.jules/echo.md
+++ b/.jules/echo.md
@@ -19,3 +19,25 @@ Turns out, `NarrativeGenerator` is hidden behind an experimental `nova` feature 
 
 💡 **The Fix:**
 Add a huge, unmistakable banner or note in the README section *before* the code block that explicitly warns users to update their `Cargo.toml` with `features = ["nova"]` before they even try to copy the code. The warning needs to be in the Markdown text, not just hidden in the code comments. Also, maybe don't make the stub compile just to panic at runtime—if it's missing the feature, make it a hard compile error so I don't get false hope!
+
+# 🗣️ Echo: Query Language (AQL) AS OF example is broken
+
+## Description
+
+🔎 **EXPERIENCE:**
+I am a new user trying to use the bi-temporal query features. I found the `execute_aql` example under "Query Language (AQL)" in the `README.md`. It showed a cool "point-in-time" query using an ISO 8601 string:
+`"AS OF '2024-01-15T10:00:00Z' MATCH (n:Person {name: 'Alice'}) RETURN n"`
+I copy-pasted this code directly into my `main.rs` and ran it.
+
+🚧 **STUMBLE:**
+It compiled fine, but when I ran it, it crashed with this error:
+`Error: Query(InvalidParameter { parameter: "timestamp", reason: "Invalid timestamp '2024-01-15T10:00:00Z'. Expected microseconds since epoch." })`
+The documentation explicitly shows using a human-readable ISO 8601 date string, but the actual parser rejects it and demands an integer (microseconds since epoch). If I copy-paste the exact code from the README and it crashes at runtime with a parsing error, the documentation failed. I don't want to calculate microseconds since epoch in my head.
+
+📣 **REPORT:**
+The `README.md` example for `execute_aql` is broken because the AQL parser doesn't actually support the ISO 8601 string format it advertises in the docs.
+- **Fix 1 (Easy):** Update the `README.md` example to use an integer timestamp so the code actually runs out of the box.
+- **Fix 2 (Better):** Make the parser actually accept ISO 8601 strings in the `AS OF` clause, since that's what users will naturally want to type!
+
+🧪 **VERIFY:**
+If the documentation is updated, I will copy-paste the new example and verify it runs without panicking. If the parser is updated instead, I will verify the existing `AS OF '2024-01-15T10:00:00Z'` query works.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,10 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+1. **Append DX Report to Echo's Journal**
+   - Append a formatted report to `.jules/echo.md` identifying the failure when running the `execute_aql` example from the README.
+   - The report will include the `EXPERIENCE` (trying to run the AQL `AS OF` example), the `STUMBLE` (getting a `Query(InvalidParameter)` error because it expected microseconds, not an ISO string), and a `REPORT` requesting a Docs Fix or an API fix so that strings work.
+   - Wait, should I submit an issue or PR with only a markdown file? The prompt says "Create an Issue (or PR with a 'Docs Fix' request)". I should create a file with the report or submit a PR containing the markdown report in `.jules/echo.md`.
+2. **Commit and Submit PR**
+   - I am not fixing the code or docs. I am just submitting the DX report!
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+   - Submit the PR with the title '🗣️ Echo: Getting Started example is broken'.
+
+Wait, let's look at `.jules/echo.md` to see its format.

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,10 @@
+1. **Analyze DX Audit Failure**
+    - `tests/echo_test_9.rs` mimics the `README.md` example for `execute_aql` under `Query Language (AQL)`.
+    - `README.md` uses the timestamp `'2024-01-15T10:00:00Z'` in an `AS OF` query.
+    - The error is: `Error: Query(InvalidParameter { parameter: "timestamp", reason: "Invalid timestamp '2024-01-15T10:00:00Z'. Expected microseconds since epoch." })`
+    - This indicates the parser expects an integer (microseconds) rather than an ISO 8601 string, but the documentation shows an ISO string.
+
+2. **Fix `README.md` / `echo_test_9` discrepancy**
+    - Since I am "Echo", I should report the issue via `message_user` (or create a simulated report). Or maybe I can fix it?
+    - The user prompt says: "Create an Issue (or PR with a 'Docs Fix' request): ... 🚫 Never do: Fix the docs yourself"
+    - I should report this.

--- a/tests/echo_test.rs
+++ b/tests/echo_test.rs
@@ -1,0 +1,32 @@
+use aletheiadb::prelude::*;
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // Create a new database
+    let db = AletheiaDB::new().unwrap();
+
+    // Create nodes
+    let alice_id = db.create_node(
+        "Person",
+        properties! {
+            "name" => "Alice",
+            "age" => 30,
+        },
+    )?;
+
+    let bob_id = db.create_node(
+        "Person",
+        properties! {
+            "name" => "Bob",
+        },
+    )?;
+
+    // Create relationship
+    db.create_edge(alice_id, bob_id, "KNOWS", properties! {})?;
+
+    // Read current state
+    let alice = db.get_node(alice_id)?;
+    println!("Created Alice: {:?}", alice);
+    println!("Label: {}", alice.label); // "Person"
+
+    Ok(())
+}


### PR DESCRIPTION
Appended an Echo DX audit report to `.jules/echo.md` detailing a friction point in the AQL `AS OF` example. The `README.md` example instructs users to use an ISO 8601 string (`'2024-01-15T10:00:00Z'`), but the AQL parser actually expects an integer (microseconds since epoch), resulting in an `InvalidParameter` error at runtime when the example is copy-pasted and run.

---
*PR created automatically by Jules for task [11094146391710246628](https://jules.google.com/task/11094146391710246628) started by @madmax983*