### PR TITLE
⚖️ Elenchus: Weak Assertions Fix for Query Planner and HNSW Tests

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -339,3 +339,17 @@
 **Finding:** The FNV-1a fallback tests for `IdentityHasher` (`test_identity_hasher_write_fallback_fnv` and `test_identity_hasher_write_fallback_fnv_dirty`) were tautological. They exactly mirrored the source implementation by reconstructing the FNV-1a multiplication and XOR sequence to generate their `expected` values. This meant they only asserted that "the code is the code" and provided no independent verification that the hashing logic was correct or consistent with standard FNV-1a.
 **Evidence:** The original tests explicitly copied the sequence `expected ^= 1; expected = expected.wrapping_mul(FNV_PRIME);` which exactly mirrors the `write` loop. Any mutation altering `FNV_PRIME` or the operation order would survive if the same change was incorrectly made to the test or if it was inherently flawed.
 **Recommendation:** Refactored the tests to use independently pre-computed integer constants as the `expected` values (the Oracle Problem solution). This ensures the implementation matches the ground truth rather than itself.
+
+**[HNSW Reentrancy Weak Assertions]**
+**Module:** `tests/havoc/havoc_hnsw_reentrancy.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The tests `test_reentrant_search_returns_error` and `test_reentrant_search_with_filter_returns_error` ended with a weak assertion `assert!(result.is_ok());` which only verified that the outer search did not fail, but did not verify that it actually returned the expected items.
+**Evidence:** The final assertion in both tests was `assert!(result.is_ok());`.
+**Recommendation:** Replaced `assert!(result.is_ok());` with `assert_eq!(result.unwrap().len(), 1);` and verified the correct node was returned to ensure the outer search actually succeeded and functioned as expected.
+
+**[Query Planner Integration Weak Assertions]**
+**Module:** `src/query/converter.rs`, `tests/hybrid_query_planner.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Multiple planner integration tests in `src/query/converter.rs` (e.g., `test_planner_integration_simple_match`, `test_planner_integration_with_filter`) and `tests/hybrid_query_planner.rs` (`test_minimal_query_planning`) used weak assertions (`assert!(result.is_ok());`) when planning queries. This only proves that the planner didn't panic or return an error, but it doesn't prove that it produced a valid or non-empty physical plan.
+**Evidence:** The tests called `planner.plan(query)` followed by `assert!(result.is_ok());` without inspecting the generated `PhysicalPlan`.
+**Recommendation:** Added assertions to unwrap the result and explicitly check that `!matches!(plan.root, PhysicalOp::Empty)` to ensure the planner actually built a meaningful execution plan.

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -1513,10 +1513,10 @@ mod tests {
         // Plan the query
         let result = planner.plan(query);
         let plan = result.unwrap();
-        assert!(!matches!(
-            plan.root,
-            crate::query::planner::PhysicalOp::Empty
-        ), "Query plan should not be empty");
+        assert!(
+            !matches!(plan.root, crate::query::planner::PhysicalOp::Empty),
+            "Query plan should not be empty"
+        );
     }
 
     #[test]
@@ -1537,10 +1537,10 @@ mod tests {
         // Plan the query
         let result = planner.plan(query);
         let plan = result.unwrap();
-        assert!(!matches!(
-            plan.root,
-            crate::query::planner::PhysicalOp::Empty
-        ), "Query plan should not be empty");
+        assert!(
+            !matches!(plan.root, crate::query::planner::PhysicalOp::Empty),
+            "Query plan should not be empty"
+        );
     }
 
     #[test]
