### PR TITLE
Simplify storage/index_persistence: dedup CRC, fix println

### DIFF
--- a/src/storage/index_persistence/manifest.rs
+++ b/src/storage/index_persistence/manifest.rs
@@ -104,19 +104,7 @@ impl IndexManifest {
 /// - The file cannot be written (e.g., permission denied, disk full).
 /// - The atomic rename operation fails.
 pub fn save_manifest(manifest: &IndexManifest, path: &Path) -> Result<()> {
-    let encoded = bitcode::encode(manifest);
-
-    // Calculate CRC32 of the encoded data
-    let mut hasher = Hasher::new();
-    hasher.update(&encoded);
-    let checksum = hasher.finalize();
-
-    // Write data + checksum
-    let mut data_with_checksum = encoded;
-    data_with_checksum.extend_from_slice(&checksum.to_le_bytes());
-
-    super::atomic_write(path, &data_with_checksum)?;
-    Ok(())
+    super::common::save_encoded_with_crc(manifest, path)
 }
 
 /// Load manifest from disk and validate CRC32 checksum.

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -291,7 +291,7 @@ pub(crate) fn load_vector_indexes(
         // Register index with CurrentStorage
         current.register_vector_index(property_name, index, config);
 
-        println!(
+        eprintln!(
             "✓ Loaded vector index '{}': {} dimensions, {} vectors",
             property_name, meta.dimensions, meta.vector_count
         );

--- a/src/storage/index_persistence/temporal_adjacency.rs
+++ b/src/storage/index_persistence/temporal_adjacency.rs
@@ -107,9 +107,6 @@ pub fn load_temporal_adjacency_index(data_dir: &Path) -> Result<Arc<TemporalAdja
 ///
 /// Only outgoing edges are persisted to disk. The incoming index is automatically
 /// rebuilt during load by calling insert_edge(), which populates both directions.
-///
-/// ⚡ Bolt Optimization: Replacing Vec::new() with Vec::with_capacity() using the exact length of the DashMap (`index.outgoing.len()`).
-/// This removes unnecessary intermediate heap reallocations that occur as the vector expands to accommodate all items.
 fn extract_outgoing_data(index: &TemporalAdjacencyIndex) -> Vec<NodeAdjacencyEntry> {
     let mut outgoing_entries = Vec::with_capacity(index.outgoing.len());
 


### PR DESCRIPTION
## Summary
- Replaced `save_manifest()` body with call to `common::save_encoded_with_crc()` — was copy-pasted CRC+encode+atomic_write logic identical to the existing generic helper (-13 lines)
- Fixed `println!` → `eprintln!` for vector index load message (only `println!` in the entire module; all other diagnostic logging uses `eprintln!`)
- Removed Bolt Optimization comment from `temporal_adjacency.rs`

Part of systematic storage layer code quality sweep (Phase 5/6: `storage/index_persistence/`).

## Test plan
- [x] All 80 index_persistence tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)