### PR TITLE
🎻 Bard: [documentation update] Add documentation for public structs in sharded and distributed vector indexes

### DIFF
--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -232,6 +232,28 @@ pub enum CircuitState {
 }
 
 /// Configuration for circuit breaker.
+///
+/// The `CircuitBreakerConfig` defines the thresholds and durations for the
+/// [`NodeCircuitBreaker`] to transition between `Closed`, `Open`, and `HalfOpen` states.
+/// It helps prevent cascading failures in a distributed setup when remote nodes are unresponsive.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::CircuitBreakerConfig;
+/// use std::time::Duration;
+///
+/// let config = CircuitBreakerConfig {
+///     failure_threshold: 5,
+///     open_duration: Duration::from_secs(30),
+///     success_threshold: 3,
+/// };
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct CircuitBreakerConfig {
     /// Number of failures before opening circuit.
@@ -253,6 +275,29 @@ impl Default for CircuitBreakerConfig {
 }
 
 /// Circuit breaker for a single node connection.
+///
+/// The `NodeCircuitBreaker` tracks failures and successes of requests to a remote node
+/// (typically represented by a [`VectorNodeClient`]). If failures exceed the configured
+/// threshold, it transitions to an `Open` state, failing fast. After a timeout, it transitions
+/// to a `HalfOpen` state to test if the node has recovered.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::{CircuitBreakerConfig, NodeCircuitBreaker, CircuitState};
+///
+/// let config = CircuitBreakerConfig::default();
+/// let breaker = NodeCircuitBreaker::new(config);
+///
+/// // Initially, the circuit is closed and allows requests
+/// assert_eq!(breaker.state(), CircuitState::Closed);
+/// assert!(breaker.should_allow());
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug)]
 pub struct NodeCircuitBreaker {
     config: CircuitBreakerConfig,
@@ -417,6 +462,31 @@ impl NodeCircuitBreaker {
 // ============================================================================
 
 /// A connection to a remote vector index node.
+///
+/// The `NodeConnection` wraps a [`VectorNodeClient`] with a [`NodeCircuitBreaker`]
+/// and tracks basic metrics (requests, failures). It acts as the primary interface
+/// for executing requests against a specific node in a distributed index.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::{
+///     MockVectorNodeClient, NodeConnection, CircuitBreakerConfig
+/// };
+/// use aletheiadb::index::vector::DistanceMetric;
+/// use std::sync::Arc;
+///
+/// let client = Arc::new(MockVectorNodeClient::new(0, 384, DistanceMetric::Cosine));
+/// let connection = NodeConnection::new(client, CircuitBreakerConfig::default());
+///
+/// assert_eq!(connection.node_id(), 0);
+/// assert!(connection.is_available());
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 pub struct NodeConnection<C: VectorNodeClient> {
     /// The client for this node.
     client: Arc<C>,
@@ -509,6 +579,29 @@ impl<C: VectorNodeClient> NodeConnection<C> {
 }
 
 /// Statistics for a node connection.
+///
+/// `NodeConnectionStats` contains diagnostic information about a [`NodeConnection`],
+/// including its current circuit state, total requests, and total failures.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::{NodeConnectionStats, CircuitState};
+///
+/// let stats = NodeConnectionStats {
+///     node_id: 1,
+///     circuit_state: CircuitState::Closed,
+///     request_count: 100,
+///     failure_count: 2,
+/// };
+///
+/// assert_eq!(stats.success_rate(), 0.98);
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct NodeConnectionStats {
     /// Node ID.
@@ -537,6 +630,26 @@ impl NodeConnectionStats {
 // ============================================================================
 
 /// Configuration for a single vector node.
+///
+/// The `VectorNodeConfig` describes how to connect to a specific remote node,
+/// including its endpoint, timeout settings, and specific [`CircuitBreakerConfig`].
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::VectorNodeConfig;
+/// use std::time::Duration;
+///
+/// let node_config = VectorNodeConfig::new(1, "node1:9000")
+///     .with_timeout(Duration::from_secs(10));
+///
+/// assert_eq!(node_config.node_id, 1);
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct VectorNodeConfig {
     /// Node ID (must be unique).
@@ -584,6 +697,28 @@ pub enum RoutingStrategy {
 }
 
 /// Configuration for the distributed vector index.
+///
+/// The `DistributedVectorConfig` sets up the topology and behavior for a
+/// [`DistributedVectorIndex`], including the expected vector dimensionality,
+/// distance metric, routing strategy, and the list of [`VectorNodeConfig`]s.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::{DistributedVectorConfig, VectorNodeConfig};
+/// use aletheiadb::index::vector::DistanceMetric;
+///
+/// let config = DistributedVectorConfig::new(384, DistanceMetric::Cosine)
+///     .with_node(VectorNodeConfig::new(0, "node0:9000"))
+///     .with_node(VectorNodeConfig::new(1, "node1:9000"));
+///
+/// assert!(config.validate().is_ok());
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct DistributedVectorConfig {
     /// Vector dimensionality.
@@ -671,6 +806,27 @@ impl DistributedVectorConfig {
 // ============================================================================
 
 /// Statistics for the distributed index.
+///
+/// `DistributedIndexStats` provides a cluster-wide summary of the [`DistributedVectorIndex`],
+/// aggregating counts and holding detailed [`NodeConnectionStats`] for all participating nodes.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::{DistributedIndexStats, NodeConnectionStats, CircuitState};
+///
+/// let stats = DistributedIndexStats {
+///     total_vectors: 1000,
+///     node_count: 2,
+///     available_nodes: 2,
+///     node_stats: vec![], // Would contain actual node stats
+/// };
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct DistributedIndexStats {
     /// Total vectors across all nodes.
@@ -684,6 +840,31 @@ pub struct DistributedIndexStats {
 }
 
 /// Statistics for rebalancing the distributed index.
+///
+/// `RebalanceStats` describes the current balance of vectors across nodes in a
+/// [`DistributedVectorIndex`]. It helps determine if rebalancing is necessary based
+/// on the `imbalance_ratio` compared to the [`RECOMMENDED_IMBALANCE_THRESHOLD`].
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::distributed::RebalanceStats;
+///
+/// let stats = RebalanceStats {
+///     total_vectors: 200,
+///     node_count: 2,
+///     min_node_size: 50,
+///     max_node_size: 150,
+///     imbalance_ratio: 3.0,
+///     vectors_to_move: 50,
+///     node_sizes: vec![(0, 50), (1, 150)],
+/// };
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct RebalanceStats {
     /// Total vectors across all nodes.
@@ -707,6 +888,33 @@ pub struct RebalanceStats {
 /// This structure provides horizontal scalability by partitioning vectors
 /// across multiple remote nodes and coordinating search operations using
 /// a scatter-gather pattern.
+///
+/// See [`DistributedVectorConfig`] for configuring the topology, and
+/// [`VectorNodeClient`] for the required abstraction to interface with remote nodes.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() -> aletheiadb::core::error::Result<()> {
+/// use std::sync::Arc;
+/// use aletheiadb::index::vector::distributed::{
+///     DistributedVectorIndex, DistributedVectorConfig, VectorNodeConfig, MockVectorNodeClient
+/// };
+/// use aletheiadb::index::vector::DistanceMetric;
+///
+/// let config = DistributedVectorConfig::new(128, DistanceMetric::Cosine)
+///     .with_node(VectorNodeConfig::new(0, "node0:9000"));
+///
+/// let client = Arc::new(MockVectorNodeClient::new(0, 128, DistanceMetric::Cosine));
+/// let index = DistributedVectorIndex::new(config, vec![client])?;
+///
+/// assert_eq!(index.node_count(), 1);
+/// # Ok(())
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 pub struct DistributedVectorIndex<C: VectorNodeClient> {
     /// Configuration.
     config: DistributedVectorConfig,
@@ -1107,6 +1315,33 @@ impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
 // ============================================================================
 
 /// Mock client for testing distributed vector operations.
+///
+/// `MockVectorNodeClient` implements the [`VectorNodeClient`] trait in-memory
+/// without actually performing any network I/O. It tracks vectors in a local hash map
+/// and implements simple distance calculations, making it ideal for unit testing
+/// [`DistributedVectorIndex`] logic.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() -> aletheiadb::core::error::Result<()> {
+/// use aletheiadb::index::vector::distributed::{MockVectorNodeClient, VectorNodeClient};
+/// use aletheiadb::index::vector::DistanceMetric;
+/// use aletheiadb::core::id::NodeId;
+///
+/// let client = MockVectorNodeClient::new(0, 128, DistanceMetric::Cosine);
+///
+/// let node_id = NodeId::new(42).unwrap();
+/// let vec = vec![0.1f32; 128];
+/// client.add(node_id, &vec)?;
+///
+/// assert_eq!(client.len()?, 1);
+/// # Ok(())
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug)]
 pub struct MockVectorNodeClient {
     node_id: u16,

--- a/src/index/vector/sharded.rs
+++ b/src/index/vector/sharded.rs
@@ -105,6 +105,27 @@ pub enum ShardingStrategy {
 }
 
 /// Statistics for the sharded index.
+///
+/// `ShardStats` details the distribution of vectors across all shards within a
+/// [`ShardedVectorIndex`]. It computes the `imbalance_ratio` which is critical
+/// for determining if a rebalance operation is necessary.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::sharded::ShardStats;
+///
+/// let stats = ShardStats {
+///     shard_sizes: vec![100, 150, 120, 90],
+///     total_vectors: 460,
+///     imbalance_ratio: 1.66,
+/// };
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Default, Clone)]
 pub struct ShardStats {
     /// Number of vectors in each shard.
@@ -116,6 +137,25 @@ pub struct ShardStats {
 }
 
 /// Configuration for rebalancing shards.
+///
+/// The `RebalanceConfig` sets thresholds and limits for the rebalancing process
+/// inside a [`ShardedVectorIndex`]. It determines when the index is considered
+/// unbalanced and how aggressively it should attempt to fix the distribution.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::sharded::RebalanceConfig;
+///
+/// let config = RebalanceConfig::new()
+///     .with_imbalance_threshold(1.5)
+///     .with_batch_size(2000);
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct RebalanceConfig {
     /// Trigger rebalancing when imbalance ratio exceeds this threshold.
@@ -153,6 +193,27 @@ impl RebalanceConfig {
 }
 
 /// Configuration for the sharded vector index.
+///
+/// `ShardedVectorConfig` dictates the architecture of a [`ShardedVectorIndex`],
+/// configuring the number of shards, the underlying `HnswConfig` for each shard,
+/// and the [`ShardingStrategy`] used to route vectors.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() {
+/// use aletheiadb::index::vector::sharded::{ShardedVectorConfig, ShardingStrategy};
+/// use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
+///
+/// let hnsw_cfg = HnswConfig::new(384, DistanceMetric::Cosine);
+/// let config = ShardedVectorConfig::new(4)
+///     .with_strategy(ShardingStrategy::HashBased)
+///     .with_hnsw_config(hnsw_cfg);
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 #[derive(Debug, Clone)]
 pub struct ShardedVectorConfig {
     /// Number of shards.
@@ -206,11 +267,39 @@ impl Default for ShardedVectorConfig {
 /// This structure provides horizontal scalability by partitioning vectors
 /// across multiple shards and coordinating search operations.
 ///
+/// See [`ShardedVectorConfig`] for initialization options and [`ShardingStrategy`]
+/// for details on vector distribution.
+///
 /// # Fixed Shard Count
 ///
 /// The number of shards is fixed at construction time. This is because the
 /// routing algorithm (hash % num_shards) depends on a consistent shard count.
 /// Changing it would cause existing vectors to be routed to wrong shards.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "nova")]
+/// # fn main() -> aletheiadb::core::error::Result<()> {
+/// use aletheiadb::index::vector::sharded::{ShardedVectorIndex, ShardedVectorConfig, ShardingStrategy};
+/// use aletheiadb::index::vector::{HnswConfig, DistanceMetric, VectorIndex};
+/// use aletheiadb::core::id::NodeId;
+///
+/// let config = ShardedVectorConfig::new(4)
+///     .with_hnsw_config(HnswConfig::new(384, DistanceMetric::Cosine));
+///
+/// let index = ShardedVectorIndex::new(config)?;
+///
+/// let node = NodeId::new(1).unwrap();
+/// let embedding = vec![0.1f32; 384];
+/// index.add(node, &embedding)?;
+///
+/// assert_eq!(index.len(), 1);
+/// # Ok(())
+/// # }
+/// # #[cfg(not(feature = "nova"))]
+/// # fn main() {}
+/// ```
 pub struct ShardedVectorIndex {
     /// Configuration for this index.
     config: ShardedVectorConfig,


### PR DESCRIPTION
📖 Chapter: Vector Search Distribution (`src/index/vector/distributed.rs` & `src/index/vector/sharded.rs`)
    
    🔦 Insight: Several core public structures managing how AletheiaDB distributes and shards vector indexes were lacking `///` documentation and examples. This update demystifies the configuration and state tracking for distributed (Scatter-Gather via Network) and sharded (Hash/Range-based Partitioning) vector topologies, making it significantly easier for users to configure circuit breakers, node connection limits, and rebalance thresholds.
    
    🧪 Example: Added 14 executable doctests showing how to configure `CircuitBreakerConfig`, evaluate `NodeConnectionStats`, spin up a `ShardedVectorIndex`, and analyze `RebalanceStats`.
    
    🖼️ Preview: All undocumented structs in the targeted files now properly render in `cargo doc` with contextual intra-doc links, `## Examples` sections, and correct feature flagging (`#[cfg(feature = "nova")]`).

---
*PR created automatically by Jules for task [15456420695421564658](https://jules.google.com/task/15456420695421564658) started by @madmax983*