### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,7 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+
+**[Temporal TimeRange Max Timestamp and Deserialize Mutants]**
+**Learning:** `cargo mutants` revealed missing test coverage for `MAX_VALID_TIMESTAMP` bounds checking in open ranges (`TimeRange::from` and `TimeRange::at`), empty range overlap edge cases (`TimeRange::overlaps` short-circuit behavior), and deserialization stringency (`BiTemporalInterval::deserialize` exact consumed length checking against buffer size `> 48`).
+**Action:** Added targeted unit tests checking `#[should_panic]` when `MAX_VALID_TIMESTAMP` is exceeded, explicitly testing overlap between empty point-ranges within larger non-empty ranges, and appending excess bytes to binary formats to verify exact parser length consumption limits.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1944,4 +1944,59 @@ mod sentry_tests {
         let err = result.unwrap_err();
         assert!(format!("{}", err).contains("Deserialized TimeRange invalid"));
     }
+
+    #[test]
+    #[should_panic(expected = "exceeds MAX_VALID_TIMESTAMP")]
+    fn test_sentry_timerange_from_exceeds_max_valid() {
+        // 🛡️ Sentry Test: Verify TimeRange::from panics if start > MAX_VALID_TIMESTAMP
+        let ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let _ = TimeRange::from(ts);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds MAX_VALID_TIMESTAMP")]
+    fn test_sentry_timerange_at_exceeds_max_valid() {
+        // 🛡️ Sentry Test: Verify TimeRange::at panics if timestamp > MAX_VALID_TIMESTAMP
+        let ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let _ = TimeRange::at(ts);
+    }
+
+    #[test]
+    fn test_sentry_timerange_close_at_exceeds_max_valid() {
+        // 🛡️ Sentry Test: Verify TimeRange::close_at returns error if end > MAX_VALID_TIMESTAMP
+        let open = TimeRange::from(100.into());
+        let ts = HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let result = open.close_at(ts);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sentry_overlaps_empty_range_inside_non_empty() {
+        // 🛡️ Sentry Test: Verify overlaps() returns false when one range is empty, even if inside the other
+        // This targets the || mutant in is_empty() checks
+        let wide = TimeRange::new(100.into(), 200.into()).unwrap();
+        let point = TimeRange::at(150.into());
+
+        assert!(
+            !wide.overlaps(&point),
+            "Non-empty range should not overlap an empty range inside it"
+        );
+        assert!(
+            !point.overlaps(&wide),
+            "Empty range should not overlap a non-empty range"
+        );
+    }
+
+    #[test]
+    fn test_sentry_bitemporal_deserialize_excess_bytes() {
+        // 🛡️ Sentry Test: Verify BiTemporalInterval::deserialize returns correct consumed length
+        // even if given a buffer larger than required (kills < vs == mutant)
+        let interval = BiTemporalInterval::now(100.into(), 200.into());
+        let mut bytes = interval.serialize();
+        bytes.push(0xFF); // length is now 49
+
+        let (parsed, consumed) = BiTemporalInterval::deserialize(&bytes).unwrap();
+        assert_eq!(parsed, interval);
+        assert_eq!(consumed, 48, "Should consume exactly 48 bytes");
+    }
 }


### PR DESCRIPTION
🎯 Target: `src/core/temporal.rs`
💥 Risk: Uncovered mutants around unbounded timestamp creation, short-circuit edge cases for empty ranges overlapping, and strict bounds checking during deserialization that could lead to logic bugs or unhandled panics.
🧪 Strategy: Added specific edge case unit tests verifying `MAX_VALID_TIMESTAMP` panics for open-ended range creation, verifying zero-duration point ranges properly overlap against enclosing continuous ranges, and ensuring `deserialize` correctly limits its buffer reading sizes.
🔬 Verification: `cargo test --lib core::temporal`

---
*PR created automatically by Jules for task [15563266277623978346](https://jules.google.com/task/15563266277623978346) started by @madmax983*