### PR TITLE
⚔️ Elenchus: temporal Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -339,3 +339,10 @@
 **Finding:** The FNV-1a fallback tests for `IdentityHasher` (`test_identity_hasher_write_fallback_fnv` and `test_identity_hasher_write_fallback_fnv_dirty`) were tautological. They exactly mirrored the source implementation by reconstructing the FNV-1a multiplication and XOR sequence to generate their `expected` values. This meant they only asserted that "the code is the code" and provided no independent verification that the hashing logic was correct or consistent with standard FNV-1a.
 **Evidence:** The original tests explicitly copied the sequence `expected ^= 1; expected = expected.wrapping_mul(FNV_PRIME);` which exactly mirrors the `write` loop. Any mutation altering `FNV_PRIME` or the operation order would survive if the same change was incorrectly made to the test or if it was inherently flawed.
 **Recommendation:** Refactored the tests to use independently pre-computed integer constants as the `expected` values (the Oracle Problem solution). This ensures the implementation matches the ground truth rather than itself.
+
+**[TimeRange Constructor Coverage Gap]**
+**Module:** `src/core/temporal.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The `TimeRange` constructors `from`, `at`, and `between` lacked explicit coverage for boundary conditions and panic behavior on inputs exceeding `MAX_VALID_TIMESTAMP`.
+**Evidence:** Mutation testing revealed that removing the panic logic or altering boundary condition checks in `TimeRange::from` and `TimeRange::at` did not fail any tests. `TimeRange::between` was completely unexercised directly.
+**Recommendation:** Added `test_elenchus_timerange_between` to verify `between` delegates properly to `new`. Added `test_elenchus_timerange_from_panics_on_overflow` and `test_elenchus_timerange_at_panics_on_overflow` using `#[should_panic]` to explicitly enforce safety limits.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1609,6 +1609,33 @@ mod sentry_tests {
     use super::*;
 
     #[test]
+    fn test_elenchus_timerange_between() {
+        // ⚔️ Elenchus Test: Verify TimeRange::between behaves identically to TimeRange::new
+        let start = 100.into();
+        let end = 200.into();
+        let range1 = TimeRange::between(start, end).unwrap();
+        let range2 = TimeRange::new(start, end).unwrap();
+        assert_eq!(range1.start(), range2.start());
+        assert_eq!(range1.end(), range2.end());
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds MAX_VALID_TIMESTAMP")]
+    fn test_elenchus_timerange_from_panics_on_overflow() {
+        // ⚔️ Elenchus Test: Verify TimeRange::from panics if timestamp > MAX_VALID_TIMESTAMP (and != TIMESTAMP_MAX)
+        let invalid_ts = crate::core::hlc::HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let _ = TimeRange::from(invalid_ts);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds MAX_VALID_TIMESTAMP")]
+    fn test_elenchus_timerange_at_panics_on_overflow() {
+        // ⚔️ Elenchus Test: Verify TimeRange::at panics if timestamp > MAX_VALID_TIMESTAMP (and != TIMESTAMP_MAX)
+        let invalid_ts = crate::core::hlc::HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let _ = TimeRange::at(invalid_ts);
+    }
+
+    #[test]
     fn test_sentry_bitemporal_is_current_mixed_state() {
         // 🛡️ Sentry Test: Verify BiTemporalInterval::is_current() correctly handles mixed states.
         // This test ensures that if only one dimension is open (current), is_current() returns false.

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1623,7 +1623,8 @@ mod sentry_tests {
     #[should_panic(expected = "exceeds MAX_VALID_TIMESTAMP")]
     fn test_elenchus_timerange_from_panics_on_overflow() {
         // ⚔️ Elenchus Test: Verify TimeRange::from panics if timestamp > MAX_VALID_TIMESTAMP (and != TIMESTAMP_MAX)
-        let invalid_ts = crate::core::hlc::HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let invalid_ts =
+            crate::core::hlc::HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
         let _ = TimeRange::from(invalid_ts);
     }
 
@@ -1631,7 +1632,8 @@ mod sentry_tests {
     #[should_panic(expected = "exceeds MAX_VALID_TIMESTAMP")]
     fn test_elenchus_timerange_at_panics_on_overflow() {
         // ⚔️ Elenchus Test: Verify TimeRange::at panics if timestamp > MAX_VALID_TIMESTAMP (and != TIMESTAMP_MAX)
-        let invalid_ts = crate::core::hlc::HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
+        let invalid_ts =
+            crate::core::hlc::HybridTimestamp::new_unchecked(MAX_VALID_TIMESTAMP + 1, 0);
         let _ = TimeRange::at(invalid_ts);
     }
 


### PR DESCRIPTION
This PR addresses coverage and assertion gaps discovered by the Elenchus persona regarding `TimeRange` constructors (`from`, `at`, and `between`). Previously, these constructors did not have explicit bounds tests, and mutants attempting to bypass `MAX_VALID_TIMESTAMP` panics could survive. 

New tests include:
- `test_elenchus_timerange_between`: verifying standard initialization wrapper.
- `test_elenchus_timerange_from_panics_on_overflow`: strict overflow panic checking.
- `test_elenchus_timerange_at_panics_on_overflow`: strict overflow panic checking.

The verdicts have also been cataloged in `.jules/elenchus.md`.

---
*PR created automatically by Jules for task [17621633741588303175](https://jules.google.com/task/17621633741588303175) started by @madmax983*