### PR TITLE
🔒 Warden: Prevent DoS via unbounded SparseVec dimension allocation

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -36,3 +36,6 @@
 2025-02-15 - [Warden: Replace unsafe transmute_vec with bytemuck::cast_vec]
 **Threat:** `Vec::from_raw_parts` was used in `AdjacencyIndex::import_csr` to transmute types without proper capacity checks, which can lead to Undefined Behavior.
 **Defense:** Replaced the `unsafe` block and `transmute_vec` with `bytemuck::cast_vec` for safe zero-copy transmutation. Added `bytemuck::Pod` and `bytemuck::Zeroable` derivations to `NodeId`.
+2026-02-15 - [Warden: Sparse Vector Dimension Memory Exhaustion DoS]
+**Threat:** `deserialize_sparse_vector` only validated `nnz` (number of non-zero elements) against the `MAX_VECTOR_DIMENSIONS` limit, allowing malicious payloads to define an unbounded `dimension` (e.g., 2 billion) for sparse vectors. If the system later attempted to convert this sparse vector to a dense vector via `.to_dense()`, it would attempt to allocate `vec![0.0; dimension]`, causing an Out-Of-Memory (OOM) panic and enabling a Denial of Service.
+**Defense:** Added an explicit `validate_vector_dimensions(dimension as usize)?;` check directly after reading the dimension from the bytes, cleanly rejecting payloads before they bypass standard validations.

--- a/src/core/vector/serialization.rs
+++ b/src/core/vector/serialization.rs
@@ -332,6 +332,11 @@ pub fn deserialize_sparse_vector(bytes: &[u8]) -> Result<(Arc<SparseVec>, usize)
     }
 
     let dimension = u32::from_le_bytes(bytes[1..5].try_into().unwrap());
+
+    // Validate dimension first to prevent DoS via memory exhaustion from massive sparse vectors
+    // that might bypass SparseVec::new validation via early exit.
+    validate_vector_dimensions(dimension as usize)?;
+
     let nnz = u32::from_le_bytes(bytes[5..9].try_into().unwrap()) as usize;
 
     // Validate nnz doesn't exceed dimension


### PR DESCRIPTION
🦠 Threat:
`deserialize_sparse_vector` only validated `nnz` (number of non-zero elements) against the `MAX_VECTOR_DIMENSIONS` limit, allowing malicious payloads to define an unbounded `dimension` (e.g., 2 billion) for sparse vectors. If the system later attempted to convert this sparse vector to a dense vector via `.to_dense()`, it would attempt to allocate `vec![0.0; dimension]`, causing an Out-Of-Memory (OOM) panic and enabling a Denial of Service.

🛡️ Defense:
Added an explicit `validate_vector_dimensions(dimension as usize)?;` check directly after reading the dimension from the bytes, cleanly rejecting payloads before they bypass standard validations.

💥 Severity:
High - Unbounded memory allocation (OOM) could reliably crash the database process via a single maliciously crafted payload.

🧪 Verification:
Wrote and executed `test_sparse_dos` (subsequently deleted to keep tree clean) which confirmed the attack crashed the test process previously, and gracefully returned `DimensionTooLarge` error after the patch. Ran `cargo test`, `cargo clippy`, and `cargo audit` to confirm system stability and security.

---
*PR created automatically by Jules for task [11388737079833282675](https://jules.google.com/task/11388737079833282675) started by @madmax983*