### PR TITLE
⚡ Bolt: Optimize PropertyMap FromIterator with size_hint pre-allocation

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1559,7 +1559,9 @@ impl Default for PropertyMap {
 
 impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
     fn from_iter<I: IntoIterator<Item = (PropertyKey, PropertyValue)>>(iter: I) -> Self {
-        let mut map = HashMap::with_hasher(BuildHasherDefault::default());
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut map = HashMap::with_capacity_and_hasher(lower, BuildHasherDefault::default());
         let mut size: usize = 4; // Count field
 
         for (key, value) in iter {


### PR DESCRIPTION
⚡ Bolt: Optimize PropertyMap FromIterator with size_hint pre-allocation

💡 What: Updated `PropertyMap::from_iter` in `src/core/property.rs` to extract `iter.size_hint()` and use it to pre-allocate the underlying `HashMap` capacity using `HashMap::with_capacity_and_hasher` instead of `HashMap::with_hasher`.
🎯 Why: Collecting dynamic iterators into maps without size hints forces the map buffer to reallocate and copy elements multiple times as it grows on the heap.
📊 Impact: This eliminates heap reallocations during `PropertyMap` creation from vectors, hash maps (like applying PropertyDeltas), and any other iterator that implements `size_hint`.
🔬 Measurement: Run `cargo check` and `cargo test --lib core`. Cargo clippy warns on this code without issue.

---
*PR created automatically by Jules for task [16384067507299399805](https://jules.google.com/task/16384067507299399805) started by @madmax983*