### PR TITLE
👺 Havoc: Fix Lost Wakeup Deadlock in FlushCoordinator

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -829,6 +829,10 @@ impl FlushSignal {
 
     /// Request an immediate flush.
     pub fn request_flush(&self) {
+        // 👺 HAVOC FIX: Must acquire the mutex before notifying condvar
+        // to prevent a "lost wakeup" race condition where a waiter checks
+        // the flag just before we set it, and we notify before they sleep.
+        let _guard = self.mutex.lock().unwrap_or_else(|e| e.into_inner());
         self.requested.store(true, Ordering::Release);
         self.condvar.notify_all();
     }


### PR DESCRIPTION
🧨 **The Trigger:** A thread checks the atomic `requested` flag and is preempted before calling `wait_timeout`. Another thread calls `request_flush()`, sets the flag, and calls `notify_all()` WITHOUT holding the mutex. The first thread resumes and goes to sleep, missing the wakeup.
📉 **The Stack Trace:** (Deadlock / Thread hangs on wait until timeout)
🧪 **Reproduction:** Run `RUSTFLAGS="--cfg loom" cargo test --test havoc_flush_signal`
😈 **Comment:** You assumed `AtomicBool` would save you from acquiring the lock. You were wrong.

---
*PR created automatically by Jules for task [6154358918371052654](https://jules.google.com/task/6154358918371052654) started by @madmax983*