### PR TITLE
fix(sql): address PR #2288 review comments

### DIFF
--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -366,7 +366,7 @@ impl CostModel {
 
             PhysicalOp::NodeScan { estimated_rows, .. } => self.estimate_node_scan(*estimated_rows),
 
-            PhysicalOp::EdgeScan { estimated_rows, .. } => self.estimate_node_scan(*estimated_rows),
+            PhysicalOp::EdgeScan { estimated_rows, .. } => self.estimate_edge_scan(*estimated_rows),
 
             // PropertyScan is cheaper than NodeScan+Filter because it skips predicate
             // evaluation on non-matching nodes at the storage level
@@ -538,6 +538,21 @@ impl CostModel {
         Cost {
             cpu: self.operation_costs.node_lookup * estimated_rows as f64,
             io: (estimated_rows as f64 / BATCH_IO_ROWS).ceil(), // Batch I/O
+            memory: estimated_rows * std::mem::size_of::<u64>() * ESTIMATED_FIELDS_PER_NODE,
+            network: 0.0,
+        }
+    }
+
+    /// Estimate cost for a full edge scan.
+    ///
+    /// Currently mirrors `estimate_node_scan` since edges and nodes have similar
+    /// storage characteristics, but is kept as a separate method so the cost model
+    /// can diverge later (e.g. edges may have fewer properties or different I/O
+    /// patterns).
+    fn estimate_edge_scan(&self, estimated_rows: usize) -> Cost {
+        Cost {
+            cpu: self.operation_costs.node_lookup * estimated_rows as f64,
+            io: (estimated_rows as f64 / BATCH_IO_ROWS).ceil(),
             memory: estimated_rows * std::mem::size_of::<u64>() * ESTIMATED_FIELDS_PER_NODE,
             network: 0.0,
         }
@@ -802,5 +817,61 @@ mod tests {
             offset: 0,
         };
         assert_eq!(model.estimate_cardinality(&limit, &stats), 5);
+    }
+
+    #[test]
+    fn test_edge_scan_cost() {
+        let model = CostModel::default();
+        let stats = test_stats();
+
+        let op = PhysicalOp::EdgeScan {
+            edge_type: Some("KNOWS".to_string()),
+            estimated_rows: 500,
+        };
+
+        let cost = model.estimate(&op, &stats);
+        assert!(cost.cpu > 0.0, "EdgeScan should have positive CPU cost");
+        assert!(cost.io > 0.0, "EdgeScan should have positive I/O cost");
+        assert!(cost.memory > 0, "EdgeScan should have positive memory cost");
+    }
+
+    #[test]
+    fn test_edge_scan_cardinality() {
+        let model = CostModel::default();
+        let stats = test_stats();
+
+        let op = PhysicalOp::EdgeScan {
+            edge_type: None,
+            estimated_rows: 750,
+        };
+        assert_eq!(model.estimate_cardinality(&op, &stats), 750);
+    }
+
+    #[test]
+    fn test_edge_scan_cost_matches_node_scan_for_now() {
+        // The edge scan cost model currently mirrors node scan.
+        // This test documents that contract so we notice when they diverge.
+        let model = CostModel::default();
+        let stats = test_stats();
+        let rows = 200;
+
+        let node_cost = model.estimate(
+            &PhysicalOp::NodeScan {
+                label: None,
+                estimated_rows: rows,
+            },
+            &stats,
+        );
+        let edge_cost = model.estimate(
+            &PhysicalOp::EdgeScan {
+                edge_type: None,
+                estimated_rows: rows,
+            },
+            &stats,
+        );
+
+        assert_eq!(node_cost.cpu, edge_cost.cpu);
+        assert_eq!(node_cost.io, edge_cost.io);
+        assert_eq!(node_cost.memory, edge_cost.memory);
     }
 }

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -1835,4 +1835,47 @@ mod tests {
             _ => panic!("Expected IndexNotFound error, got {:?}", err),
         }
     }
