### PR TITLE
Deduplicate OrderedFloat and merge_results, update GSPS magic

### DIFF
--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -61,10 +61,8 @@ use crate::core::error::{Error, Result, VectorError};
 use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::vector::validate_vector;
-use crate::index::vector::{DistanceMetric, Quantization, VectorIndex};
+use crate::index::vector::{DistanceMetric, Quantization, VectorIndex, merge_top_k_results};
 use rayon::prelude::*;
-use std::cmp::Reverse;
-use std::collections::BinaryHeap;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
@@ -1110,61 +1108,7 @@ impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
 
     /// Merge search results from multiple nodes using a min-heap for efficiency.
     fn merge_results(node_results: Vec<Vec<(NodeId, f32)>>, k: usize) -> Vec<(NodeId, f32)> {
-        if k == 0 {
-            return Vec::new();
-        }
-
-        let mut heap: BinaryHeap<(Reverse<OrderedFloat>, NodeId)> =
-            BinaryHeap::with_capacity(k + 1);
-
-        for results in node_results {
-            for (id, score) in results {
-                let ordered_score = OrderedFloat(score);
-
-                if heap.len() < k {
-                    heap.push((Reverse(ordered_score), id));
-                } else if let Some(&(Reverse(min_score), _)) = heap.peek()
-                    && ordered_score > min_score
-                {
-                    heap.pop();
-                    heap.push((Reverse(ordered_score), id));
-                }
-            }
-        }
-
-        let mut results: Vec<(NodeId, f32)> = heap
-            .into_iter()
-            .map(|(Reverse(score), id)| (id, score.0))
-            .collect();
-
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-
-        results
-    }
-}
-
-/// Wrapper for f32 that implements Ord for use in BinaryHeap.
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct OrderedFloat(f32);
-
-impl Eq for OrderedFloat {}
-
-impl PartialOrd for OrderedFloat {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OrderedFloat {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0
-            .partial_cmp(&other.0)
-            .unwrap_or_else(|| match (self.0.is_nan(), other.0.is_nan()) {
-                (true, true) => std::cmp::Ordering::Equal,
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                (false, false) => unreachable!(),
-            })
+        merge_top_k_results(node_results, k)
     }
 }
 

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -746,6 +746,79 @@ pub use sharded::{
     ShardingStrategy,
 };
 
+// ============================================================================
+// Shared utilities for distributed and sharded vector indexes
+// ============================================================================
+
+/// Wrapper for f32 that implements Ord for use in BinaryHeap.
+///
+/// NaN values are treated as less than all other values for consistent ordering.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct OrderedFloat(pub f32);
+
+impl Eq for OrderedFloat {}
+
+impl PartialOrd for OrderedFloat {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OrderedFloat {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0
+            .partial_cmp(&other.0)
+            .unwrap_or_else(|| match (self.0.is_nan(), other.0.is_nan()) {
+                (true, true) => std::cmp::Ordering::Equal,
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                (false, false) => unreachable!(),
+            })
+    }
+}
+
+/// Merge search results from multiple sources using a min-heap for top-k efficiency.
+///
+/// O(n log k) where n is total results and k is the desired count.
+pub(crate) fn merge_top_k_results(
+    all_results: Vec<Vec<(crate::core::id::NodeId, f32)>>,
+    k: usize,
+) -> Vec<(crate::core::id::NodeId, f32)> {
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+
+    if k == 0 {
+        return Vec::new();
+    }
+
+    let mut heap: BinaryHeap<(Reverse<OrderedFloat>, crate::core::id::NodeId)> =
+        BinaryHeap::with_capacity(k + 1);
+
+    for results in all_results {
+        for (id, score) in results {
+            let ordered_score = OrderedFloat(score);
+
+            if heap.len() < k {
+                heap.push((Reverse(ordered_score), id));
+            } else if let Some(&(Reverse(min_score), _)) = heap.peek()
+                && ordered_score > min_score
+            {
+                heap.pop();
+                heap.push((Reverse(ordered_score), id));
+            }
+        }
+    }
+
+    let mut results: Vec<(crate::core::id::NodeId, f32)> = heap
+        .into_iter()
+        .map(|(Reverse(score), id)| (id, score.0))
+        .collect();
+
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    results
+}
+
 // Distributed vector index (VS-107)
 pub mod distributed;
 

--- a/src/index/vector/sharded.rs
+++ b/src/index/vector/sharded.rs
@@ -75,10 +75,10 @@
 use crate::core::error::{Error, Result, VectorError};
 use crate::core::id::NodeId;
 use crate::core::vector::validate_vector;
