### PR TITLE
🛡️ Sentry: [test coverage improvement] for index_persistence modules

### DIFF
--- a/src/storage/index_persistence/api.rs
+++ b/src/storage/index_persistence/api.rs
@@ -88,3 +88,17 @@ pub struct VectorIndexStatus {
     /// Number of temporal snapshots
     pub snapshot_count: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_persistence_config_default() {
+        let config = PersistenceConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.data_dir, PathBuf::from("data"));
+        assert!(config.load_on_startup);
+        assert!(config.use_mmap);
+    }
+}

--- a/src/storage/index_persistence/error.rs
+++ b/src/storage/index_persistence/error.rs
@@ -86,3 +86,33 @@ impl IndexPersistenceError {
 
 /// Result type for index persistence operations.
 pub type Result<T> = std::result::Result<T, IndexPersistenceError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn test_is_not_found_returns_true_for_not_found_error() {
+        let err =
+            IndexPersistenceError::Io(io::Error::new(io::ErrorKind::NotFound, "file not found"));
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_not_found_returns_false_for_other_io_errors() {
+        let err = IndexPersistenceError::Io(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "permission denied",
+        ));
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn test_is_not_found_returns_false_for_non_io_errors() {
+        let err = IndexPersistenceError::MissingIndex {
+            name: "test".to_string(),
+        };
+        assert!(!err.is_not_found());
+    }
+}


### PR DESCRIPTION
🎯 Target: `src/storage/index_persistence/api.rs` and `src/storage/index_persistence/error.rs`
💣 Risk: Missing test coverage for error type conversions (specifically identifying if an error is a "not found" IO error) and default configurations could lead to silent regressions if defaults are accidentally changed or if the underlying IO error matching breaks, impacting the database's ability to gracefully handle missing index files during startup/recovery.
🧪 Strategy: Added `#[cfg(test)] mod tests` blocks. For `error.rs`, added unit tests to verify `IndexPersistenceError::is_not_found()` correctly identifies `ErrorKind::NotFound` and rejects other IO/custom errors. For `api.rs`, added a test to verify `PersistenceConfig::default()` produces the expected baseline configuration.
🔬 Verification: `cargo test --lib -- src/storage/index_persistence/api.rs src/storage/index_persistence/error.rs`

---
*PR created automatically by Jules for task [3573220404287449635](https://jules.google.com/task/3573220404287449635) started by @madmax983*