### PR TITLE
⚡ Bolt: Use stack array for SegmentMetadata reading

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -310,10 +310,12 @@ impl FlushCoordinator {
     }
 
     /// Read segment metadata from a companion file.
+    ///
+    /// ⚡ Bolt Optimization: Replace Vec::new() heap allocation with a fixed 24-byte stack array when reading metadata.
     pub fn read_segment_metadata(&self, segment_id: u64) -> Option<SegmentMetadata> {
         let meta_path = self.segment_meta_path(segment_id);
-        let mut bytes = Vec::new();
-        File::open(&meta_path).ok()?.read_to_end(&mut bytes).ok()?;
+        let mut bytes = [0u8; 24];
+        File::open(&meta_path).ok()?.read_exact(&mut bytes).ok()?;
         SegmentMetadata::from_bytes(&bytes)
     }
 


### PR DESCRIPTION
💡 What: Switched from using a dynamically allocated `Vec` and `read_to_end` to a fixed-size `[0u8; 24]` stack array with `read_exact`.
🎯 Why: `Vec::new()` creates a heap allocation every time `read_segment_metadata` is called. Because the `SegmentMetadata` struct is serialized and deserialized as a known 24-byte structure, reading exactly 24 bytes into a stack array removes this memory overhead completely.
📊 Impact: Eliminates one heap allocation on every WAL segment metadata read, leading to faster IO parsing and reduced memory fragmentation.
🔬 Measurement: Run `cargo test --features nova --lib flush_coordinator`.

---
*PR created automatically by Jules for task [433694887747779167](https://jules.google.com/task/433694887747779167) started by @madmax983*