### PR TITLE
⚡ Bolt: Remove intermediate vector allocation in VectorRerankIterator

### DIFF
--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1118,7 +1118,7 @@ impl Ord for ScoredRow {
 
 /// Iterator for vector reranking.
 pub struct VectorRerankIterator {
-    sorted: Option<std::vec::IntoIter<(QueryRow, f32)>>,
+    sorted: Option<std::vec::IntoIter<Reverse<ScoredRow>>>,
     input: Option<Box<dyn ResultIterator>>,
     embedding: Arc<[f32]>,
     k: usize,
@@ -1236,18 +1236,12 @@ impl ResultIterator for VectorRerankIterator {
             // [Smallest Reverse<ScoredRow>, ..., Largest Reverse<ScoredRow>]
             // Smallest Reverse<ScoredRow> corresponds to Largest ScoredRow (highest score).
             // So the result is [Highest Score, ..., Lowest Score], which is exactly what we want.
-            let sorted_rows: Vec<(QueryRow, f32)> = heap
-                .into_sorted_vec()
-                .into_iter()
-                .map(|Reverse(item)| (item.row, item.score))
-                .collect();
-
-            self.sorted = Some(sorted_rows.into_iter());
+            self.sorted = Some(heap.into_sorted_vec().into_iter());
         }
 
-        self.sorted.as_mut()?.next().map(|(mut row, score)| {
-            row.score = Some(score);
-            Ok(row)
+        self.sorted.as_mut()?.next().map(|Reverse(mut item)| {
+            item.row.score = Some(item.score);
+            Ok(item.row)
         })
     }
 


### PR DESCRIPTION
💡 What: Modified `VectorRerankIterator` in `src/query/executor/iterators.rs` to avoid using `.collect::<Vec<_>>()` when building `self.sorted`. Changed `self.sorted` to store `std::vec::IntoIter<Reverse<ScoredRow>>` and lazily map it to `(QueryRow, f32)` in `.next()`.
🎯 Why: `BinaryHeap::into_sorted_vec()` already allocates and returns a `Vec`. The previous code chained `.into_iter().map(...).collect::<Vec<_>>()` which caused an extra O(N) heap allocation and copying of elements just to drop the `Reverse` wrapper. This violates the zero-cost abstraction principle for no benefit.
📊 Impact: Completely removes 1 unnecessary heap allocation per vector rerank execution (which scales linearly with `k`).
🔬 Measurement: Run `cargo test --lib query::executor` and `cargo bench` if available to see reduced allocation pressure during vector searches.

---
*PR created automatically by Jules for task [9575134249538589106](https://jules.google.com/task/9575134249538589106) started by @madmax983*