### PR TITLE
⚡ Bolt: [Performance Improvement] Remove intermediate Vec allocation in VectorRerankIterator

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1096,7 +1096,7 @@ impl Ord for ScoredRow {
 
 /// Iterator for vector reranking.
 pub struct VectorRerankIterator {
-    sorted: Option<std::vec::IntoIter<(QueryRow, f32)>>,
+    sorted: Option<std::vec::IntoIter<Reverse<ScoredRow>>>,
     input: Option<Box<dyn ResultIterator>>,
     embedding: Arc<[f32]>,
     k: usize,
@@ -1214,17 +1214,12 @@ impl ResultIterator for VectorRerankIterator {
             // [Smallest Reverse<ScoredRow>, ..., Largest Reverse<ScoredRow>]
             // Smallest Reverse<ScoredRow> corresponds to Largest ScoredRow (highest score).
             // So the result is [Highest Score, ..., Lowest Score], which is exactly what we want.
-            let sorted_rows: Vec<(QueryRow, f32)> = heap
-                .into_sorted_vec()
-                .into_iter()
-                .map(|Reverse(item)| (item.row, item.score))
-                .collect();
-
-            self.sorted = Some(sorted_rows.into_iter());
+            self.sorted = Some(heap.into_sorted_vec().into_iter());
         }
 
-        self.sorted.as_mut()?.next().map(|(mut row, score)| {
-            row.score = Some(score);
+        self.sorted.as_mut()?.next().map(|Reverse(item)| {
+            let mut row = item.row;
+            row.score = Some(item.score);
             Ok(row)
         })
     }


### PR DESCRIPTION
💡 **What:** 
Updated `VectorRerankIterator::next` to avoid an intermediate `.collect::<Vec<_>>()` allocation when converting the top-k results from a `BinaryHeap` into a sorted iterator. We now store `std::vec::IntoIter<Reverse<ScoredRow>>` inside `VectorRerankIterator` directly instead of forcing the intermediate conversion to `Vec<(QueryRow, f32)>`. 

🎯 **Why:** 
Vector reranking currently allocates a new temporary `Vec` simply to map the `Reverse<ScoredRow>` wrapper out, only to immediately convert it back into an iterator. This constitutes a redundant heap allocation proportional to the number of returned results (`k`), which affects every query requiring vector-based reranking.

📊 **Impact:** 
Eliminates one heap allocation of size `O(k)` per vector reranking query. This contributes towards zero-cost vector search post-processing.

🔬 **Measurement:** 
Run `cargo test --lib query::executor::iterators` and observe no semantic regressions in `test_vector_rerank_heap_logic`.

---
*PR created automatically by Jules for task [11117486536394456675](https://jules.google.com/task/11117486536394456675) started by @madmax983*