+
+    #[test]
+    fn test_plan_edge_scan() {
+        let planner = test_planner();
+
+        let query = Query {
+            ops: vec![
+                QueryOp::ScanEdges {
+                    edge_type: Some("KNOWS".to_string()),
+                },
+                QueryOp::Limit(10),
+            ],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        let explain = plan.explain();
+        assert!(
+            explain.contains("EdgeScan") || explain.contains("Limit"),
+            "Plan should contain EdgeScan: {}",
+            explain
+        );
+    }
+
+    #[test]
+    fn test_plan_edge_scan_no_type() {
+        let planner = test_planner();
+
+        let query = Query {
+            ops: vec![QueryOp::ScanEdges { edge_type: None }, QueryOp::Limit(5)],
+            temporal_context: None,
+            hints: QueryHints::default(),
+        };
+
+        let plan = planner.plan(query).unwrap();
+        let explain = plan.explain();
+        assert!(
+            explain.contains("EdgeScan"),
+            "Plan should contain EdgeScan: {}",
+            explain
+        );
+    }
 }

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -1981,4 +1981,65 @@ mod tests {
         assert!(explain.contains("label: Some(\"Document\")"));
         assert!(explain.contains("prop: document_embedding"));
     }
+
+    // ==================== EdgeScan Coverage Tests ====================
+
+    #[test]
+    fn test_edge_scan_name() {
+        let op = PhysicalOp::EdgeScan {
+            edge_type: Some("KNOWS".to_string()),
+            estimated_rows: 500,
+        };
+        assert_eq!(op.name(), "EdgeScan");
+    }
+
+    #[test]
+    fn test_edge_scan_is_leaf() {
+        let op = PhysicalOp::EdgeScan {
+            edge_type: None,
+            estimated_rows: 100,
+        };
+        assert!(op.is_leaf());
+    }
+
+    #[test]
+    fn test_edge_scan_depth() {
+        let op = PhysicalOp::EdgeScan {
+            edge_type: Some("FOLLOWS".to_string()),
+            estimated_rows: 200,
+        };
+        assert_eq!(op.depth(), 1);
+    }
+
+    #[test]
+    fn test_edge_scan_explain_with_type() {
+        let op = PhysicalOp::EdgeScan {
+            edge_type: Some("KNOWS".to_string()),
+            estimated_rows: 500,
+        };
+        let explain = op.explain();
+        assert!(explain.contains("EdgeScan"));
+        assert!(explain.contains("KNOWS"));
+        assert!(explain.contains("500"));
+    }
+
+    #[test]
+    fn test_edge_scan_explain_without_type() {
+        let op = PhysicalOp::EdgeScan {
+            edge_type: None,
+            estimated_rows: 1000,
+        };
+        let explain = op.explain();
+        assert!(explain.contains("EdgeScan"));
+        assert!(explain.contains("1000"));
+    }
+
+    #[test]
+    fn test_edge_scan_get_input_is_none() {
+        let op = PhysicalOp::EdgeScan {
+            edge_type: None,
+            estimated_rows: 100,
+        };
+        assert!(op.get_input().is_none());
+    }
 }

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -40,6 +40,9 @@ use super::{OptimizationRule, Statistics};
 /// Default cardinality estimate for node scans without statistics.
 const DEFAULT_NODE_SCAN_CARDINALITY: usize = 1000;
 
+/// Default cardinality estimate for edge scans without statistics.
+const DEFAULT_EDGE_SCAN_CARDINALITY: usize = 1000;
+
 /// Default cardinality estimate for property-indexed scans (~10% of full scan).
 const DEFAULT_PROPERTY_SCAN_CARDINALITY: usize = 100;
 
