### PR TITLE
Delete redundant predicates_equal, name constants, hoist allocations

### DIFF
--- a/src/query/planner/rules/mod.rs
+++ b/src/query/planner/rules/mod.rs
@@ -45,10 +45,6 @@ pub fn default_rules() -> Vec<Box<dyn OptimizationRule>> {
         Box::new(FilterScanFusion),
         Box::new(LimitPushdown),
         Box::new(OperationReordering),
-        // Future rules:
-        // Box::new(VectorSearchReordering),
-        // Box::new(TemporalBatching),
-        // Box::new(IndexSelection),
     ]
 }
 

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -37,6 +37,18 @@ use crate::query::plan::{BinaryOp, LogicalOp, LogicalPlan, ScanOp, UnaryOp};
 
 use super::{OptimizationRule, Statistics};
 
+/// Default cardinality estimate for node scans without statistics.
+const DEFAULT_NODE_SCAN_CARDINALITY: usize = 1000;
+
+/// Default cardinality estimate for property-indexed scans (~10% of full scan).
+const DEFAULT_PROPERTY_SCAN_CARDINALITY: usize = 100;
+
+/// Default selectivity estimate for filter predicates (10%).
+const DEFAULT_FILTER_SELECTIVITY: f64 = 0.1;
+
+/// Default selectivity for join operations (10% of cross product).
+const DEFAULT_JOIN_SELECTIVITY: f64 = 0.1;
+
 // Selectivity estimates for different predicate types
 // (0.0 = filters everything, 1.0 = filters nothing)
 /// Selectivity for `IS NULL` checks (0.1). Assumes nulls are relatively rare.
@@ -368,135 +380,39 @@ impl OperationReordering {
         match op {
             LogicalOp::Scan(scan) => match scan {
                 ScanOp::NodeLookup(ids) => ids.len(),
-                ScanOp::NodeScan { estimated_rows, .. } => estimated_rows.unwrap_or(1000),
+                ScanOp::NodeScan { estimated_rows, .. } => {
+                    estimated_rows.unwrap_or(DEFAULT_NODE_SCAN_CARDINALITY)
+                }
                 ScanOp::VectorSearch { k, .. } => *k,
                 ScanOp::TemporalNodeLookup { node_ids, .. } => node_ids.len(),
                 ScanOp::TemporalVectorSearch { k, .. } => *k,
                 ScanOp::SimilarToNode { k, .. } => *k,
-                ScanOp::PropertyScan { .. } => 100, // ~10% selectivity estimate
+                ScanOp::PropertyScan { .. } => DEFAULT_PROPERTY_SCAN_CARDINALITY,
             },
             LogicalOp::Unary {
                 op: UnaryOp::Filter(_),
                 input,
-            } => {
-                // Assume 10% selectivity by default
-                (self.estimate_cardinality(input) as f64 * 0.1) as usize
-            }
+            } => (self.estimate_cardinality(input) as f64 * DEFAULT_FILTER_SELECTIVITY) as usize,
             LogicalOp::Unary {
                 op: UnaryOp::Limit(n),
                 ..
             } => *n,
             LogicalOp::Unary { input, .. } => self.estimate_cardinality(input),
             LogicalOp::Binary { left, right, .. } => {
-                // For joins, assume 10% of cross product
                 let left_card = self.estimate_cardinality(left);
                 let right_card = self.estimate_cardinality(right);
-                (left_card as f64 * right_card as f64 * 0.1) as usize
+                (left_card as f64 * right_card as f64 * DEFAULT_JOIN_SELECTIVITY) as usize
             }
             LogicalOp::Empty => 0,
         }
     }
 
     /// Check if two filter chains are equal (same filters in same order).
-    fn filters_equal(&self, a: &LogicalOp, b: &LogicalOp) -> bool {
-        match (a, b) {
-            (
-                LogicalOp::Unary {
-                    op: UnaryOp::Filter(pred_a),
-                    input: input_a,
-                },
-                LogicalOp::Unary {
-                    op: UnaryOp::Filter(pred_b),
-                    input: input_b,
-                },
-            ) => {
-                // Check if predicates are equal (simple comparison)
-                self.predicates_equal(pred_a, pred_b) && self.filters_equal(input_a, input_b)
-            }
-            // If not both filters, just check if they're the same type
-            _ => std::mem::discriminant(a) == std::mem::discriminant(b),
-        }
-    }
-
-    /// Structural predicate equality check.
     ///
