### PR TITLE
⚡ Bolt: Optimize Vec allocation in VectorRerankIterator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,6 @@
 **[DashMap Guard iterators and .cloned()]**
 **Learning:** In AletheiaDB, `CurrentIndexes` iterators (`iter_nodes`, `iter_edges`) yield `impl Deref<Target = Node>` representing DashMap guards, not simple references (`&T`). Thus, attempting to apply `.cloned()` fails to compile since it strictly requires `&T`.
 **Action:** Always use `.map(|n| n.clone())` instead of `.cloned()` when iterating over DashMap guards or opaque `impl Deref` types.
+**[VectorRerankIterator Vec Pre-allocation]**
+**Learning:** The `VectorRerankIterator` in `src/query/executor/iterators.rs` called `.collect::<Vec<_>>()` to create an intermediate vector of `(QueryRow, f32)` tuples from a `Vec<std::cmp::Reverse<ScoredRow>>` when initializing its sorted output iterator. This caused an unnecessary heap allocation of size `K` on every top-K vector query.
+**Action:** Store the `std::vec::IntoIter<std::cmp::Reverse<ScoredRow>>` directly in the struct, and lazily map the items to `QueryRow` with scores during the `.next()` method. This leverages the existing allocation from `BinaryHeap::into_sorted_vec()`.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1096,7 +1096,7 @@ impl Ord for ScoredRow {
 
 /// Iterator for vector reranking.
 pub struct VectorRerankIterator {
-    sorted: Option<std::vec::IntoIter<(QueryRow, f32)>>,
+    sorted: Option<std::vec::IntoIter<std::cmp::Reverse<ScoredRow>>>,
     input: Option<Box<dyn ResultIterator>>,
     embedding: Arc<[f32]>,
     k: usize,
@@ -1214,17 +1214,12 @@ impl ResultIterator for VectorRerankIterator {
             // [Smallest Reverse<ScoredRow>, ..., Largest Reverse<ScoredRow>]
             // Smallest Reverse<ScoredRow> corresponds to Largest ScoredRow (highest score).
             // So the result is [Highest Score, ..., Lowest Score], which is exactly what we want.
-            let sorted_rows: Vec<(QueryRow, f32)> = heap
-                .into_sorted_vec()
-                .into_iter()
-                .map(|Reverse(item)| (item.row, item.score))
-                .collect();
-
-            self.sorted = Some(sorted_rows.into_iter());
+            self.sorted = Some(heap.into_sorted_vec().into_iter());
         }
 
-        self.sorted.as_mut()?.next().map(|(mut row, score)| {
-            row.score = Some(score);
+        self.sorted.as_mut()?.next().map(|std::cmp::Reverse(item)| {
+            let mut row = item.row;
+            row.score = Some(item.score);
             Ok(row)
         })
     }


### PR DESCRIPTION
💡 What: Eliminated an intermediate `.collect::<Vec<_>>()` allocation inside `VectorRerankIterator`. The `sorted` field now stores `std::vec::IntoIter<std::cmp::Reverse<ScoredRow>>` directly.
🎯 Why: Creating a secondary `Vec` solely to map `Reverse<ScoredRow>` into a tuple of `(QueryRow, f32)` creates an unnecessary heap allocation of size K on the hot path for top-K vector search queries.
📊 Impact: Removes one `Vec` allocation of size K per vector search query, reusing the existing allocation provided by `BinaryHeap::into_sorted_vec()`.
🔬 Measurement: Run `cargo test --lib query`.

---
*PR created automatically by Jules for task [16071170077041632842](https://jules.google.com/task/16071170077041632842) started by @madmax983*