### PR TITLE
👺 Havoc: HnswIndex TOCTOU Capacity Overflow

### DIFF
--- a/src/index/vector/hnsw/mod.rs
+++ b/src/index/vector/hnsw/mod.rs
@@ -911,7 +911,7 @@ impl VectorIndex for HnswIndex {
                             || index.remove(existing_key),
                             "Failed to remove existing vector",
                         )?;
-                    } else if index.size() >= index.capacity() {
+                    } else if index.size() + 128 >= index.capacity() {
                         let new_capacity = (index.capacity() * 2).max(1024);
                         self.retry_usearch(
                             || index.reserve(new_capacity),
@@ -964,7 +964,7 @@ impl VectorIndex for HnswIndex {
 
                     let index = self.inner.write();
 
-                    if index.size() >= index.capacity() {
+                    if index.size() + 128 >= index.capacity() {
                         let new_capacity = (index.capacity() * 2).max(1024);
                         self.retry_usearch(
                             || index.reserve(new_capacity),


### PR DESCRIPTION
* 🧨 **The Trigger:** 150 concurrent threads all pass the optimistic `check_and_expand_capacity` read-lock check. They then serialize on `inner.write()` but the inner safety check `index.size() >= index.capacity()` lacks the required 128-element padding, causing the underlying usearch C++ library to overflow and panic.
* 📉 **The Stack Trace:** (usearch crash during concurrent `add`)
* 🧪 **Reproduction:** Run `cargo test --test havoc_hnsw_capacity`
* 😈 **Comment:** You assumed a read lock check was enough. It's only a hint. The real safety check must enforce the same padding requirements under the write lock.

---
*PR created automatically by Jules for task [15267198308133924327](https://jules.google.com/task/15267198308133924327) started by @madmax983*