### PR TITLE
🪒 Razor: Delete StorageSnapshot trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
 **Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
 **Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
+
+## [Reduction]
+**Bloat:** `StorageSnapshot` trait (Single-implementation abstraction used only by `CurrentStorageSnapshot` internally for checkpointing).
+**Cut:** Deleted the `StorageSnapshot` trait. Refactored `CurrentStorageSnapshot` to use concrete types and inherent methods.
+**Saved:** ~30 lines of boilerplate (trait definition, impl blocks, associated types) + removed cognitive load of an unnecessary abstraction.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,14 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+1. **Delete the `StorageSnapshot` trait in `src/storage/snapshot.rs`.**
+   - It's an over-engineered abstraction for taking snapshots of the storage. There's only one implementation: `CurrentStorageSnapshot` (though `HistoricalStorageSnapshot` exists but doesn't implement the trait).
+
+2. **Refactor `CurrentStorageSnapshot` to remove trait implementation.**
+   - Change `type NodeIter` to actual types and directly implement `iter_nodes` and `iter_edges` on the struct.
+
+3. **Update consumers to use `CurrentStorageSnapshot` and `HistoricalStorageSnapshot` concretely.**
+   - Remove `use crate::storage::snapshot::StorageSnapshot;` imports in files like `src/storage/checkpoint.rs`.
+   - Update usages to use concrete methods.
+
+4. **Complete pre-commit steps.**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+5. **Create a PR with the title 🪒 Razor: Delete StorageSnapshot trait.**


### PR DESCRIPTION
This PR deletes the `StorageSnapshot` trait from `src/storage/snapshot.rs` and refactors its sole implementation, `CurrentStorageSnapshot`, to use concrete types and inherent public methods.

By removing this single-implementation abstraction, we reduce boilerplate (trait definition, `impl` blocks, associated types) and eliminate the cognitive load of an unnecessary abstraction, aligning with the KISS principle. Consumers in `src/storage/checkpoint.rs` and `src/storage/mod.rs` have been updated to use the concrete struct directly.

This change adheres to the "Razor" persona directives.
- Ran `cargo check`, `cargo clippy`, `cargo fmt`, and `cargo test --lib` successfully.
- Updated `.jules/razor.md` with the reduction details.

---
*PR created automatically by Jules for task [16207413287965884433](https://jules.google.com/task/16207413287965884433) started by @madmax983*