### PR TITLE
🪒 Razor: Simplify experimental traits to concrete types

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,13 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `PropagationModel` and `Resonator` traits (Single-implementation abstractions in experimental features).
+**Cut:** Deleted the single-implementation traits. Refactored `Sybil` and `EchoChamber` to use concrete structs `LinearPropagation` and `ActivityDensityResonator` directly.
+**Saved:** ~30 lines of boilerplate + cognitive load of unnecessary abstractions.
+
+## [Reduction]
+**Bloat:** `SemanticRule` trait and `Box<dyn SemanticRule>` in `Sentinel` (Overkill dynamic dispatch for two variants).
+**Cut:** Replaced `SemanticRule` trait with a concrete `enum SemanticRule` containing `VectorBan` and `NumericRange` variants. Updated `Sentinel` to store `Vec<SemanticRule>`.
+**Saved:** Dynamic dispatch overhead, heap allocations, and simplified validation loop logic.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -196,7 +191,7 @@ impl Resonator for ActivityDensityResonator {
 /// ```
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -239,13 +234,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -306,7 +301,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );

--- a/src/experimental/sentinel.rs
+++ b/src/experimental/sentinel.rs
@@ -18,7 +18,7 @@
 //! // Rule: Ban anything semantically similar to "Hate Speech" (vector: [1.0, 0.0])
 //! let mut ban_rule = VectorBanRule::new("embedding", 0.9);
 //! ban_rule.add_banned_vector(vec![1.0, 0.0]).unwrap();
-//! sentinel.add_rule(Box::new(ban_rule));
+//! sentinel.add_rule(SemanticRule::VectorBan(ban_rule));
 //!
 //! // This should fail validation
 //! let toxic_props = PropertyMapBuilder::new()
@@ -33,15 +33,29 @@ use crate::core::property::PropertyMap;
 use crate::core::vector::cosine_similarity;
 
 /// A rule that validates a PropertyMap.
