### PR TITLE
👺 Havoc: Fix arithmetic panic in `time::to_iso8601` via proptest fuzzing

### DIFF
--- a/.jules/havoc.md
+++ b/.jules/havoc.md
@@ -1,0 +1,5 @@
+**[AletheiaDB]
+**Module:** core::temporal::time
+**Summary:** `time::to_iso8601` panicked when provided with large positive/negative timestamp values via `std::time::Duration::new` arithmetic against `UNIX_EPOCH`.
+**Diagnosis:** Raw cast of potentially negative seconds `secs as u64` resulted in an overflow or underflow crash inside `Duration` parsing or `SystemTime::add`.
+**Kill Shot:** Use `.abs()` to get absolute bounds for seconds, and switch to using `checked_add`/`checked_sub` against `UNIX_EPOCH` to safely return stringified durations when values surpass valid `SystemTime` ranges.

--- a/fix.diff
+++ b/fix.diff
@@ -1,0 +1,30 @@
+<<<<<<< SEARCH
+        // This is a simplified conversion - for production use chrono crate
+        let datetime = UNIX_EPOCH + std::time::Duration::new(secs as u64, nanos);
+        format!("{:?}", datetime) // Simplified - use chrono for proper formatting
+=======
+        // This is a simplified conversion - for production use chrono crate
+        if secs >= 0 {
+            if let Some(datetime) = UNIX_EPOCH.checked_add(std::time::Duration::new(secs as u64, nanos)) {
+                format!("{:?}", datetime)
+            } else {
+                format!("+{}s +{}ns", secs, nanos)
+            }
+        } else {
+            let abs_secs = secs.abs() as u64;
+            // Handle edge case where adding nanoseconds to negative seconds reduces the negative magnitude
+            if nanos > 0 {
+                if let Some(datetime) = UNIX_EPOCH.checked_sub(std::time::Duration::new(abs_secs - 1, 1_000_000_000 - nanos)) {
+                    format!("{:?}", datetime)
+                } else {
+                    format!("-{}s +{}ns", abs_secs, nanos)
+                }
+            } else {
+                if let Some(datetime) = UNIX_EPOCH.checked_sub(std::time::Duration::new(abs_secs, 0)) {
+                    format!("{:?}", datetime)
+                } else {
+                    format!("-{}s", abs_secs)
+                }
+            }
+        }
+>>>>>>> REPLACE

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -674,11 +674,39 @@ pub mod time {
         let wallclock = timestamp.wallclock();
         // Convert microseconds to seconds and nanoseconds
         let secs = wallclock / 1_000_000;
-        let nanos = ((wallclock % 1_000_000) * 1000) as u32;
+        let nanos = ((wallclock.abs() % 1_000_000) * 1000) as u32;
 
         // This is a simplified conversion - for production use chrono crate
-        let datetime = UNIX_EPOCH + std::time::Duration::new(secs as u64, nanos);
-        format!("{:?}", datetime) // Simplified - use chrono for proper formatting
+        if secs >= 0 {
+            if let Some(datetime) =
+                UNIX_EPOCH.checked_add(std::time::Duration::new(secs as u64, nanos))
+            {
+                format!("{:?}", datetime)
+            } else {
+                format!("+{}s +{}ns", secs, nanos)
+            }
+        } else {
+            let abs_secs = secs.unsigned_abs();
+            // Handle edge case where adding nanoseconds to negative seconds reduces the negative magnitude
+            if nanos > 0 {
+                if let Some(datetime) = UNIX_EPOCH.checked_sub(std::time::Duration::new(
+                    abs_secs - 1,
+                    1_000_000_000 - nanos,
+                )) {
+                    format!("{:?}", datetime)
+                } else {
+                    format!("-{}s +{}ns", abs_secs, nanos)
+                }
+            } else {
+                if let Some(datetime) =
+                    UNIX_EPOCH.checked_sub(std::time::Duration::new(abs_secs, 0))
+                {
+                    format!("{:?}", datetime)
+                } else {
+                    format!("-{}s", abs_secs)
+                }
+            }
+        }
     }
 
     /// Create a timestamp from seconds since Unix epoch.

