### PR TITLE
Name display constants, eliminate redundant lookups in executor

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -275,28 +275,19 @@ impl ResultIterator for TemporalNodeIterator {
             let historical = self.historical.read();
 
             // Find the version valid at the requested time
-            let version_id =
-                historical
-                    .find_node_version_at_time(id, self.valid_time, self.transaction_time)
-                    .ok_or(crate::core::error::TemporalError::NodeNotFoundAtTime {
-                        node_id: id,
-                        valid_time: self.valid_time,
-                        transaction_time: self.transaction_time,
-                    })?;
+            let version_id = historical
+                .find_node_version_at_time(id, self.valid_time, self.transaction_time)
+                .ok_or(crate::core::error::TemporalError::NodeNotFoundAtTime {
+                    node_id: id,
+                    valid_time: self.valid_time,
+                    transaction_time: self.transaction_time,
+                })?;
 
-            // INVARIANT: If find_node_version_at_time returns a version_id,
-            // that version MUST exist in storage. If this fails, it indicates
-            // a critical data inconsistency (broken version chain or dangling version_id).
-            debug_assert!(
-                historical.get_node_version(version_id).is_some(),
-                "INVARIANT VIOLATION: find_node_version_at_time returned non-existent version_id {}",
-                version_id
-            );
-
-            // Get the version metadata
-            let version = historical
-                .get_node_version(version_id)
-                .ok_or(crate::core::error::TemporalError::VersionNotFound(version_id))?;
+            // Get the version metadata (also validates the invariant that
+            // find_node_version_at_time only returns existing version IDs)
+            let version = historical.get_node_version(version_id).ok_or(
+                crate::core::error::TemporalError::VersionNotFound(version_id),
+            )?;
 
             // Reconstruct the properties from the version
             let properties = historical.reconstruct_node_properties(version_id)?;
@@ -358,19 +349,11 @@ impl BatchTemporalNodeIterator {
                         transaction_time,
                     })?;
 
-                // INVARIANT: If find_node_version_at_time returns a version_id,
-                // that version MUST exist in storage. If this fails, it indicates
-                // a critical data inconsistency (broken version chain or dangling version_id).
-                debug_assert!(
-                    guard.get_node_version(version_id).is_some(),
-                    "INVARIANT VIOLATION: find_node_version_at_time returned non-existent version_id {}",
-                    version_id
-                );
-
-                // Get the version metadata
-                let version = guard
-                    .get_node_version(version_id)
-                    .ok_or(crate::core::error::TemporalError::VersionNotFound(version_id))?;
+                // Get the version metadata (also validates the invariant that
+                // find_node_version_at_time only returns existing version IDs)
+                let version = guard.get_node_version(version_id).ok_or(
+                    crate::core::error::TemporalError::VersionNotFound(version_id),
+                )?;
 
                 // Reconstruct the properties from the version
                 let properties = guard.reconstruct_node_properties(version_id)?;
@@ -516,16 +499,8 @@ impl TemporalNodeScanIterator {
                 transaction_time: self.transaction_time,
             })?;
 
-        // INVARIANT: If find_node_version_at_time returns a version_id,
-        // that version MUST exist in storage. If this fails, it indicates
-        // a critical data inconsistency (broken version chain or dangling version_id).
-        debug_assert!(
-            guard.get_node_version(version_id).is_some(),
-            "INVARIANT VIOLATION: find_node_version_at_time returned non-existent version_id {}",
-            version_id
-        );
-
-        // Step 2: Get the version metadata
+        // Step 2: Get the version metadata (also validates the invariant that
+        // find_node_version_at_time only returns existing version IDs)
         let version = guard.get_node_version(version_id).ok_or(
             crate::core::error::TemporalError::VersionNotFound(version_id),
         )?;
