### PR TITLE
⚡ Bolt: Remove intermediate allocations and clones in ShardCoordinator

### DIFF
--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -885,7 +885,7 @@ impl ShardCoordinator {
             let log = self.commit_log.read().expect("Commit log lock poisoned");
             log.pending_commits()
                 .into_iter()
-                .map(|d| (d.tx_id, d.participants.clone(), d.commit_timestamp))
+                .map(|d| (d.tx_id, d.participants, d.commit_timestamp))
                 .collect::<Vec<_>>()
         };
 
@@ -1005,7 +1005,7 @@ impl ShardCoordinator {
         }
 
         // Re-attempt recovery using single-transaction recovery
-        let decisions = {
+        let decision = {
             let log = self
                 .commit_log
                 .read()
@@ -1014,12 +1014,11 @@ impl ShardCoordinator {
                 })?;
             log.pending_commits()
                 .into_iter()
-                .filter(|d| d.tx_id == tx_id)
-                .map(|d| (d.tx_id, d.participants.clone(), d.commit_timestamp))
-                .collect::<Vec<_>>()
+                .find(|d| d.tx_id == tx_id)
+                .map(|d| (d.tx_id, d.participants, d.commit_timestamp))
         };
 
-        if let Some((found_tx_id, participants, commit_timestamp)) = decisions.into_iter().next() {
+        if let Some((found_tx_id, participants, commit_timestamp)) = decision {
             let mut tx =
                 DistributedTransaction::new(found_tx_id, participants, self.transaction_timeout);
             tx.begin_prepare().ok();


### PR DESCRIPTION
* 💡 What: Removed `.clone()` in `recover_pending_transactions` and replaced `.filter().map().collect().into_iter().next()` with short-circuiting `.find().map()` in `retry_dead_lettered_transaction`.
* 🎯 Why: Iterators over owned values don't need `.clone()` when the values are moved. Collecting an entire filtered list just to get the first element wastes CPU cycles evaluating the rest of the list and allocates unnecessary memory on the heap.
* 📊 Impact: Eliminates one O(N) heap allocation (where N is pending commits) and skips unnecessary evaluations, significantly reducing memory churn in edge cases of transaction recovery.
* 🔬 Measurement: Run `cargo test --lib storage::sharding` to verify transaction recovery works correctly without allocations.

---
*PR created automatically by Jules for task [11214434281427807851](https://jules.google.com/task/11214434281427807851) started by @madmax983*