-    /// Performs deep structural comparison of predicates to determine if they
-    /// are semantically equivalent. This is used to detect if filter reordering
-    /// actually changed the plan structure.
-    fn predicates_equal(&self, a: &Predicate, b: &Predicate) -> bool {
-        match (a, b) {
-            (Predicate::Eq { key: k1, value: v1 }, Predicate::Eq { key: k2, value: v2 }) => {
-                k1 == k2 && v1 == v2
-            }
-            (Predicate::Ne { key: k1, value: v1 }, Predicate::Ne { key: k2, value: v2 }) => {
-                k1 == k2 && v1 == v2
-            }
-            (Predicate::Gt { key: k1, value: v1 }, Predicate::Gt { key: k2, value: v2 }) => {
-                k1 == k2 && v1 == v2
-            }
-            (Predicate::Gte { key: k1, value: v1 }, Predicate::Gte { key: k2, value: v2 }) => {
-                k1 == k2 && v1 == v2
-            }
-            (Predicate::Lt { key: k1, value: v1 }, Predicate::Lt { key: k2, value: v2 }) => {
-                k1 == k2 && v1 == v2
-            }
-            (Predicate::Lte { key: k1, value: v1 }, Predicate::Lte { key: k2, value: v2 }) => {
-                k1 == k2 && v1 == v2
-            }
-            (
-                Predicate::In {
-                    key: k1,
-                    values: vs1,
-                },
-                Predicate::In {
-                    key: k2,
-                    values: vs2,
-                },
-            ) => k1 == k2 && vs1 == vs2,
-            (
-                Predicate::Contains {
-                    key: k1,
-                    substring: s1,
-                },
-                Predicate::Contains {
-                    key: k2,
-                    substring: s2,
-                },
-            ) => k1 == k2 && s1 == s2,
-            (
-                Predicate::StartsWith {
-                    key: k1,
-                    prefix: p1,
-                },
-                Predicate::StartsWith {
-                    key: k2,
-                    prefix: p2,
-                },
-            ) => k1 == k2 && p1 == p2,
-            (
-                Predicate::EndsWith {
-                    key: k1,
-                    suffix: s1,
-                },
-                Predicate::EndsWith {
-                    key: k2,
-                    suffix: s2,
-                },
-            ) => k1 == k2 && s1 == s2,
-            (Predicate::Exists(k1), Predicate::Exists(k2)) => k1 == k2,
-            (Predicate::NotExists(k1), Predicate::NotExists(k2)) => k1 == k2,
-            (Predicate::And(v1), Predicate::And(v2)) | (Predicate::Or(v1), Predicate::Or(v2)) => {
-                v1.len() == v2.len()
-                    && v1
-                        .iter()
-                        .zip(v2.iter())
-                        .all(|(p1, p2)| self.predicates_equal(p1, p2))
-            }
-            (Predicate::Not(p1), Predicate::Not(p2)) => self.predicates_equal(p1, p2),
-            (Predicate::True, Predicate::True) => true,
-            (Predicate::False, Predicate::False) => true,
-            _ => false,
-        }
+    /// `LogicalOp` and `Predicate` both derive `PartialEq`, so a direct `==`
+    /// comparison is sufficient.
+    fn filters_equal(&self, a: &LogicalOp, b: &LogicalOp) -> bool {
+        a == b
     }
 }
 
