### PR TITLE
⚡ Bolt: Optimize pending_commits allocations in Coordinator

### DIFF
--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -885,7 +885,7 @@ impl ShardCoordinator {
             let log = self.commit_log.read().expect("Commit log lock poisoned");
             log.pending_commits()
                 .into_iter()
-                .map(|d| (d.tx_id, d.participants.clone(), d.commit_timestamp))
+                .map(|d| (d.tx_id, d.participants, d.commit_timestamp))
                 .collect::<Vec<_>>()
         };
 
@@ -1005,7 +1005,7 @@ impl ShardCoordinator {
         }
 
         // Re-attempt recovery using single-transaction recovery
-        let decisions = {
+        let decision = {
             let log = self
                 .commit_log
                 .read()
@@ -1014,12 +1014,11 @@ impl ShardCoordinator {
                 })?;
             log.pending_commits()
                 .into_iter()
-                .filter(|d| d.tx_id == tx_id)
-                .map(|d| (d.tx_id, d.participants.clone(), d.commit_timestamp))
-                .collect::<Vec<_>>()
+                .find(|d| d.tx_id == tx_id)
+                .map(|d| (d.tx_id, d.participants, d.commit_timestamp))
         };
 
-        if let Some((found_tx_id, participants, commit_timestamp)) = decisions.into_iter().next() {
+        if let Some((found_tx_id, participants, commit_timestamp)) = decision {
             let mut tx =
                 DistributedTransaction::new(found_tx_id, participants, self.transaction_timeout);
             tx.begin_prepare().ok();

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -1880,4 +1880,53 @@ mod tests {
         let second = run_distributed_tx(&coordinator, &shards).unwrap();
         assert!(second > first);
     }
+
+    #[test]
+    fn test_retry_dead_lettered_transaction() {
+        let coordinator = ShardCoordinator::new(test_config());
+        let tx_id = TxId::new(12345);
+        let participants = vec![ShardId::new(0).unwrap(), ShardId::new(1).unwrap()];
+        let ts = crate::core::hlc::HybridTimestamp::new(1000, 0).unwrap();
+
+        // 1. Initially it should fail because it's not in the dead letter queue
+        let res = coordinator.retry_dead_lettered_transaction(tx_id);
+        assert!(res.is_err());
+        if let Err(DistributedTxError::Aborted { reason }) = res {
+            assert!(reason.contains("not found in dead letter queue"));
+        } else {
+            panic!("Expected Aborted error");
+        }
+
+        // 2. Add an entry to the commit log
+        {
+            let log = coordinator.commit_log.read().unwrap();
+            log.log_commit(tx_id, participants.clone(), Some(ts))
+                .unwrap();
+        }
+
+        // 3. Add to dead letter queue
+        let dead_letter = DeadLetteredTransaction {
+            tx_id,
+            reason: "Simulated failure".to_string(),
+            last_attempt: std::time::Instant::now(),
+            attempt_count: 5,
+        };
+        {
+            let mut dlq = coordinator.dead_letter_queue.write().unwrap();
+            dlq.insert(tx_id, dead_letter);
+        }
+
+        // 4. Retry it
+        let res = coordinator.retry_dead_lettered_transaction(tx_id);
+        assert!(res.is_ok(), "Expected Ok, got {:?}", res);
+
+        // 5. Depending on the mock, it might have completed or be pending.
+        // It succeeds because the transaction commits successfully or handles error internally.
+
+        // 6. Verify it's no longer in the dead letter queue
+        {
+            let dlq = coordinator.dead_letter_queue.read().unwrap();
+            assert!(dlq.get(&tx_id).is_none());
+        }
+    }
 }


### PR DESCRIPTION
## 💡 What
Optimized how `pending_commits()` from `commit_log` is consumed inside `recover_pending_transactions` and `retry_transaction` in `src/storage/sharding/coordinator.rs`.
- Removed an unnecessary `.clone()` on the `participants` vector when ownership is already yielded by `into_iter()`.
- Replaced an inefficient iterator chain `.filter(...).map(...).collect::<Vec<_>>().into_iter().next()` with `.find(...).map(...)`.

## 🎯 Why
In high-throughput environments, repeatedly cloning vectors (`participants`) and allocating intermediate heap structures (`Vec<CommitLogEntry>`) inside tight loops or locks adds significant allocator pressure. The elements returned by `pending_commits()` are already owned, so they can be consumed without cloning. 

## 📊 Impact
Reduces heap allocations per recovery / retry transaction step. It prevents an entire vector from being allocated and populated just to extract the first element in `retry_transaction`.

## 🔬 Measurement
Run `cargo test --lib storage::sharding` and verify `cargo clippy`. Performance gains can be benchmarked under simulated network partitions or high retry loads.

---
*PR created automatically by Jules for task [7676824485121342034](https://jules.google.com/task/7676824485121342034) started by @madmax983*