### PR TITLE
🤖 Sentinel: [operation_reordering] Test gaps closed

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -178,3 +178,15 @@
 **Summary:** Mutants regarding `Edge::connects` replacing boolean logic `&&` with `||`, equalities `==` with `!=`, and returning default `true` or `false` booleans survived.
 **Diagnosis:** WEAK_TEST - Existing tests verified positive path matching combinations and single mismatch, but neglected explicit exhaustive mismatches enforcing exact combinatorics and short-circuit `&&` behaviors alongside preventing a simple blanket return.
 **Kill Shot:** Appended explicit exact boundary combinatorial tests `test_edge_connects_exhaustive` directly to `tests` module inside `src/core/graph.rs`.
+
+**[Weak Test Coverage in Query Operation Reordering Math and Logic]**
+**Module:** `src/query/planner/rules/operation_reordering.rs`
+**Summary:** Mutants regarding math operators inside `estimate_cardinality` (`replace * with +` and `/`) survived testing, allowing logic errors in cardinality estimations to persist unnoticed. Additionally, a mutant deleting the `LogicalOp::Unary { op: UnaryOp::Filter(pred_a), input: input_a }` match arm from `filters_equal` survived, alongside a `replace && with ||` inside it.
+**Diagnosis:** MISSING_TEST - The test suite verified high-level join ordering logic relying on estimations but neglected explicitly testing the math of `estimate_cardinality` calculations itself. Also, the suite lacked a deep structural equivalence check testing the equality operator behavior for the `Filter` vs `Filter` match arm, allowing it to silently fallback to `std::mem::discriminant(a) == std::mem::discriminant(b)` which coincidentally allowed some tests to pass.
+**Kill Shot:** Added `test_estimate_cardinality_exact` to strictly enforce the scaling logic and `test_filters_equal_match_arms` to verify exact matching and mismatched combinations between `Filter` operators and `NodeScan` operators.
+
+**[Suspected Bug: operation_reordering filters_equal fallback]**
+**Module:** `src/query/planner/rules/operation_reordering.rs`
+**Summary:** The fallback `_` arm of `OperationReordering::filters_equal` performed a shallow discriminant equality check (`std::mem::discriminant(a) == std::mem::discriminant(b)`), returning `true` for structurally different inputs (like two `NodeScan` operators with different labels). This issue was masked by tests which didn't assert mismatched base structures.
+**Diagnosis:** SUSPECTED_BUG - Found while writing test coverage. The shallow discriminant check incorrectly evaluated `filters_equal` as true when base input scanning operators had divergent internal data. This masked optimization regressions because `apply` would falsely return `None` (claiming unchanged plan) even if the base inputs changed structurally.
+**Kill Shot:** Replaced `std::mem::discriminant(a) == std::mem::discriminant(b)` with `a == b` in `filters_equal` and updated `test_filters_equal_match_arms` to explicitly assert the exact input mismatched failure behavior.

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -413,8 +413,8 @@ impl OperationReordering {
                 // Check if predicates are equal (simple comparison)
                 self.predicates_equal(pred_a, pred_b) && self.filters_equal(input_a, input_b)
             }
-            // If not both filters, just check if they're the same type
-            _ => std::mem::discriminant(a) == std::mem::discriminant(b),
+            // If not both filters, check if they're identical
+            _ => a == b,
         }
     }
 
@@ -1272,5 +1272,73 @@ mod tests {
             &Predicate::Or(vec![Predicate::eq("a", 1)]),
             &Predicate::Or(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
         ));
+    }
+    #[test]
+    fn test_estimate_cardinality_exact() {
+        let rule = OperationReordering;
+
+        let scan = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Table".to_string()),
+            estimated_rows: Some(1000),
+        });
+
+        // Base scan cardinality
+        assert_eq!(rule.estimate_cardinality(&scan), 1000);
+
+        // Filter cardinality: 1000 * 0.1 = 100
+        let filter = LogicalOp::unary(UnaryOp::Filter(Predicate::eq("a", 1)), scan.clone());
+        assert_eq!(rule.estimate_cardinality(&filter), 100);
+
+        // Limit cardinality
+        let limit = LogicalOp::unary(UnaryOp::Limit(50), scan.clone());
+        assert_eq!(rule.estimate_cardinality(&limit), 50);
+
+        // Join cardinality: 1000 * 1000 * 0.1 = 100000
+        let join = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "a".to_string(),
+                right_key: "b".to_string(),
+            },
+            scan.clone(),
+            scan.clone(),
+        );
+        assert_eq!(rule.estimate_cardinality(&join), 100000);
+    }
+
+    #[test]
+    fn test_filters_equal_match_arms() {
+        let rule = OperationReordering;
+
+        let scan1 = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("A".to_string()),
+            estimated_rows: Some(10),
+        });
+        let scan2 = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("B".to_string()),
+            estimated_rows: Some(10),
+        });
+
+        let filter1 = LogicalOp::unary(UnaryOp::Filter(Predicate::eq("a", 1)), scan1.clone());
+        let filter2 = LogicalOp::unary(UnaryOp::Filter(Predicate::eq("a", 1)), scan1.clone());
+        let filter_diff_pred =
+            LogicalOp::unary(UnaryOp::Filter(Predicate::eq("b", 1)), scan1.clone());
+        let filter_diff_input =
+            LogicalOp::unary(UnaryOp::Filter(Predicate::eq("a", 1)), scan2.clone());
+
+        // Both filters equal
+        assert!(rule.filters_equal(&filter1, &filter2));
+
+        // Predicates differ
+        assert!(!rule.filters_equal(&filter1, &filter_diff_pred));
+
+        // Inputs differ
+        assert!(!rule.filters_equal(&filter1, &filter_diff_input));
+
+        // Non-filter vs filter
+        assert!(!rule.filters_equal(&filter1, &scan1));
+        assert!(!rule.filters_equal(&scan1, &filter1));
+
+        // Same non-filter types with different internal data
+        assert!(!rule.filters_equal(&scan1, &scan2));
     }
 }


### PR DESCRIPTION
**🤖 Sentinel: [operation_reordering] Test coverage for cardinality estimation and filters_equal**

* **🧬 Mutants Found:** Dozens of equivalent/surviving mutants in `operation_reordering.rs` related to math operator replacements inside `estimate_cardinality` and `filters_equal` logic.
* **🎯 Tests Added/Strengthened:** 
  * Added `test_estimate_cardinality_exact` to strictly enforce the scaling logic and arithmetic.
  * Added `test_filters_equal_match_arms` to verify exact matching and mismatched combinations between `Filter` operators and other operators (e.g. `NodeScan`).
* **⚠️ Suspected Bugs:**
  * **[Suspected Code Bug]**: The fallback `_` arm of `OperationReordering::filters_equal` performed a shallow discriminant equality check (`std::mem::discriminant(a) == std::mem::discriminant(b)`), returning `true` for structurally different inputs (like two `NodeScan` operators with different labels). This masked optimization regressions. Replaced `std::mem::discriminant(a) == std::mem::discriminant(b)` with `a == b` to properly evaluate structural equality.
* **📊 Kill Rate:** Increased strict bounds checking in `operation_reordering.rs`.
* **🔗 Havoc Interaction:** N/A.

---
*PR created automatically by Jules for task [4779582057271975850](https://jules.google.com/task/4779582057271975850) started by @madmax983*