-pub trait SemanticRule {
+pub enum SemanticRule {
+    /// Ban specific vectors
+    VectorBan(VectorBanRule),
+    /// Enforce numeric ranges
+    NumericRange(NumericRangeRule),
+}
+
+impl SemanticRule {
     /// Validate the given properties.
     /// Returns Ok if valid, Err with a reason if invalid.
-    fn validate(&self, props: &PropertyMap) -> Result<()>;
+    /// Validate the given properties.
+    /// Returns Ok if valid, Err with a reason if invalid.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
+        match self {
+            Self::VectorBan(rule) => rule.validate(props),
+            Self::NumericRange(rule) => rule.validate(props),
+        }
+    }
 }
 
 /// The Sentinel validates data against a set of rules.
 pub struct Sentinel {
-    rules: Vec<Box<dyn SemanticRule>>,
+    rules: Vec<SemanticRule>,
 }
 
 impl Sentinel {
@@ -51,11 +65,13 @@ impl Sentinel {
     }
 
     /// Add a rule to the Sentinel.
-    pub fn add_rule(&mut self, rule: Box<dyn SemanticRule>) {
+    pub fn add_rule(&mut self, rule: SemanticRule) {
         self.rules.push(rule);
     }
 
     /// Validate a PropertyMap against all rules.
+    /// Validate the given properties.
+    /// Returns Ok if valid, Err with a reason if invalid.
     pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         for rule in &self.rules {
             rule.validate(props)?;
@@ -106,8 +122,10 @@ impl VectorBanRule {
     }
 }
 
-impl SemanticRule for VectorBanRule {
-    fn validate(&self, props: &PropertyMap) -> Result<()> {
+impl VectorBanRule {
+    /// Validate the given properties.
+    /// Returns Ok if valid, Err with a reason if invalid.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         // If the property doesn't exist or isn't a vector, we skip validation (or should we fail?)
         // Let's be lenient: if no vector is provided, the rule doesn't apply.
         // Unless it's a required field, which is a different rule (SchemaRule).
@@ -188,8 +206,10 @@ impl NumericRangeRule {
     }
 }
 
-impl SemanticRule for NumericRangeRule {
-    fn validate(&self, props: &PropertyMap) -> Result<()> {
+impl NumericRangeRule {
+    /// Validate the given properties.
+    /// Returns Ok if valid, Err with a reason if invalid.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         let val = match props.get(&self.property_name) {
             Some(v) => v,
             None => return Ok(()),
@@ -329,11 +349,11 @@ mod tests {
         // Rule 1: Ban toxic vectors
         let mut ban_rule = VectorBanRule::new("embedding", 0.8);
         ban_rule.add_banned_vector(vec![1.0, 0.0]).unwrap();
-        sentinel.add_rule(Box::new(ban_rule));
+        sentinel.add_rule(SemanticRule::VectorBan(ban_rule));
 
         // Rule 2: Age must be >= 18
         let range_rule = NumericRangeRule::new("age").min(18.0);
-        sentinel.add_rule(Box::new(range_rule));
+        sentinel.add_rule(SemanticRule::NumericRange(range_rule));
 
         // Valid Insert
         let valid = PropertyMapBuilder::new()

--- a/src/experimental/sybil.rs
+++ b/src/experimental/sybil.rs
@@ -45,24 +45,6 @@ use std::collections::HashMap;
 pub type PropagationState = HashMap<NodeId, Vec<f32>>;
 
 /// Defines how a node updates its state based on its neighbors.
-pub trait PropagationModel {
-    /// Calculate the next state for a node.
-    ///
-    /// # Arguments
-    /// * `node_id` - The node being updated.
-    /// * `current_self` - The node's current vector (if any).
-    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
-    ///
-    /// # Returns
-    /// The new vector state for the node.
-    fn next_state(
-        &self,
-        node_id: NodeId,
-        current_self: Option<&[f32]>,
-        neighbors: &[(NodeId, &[f32])],
-    ) -> Option<Vec<f32>>;
-}
-
 /// A simple linear propagation model.
 /// New State = (1 - alpha) * Old State + alpha * Average(Neighbor States)
 pub struct LinearPropagation {
@@ -81,8 +63,17 @@ impl LinearPropagation {
     }
 }
 
-impl PropagationModel for LinearPropagation {
-    fn next_state(
+impl LinearPropagation {
+    /// Calculate the next state for a node.
+    ///
+    /// # Arguments
+    /// * `node_id` - The node being updated.
+    /// * `current_self` - The node's current vector (if any).
+    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
+    ///
+    /// # Returns
+    /// The new vector state for the node.
+    pub fn next_state(
         &self,
         _node_id: NodeId,
         current_self: Option<&[f32]>,
@@ -156,10 +147,10 @@ impl<'a> Sybil<'a> {
     /// * `property_name` - The vector property to use as the "meme".
     /// * `model` - The propagation logic.
     /// * `steps` - Number of iterations.
-    pub fn simulate<M: PropagationModel>(
+    pub fn simulate(
         &self,
         property_name: &str,
-        model: &M,
+        model: &LinearPropagation,
         steps: usize,
     ) -> Result<PropagationState> {
         // Step 1: Load Initial State


### PR DESCRIPTION
**Razor Reduction Report:**

**1. Sybil Propagation Model**
* 🚧 **Smell:** `PropagationModel` was a one-time trait implemented only by `LinearPropagation`.
* ✨ **Solution:** Removed the trait and strongly-typed the `simulate` method to expect `LinearPropagation`.
* 🧹 **Benefit:** Removed unnecessary abstraction, increasing code clarity.

**2. Echo Resonator**
* 🚧 **Smell:** `Resonator` was a one-time trait implemented only by `ActivityDensityResonator`.
* ✨ **Solution:** Removed the trait and passed `ActivityDensityResonator` directly into the `EchoChamber`.
* 🧹 **Benefit:** Reduced file size and abstract indirection without losing any functionality.

**3. Sentinel Semantic Rules**
* 🚧 **Smell:** `SemanticRule` was a trait used as a `Box<dyn SemanticRule>` to hold two specific rules: `VectorBanRule` and `NumericRangeRule`.
* ✨ **Solution:** Flattened into a simple `enum SemanticRule` containing the two variants.
* 🧹 **Benefit:** Eliminated dynamic dispatch and heap allocation.

**🛡️ Verification:**
* Verified tests pass (`cargo test --all-features --lib experimental`).
* Verified linter is clean (`cargo clippy --all-targets --all-features -- -D warnings`).
* Updated journal `.jules/razor.md`.

---
*PR created automatically by Jules for task [13329940551731150895](https://jules.google.com/task/13329940551731150895) started by @madmax983*