### PR TITLE
⚡ Bolt: Pre-allocate capacity in QueryBuilder::new

### DIFF
--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -138,7 +138,9 @@ impl QueryBuilder<state::Initial> {
     #[must_use]
     pub fn new() -> Self {
         QueryBuilder {
-            ops: Vec::new(),
+            // ⚡ Bolt Optimization: Most queries have at least 2 operations (Start + something else)
+            // Pre-allocate a small capacity to avoid the first few reallocations which are statistically common.
+            ops: Vec::with_capacity(4),
             temporal_context: None,
             hints: QueryHints::default(),
             _phantom: PhantomData,


### PR DESCRIPTION
💡 What: Added `Vec::with_capacity(4)` to initialize `QueryBuilder::ops` instead of `Vec::new()`.
🎯 Why: `Vec::new()` creates a zero-capacity vector that requires an immediate allocation when the first `QueryOp` (such as `StartNode`) is added. Because queries practically always have multiple operations (start + filters + traversal + etc.), we can statically anticipate this footprint.
📊 Impact: Avoids the first few dynamic heap allocations/re-sizes (and associated memory moves) every time a new query is built.
🔬 Measurement: Run benchmark `cargo bench --bench query_builder` (if available) or `cargo test --lib query::builder`.

---
*PR created automatically by Jules for task [18013625562617987444](https://jules.google.com/task/18013625562617987444) started by @madmax983*