### PR TITLE
Simplify storage root files: name compression constants, clean comments

### DIFF
--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1,5 +1,8 @@
 //! Checkpoint system with full state snapshot via index persistence.
 //!
+//! Zstd compression levels range from [`MIN_ZSTD_LEVEL`] (fastest) to
+//! [`MAX_ZSTD_LEVEL`] (best ratio). Default is [`DEFAULT_ZSTD_LEVEL`].
+//!
 //! This module integrates the checkpoint system with index persistence to enable:
 //! - Full state snapshots (not just metadata)
 //! - Fast recovery by loading indexes from disk instead of replaying WAL
@@ -61,6 +64,13 @@ use crate::storage::redb_cold_storage::RedbColdStorage;
 use crate::storage::wal::LSN;
 use crate::storage::wal::concurrent_system::ConcurrentWalSystem;
 
+/// Minimum valid zstd compression level.
+pub const MIN_ZSTD_LEVEL: i32 = 1;
+/// Maximum valid zstd compression level.
+pub const MAX_ZSTD_LEVEL: i32 = 22;
+/// Default zstd compression level (balances speed and ratio).
+pub const DEFAULT_ZSTD_LEVEL: i32 = 3;
+
 /// Convert IndexPersistenceError to our Result type.
 fn persistence_err(e: IndexPersistenceError) -> crate::core::error::Error {
     StorageError::CheckpointError {
@@ -91,7 +101,7 @@ impl Default for CheckpointConfig {
             checkpoint_interval: Duration::from_secs(300), // 5 minutes
             min_wal_entries: 1000,
             enable_compression: true,
-            compression_level: 3,
+            compression_level: DEFAULT_ZSTD_LEVEL,
         }
     }
 }
@@ -210,7 +220,9 @@ impl CheckpointManager {
     /// ```
     pub fn new(config: CheckpointConfig) -> Result<Self> {
         // Validate compression level (zstd supports 1-22)
-        if config.enable_compression && !(1..=22).contains(&config.compression_level) {
+        if config.enable_compression
+            && !(MIN_ZSTD_LEVEL..=MAX_ZSTD_LEVEL).contains(&config.compression_level)
+        {
             return Err(StorageError::CheckpointError {
                 reason: format!(
                     "Invalid compression level {}: must be 1-22 for zstd",
@@ -676,8 +688,6 @@ impl CheckpointManager {
         &self,
         snapshot: &crate::storage::snapshot::CurrentStorageSnapshot,
     ) -> Result<GraphIndexData> {
-        // ⚡ Bolt Optimization: Uses `Vec::with_capacity` pre-allocated to the snapshot's node and edge count
-        // to avoid multiple heap reallocations when persisting thousands or millions of entities.
         let mut nodes = Vec::with_capacity(snapshot.node_count());
         let mut edges = Vec::with_capacity(snapshot.edge_count());
 
@@ -745,9 +755,6 @@ impl CheckpointManager {
             PersistedVersionType,
         };
 
-        // ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the snapshot's version counts.
-        // While not all versions are anchors (so anchor vecs might be slightly over-allocated),
-        // this completely eliminates reallocation overhead during the critical persistence path.
         let mut node_versions = Vec::with_capacity(snapshot.node_version_count());
         let mut node_anchors = Vec::with_capacity(snapshot.node_version_count());
         let mut edge_versions = Vec::with_capacity(snapshot.edge_version_count());

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -154,7 +154,6 @@ pub(crate) fn replay_wal_into_storage(
                     None => node_id.as_u64(),
                 });
 
-                // Label is already an InternedString (no allocation needed!)
                 let interned_label = label;
 
                 // Transaction time comes from when the WAL entry was logged
@@ -195,7 +194,6 @@ pub(crate) fn replay_wal_into_storage(
                     None => edge_id.as_u64(),
                 });
 
-                // Label is already an InternedString (no allocation needed!)
                 let interned_label = label;
 
                 let commit_timestamp = entry.timestamp;
@@ -235,7 +233,6 @@ pub(crate) fn replay_wal_into_storage(
             } => {
                 next_version_id = next_version_id.max(version_id.as_u64() + 1);
 
-                // Label is already an InternedString (no allocation needed!)
                 let interned_label = label;
 
                 let commit_timestamp = entry.timestamp;
@@ -277,7 +274,6 @@ pub(crate) fn replay_wal_into_storage(
 
                 let current_edge = current.get_edge(edge_id)?;
 
-                // Label is already an InternedString (no allocation needed!)
                 let interned_label = label;
 
                 let commit_timestamp = entry.timestamp;

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -53,13 +53,9 @@ use std::sync::Arc;
 pub struct CurrentStorageSnapshot {
     /// LSN at which snapshot was taken
     lsn: LSN,
-    /// Arc reference to a contiguous block of nodes.
-    /// ⚡ Bolt Optimization: Replaces `Vec<Arc<Node>>` to eliminate thousands of
-    /// individual heap allocations and improve cache locality during checkpointing.
+    /// Contiguous block of nodes shared via Arc for cache locality.
     nodes: Arc<Vec<Node>>,
-    /// Arc reference to a contiguous block of edges.
-    /// ⚡ Bolt Optimization: Replaces `Vec<Arc<Edge>>` to eliminate thousands of
-    /// individual heap allocations and improve cache locality during checkpointing.
+    /// Contiguous block of edges shared via Arc for cache locality.
     edges: Arc<Vec<Edge>>,
 }
 


### PR DESCRIPTION
## Summary
- Extracted `MIN_ZSTD_LEVEL` (1), `MAX_ZSTD_LEVEL` (22), `DEFAULT_ZSTD_LEVEL` (3) constants in `checkpoint.rs`, replacing hardcoded magic numbers in default config and validation
- Removed 4 identical "Label is already InternedString" comments from `recovery.rs` (repeated on every CreateNode/CreateEdge/UpdateNode/UpdateEdge path)
- Removed 4 Bolt Optimization comments from `snapshot.rs` and `checkpoint.rs` that narrated what `Vec::with_capacity` and `Arc<Vec<T>>` do

Part of systematic storage layer code quality sweep (Phase 4/6: storage root files).

## Test plan
- [x] All 43 checkpoint + snapshot tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)