@@ -1561,10 +1561,10 @@ mod tests {
         // Plan the query
         let result = planner.plan(query);
         let plan = result.unwrap();
-        assert!(!matches!(
-            plan.root,
-            crate::query::planner::PhysicalOp::Empty
-        ), "Query plan should not be empty");
+        assert!(
+            !matches!(plan.root, crate::query::planner::PhysicalOp::Empty),
+            "Query plan should not be empty"
+        );
 
         // Temporal queries should include temporal context in the plan
         assert!(plan.is_temporal());

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -1512,7 +1512,11 @@ mod tests {
 
         // Plan the query
         let result = planner.plan(query);
-        assert!(result.is_ok());
+        let plan = result.unwrap();
+        assert!(!matches!(
+            plan.root,
+            crate::query::planner::PhysicalOp::Empty
+        ), "Query plan should not be empty");
     }
 
     #[test]
@@ -1532,7 +1536,11 @@ mod tests {
 
         // Plan the query
         let result = planner.plan(query);
-        assert!(result.is_ok());
+        let plan = result.unwrap();
+        assert!(!matches!(
+            plan.root,
+            crate::query::planner::PhysicalOp::Empty
+        ), "Query plan should not be empty");
     }
 
     #[test]
@@ -1552,9 +1560,12 @@ mod tests {
 
         // Plan the query
         let result = planner.plan(query);
-        assert!(result.is_ok());
-
         let plan = result.unwrap();
+        assert!(!matches!(
+            plan.root,
+            crate::query::planner::PhysicalOp::Empty
+        ), "Query plan should not be empty");
+
         // Temporal queries should include temporal context in the plan
         assert!(plan.is_temporal());
     }

--- a/tests/havoc/havoc_hnsw_reentrancy.rs
+++ b/tests/havoc/havoc_hnsw_reentrancy.rs
@@ -32,8 +32,10 @@ fn test_reentrant_search_returns_error() {
         true
     });
 
-    // The outer search should succeed
-    assert!(result.is_ok());
+    // The outer search should succeed and return the one added node
+    let results = result.unwrap();
+    assert_eq!(results.len(), 1, "Outer search should find 1 node");
+    assert_eq!(results[0].0, NodeId::new(1).unwrap(), "Should find Node 1");
 }
 
 #[test]
@@ -67,5 +69,8 @@ fn test_reentrant_search_with_filter_returns_error() {
         true
     });
 
-    assert!(result.is_ok());
+    // The outer search should succeed and return the one added node
+    let results = result.unwrap();
+    assert_eq!(results.len(), 1, "Outer search should find 1 node");
+    assert_eq!(results[0].0, NodeId::new(1).unwrap(), "Should find Node 1");
 }

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -388,10 +388,10 @@ fn test_minimal_query() {
     let result = planner.plan(query);
     assert!(result.is_ok());
     let plan = result.unwrap();
-    assert!(!matches!(
-        plan.root,
-        aletheiadb::query::planner::PhysicalOp::Empty
-    ), "Query plan should not be empty");
+    assert!(
+        !matches!(plan.root, aletheiadb::query::planner::PhysicalOp::Empty),
+        "Query plan should not be empty"
+    );
     println!("✓ Minimal query plans successfully");
 }
 

--- a/tests/hybrid_query_planner.rs
+++ b/tests/hybrid_query_planner.rs
@@ -387,6 +387,11 @@ fn test_minimal_query() {
     // Planning should succeed (execution would return empty results)
     let result = planner.plan(query);
     assert!(result.is_ok());
+    let plan = result.unwrap();
+    assert!(!matches!(
+        plan.root,
+        aletheiadb::query::planner::PhysicalOp::Empty
+    ), "Query plan should not be empty");
     println!("✓ Minimal query plans successfully");
 }
 


### PR DESCRIPTION
This submission replaces several weak `assert!(result.is_ok())` assertions in the query planner integration tests (`src/query/converter.rs` and `tests/hybrid_query_planner.rs`) and the HNSW reentrancy tests (`tests/havoc/havoc_hnsw_reentrancy.rs`).

For the planner tests, it now asserts that the generated query plan's root is not `Empty`, ensuring that a meaningful plan was actually constructed. For the HNSW tests, it asserts that the search explicitly succeeded and correctly matched the expected result length and specific `NodeId`.

The `Elenchus` journal (`.jules/elenchus.md`) has been updated to document these weak assertion findings and their respective fixes.

---
*PR created automatically by Jules for task [8503191227214146408](https://jules.google.com/task/8503191227214146408) started by @madmax983*