### PR TITLE
Deduplicate parser helpers, name magic constants in query frontend

### DIFF
--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -343,7 +343,7 @@ impl<'a> Lexer<'a> {
     /// ```
     pub fn tokenize(input: &str) -> Result<Vec<Token>, LexerError> {
         let mut lexer = Lexer::new(input);
-        let mut tokens = Vec::new();
+        let mut tokens = Vec::with_capacity(input.len() / 4);
 
         loop {
             let token = lexer.next_token()?;
@@ -682,7 +682,7 @@ impl<'a> Lexer<'a> {
         let mut has_dot = false;
         let mut has_exp = false;
 
-        while let Some(&(pos, ch)) = self.chars.peek() {
+        while let Some(&(_, ch)) = self.chars.peek() {
             match ch {
                 '0'..='9' => {
                     self.advance();
@@ -715,7 +715,6 @@ impl<'a> Lexer<'a> {
                 }
                 _ => break,
             }
-            let _ = pos; // silence unused warning
         }
 
         let text = &self.input[start_pos..self.position + self.current_offset()];

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -57,6 +57,13 @@ use super::lexer::{Lexer, LexerError, Token};
 /// Maximum recursion depth for parsing expressions to prevent stack overflow.
 const MAX_RECURSION_DEPTH: usize = 100;
 
+/// Default result limit for vector similarity searches (SIMILAR TO, FIND SIMILAR).
+const DEFAULT_VECTOR_SEARCH_LIMIT: usize = 10;
+
+/// Maximum depth for unbounded variable-length traversals (`*n..`).
+/// Uses half of `usize::MAX` to avoid overflow in range arithmetic.
+const UNBOUNDED_MAX_DEPTH: usize = usize::MAX / 2;
+
 /// Error type for parser errors.
 ///
 /// This error provides detailed information about what went wrong during parsing,
@@ -379,7 +386,7 @@ impl Parser {
             self.advance();
             self.parse_usize()?
         } else {
-            10 // default limit
+            DEFAULT_VECTOR_SEARCH_LIMIT
         };
 
         Ok(SourceClause::VectorSearch {
@@ -403,7 +410,7 @@ impl Parser {
             self.advance();
             self.parse_usize()?
         } else {
-            10 // default limit
+            DEFAULT_VECTOR_SEARCH_LIMIT
         };
 
         Ok(SourceClause::FindSimilar { node_ref, limit })
@@ -729,7 +736,7 @@ impl Parser {
             // Since we can't express min with Variable, use a large max
             Ok(DepthSpec::Range {
                 min,
-                max: usize::MAX / 2, // Use half max to avoid overflow issues
+                max: UNBOUNDED_MAX_DEPTH,
             })
         }
     }
@@ -930,12 +937,7 @@ impl Parser {
     }
 
     fn parse_not_predicate(&mut self, depth: usize) -> Result<PredicateExpr, ParseError> {
-        if depth > MAX_RECURSION_DEPTH {
-            return Err(self.error(
-                format!("Recursion limit exceeded (max {})", MAX_RECURSION_DEPTH),
-                None,
-            ));
-        }
+        self.check_recursion_depth(depth)?;
 
         if self.check(&Token::Not) {
             self.advance();
@@ -980,12 +982,7 @@ impl Parser {
     }
 
     fn parse_grouped_predicate(&mut self, depth: usize) -> Result<PredicateExpr, ParseError> {
-        if depth > MAX_RECURSION_DEPTH {
-            return Err(self.error(
-                format!("Recursion limit exceeded (max {})", MAX_RECURSION_DEPTH),
-                None,
-            ));
-        }
+        self.check_recursion_depth(depth)?;
 
         self.advance();
         let pred = self.parse_predicate(depth + 1)?;
@@ -1011,69 +1008,39 @@ impl Parser {
         };
         self.expect(&Token::Null)?;
 
-        if let Expression::Property(prop) = expr {
-            Ok(if is_not {
-                PredicateExpr::IsNotNull(prop)
-            } else {
-                PredicateExpr::IsNull(prop)
-            })
+        let prop = self.require_property_expr(expr, "IS NULL")?;
+        Ok(if is_not {
+            PredicateExpr::IsNotNull(prop)
         } else {
-            Err(self.error(
-                "IS NULL requires property access".to_string(),
-                Some("property".to_string()),
-            ))
-        }
+            PredicateExpr::IsNull(prop)
+        })
     }
 
     fn parse_string_predicate(&mut self, expr: Expression) -> Result<PredicateExpr, ParseError> {
         if self.check(&Token::Contains) {
             self.advance();
             let substring = self.parse_string()?;
-            if let Expression::Property(prop) = expr {
-                return Ok(PredicateExpr::Contains {
-                    property: prop,
-                    substring,
-                });
-            } else {
-                return Err(self.error(
-                    "CONTAINS requires a property expression".to_string(),
-                    Some("property.name CONTAINS 'value'".to_string()),
-                ));
-            }
+            let property = self.require_property_expr(expr, "CONTAINS")?;
+            return Ok(PredicateExpr::Contains {
+                property,
+                substring,
+            });
         }
 
         if self.check(&Token::Starts) {
             self.advance();
             self.expect(&Token::With)?;
             let prefix = self.parse_string()?;
-            if let Expression::Property(prop) = expr {
-                return Ok(PredicateExpr::StartsWith {
-                    property: prop,
-                    prefix,
-                });
-            } else {
-                return Err(self.error(
-                    "STARTS WITH requires a property expression".to_string(),
-                    Some("property.name STARTS WITH 'value'".to_string()),
-                ));
-            }
+            let property = self.require_property_expr(expr, "STARTS WITH")?;
+            return Ok(PredicateExpr::StartsWith { property, prefix });
         }
 
         if self.check(&Token::Ends) {
             self.advance();
             self.expect(&Token::With)?;
             let suffix = self.parse_string()?;
-            if let Expression::Property(prop) = expr {
-                return Ok(PredicateExpr::EndsWith {
-                    property: prop,
-                    suffix,
-                });
-            } else {
-                return Err(self.error(
-                    "ENDS WITH requires a property expression".to_string(),
-                    Some("property.name ENDS WITH 'value'".to_string()),
-                ));
-            }
+            let property = self.require_property_expr(expr, "ENDS WITH")?;
+            return Ok(PredicateExpr::EndsWith { property, suffix });
         }
 
         Err(self.error("Expected string predicate".to_string(), None))
@@ -1093,17 +1060,8 @@ impl Parser {
             }
         }
         self.expect(&Token::RightBracket)?;
-        if let Expression::Property(prop) = expr {
-            Ok(PredicateExpr::In {
-                property: prop,
-                values,
-            })
-        } else {
-            Err(self.error(
-                "IN requires a property expression".to_string(),
-                Some("property.name IN [...]".to_string()),
-            ))
-        }
+        let property = self.require_property_expr(expr, "IN")?;
+        Ok(PredicateExpr::In { property, values })
     }
 
     fn parse_comparison_predicate(
@@ -1362,6 +1320,34 @@ impl Parser {
 
     fn is_at_end(&self) -> bool {
         matches!(self.current(), Some(Token::Eof) | None)
+    }
+
+    fn check_recursion_depth(&self, depth: usize) -> Result<(), ParseError> {
+        if depth > MAX_RECURSION_DEPTH {
+            return Err(self.error(
+                format!("Recursion limit exceeded (max {MAX_RECURSION_DEPTH})"),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Extracts a [`PropertyAccess`] from an expression, returning a parse error
+    /// if the expression is not a property reference. Used by predicates that
+    /// require a property on the left-hand side (IS NULL, CONTAINS, IN, etc.).
+    fn require_property_expr(
+        &self,
+        expr: Expression,
+        context: &str,
+    ) -> Result<PropertyAccess, ParseError> {
+        if let Expression::Property(prop) = expr {
+            Ok(prop)
+        } else {
+            Err(self.error(
+                format!("{context} requires a property expression"),
+                Some(format!("property.name {context} ...")),
+            ))
+        }
     }
 
     fn expect(&mut self, expected: &Token) -> Result<(), ParseError> {


### PR DESCRIPTION
## Summary
- Extract `require_property_expr()` helper to consolidate 5 duplicated property-check-or-error blocks (IS NULL, CONTAINS, STARTS WITH, ENDS WITH, IN predicates)
- Extract `check_recursion_depth()` helper to deduplicate 2 identical recursion limit guards
- Name magic constants: `DEFAULT_VECTOR_SEARCH_LIMIT` (was `10`) and `UNBOUNDED_MAX_DEPTH` (was `usize::MAX / 2`)
- Fix unused variable pattern in lexer `read_number` (`let _ = pos` → `_` in destructure)
- Pre-allocate token Vec in `tokenize()` based on input length

**Part of the `src/query/` simplify sweep (Phase 1: Parsing Frontend)**

Net: -15 lines, 5 fewer copy-paste blocks.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test` — 3,044 unit + 289 doc tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)