### PR TITLE
🗣️ Echo: README Transaction Examples are broken

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
## 🔎 EXPERIENCE
I am a new user trying to run the 'Basic Graph Operations' and 'Explicit read transaction' examples in the README to understand the API.

## 🚧 STUMBLE
When I copy-pasted the examples into my `main.rs`, they failed to compile with multiple errors:
1. `db` was used before being initialized in the explicit read transaction example.
2. `alice_id` was undefined in the `db.read` block.
3. `PropertyMap` was unresolved because it is not included in `aletheiadb::prelude::*`, and `aletheiadb::PropertyMap` was not used.
4. Type inference failed for the generic parameter `E` (error type) in `Ok(root)` within closures.

## 📣 REPORT
The README code blocks are not independent and omit crucial initialization/imports. This violates the 'README Run' principle. 
- Please make sure the example demonstrates full standalone execution, or explicitly state what needs to be imported/initialized.
- Consider adding `PropertyMap` to `aletheiadb::prelude::*`.
- Consider using explicitly typed `Ok::<_, aletheiadb::Error>(...)` when returning from transaction blocks if type inference fails.

## 🧪 VERIFY
I tried wrapping the examples in a standalone `main` block and explicitly imported/initialized the missing parts, which allowed the code to compile. But without those fixes, new users will stumble immediately.

---
*PR created automatically by Jules for task [17516136374992814700](https://jules.google.com/task/17516136374992814700) started by @madmax983*