### PR TITLE
⚡ Bolt: Optimize traversal plan serialization memory allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 **Optimize Checkpoint Serialization Vec Pre-allocation**
 **Learning:** Found multiple vectors (`nodes`, `edges`, `node_versions`, `edge_versions`, etc.) in `extract_graph_data_from_snapshot` and `extract_temporal_data_from_snapshot` within `src/storage/checkpoint.rs` being created without capacity, resulting in potentially multiple heap reallocations when persisting thousands or millions of entities. `clippy::unused_doc_comments` lint caught the invalid `///` doc comment usage inside function bodies.
 **Action:** Use `Vec::with_capacity(n)` instead of `Vec::new()` when initializing vectors and calculating their capacity using snapshot's `node_count`, `edge_count`, `node_version_count`, and `edge_version_count` methods. Use standard `//` for inline comments to avoid unused doc comment warnings.
+
+**Optimize Traversal Plan Serialization Vec Pre-allocation**
+**Learning:** Initializing the serialized traversal plan with `Vec::new()` and repeatedly pushing/extending primitive byte arrays (`u32`, `u16`, `[u8]`) into it inside nested loops creates an arbitrary number of heap reallocations because the byte capacity size isn't known ahead of time.
+**Action:** When serializing structs into byte arrays, always calculate the exact required capacity first using iterator combinators (e.g., `.sum::<usize>()`) over the inputs (e.g., node paths, string lengths) and initialize the buffer with `Vec::with_capacity(capacity)`.

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-git diff HEAD~1..HEAD --name-only

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -976,6 +976,91 @@ mod tests {
         assert_ne!(shard_id_1, shard_id_2);
     }
 
+    // ==================== Serialization Tests ====================
+
+    #[test]
+    fn test_serialize_traversal_plan() {
+        use crate::storage::sharding::router::{TraversalPlan, TraversalStep};
+        use std::collections::HashSet;
+
+        let executor: QueryExecutor<MockShardClient> =
+            QueryExecutor::new(ExecutorConfig::default(), test_router());
+
+        let mut plan = TraversalPlan {
+            start_shard: make_shard_id(0),
+            involved_shards: HashSet::new(),
+            steps: vec![],
+            is_distributed: false,
+            estimated_cost: 0.0,
+        };
+
+        plan.involved_shards.insert(make_shard_id(0));
+        plan.involved_shards.insert(make_shard_id(1));
+
+        plan.steps.push(TraversalStep {
+            shard_id: make_shard_id(0),
+            edge_labels: vec!["KNOWS".to_string(), "FRIEND".to_string()],
+            may_cross_shard: true,
+        });
+
+        plan.steps.push(TraversalStep {
+            shard_id: make_shard_id(1),
+            edge_labels: vec!["WORKS_AT".to_string()],
+            may_cross_shard: false,
+        });
+
+        let serialized = executor.serialize_traversal_plan(&plan);
+
+        // Expected length calculation
+        // 4 bytes for number of steps
+        // Step 1: 2 (shard_id) + 4 (num labels) + (4 + 5) (KNOWS) + (4 + 6) (FRIEND) + 1 (cross shard) = 26 bytes
+        // Step 2: 2 (shard_id) + 4 (num labels) + (4 + 8) (WORKS_AT) + 1 (cross shard) = 19 bytes
+        // Total = 4 + 26 + 19 = 49 bytes
+        assert_eq!(serialized.len(), 49);
+
+        let mut offset = 0;
+
+        // Num steps
+        let num_steps = u32::from_le_bytes([
+            serialized[offset],
+            serialized[offset + 1],
+            serialized[offset + 2],
+            serialized[offset + 3],
+        ]);
+        assert_eq!(num_steps, 2);
+        offset += 4;
+
+        // Step 1
+        let shard_1 = u16::from_le_bytes([serialized[offset], serialized[offset + 1]]);
+        assert_eq!(shard_1, 0);
+        offset += 2;
+
+        let num_labels_1 = u32::from_le_bytes([
+            serialized[offset],
+            serialized[offset + 1],
+            serialized[offset + 2],
+            serialized[offset + 3],
+        ]);
+        assert_eq!(num_labels_1, 2);
+        offset += 4;
+
+        // Label 1
+        let label_1_len = u32::from_le_bytes([
+            serialized[offset],
+            serialized[offset + 1],
+            serialized[offset + 2],
+            serialized[offset + 3],
+        ]);
+        assert_eq!(label_1_len, 5);
+        offset += 4;
+
+        let label_1 = std::str::from_utf8(&serialized[offset..offset + 5]).unwrap();
+        assert_eq!(label_1, "KNOWS");
+
+        // Skip rest of checks, ensuring the capacity matches actual output is the main goal
+        assert_eq!(serialized.capacity(), serialized.len());
+    }
+
     // ==================== ExecutorStats Tests ====================
 
     #[test]

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -562,7 +562,23 @@ impl<C: ShardClient> QueryExecutor<C> {
 
     fn serialize_traversal_plan(&self, plan: &TraversalPlan) -> Vec<u8> {
         // Simplified serialization
-        let mut data = Vec::new();
+        // ⚡ Bolt Optimization: Pre-calculate vector capacity based on the steps and edge labels
+        // to avoid multiple heap reallocations.
+        let capacity = 4 + plan
+            .steps
+            .iter()
+            .map(|step| {
+                2 + 4
+                    + step
+                        .edge_labels
+                        .iter()
+                        .map(|label| 4 + label.len())
+                        .sum::<usize>()
+                    + 1
+            })
+            .sum::<usize>();
+
+        let mut data = Vec::with_capacity(capacity);
         data.extend_from_slice(&(plan.steps.len() as u32).to_le_bytes());
         for step in &plan.steps {
             data.extend_from_slice(&step.shard_id.as_u16().to_le_bytes());


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(capacity)` when serializing `TraversalPlan` into a byte array. The byte capacity is now precisely pre-calculated using `.sum::<usize>()` over the length of steps and string edge labels before the vector is allocated.
🎯 Why: `Vec::new()` requires multiple dynamic heap reallocations when `.extend_from_slice()` and `.push()` are used repeatedly in the nested loops traversing steps and their varying string labels.
📊 Impact: Eliminates multiple intermediate heap allocations and memory copies during the creation of the byte buffer for distributed traversal query serialization, scaling well as the number of query plan steps increases.
🔬 Measurement: Run `cargo test --lib storage::sharding` to verify executor logic remains identical.

---
*PR created automatically by Jules for task [11252702104577261220](https://jules.google.com/task/11252702104577261220) started by @madmax983*