### PR TITLE
🛡️ Sentry: [test coverage improvement] Enhance SparseVec slow-path validation and empty vector tests

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,10 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+**SparseVec Input Validation**
+**Learning:** In sparse vector construction, table-driven tests that use single elements or sorted arrays only exercise the "fast-path" O(N) validation. The "slow-path" (which sorts and re-validates) must be explicitly targeted by providing unsorted input arrays containing the invalid elements.
+**Action:** Always ensure test data explicitly bypasses fast-paths or early-returns if testing fallback logic or deeper validation loops.
+
+**Sparse Vector Similarity on Empty Vectors**
+**Learning:** Sparse vector operations like `sparse_dot_product` and `sparse_euclidean_distance` gracefully handle fully empty vectors (nnz = 0).
+**Action:** Always test the extreme boundary condition of two entirely empty structures when dealing with iterators or zip-based operations to guarantee no NaN or panic is produced.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,15 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+1. **Target Area Selection**: The `src/core/vector/sparse.rs` module manages the `SparseVec` struct and various sparse vector similarity/distance functions (`sparse_dot_product`, `sparse_cosine_similarity`, `sparse_euclidean_distance`, `sparse_squared_euclidean_distance`).
+
+2. **Gaps Identified**:
+   - `SparseVec::new`: In `src/core/vector/sparse.rs`, there's a slow-path validation flow when indices are not strictly sorted (lines 195-234). The current table-driven test `test_sparse_vec_new_invalid_inputs` tests error conditions (duplicate indices, out of bounds, NaN, etc.), but the inputs provided in the test are either single elements or already sorted. Thus, the validation logic inside the `if is_sorted` else block (the slow path) is never hit with invalid inputs. The existing invalid inputs fail immediately on the "fast path" validation.
+   - We need tests that trigger the "slow path" (unsorted input) and *then* fail due to out-of-bounds, duplicate indices, or NaN values, to guarantee the slow-path validation logic is thoroughly tested.
+   - `sparse_euclidean_distance`: There is no test for computing the Euclidean distance of two *empty* (all zeros) sparse vectors.
+   - `sparse_dot_product`: There is no test for computing the dot product of two *empty* (all zeros) sparse vectors.
+   - `sparse_cosine_similarity`: There is no test for computing the cosine similarity of two *empty* (all zeros) sparse vectors.
+
+3. **Plan**:
+   - Update `test_sparse_vec_new_invalid_inputs` in `src/core/vector/sparse.rs` to include test cases that deliberately pass unsorted arrays containing duplicate indices, out of bounds indices, and NaN/Infinity values. This ensures the slow-path validation is covered.
+   - Add a test `test_sparse_euclidean_distance_empty_vectors` in `src/core/vector/tests.rs` comparing two empty vectors.
+   - Modify `test_sparse_dot_product_empty` in `src/core/vector/tests.rs` to also test two empty vectors.
+   - Add test `test_sparse_cosine_similarity_empty_vectors` in `src/core/vector/tests.rs` comparing two empty vectors.
+   - Run verification and commit.

--- a/src/core/vector/sparse.rs
+++ b/src/core/vector/sparse.rs
@@ -770,6 +770,41 @@ mod tests {
                 dimension: 10,
                 expected_error_contains: "infinity",
             },
