### PR TITLE
👺 Havoc: Expose HNSW Deadlock via Loom

### DIFF
--- a/tests/havoc/havoc_loom_hnsw_deadlock.rs
+++ b/tests/havoc/havoc_loom_hnsw_deadlock.rs
@@ -66,7 +66,7 @@ impl MockHnswIndex {
 
 #[test]
 #[should_panic]
-#[ignore] // Ignored because it crashes the test runner with SIGABRT
+
 fn test_deadlock_reproduction() {
     loom::model(|| {
         let index = Arc::new(MockHnswIndex::new());


### PR DESCRIPTION
🧨 **The Trigger:**
The `HnswIndex::add` method experiences a lock ordering inversion under certain thread interleavings, modeled in `test_deadlock_reproduction`. Specifically, a thread in the `add_vacant` path acquires `inner` then `id_mapping` (while `add_occupied` acquires `id_mapping` then `inner`).

📉 **The Stack Trace:**
```
thread 'havoc_suites::vector::havoc_loom_hnsw_deadlock::test_deadlock_reproduction' panicked at library/core/src/panicking.rs:233:5:
panic in a destructor during cleanup
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--test havoc`

Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc-xxx test_deadlock_reproduction` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:**
Run `RUSTFLAGS="--cfg loom" cargo test test_deadlock_reproduction`.

😈 **Comment:**
"You assumed lock ordering across DashMap entries and RwLocks would never cause an inversion. You were wrong."

---
*PR created automatically by Jules for task [6443127853207110928](https://jules.google.com/task/6443127853207110928) started by @madmax983*