### PR TITLE
⚡ Bolt: Optimize Vec allocations in checkpoint serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Optimize Vec allocations with Vec::with_capacity in loops over collections**
 **Learning:** Initializing a vector with `Vec::new()` and then populating it in a loop whose length is known (e.g. iterating over a `DashMap`) causes unnecessary intermediate heap reallocations.
 **Action:** Use `Vec::with_capacity(collection.len())` when the target collection size is known in advance to avoid these reallocations.
+
+**Optimize Checkpoint Serialization Vec Pre-allocation**
+**Learning:** Found multiple vectors (`nodes`, `edges`, `node_versions`, `edge_versions`, etc.) in `extract_graph_data_from_snapshot` and `extract_temporal_data_from_snapshot` within `src/storage/checkpoint.rs` being created without capacity, resulting in potentially multiple heap reallocations when persisting thousands or millions of entities. `clippy::unused_doc_comments` lint caught the invalid `///` doc comment usage inside function bodies.
+**Action:** Use `Vec::with_capacity(n)` instead of `Vec::new()` when initializing vectors and calculating their capacity using snapshot's `node_count`, `edge_count`, `node_version_count`, and `edge_version_count` methods. Use standard `//` for inline comments to avoid unused doc comment warnings.

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -676,8 +676,10 @@ impl CheckpointManager {
         &self,
         snapshot: &crate::storage::snapshot::CurrentStorageSnapshot,
     ) -> Result<GraphIndexData> {
-        let mut nodes = Vec::new();
-        let mut edges = Vec::new();
+        // ⚡ Bolt Optimization: Uses `Vec::with_capacity` pre-allocated to the snapshot's node and edge count
+        // to avoid multiple heap reallocations when persisting thousands or millions of entities.
+        let mut nodes = Vec::with_capacity(snapshot.node_count());
+        let mut edges = Vec::with_capacity(snapshot.edge_count());
 
         // Extract all nodes from snapshot (isolated from concurrent writes)
         for node in snapshot.iter_nodes() {
@@ -743,10 +745,13 @@ impl CheckpointManager {
             PersistedVersionType,
         };
 
-        let mut node_versions = Vec::new();
-        let mut node_anchors = Vec::new();
-        let mut edge_versions = Vec::new();
-        let mut edge_anchors = Vec::new();
+        // ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the snapshot's version counts.
+        // While not all versions are anchors (so anchor vecs might be slightly over-allocated),
+        // this completely eliminates reallocation overhead during the critical persistence path.
+        let mut node_versions = Vec::with_capacity(snapshot.node_version_count());
+        let mut node_anchors = Vec::with_capacity(snapshot.node_version_count());
+        let mut edge_versions = Vec::with_capacity(snapshot.edge_version_count());
+        let mut edge_anchors = Vec::with_capacity(snapshot.edge_version_count());
 
         // Extract node versions from snapshot (isolated from concurrent writes)
         for version_arc in snapshot.iter_node_versions() {


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(n)` in `src/storage/checkpoint.rs` for node/edge and temporal version data extraction during checkpointing.
🎯 Why: Iteratively pushing to dynamically growing vectors when parsing snapshots with thousands or millions of entities causes significant reallocation and memory fragmentation overhead. The snapshot's `node_count`, `edge_count`, `node_version_count`, and `edge_version_count` allow exact pre-allocation.
📊 Impact: Eliminates multiple dynamic heap reallocations when writing graph index and temporal data during serialization/checkpoint paths.
🔬 Measurement: Run `cargo test --lib storage::checkpoint` and observe normal test passing. Profile checkpointing of large databases to measure memory/time reduction.

---
*PR created automatically by Jules for task [7017089180209899696](https://jules.google.com/task/7017089180209899696) started by @madmax983*