@@ -389,7 +392,7 @@ impl OperationReordering {
                 ScanOp::SimilarToNode { k, .. } => *k,
                 ScanOp::PropertyScan { .. } => DEFAULT_PROPERTY_SCAN_CARDINALITY,
                 ScanOp::EdgeScan { estimated_rows, .. } => {
-                    estimated_rows.unwrap_or(DEFAULT_NODE_SCAN_CARDINALITY)
+                    estimated_rows.unwrap_or(DEFAULT_EDGE_SCAN_CARDINALITY)
                 }
             },
             LogicalOp::Unary {

--- a/src/sql/converter.rs
+++ b/src/sql/converter.rs
@@ -22,6 +22,10 @@ use super::parser::SqlParser;
 use super::temporal_parser;
 use super::vector_parser::{self, EmbeddingRef, VectorOp};
 
+/// Default k for SIMILAR_TO threshold-based search when no explicit limit is given.
+/// This is an approximation: we over-fetch candidates then filter by threshold.
+const SIMILAR_TO_DEFAULT_K: usize = 100;
+
 /// Parameter values that can be bound to SQL queries.
 #[derive(Debug, Clone)]
 pub enum SqlParameterValue {
@@ -604,9 +608,23 @@ impl SqlConverter {
                     );
                 } else {
                     // Standalone k-NN search.
-                    let k = k.unwrap_or(10);
+                    let limit = k.unwrap_or(10);
+
+                    // If OFFSET is present, VectorSearch must fetch enough rows so
+                    // that after Skip(offset) we still have `limit` results.
+                    let offset = query.ops.iter().find_map(|op| {
+                        if let QueryOp::Skip(n) = op {
+                            Some(*n)
+                        } else {
+                            None
+                        }
+                    });
+                    let effective_k = limit + offset.unwrap_or(0);
+
                     // Remove the Limit op since VectorSearch has its own k.
+                    // Keep Skip so offset semantics are preserved.
                     query.ops.retain(|op| !matches!(op, QueryOp::Limit(_)));
+
                     // Insert VectorSearch after source ops.
                     let pos = query
                         .ops
@@ -619,11 +637,16 @@ impl SqlConverter {
                         pos,
                         QueryOp::VectorSearch {
                             embedding,
-                            k,
+                            k: effective_k,
                             metric: *metric,
                             property_key: Some(property_key.clone()),
                         },
                     );
+
+                    // Re-add Limit after Skip so the final row count equals `limit`.
+                    if offset.is_some() {
+                        query.ops.push(QueryOp::Limit(limit));
+                    }
                 }
             }
             VectorOp::KnnFunction {
@@ -633,6 +656,17 @@ impl SqlConverter {
                 ..
             } => {
                 let embedding = self.resolve_embedding(embedding_ref)?;
+
+                // Preserve label filter from the ScanNodes we are about to remove.
+                // e.g. `FROM KNN('Documents', ...)` produces ScanNodes { label: Some("documents") }.
+                let label = query.ops.iter().find_map(|op| {
+                    if let QueryOp::ScanNodes { label: Some(l) } = op {
+                        Some(l.clone())
+                    } else {
+                        None
+                    }
+                });
+
                 // Replace the scan with VectorSearch.
                 query
                     .ops
@@ -646,19 +680,22 @@ impl SqlConverter {
                         property_key: Some(property_key.clone()),
                     },
                 );
+
+                // Re-apply label filter so results are scoped to the original label.
+                if let Some(l) = label {
+                    query.ops.insert(1, QueryOp::FilterLabel(l));
+                }
             }
             VectorOp::SimilarToFilter {
                 property_key,
                 embedding_ref,
                 threshold,
             } => {
-                // Validate that the parameters resolve correctly.
-                // A full implementation would add a VectorFilter QueryOp; for now
-                // we validate and use VectorSearch with a large k as an approximation.
+                // A full implementation would add a dedicated VectorFilter QueryOp.
+                // For now we over-fetch with VectorSearch and post-filter by threshold.
                 let embedding = self.resolve_embedding(embedding_ref)?;
 
-                // Use a reasonable default k for threshold-based search.
-                let k = 100;
+                let k = SIMILAR_TO_DEFAULT_K;
                 let pos = query
                     .ops
                     .iter()
@@ -675,7 +712,17 @@ impl SqlConverter {
                         property_key: Some(property_key.clone()),
                     },
                 );
-                let _ = threshold; // Threshold filtering will be applied post-search
+
+                // Enforce the similarity threshold as a post-search filter.
+                // VectorSearch returns a "score" property for each result;
+                // we keep only results whose score >= the user-specified threshold.
+                query.ops.insert(
+                    pos + 1,
+                    QueryOp::Filter(Predicate::Gte {
+                        key: "score".to_string(),
+                        value: PredicateValue::Float(*threshold),
+                    }),
+                );
             }
         }
 

