### PR TITLE
⚡ Bolt: Optimize path allocation in TraversalIterator

### DIFF
--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1258,7 +1258,7 @@ fn test_e2e_multi_hop_traversal() {
     // but the executor may only return terminal-depth nodes depending on the
     // TraversalDepth::Range semantics.  Assert at least 1 result.
     assert!(
-        rows.len() >= 1,
+        !rows.is_empty(),
         "expected at least 1 result from *1..2 traversal, got {}",
         rows.len()
     );

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -829,7 +829,10 @@ impl ResultIterator for TraversalIterator {
                 let neighbors = self.get_neighbors(node_id);
                 for (target, edge_id) in neighbors {
                     if self.visited.insert(target) {
-                        let mut new_path = path.clone();
+                        // ⚡ Bolt Optimization: Pre-allocate capacity for new path to avoid reallocations.
+                        // We are adding exactly 2 elements (edge and node) to the current path length.
+                        let mut new_path = Vec::with_capacity(path.len() + 2);
+                        new_path.extend_from_slice(&path);
                         new_path.push(EntityId::Edge(edge_id));
                         new_path.push(EntityId::Node(target));
                         self.frontier


### PR DESCRIPTION
💡 What: Replaced `path.clone()` followed by two `push()` calls with explicitly pre-allocating a new `Vec` with the exact required capacity and using `extend_from_slice()`. Also fixed a clippy `len_zero` warning in a cypher test.

🎯 Why: Calling `.clone()` on a `Vec` allocates exactly `len` capacity. Immediately pushing elements into that cloned `Vec` guarantees a reallocation, adding heap overhead in a tight hot loop (traversal neighbor expansion).

📊 Impact: Eliminates guaranteed heap reallocations per neighbor expanded during variable-length traversals.

🔬 Measurement: Run `cargo bench` on path queries or observe reduced allocation counts via heap profilers on traversal endpoints. Run `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [6511419251312850333](https://jules.google.com/task/6511419251312850333) started by @madmax983*