@@ -960,40 +876,34 @@ mod tests {
 
     #[test]
     fn test_predicates_equal_basic() {
-        let rule = OperationReordering;
-
-        // Same predicates should be equal
+        // Same predicates should be equal (Predicate derives PartialEq)
         let p1 = Predicate::eq("name", "Alice");
         let p2 = Predicate::eq("name", "Alice");
-        assert!(rule.predicates_equal(&p1, &p2));
+        assert_eq!(p1, p2);
 
         // Different values should not be equal
         let p3 = Predicate::eq("name", "Bob");
-        assert!(!rule.predicates_equal(&p1, &p3));
+        assert_ne!(p1, p3);
 
         // Different keys should not be equal
         let p4 = Predicate::eq("age", "Alice");
-        assert!(!rule.predicates_equal(&p1, &p4));
+        assert_ne!(p1, p4);
     }
 
     #[test]
     fn test_predicates_equal_different_types() {
-        let rule = OperationReordering;
-
         // Different predicate types should not be equal
         let p1 = Predicate::eq("name", "Alice");
         let p2 = Predicate::ne("name", "Alice");
-        assert!(!rule.predicates_equal(&p1, &p2));
+        assert_ne!(p1, p2);
 
         let p3 = Predicate::gt("age", 30i64);
         let p4 = Predicate::lt("age", 30i64);
-        assert!(!rule.predicates_equal(&p3, &p4));
+        assert_ne!(p3, p4);
     }
 
     #[test]
     fn test_predicates_equal_and_or() {
-        let rule = OperationReordering;
-
         // Same AND predicates
         let p1 = Predicate::And(vec![
             Predicate::eq("name", "Alice"),
@@ -1003,54 +913,50 @@ mod tests {
             Predicate::eq("name", "Alice"),
             Predicate::gt("age", 30i64),
         ]);
-        assert!(rule.predicates_equal(&p1, &p2));
+        assert_eq!(p1, p2);
 
         // Different order in AND should not be equal (structural comparison)
         let p3 = Predicate::And(vec![
             Predicate::gt("age", 30i64),
             Predicate::eq("name", "Alice"),
         ]);
-        assert!(!rule.predicates_equal(&p1, &p3));
+        assert_ne!(p1, p3);
 
         // Different length AND
         let p4 = Predicate::And(vec![Predicate::eq("name", "Alice")]);
-        assert!(!rule.predicates_equal(&p1, &p4));
+        assert_ne!(p1, p4);
 
         // AND vs OR
         let p5 = Predicate::Or(vec![
             Predicate::eq("name", "Alice"),
             Predicate::gt("age", 30i64),
         ]);
-        assert!(!rule.predicates_equal(&p1, &p5));
+        assert_ne!(p1, p5);
     }
 
     #[test]
     fn test_predicates_equal_not() {
-        let rule = OperationReordering;
-
         // Same NOT predicates
         let p1 = Predicate::Not(Box::new(Predicate::eq("active", true)));
         let p2 = Predicate::Not(Box::new(Predicate::eq("active", true)));
-        assert!(rule.predicates_equal(&p1, &p2));
+        assert_eq!(p1, p2);
 
         // Different inner predicates
         let p3 = Predicate::Not(Box::new(Predicate::eq("active", false)));
-        assert!(!rule.predicates_equal(&p1, &p3));
+        assert_ne!(p1, p3);
     }
 
     #[test]
     fn test_predicates_equal_all_variants() {
-        let rule = OperationReordering;
-
-        // Test all variants for coverage
-        assert!(rule.predicates_equal(&Predicate::True, &Predicate::True));
-        assert!(rule.predicates_equal(&Predicate::False, &Predicate::False));
-        assert!(!rule.predicates_equal(&Predicate::True, &Predicate::False));
+        // Test all variants for coverage (Predicate derives PartialEq)
+        assert_eq!(Predicate::True, Predicate::True);
+        assert_eq!(Predicate::False, Predicate::False);
+        assert_ne!(Predicate::True, Predicate::False);
 
         // String predicates
         let c1 = Predicate::contains("text", "hello");
         let c2 = Predicate::contains("text", "hello");
-        assert!(rule.predicates_equal(&c1, &c2));
+        assert_eq!(c1, c2);
 
         let s1 = Predicate::StartsWith {
             key: "text".to_string(),
@@ -1060,7 +966,7 @@ mod tests {
             key: "text".to_string(),
             prefix: "hello".to_string(),
         };
-        assert!(rule.predicates_equal(&s1, &s2));
+        assert_eq!(s1, s2);
 
         let e1 = Predicate::EndsWith {
             key: "text".to_string(),
@@ -1070,7 +976,7 @@ mod tests {
             key: "text".to_string(),
             suffix: "world".to_string(),
         };
-        assert!(rule.predicates_equal(&e1, &e2));
+        assert_eq!(e1, e2);
 
         // In predicate
         let i1 = Predicate::In {
@@ -1087,16 +993,16 @@ mod tests {
                 crate::query::ir::PredicateValue::Int(2),
             ],
         };
-        assert!(rule.predicates_equal(&i1, &i2));
+        assert_eq!(i1, i2);
 
         // Exists predicates
         let ex1 = Predicate::exists("prop");
         let ex2 = Predicate::exists("prop");
-        assert!(rule.predicates_equal(&ex1, &ex2));
+        assert_eq!(ex1, ex2);
 
         let nex1 = Predicate::NotExists("prop".to_string());
         let nex2 = Predicate::NotExists("prop".to_string());
-        assert!(rule.predicates_equal(&nex1, &nex2));
+        assert_eq!(nex1, nex2);
     }
 
     #[test]
@@ -1116,161 +1022,161 @@ mod tests {
 
     #[test]
     fn test_predicates_equal_exhaustive_mismatches() {
-        let rule = OperationReordering;
+        // Predicate derives PartialEq, so we use assert_ne! directly.
 
         // Eq mismatches
-        assert!(!rule.predicates_equal(&Predicate::eq("a", 1), &Predicate::eq("b", 1)));
-        assert!(!rule.predicates_equal(&Predicate::eq("a", 1), &Predicate::eq("a", 2)));
+        assert_ne!(Predicate::eq("a", 1), Predicate::eq("b", 1));
+        assert_ne!(Predicate::eq("a", 1), Predicate::eq("a", 2));
 
         // Ne mismatches
-        assert!(!rule.predicates_equal(&Predicate::ne("a", 1), &Predicate::ne("b", 1)));
-        assert!(!rule.predicates_equal(&Predicate::ne("a", 1), &Predicate::ne("a", 2)));
+        assert_ne!(Predicate::ne("a", 1), Predicate::ne("b", 1));
+        assert_ne!(Predicate::ne("a", 1), Predicate::ne("a", 2));
 
         // Gt mismatches
-        assert!(!rule.predicates_equal(&Predicate::gt("a", 1), &Predicate::gt("b", 1)));
-        assert!(!rule.predicates_equal(&Predicate::gt("a", 1), &Predicate::gt("a", 2)));
+        assert_ne!(Predicate::gt("a", 1), Predicate::gt("b", 1));
+        assert_ne!(Predicate::gt("a", 1), Predicate::gt("a", 2));
 
         // Gte mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::Gte {
+        assert_ne!(
+            Predicate::Gte {
                 key: "a".to_string(),
                 value: crate::query::ir::PredicateValue::Int(1)
             },
-            &Predicate::Gte {
+            Predicate::Gte {
                 key: "b".to_string(),
                 value: crate::query::ir::PredicateValue::Int(1)
             }
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::Gte {
+        );
+        assert_ne!(
+            Predicate::Gte {
                 key: "a".to_string(),
                 value: crate::query::ir::PredicateValue::Int(1)
             },
-            &Predicate::Gte {
+            Predicate::Gte {
                 key: "a".to_string(),
                 value: crate::query::ir::PredicateValue::Int(2)
             }
-        ));
+        );
 
         // Lt mismatches
-        assert!(!rule.predicates_equal(&Predicate::lt("a", 1), &Predicate::lt("b", 1)));
-        assert!(!rule.predicates_equal(&Predicate::lt("a", 1), &Predicate::lt("a", 2)));
+        assert_ne!(Predicate::lt("a", 1), Predicate::lt("b", 1));
+        assert_ne!(Predicate::lt("a", 1), Predicate::lt("a", 2));
 
         // Lte mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::Lte {
+        assert_ne!(
+            Predicate::Lte {
                 key: "a".to_string(),
                 value: crate::query::ir::PredicateValue::Int(1)
             },
-            &Predicate::Lte {
+            Predicate::Lte {
                 key: "b".to_string(),
                 value: crate::query::ir::PredicateValue::Int(1)
             }
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::Lte {
+        );
+        assert_ne!(
+            Predicate::Lte {
                 key: "a".to_string(),
                 value: crate::query::ir::PredicateValue::Int(1)
             },
-            &Predicate::Lte {
+            Predicate::Lte {
                 key: "a".to_string(),
                 value: crate::query::ir::PredicateValue::Int(2)
             }
-        ));
+        );
 
         // In mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::In {
+        assert_ne!(
+            Predicate::In {
                 key: "a".to_string(),
                 values: vec![crate::query::ir::PredicateValue::Int(1)]
             },
-            &Predicate::In {
+            Predicate::In {
                 key: "b".to_string(),
                 values: vec![crate::query::ir::PredicateValue::Int(1)]
             }
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::In {
+        );
+        assert_ne!(
+            Predicate::In {
                 key: "a".to_string(),
                 values: vec![crate::query::ir::PredicateValue::Int(1)]
             },
-            &Predicate::In {
+            Predicate::In {
                 key: "a".to_string(),
                 values: vec![crate::query::ir::PredicateValue::Int(2)]
             }
-        ));
+        );
 
         // Contains mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::contains("a", "abc"),
-            &Predicate::contains("b", "abc")
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::contains("a", "abc"),
-            &Predicate::contains("a", "xyz")
-        ));
+        assert_ne!(
+            Predicate::contains("a", "abc"),
+            Predicate::contains("b", "abc")
+        );
+        assert_ne!(
+            Predicate::contains("a", "abc"),
+            Predicate::contains("a", "xyz")
+        );
 
         // StartsWith mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::StartsWith {
+        assert_ne!(
+            Predicate::StartsWith {
                 key: "a".to_string(),
                 prefix: "abc".to_string()
             },
-            &Predicate::StartsWith {
+            Predicate::StartsWith {
                 key: "b".to_string(),
                 prefix: "abc".to_string()
             }
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::StartsWith {
+        );
+        assert_ne!(
+            Predicate::StartsWith {
                 key: "a".to_string(),
                 prefix: "abc".to_string()
             },
-            &Predicate::StartsWith {
+            Predicate::StartsWith {
                 key: "a".to_string(),
                 prefix: "xyz".to_string()
             }
-        ));
+        );
 
         // EndsWith mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::EndsWith {
+        assert_ne!(
+            Predicate::EndsWith {
                 key: "a".to_string(),
                 suffix: "abc".to_string()
             },
-            &Predicate::EndsWith {
+            Predicate::EndsWith {
                 key: "b".to_string(),
                 suffix: "abc".to_string()
             }
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::EndsWith {
+        );
+        assert_ne!(
+            Predicate::EndsWith {
                 key: "a".to_string(),
                 suffix: "abc".to_string()
             },
-            &Predicate::EndsWith {
+            Predicate::EndsWith {
                 key: "a".to_string(),
                 suffix: "xyz".to_string()
             }
-        ));
+        );
 
         // Exists mismatches
-        assert!(!rule.predicates_equal(&Predicate::exists("a"), &Predicate::exists("b")));
+        assert_ne!(Predicate::exists("a"), Predicate::exists("b"));
 
         // NotExists mismatches
-        assert!(!rule.predicates_equal(
-            &Predicate::NotExists("a".to_string()),
-            &Predicate::NotExists("b".to_string())
-        ));
+        assert_ne!(
+            Predicate::NotExists("a".to_string()),
+            Predicate::NotExists("b".to_string())
+        );
 
         // And / Or structural mismatches (different sizes)
-        assert!(!rule.predicates_equal(
-            &Predicate::And(vec![Predicate::eq("a", 1)]),
-            &Predicate::And(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
-        ));
-        assert!(!rule.predicates_equal(
-            &Predicate::Or(vec![Predicate::eq("a", 1)]),
-            &Predicate::Or(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
-        ));
+        assert_ne!(
+            Predicate::And(vec![Predicate::eq("a", 1)]),
+            Predicate::And(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
+        );
+        assert_ne!(
+            Predicate::Or(vec![Predicate::eq("a", 1)]),
+            Predicate::Or(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
+        );
     }
 }

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -69,6 +69,12 @@ use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::hash::BuildHasherDefault;
 
+/// Per-hop structural cost to prefer shorter paths when semantic costs are equal.
+const STRUCTURAL_HOP_COST: f32 = 0.1;
+
+/// Default cost assigned to nodes without embeddings.
+const NO_EMBEDDING_COST: f32 = 1.0;
+
 /// State for priority queue (min-heap based on cost).
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct State {
@@ -200,6 +206,9 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             depth: 0,
         });
 
+        // Reuse allocation across iterations
+        let mut neighbors = Vec::new();
+
         while let Some(State { cost, node, depth }) = pq.pop() {
             if node == end {
                 return Ok(Some(self.reconstruct_path(came_from, end)));
@@ -219,7 +228,7 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             }
 
             // Collect neighbors (outgoing, or both directions if bidirectional)
-            let mut neighbors = Vec::new();
+            neighbors.clear();
 
             // Get outgoing edges
             for edge_id in self.db.get_outgoing_edges(node) {
@@ -238,14 +247,11 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             }
 
             // Process all neighbors
-            for target in neighbors {
+            for &target in &neighbors {
                 // Calculate semantic cost of moving to target
                 let semantic_cost = self.calculate_semantic_cost(target, query_embedding)?;
 
-                // Total cost = current cost + semantic cost + structural cost (1.0 for hop)
-                // We add 1.0 structural cost to prefer shorter paths if semantics are equal.
-                // Adjustable weight could be added later.
-                let new_cost = cost + semantic_cost + 0.1; // Small structural cost
+                let new_cost = cost + semantic_cost + STRUCTURAL_HOP_COST;
 
                 if new_cost < *dist.get(&target).unwrap_or(&f32::INFINITY) {
                     dist.insert(target, new_cost);
@@ -335,6 +341,9 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             depth: 0,
         });
 
+        // Reuse allocation across iterations
+        let mut neighbor_edges = Vec::new();
+
         while let Some(State { cost, node, depth }) = pq.pop() {
             if node == end {
                 return Ok(Some(self.reconstruct_path(came_from, end)));
@@ -353,7 +362,7 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             }
 
             // Collect neighbors (outgoing, or both directions if bidirectional)
-            let mut neighbor_edges = Vec::new();
+            neighbor_edges.clear();
 
             // Get outgoing edges at the specified time
             for edge_id in self.db.get_outgoing_edges_at_time(node, time, time) {
@@ -367,7 +376,7 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
                 }
             }
 
-            for (edge_id, is_outgoing) in neighbor_edges {
+            for &(edge_id, is_outgoing) in &neighbor_edges {
                 // Get edge details at the specified time
                 if let Ok(edge) = self.db.get_edge_at_time(edge_id, time, time) {
                     // For outgoing edges, target is the neighbor; for incoming, source is the neighbor
@@ -388,7 +397,7 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
                         let semantic_cost =
                             self.compute_semantic_cost(target_embedding, query_embedding)?;
 
-                        let new_cost = cost + semantic_cost + 0.1;
+                        let new_cost = cost + semantic_cost + STRUCTURAL_HOP_COST;
 
                         if new_cost < *dist.get(&target).unwrap_or(&f32::INFINITY) {
                             dist.insert(target, new_cost);
@@ -444,7 +453,7 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
             }
         } else {
             // Penalize nodes without embeddings
-            Ok(1.0)
+            Ok(NO_EMBEDDING_COST)
         }
     }
 


### PR DESCRIPTION
## Summary
- **Delete `predicates_equal()` (~75 lines)** — `Predicate` derives `PartialEq`, so the hand-rolled structural comparison was entirely redundant. Simplified `filters_equal()` to `==` since `LogicalOp` also derives `PartialEq`.
- Name 4 magic constants in `operation_reordering.rs`: `DEFAULT_NODE_SCAN_CARDINALITY` (1000), `DEFAULT_PROPERTY_SCAN_CARDINALITY` (100), `DEFAULT_FILTER_SELECTIVITY` (0.1), `DEFAULT_JOIN_SELECTIVITY` (0.1)
- Name 2 magic constants in `semantic_pathfinding.rs`: `STRUCTURAL_HOP_COST` (0.1), `NO_EMBEDDING_COST` (1.0)
- Hoist `neighbors`/`neighbor_edges` Vecs before Dijkstra loops to reuse allocations across iterations (avoids per-iteration heap allocation)
- Remove stale commented-out future rules from `rules/mod.rs`

**Part of the `src/query/` simplify sweep (Phase 4: Optimization Rules & Features)**

Net: **-89 lines** across 3 files.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test` — 3,044 unit + 289 doc tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)