### PR TITLE
🪒 Razor: De-Abstract single implementation Resonator trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `Resonator` trait in `src/experimental/echo.rs` (Single-implementation trait for DI).
+**Cut:** Deleted the `Resonator` trait and replaced `Box<dyn Resonator>` usages directly with the concrete struct `ActivityDensityResonator`. Removed generic parameters `<R: Resonator>`.
+**Saved:** ~10 lines of trait definition boilerplate, removed heap allocation for dynamic dispatch, and lowered cognitive overhead of following abstract layer mappings.

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -55,12 +55,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// It looks at the "Last N" microseconds of history and bins updates into
@@ -81,8 +75,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -128,7 +123,7 @@ impl Resonator for ActivityDensityResonator {
 /// The Echo Chamber finds resonant nodes.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -146,13 +141,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -213,7 +208,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
🪒 **Razor: De-Abstract single implementation Resonator trait**

*   **Bloat:** The `Resonator` trait in `src/experimental/echo.rs` was a classic single-implementation trait used only by `ActivityDensityResonator`. It added an unnecessary layer of dynamic dispatch (`Box<dyn Resonator>`) and cognitive overhead without providing any polymorphism in practice.
*   **Cut:** Deleted the `Resonator` trait definition entirely. Refactored `EchoChamber` to accept and store the concrete `ActivityDensityResonator` struct directly by value.
*   **Saved:** Removed trait boilerplate, eliminated heap allocations for `Box<dyn Resonator>`, and made the `EchoChamber` API more explicit and simpler to follow.

Verified via `cargo check`, `cargo test`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [9086361276996883527](https://jules.google.com/task/9086361276996883527) started by @madmax983*