### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ let _doc2_id = db.create_node("Document",
 // Find similar nodes
 // Note: find_similar excludes the query node itself from results
 let similar = db.find_similar(doc_id, 10)?;
+println!("Found similar: {:?}", similar);
 ```
 
 ### Hybrid Queries (Graph + Vector + Temporal)
@@ -694,13 +695,13 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new().unwrap();
 
     // Basic graph query
-    let results = db.execute_aql(
+    let _results = db.execute_aql(
         "MATCH (n:Person {name: 'Alice'})-[:KNOWS]->(friend:Person) RETURN friend"
     )?;
 
     // Bi-temporal query (point-in-time)
-    let results = db.execute_aql(
-        "AS OF '2024-01-15T10:00:00Z' MATCH (n:Person {name: 'Alice'}) RETURN n"
+    let _results = db.execute_aql(
+        "AS OF 1705312800000000 MATCH (n:Person {name: 'Alice'}) RETURN n"
     )?;
 
     Ok(())
@@ -718,7 +719,7 @@ RANK BY SIMILARITY TO $bob_embedding TOP 10
 RETURN friend
 
 -- Full hybrid: temporal + graph + vector
-AS OF '2024-06-01T00:00:00Z'
+AS OF 1717200000000000
 MATCH (user:User {id: $user_id})-[:VIEWED]->(item:Product)
 RANK BY SIMILARITY TO $recommendation_embedding TOP 20
 WHERE item.price < 100
@@ -818,7 +819,7 @@ use std::sync::Arc;
 
 // Note: Requires `tokio` dependency in Cargo.toml
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Enable in Cargo.toml: features = ["embedding-openai"]
 
     // 1. Create embedding service


### PR DESCRIPTION
This PR addresses several Developer Experience (DX) friction points found during the "README Run" audit by the Echo persona. 

The issues fixed in the `README.md` examples include:
1. **AQL Runtime Crash:** The `AS OF '2024-01-15T10:00:00Z'` query in `execute_aql` crashed at runtime because it expects integer microseconds. This has been updated to use `1705312800000000` (and `1717200000000000` for the other example).
2. **Unused Variable Warnings:** Several examples declared variables like `results`, `bob_id`, and `doc2_id` but never used them, causing annoying yellow warnings for new users. These were either prefixed with `_` or actively consumed.
3. **Missing Output:** The vector search `find_similar` example returned a value but didn't do anything with it. A `println!` was added.
4. **Result Shadowing:** The embedding generation example used a generic `Result` in its `main` signature, which conflicted with the `aletheiadb::prelude::Result`. This was fully qualified to `std::result::Result`.

---
*PR created automatically by Jules for task [5844462113379363399](https://jules.google.com/task/5844462113379363399) started by @madmax983*