### PR TITLE
🤖 Sentinel: [Weak Test Coverage in ID Default Conversions]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -165,4 +165,5 @@
 **Module:** `src/core/id.rs`
 **Summary:** Mutants returning `Ok(Default::default())` survived in `TryFrom<u64>` and `FromStr` implementations for `NodeId`, `EdgeId`, `VersionId`, and `TxId`.
 **Diagnosis:** WEAK_TEST - Tests converted `42` and then asserted `assert_eq!(converted, IdType::new(42).unwrap())`. Since `IdType::new(42)` itself wasn't directly tested in the conversion assertions to not equal `Default::default()` (which wraps `0`), it allowed the conversion functions to return `0` unchecked against the explicit expectation of `42`.
+
 **Kill Shot:** Appended explicit exact value assertions `assert_eq!(converted.as_u64(), 42)` within `tests_conversions` inside `src/core/id.rs`.

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -1824,12 +1824,14 @@ mod tests_conversions {
     #[test]
     fn test_node_id_conversions() {
         let n = NodeId::try_from(42).unwrap();
+        assert_eq!(n.as_u64(), 42);
         assert_eq!(n, NodeId::new(42).unwrap());
 
         let err = NodeId::try_from(u64::MAX).unwrap_err();
         assert!(matches!(err, StorageError::InvalidId { .. }));
 
         let n2 = NodeId::from_str("42").unwrap();
+        assert_eq!(n2.as_u64(), 42);
         assert_eq!(n2, n);
 
         let err = NodeId::from_str("invalid").unwrap_err();
@@ -1845,12 +1847,14 @@ mod tests_conversions {
     #[test]
     fn test_edge_id_conversions() {
         let e = EdgeId::try_from(42).unwrap();
+        assert_eq!(e.as_u64(), 42);
         assert_eq!(e, EdgeId::new(42).unwrap());
 
         let err = EdgeId::try_from(u64::MAX).unwrap_err();
         assert!(matches!(err, StorageError::InvalidId { .. }));
 
         let e2 = EdgeId::from_str("42").unwrap();
+        assert_eq!(e2.as_u64(), 42);
         assert_eq!(e2, e);
 
         let err = EdgeId::from_str("invalid").unwrap_err();
@@ -1863,12 +1867,14 @@ mod tests_conversions {
     #[test]
     fn test_version_id_conversions() {
         let v = VersionId::try_from(42).unwrap();
+        assert_eq!(v.as_u64(), 42);
         assert_eq!(v, VersionId::new(42).unwrap());
 
         let err = VersionId::try_from(u64::MAX).unwrap_err();
         assert!(matches!(err, StorageError::InvalidId { .. }));
 
         let v2 = VersionId::from_str("42").unwrap();
+        assert_eq!(v2.as_u64(), 42);
         assert_eq!(v2, v);
 
         let err = VersionId::from_str("invalid").unwrap_err();
@@ -1881,9 +1887,11 @@ mod tests_conversions {
     #[test]
     fn test_tx_id_conversions() {
         let t = TxId::try_from(42).unwrap();
+        assert_eq!(t.as_u64(), 42);
         assert_eq!(t, TxId::new(42));
 
         let t2 = TxId::from_str("42").unwrap();
+        assert_eq!(t2.as_u64(), 42);
         assert_eq!(t2, t);
 
         let err = TxId::from_str("invalid").unwrap_err();


### PR DESCRIPTION
# 🤖 Sentinel: [Weak Test Coverage in ID Default Conversions]

## 🧬 Mutants Found
4 surviving mutants found in `src/core/id.rs` where `TryFrom<u64>` and `FromStr` implementations for `NodeId`, `EdgeId`, `VersionId`, and `TxId` could return `Ok(Default::default())` without failing tests.

## 🎯 Tests Added/Strengthened
Strengthened the existing `test_node_id_conversions`, `test_edge_id_conversions`, `test_version_id_conversions`, and `test_tx_id_conversions` inside `src/core/id.rs` by adding explicit integer equality assertions (`assert_eq!(id.as_u64(), 42)`). Previously, these tests only verified the result against `IdType::new(42).unwrap()`, which would act tautologically if the constructor was also mutated to return `Default::default()`.

## ⚠️ Suspected Bugs
None found in this sweep. The implementation correctly passes the strengthened tests.

## 📊 Kill Rate
Addressed the specific mutants in `id.rs` converting to default IDs unchecked.

## 🔗 Havoc Interaction
None observed. Havoc handles deeper concurrency and fuzzing, these were isolated logic gaps.

---
*PR created automatically by Jules for task [6825559902098530047](https://jules.google.com/task/6825559902098530047) started by @madmax983*