### PR TITLE
⚡ Bolt: Optimize VectorRerankIterator by removing intermediate Vector allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Optimize Vec allocations with Vec::with_capacity in loops over collections**
 **Learning:** Initializing a vector with `Vec::new()` and then populating it in a loop whose length is known (e.g. iterating over a `DashMap`) causes unnecessary intermediate heap reallocations.
 **Action:** Use `Vec::with_capacity(collection.len())` when the target collection size is known in advance to avoid these reallocations.
+
+**Optimize Iterator conversions by using Map rather than Collect**
+**Learning:** Calling `.into_iter().map(...).collect()` on a collection just to store the result as a `std::vec::IntoIter` inside a struct forces an unnecessary intermediate heap allocation.
+**Action:** Change the struct field's type to hold the original collection's iterator directly (or `Map`) and perform the mapping lazily in the `.next()` method. This completely eliminates the extra `Vec` allocation per query.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,25 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+1. **Optimize `VectorRerankIterator` in `src/query/executor/iterators.rs`**
+   - The current code constructs an intermediate `Vec<(QueryRow, f32)>` just to convert it to an iterator for `self.sorted`:
+     ```rust
+     let sorted_rows: Vec<(QueryRow, f32)> = heap
+         .into_sorted_vec()
+         .into_iter()
+         .map(|Reverse(item)| (item.row, item.score))
+         .collect();
+     self.sorted = Some(sorted_rows.into_iter());
+     ```
+   - Change `VectorRerankIterator::sorted` from `Option<std::vec::IntoIter<(QueryRow, f32)>>` to `Option<std::vec::IntoIter<std::cmp::Reverse<ScoredRow>>>`.
+   - Update `next` implementation to handle `std::cmp::Reverse<ScoredRow>` instead of `(QueryRow, f32)`. This completely eliminates the extra vector allocation of size `k`.
+   - Update `self.sorted = Some(heap.into_sorted_vec().into_iter())` instead of `.collect()`.
+
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`.
+   - Run `cargo test`.
+   - Run `cargo fmt --all`.
+
+3. **Create a PR with the title '⚡ Bolt: Optimize VectorRerankIterator by removing intermediate Vector allocation'**
+   - The PR description will contain:
+     * 💡 What: Changed `VectorRerankIterator` to iterate directly over `BinaryHeap::into_sorted_vec` without an intermediate mapping to a new `Vec`.
+     * 🎯 Why: To avoid allocating an extra `Vec` of up to size `k` every time a vector rerank query executes.
+     * 📊 Impact: Removes 1 heap allocation per vector rerank execution.
+     * 🔬 Measurement: Run bench `process_data` (or test rerank queries) to verify correctness and see fewer allocs.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1118,7 +1118,7 @@ impl Ord for ScoredRow {
 
 /// Iterator for vector reranking.
 pub struct VectorRerankIterator {
-    sorted: Option<std::vec::IntoIter<(QueryRow, f32)>>,
+    sorted: Option<std::vec::IntoIter<Reverse<ScoredRow>>>,
     input: Option<Box<dyn ResultIterator>>,
     embedding: Arc<[f32]>,
     k: usize,
@@ -1236,17 +1236,12 @@ impl ResultIterator for VectorRerankIterator {
             // [Smallest Reverse<ScoredRow>, ..., Largest Reverse<ScoredRow>]
             // Smallest Reverse<ScoredRow> corresponds to Largest ScoredRow (highest score).
             // So the result is [Highest Score, ..., Lowest Score], which is exactly what we want.
-            let sorted_rows: Vec<(QueryRow, f32)> = heap
-                .into_sorted_vec()
-                .into_iter()
-                .map(|Reverse(item)| (item.row, item.score))
-                .collect();
-
-            self.sorted = Some(sorted_rows.into_iter());
+            self.sorted = Some(heap.into_sorted_vec().into_iter());
         }
 
-        self.sorted.as_mut()?.next().map(|(mut row, score)| {
-            row.score = Some(score);
+        self.sorted.as_mut()?.next().map(|Reverse(item)| {
+            let mut row = item.row;
+            row.score = Some(item.score);
             Ok(row)
         })
     }


### PR DESCRIPTION
💡 What: Changed `VectorRerankIterator` to iterate directly over `BinaryHeap::into_sorted_vec` without an intermediate mapping to a new `Vec`.
🎯 Why: To avoid allocating an extra `Vec` of up to size `k` every time a vector rerank query executes.
📊 Impact: Removes 1 heap allocation per vector rerank execution.
🔬 Measurement: Run bench `process_data` (or test rerank queries) to verify correctness and see fewer allocs.

---
*PR created automatically by Jules for task [343495905839532277](https://jules.google.com/task/343495905839532277) started by @madmax983*