### PR TITLE
🗺️ Atlas: Enforce Facade pattern on vector index implementations

### DIFF
--- a/benches/hnsw_index.rs
+++ b/benches/hnsw_index.rs
@@ -10,8 +10,8 @@
 mod common;
 
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::hnsw::{HnswConfig, HnswIndex};
 use aletheiadb::index::vector::{DistanceMetric, VectorIndex};
+use aletheiadb::index::vector::{HnswConfig, HnswIndex};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
 use std::sync::Arc;

--- a/benches/hybrid_query.rs
+++ b/benches/hybrid_query.rs
@@ -14,10 +14,8 @@ use aletheiadb::core::id::NodeId;
 use aletheiadb::core::property::PropertyMapBuilder;
 use aletheiadb::core::vector::cosine_similarity;
 use aletheiadb::db::AletheiaDB;
-use aletheiadb::index::vector::temporal::{
-    RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
-};
 use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::index::vector::{RetentionPolicy, SnapshotStrategy, TemporalVectorConfig};
 use aletheiadb::query::hybrid::{find_similar_as_of, traverse_and_rank};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::cmp::Ordering;

--- a/benches/query_optimization.rs
+++ b/benches/query_optimization.rs
@@ -13,7 +13,7 @@ mod common;
 
 use aletheiadb::PropertyMapBuilder;
 use aletheiadb::core::NodeId;
-use aletheiadb::index::vector::{DistanceMetric, hnsw::HnswConfig};
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 use aletheiadb::query::builder::QueryBuilder;
 use aletheiadb::query::planner::{QueryPlanner, Statistics};
 use aletheiadb::storage::CurrentStorage;

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -25,7 +25,7 @@ use aletheiadb::core::interning::GLOBAL_INTERNER;
 use aletheiadb::core::property::PropertyMapBuilder;
 use aletheiadb::core::temporal::time;
 use aletheiadb::index::vector::DistanceMetric;
-use aletheiadb::index::vector::hnsw::HnswConfig;
+use aletheiadb::index::vector::HnswConfig;
 use aletheiadb::storage::current::CurrentStorage;
 use aletheiadb::storage::historical::HistoricalStorage;
 use aletheiadb::storage::wal::WalOperation;

--- a/benches/temporal_vector.rs
+++ b/benches/temporal_vector.rs
@@ -11,10 +11,10 @@ mod common;
 
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::temporal::TimeRange;
-use aletheiadb::index::vector::temporal::{
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, VectorIndex};
+use aletheiadb::index::vector::{
     RetentionPolicy, SnapshotStrategy, TemporalVectorConfig, TemporalVectorIndex,
 };
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig, HnswIndex, VectorIndex};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
 use std::sync::Arc;

--- a/examples/bench_search.rs
+++ b/examples/bench_search.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::hnsw::{HnswConfig, HnswIndex};
 use aletheiadb::index::vector::{DistanceMetric, VectorIndex};
+use aletheiadb::index::vector::{HnswConfig, HnswIndex};
 use std::time::Instant;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/russian_writers.rs
+++ b/examples/russian_writers.rs
@@ -736,10 +736,8 @@ fn populate_database(demo: &mut DemoData) -> Result<()> {
     // 1. Current index: for fast similarity searches (find_similar)
     // 2. Temporal index: for tracking semantic drift over time
     println!("\n  Setting up vector indexes...");
-    use aletheiadb::index::vector::temporal::{
-        RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
-    };
     use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+    use aletheiadb::index::vector::{RetentionPolicy, SnapshotStrategy, TemporalVectorConfig};
 
     let hnsw_config = HnswConfig::new(384, DistanceMetric::Cosine);
 

--- a/examples/vector_quick_start.rs
+++ b/examples/vector_quick_start.rs
@@ -1,4 +1,4 @@
-use aletheiadb::index::vector::temporal::TemporalVectorConfig;
+use aletheiadb::index::vector::TemporalVectorConfig;
 use aletheiadb::{AletheiaDB, DistanceMetric, HnswConfig, properties};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-git diff HEAD~1..HEAD --name-only

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. Refactor `VersionMetadata` in `src/index/temporal.rs` to `TimelineVersionMetadata` to prevent confusion with `src/core/version.rs::VersionMetadata`.
-2. Format the code with `cargo fmt --all`.
-3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
-4. Run `cargo test`.
-5. Journal the finding in `.jules/atlas.md`.
-6. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/src/index/vector/hnsw/mod.rs
+++ b/src/index/vector/hnsw/mod.rs
@@ -18,11 +18,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind, ffi::Matches};
 
 /// HNSW configuration and builder.
