### PR TITLE
⚡ Bolt: Remove unnecessary Vec allocation in VectorRerankIterator

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1096,7 +1096,7 @@ impl Ord for ScoredRow {
 
 /// Iterator for vector reranking.
 pub struct VectorRerankIterator {
-    sorted: Option<std::vec::IntoIter<(QueryRow, f32)>>,
+    sorted: Option<std::vec::IntoIter<std::cmp::Reverse<ScoredRow>>>,
     input: Option<Box<dyn ResultIterator>>,
     embedding: Arc<[f32]>,
     k: usize,
@@ -1214,19 +1214,16 @@ impl ResultIterator for VectorRerankIterator {
             // [Smallest Reverse<ScoredRow>, ..., Largest Reverse<ScoredRow>]
             // Smallest Reverse<ScoredRow> corresponds to Largest ScoredRow (highest score).
             // So the result is [Highest Score, ..., Lowest Score], which is exactly what we want.
-            let sorted_rows: Vec<(QueryRow, f32)> = heap
-                .into_sorted_vec()
-                .into_iter()
-                .map(|Reverse(item)| (item.row, item.score))
-                .collect();
-
-            self.sorted = Some(sorted_rows.into_iter());
+            self.sorted = Some(heap.into_sorted_vec().into_iter());
         }
 
-        self.sorted.as_mut()?.next().map(|(mut row, score)| {
-            row.score = Some(score);
-            Ok(row)
-        })
+        self.sorted
+            .as_mut()?
+            .next()
+            .map(|std::cmp::Reverse(mut item)| {
+                item.row.score = Some(item.score);
+                Ok(item.row)
+            })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
💡 **What**: Replaced collecting `heap.into_sorted_vec()` into a secondary `Vec<(QueryRow, f32)>` with directly storing the `std::vec::IntoIter` of `Reverse<ScoredRow>`. The conversion and `Reverse` unwrap are now done lazily in `next()`.
🎯 **Why**: Unnecessary intermediate `.collect::<Vec<_>>()` chains create redundant heap allocations and redundant passes over the data.
📊 **Impact**: Eliminates one full `Vec` allocation and one full loop over the resulting set per query execution for vector reranking.
🔬 **Measurement**: Run `cargo check` and `cargo test --lib query` to verify behavior hasn't changed. Run `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [10867031477731261927](https://jules.google.com/task/10867031477731261927) started by @madmax983*