### PR TITLE
Remove Warden verification artifacts from vector module

### DIFF
--- a/src/core/vector/ops.rs
+++ b/src/core/vector/ops.rs
@@ -723,7 +723,5 @@ pub fn is_normalized(v: &[f32], tolerance: f32) -> bool {
 /// ```
 #[inline]
 pub fn is_normalized_default(v: &[f32]) -> bool {
-    // We can't import NORMALIZATION_TOLERANCE from constants because of visibility/import loops?
-    // Actually constants.rs is a sibling.
     is_normalized(v, super::constants::NORMALIZATION_TOLERANCE)
 }

--- a/src/core/vector/serialization.rs
+++ b/src/core/vector/serialization.rs
@@ -114,7 +114,6 @@ pub fn try_serialize_vector_into(v: &[f32], buffer: &mut Vec<u8>) -> Result<()> 
         //    overflow is not possible on 64-bit or 32-bit systems.
         // 4. Alignment is not an issue - we're copying to a Vec<u8>
         //
-        // Verified by Warden (2026-02-15): Input slice 'v' is valid &[f32]. size_of_val is correct. u8 alignment is 1.
         let byte_slice = unsafe {
             std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v))
         };
@@ -214,8 +213,6 @@ pub fn deserialize_vector(bytes: &[u8]) -> Result<(Arc<[f32]>, usize)> {
         //    `data_slice` into the aligned `Vec` buffer.
         // 4. After the copy, the memory is initialized, so calling `set_len` is safe.
         // 5. Any bit pattern is valid for f32 (including NaN, infinity).
-        //
-        // Verified by Warden (2026-02-15): Destination buffer is allocated via Vec::with_capacity(dimension), ensuring correct f32 alignment. Source buffer length is explicitly checked against capacity * 4.
         let mut values = Vec::with_capacity(dimension);
         if dimension > 0 {
             unsafe {

--- a/src/core/vector/simd.rs
+++ b/src/core/vector/simd.rs
@@ -36,7 +36,6 @@ pub(crate) mod x86_ops {
     #[target_feature(enable = "avx2", enable = "fma")]
     #[inline]
     pub unsafe fn dot_and_magnitudes_avx2(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
-        // Warden: Enforce length equality to prevent buffer over-reads
         assert_eq!(a.len(), b.len());
         // SAFETY: The unsafe block is required by the `unsafe_op_in_unsafe_fn` lint.
         // The caller guarantees AVX2 and FMA are available via runtime feature detection.
@@ -106,7 +105,6 @@ pub(crate) mod x86_ops {
     #[target_feature(enable = "sse2")]
     #[inline]
     pub unsafe fn dot_and_magnitudes_sse2(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
-        // Warden: Enforce length equality to prevent buffer over-reads
         assert_eq!(a.len(), b.len());
         // SAFETY: The unsafe block is required by the `unsafe_op_in_unsafe_fn` lint.
         // The caller guarantees SSE2 is available via runtime feature detection.
@@ -178,7 +176,6 @@ pub(crate) mod x86_ops {
     #[target_feature(enable = "avx2", enable = "fma")]
     #[inline]
     pub unsafe fn dot_product_avx2(a: &[f32], b: &[f32]) -> f32 {
-        // Warden: Enforce length equality to prevent buffer over-reads
         assert_eq!(a.len(), b.len());
         // SAFETY: The unsafe block is required by the `unsafe_op_in_unsafe_fn` lint.
         // The caller guarantees AVX2 and FMA are available via runtime feature detection.
@@ -224,7 +221,6 @@ pub(crate) mod x86_ops {
     #[target_feature(enable = "sse2")]
     #[inline]
     pub unsafe fn dot_product_sse2(a: &[f32], b: &[f32]) -> f32 {
-        // Warden: Enforce length equality to prevent buffer over-reads
         assert_eq!(a.len(), b.len());
         // SAFETY: The unsafe block is required by the `unsafe_op_in_unsafe_fn` lint.
         // The caller guarantees SSE2 is available via runtime feature detection.
@@ -267,7 +263,6 @@ pub(crate) mod x86_ops {
     #[target_feature(enable = "avx2", enable = "fma")]
     #[inline]
     pub unsafe fn squared_diff_sum_avx2(a: &[f32], b: &[f32]) -> f32 {
-        // Warden: Enforce length equality to prevent buffer over-reads
         assert_eq!(a.len(), b.len());
         // SAFETY: The unsafe block is required by the `unsafe_op_in_unsafe_fn` lint.
         // All unsafe operations within this unsafe fn must still be in an unsafe block.
@@ -319,7 +314,6 @@ pub(crate) mod x86_ops {
     #[target_feature(enable = "sse2")]
     #[inline]
     pub unsafe fn squared_diff_sum_sse2(a: &[f32], b: &[f32]) -> f32 {
-        // Warden: Enforce length equality to prevent buffer over-reads
         assert_eq!(a.len(), b.len());
         // SAFETY: The unsafe block is required by the `unsafe_op_in_unsafe_fn` lint.
         // All unsafe operations within this unsafe fn must still be in an unsafe block.


### PR DESCRIPTION
## Summary
- Removed 6 redundant `// Warden: Enforce length equality` comments in `simd.rs` — the `assert_eq!` on the next line is self-documenting
- Removed 2 timestamped `// Verified by Warden (2026-02-15)` comments in `serialization.rs` — safety invariants are already documented in the preceding SAFETY bullet points
- Removed confused import-loop comment in `ops.rs` — the code already imports correctly

Part of systematic core layer code quality sweep (Phase 5/6: vector perf).

## Test plan
- [x] All 314 vector tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)