### PR TITLE
Rename leftover GALLIFREYDB env vars to ALETHEIADB

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -10,10 +10,10 @@
 //! cargo run --bin aletheia-server --features http-server
 //!
 //! # Run with custom port
-//! GALLIFREYDB_PORT=3000 cargo run --bin aletheia-server --features http-server
+//! ALETHEIADB_PORT=3000 cargo run --bin aletheia-server --features http-server
 //!
 //! # Run with permissive CORS (development only!)
-//! GALLIFREYDB_CORS_PERMISSIVE=true cargo run --bin aletheia-server --features http-server
+//! ALETHEIADB_CORS_PERMISSIVE=true cargo run --bin aletheia-server --features http-server
 //!
 //! # Health check
 //! curl http://localhost:8080/status
@@ -21,10 +21,10 @@
 //!
 //! # Environment Variables
 //!
-//! - `GALLIFREYDB_PORT`: Port to listen on (default: 8080)
-//! - `GALLIFREYDB_HOST`: Host to bind to (default: 0.0.0.0)
-//! - `GALLIFREYDB_CORS_PERMISSIVE`: Set to "true" to allow any origin (default: false)
-//! - `GALLIFREYDB_CORS_ORIGINS`: Comma-separated list of allowed origins
+//! - `ALETHEIADB_PORT`: Port to listen on (default: 8080)
+//! - `ALETHEIADB_HOST`: Host to bind to (default: 0.0.0.0)
+//! - `ALETHEIADB_CORS_PERMISSIVE`: Set to "true" to allow any origin (default: false)
+//! - `ALETHEIADB_CORS_ORIGINS`: Comma-separated list of allowed origins
 //!
 //! # Endpoints
 //!
@@ -33,8 +33,8 @@
 //! # Security Notes
 //!
 //! - By default, CORS is restrictive (only localhost:3000 allowed)
-//! - Set `GALLIFREYDB_CORS_ORIGINS` to configure allowed origins for production
-//! - Only use `GALLIFREYDB_CORS_PERMISSIVE=true` in development environments
+//! - Set `ALETHEIADB_CORS_ORIGINS` to configure allowed origins for production
+//! - Only use `ALETHEIADB_CORS_PERMISSIVE=true` in development environments
 //!
 //! # Graceful Shutdown
 //!
