### PR TITLE
Name magic constants in cost model, deduplicate SortKey

### DIFF
--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -301,16 +301,8 @@ pub enum BinaryOp {
     },
 }
 
-/// Key for sorting results.
-#[derive(Debug, Clone, PartialEq)]
-pub enum SortKey {
-    /// Sort by a property value
-    Property(String),
-    /// Sort by similarity score
-    Score,
-    /// Sort by timestamp
-    Timestamp,
-}
+/// Re-export `SortKey` from the IR to avoid maintaining two identical enums.
+pub use super::ir::SortKey;
 
 /// Temporal context for a query.
 ///

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -13,6 +13,36 @@
 use super::physical::PhysicalOp;
 use super::stats::Statistics;
 
+// ── Cardinality / selectivity defaults ───────────────────────────────────────
+
+/// Default fraction of rows surviving a filter when statistics are unavailable.
+const DEFAULT_FILTER_SELECTIVITY: f64 = 0.1;
+
+/// Default fraction of rows remaining after a DISTINCT operation.
+const DEFAULT_DISTINCT_RATIO: f64 = 0.5;
+
+/// Default fraction of the cross-product surviving a join predicate.
+const DEFAULT_JOIN_SELECTIVITY: f64 = 0.1;
+
+// ── Memory estimation factors ────────────────────────────────────────────────
+
+/// Estimated number of property fields stored per current-state node.
+const ESTIMATED_FIELDS_PER_NODE: usize = 10;
+
+/// Estimated number of property fields stored per temporal (versioned) node.
+const ESTIMATED_FIELDS_PER_TEMPORAL_NODE: usize = 20;
+
+// ── I/O and overhead factors ─────────────────────────────────────────────────
+
+/// Number of rows assumed per sequential I/O batch during a node scan.
+const BATCH_IO_ROWS: f64 = 1000.0;
+
+/// Multiplicative overhead applied to HNSW search when a label filter is active.
+const FILTERED_SEARCH_OVERHEAD: f64 = 2.0;
+
+/// Multiplicative overhead for temporal vector search snapshot lookups.
+const TEMPORAL_SNAPSHOT_OVERHEAD: f64 = 1.5;
+
 /// Estimated cost of executing a query plan.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Cost {
