### PR TITLE
🛡️ Sentry: Replace From with TryFrom for vectors to prevent DoS via panic

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -22,3 +22,6 @@
 ## Panic Risks in Query Iterators and Mock Clients
 **Learning:** `unwrap()` inside iterator implementations (like `VectorRerankIterator::next`) or trait implementations for mock clients (like `MockVectorNodeClient`) pose a significant availability risk, as a panic can crash the thread handling the query or the entire database process.
 **Action:** Always gracefully handle `None` on iterators (returning `None` or propagating errors) and map lock poisoning errors (`PoisonError`) to domain-specific errors (e.g. `VectorError`) to ensure the system degrades gracefully instead of crashing during simulated faults or unexpected states.
+## Trait Implementation Invariants
+**Learning:** Fallible conversions of dynamic data must use `TryFrom` instead of `From` to avoid introducing DoS vulnerabilities through panics.
+**Action:** Always prefer `TryFrom` when converting data that might fail validation, and ensure all callers handle the resulting `Result` appropriately.

--- a/examples/vector_quick_start.rs
+++ b/examples/vector_quick_start.rs
@@ -1,5 +1,5 @@
 use aletheiadb::index::vector::temporal::TemporalVectorConfig;
-use aletheiadb::{AletheiaDB, DistanceMetric, HnswConfig, properties};
+use aletheiadb::{AletheiaDB, DistanceMetric, HnswConfig, properties, PropertyValue};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new().unwrap();
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Document",
         properties! {
             "title" => "Introduction to Rust",
-            "embedding" => &embedding[..],
+            "embedding" => PropertyValue::try_from(&embedding[..]).unwrap(),
         },
     )?;
 
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Document",
         properties! {
             "title" => "Rust for Beginners",
-            "embedding" => &embedding[..], // Same embedding for max similarity
+            "embedding" => PropertyValue::try_from(&embedding[..]).unwrap(), // Same embedding for max similarity
         },
     )?;
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1119,16 +1119,21 @@ impl From<Vec<PropertyValue>> for PropertyValue {
     }
 }
 