--- a/src/sql/tests.rs
+++ b/src/sql/tests.rs
@@ -1266,41 +1266,29 @@ mod phase3_graph {
 
     #[test]
     fn test_parse_multiple_match_clauses() {
-        // Multiple MATCH clauses should all be extracted
-        let result = parse_sql(
+        // Multiple MATCH clauses should all be extracted and produce two traversal ops.
+        let query = parse_sql(
             "SELECT * FROM nodes AS a MATCH (a)-[:KNOWS]->(b) MATCH (b)-[:WORKS_AT]->(c) WHERE a.name = 'Alice'",
+        )
+        .unwrap();
+
+        let traverse_count = query
+            .ops
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    QueryOp::TraverseOut { .. }
+                        | QueryOp::TraverseIn { .. }
+                        | QueryOp::TraverseBoth { .. }
+                )
+            })
+            .count();
+        assert_eq!(
+            traverse_count, 2,
+            "Expected exactly 2 traversal ops, got {}",
+            traverse_count
         );
-        // Should either work (extracting both patterns) or give a clear error
-        match result {
-            Ok(query) => {
-                // If supported, should have two traversal ops
-                let traverse_count = query
-                    .ops
-                    .iter()
-                    .filter(|op| {
-                        matches!(
-                            op,
-                            QueryOp::TraverseOut { .. }
-                                | QueryOp::TraverseIn { .. }
-                                | QueryOp::TraverseBoth { .. }
-                        )
-                    })
-                    .count();
-                assert!(
-                    traverse_count >= 2,
-                    "Expected 2 traversal ops, got {}",
-                    traverse_count
-                );
-            }
-            Err(e) => {
-                // If not supported, error should be clear
-                assert!(
-                    e.to_string().contains("MATCH") || e.to_string().contains("multiple"),
-                    "Error should mention MATCH: {}",
-                    e
-                );
-            }
-        }
     }
 
     #[test]
