### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -92,3 +92,7 @@
 ## 2025-03-05 - Experimental Feature Leaks II & Doctest Conditionals
 **Confusion:** Several experimental modules (`chronos`, `echo`, `sherlock`, and `temporal_narrative`) in `src/experimental/mod.rs` were missing their `#[cfg(feature = "nova")]` gating attributes. This allowed them to leak into the public API without the required feature flag enabled. Furthermore, the doctests for `sherlock` (in `mod.rs`) and `kairos` used an anonymous block (`# { ... }`) for feature gating, which generated `main function not found` or `expressions at the top level` warnings in `cargo test --doc`.
 **Clarification:** Added the missing `#[cfg(feature = "nova")]` attributes to the exposed experimental modules. Fixed the doctests to use conditional compilation on the `main` function and imports themselves (`# #[cfg(feature = "nova")] \n fn main() { ... }`), and added an empty fallback `main` function for when the feature is disabled.
+
+## 2025-03-05 - Redundant Explicit Link Targets in Documentation
+**Confusion:** Using full path references like `[\`PropertyMap\`](crate::core::property::PropertyMap)` in documentation where the link text can be resolved directly causes a `rustdoc::redundant_explicit_links` warning.
+**Clarification:** Use implicit intra-doc links like `[\`PropertyMap\`]` directly if the item is in scope or can be naturally resolved by rustdoc, avoiding the explicit and redundant target path.

--- a/src/core/graph.rs
+++ b/src/core/graph.rs
@@ -3,6 +3,17 @@
 //! This module defines the fundamental graph elements that make up AletheiaDB's
 //! current state. These structures are optimized for the "hot path" - fast access
 //! to current data without temporal overhead.
+//!
+//! # The "Fast Path" Architecture
+//!
+//! AletheiaDB splits storage into two paths:
+//! - **Current Storage (Fast Path)**: Stores the latest version of every node and edge.
+//! - **Historical Storage**: Stores older versions compressed as anchor snapshots and delta updates.
+//!
+//! The structures in this module (`Node` and `Edge`) represent entities in the Fast Path.
+//! When you query the database without specifying a historical time, you interact with
+//! these types. They are designed to be cloned cheaply thanks to internal `Arc` sharing
+//! for `properties` ([`PropertyMap`]) and `label` ([`InternedString`]).
 
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
@@ -21,6 +32,35 @@ fn matches_label(label_id: InternedString, label: &str) -> bool {
 ///
 /// This represents the current version of a node, optimized for fast access.
 /// Historical versions are stored separately in the temporal storage layer.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+/// use aletheiadb::core::Node;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let db = AletheiaDB::new()?;
+///
+/// // Create a node
+/// let node_id = db.create_node(
+///     "Person",
+///     PropertyMapBuilder::new()
+///         .insert("name", "Alice")
+///         .insert("age", 30)
+///         .build()
+/// )?;
+///
+/// // Retrieve the current Node state
+/// let node: Node = db.get_node(node_id)?;
+///
+/// // Access fields (label is an InternedString, properties is a PropertyMap)
+/// assert!(node.has_label_str("Person"));
+/// assert_eq!(node.get_property("name").and_then(|v| v.as_str()), Some("Alice"));
+/// assert_eq!(node.get_property("age").and_then(|v| v.as_int()), Some(30));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, PartialEq)]
 pub struct Node {
     /// Unique identifier for this node.
@@ -141,6 +181,39 @@ impl std::fmt::Debug for Node {
 ///
 /// Edges are directed relationships between nodes with properties.
 /// This represents the current version, optimized for fast traversals.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+/// use aletheiadb::core::Edge;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let db = AletheiaDB::new()?;
+///
+/// // Create two nodes
+/// let source_id = db.create_node("Person", PropertyMapBuilder::new().build())?;
+/// let target_id = db.create_node("Company", PropertyMapBuilder::new().build())?;
+///
+/// // Create a directed edge between them
+/// let edge_id = db.create_edge(
+///     source_id,
+///     target_id,
+///     "WORKS_FOR",
+///     PropertyMapBuilder::new().insert("since", 2021).build()
+/// )?;
+///
+/// // Retrieve the current Edge state
+/// let edge: Edge = db.get_edge(edge_id)?;
+///
+/// // Access fields to inspect the relationship
+/// assert!(edge.has_label_str("WORKS_FOR"));
+/// assert_eq!(edge.source, source_id);
+/// assert_eq!(edge.target, target_id);
+/// assert_eq!(edge.get_property("since").and_then(|v| v.as_int()), Some(2021));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, PartialEq)]
 pub struct Edge {
     /// Unique identifier for this edge.


### PR DESCRIPTION
📖 Chapter: Core Graph Module (`src/core/graph.rs`)

💡 Insight: The `Node` and `Edge` structs lacked high-level context explaining their role in the overall architecture. They exist on the "Fast Path" (Current Storage), separated from historical snapshot data. We clarified this architectural distinction directly in the module documentation. Furthermore, these fundamental types lacked practical usage examples.

🧪 Example: Added comprehensive, executable `rust,no_run` doctests to both the `Node` and `Edge` structs demonstrating how to interact with them via the database API, inspect their fields, and access their `PropertyMap`.

🖼️ Preview: Documentation for `core::graph` now successfully generates via `cargo doc` with zero warnings.

---
*PR created automatically by Jules for task [6746538890479923887](https://jules.google.com/task/6746538890479923887) started by @madmax983*