### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/cypher/tests.rs
+++ b/src/cypher/tests.rs
@@ -1258,7 +1258,7 @@ fn test_e2e_multi_hop_traversal() {
     // but the executor may only return terminal-depth nodes depending on the
     // TraversalDepth::Range semantics.  Assert at least 1 result.
     assert!(
-        rows.len() >= 1,
+        !rows.is_empty(),
         "expected at least 1 result from *1..2 traversal, got {}",
         rows.len()
     );

--- a/src/storage/index_persistence/manifest.rs
+++ b/src/storage/index_persistence/manifest.rs
@@ -62,7 +62,25 @@ impl IndexManifest {
         }
     }
 
-    /// Update the last_modified timestamp.
+    /// Update the `last_modified` timestamp to the current system time.
+    ///
+    /// This is automatically called by methods that mutate the manifest
+    /// (like `set_lsn`) to ensure the metadata accurately reflects when
+    /// the index state was last changed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aletheiadb::storage::index_persistence::formats::IndexManifest;
+    ///
+    /// let mut manifest = IndexManifest::new(100);
+    /// let original_time = manifest.last_modified;
+    ///
+    /// // Simulate some delay (or just force an update)
+    /// manifest.touch();
+    ///
+    /// assert!(manifest.last_modified >= original_time);
+    /// ```
     pub fn touch(&mut self) {
         self.last_modified = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -70,7 +88,21 @@ impl IndexManifest {
             .as_secs() as i64;
     }
 
-    /// Update the LSN.
+    /// Update the Last Sequence Number (LSN) and touch the modified timestamp.
+    ///
+    /// The LSN acts as the watermark for WAL replay. Upon crash recovery,
+    /// any WAL entries with an LSN greater than this value will be replayed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aletheiadb::storage::index_persistence::formats::IndexManifest;
+    ///
+    /// let mut manifest = IndexManifest::new(100);
+    /// manifest.set_lsn(200);
+    ///
+    /// assert_eq!(manifest.lsn, 200);
+    /// ```
     pub fn set_lsn(&mut self, lsn: u64) {
         self.lsn = lsn;
         self.touch();

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -58,6 +58,30 @@ use super::{MANIFEST_VERSION, TEMPORAL_MAGIC};
 ///
 /// # Errors
 ///
+/// Convert NodeVersion to NodeVersionEntry for persistence.
+///
+/// This function flattens the `NodeVersion` structure into a `NodeVersionEntry` suitable for disk storage.
+/// It handles both `Anchor` and `Delta` versions.
+///
+/// # Vector Delta Handling
+///
+/// If the version contains `VectorDelta::Sparse`, this function will return an error.
+/// Sparse deltas rely on the base version to be fully reconstructed, which is complex during persistence.
+/// Therefore, sparse deltas must be materialized (converted to full vectors) before persistence.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::core::version::NodeVersion;
+/// use aletheiadb::core::id::{NodeId, VersionId, TxId};
+/// use aletheiadb::core::interning::InternedString;
+/// use aletheiadb::core::temporal::BiTemporalInterval;
+/// // ... create a valid NodeVersion ...
+/// // let entry = convert_node_version(&version).unwrap();
+/// ```
+///
+/// # Errors
+///
 /// Returns an error if:
 /// - Property conversion fails (e.g., unsupported Array type).
 /// - A `VectorDelta::Sparse` is encountered (preventing data loss).
@@ -154,6 +178,13 @@ pub fn convert_node_version(version: &NodeVersion) -> Result<NodeVersionEntry> {
 /// Convert EdgeVersion to EdgeVersionEntry for persistence.
 ///
 /// Similar to `convert_node_version`, this flattens `EdgeVersion` for storage.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::core::version::EdgeVersion;
+/// // let entry = convert_edge_version(&edge_version).unwrap();
+/// ```
 ///
 /// # Errors
 ///

--- a/src/storage/index_persistence/tracker.rs
+++ b/src/storage/index_persistence/tracker.rs
@@ -98,6 +98,19 @@ impl PersistenceTracker {
     }
 
     /// Set the starting LSN for all components (used during initialization/recovery).
+    ///
+    /// This establishes the baseline Sequence Number across all index types,
+    /// typically loaded from the latest `IndexManifest` during database startup.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use aletheiadb::storage::index_persistence::tracker::PersistenceTracker;
+    ///
+    /// let tracker = PersistenceTracker::new();
+    /// tracker.set_start_lsn(500);
+    /// assert_eq!(tracker.get_safe_manifest_lsn(), 500);
+    /// ```
     pub fn set_start_lsn(&self, lsn: u64) {
         self.last_vector_lsn.store(lsn, Ordering::Relaxed);
         self.last_graph_lsn.store(lsn, Ordering::Relaxed);
@@ -106,6 +119,17 @@ impl PersistenceTracker {
     }
 
     /// Update the last persisted LSN for vector indexes.
+    ///
+    /// Uses atomic `fetch_max` to ensure the LSN only moves forward.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use aletheiadb::storage::index_persistence::tracker::PersistenceTracker;
+    ///
+    /// let tracker = PersistenceTracker::new();
+    /// tracker.update_vector_lsn(100);
+    /// ```
     pub fn update_vector_lsn(&self, lsn: u64) {
         self.last_vector_lsn.fetch_max(lsn, Ordering::Release);
     }
@@ -159,6 +183,19 @@ impl PersistenceTracker {
     /// This LSN represents the point in time up to which ALL persisted components are consistent.
     /// WAL replay should start from this LSN to ensure no operations are missed for components
     /// that might be lagging behind.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use aletheiadb::storage::index_persistence::tracker::PersistenceTracker;
+    ///
+    /// let tracker = PersistenceTracker::new();
+    /// tracker.set_start_lsn(100);
+    /// tracker.update_vector_lsn(150);
+    ///
+    /// // The safe LSN is still 100 because the other components haven't caught up
+    /// assert_eq!(tracker.get_safe_manifest_lsn(), 100);
+    /// ```
     pub fn get_safe_manifest_lsn(&self) -> u64 {
         let vector = self.last_vector_lsn.load(Ordering::Acquire);
         let graph = self.last_graph_lsn.load(Ordering::Acquire);
@@ -170,6 +207,18 @@ impl PersistenceTracker {
     }
 
     /// Increment vector mutation counter.
+    ///
+    /// Should be called by the write path whenever a vector property is added or updated.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use aletheiadb::storage::index_persistence::tracker::PersistenceTracker;
+    ///
+    /// let tracker = PersistenceTracker::new();
+    /// tracker.record_vector_mutation();
+    /// assert_eq!(tracker.get_vector_mutations(), 1);
+    /// ```
     pub fn record_vector_mutation(&self) {
         self.vector_mutations.fetch_add(1, Ordering::Relaxed);
     }
@@ -190,6 +239,23 @@ impl PersistenceTracker {
     }
 
     /// Get and reset vector mutation counter, updating last persist time.
+    ///
+    /// This atomic operation is used by the background persistence worker
+    /// after successfully saving the vector index to disk.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use aletheiadb::storage::index_persistence::tracker::PersistenceTracker;
+    ///
+    /// let tracker = PersistenceTracker::new();
+    /// tracker.record_vector_mutation();
+    /// tracker.record_vector_mutation();
+    ///
+    /// let prior_count = tracker.reset_vector_mutations();
+    /// assert_eq!(prior_count, 2);
+    /// assert_eq!(tracker.get_vector_mutations(), 0);
+    /// ```
     pub fn reset_vector_mutations(&self) -> u64 {
         let count = self.vector_mutations.swap(0, Ordering::Relaxed);
         self.last_vector_persist.store(


### PR DESCRIPTION
* 📖 Chapter: The `storage::index_persistence` module (`manifest.rs`, `tracker.rs`, `temporal.rs`).
* 💡 Insight: Clarified the `IndexManifest` methods, the atomic operation rules for `PersistenceTracker` to synchronize write metrics, and the critical data-loss protection rules for `convert_node_version` involving `VectorDelta::Sparse`.
* 🧪 Example: Added multiple doctests demonstrating expected usage (and marked internal-only tests as `ignore` where they couldn't be easily invoked outside the crate).
* 🖼️ Preview: Documentation for `PersistenceTracker` now clearly explains its role as a thread-safe barrier, and `TemporalIndexData` conversion clearly warns users about unmaterialized vector deltas.

---
*PR created automatically by Jules for task [14206278566579546370](https://jules.google.com/task/14206278566579546370) started by @madmax983*