@@ -1605,6 +1593,135 @@ mod phase4_vector {
 
         // VectorSearch should be the first op, replacing ScanNodes
         assert!(matches!(&query.ops[0], QueryOp::VectorSearch { .. }));
+        // No ScanNodes should remain
+        assert!(
+            !query
+                .ops
+                .iter()
+                .any(|op| matches!(op, QueryOp::ScanNodes { .. }))
+        );
+    }
+
+    #[test]
+    fn test_similar_to_enforces_threshold() {
+        let embedding: Arc<[f32]> = vec![0.1, 0.2, 0.3].into();
+        let mut params = HashMap::new();
+        params.insert(
+            "query_embedding".to_string(),
+            SqlParameterValue::Embedding(embedding),
+        );
+
+        let query = parse_sql_with_params(
+            "SELECT * FROM Documents WHERE SIMILAR_TO(embedding, $query_embedding, 0.8)",
+            params,
+        )
+        .unwrap();
+
+        // Should have a VectorSearch followed by a Filter(Gte score 0.8)
+        assert!(
+            query
+                .ops
+                .iter()
+                .any(|op| matches!(op, QueryOp::VectorSearch { .. }))
+        );
+        let has_score_filter = query.ops.iter().any(|op| {
+            matches!(
+                op,
+                QueryOp::Filter(Predicate::Gte {
+                    key,
+                    value: PredicateValue::Float(t),
+                }) if key == "score" && (*t - 0.8).abs() < f64::EPSILON
+            )
+        });
+        assert!(
+            has_score_filter,
+            "Expected a Filter(Gte score >= 0.8) op, got: {:?}",
+            query.ops
+        );
+    }
+
+    #[test]
+    fn test_knn_offset_accounts_for_skip() {
+        // LIMIT 10 OFFSET 5 should produce VectorSearch(k=15) + Skip(5) + Limit(10)
+        let query = parse_sql(
+            "SELECT * FROM Documents ORDER BY embedding <=> '[0.1, 0.2]'::vector LIMIT 10 OFFSET 5",
+        )
+        .unwrap();
+
+        if let Some(QueryOp::VectorSearch { k, .. }) = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::VectorSearch { .. }))
+        {
+            assert_eq!(*k, 15, "k should be limit + offset = 15");
+        } else {
+            panic!("Expected VectorSearch op");
+        }
+
+        assert!(
+            query.ops.iter().any(|op| matches!(op, QueryOp::Skip(5))),
+            "Expected Skip(5), got: {:?}",
+            query.ops
+        );
+        assert!(
+            query.ops.iter().any(|op| matches!(op, QueryOp::Limit(10))),
+            "Expected Limit(10), got: {:?}",
+            query.ops
+        );
+    }
+
+    #[test]
+    fn test_knn_without_offset_no_extra_limit() {
+        // LIMIT 10 without OFFSET should produce VectorSearch(k=10) and no Limit op
+        let query = parse_sql(
+            "SELECT * FROM Documents ORDER BY embedding <=> '[0.1, 0.2]'::vector LIMIT 10",
+        )
+        .unwrap();
+
+        if let Some(QueryOp::VectorSearch { k, .. }) = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::VectorSearch { .. }))
+        {
+            assert_eq!(*k, 10);
+        } else {
+            panic!("Expected VectorSearch op");
+        }
+
+        // No Limit op should remain (VectorSearch handles it)
+        assert!(
+            !query.ops.iter().any(|op| matches!(op, QueryOp::Limit(_))),
+            "No Limit op expected without OFFSET, got: {:?}",
+            query.ops
+        );
+    }
+
+    #[test]
+    fn test_knn_function_preserves_label_filter() {
+        let embedding: Arc<[f32]> = vec![0.1, 0.2, 0.3].into();
+        let mut params = HashMap::new();
+        params.insert("query".to_string(), SqlParameterValue::Embedding(embedding));
+
+        let query = parse_sql_with_params(
+            "SELECT * FROM KNN('Documents', 'embedding', $query, 10)",
+            params,
+        )
+        .unwrap();
+
+        // VectorSearch should be first
+        assert!(matches!(&query.ops[0], QueryOp::VectorSearch { .. }));
+
+        // FilterLabel should follow to scope results to 'documents'
+        let has_label_filter = query
+            .ops
+            .iter()
+            .any(|op| matches!(op, QueryOp::FilterLabel(l) if l == "documents"));
+        assert!(
+            has_label_filter,
+            "Expected FilterLabel('documents'), got: {:?}",
+            query.ops
+        );
+
         // No ScanNodes should remain
         assert!(
             !query


### PR DESCRIPTION
## Summary

Follow-up to #2288 addressing all review comments from Gemini and Codex.

### Bug Fixes (Codex)
- **P1: SIMILAR_TO threshold enforcement** — `WHERE SIMILAR_TO(embedding, $vec, 0.8)` now actually enforces the 0.8 cutoff via a `Filter(Predicate::Gte { key: "score", value: threshold })` after VectorSearch
- **P1: KNN() label filter preservation** — `FROM KNN('Documents', ...)` now scopes results to the Documents label via `FilterLabel` instead of searching all labels
- **P2: k-NN + OFFSET row loss** — `ORDER BY embedding <=> $vec LIMIT 10 OFFSET 5` now correctly requests `k = limit + offset = 15` and re-applies LIMIT after OFFSET

### Quality Improvements (Gemini)
- **Decoupled edge scan cost** — `estimate_edge_scan()` is now a separate method from `estimate_node_scan()` in cost.rs
- **DEFAULT_EDGE_SCAN_CARDINALITY** — Separate constant for edge scan cardinality estimates
- **SIMILAR_TO_DEFAULT_K** — Extracted magic number `k=100` into a named constant
- **Strengthened multi-MATCH test** — Uses `unwrap()` + exact assertion instead of defensive match

### Coverage
- Added 15 new tests covering EdgeScan planning, cost estimation, explain output, and all three bug fixes
- Targets 85%+ patch coverage to pass codecov/patch gate

## Test plan
- [x] All 3,255 tests pass (`cargo test --features sql`)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Formatted (`cargo fmt --all`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)