### PR TITLE
Simplify storage/sharding: name routing constants, update magic

### DIFF
--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -333,9 +333,6 @@ impl<C: ShardClient> QueryExecutor<C> {
         let start = Instant::now();
         let timeout = query.timeout.unwrap_or(self.config.default_timeout);
 
-        // Determine target shards
-        // ⚡ Bolt Optimization: Avoid cloning target shards when provided in the query
-        // by using Cow to borrow the slice instead of allocating a new Vec.
         let target_shards: Cow<'_, [ShardId]> = match &query.target_shards {
             Some(shards) => Cow::Borrowed(shards),
             None => Cow::Owned(self.clients.keys().copied().collect()),

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -11,7 +11,7 @@
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────┐
 //! │ Header (16 bytes)                                           │
-//! │   Magic: "GDB2" (4 bytes)                                  │
+//! │   Magic: "ADB2" (4 bytes)                                  │
 //! │   Version: u8                                               │
 //! │   Reserved: 3 bytes                                         │
 //! │   Entry count: u64                                          │
@@ -41,8 +41,8 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Magic bytes for the commit log file.
-const COMMIT_LOG_MAGIC: [u8; 4] = *b"GDB2";
+/// Magic bytes for the commit log file (AletheiaDB 2PC).
+const COMMIT_LOG_MAGIC: [u8; 4] = *b"ADB2";
 
 /// Current commit log format version.
 const COMMIT_LOG_VERSION: u8 = 2;

--- a/src/storage/sharding/router.rs
+++ b/src/storage/sharding/router.rs
@@ -5,6 +5,13 @@ use super::types::ShardId;
 use crate::core::id::NodeId;
 use std::collections::{HashMap, HashSet};
 
+/// Cost multiplier per additional shard involved in a query.
+const CROSS_SHARD_PENALTY: f64 = 2.0;
+/// Base cost per traversal hop within a single shard.
+const HOP_COST: f64 = 1.5;
+/// Cost per traversal hop that crosses a shard boundary.
+const CROSS_SHARD_HOP_COST: f64 = 3.0;
+
 /// A step in a multi-shard traversal plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraversalStep {
@@ -150,8 +157,7 @@ impl ShardRouter {
             // Calculate cost based on number of shards involved
             // Cross-shard queries have higher cost due to network latency
             let base_cost = 1.0;
-            let cross_shard_penalty = 2.0; // ~2x cost per additional shard
-            let cost = base_cost + (involved_shards.len() as f64 - 1.0) * cross_shard_penalty;
+            let cost = base_cost + (involved_shards.len() as f64 - 1.0) * CROSS_SHARD_PENALTY;
 
             TraversalPlan::multi_shard(start_shard, involved_shards).with_cost(cost)
         }
@@ -198,13 +204,11 @@ impl ShardRouter {
         }
 
         // Estimate cost based on hops and potential cross-shard operations
-        let hop_cost = 1.5; // Cost per hop
-        let cross_shard_cost = 3.0; // Additional cost for cross-shard hops
         let mut cost = 1.0;
         for step in &plan.steps {
-            cost += hop_cost;
+            cost += HOP_COST;
             if step.may_cross_shard {
-                cost += cross_shard_cost;
+                cost += CROSS_SHARD_HOP_COST;
             }
         }
         plan.estimated_cost = cost;

--- a/src/storage/sharding/transaction.rs
+++ b/src/storage/sharding/transaction.rs
@@ -14,6 +14,9 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+/// Default number of retries for distributed transaction operations.
+const DEFAULT_RETRIES: u32 = 3;
+
 /// Phase of the distributed transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransactionPhase {
@@ -208,7 +211,7 @@ impl DistributedTransaction {
             participants: participant_map,
             start_time: Instant::now(),
             timeout,
-            retries_remaining: 3,
+            retries_remaining: DEFAULT_RETRIES,
             commit_decision_logged: false,
             commit_timestamp: None,
         }


### PR DESCRIPTION
## Summary
- Extracted `CROSS_SHARD_PENALTY`, `HOP_COST`, `CROSS_SHARD_HOP_COST` constants in `router.rs`, replacing 3 inline magic number literals used for query cost estimation
- Extracted `DEFAULT_RETRIES` constant in `transaction.rs` for distributed transaction retry count
- Updated commit log magic bytes from `"GDB2"` (legacy GallifreyDB name) to `"ADB2"` (AletheiaDB) in `persistent_commit_log.rs` and its doc diagram
- Removed Bolt Optimization comment from `executor.rs`

Part of systematic storage layer code quality sweep (Phase 6/6: `storage/sharding/`).

## Test plan
- [x] All 242 sharding tests pass (including persistent_commit_log round-trip tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)