### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -3801,6 +3801,27 @@ mod sentry_tests {
         }
     }
 
+    #[test]
+    #[should_panic(expected = "Property insertion failed")]
+    fn test_property_map_insert_recursion_panic() {
+        let mut nested_array = PropertyValue::Array(std::sync::Arc::new(vec![]));
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            nested_array = PropertyValue::Array(std::sync::Arc::new(vec![nested_array]));
+        }
+        PropertyMapBuilder::new().insert("key", nested_array);
+    }
+
+    #[test]
+    #[should_panic(expected = "Property insertion failed")]
+    fn test_property_map_insert_by_key_recursion_panic() {
+        let mut nested_array = PropertyValue::Array(std::sync::Arc::new(vec![]));
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            nested_array = PropertyValue::Array(std::sync::Arc::new(vec![nested_array]));
+        }
+        let key = GLOBAL_INTERNER.intern("key").unwrap();
+        PropertyMapBuilder::new().insert_by_key(key, nested_array);
+    }
+
     /// 🎯 Target: PropertyMapBuilder::remove correctness
     /// 💣 Risk: Removing a key should actually remove it and update size/len correctly.
     /// 🧪 Strategy: Insert keys, remove one, verify map state.


### PR DESCRIPTION
* 🎯 Target: `PropertyMapBuilder::insert` and `insert_by_key` in `src/core/property.rs`.
* 💣 Risk: Code panics when recursion depth limit (`MAX_RECURSION_DEPTH`) is exceeded during `serialized_size` calculation due to unhandled `.expect()`.
* 🧪 Strategy: Added `#[should_panic]` tests to formally document and verify these explosion points.
* 🔬 Verification: `cargo test --lib core::property`

---
*PR created automatically by Jules for task [10890824211172432917](https://jules.google.com/task/10890824211172432917) started by @madmax983*