### PR TITLE
🎻 Bard: Useless Getter Documentation Noise

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -92,3 +92,7 @@
 ## 2025-03-05 - Experimental Feature Leaks II & Doctest Conditionals
 **Confusion:** Several experimental modules (`chronos`, `echo`, `sherlock`, and `temporal_narrative`) in `src/experimental/mod.rs` were missing their `#[cfg(feature = "nova")]` gating attributes. This allowed them to leak into the public API without the required feature flag enabled. Furthermore, the doctests for `sherlock` (in `mod.rs`) and `kairos` used an anonymous block (`# { ... }`) for feature gating, which generated `main function not found` or `expressions at the top level` warnings in `cargo test --doc`.
 **Clarification:** Added the missing `#[cfg(feature = "nova")]` attributes to the exposed experimental modules. Fixed the doctests to use conditional compilation on the `main` function and imports themselves (`# #[cfg(feature = "nova")] \n fn main() { ... }`), and added an empty fallback `main` function for when the feature is disabled.
+
+## 2025-03-05 - Useless Getter Noise
+**Confusion:** Trivial getter methods were documented with auto-generated noise like `/// Returns the configuration.`. This added zero value to the developer experience, cluttering `cargo doc` output without explaining *why* the method exists or *how* it should be used in the architecture.
+**Clarification:** Eliminated these "Getters docs" violations by replacing them with `# The Spark` sections. We now document *why* someone would need to retrieve the dimensionality, scoring method, or shard count (e.g., for query planning, safety boundaries, or cluster configuration checks).

--- a/src/honeycomb/config.rs
+++ b/src/honeycomb/config.rs
@@ -123,7 +123,13 @@ impl Options {
         Ok(())
     }
 
-    /// Returns the batch endpoint URL.
+    /// The fully qualified URL for bulk event ingestion.
+    ///
+    /// # The Spark
+    /// The Honeycomb API requires events to be routed to specific datasets. This method
+    /// automatically constructs the correct `/1/batch/{dataset}` path by sanitizing the
+    /// base API host (removing trailing slashes) and appending the configured dataset,
+    /// ensuring the HTTP client always targets the correct ingestion route.
     pub fn batch_endpoint(&self) -> String {
         format!(
             "{}/1/batch/{}",

--- a/src/index/vector/sharded.rs
+++ b/src/index/vector/sharded.rs
@@ -357,17 +357,34 @@ impl ShardedVectorIndex {
         Self::new(config)
     }
 
-    /// Returns the number of shards.
+    /// The current number of active shards in the cluster.
+    ///
+    /// # The Spark
+    /// Knowing the total number of shards is critical for query planning. When executing
+    /// a distributed vector search, the coordinator uses this count to pre-allocate
+    /// result aggregation buffers and calculate the expected network fan-out latency.
     pub fn num_shards(&self) -> usize {
         self.shards.len()
     }
 
-    /// Returns the sharding strategy.
+    /// The algorithmic strategy used to route data to specific shards.
+    ///
+    /// # The Spark
+    /// Data placement dictates performance. A `Hash` strategy ensures uniform storage
+    /// distribution but requires broadcasting queries to all shards. Conversely, a
+    /// semantic or geographical strategy might allow targeted routing. Query planners
+    /// check this to determine if a full scatter-gather is required.
     pub fn strategy(&self) -> ShardingStrategy {
         self.config.strategy
     }
 
-    /// Returns the configuration.
+    /// The immutable configuration defining this sharded deployment.
+    ///
+    /// # The Spark
+    /// Distributed systems require absolute agreement on configuration to prevent
+    /// split-brain scenarios or data corruption. This provides access to the cluster's
+    /// baseline truths, such as rebalance thresholds and strategy choices, which are
+    /// necessary for health-checking background tasks.
     pub fn config(&self) -> &ShardedVectorConfig {
         &self.config
     }

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -567,19 +567,36 @@ impl SparseVectorIndex {
         self.len() == 0
     }
 
-    /// Returns the configured dimensions.
+    /// The maximum vocabulary size or feature space of this index.
+    ///
+    /// # The Spark
+    /// When querying a sparse index, the query vector's dimensions cannot exceed
+    /// the index's configured dimensions. This acts as a safety boundary to prevent
+    /// out-of-bounds memory access during dot-product calculations.
     #[must_use]
     pub fn dimensions(&self) -> usize {
         self.config.dimensions
     }
 
-    /// Returns the scoring method.
+    /// The similarity metric used to rank search results.
+    ///
+    /// # The Spark
+    /// Different applications require different scoring mechanisms. For example,
+    /// `BM25` is ideal for term-frequency based text search, while raw `DotProduct`
+    /// might be used for neural sparse embeddings (like SPLADE). This method lets
+    /// you dynamically check the index's behavior before executing complex queries.
     #[must_use]
     pub fn scoring(&self) -> ScoringMethod {
         self.config.scoring
     }
 
-    /// Returns the configuration.
+    /// The immutable configuration used to instantiate this index.
+    ///
+    /// # The Spark
+    /// Sparse indexes rely on a strict set of configuration parameters (like capacity
+    /// and dimensions) that cannot change after creation. This method provides read-only
+    /// access to those parameters, typically used by cluster managers to verify shard
+    /// compatibility before routing queries.
     #[must_use]
     pub fn config(&self) -> &SparseIndexConfig {
         &self.config

--- a/src/index/vector/temporal/mod.rs
+++ b/src/index/vector/temporal/mod.rs
@@ -1377,12 +1377,23 @@ impl TemporalVectorIndex {
         &self.current
     }
 
-    /// Returns the vector dimensionality.
+    /// The vector dimensionality inherited from the current state index.
+    ///
+    /// # The Spark
+    /// Temporal indexes manage multiple historical snapshots, but all snapshots must
+    /// share the exact same vector space dimensionality. We proxy this call to the
+    /// `current` index because it acts as the authoritative source of truth for the
+    /// entire temporal chain.
     pub fn dimensions(&self) -> usize {
         self.current.dimensions()
     }
 
-    /// Returns the distance metric used.
+    /// The distance metric inherited from the current state index.
+    ///
+    /// # The Spark
+    /// To ensure queries spanning across time return comparable similarity scores,
+    /// the distance metric (e.g., Cosine vs Euclidean) must remain constant across
+    /// all historical snapshots. We proxy this directly to the `current` index.
     pub fn distance_metric(&self) -> DistanceMetric {
         self.current.distance_metric()
     }


### PR DESCRIPTION
📖 Chapter: Various configuration getter methods across vector indexing and honeycomb configurations.
🔦 Insight: Removed "Getters" docs violations (`/// Returns the x` and `/// Gets the x`) and replaced them with `# The Spark` sections explaining *why* the method is useful (e.g. `dimensions()` checking for safety boundaries, `num_shards()` for query planning fan-out).
🧪 Example: N/A (Documentation change only)
🖼️ Preview: (Documentation properly generated)

---
*PR created automatically by Jules for task [9584021315803082339](https://jules.google.com/task/9584021315803082339) started by @madmax983*