### PR TITLE
👺 Havoc: Loom Model for GroupCommitCoordinator Deadlocks

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,14 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+👺 Havoc: Loom Model for GroupCommitCoordinator Deadlocks
+
+🧨 The Trigger:
+High-concurrency Group Commit operations (registering, starting flushes, waiting for `flush_complete` Condvar timeouts, and finishing flushes) could theoretically deadlock if spurious wakeups or incorrect lock acquisition orders are hit, especially around `flushed_epoch` transitions and `completed_epochs` set modifications.
+
+📉 The Stack Trace:
+(N/A - Deadlocks freeze the threads in Loom without a stack trace unless explicitly panicked, but the intent was to ensure no threads hang indefinitely during epoch resolution)
+
+🧪 Reproduction:
+Run the loom model directly:
+`RUSTFLAGS="--cfg loom" cargo test --test havoc test_group_commit_coordinator_deadlock`
+
+😈 Comment:
+"I tried to break your little group commit epochs. I assumed that a thread timing out on wait_for_flush while another thread successfully finished the flush would result in a lost wakeup or poison the lock. You survived this one."

--- a/tests/havoc/havoc_loom_group_commit.rs
+++ b/tests/havoc/havoc_loom_group_commit.rs
@@ -1,0 +1,51 @@
+#![cfg(loom)]
+
+use std::time::Duration;
+use loom::sync::Arc;
+use loom::thread;
+use aletheiadb::storage::wal::group_commit::{GroupCommitCoordinator, GroupCommitConfig};
+
+#[test]
+fn test_group_commit_coordinator_deadlock() {
+    loom::model(|| {
+        let config = GroupCommitConfig {
+            max_delay_ms: 5,
+            max_batch_size: 2,
+            timeout_multiplier: 1,
+            timeout_base_ms: 1,
+            timeout_min_ms: 1,
+            timeout_max_ms: 5,
+            recent_errors_capacity: 10,
+        };
+
+        let coord = Arc::new(GroupCommitCoordinator::with_config(config));
+
+        let coord1 = Arc::clone(&coord);
+        let t1 = thread::spawn(move || {
+            let (epoch, should_flush) = coord1.register_transaction().unwrap();
+
+            if should_flush {
+                let flush_epoch = coord1.start_flush().unwrap();
+                coord1.finish_flush(flush_epoch, Ok(())).unwrap();
+            } else {
+                 // Simulate timeout
+                 let _ = coord1.wait_for_flush(epoch);
+            }
+        });
+
+        let coord2 = Arc::clone(&coord);
+        let t2 = thread::spawn(move || {
+            let (epoch, should_flush) = coord2.register_transaction().unwrap();
+
+            if should_flush {
+                let flush_epoch = coord2.start_flush().unwrap();
+                coord2.finish_flush(flush_epoch, Ok(())).unwrap();
+            } else {
+                let _ = coord2.wait_for_flush(epoch);
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}

--- a/tests/havoc/wal.rs
+++ b/tests/havoc/wal.rs
@@ -8,3 +8,5 @@ mod havoc_loom_ring_buffer;
 mod havoc_ring_buffer_torture;
 #[path = "havoc_wal_gaps.rs"]
 mod havoc_wal_gaps;
+#[path = "havoc_loom_group_commit.rs"]
+mod havoc_loom_group_commit;


### PR DESCRIPTION
👺 Havoc: Loom Model for GroupCommitCoordinator Deadlocks

🧨 **The Trigger:**
High-concurrency Group Commit operations (registering, starting flushes, waiting for `flush_complete` Condvar timeouts, and finishing flushes) could theoretically deadlock if spurious wakeups or incorrect lock acquisition orders are hit, especially around `flushed_epoch` transitions and `completed_epochs` set modifications.

📉 **The Stack Trace:**
(N/A - Deadlocks freeze the threads in Loom without a stack trace unless explicitly panicked, but the intent was to ensure no threads hang indefinitely during epoch resolution)

🧪 **Reproduction:**
Run the loom model directly:
`RUSTFLAGS="--cfg loom" cargo test --test havoc test_group_commit_coordinator_deadlock`

😈 **Comment:**
"I tried to break your little group commit epochs. I assumed that a thread timing out on `wait_for_flush` while another thread successfully finished the flush would result in a lost wakeup or poison the lock. You survived this one."

---
*PR created automatically by Jules for task [15204695631390782689](https://jules.google.com/task/15204695631390782689) started by @madmax983*