### PR TITLE
🛡️ Sentry: [vector serialization test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -26,3 +26,7 @@
 **[Temporal TimeRange Max Timestamp and Deserialize Mutants]**
 **Learning:** `cargo mutants` revealed missing test coverage for `MAX_VALID_TIMESTAMP` bounds checking in open ranges (`TimeRange::from` and `TimeRange::at`), empty range overlap edge cases (`TimeRange::overlaps` short-circuit behavior), and deserialization stringency (`BiTemporalInterval::deserialize` exact consumed length checking against buffer size `> 48`).
 **Action:** Added targeted unit tests checking `#[should_panic]` when `MAX_VALID_TIMESTAMP` is exceeded, explicitly testing overlap between empty point-ranges within larger non-empty ranges, and appending excess bytes to binary formats to verify exact parser length consumption limits.
+
+**[Vector Serialization Boundary Coverage]**
+**Learning:** In Rust, `try_into().unwrap()` is often mathematically infallible after explicit length checks, but relying on this without targeted 'buffer too short' tests creates a false sense of security. Binary deserialization must have boundary tests confirming exactly where short buffers are rejected to lock in the length check correctness.
+**Action:** Always write explicit boundary tests that truncate valid serialized output byte-by-byte for both header and payload sizes before calling deserialization functions.

--- a/src/core/vector/serialization.rs
+++ b/src/core/vector/serialization.rs
@@ -720,6 +720,64 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_vector_buffer_too_short() {
+        // 🛡️ Sentry: Ensure memory safety and prevent out-of-bounds panics
+        // during binary deserialization (buffer too short boundary tests).
+
+        let valid_vector = [1.0f32, 2.0, 3.0];
+        let bytes = serialize_vector(&valid_vector);
+
+        // Header truncation (need at least 5 bytes)
+        for i in 0..5 {
+            let truncated = &bytes[0..i];
+            let result = deserialize_vector(truncated);
+            assert!(result.is_err());
+            if let Err(e) = result {
+                assert!(e.to_string().contains("Buffer too short"));
+            }
+        }
+
+        // Payload truncation
+        for i in 5..bytes.len() {
+            let truncated = &bytes[0..i];
+            let result = deserialize_vector(truncated);
+            assert!(result.is_err());
+            if let Err(e) = result {
+                assert!(e.to_string().contains("Buffer too short"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_deserialize_sparse_vector_buffer_too_short() {
+        // 🛡️ Sentry: Ensure memory safety and prevent out-of-bounds panics
+        // during binary deserialization (buffer too short boundary tests).
+
+        let valid_sparse = SparseVec::new(vec![0, 2], vec![1.0, 2.0], 5).unwrap();
+        let bytes = serialize_sparse_vector(&valid_sparse);
+
+        // Header truncation (need at least 9 bytes)
+        for i in 0..9 {
+            let truncated = &bytes[0..i];
+            let result = deserialize_sparse_vector(truncated);
+            assert!(result.is_err());
+            if let Err(e) = result {
+                assert!(e.to_string().contains("Buffer too short"));
+            }
+        }
+
+        // Payload truncation
+        for i in 9..bytes.len() {
+            let truncated = &bytes[0..i];
+            let result = deserialize_sparse_vector(truncated);
+            assert!(result.is_err());
+            if let Err(e) = result {
+                assert!(e.to_string().contains("Buffer too short"));
+            }
+        }
+    }
+
+    #[test]
     fn test_deserialize_sparse_vector_errors() {
         // Empty buffer
         let result = deserialize_sparse_vector(&[]);


### PR DESCRIPTION
🎯 Target: `src/core/vector/serialization.rs`
💣 Risk: Prevents out-of-bounds panics during binary deserialization by verifying length checks preceding `.try_into().unwrap()` calls.
🧪 Strategy: Added 'buffer too short' boundary tests (covering both header and payload truncation) by iterating through truncated valid byte arrays and ensuring `Buffer too short` is gracefully returned.
🔬 Verification: Run `cargo test --lib vector::serialization`

---
*PR created automatically by Jules for task [5224823693166721128](https://jules.google.com/task/5224823693166721128) started by @madmax983*