### PR TITLE
🗣️ Echo: Fix compilation errors and warnings in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,10 +490,8 @@ let results = db.query()
 for row in results {
     // Access score from metadata
     let row = row?;
-    if let Some(score) = row.score {
-        if score > 0.8 {
-            println!("High similarity match: {:?}", row.entity);
-        }
+    if row.score.unwrap_or(0.0) > 0.8 {
+        println!("High similarity match: {:?}", row.entity);
     }
 }
 
@@ -694,12 +692,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new().unwrap();
 
     // Basic graph query
-    let results = db.execute_aql(
+    let _results = db.execute_aql(
         "MATCH (n:Person {name: 'Alice'})-[:KNOWS]->(friend:Person) RETURN friend"
     )?;
 
     // Bi-temporal query (point-in-time)
-    let results = db.execute_aql(
+    let _results = db.execute_aql(
         "AS OF '2024-01-15T10:00:00Z' MATCH (n:Person {name: 'Alice'}) RETURN n"
     )?;
 
@@ -794,13 +792,16 @@ For complex operations involving multiple updates, use explicit transactions.
 ```rust
 use aletheiadb::prelude::*;
 
+let db = AletheiaDB::new().unwrap();
+let alice_id = db.create_node("Person", PropertyMap::new()).unwrap();
+
 // Explicit read transaction
-let result = db.read(|tx| {
+let result: std::result::Result<InternedString, aletheiadb::Error> = db.read(|tx| {
     tx.get_node(alice_id).map(|node| node.label.clone())
-})?;
+});
 
 // Explicit write transaction with multiple operations
-db.write(|tx| {
+db.write(|tx: &mut aletheiadb::api::transaction::WriteTransaction| {
     let node1 = tx.create_node("Event", PropertyMap::new())?;
     let node2 = tx.create_node("Event", PropertyMap::new())?;
     tx.create_edge(node1, node2, "FOLLOWS", PropertyMap::new())
@@ -813,7 +814,8 @@ AletheiaDB includes an optional embedding generation system for semantic search:
 
 ```rust
 use aletheiadb::{AletheiaDB, properties};
-use aletheiadb::embeddings::{EmbeddingService, providers::openai::*};
+use aletheiadb::embeddings::EmbeddingService;
+use aletheiadb::embeddings::providers::openai::{OpenAIConfig, OpenAIModel, OpenAIProvider};
 use std::sync::Arc;
 
 // Note: Requires `tokio` dependency in Cargo.toml
@@ -831,7 +833,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "AletheiaDB is a bi-temporal graph database",
         "It tracks both valid time and transaction time",
     ];
-    let embeddings = service.embed_batch(&documents).await?;
+    let embeddings: Vec<Vec<f32>> = service.embed_batch(&documents).await?;
 
     // 3. Store with vectors
     let db = AletheiaDB::new()?;
@@ -885,7 +887,7 @@ fn main() {
     let config = observability::Config::from_env();
     observability::init(config);
 
-    let db = aletheiadb::AletheiaDB::new().unwrap();
+    let _db = aletheiadb::AletheiaDB::new().unwrap();
 
     // Metrics automatically collected
     // Check for critical errors


### PR DESCRIPTION
🗣️ Echo: Getting Started example is broken

🤦 **The Confusion:**
I performed the "README Run" by copy-pasting code blocks from `README.md` into my own `main.rs` file, and ran into several compilation errors and warnings that made me feel like I was doing something wrong.
1. The "Hybrid Queries" example emits a `warning: this if statement can be collapsed` for the `clippy::collapsible_if` lint because of nested `if let Some(score) = row.score` and `if score > 0.8`.
2. The "Query Language (AQL)" example emits two `warning: unused variable: results` warnings because the query results are returned but never used or printed.
3. The "Transactions" example is missing variable initializations (`db` and `alice_id` don't exist in scope) and throws multiple `E0282: type annotations needed` errors on the transaction closures because the compiler can't infer the type of `tx`.
4. The "Embedding Generation" example fails completely because `OpenAIConfig`, `OpenAIModel`, and `OpenAIProvider` are not in scope. The compiler complains about `use of undeclared type`, and it also throws an `E0282: type annotations needed` for the `embeddings` variable.

🕵️ **The Reality:**
1. The nested `if` statements in the hybrid query loop trigger a clippy warning that is noisy for new users.
2. The AQL example assigns `let results = ...` but doesn't do anything with it.
3. The Transactions example is a partial snippet, but unlike others, it lacks enough context to compile. The closure type inference fails because the methods called on `tx` don't provide enough information without explicit type hints or proper `db` initialization. Moreover, `node.label` returns an `InternedString`, not a `String`.
4. The Embedding Generation example assumes the user has imported `aletheiadb::embeddings::providers::openai::{OpenAIConfig, OpenAIModel, OpenAIProvider}`, but the example only imports `aletheiadb::embeddings::{EmbeddingService, providers::openai::*}`. Additionally, `service.embed_batch` needs a type annotation like `let embeddings: Vec<Vec<f32>> = ...`.

💡 **The Fix:**
1. Refactored the `if` statements in the "Hybrid Queries" example to `if row.score.unwrap_or(0.0) > 0.8`.
2. Renamed the variables to `let _results = ...` in the "Query Language (AQL)" example.
3. Added `let db = AletheiaDB::new().unwrap();` and explicitly typed the closure output (`let result: std::result::Result<InternedString, aletheiadb::Error>`) in the "Transactions" example.
4. Added the missing imports for the `OpenAI` types and provided a type annotation for `embeddings` in the "Embedding Generation" example.
5. In the Observability example, ignored the unused `db` variable.

---
*PR created automatically by Jules for task [14298294546477292378](https://jules.google.com/task/14298294546477292378) started by @madmax983*