-impl From<Vec<f32>> for PropertyValue {
-    fn from(v: Vec<f32>) -> Self {
-        // Use v.into() to reuse the Vec's buffer, avoiding allocation and copy
-        PropertyValue::Vector(v.into())
+impl TryFrom<Vec<f32>> for PropertyValue {
+    type Error = crate::core::error::Error;
+
+    fn try_from(v: Vec<f32>) -> Result<Self> {
+        validate_vector_dimensions(v.len())?;
+        Ok(PropertyValue::Vector(v.into()))
     }
 }
 
-impl From<&[f32]> for PropertyValue {
-    fn from(v: &[f32]) -> Self {
-        PropertyValue::Vector(Arc::from(v))
+impl TryFrom<&[f32]> for PropertyValue {
+    type Error = crate::core::error::Error;
+
+    fn try_from(v: &[f32]) -> Result<Self> {
+        validate_vector_dimensions(v.len())?;
+        Ok(PropertyValue::Vector(Arc::from(v)))
     }
 }
 
@@ -2092,7 +2097,7 @@ mod tests {
     #[test]
     fn test_vector_from_vec() {
         let data: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4, 0.5];
-        let vec_prop: PropertyValue = data.clone().into();
+        let vec_prop: PropertyValue = data.clone().try_into().unwrap();
 
         assert_eq!(vec_prop.as_vector(), Some(&data[..]));
     }
@@ -2100,7 +2105,7 @@ mod tests {
     #[test]
     fn test_vector_from_slice() {
         let data = [1.5f32, 2.5, 3.5];
-        let vec_prop: PropertyValue = (&data[..]).into();
+        let vec_prop: PropertyValue = (&data[..]).try_into().unwrap();
 
         assert_eq!(vec_prop.as_vector(), Some(&data[..]));
     }
@@ -3371,7 +3376,7 @@ mod tests {
             .insert("a", 1)
             .insert("b", "test")
             .remove("a")
-            .insert("c", vec![1.0f32, 2.0])
+            .insert("c", PropertyValue::vector(vec![1.0f32, 2.0]))
             .build();
 
         let serialized = map.serialize().unwrap();
@@ -4268,5 +4273,21 @@ mod sentry_tests {
             f1.semantically_equal(&f2),
             "semantically_equal should treat NaN as equal"
         );
+    }
+
+    #[test]
+    fn test_vector_from_vec_excessive_dimensions() {
+        use crate::core::vector::constants::MAX_VECTOR_DIMENSIONS;
+        let max_size: Vec<f32> = vec![0.0; MAX_VECTOR_DIMENSIONS + 1];
+        let result: std::result::Result<PropertyValue, _> = max_size.try_into();
+        assert!(result.is_err(), "Expected error for excessive dimensions");
+    }
+
+    #[test]
+    fn test_vector_from_slice_excessive_dimensions() {
+        use crate::core::vector::constants::MAX_VECTOR_DIMENSIONS;
+        let max_size: Vec<f32> = vec![0.0; MAX_VECTOR_DIMENSIONS + 1];
+        let result: std::result::Result<PropertyValue, _> = max_size.as_slice().try_into();
+        assert!(result.is_err(), "Expected error for excessive dimensions");
     }
 }

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -551,7 +551,7 @@ impl PropertyDelta {
                         && let Some(base_vec) = base_value.as_vector()
                     {
                         let new_vec = vec_delta.apply(base_vec);
-                        result.insert(*key, new_vec.into());
+                        result.insert(*key, new_vec.try_into().unwrap());
                     }
                 }
             }
@@ -626,7 +626,7 @@ impl PropertyDelta {
 
                         // Apply sparse delta to get full vector
                         let new_vec = vec_delta.apply(base_vec);
-                        self.changed.insert(key, new_vec.into());
+                        self.changed.insert(key, new_vec.try_into().unwrap());
                     }
                 }
             }

--- a/src/experimental/chimera.rs
+++ b/src/experimental/chimera.rs
@@ -262,7 +262,7 @@ impl<'a> ChimeraEngine<'a> {
                 .zip(vb.iter())
                 .map(|(x, y)| op(*x as f64, *y as f64) as f32)
                 .collect();
-            return Some(PropertyValue::from(res));
+            return PropertyValue::try_from(res).ok();
         }
 
         // Try scalars
@@ -271,7 +271,7 @@ impl<'a> ChimeraEngine<'a> {
 
         if let (Some(x), Some(y)) = (na, nb) {
             let res = op(x, y);
-            Some(PropertyValue::from(res))
+            Some(PropertyValue::Float(res))
         } else {
             // Fallback for non-numerics under numeric strategy
             Some(a.clone())


### PR DESCRIPTION
🎯 **Target:** `src/core/property.rs`, specifically `PropertyValue` conversions from `Vec<f32>` and `&[f32]`.

💣 **Risk:** Previously, `PropertyValue` implemented `From<Vec<f32>>` and `From<&[f32]>`. Because `From` is strictly for infallible conversions, these implementations bypassed the `validate_vector_dimensions` check present in the explicit `PropertyValue::vector` constructor. If an excessively large vector was passed through an `.into()` conversion, it would silently bypass validation, potentially causing OOM or serialization errors downstream. If we added the validation to `From` with an `.unwrap_or_else(|e| panic!("{}"))`, it would create a Denial of Service (DoS) vulnerability where invalid dynamic input could crash the entire application process.

🧪 **Strategy:** 
1. Completely removed the `From<Vec<f32>>` and `From<&[f32]>` implementations to avoid the standard library's blanket `TryFrom` conflict.
2. Added `TryFrom<Vec<f32>>` and `TryFrom<&[f32]>` implementations that correctly execute `validate_vector_dimensions` and return a `Result`.
3. Updated internal usages (e.g., in `src/core/version.rs` and `examples/vector_quick_start.rs`) to use `try_into().unwrap()` where the base vectors are already known to be valid or hardcoded.
4. Updated `src/experimental/chimera.rs` to use `.try_into().ok()` to gracefully ignore invalid numeric vectors during query execution rather than crashing.
5. Added unit tests `test_vector_from_vec_excessive_dimensions` and `test_vector_from_slice_excessive_dimensions` to verify the new error paths.

🔬 **Verification:** 
Run the specific tests:
```bash
cargo test --lib core::property
cargo test --lib core::version
cargo test --lib experimental::chimera
cargo check --examples --features "nova observability embedding-openai mcp-server sharding-rpc"
```

---
*PR created automatically by Jules for task [9557231198622842234](https://jules.google.com/task/9557231198622842234) started by @madmax983*