### PR TITLE
🗺️ Atlas: Encapsulate Storage Submodules (index_persistence, sharding, wal)

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -79,3 +79,7 @@
 **[Broke Storage-API Dependency Cycle]
 **Tangle:** The `storage` module had an implementation of `From<&crate::api::transaction::BufferedWrite> for WalOperation` in `src/storage/wal/entry.rs`, meaning the underlying storage engine depended structurally on the public API layer.
 **Blueprint:** Moved the `From` implementation to `src/api/transaction/write_buffer.rs`. Now, the `api` module is aware of how its `BufferedWrite` converts into a `WalOperation` to send down to `storage`, enforcing a unidirectional dependency graph from `api` -> `storage`.
+
+## 2026-05-25 - Encapsulating Storage Submodules (index_persistence, sharding, wal)
+**Tangle:** The `src/storage/index_persistence/mod.rs`, `src/storage/sharding/mod.rs`, and `src/storage/wal.rs` modules exposed all of their internal implementation submodules publicly via `pub mod`. This creates a "Leaky Abstraction" smell where consumers of these systems can bypass the intended public API and depend on internal structs and logic.
+**Blueprint:** Refactored module declarations from `pub mod` to `pub(crate) mod` in these modules, strictly enforcing module boundaries. Tests and benchmarks were updated to use exported API types.

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -29,7 +29,7 @@ use aletheiadb::index::vector::hnsw::HnswConfig;
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
 use aletheiadb::storage::wal::WalOperation;
-use aletheiadb::storage::wal::concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
+use aletheiadb::storage::wal::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
 use aletheiadb::storage::{CheckpointManager, UnifiedCheckpointConfig};
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;

--- a/benches/wal_batch_append.rs
+++ b/benches/wal_batch_append.rs
@@ -14,9 +14,8 @@
 use aletheiadb::{
     core::{PropertyMapBuilder, id::NodeId, interning::GLOBAL_INTERNER, temporal::time},
     storage::wal::{
-        WalOperation,
+        DurabilityMode, WalOperation,
         concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig},
-        durability::DurabilityMode,
     },
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};

--- a/benches/wal_serialization.rs
+++ b/benches/wal_serialization.rs
@@ -13,9 +13,8 @@ use aletheiadb::{
         temporal::time,
     },
     storage::wal::{
-        WalOperation,
+        DurabilityMode, WalOperation,
         concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig},
-        durability::DurabilityMode,
     },
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -84,17 +84,17 @@ mod error;
 pub mod formats;
 pub mod graph;
 pub mod loader;
-pub mod manifest;
+pub(crate) mod manifest;
 /// Persistence operations implementation.
-pub mod operations;
-pub mod strings;
+pub(crate) mod operations;
+pub(crate) mod strings;
 pub mod temporal;
 pub mod temporal_adjacency;
 /// Persistence mutation tracking.
-pub mod tracker;
+pub(crate) mod tracker;
 pub mod vector;
 /// Background persistence worker thread.
-pub mod worker;
+pub(crate) mod worker;
 
 #[cfg(test)]
 mod dos_tests;

--- a/src/storage/sharding/mod.rs
+++ b/src/storage/sharding/mod.rs
@@ -46,15 +46,15 @@
 
 pub mod config;
 pub mod coordinator;
-pub mod executor;
-pub mod migration;
-pub mod network;
+pub(crate) mod executor;
+pub(crate) mod migration;
+pub(crate) mod network;
 pub mod persistent_commit_log;
-pub mod rebalance;
-pub mod router;
-pub mod rpc_client;
-pub mod simulation;
-pub mod transaction;
+pub(crate) mod rebalance;
+pub(crate) mod router;
+pub(crate) mod rpc_client;
+pub(crate) mod simulation;
+pub(crate) mod transaction;
 pub mod types;
 
 // Re-export commonly used types

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -102,7 +102,7 @@
 //! - **20-50% throughput improvement** for batch sizes > 10
 
 // Durability mode support
-pub mod durability;
+pub(crate) mod durability;
 pub mod group_commit;
 
 // Concurrent WAL modules
@@ -116,7 +116,7 @@ pub mod stripe;
 
 // New modules for data structures and serialization
 pub mod entry;
-pub mod serialization;
+pub(crate) mod serialization;
 
 // Re-export key types
 pub use durability::{DurabilityMode, WriteOptions};
@@ -126,4 +126,5 @@ pub use group_commit::GroupCommitCoordinator;
 pub use entry::{LSN, WalEntry, WalOperation};
 
 // Re-export serialization helpers (needed by concurrent.rs via super::)
+pub use concurrent_system::{ConcurrentWalSystem, ConcurrentWalSystemConfig};
 pub(crate) use serialization::estimate_entry_capacity;


### PR DESCRIPTION
🕸️ Tangle: The `src/storage/index_persistence/mod.rs`, `src/storage/sharding/mod.rs`, and `src/storage/wal.rs` modules exposed all of their internal implementation submodules publicly via `pub mod`. This created a "Leaky Abstraction" smell where external crates and users could bypass the intended public API and depend on internal structs and logic.

📐 Blueprint: Refactored module declarations from `pub mod` to `pub(crate) mod` in these modules, strictly enforcing module boundaries. Only intentionally public modules like `index_persistence::api` and specific submodules needed externally by tests or benchmarks were kept `pub mod`. Updated benchmarks and tests to use the exported API types instead of internal implementations.

🧱 Stability: Reduced coupling across the storage layer, preventing future namespace leaks and enforcing a strictly unidirectional dependency graph.

🔬 Verification: Builds successfully (`cargo check --all-targets --all-features`). All tests and benchmarks pass (`cargo test --all-targets --all-features`). Lints and formatting are green (`cargo clippy --all-targets --all-features -- -D warnings` & `cargo fmt --all`).

---
*PR created automatically by Jules for task [3219647919260606400](https://jules.google.com/task/3219647919260606400) started by @madmax983*