### PR TITLE
Replace magic numbers with named constants in serialization

### DIFF
--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -561,22 +561,27 @@ impl<C: ShardClient> QueryExecutor<C> {
     }
 
     fn serialize_traversal_plan(&self, plan: &TraversalPlan) -> Vec<u8> {
-        // Simplified serialization
-        // ⚡ Bolt Optimization: Pre-calculate vector capacity based on the steps and edge labels
-        // to avoid multiple heap reallocations.
-        let capacity = 4 + plan
-            .steps
-            .iter()
-            .map(|step| {
-                2 + 4
-                    + step
-                        .edge_labels
-                        .iter()
-                        .map(|label| 4 + label.len())
-                        .sum::<usize>()
-                    + 1
-            })
-            .sum::<usize>();
+        const STEP_COUNT_SIZE: usize = size_of::<u32>();
+        const SHARD_ID_SIZE: usize = size_of::<u16>();
+        const LABEL_COUNT_SIZE: usize = size_of::<u32>();
+        const LABEL_LEN_SIZE: usize = size_of::<u32>();
+        const CROSS_SHARD_FLAG_SIZE: usize = size_of::<u8>();
+
+        let capacity = STEP_COUNT_SIZE
+            + plan
+                .steps
+                .iter()
+                .map(|step| {
+                    SHARD_ID_SIZE
+                        + LABEL_COUNT_SIZE
+                        + step
+                            .edge_labels
+                            .iter()
+                            .map(|label| LABEL_LEN_SIZE + label.len())
+                            .sum::<usize>()
+                        + CROSS_SHARD_FLAG_SIZE
+                })
+                .sum::<usize>();
 
         let mut data = Vec::with_capacity(capacity);
         data.extend_from_slice(&(plan.steps.len() as u32).to_le_bytes());


### PR DESCRIPTION
## Summary
- Replaced magic number literals (`2`, `4`, `1`) in `serialize_traversal_plan` capacity calculation with named `const` values using `size_of::<T>()`
- Removed two unnecessary comments: `// Simplified serialization` and the verbose `// ⚡ Bolt Optimization:` narration
- The capacity formula now self-documents the wire format: `STEP_COUNT_SIZE`, `SHARD_ID_SIZE`, `LABEL_COUNT_SIZE`, `LABEL_LEN_SIZE`, `CROSS_SHARD_FLAG_SIZE`

## Test plan
- [x] All 22 executor tests pass including `test_serialize_traversal_plan`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied
- [x] Capacity assertion (`capacity == len`) still holds in test

🤖 Generated with [Claude Code](https://claude.com/claude-code)