### PR TITLE
🔒 Warden: Fix AWS-LC vulnerabilities

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -36,3 +36,6 @@
 2025-02-15 - [Warden: Replace unsafe transmute_vec with bytemuck::cast_vec]
 **Threat:** `Vec::from_raw_parts` was used in `AdjacencyIndex::import_csr` to transmute types without proper capacity checks, which can lead to Undefined Behavior.
 **Defense:** Replaced the `unsafe` block and `transmute_vec` with `bytemuck::cast_vec` for safe zero-copy transmutation. Added `bytemuck::Pod` and `bytemuck::Zeroable` derivations to `NodeId`.
+**2026-03-24 - Fix AWS-LC vulnerabilities**
+**Threat:** `aws-lc-sys` and `rustls-webpki` had vulnerabilities resulting in possible logic bypass and certificate chain bypass.
+**Defense:** Updated vulnerable dependencies `aws-lc-sys` and `rustls-webpki` to secure versions using `cargo update` and verified via `cargo audit`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,9 +394,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -3075,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
🦠 Threat: `aws-lc-sys` and `rustls-webpki` had vulnerabilities resulting in possible logic bypass and certificate chain bypass.
🛡️ Defense: Updated vulnerable dependencies `aws-lc-sys` and `rustls-webpki` to secure versions using `cargo update` and verified via `cargo audit`.
💥 Severity: Critical - could allow attackers to bypass certificate validation.
🧪 Verification: `cargo audit` returns no further errors for these crates.

---
*PR created automatically by Jules for task [14074856164703032218](https://jules.google.com/task/14074856164703032218) started by @madmax983*