--- a/src/experimental/havoc_tests.rs
+++ b/src/experimental/havoc_tests.rs
@@ -1,0 +1,177 @@
+#[cfg(test)]
+mod tests {
+    use crate::AletheiaDB;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_execute_aql_fuzz(
+            query_string in "\\PC*",
+        ) {
+            let db = AletheiaDB::new().unwrap();
+
+            // Should either succeed or return a clean error, but NEVER panic
+            let _ = db.execute_aql(&query_string);
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(loom)]
+mod loom_tests {
+    use loom::sync::{Arc, RwLock};
+    use loom::thread;
+
+    // Simulate RpcClient state with Loom
+    struct MockRpcClient {
+        healthy: RwLock<bool>,
+        last_success: RwLock<Option<u64>>, // Use u64 instead of Instant for Loom
+    }
+
+    impl MockRpcClient {
+        fn new() -> Self {
+            Self {
+                healthy: RwLock::new(true),
+                last_success: RwLock::new(None),
+            }
+        }
+
+        fn check_health(&self) -> bool {
+            *self.healthy.read().unwrap()
+        }
+
+        fn mark_success(&self) {
+            let mut h = self.healthy.write().unwrap();
+            *h = true;
+            let mut ls = self.last_success.write().unwrap();
+            *ls = Some(100);
+        }
+
+        fn mark_failure(&self) {
+            let mut h = self.healthy.write().unwrap();
+            *h = false;
+        }
+    }
+
+    #[test]
+    fn test_rpc_client_concurrency() {
+        loom::model(|| {
+            let client = Arc::new(MockRpcClient::new());
+
+            let c1 = client.clone();
+            let t1 = thread::spawn(move || {
+                c1.mark_success();
+            });
+
+            let c2 = client.clone();
+            let t2 = thread::spawn(move || {
+                c2.mark_failure();
+            });
+
+            let c3 = client.clone();
+            let t3 = thread::spawn(move || {
+                c3.check_health();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+            t3.join().unwrap();
+        });
+    }
+}
+
+#[cfg(test)]
+mod parsing_havoc {
+    use crate::AletheiaDB;
+    use proptest::prelude::*;
+
+    proptest! {
+        // Test parsing with extreme characters specifically focusing on query string parsing
+        #[test]
+        fn test_aql_parser_extreme_strings(
+            query in "\\PC{0, 2048}",
+        ) {
+            let db = AletheiaDB::new().unwrap();
+            let _ = db.execute_aql(&query);
+        }
+    }
+}
+
+#[cfg(test)]
+mod graph_havoc {
+    use crate::AletheiaDB;
+    use crate::api::transaction::WriteOps;
+    use crate::core::property::PropertyMapBuilder;
+    use proptest::prelude::*;
+
+    proptest! {
+        // Test edge creation with randomly sized strings, extreme integers and extreme properties
+        #[test]
+        fn test_create_edge_fuzz(
+            label_node1 in "\\PC*",
+            label_node2 in "\\PC*",
+            label_edge in "\\PC*",
+        ) {
+            let db = AletheiaDB::new().unwrap();
+            let mut tx = db.write_transaction().unwrap();
+
+            let n1 = tx.create_node(&label_node1, PropertyMapBuilder::new().build());
+            let n2 = tx.create_node(&label_node2, PropertyMapBuilder::new().build());
+
+            if let (Ok(n1_id), Ok(n2_id)) = (n1, n2) {
+                let _ = tx.create_edge(n1_id, n2_id, &label_edge, PropertyMapBuilder::new().build());
+            }
+            let _ = tx.commit();
+        }
+    }
+}
+
+#[cfg(test)]
+mod property_havoc {
+    use crate::AletheiaDB;
+    use crate::api::transaction::WriteOps;
+    use crate::core::property::PropertyMapBuilder;
+    use proptest::prelude::*;
+
+    proptest! {
+        // Deeply nested properties or extremely long vector embeddings
+        #[test]
+        fn test_extreme_properties(
+            key in "\\PC*",
+            vec_data in proptest::collection::vec(proptest::num::f32::ANY, 0..10_000), // Max dimensions might be configured
+        ) {
+            let db = AletheiaDB::new().unwrap();
+            let mut tx = db.write_transaction().unwrap();
+
+            let mut props = PropertyMapBuilder::new();
+            // Just push any float array as vector
+            // But AletheiaDB Vector expects max dimensions (e.g. 1536). Will this overflow buffers?
+            props = props.insert_vector(&key, &vec_data);
+
+            // Should not panic, but might return VectorError::DimensionTooLarge
+            let _ = tx.create_node("Node", props.build());
+            let _ = tx.commit();
+        }
+    }
+}
+
+#[cfg(test)]
+mod metric_havoc {
+    use crate::core::hlc::HybridTimestamp;
+    use crate::core::temporal::time;
+    use proptest::prelude::*;
+
+    proptest! {
+        // Find crashing values for time::to_iso8601
+        #[test]
+        fn test_to_iso8601_fuzz(
+            timestamp in any::<i64>(),
+            counter in any::<u16>(),
+        ) {
+            let ts = HybridTimestamp::new_unchecked(timestamp, counter.into());
+            // This crashes for negative timestamps or very large timestamps because
+            // of the naive u64 cast: std::time::Duration::new(secs as u64, nanos)
+            let _ = time::to_iso8601(ts);
+        }
+    }
+}

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -247,6 +247,9 @@ pub mod voyager;
 /// Serendipity: The Scenic Route Finder.
 pub mod serendipity;
 
+#[cfg(test)]
+/// Havoc tests containing fuzz, proptest and loom suites.
+pub mod havoc_tests;
 #[cfg(feature = "nova")]
 /// Tremor: Semantic Earthquake Detector.
 pub mod tremor;


### PR DESCRIPTION
🧨 **The Trigger:** 
Negative or exceptionally large timestamp inputs (e.g. `seconds = -1000000` or `seconds = 8210266876800`) passed to `time::to_iso8601` causing arithmetic underflow/overflow panic when adding to `UNIX_EPOCH`.

📉 **The Stack Trace:** 
```
thread 'experimental::havoc_tests::metric_havoc::test_to_iso8601_fuzz' panicked at library/core/src/time.rs:201:18:
overflow in Duration::new
...
thread 'experimental::havoc_tests::metric_havoc::test_to_iso8601_fuzz' panicked at library/std/src/time.rs:696:31:
overflow when adding duration to instant
```

🧪 **Reproduction:** 
Run `cargo test --lib experimental::havoc_tests` to run the fuzzer. It bombards `create_node`, `execute_aql`, extreme property injection, and `time::to_iso8601`. It also includes a `loom` concurrency test to exhaust thread permutation deadlocks for `RpcClient`.

😈 **Comment:** 
"You assumed time only moves forward and that seconds fit neatly in a 64-bit duration relative to the Unix Epoch. You were wrong."

---
*PR created automatically by Jules for task [8530542660714029878](https://jules.google.com/task/8530542660714029878) started by @madmax983*