### PR TITLE
Simplify storage/wal: deduplicate constants, extract shutdown helper

### DIFF
--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -262,6 +262,17 @@ impl ConcurrentWal {
         self.stripes.get(id)
     }
 
+    /// Check if the WAL is shutting down and return an error if so.
+    #[inline]
+    fn check_not_shutting_down(&self) -> Result<()> {
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return Err(Error::Storage(StorageError::WalError {
+                reason: "WAL is shutting down".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
     /// Append an operation (async mode - returns immediately after buffering).
     ///
     /// The entry is buffered in a stripe's ring buffer and will be
@@ -275,11 +286,7 @@ impl ConcurrentWal {
     ///
     /// The allocated LSN for this entry.
     pub fn append_async(&self, operation: WalOperation) -> Result<LSN> {
-        if self.shutdown_requested.load(Ordering::SeqCst) {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: "WAL is shutting down".to_string(),
-            }));
-        }
+        self.check_not_shutting_down()?;
         let _guard = ActiveBatchGuard::new(&self.active_batches);
 
         let lsn = self.lsn_allocator.allocate();
@@ -307,11 +314,7 @@ impl ConcurrentWal {
     /// - `Ok(lsn)` - The entry is now durable
     /// - `Err(...)` - Flush failed
     pub fn append_sync(&self, operation: WalOperation) -> Result<LSN> {
-        if self.shutdown_requested.load(Ordering::SeqCst) {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: "WAL is shutting down".to_string(),
-            }));
-        }
+        self.check_not_shutting_down()?;
         let _guard = ActiveBatchGuard::new(&self.active_batches);
 
         let lsn = self.lsn_allocator.allocate();
@@ -341,11 +344,7 @@ impl ConcurrentWal {
     /// This method will block if the buffer is full until space becomes
     /// available (backpressure).
     pub fn append_with_handle(&self, operation: WalOperation) -> Result<(LSN, CompletionHandle)> {
-        if self.shutdown_requested.load(Ordering::SeqCst) {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: "WAL is shutting down".to_string(),
-            }));
-        }
+        self.check_not_shutting_down()?;
         let _guard = ActiveBatchGuard::new(&self.active_batches);
 
         let lsn = self.lsn_allocator.allocate();
@@ -399,11 +398,7 @@ impl ConcurrentWal {
     /// assert_eq!(lsns.len(), 3);
     /// ```
     pub fn append_batch(&self, operations: Vec<WalOperation>) -> Result<Vec<LSN>> {
-        if self.shutdown_requested.load(Ordering::SeqCst) {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: "WAL is shutting down".to_string(),
-            }));
-        }
+        self.check_not_shutting_down()?;
         let _guard = ActiveBatchGuard::new(&self.active_batches);
 
         // Handle empty batch early