@@ -1185,7 +1160,7 @@ impl ResultIterator for VectorRerankIterator {
         if self.sorted.is_none() && self.input.is_some() {
             // Check if vector index is configured
             let vector_property = match &self.vector_property {
-                Some(prop) => prop.clone(),
+                Some(prop) => prop.as_str(),
                 None => {
                     return Some(Err(crate::core::error::Error::Vector(
                         crate::core::error::VectorError::IndexError(
@@ -1205,7 +1180,7 @@ impl ResultIterator for VectorRerankIterator {
                 match result {
                     Ok(row) => {
                         // Get vector from node and compute similarity
-                        if let Some(similarity) = self.compute_similarity(&row, &vector_property) {
+                        if let Some(similarity) = self.compute_similarity(&row, vector_property) {
                             debug_assert!(similarity.is_finite(), "Non-finite similarity score");
                             if heap.len() < self.k {
                                 heap.push(Reverse(ScoredRow {

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -11,6 +11,15 @@ use crate::core::{EdgeId, NodeId};
 
 use super::iterators::ResultIterator;
 
+/// Score threshold above which results are highlighted green in display output.
+const HIGH_SCORE_THRESHOLD: f64 = 0.8;
+
+/// Score threshold below which results are highlighted yellow in display output.
+const LOW_SCORE_THRESHOLD: f64 = 0.5;
+
+/// Maximum number of properties shown per node in display output.
+const MAX_DISPLAY_PROPERTIES: usize = 5;
+
 /// A path through the graph, represented as a sequence of entity IDs.
 pub type Path = Vec<EntityId>;
 
@@ -459,9 +468,9 @@ impl std::fmt::Display for QueryResult {
             if let Some(scores) = &self.scores {
                 if let Some(score) = scores.get(i) {
                     let mut cell = comfy_table::Cell::new(format!("{:.4}", score));
-                    if *score > 0.8 {
+                    if f64::from(*score) > HIGH_SCORE_THRESHOLD {
                         cell = cell.fg(comfy_table::Color::Green);
-                    } else if *score < 0.5 {
+                    } else if f64::from(*score) < LOW_SCORE_THRESHOLD {
                         cell = cell.fg(comfy_table::Color::Yellow);
                     }
                     row.add_cell(cell);
@@ -476,7 +485,7 @@ impl std::fmt::Display for QueryResult {
                     // Format map compactly
                     let mut parts: Vec<String> = map
                         .iter()
-                        .take(5) // Limit to 5 properties
+                        .take(MAX_DISPLAY_PROPERTIES)
                         .map(|(k, v)| {
                             // resolve key
                             let k_str = crate::core::interning::GLOBAL_INTERNER
@@ -486,8 +495,8 @@ impl std::fmt::Display for QueryResult {
                         })
                         .collect();
 
-                    if map.len() > 5 {
-                        parts.push(format!("... (+{})", map.len() - 5));
+                    if map.len() > MAX_DISPLAY_PROPERTIES {
+                        parts.push(format!("... (+{})", map.len() - MAX_DISPLAY_PROPERTIES));
                     }
 
                     let content = if parts.is_empty() {
@@ -557,22 +566,25 @@ impl QueryResults {
             rows.push(row?);
         }
 
-        // Determine which fields we have
-        let has_any_scores = rows.iter().any(|r| r.score.is_some());
-        let has_any_paths = rows.iter().any(|r| r.path.is_some());
-        let has_any_versions = rows.iter().any(|r| r.timestamp.is_some());
-        let has_any_nodes = rows.iter().any(|r| r.entity.as_node().is_some());
+        // Determine which fields we have (single pass)
+        let (mut has_any_scores, mut has_any_paths, mut has_any_versions, mut has_any_nodes) =
+            (false, false, false, false);
+        let mut node_count = 0usize;
+        for row in &rows {
+            has_any_scores = has_any_scores || row.score.is_some();
+            has_any_paths = has_any_paths || row.path.is_some();
+            has_any_versions = has_any_versions || row.timestamp.is_some();
+            if row.entity.as_node().is_some() {
+                has_any_nodes = true;
+                node_count += 1;
+            }
+        }
 
         // Second pass: extract data with padding
         let capacity = rows.len();
-        let node_capacity = if has_any_nodes {
-            rows.iter().filter(|r| r.entity.as_node().is_some()).count()
-        } else {
-            0
-        };
-        let mut nodes = Vec::with_capacity(node_capacity);
+        let mut nodes = Vec::with_capacity(node_count);
         let mut properties = if has_any_nodes {
-            Some(Vec::with_capacity(node_capacity))
+            Some(Vec::with_capacity(node_count))
         } else {
             None
         };


### PR DESCRIPTION
## Summary
- Name 3 magic constants in results.rs: `HIGH_SCORE_THRESHOLD` (0.8), `LOW_SCORE_THRESHOLD` (0.5), `MAX_DISPLAY_PROPERTIES` (5)
- Merge 5 separate linear scans into a single pass in `collect_structured()` (was: 4 `.iter().any()` + 1 `.iter().filter().count()`)
- Remove 3 redundant `debug_assert!(get_node_version().is_some())` lookups — each preceded an identical `.ok_or_else()` call that already handles None
- Borrow `vector_property` as `&str` instead of `.clone()`-ing the `String` in `VectorRerankIterator`

**Part of the `src/query/` simplify sweep (Phase 5: Execution Engine & Root)**

Net: -13 lines across 2 files.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test` — 3,044 unit + 289 doc tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)