-pub mod config;
+pub(crate) mod config;
 /// Persistence logic for HNSW index.
-pub mod persistence;
+pub(crate) mod persistence;
 /// Statistics for HNSW index.
-pub mod stats;
+pub(crate) mod stats;
 
 #[cfg(test)]
 mod tests;

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -714,10 +714,10 @@ mod tests {
 }
 
 // HNSW implementation
-pub mod hnsw;
+pub(crate) mod hnsw;
 
 // Temporal vector index (Phase 3)
-pub mod temporal;
+pub(crate) mod temporal;
 
 // Re-export HNSW types for convenience
 pub use hnsw::{HnswConfig, HnswIndex, HnswIndexBuilder};
@@ -729,7 +729,7 @@ pub use temporal::{
 };
 
 // Sparse vector index (Phase 5)
-pub mod sparse;
+pub(crate) mod sparse;
 
 // Re-export sparse types for convenience
 pub use sparse::{
@@ -738,7 +738,7 @@ pub use sparse::{
 };
 
 // Sharded vector index (VS-103)
-pub mod sharded;
+pub(crate) mod sharded;
 
 // Re-export sharded types for convenience
 pub use sharded::{
@@ -747,7 +747,7 @@ pub use sharded::{
 };
 
 // Distributed vector index (VS-107)
-pub mod distributed;
+pub(crate) mod distributed;
 
 // Re-export distributed types for convenience
 pub use distributed::{

--- a/src/index/vector/temporal/mod.rs
+++ b/src/index/vector/temporal/mod.rs
@@ -92,12 +92,12 @@ use crate::index::vector::{DistanceMetric, TemporalSearchResults, VectorIndex};
 
 // Submodules
 /// Configuration types for temporal vector indexing.
-pub mod config;
+pub(crate) mod config;
 /// Observers for reacting to storage events.
-pub mod observer;
+pub(crate) mod observer;
 pub(crate) mod snapshot;
 /// Statistics and monitoring types.
-pub mod stats;
+pub(crate) mod stats;
 
 // Re-exports
 pub use config::{DriftMetric, RetentionPolicy, SnapshotStrategy, TemporalVectorConfig};

--- a/test_mutants.sh
+++ b/test_mutants.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-cargo mutants --file src/core/graph.rs --timeout 60 > mutants_graph.log 2>&1

--- a/tests/hnsw_allocation_tests.rs
+++ b/tests/hnsw_allocation_tests.rs
@@ -26,8 +26,8 @@
 
 use aletheiadb::core::error::Result;
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::hnsw::{HnswConfig, HnswIndex};
 use aletheiadb::index::vector::{DistanceMetric, VectorIndex};
+use aletheiadb::index::vector::{HnswConfig, HnswIndex};
 
 /// Test that add() accepts slices and doesn't require Vec allocation per call.
 ///

--- a/tests/hnsw_persistence_perf.rs
+++ b/tests/hnsw_persistence_perf.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::NodeId;
-use aletheiadb::index::vector::hnsw::HnswConfig;
-use aletheiadb::index::vector::hnsw::HnswIndex;
+use aletheiadb::index::vector::HnswConfig;
+use aletheiadb::index::vector::HnswIndex;
 use aletheiadb::index::vector::{DistanceMetric, VectorIndex};
 use std::time::Instant;
 use tempfile::tempdir;

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -1171,9 +1171,7 @@ fn test_direct_traverse_and_rank_with_different_label() {
 #[test]
 #[ignore = "Temporal + Vector query pattern not yet implemented in planner (Phase 3)"]
 fn test_temporal_vector_query() {
-    use aletheiadb::index::vector::temporal::{
-        RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
-    };
+    use aletheiadb::index::vector::{RetentionPolicy, SnapshotStrategy, TemporalVectorConfig};
 
     // Create database with temporal vector indexing
     let db = AletheiaDB::with_config(AnchorConfig {

--- a/tests/semantic_drift_detection.rs
+++ b/tests/semantic_drift_detection.rs
@@ -6,10 +6,10 @@
 use aletheiadb::core::error::Result;
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::temporal::TimeRange;
-use aletheiadb::index::vector::temporal::{
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::index::vector::{
     DriftMetric, RetentionPolicy, SnapshotStrategy, TemporalVectorConfig, TemporalVectorIndex,
 };
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 
 /// Creates a normalized vector from raw values.
 fn normalize(v: &[f32]) -> Vec<f32> {

--- a/tests/temporal_vector.rs
+++ b/tests/temporal_vector.rs
@@ -10,10 +10,10 @@
 use aletheiadb::core::error::Result;
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::temporal::{TimeRange, time};
-use aletheiadb::index::vector::temporal::{
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::index::vector::{
     RetentionPolicy, SnapshotStrategy, TemporalVectorConfig, TemporalVectorIndex,
 };
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 use std::time::Duration;
 
 /// Helper to create a test temporal vector index with default config

--- a/tests/temporal_vector_integration.rs
+++ b/tests/temporal_vector_integration.rs
@@ -5,7 +5,7 @@
 
 use aletheiadb::{
     AletheiaDB, DistanceMetric, Error, HnswConfig, PropertyMapBuilder, ReadOps, WriteOps,
-    index::vector::temporal::TemporalVectorConfig, storage::version::AnchorConfig,
+    index::vector::TemporalVectorConfig, storage::version::AnchorConfig,
 };
 
 #[test]

--- a/tests/temporal_vector_tests.rs
+++ b/tests/temporal_vector_tests.rs
@@ -2,7 +2,7 @@ use aletheiadb::core::error::Result;
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::temporal::TimeRange;
 use aletheiadb::index::VectorIndex;
-use aletheiadb::index::vector::temporal::*;
+use aletheiadb::index::vector::*;
 use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 
 fn create_test_index() -> Result<TemporalVectorIndex> {

--- a/tests/vector_api_tests.rs
+++ b/tests/vector_api_tests.rs
@@ -3,10 +3,10 @@ use aletheiadb::Error;
 use aletheiadb::WriteOps;
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::property::PropertyMapBuilder;
-use aletheiadb::index::vector::temporal::{
+use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
+use aletheiadb::index::vector::{
     DriftMetric, RetentionPolicy, SnapshotStrategy, TemporalVectorConfig,
 };
-use aletheiadb::index::vector::{DistanceMetric, HnswConfig};
 use std::sync::Arc;
 use std::thread;
 

--- a/tests/verify_config_limit.rs
+++ b/tests/verify_config_limit.rs
@@ -1,7 +1,7 @@
 use aletheiadb::core::id::NodeId;
 use aletheiadb::index::vector::DistanceMetric;
-use aletheiadb::index::vector::hnsw::HnswConfig;
-use aletheiadb::index::vector::temporal::{
+use aletheiadb::index::vector::HnswConfig;
+use aletheiadb::index::vector::{
     RetentionPolicy, SnapshotStrategy, TemporalVectorConfig, TemporalVectorIndex,
 };
 


### PR DESCRIPTION
🕸️ Tangle: The structural problem was that the `vector` index module leaked its internal implementation submodules (`hnsw`, `temporal`, `sparse`, `sharded`, `distributed`), creating a confusing public API.
📐 Blueprint: Changed these internal modules from `pub mod` to `pub(crate) mod` to enforce the Facade pattern. The clean API surface is retained via existing `pub use` statements at the `aletheiadb::index::vector` level.
🧱 Stability: Reduced coupling, simplified public API, and fixed examples/benches that inappropriately relied on internal paths.
🔬 Verification: Builds successfully, strict separation enforced. All tests pass.

---
*PR created automatically by Jules for task [12537067175582367049](https://jules.google.com/task/12537067175582367049) started by @madmax983*