@@ -460,11 +455,7 @@ impl ConcurrentWal {
         &self,
         operations: Vec<WalOperation>,
     ) -> Result<(Vec<LSN>, Vec<CompletionHandle>)> {
-        if self.shutdown_requested.load(Ordering::SeqCst) {
-            return Err(Error::Storage(StorageError::WalError {
-                reason: "WAL is shutting down".to_string(),
-            }));
-        }
+        self.check_not_shutting_down()?;
         let _guard = ActiveBatchGuard::new(&self.active_batches);
 
         // Handle empty batch early
@@ -546,7 +537,8 @@ impl ConcurrentWal {
     /// This is called by the flush coordinator. Entries are returned
     /// sorted by LSN to ensure correct write order.
     pub fn drain_all(&self) -> Vec<PendingEntry> {
-        let mut all_entries = Vec::new();
+        let total_pending: usize = self.stripes.iter().map(|s| s.pending_count()).sum();
+        let mut all_entries = Vec::with_capacity(total_pending);
 
         for stripe in &self.stripes {
             all_entries.extend(stripe.drain());

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -43,14 +43,7 @@ use super::ring_buffer::PendingEntry;
 
 use crate::core::error::{Error, Result, StorageError};
 
-/// Magic bytes identifying a AletheiaDB WAL segment file.
-const WAL_MAGIC: [u8; 4] = *b"GWAL";
-
-/// Current WAL format version.
-const WAL_VERSION: u8 = 1;
-
-/// Size of the WAL segment header (magic + version).
-const WAL_HEADER_SIZE: usize = 5;
+use super::segment_reader::{WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION};
 
 /// Metadata about a WAL segment's LSN range.
 ///

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -24,6 +24,10 @@ use crate::core::hlc::HybridTimestamp;
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::property::PropertyMap;
 
+use super::serialization::{
+    OP_CHECKPOINT, OP_CREATE_EDGE, OP_CREATE_NODE, OP_DELETE_EDGE, OP_DELETE_NODE, OP_UPDATE_EDGE,
+    OP_UPDATE_NODE,
+};
 use super::{LSN, WalEntry, WalOperation};
 
 /// Magic bytes identifying a AletheiaDB WAL segment file.
@@ -386,8 +390,7 @@ pub(crate) fn parse_entry_at(
 
     // Parse operation data based on type and version
     let operation = match op_type {
-        1 => {
-            // CreateNode
+        OP_CREATE_NODE => {
             if current_offset.checked_add(12).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
@@ -445,8 +448,7 @@ pub(crate) fn parse_entry_at(
                 valid_from,
             }
         }
-        2 => {
-            // CreateEdge
+        OP_CREATE_EDGE => {
             if current_offset.checked_add(28).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
@@ -509,8 +511,7 @@ pub(crate) fn parse_entry_at(
                 valid_from,
             }
         }
-        3 => {
-            // UpdateNode
+        OP_UPDATE_NODE => {
             if current_offset.checked_add(16).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
@@ -575,8 +576,7 @@ pub(crate) fn parse_entry_at(
                 valid_from,
             }
         }
-        4 => {
-            // UpdateEdge
+        OP_UPDATE_EDGE => {
             // V0: 16 bytes (EdgeId + VersionId)
             // V1+: 20 bytes (EdgeId + VersionId + LabelId)
             let required = if version >= WAL_VERSION { 20 } else { 16 };
@@ -644,8 +644,8 @@ pub(crate) fn parse_entry_at(
                 valid_from,
             }
         }
-        5 => {
-            // Checkpoint: Phase 2: LSN (8 bytes) + HybridTimestamp (12 bytes) = 20 bytes
+        OP_CHECKPOINT => {
+            // LSN (8 bytes) + HybridTimestamp (12 bytes) = 20 bytes
             if current_offset.checked_add(20).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
@@ -673,8 +673,7 @@ pub(crate) fn parse_entry_at(
                 timestamp: cp_timestamp,
             }
         }
-        6 => {
-            // DeleteNode
+        OP_DELETE_NODE => {
             if current_offset.checked_add(8).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),
@@ -703,8 +702,7 @@ pub(crate) fn parse_entry_at(
                 valid_from,
             }
         }
-        7 => {
-            // DeleteEdge
+        OP_DELETE_EDGE => {
             if current_offset.checked_add(8).ok_or_else(|| {
                 Error::Storage(StorageError::CorruptedData(
                     "WAL offset overflow".to_string(),

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -7,6 +7,16 @@ use crate::core::error::Result;
 use crate::core::interning::InternedString;
 use crate::core::temporal::Timestamp;
 
+// WAL operation type tags for the binary format.
+// These must match the deserialization in segment_reader.rs.
+pub(crate) const OP_CREATE_NODE: u8 = 1;
+pub(crate) const OP_CREATE_EDGE: u8 = 2;
+pub(crate) const OP_UPDATE_NODE: u8 = 3;
+pub(crate) const OP_UPDATE_EDGE: u8 = 4;
+pub(crate) const OP_CHECKPOINT: u8 = 5;
+pub(crate) const OP_DELETE_NODE: u8 = 6;
+pub(crate) const OP_DELETE_EDGE: u8 = 7;
+
 /// Helper to serialize an InternedString into the buffer (4-byte ID)
 #[inline(always)]
 fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
@@ -121,7 +131,7 @@ pub(crate) fn serialize_operation_into(
             properties,
             valid_from,
         } => {
-            buffer.push(1); // operation type
+            buffer.push(OP_CREATE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
@@ -135,7 +145,7 @@ pub(crate) fn serialize_operation_into(
             properties,
             valid_from,
         } => {
-            buffer.push(2); // operation type
+            buffer.push(OP_CREATE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&source.as_u64().to_le_bytes());
             buffer.extend_from_slice(&target.as_u64().to_le_bytes());
@@ -150,7 +160,7 @@ pub(crate) fn serialize_operation_into(
             properties,
             valid_from,
         } => {
-            buffer.push(3); // operation type
+            buffer.push(OP_UPDATE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
             serialize_interned_string(*label, buffer);
@@ -164,7 +174,7 @@ pub(crate) fn serialize_operation_into(
             properties,
             valid_from,
         } => {
-            buffer.push(4); // operation type
+            buffer.push(OP_UPDATE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             buffer.extend_from_slice(&version_id.as_u64().to_le_bytes());
             serialize_interned_string(*label, buffer);
@@ -175,7 +185,7 @@ pub(crate) fn serialize_operation_into(
             node_id,
             valid_from,
         } => {
-            buffer.push(6); // operation type
+            buffer.push(OP_DELETE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             valid_from.serialize_into(buffer);
         }
@@ -183,12 +193,12 @@ pub(crate) fn serialize_operation_into(
             edge_id,
             valid_from,
         } => {
-            buffer.push(7); // operation type
+            buffer.push(OP_DELETE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
             valid_from.serialize_into(buffer);
         }
         WalOperation::Checkpoint { lsn, timestamp } => {
-            buffer.push(5); // operation type
+            buffer.push(OP_CHECKPOINT);
             buffer.extend_from_slice(&lsn.0.to_le_bytes());
             // Phase 2: Use HybridTimestamp serialization
             timestamp.serialize_into(buffer);


### PR DESCRIPTION
## Summary
- **Named operation type constants**: Defined `OP_CREATE_NODE` through `OP_DELETE_EDGE` in `serialization.rs`, replacing 14 inline magic number literals across serialization and deserialization code. Both `serialization.rs` and `segment_reader.rs` now share the same constants, eliminating format divergence risk.
- **Deduplicated WAL format constants**: Removed duplicate `WAL_MAGIC`/`WAL_VERSION`/`WAL_HEADER_SIZE` definitions from `flush_coordinator.rs`; it now imports from `segment_reader.rs` (single source of truth).
- **Extracted `check_not_shutting_down()` helper**: Replaced 5 identical shutdown-check blocks in `concurrent.rs` with a single helper method.
- **Pre-allocated `drain_all()` Vec**: Added `pending_count()` capacity hint to avoid reallocation during flush hot path.

Part of systematic storage layer code quality sweep (Phase 3/6: `storage/wal/`).

## Test plan
- [x] All 218 WAL tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)