### PR TITLE
Remove duplicate tracing spans in find_similar_by_embedding_with_label

### DIFF
--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -484,10 +484,6 @@ impl AletheiaDB {
     ) -> Result<Vec<(NodeId, f32)>> {
         #[cfg(feature = "observability")]
         let _span = tracing::info_span!("find_similar_by_embedding_with_label").entered();
-        #[cfg(feature = "observability")]
-        let _span = tracing::info_span!("find_similar_by_embedding").entered();
-        #[cfg(feature = "observability")]
-        let _span = tracing::info_span!("find_similar").entered();
         self.current
             .find_similar_by_embedding_with_label(embedding, label, k)
             .record_error_metric()


### PR DESCRIPTION
## Summary
- Remove two copy-pasted tracing spans that shadowed the correct span name in `find_similar_by_embedding_with_label()`

**Part of systematic code quality sweep: db/ module, phase 4 (vector)**

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)