### PR TITLE
🛡️ Sentry: [experimental module test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,10 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+
+**Experimental Features Missing Coverage**
+**Learning:** Experimental modules like `sybil`, `fossil`, and `temporal_diff` have partial coverage that miss fundamental components:
+- `sybil` lacked tests for `LinearPropagation` handling of default states, mismatched dimensions, and empty neighbor lists.
+- `fossil` lacked validation logic tests for the error paths of dimension mismatches.
+- `temporal_diff` completely missed covering `EntityChange::Edge` generation.
+**Action:** When working in the experimental/ folder, trace match statements over enums and ensure every branch (`Edge` vs `Node`, `None` vs `Some`) and early-return error paths are explicitly checked.

--- a/src/experimental/fossil.rs
+++ b/src/experimental/fossil.rs
@@ -278,4 +278,48 @@ mod tests {
         );
         assert!(result.fossil_index > 1.0, "Fossil index should be high");
     }
+
+    #[test]
+    fn test_fossil_detection_dimension_mismatch() {
+        let db = AletheiaDB::new().unwrap();
+        let mut node = NodeId::new(0).unwrap();
+        db.write(|tx| {
+            node = tx
+                .create_node(
+                    "Concept",
+                    PropertyMapBuilder::new()
+                        .insert_vector("vec", &[0.0, 0.0])
+                        .build(),
+                )
+                .unwrap();
+            Ok::<(), crate::core::error::Error>(())
+        })
+        .unwrap();
+
+        let start = time::now();
+        std::thread::sleep(Duration::from_millis(10));
+
+        db.write(|tx| {
+            tx.update_node(
+                node,
+                PropertyMapBuilder::new()
+                    .insert_vector("vec", &[0.0, 0.0, 0.0]) // Changed dimension
+                    .build(),
+            )
+            .unwrap();
+            Ok::<(), crate::core::error::Error>(())
+        })
+        .unwrap();
+
+        let end = time::now();
+        let window = TimeRange::new(start, end).unwrap();
+        let detector = FossilDetector::new(&db);
+
+        let result = detector.detect_fossil(node, window, "vec");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Dimension mismatch between start and end vectors"
+        );
+    }
 }

--- a/src/experimental/sybil.rs
+++ b/src/experimental/sybil.rs
@@ -389,4 +389,37 @@ mod tests {
         let state_2 = sybil.simulate("val", &model, 2).unwrap();
         assert_eq!(state_2.get(&node_c).unwrap(), &[1.0]);
     }
+
+    #[test]
+    fn test_linear_propagation_no_state_adopts_avg() {
+        let alpha = 0.5;
+        let model = LinearPropagation::new(alpha);
+        let neighbors: Vec<(NodeId, &[f32])> = vec![
+            (NodeId::new(1).unwrap(), &[1.0, 1.0]),
+            (NodeId::new(2).unwrap(), &[3.0, 3.0]),
+        ];
+        let next = model.next_state(NodeId::new(0).unwrap(), None, &neighbors);
+        assert_eq!(next, Some(vec![2.0, 2.0]));
+    }
+
+    #[test]
+    fn test_linear_propagation_mismatched_dimensions() {
+        let alpha = 0.5;
+        let model = LinearPropagation::new(alpha);
+        let self_vec: &[f32] = &[0.0];
+        let neighbors: Vec<(NodeId, &[f32])> = vec![
+            (NodeId::new(1).unwrap(), &[1.0, 1.0]), // Dim 2 vs Dim 1
+        ];
+        let next = model.next_state(NodeId::new(0).unwrap(), Some(self_vec), &neighbors);
+        assert_eq!(next, Some(vec![0.0]));
+    }
+
+    #[test]
+    fn test_linear_propagation_empty_neighbors() {
+        let alpha = 0.5;
+        let model = LinearPropagation::new(alpha);
+        let self_vec: &[f32] = &[0.0];
+        let next = model.next_state(NodeId::new(0).unwrap(), Some(self_vec), &[]);
+        assert_eq!(next, Some(vec![0.0]));
+    }
 }

--- a/src/experimental/temporal_diff.rs
+++ b/src/experimental/temporal_diff.rs
@@ -251,6 +251,7 @@ mod tests {
     use crate::api::transaction::WriteOps;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::time;
+    use std::time::Duration;
 
     #[test]
     fn test_temporal_diff_lifecycle() {
@@ -417,5 +418,40 @@ mod tests {
             !diff_changed.is_empty(),
             "Diff with changed should not be empty"
         );
+    }
+
+    #[test]
+    fn test_temporal_diff_edge_changes() {
+        let db = AletheiaDB::new().unwrap();
+        let t0 = time::now();
+        std::thread::sleep(Duration::from_millis(10));
+        let n1 = db
+            .create_node("Node", PropertyMapBuilder::new().build())
+            .unwrap();
+        let n2 = db
+            .create_node("Node", PropertyMapBuilder::new().build())
+            .unwrap();
+        let props1 = PropertyMapBuilder::new().insert("weight", 1.0).build();
+        let edge_id = db.create_edge(n1, n2, "LINK", props1).unwrap();
+        let t1 = time::now();
+        std::thread::sleep(Duration::from_millis(10));
+        let props2 = PropertyMapBuilder::new().insert("weight", 2.0).build();
+        db.write(|tx| tx.update_edge(edge_id, props2)).unwrap();
+        let t2 = time::now();
+        std::thread::sleep(Duration::from_millis(10));
+        db.write(|tx| tx.delete_edge(edge_id)).unwrap();
+        let t3 = time::now();
+        let diff_engine = TemporalDiff::new(&db);
+
+        let diff1 = diff_engine.compute_diff(t0, t1, None).unwrap();
+        assert!(diff1.changes.iter().any(
+            |c| matches!(c, EntityChange::Edge { id, change: ChangeType::Added } if *id == edge_id)
+        ));
+
+        let diff2 = diff_engine.compute_diff(t1, t2, None).unwrap();
+        assert!(diff2.changes.iter().any(|c| matches!(c, EntityChange::Edge { id, change: ChangeType::Modified { .. } } if *id == edge_id)));
+
+        let diff3 = diff_engine.compute_diff(t2, t3, None).unwrap();
+        assert!(diff3.changes.iter().any(|c| matches!(c, EntityChange::Edge { id, change: ChangeType::Removed } if *id == edge_id)));
     }
 }


### PR DESCRIPTION
🎯 **Target:** Added comprehensive test coverage for untested paths and edge cases in `src/experimental/sybil.rs`, `src/experimental/fossil.rs`, and `src/experimental/temporal_diff.rs`.
💥 **Risk:** Experimental features lacked validation for fundamental components (e.g. dimensional mismatches in `fossil`, empty neighbors and adoption algorithms in `sybil`, and missing `Edge` change coverage in `temporal_diff.rs`), introducing the possibility of silent runtime logic errors.
🧪 **Strategy:** Added table-driven and edge-case unit tests inside the `#[cfg(test)]` modules, ensuring explicit test bounds mapping `LinearPropagation`, error paths for vector differences, and complete node vs. edge change detection across `compute_diff`.
🔬 **Verification:** `RUSTFLAGS="--cfg nova" cargo test --all-features --lib experimental::temporal_diff`, `experimental::fossil`, `experimental::sybil`.

---
*PR created automatically by Jules for task [7650473806447030397](https://jules.google.com/task/7650473806447030397) started by @madmax983*