### PR TITLE
⚡ Bolt: pre-allocate get_all_nodes and get_all_edges vector containers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 **Optimize Checkpoint Serialization Vec Pre-allocation**
 **Learning:** Found multiple vectors (`nodes`, `edges`, `node_versions`, `edge_versions`, etc.) in `extract_graph_data_from_snapshot` and `extract_temporal_data_from_snapshot` within `src/storage/checkpoint.rs` being created without capacity, resulting in potentially multiple heap reallocations when persisting thousands or millions of entities. `clippy::unused_doc_comments` lint caught the invalid `///` doc comment usage inside function bodies.
 **Action:** Use `Vec::with_capacity(n)` instead of `Vec::new()` when initializing vectors and calculating their capacity using snapshot's `node_count`, `edge_count`, `node_version_count`, and `edge_version_count` methods. Use standard `//` for inline comments to avoid unused doc comment warnings.
+
+**[DashMap Guard iterators and .cloned()]**
+**Learning:** In AletheiaDB, `CurrentIndexes` iterators (`iter_nodes`, `iter_edges`) yield `impl Deref<Target = Node>` representing DashMap guards, not simple references (`&T`). Thus, attempting to apply `.cloned()` fails to compile since it strictly requires `&T`.
+**Action:** Always use `.map(|n| n.clone())` instead of `.cloned()` when iterating over DashMap guards or opaque `impl Deref` types.

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1841,14 +1841,18 @@ impl CurrentStorage {
     ///
     /// Used by recovery property tests to verify invariants.
     pub fn get_all_nodes(&self) -> Vec<crate::Node> {
-        self.indexes.iter_nodes().map(|n| n.clone()).collect()
+        let mut nodes = Vec::with_capacity(self.indexes.node_count());
+        nodes.extend(self.indexes.iter_nodes().map(|n| n.clone()));
+        nodes
     }
 
     /// Get all edges in the current storage.
     ///
     /// Used by recovery property tests to verify invariants.
     pub fn get_all_edges(&self) -> Vec<crate::Edge> {
-        self.indexes.iter_edges().map(|e| e.clone()).collect()
+        let mut edges = Vec::with_capacity(self.indexes.edge_count());
+        edges.extend(self.indexes.iter_edges().map(|e| e.clone()));
+        edges
     }
 
     /// Get nodes by label.
@@ -2133,13 +2137,17 @@ impl CurrentStorage {
 
         // Collect all nodes into a single contiguous block on the heap, and share it via Arc.
         // ⚡ Bolt Optimization: Avoids thousands of individual `Arc::new()` heap allocations.
-        let nodes: Arc<Vec<Node>> =
-            Arc::new(self.indexes.iter_nodes().map(|n| n.clone()).collect());
+        // ⚡ Bolt Optimization: Pre-allocate vector using known node_count to avoid reallocations during collect()
+        let mut n = Vec::with_capacity(self.indexes.node_count());
+        n.extend(self.indexes.iter_nodes().map(|n| n.clone()));
+        let nodes: Arc<Vec<Node>> = Arc::new(n);
 
         // Collect all edges into a single contiguous block on the heap, and share it via Arc.
         // ⚡ Bolt Optimization: Avoids thousands of individual `Arc::new()` heap allocations.
-        let edges: Arc<Vec<Edge>> =
-            Arc::new(self.indexes.iter_edges().map(|e| e.clone()).collect());
+        // ⚡ Bolt Optimization: Pre-allocate vector using known edge_count to avoid reallocations during collect()
+        let mut e = Vec::with_capacity(self.indexes.edge_count());
+        e.extend(self.indexes.iter_edges().map(|e| e.clone()));
+        let edges: Arc<Vec<Edge>> = Arc::new(e);
 
         CurrentStorageSnapshot::new(lsn, nodes, edges)
     }


### PR DESCRIPTION
💡 **What:** 
Optimized vector creations in `src/storage/current/mod.rs` (specifically `get_all_nodes`, `get_all_edges`, and `create_snapshot`). Replaced `iter().map().collect()` patterns with `Vec::with_capacity()` utilizing the known `node_count()` and `edge_count()` of the `CurrentIndexes` struct.

🎯 **Why:** 
When extracting entire collections of nodes or edges to return to callers or persist, `.collect()` could trigger multiple internal heap re-allocations because iterators over `DashMap` guards may not always hint their size perfectly depending on internal layouts. Explicitly using `with_capacity()` on the exact count known upfront guarantees a single allocation block.

📊 **Impact:** 
Eliminates arbitrary heap reallocations when dumping full datasets or capturing snapshots. Time complexity remains O(N), but we strictly reduce the constant factor from resizing vectors.

🔬 **Measurement:** 
Unit tests pass: `cargo test --lib storage::current` ensures the logic remains identical.
Lints pass: `cargo clippy --all-targets --all-features -- -D warnings` ensures no issues.

---
*PR created automatically by Jules for task [15451207885067008695](https://jules.google.com/task/15451207885067008695) started by @madmax983*