-use crate::index::vector::{DistanceMetric, HnswConfig, HnswIndex, Quantization, VectorIndex};
+use crate::index::vector::{
+    DistanceMetric, HnswConfig, HnswIndex, Quantization, VectorIndex, merge_top_k_results,
+};
 use rayon::prelude::*;
-use std::cmp::Reverse;
-use std::collections::BinaryHeap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
@@ -558,72 +558,8 @@ impl ShardedVectorIndex {
     }
 
     /// Merge search results from multiple shards using a min-heap for efficiency.
-    ///
-    /// This is O(n log k) where n is total results and k is the desired count,
-    /// compared to O(n log n) for sorting all results.
     fn merge_results(shard_results: Vec<Vec<(NodeId, f32)>>, k: usize) -> Vec<(NodeId, f32)> {
-        if k == 0 {
-            return Vec::new();
-        }
-
-        // Use a min-heap to track the top-k results
-        // We store (Reverse(score), NodeId) so the smallest score is at the top
-        let mut heap: BinaryHeap<(Reverse<OrderedFloat>, NodeId)> =
-            BinaryHeap::with_capacity(k + 1);
-
-        for results in shard_results {
-            for (id, score) in results {
-                let ordered_score = OrderedFloat(score);
-
-                if heap.len() < k {
-                    heap.push((Reverse(ordered_score), id));
-                } else if let Some(&(Reverse(min_score), _)) = heap.peek()
-                    && ordered_score > min_score
-                {
-                    heap.pop();
-                    heap.push((Reverse(ordered_score), id));
-                }
-            }
-        }
-
-        // Extract results and sort by descending score
-        let mut results: Vec<(NodeId, f32)> = heap
-            .into_iter()
-            .map(|(Reverse(score), id)| (id, score.0))
-            .collect();
-
-        // Sort descending by score
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-
-        results
-    }
-}
-
-/// Wrapper for f32 that implements Ord for use in BinaryHeap.
-///
-/// NaN values are treated as less than all other values for consistent ordering.
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct OrderedFloat(f32);
-
-impl Eq for OrderedFloat {}
-
-impl PartialOrd for OrderedFloat {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OrderedFloat {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.partial_cmp(&other.0).unwrap_or_else(|| {
-            // Handle NaN: treat NaN as less than everything
-            match (self.0.is_nan(), other.0.is_nan()) {
-                (true, true) => std::cmp::Ordering::Equal,
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                (false, false) => unreachable!(),
-            }
-        })
+        merge_top_k_results(shard_results, k)
     }
 }
 
@@ -841,6 +777,7 @@ impl VectorIndex for ShardedVectorIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index::vector::OrderedFloat;
 
     // ============================================================
     // Configuration Tests

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -83,8 +83,8 @@ use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 /// This prevents DoS attacks via excessive memory allocation.
 const MAX_K: usize = 100_000;
 
-/// Magic bytes for sparse index files: "GSPS"
-const SPARSE_INDEX_MAGIC: [u8; 4] = [0x47, 0x53, 0x50, 0x53];
+/// Magic bytes for sparse index files: "ASPS" (AletheiaDB SParse Search).
+const SPARSE_INDEX_MAGIC: [u8; 4] = [0x41, 0x53, 0x50, 0x53];
 
 /// Current format version for sparse index persistence
 const SPARSE_INDEX_VERSION: u16 = 1;
@@ -630,7 +630,7 @@ impl SparseVectorIndex {
     /// Saves the index to a file.
     ///
     /// The file format is:
-    /// - 4 bytes: Magic bytes "GSPS"
+    /// - 4 bytes: Magic bytes "ASPS"
     /// - 2 bytes: Format version (little-endian u16)
     /// - N bytes: Bitcode-encoded index data
     /// - 4 bytes: CRC32 checksum of all preceding bytes
@@ -2091,7 +2091,7 @@ mod tests {
         let path = dir.path().join("too_small.gsp");
 
         // Write file that's too small
-        fs::write(&path, b"GSPS").unwrap();
+        fs::write(&path, b"ASPS").unwrap();
 
         let config = SparseIndexConfig::new(100);
         let result = SparseVectorIndex::load(&path, config);


### PR DESCRIPTION
## Summary
- Extracted `OrderedFloat` struct and `merge_top_k_results()` function into `vector/mod.rs`, eliminating identical copies in `distributed.rs` and `sharded.rs` (~130 lines of duplication → single source of truth)
- Updated sparse index magic bytes from `"GSPS"` (legacy GallifreyDB SParse Search) to `"ASPS"` (AletheiaDB) in `sparse.rs`
- Net **-46 lines**

Part of systematic index layer code quality sweep (Phase 4/6: vector variants).

## Test plan
- [x] All 149 vector variant tests pass (47 sharded + 58 distributed + 44 sparse)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)