### PR TITLE
⚔️ Elenchus: core::temporal Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -339,3 +339,10 @@
 **Finding:** The FNV-1a fallback tests for `IdentityHasher` (`test_identity_hasher_write_fallback_fnv` and `test_identity_hasher_write_fallback_fnv_dirty`) were tautological. They exactly mirrored the source implementation by reconstructing the FNV-1a multiplication and XOR sequence to generate their `expected` values. This meant they only asserted that "the code is the code" and provided no independent verification that the hashing logic was correct or consistent with standard FNV-1a.
 **Evidence:** The original tests explicitly copied the sequence `expected ^= 1; expected = expected.wrapping_mul(FNV_PRIME);` which exactly mirrors the `write` loop. Any mutation altering `FNV_PRIME` or the operation order would survive if the same change was incorrectly made to the test or if it was inherently flawed.
 **Recommendation:** Refactored the tests to use independently pre-computed integer constants as the `expected` values (the Oracle Problem solution). This ensures the implementation matches the ground truth rather than itself.
+
+**[Temporal Range Safety Gaps]**
+**Module:** `src/core/temporal.rs`
+**Severity:** 🟡 Suspect
+**Finding:** TimeRange boundaries `from`, `at`, `new`, and `close_at` as well as BiTemporal boundaries `close_valid_time`, `close_transaction_time`, and `close_both` had logic enforcing `MAX_VALID_TIMESTAMP` but lacked direct unit testing for panics/errors. This allowed mutants that bypassed sentinel checks (e.g. `start == TIMESTAMP_MAX`) to survive. Furthermore, `BiTemporalInterval::deserialize` did not explicitly test the short buffer negative case.
+**Evidence:** 70+ surviving mutants in `cargo mutants` run against `core::temporal` primarily modifying boundary assertions and return defaults.
+**Recommendation:** Add sentinel/validity checks as `test_sentry_timerange_*` and `test_sentry_bitemporal_*` asserting on `catch_unwind` and explicit `unwrap_err` states.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,5 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+1. **Explore Mutants and Test Holes**: Looked into `temporal_mutants.txt` which indicated around 76 surviving mutants mainly related to `MAX_VALID_TIMESTAMP` handling missing error tests, and default returns for serializers/deserializers.
+2. **Implement Missing Tests in `src/core/temporal.rs`**: Handled by applying `test_sentry_timerange_from_timestamp_max`, `test_sentry_timerange_from_invalid_timestamp`, `test_sentry_timerange_at_invalid_timestamp`, `test_sentry_timerange_new_invalid_timestamp`, and `test_sentry_timerange_close_at_invalid_timestamp` and `BiTemporalInterval` counterparts.
+3. **Verify Functionality**: Used `cargo test --lib core::temporal` to ensure tests compile and execute cleanly.
+4. **Log Learnings**: Appended Elenchus verdict to `.jules/elenchus.md`.
+5. **Pre-commit Steps**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1944,4 +1944,99 @@ mod sentry_tests {
         let err = result.unwrap_err();
         assert!(format!("{}", err).contains("Deserialized TimeRange invalid"));
     }
+
+    #[test]
+    fn test_sentry_timerange_from_timestamp_max() {
+        let range = TimeRange::from(TIMESTAMP_MAX);
+        assert_eq!(range.start(), TIMESTAMP_MAX);
+        assert_eq!(range.end(), TIMESTAMP_MAX);
+        assert!(range.is_empty());
+    }
+
+    #[test]
+    fn test_sentry_timerange_from_invalid_timestamp() {
+        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let result = std::panic::catch_unwind(|| {
+            TimeRange::from(invalid_ts);
+        });
+        assert!(
+            result.is_err(),
+            "TimeRange::from should panic on invalid timestamp"
+        );
+    }
+
+    #[test]
+    fn test_sentry_timerange_at_invalid_timestamp() {
+        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let result = std::panic::catch_unwind(|| {
+            TimeRange::at(invalid_ts);
+        });
+        assert!(
+            result.is_err(),
+            "TimeRange::at should panic on invalid timestamp"
+        );
+    }
+
+    #[test]
+    fn test_sentry_timerange_new_invalid_timestamp() {
+        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let valid_ts = HybridTimestamp::new_unchecked(100, 0);
+
+        let err1 = TimeRange::new(invalid_ts, TIMESTAMP_MAX).unwrap_err();
+        assert!(matches!(err1, TemporalError::InvalidTimestamp { .. }));
+
+        let err2 = TimeRange::new(valid_ts, invalid_ts).unwrap_err();
+        assert!(matches!(err2, TemporalError::InvalidTimestamp { .. }));
+    }
+
+    #[test]
+    fn test_sentry_timerange_close_at_invalid_timestamp() {
+        let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let range = TimeRange::from(HybridTimestamp::new_unchecked(100, 0));
+
+        let err = range.close_at(invalid_ts).unwrap_err();
+        assert!(matches!(err, TemporalError::InvalidTimestamp { .. }));
+    }
+}
+
+#[test]
+fn test_sentry_bitemporal_close_valid_time_invalid_timestamp() {
+    let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+    let interval = BiTemporalInterval::current(HybridTimestamp::new_unchecked(100, 0));
+    let result = interval.close_valid_time(invalid_ts);
+    assert!(
+        result.is_err(),
+        "close_valid_time should panic/error on invalid timestamp"
+    );
+}
+
+#[test]
+fn test_sentry_bitemporal_close_transaction_time_invalid_timestamp() {
+    let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+    let interval = BiTemporalInterval::current(HybridTimestamp::new_unchecked(100, 0));
+    let result = interval.close_transaction_time(invalid_ts);
+    assert!(
+        result.is_err(),
+        "close_transaction_time should error on invalid timestamp"
+    );
+}
+
+#[test]
+fn test_sentry_bitemporal_close_both_invalid_timestamp() {
+    let invalid_ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+    let valid_ts = HybridTimestamp::new_unchecked(100, 0);
+    let interval = BiTemporalInterval::current(valid_ts);
+
+    let result1 = interval.close_both(invalid_ts, valid_ts);
+    assert!(result1.is_err());
+
+    let result2 = interval.close_both(valid_ts, invalid_ts);
+    assert!(result2.is_err());
+}
+
+#[test]
+fn test_sentry_bitemporal_deserialize_short_buffer() {
+    let bytes = [0u8; 47];
+    let err = BiTemporalInterval::deserialize(&bytes).unwrap_err();
+    assert!(matches!(err, StorageError::CorruptedData(_)));
 }


### PR DESCRIPTION
**[Temporal Range Safety Gaps]**
**Module:** `src/core/temporal.rs`
**Severity:** 🟡 Suspect
**Finding:** TimeRange boundaries `from`, `at`, `new`, and `close_at` as well as BiTemporal boundaries `close_valid_time`, `close_transaction_time`, and `close_both` had logic enforcing `MAX_VALID_TIMESTAMP` but lacked direct unit testing for panics/errors. This allowed mutants that bypassed sentinel checks (e.g. `start == TIMESTAMP_MAX`) to survive. Furthermore, `BiTemporalInterval::deserialize` did not explicitly test the short buffer negative case.
**Evidence:** 70+ surviving mutants in `cargo mutants` run against `core::temporal` primarily modifying boundary assertions and return defaults.
**Recommendation:** Add sentinel/validity checks as `test_sentry_timerange_*` and `test_sentry_bitemporal_*` asserting on `catch_unwind` and explicit `unwrap_err` states.

---
*PR created automatically by Jules for task [9816424281791037637](https://jules.google.com/task/9816424281791037637) started by @madmax983*