@@ -46,12 +46,12 @@ use std::env;
 
 /// Parse port from environment variable with warning on invalid values.
 fn parse_port() -> u16 {
-    match env::var("GALLIFREYDB_PORT") {
+    match env::var("ALETHEIADB_PORT") {
         Ok(port_str) => match port_str.parse::<u16>() {
             Ok(port) => port,
             Err(e) => {
                 eprintln!(
-                    "WARNING: Invalid GALLIFREYDB_PORT '{}': {}. Using default port 8080.",
+                    "WARNING: Invalid ALETHEIADB_PORT '{}': {}. Using default port 8080.",
                     port_str, e
                 );
                 8080
@@ -63,13 +63,13 @@ fn parse_port() -> u16 {
 
 /// Parse host from environment variable.
 fn parse_host() -> String {
-    env::var("GALLIFREYDB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string())
+    env::var("ALETHEIADB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string())
 }
 
 /// Parse CORS configuration from environment variables.
 fn parse_cors_config() -> CorsConfig {
     // Check if permissive mode is enabled
-    let is_permissive = env::var("GALLIFREYDB_CORS_PERMISSIVE")
+    let is_permissive = env::var("ALETHEIADB_CORS_PERMISSIVE")
         .map(|v| v.to_lowercase() == "true" || v == "1")
         .unwrap_or(false);
 
@@ -78,7 +78,7 @@ fn parse_cors_config() -> CorsConfig {
     }
 
     // Parse allowed origins from comma-separated list
-    match env::var("GALLIFREYDB_CORS_ORIGINS") {
+    match env::var("ALETHEIADB_CORS_ORIGINS") {
         Ok(origins_str) => {
             let mut config = CorsConfig::restrictive();
             for origin in origins_str

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -19,6 +19,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// Default maximum number of interned strings (DoS protection)
 pub const DEFAULT_MAX_INTERNED_STRINGS: usize = 100_000;
 
+/// Maximum spin iterations in get_all_strings() before assuming deadlock.
+const MAX_SPIN_WAIT_ITERATIONS: usize = 100_000;
+
 /// Common strings that are pre-interned at startup for optimal performance.
 ///
 /// These strings represent frequently used property keys and labels across
@@ -393,13 +396,11 @@ impl StringInterner {
                     spins += 1;
 
                     // Safety valve: don't spin forever if something is truly broken
-                    if spins > 100_000 {
-                        // This should technically be unreachable given the intern() logic,
-                        // but we panic to be safe rather than returning a corrupted snapshot.
+                    if spins > MAX_SPIN_WAIT_ITERATIONS {
                         panic!(
-                            "Deadlock detected in get_all_strings: ID {} never appeared after 100k spins. \
+                            "Deadlock detected in get_all_strings: ID {} never appeared after {} spins. \
                              This indicates a bug in the interner logic (e.g. rolled back ID not properly handled).",
-                            id
+                            id, MAX_SPIN_WAIT_ITERATIONS
                         );
                     }
                 }
@@ -478,11 +479,11 @@ use std::sync::LazyLock;
 
 /// Environment variable to configure the maximum number of interned strings.
 ///
-/// Set `GALLIFREYDB_MAX_INTERNED_STRINGS` to override the default limit of 100,000.
+/// Set `ALETHEIADB_MAX_INTERNED_STRINGS` to override the default limit of 100,000.
 /// This is useful for large knowledge graphs with many unique labels or property keys.
 ///
-/// Example: `GALLIFREYDB_MAX_INTERNED_STRINGS=1000000`
-pub const MAX_INTERNED_STRINGS_ENV: &str = "GALLIFREYDB_MAX_INTERNED_STRINGS";
+/// Example: `ALETHEIADB_MAX_INTERNED_STRINGS=1000000`
+pub const MAX_INTERNED_STRINGS_ENV: &str = "ALETHEIADB_MAX_INTERNED_STRINGS";
 
 /// Global string interner for sharing common strings across the database.
 ///
@@ -495,7 +496,7 @@ pub const MAX_INTERNED_STRINGS_ENV: &str = "GALLIFREYDB_MAX_INTERNED_STRINGS";
 ///
 /// ## Configuration
 ///
-/// The maximum capacity can be configured via the `GALLIFREYDB_MAX_INTERNED_STRINGS`
+/// The maximum capacity can be configured via the `ALETHEIADB_MAX_INTERNED_STRINGS`
 /// environment variable. If not set, defaults to 100,000.
 pub static GLOBAL_INTERNER: LazyLock<StringInterner> = LazyLock::new(|| {
     let max_capacity = std::env::var(MAX_INTERNED_STRINGS_ENV)

--- a/tests/security_interner_dos.rs
+++ b/tests/security_interner_dos.rs
@@ -15,7 +15,7 @@ fn test_property_map_silent_loss_when_interner_full() {
         .arg("--exact")
         .arg("--nocapture")
         .env("WARDEN_SUBPROCESS", "1")
-        .env("GALLIFREYDB_MAX_INTERNED_STRINGS", "5") // Limit < COMMON_STRINGS.len() (10)
+        .env("ALETHEIADB_MAX_INTERNED_STRINGS", "5") // Limit < COMMON_STRINGS.len() (10)
         .output()
         .expect("failed to spawn subprocess");
 


### PR DESCRIPTION
## Summary
- Renamed all `GALLIFREYDB_*` environment variables to `ALETHEIADB_*` — these were missed during the project rename (PR #853):
  - `GALLIFREYDB_MAX_INTERNED_STRINGS` → `ALETHEIADB_MAX_INTERNED_STRINGS` (interning.rs)
  - `GALLIFREYDB_PORT` → `ALETHEIADB_PORT` (server.rs)
  - `GALLIFREYDB_HOST` → `ALETHEIADB_HOST` (server.rs)
  - `GALLIFREYDB_CORS_PERMISSIVE` → `ALETHEIADB_CORS_PERMISSIVE` (server.rs)
  - `GALLIFREYDB_CORS_ORIGINS` → `ALETHEIADB_CORS_ORIGINS` (server.rs)
- Extracted `MAX_SPIN_WAIT_ITERATIONS` constant in `interning.rs`, replacing inline `100_000` magic number in `get_all_strings()` deadlock detection

Part of systematic core layer code quality sweep (Phase 1/6: type system).

## Test plan
- [x] All 36 interning tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)