### PR TITLE
⚡ Bolt: Optimize vector allocation in temporal adjacency index persistence

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 **Optimize query target_shards Pre-allocation with Cow**
 **Learning:** In hot paths like distributed query execution (`execute` in `src/storage/sharding/executor.rs`), cloning `Vec` inputs (`shards.clone()`) creates unnecessary heap allocations and memory copies.
 **Action:** Use `std::borrow::Cow` to wrap inputs that may either be borrowed directly or constructed on the fly. `Cow<'_, [T]>` enables passing slice references without cloning when available (`Cow::Borrowed(slice)`), while retaining the ability to fall back to an owned collection (`Cow::Owned(vec)`) seamlessly. This removes a heap allocation for every query execution specifying `target_shards`.
+
+**Optimize Vec allocations with Vec::with_capacity in loops over collections**
+**Learning:** Initializing a vector with `Vec::new()` and then populating it in a loop whose length is known (e.g. iterating over a `DashMap`) causes unnecessary intermediate heap reallocations.
+**Action:** Use `Vec::with_capacity(collection.len())` when the target collection size is known in advance to avoid these reallocations.

--- a/src/storage/index_persistence/temporal_adjacency.rs
+++ b/src/storage/index_persistence/temporal_adjacency.rs
@@ -107,8 +107,11 @@ pub fn load_temporal_adjacency_index(data_dir: &Path) -> Result<Arc<TemporalAdja
 ///
 /// Only outgoing edges are persisted to disk. The incoming index is automatically
 /// rebuilt during load by calling insert_edge(), which populates both directions.
+///
+/// ⚡ Bolt Optimization: Replacing Vec::new() with Vec::with_capacity() using the exact length of the DashMap (`index.outgoing.len()`).
+/// This removes unnecessary intermediate heap reallocations that occur as the vector expands to accommodate all items.
 fn extract_outgoing_data(index: &TemporalAdjacencyIndex) -> Vec<NodeAdjacencyEntry> {
-    let mut outgoing_entries = Vec::new();
+    let mut outgoing_entries = Vec::with_capacity(index.outgoing.len());
 
     // Extract outgoing edges
     for item in index.outgoing.iter() {


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(index.outgoing.len())` in `extract_outgoing_data` in `src/storage/index_persistence/temporal_adjacency.rs`.
🎯 Why: The function iterates over `index.outgoing` (a `DashMap`) to populate a vector. Using `Vec::new()` causes intermediate heap reallocations as the vector grows. Since the total number of items is known beforehand, pre-allocating the vector avoids this overhead.
📊 Impact: Reduces heap allocations and memory copies during the persistence of the temporal adjacency index, improving snapshotting and disk-write performance for graph traversals.
🔬 Measurement: Verified via `cargo test --lib` and `cargo clippy`. No regressions, and directly eliminates the O(log N) reallocations associated with dynamic `Vec` growth.

---
*PR created automatically by Jules for task [18036091726992710350](https://jules.google.com/task/18036091726992710350) started by @madmax983*