@@ -453,8 +483,9 @@ impl CostModel {
                 (input_card as f64 * avg_degree.powi(*depth as i32)) as usize
             }
             PhysicalOp::Filter { input, .. } => {
-                // Assume 10% selectivity by default
-                (self.estimate_cardinality(input, stats) as f64 * 0.1) as usize
+                // Assume default selectivity when statistics are unavailable
+                (self.estimate_cardinality(input, stats) as f64 * DEFAULT_FILTER_SELECTIVITY)
+                    as usize
             }
             PhysicalOp::VectorRerank { k, .. } => *k,
             PhysicalOp::Limit { count, input, .. } => {
@@ -464,15 +495,15 @@ impl CostModel {
                 self.estimate_cardinality(input, stats)
             }
             PhysicalOp::Distinct { input } => {
-                // Assume 50% unique
-                self.estimate_cardinality(input, stats) / 2
+                // Assume default distinct ratio
+                (self.estimate_cardinality(input, stats) as f64 * DEFAULT_DISTINCT_RATIO) as usize
             }
             PhysicalOp::Count { .. } => 1,
             PhysicalOp::HashJoin { left, right, .. } => {
-                // Assume 10% of cross product
+                // Assume default join selectivity of cross product
                 let left_card = self.estimate_cardinality(left, stats);
                 let right_card = self.estimate_cardinality(right, stats);
-                (left_card as f64 * right_card as f64 * 0.1) as usize
+                (left_card as f64 * right_card as f64 * DEFAULT_JOIN_SELECTIVITY) as usize
             }
             PhysicalOp::Union { left, right } => {
                 self.estimate_cardinality(left, stats) + self.estimate_cardinality(right, stats)
@@ -494,8 +525,8 @@ impl CostModel {
     fn estimate_node_lookup(&self, count: usize) -> Cost {
         Cost {
             cpu: self.operation_costs.node_lookup * count as f64,
-            io: 0.0,                                         // In-memory
-            memory: count * std::mem::size_of::<u64>() * 10, // Rough estimate per node
+            io: 0.0, // In-memory
+            memory: count * std::mem::size_of::<u64>() * ESTIMATED_FIELDS_PER_NODE, // Rough estimate per node
             network: 0.0,
         }
     }
@@ -503,8 +534,8 @@ impl CostModel {
     fn estimate_node_scan(&self, estimated_rows: usize) -> Cost {
         Cost {
             cpu: self.operation_costs.node_lookup * estimated_rows as f64,
-            io: (estimated_rows as f64 / 1000.0).ceil(), // Batch I/O
-            memory: estimated_rows * std::mem::size_of::<u64>() * 10,
+            io: (estimated_rows as f64 / BATCH_IO_ROWS).ceil(), // Batch I/O
+            memory: estimated_rows * std::mem::size_of::<u64>() * ESTIMATED_FIELDS_PER_NODE,
             network: 0.0,
         }
     }
@@ -512,7 +543,11 @@ impl CostModel {
     fn estimate_hnsw_search(&self, k: usize, has_filter: bool, stats: &Statistics) -> Cost {
         let vector_count = stats.vector_count().max(1) as f64;
         let log_factor = vector_count.log2().max(1.0);
-        let filter_overhead = if has_filter { 2.0 } else { 1.0 };
+        let filter_overhead = if has_filter {
+            FILTERED_SEARCH_OVERHEAD
+        } else {
+            1.0
+        };
 
         Cost {
             cpu: self.operation_costs.hnsw_search_per_k
@@ -544,7 +579,7 @@ impl CostModel {
             cpu: lock_overhead
                 + self.operation_costs.temporal_delta * avg_delta_chain * count as f64,
             io: avg_delta_chain * count as f64,
-            memory: count * std::mem::size_of::<u64>() * 20, // Larger due to versioning
+            memory: count * std::mem::size_of::<u64>() * ESTIMATED_FIELDS_PER_TEMPORAL_NODE, // Larger due to versioning
             network: 0.0,
         }
     }
@@ -554,8 +589,8 @@ impl CostModel {
         // but may need to check multiple snapshots
         let base = self.estimate_hnsw_search(k, false, stats);
         Cost {
-            cpu: base.cpu * 1.5, // Snapshot lookup overhead
-            io: base.io + 1.0,   // Snapshot access
+            cpu: base.cpu * TEMPORAL_SNAPSHOT_OVERHEAD, // Snapshot lookup overhead
+            io: base.io + 1.0,                          // Snapshot access
             memory: base.memory,
             network: 0.0,
         }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -67,12 +67,32 @@ use crate::storage::CurrentStorage;
 
 use super::builder::Query;
 use super::ir::QueryOp;
-use super::plan::{LogicalOp, LogicalPlan, ScanOp, SortKey, TemporalContext, UnaryOp};
+use super::plan::{LogicalOp, LogicalPlan, ScanOp, TemporalContext, UnaryOp};
 
 pub use cost::{Cost, CostModel};
 pub use physical::{PhysicalOp, PhysicalPlan};
 pub use rules::OptimizationRule;
 pub use stats::Statistics;
+
+// ── Planner defaults ─────────────────────────────────────────────────────────
+
+/// Default estimated row count for a full node scan when no statistics are available.
+const DEFAULT_SCAN_ESTIMATED_ROWS: usize = 1000;
+
+/// Default estimated row count for a fused property-equality scan.
+const DEFAULT_PROPERTY_SCAN_ROWS: usize = 100;
+
+/// Fallback maximum traversal depth when the query specifies unbounded (`Variable`) depth.
+const DEFAULT_MAX_TRAVERSAL_DEPTH: usize = 10;
+
+/// Default `top_k` for vector re-rank when the caller does not provide one.
+const DEFAULT_VECTOR_TOP_K: usize = 10;
+
+/// Pseudo-property key used to represent the node label in filter predicates.
+const LABEL_PSEUDO_KEY: &str = "_label";
+
+/// Default property key assumed to hold a node's embedding vector.
+const DEFAULT_EMBEDDING_PROPERTY: &str = "embedding";
 
 /// Query planner that transforms queries into executable physical plans.
 ///
@@ -292,7 +312,10 @@ impl QueryPlanner {
                 // and performs k-NN search - all handled by the executor
                 Ok(Some(LogicalOp::Scan(ScanOp::SimilarToNode {
                     source_node: *source_node,
-                    property_key: property_key.as_deref().unwrap_or("embedding").to_string(),
+                    property_key: property_key
+                        .as_deref()
+                        .unwrap_or(DEFAULT_EMBEDDING_PROPERTY)
+                        .to_string(),
                     k: *k,
                     label_filter: label_filter.clone(),
                 })))
@@ -354,7 +377,7 @@ impl QueryPlanner {
 
             QueryOp::FilterLabel(label) => Ok(LogicalOp::unary(
                 UnaryOp::Filter(super::ir::Predicate::Eq {
-                    key: "_label".to_string(),
+                    key: LABEL_PSEUDO_KEY.to_string(),
                     value: super::ir::PredicateValue::String(label.clone()),
                 }),
                 input,
@@ -371,21 +394,13 @@ impl QueryPlanner {
 
             QueryOp::Project(props) => Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input)),
 
-            QueryOp::Sort { key, descending } => {
-                // Convert IR SortKey to Plan SortKey
-                let plan_key = match key {
-                    crate::query::ir::SortKey::Property(prop) => SortKey::Property(prop.clone()),
-                    crate::query::ir::SortKey::Score => SortKey::Score,
-                    crate::query::ir::SortKey::Timestamp => SortKey::Timestamp,
-                };
-                Ok(LogicalOp::unary(
-                    UnaryOp::Sort {
-                        key: plan_key,
-                        descending: *descending,
-                    },
-                    input,
-                ))
-            }
+            QueryOp::Sort { key, descending } => Ok(LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: key.clone(),
+                    descending: *descending,
+                },
+                input,
+            )),
 
             QueryOp::GetEdges { direction: _ } => {
                 // Handle get edges - for now, just pass through
@@ -500,7 +515,9 @@ impl QueryPlanner {
 
     /// Helper to validate vector index existence
     fn validate_vector_index(&self, property_key: Option<&str>) -> Result<String> {
-        let effective_property = property_key.unwrap_or("embedding").to_string();
+        let effective_property = property_key
+            .unwrap_or(DEFAULT_EMBEDDING_PROPERTY)
+            .to_string();
 
         if !self.storage.has_vector_index(&effective_property) {
             return Err(Error::Query(QueryError::IndexNotFound {
@@ -550,7 +567,7 @@ impl QueryPlanner {
                 estimated_rows,
             } => Ok(PhysicalOp::NodeScan {
                 label: label.clone(),
-                estimated_rows: estimated_rows.unwrap_or(1000),
+                estimated_rows: estimated_rows.unwrap_or(DEFAULT_SCAN_ESTIMATED_ROWS),
             }),
 
             ScanOp::VectorSearch {
@@ -629,8 +646,8 @@ impl QueryPlanner {
                 label: label.clone(),
                 key: key.clone(),
                 value: value.clone(),
-                // Property scans are selective - assume 10% of label's rows
-                estimated_rows: 100,
+                // Property scans are selective - assume a small fraction of label's rows
+                estimated_rows: DEFAULT_PROPERTY_SCAN_ROWS,
             }),
         }
     }
@@ -676,7 +693,7 @@ impl QueryPlanner {
                     input: Box::new(input),
                     direction: *direction,
                     label: label.clone(),
-                    depth: depth.max_depth().unwrap_or(10),
+                    depth: depth.max_depth().unwrap_or(DEFAULT_MAX_TRAVERSAL_DEPTH),
                     temporal_context: temporal_ctx,
                 })
             }
@@ -691,7 +708,7 @@ impl QueryPlanner {
                 Ok(PhysicalOp::VectorRerank {
                     input: Box::new(input),
                     embedding: embedding.clone(),
-                    k: top_k.unwrap_or(10),
+                    k: top_k.unwrap_or(DEFAULT_VECTOR_TOP_K),
                     property_key: property_key.clone(),
                 })
             }

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -30,6 +30,15 @@ use parking_lot::RwLock;
 
 use crate::core::interning::InternedString;
 
+// ── Default estimates when statistics are unavailable ─────────────────────────
+
+/// Default average outgoing edges per node when the graph is empty or stats are uninitialized.
+const DEFAULT_AVG_OUT_DEGREE: f64 = 10.0;
+
+/// Default average delta-chain length when historical stats are unavailable.
+/// Corresponds to an anchor every 10 versions (average depth ~5).
+const DEFAULT_AVG_DELTA_CHAIN_LENGTH: f64 = 5.0;
+
 /// Atomic f64 for lock-free floating-point statistics.
 ///
 /// Converts `f64` into its bit representation to be stored
@@ -247,7 +256,7 @@ impl Statistics {
         let avg = self.avg_out_degree.load(Ordering::Relaxed);
         if avg < f64::EPSILON {
             // Default estimate if not initialized or near-zero
-            10.0
+            DEFAULT_AVG_OUT_DEGREE
         } else {
             avg
         }
@@ -269,7 +278,7 @@ impl Statistics {
         let avg = self.avg_delta_chain.load(Ordering::Relaxed);
         if avg < f64::EPSILON {
             // Default estimate (anchor every 10 versions -> avg depth ~5)
-            5.0
+            DEFAULT_AVG_DELTA_CHAIN_LENGTH
         } else {
             avg
         }


### PR DESCRIPTION
## Summary
- Extract 16 named constants across planner files replacing bare numeric literals:
  - **cost.rs** (8): `DEFAULT_FILTER_SELECTIVITY`, `DEFAULT_JOIN_SELECTIVITY`, `DEFAULT_DISTINCT_RATIO`, `FILTERED_SEARCH_OVERHEAD`, `TEMPORAL_SNAPSHOT_OVERHEAD`, `ESTIMATED_FIELDS_PER_NODE`, `ESTIMATED_FIELDS_PER_TEMPORAL_NODE`, `BATCH_IO_ROWS`
  - **mod.rs** (6): `DEFAULT_SCAN_ESTIMATED_ROWS`, `DEFAULT_PROPERTY_SCAN_ROWS`, `DEFAULT_MAX_TRAVERSAL_DEPTH`, `DEFAULT_VECTOR_TOP_K`, `LABEL_PSEUDO_KEY`, `DEFAULT_EMBEDDING_PROPERTY`
  - **stats.rs** (2): `DEFAULT_AVG_OUT_DEGREE`, `DEFAULT_AVG_DELTA_CHAIN_LENGTH`
- Deduplicate `SortKey`: replace identical enum in plan.rs with re-export from ir.rs, remove manual conversion match in planner

**Part of the `src/query/` simplify sweep (Phase 3: Planning Core)**

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test` — 3,044 unit + 289 doc tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)