+            TestCase {
+                name: "Duplicate index (unsorted fast-path bypass)",
+                indices: vec![5, 1, 1],
+                values: vec![1.0, 2.0, 3.0],
+                dimension: 10,
+                expected_error_contains: "Duplicate index",
+            },
+            TestCase {
+                name: "Index out of bounds (unsorted fast-path bypass)",
+                indices: vec![5, 1, 10],
+                values: vec![1.0, 2.0, 3.0],
+                dimension: 10,
+                expected_error_contains: "out of bounds",
+            },
+            TestCase {
+                name: "NaN value (unsorted fast-path bypass)",
+                indices: vec![5, 1, 3],
+                values: vec![1.0, 2.0, f32::NAN],
+                dimension: 10,
+                expected_error_contains: "NaN",
+            },
+            TestCase {
+                name: "Infinity value (unsorted fast-path bypass)",
+                indices: vec![5, 1, 3],
+                values: vec![1.0, f32::INFINITY, 3.0],
+                dimension: 10,
+                expected_error_contains: "infinity",
+            },
+            TestCase {
+                name: "Zero value (unsorted fast-path bypass)",
+                indices: vec![5, 1, 3],
+                values: vec![1.0, 0.0, 3.0],
+                dimension: 10,
+                expected_error_contains: "zero value",
+            },
         ];
 
         for case in cases {

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2739,6 +2739,12 @@ fn test_sparse_dot_product_no_overlap() {
 
     let dot = sparse_dot_product(&a, &b).unwrap();
     assert_eq!(dot, 0.0);
+
+    let empty_a = SparseVec::new(vec![], vec![], 10).unwrap();
+    let empty_b = SparseVec::new(vec![], vec![], 10).unwrap();
+
+    let dot_empty = sparse_dot_product(&empty_a, &empty_b).unwrap();
+    assert_eq!(dot_empty, 0.0);
 }
 
 #[test]
@@ -2797,6 +2803,15 @@ fn test_sparse_cosine_similarity_orthogonal() {
 }
 
 #[test]
+fn test_sparse_cosine_similarity_empty() {
+    let a = SparseVec::new(vec![], vec![], 5).unwrap();
+    let b = SparseVec::new(vec![], vec![], 5).unwrap();
+
+    let sim = sparse_cosine_similarity(&a, &b).unwrap();
+    assert_eq!(sim, 0.0);
+}
+
+#[test]
 fn test_sparse_cosine_similarity_opposite() {
     let a = SparseVec::new(vec![0, 2], vec![1.0, 2.0], 5).unwrap();
     let b = SparseVec::new(vec![0, 2], vec![-1.0, -2.0], 5).unwrap();
@@ -2846,6 +2861,15 @@ fn test_sparse_squared_euclidean_distance_dimension_mismatch() {
         result.unwrap_err(),
         Error::Vector(VectorError::DimensionMismatch { .. })
     ));
+}
+
+#[test]
+fn test_sparse_euclidean_distance_empty_vectors() {
+    let a = SparseVec::new(vec![], vec![], 5).unwrap();
+    let b = SparseVec::new(vec![], vec![], 5).unwrap();
+
+    let dist = sparse_euclidean_distance(&a, &b).unwrap();
+    assert_eq!(dist, 0.0);
 }
 
 #[test]


### PR DESCRIPTION
🎯 Target: `src/core/vector/sparse.rs` and `src/core/vector/tests.rs` (specifically `SparseVec::new`, `sparse_euclidean_distance`, `sparse_dot_product`, and `sparse_cosine_similarity`).
💣 Risk: The construction validation for `SparseVec` has a fast-path for sorted inputs and a slow-path for unsorted inputs. The existing invalid inputs test only provided sorted inputs or single elements, bypassing the slow-path validation logic entirely. If the slow-path failed to correctly reject duplicate indices, NaNs, infinities, or out-of-bounds indices, it would lead to invalid sparse vectors being created and potentially panicking or returning incorrect mathematical results later. Additionally, operations on completely empty sparse vectors might divide by zero and return `NaN`.
🧪 Strategy: 
1. Added unsorted invalid input vectors to `test_sparse_vec_new_invalid_inputs` to force `SparseVec::new` into the slow-path validation logic, guaranteeing it properly rejects bad data.
2. Added tests for `sparse_euclidean_distance`, `sparse_dot_product`, and `sparse_cosine_similarity` comparing two entirely empty (`nnz = 0`) sparse vectors to ensure they correctly return `0.0` and handle edge cases gracefully without producing `NaN` or panicking.
🔬 Verification: Run `cargo test --lib --features nova -- core::vector`

---
*PR created automatically by Jules for task [1757806072738451218](https://jules.google.com/task/1757806072738451218) started by @madmax983*