### PR TITLE
🗺️ Atlas: Move TxVisibilityManager to core to break db/api dependency tangle

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -79,3 +79,6 @@
 **[Broke Storage-API Dependency Cycle]
 **Tangle:** The `storage` module had an implementation of `From<&crate::api::transaction::BufferedWrite> for WalOperation` in `src/storage/wal/entry.rs`, meaning the underlying storage engine depended structurally on the public API layer.
 **Blueprint:** Moved the `From` implementation to `src/api/transaction/write_buffer.rs`. Now, the `api` module is aware of how its `BufferedWrite` converts into a `WalOperation` to send down to `storage`, enforcing a unidirectional dependency graph from `api` -> `storage`.
+## 2026-05-25 - Breaking API Dependency from Storage/DB
+**Tangle:** `db` and `storage` modules were importing `TxVisibilityManager` and `TransactionSnapshot` from `api::transaction::visibility`. This created a reverse dependency where the core database and underlying storage engines were structurally dependent on the public API layer for fundamental MVCC mechanics.
+**Blueprint:** Moved `api/transaction/visibility.rs` down into the core layer as `core/transaction_visibility.rs`. Updated `db` and `api` to import these MVCC primitives from `core`, restoring a unidirectional dependency tree from `api` -> `db` -> `storage` -> `core`.

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -61,13 +61,13 @@
 
 pub mod read_tx;
 pub mod types;
-pub mod visibility;
+
 pub mod write;
 pub mod write_buffer;
 
 pub use read_tx::ReadTransaction;
 pub use types::{TxId, TxMetadata, TxState};
-pub use visibility::{CompressionStats, TransactionSnapshot, TxVisibilityManager};
+
 pub use write::WriteTransaction;
 pub use write_buffer::{BufferedWrite, WriteBuffer};
 

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -6,11 +6,12 @@
 //! - Snapshot-based reads for consistency
 //! - No commit overhead
 
-use super::{ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager};
+use super::{ReadOps, TxId, TxMetadata, TxState};
 use crate::core::error::{Result, ResultExt, StorageError};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::property::PropertyValue;
+use crate::core::transaction_visibility::{TransactionSnapshot, TxVisibilityManager};
 
 use crate::core::version::VersionMetadata;
 use crate::storage::current::CurrentStorage;

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -9,10 +9,7 @@
 //! Write transactions buffer all changes in memory until commit.
 //! On commit, changes are validated and applied atomically.
 
-use super::{
-    ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager, WriteBuffer,
-    WriteOps,
-};
+use super::{ReadOps, TxId, TxMetadata, TxState, WriteBuffer, WriteOps};
 use crate::core::error::{Result, ResultExt, StorageError, TransactionError};
 use crate::core::graph::{Edge, Node};
 use crate::core::hlc::{
@@ -23,6 +20,7 @@ use crate::core::id::{EdgeId, IdGenerator, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyMapBuilder};
 use crate::core::temporal::{Timestamp, time};
+use crate::core::transaction_visibility::{TransactionSnapshot, TxVisibilityManager};
 use crate::core::version::VersionMetadata;
 use crate::index::temporal::TemporalIndexes;
 use crate::storage::current::CurrentStorage;

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -9,6 +9,7 @@ mod tombstone_tests {
     fn create_test_write_tx() -> (WriteTransaction, TempDir) {
         let current = Arc::new(CurrentStorage::new());
         let historical = Arc::new(RwLock::new(HistoricalStorage::new()));
+        use crate::core::transaction_visibility::{TransactionSnapshot, TxVisibilityManager};
         let temporal_indexes = Arc::new(TemporalIndexes::new());
 
         let temp_dir = TempDir::new().unwrap();

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,6 +35,7 @@ pub mod interning;
 pub mod observer;
 pub mod property;
 pub mod temporal;
+pub mod transaction_visibility;
 pub mod vector;
 
 // Re-export commonly used types for convenience

--- a/src/core/transaction_visibility.rs
+++ b/src/core/transaction_visibility.rs
@@ -4,7 +4,7 @@
 //! which ensures that each transaction sees a consistent snapshot of the database
 //! from the time it started.
 
-use crate::api::transaction::types::TxId;
+use crate::core::id::TxId;
 use crate::core::temporal::Timestamp;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -1,6 +1,6 @@
-use crate::api::transaction::visibility::CompressionStats;
 use crate::core::error::{PersistenceErrorKind, Result, ResultExt, StorageError};
 use crate::core::temporal::Timestamp;
+use crate::core::transaction_visibility::CompressionStats;
 use crate::db::AletheiaDB;
 use crate::index::temporal::TemporalIndexes;
 use crate::query::planner::Statistics;

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -1,8 +1,8 @@
-use crate::api::transaction::TxVisibilityManager;
 use crate::config::AletheiaDBConfig;
 use crate::core::error::{Result, ResultExt};
 use crate::core::id::{IdGenerator, TxIdGenerator};
 use crate::core::temporal::time;
+use crate::core::transaction_visibility::TxVisibilityManager;
 use crate::core::version::AnchorConfig;
 use crate::db::AletheiaDB;
 use crate::index::temporal::TemporalIndexes;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,9 +3,9 @@
 //! This module provides the primary interface to the database, coordinating
 //! between current storage (fast path) and historical storage (temporal path).
 
-use crate::api::transaction::TxVisibilityManager;
 use crate::core::id::{IdGenerator, TxIdGenerator};
 use crate::core::temporal::Timestamp;
+use crate::core::transaction_visibility::TxVisibilityManager;
 use crate::index::temporal::TemporalIndexes;
 use crate::query::planner::Statistics;
 use crate::storage::current::CurrentStorage;


### PR DESCRIPTION
🕸️ Tangle: The structural problem is that `db` modules imported `TxVisibilityManager` and `TransactionSnapshot` from `api::transaction::visibility`. This created an anti-pattern backward dependency, where the core database layer and underlying structures were structurally dependent on the API layer for their isolation and visibility logic.

📐 Blueprint: Moved the `visibility.rs` module out of `api/transaction` and down into `core` as `transaction_visibility.rs`. `TxVisibilityManager` and `TransactionSnapshot` are fundamental MVCC abstractions, properly belonging in `core`.

🧱 Stability: This enforces a unidirectional dependency hierarchy: `api` -> `db` -> `storage` -> `core`.

🔬 Verification: The codebase compiles correctly without any cyclic or backwards import paths, and all library tests pass.

---
*PR created automatically by Jules for task [2255051512635462557](https://jules.google.com/task/2255051512635462557) started by @madmax983*