### PR TITLE
⚡ Bolt: Optimize Vec allocations in PersistentCommitLog

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 **[DashMap Guard iterators and .cloned()]**
 **Learning:** In AletheiaDB, `CurrentIndexes` iterators (`iter_nodes`, `iter_edges`) yield `impl Deref<Target = Node>` representing DashMap guards, not simple references (`&T`). Thus, attempting to apply `.cloned()` fails to compile since it strictly requires `&T`.
 **Action:** Always use `.map(|n| n.clone())` instead of `.cloned()` when iterating over DashMap guards or opaque `impl Deref` types.
+
+**[Optimize Vec allocations with Vec::with_capacity and exact size hints]**
+**Learning:** In Rust, replacing an idiomatic `.collect::<Vec<_>>()` chain with a manual `for` loop and `Vec::with_capacity()` is often a de-optimization. Iterators implementing `ExactSizeIterator` or `TrustedLen` (e.g., from slices or `std::vec::IntoIter`) automatically pre-allocate perfect capacity and elide bounds checks during `.collect()`. However, when `.filter(...)` is introduced into an iterator chain, the exact size hint is lost, causing `.collect()` to dynamically reallocate.
+**Action:** When filtering a collection of known maximum size into a `Vec`, manually pre-allocate `Vec::with_capacity(collection.len())` and use a `for` loop (or `.extend()`) to avoid all intermediate heap reallocations.

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -626,10 +626,13 @@ impl PersistentCommitLog {
         self.pending
             .read()
             .map(|p| {
-                p.values()
-                    .filter(|e| e.entry_type == EntryType::Commit)
-                    .cloned()
-                    .collect()
+                let mut result = Vec::with_capacity(p.len());
+                for value in p.values() {
+                    if value.entry_type == EntryType::Commit {
+                        result.push(value.clone());
+                    }
+                }
+                result
             })
             .unwrap_or_default()
     }
@@ -639,10 +642,13 @@ impl PersistentCommitLog {
         self.pending
             .read()
             .map(|p| {
-                p.values()
-                    .filter(|e| e.entry_type == EntryType::Abort)
-                    .cloned()
-                    .collect()
+                let mut result = Vec::with_capacity(p.len());
+                for value in p.values() {
+                    if value.entry_type == EntryType::Abort {
+                        result.push(value.clone());
+                    }
+                }
+                result
             })
             .unwrap_or_default()
     }


### PR DESCRIPTION
💡 **What**: The optimization implemented removes the `.filter(...).cloned().collect()` chain in `pending_commits` and `pending_aborts` methods inside `src/storage/sharding/persistent_commit_log.rs`. Instead, it uses `Vec::with_capacity(p.len())` and a manual `for` loop to collect the matching elements.
🎯 **Why**: The `.filter(...)` operation causes the iterator to lose its `ExactSizeIterator` trait, meaning `.collect()` does not know the final capacity ahead of time and will dynamically reallocate the `Vec` as elements are yielded, which is inefficient.
📊 **Impact**: Reduces heap allocations and reallocations when retrieving pending commits and aborts by pre-allocating the maximum possible required capacity, guaranteeing at most 1 heap allocation per call.
🔬 **Measurement**: Run `cargo test --lib storage::sharding::persistent_commit_log` to verify no regressions in the log recovery logic.

---
*PR created automatically by Jules for task [9105966504819068010](https://jules.google.com/task/9105966504819068010) started by @madmax983*