### PR TITLE
Add AQL GROUP BY and aggregation (COUNT/SUM/AVG/MIN/MAX) with execution support

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -21,6 +21,8 @@ pub struct QueryAst {
     pub where_clause: Option<WhereClause>,
     /// RETURN clause
     pub return_clause: Option<ReturnClause>,
+    /// GROUP BY clause
+    pub group_by: Option<GroupByClause>,
     /// ORDER BY clause
     pub order: Option<OrderClause>,
     /// SKIP clause
@@ -38,6 +40,7 @@ impl QueryAst {
             rank: None,
             where_clause: None,
             return_clause: None,
+            group_by: None,
             order: None,
             skip: None,
             limit: None,
@@ -69,6 +72,13 @@ impl QueryAst {
     #[must_use]
     pub fn with_return(mut self, return_clause: ReturnClause) -> Self {
         self.return_clause = Some(return_clause);
+        self
+    }
+
+    /// Add a GROUP BY clause to the query.
+    #[must_use]
+    pub fn with_group_by(mut self, group_by: GroupByClause) -> Self {
+        self.group_by = Some(group_by);
         self
     }
 
@@ -625,6 +635,13 @@ pub struct ReturnClause {
     pub distinct: bool,
 }
 
+/// GROUP BY clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupByClause {
+    /// Grouping expressions
+    pub items: Vec<Expression>,
+}
+
 impl ReturnClause {
     /// Create a new RETURN clause.
     pub fn new(items: Vec<ReturnItem>) -> Self {
@@ -726,6 +743,7 @@ mod tests {
         assert!(query.rank.is_none());
         assert!(query.where_clause.is_none());
         assert!(query.return_clause.is_none());
+        assert!(query.group_by.is_none());
         assert!(query.order.is_none());
         assert!(query.skip.is_none());
         assert!(query.limit.is_none());

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -403,9 +403,9 @@ impl AstConverter {
             self.convert_rank_clause(rank, &mut ops)?;
         }
 
-        // 5. Convert RETURN clause to projection
+        // 5. Convert RETURN/GROUP BY to projection or aggregation
         if let Some(ref return_clause) = ast.return_clause {
-            self.convert_return_clause_ops(return_clause, &mut ops)?;
+            self.convert_return_clause_ops(return_clause, ast.group_by.as_ref(), &mut ops)?;
         }
 
         // 6. Convert ORDER BY clause
@@ -450,8 +450,14 @@ impl AstConverter {
     fn convert_return_clause_ops(
         &self,
         return_clause: &ReturnClause,
+        group_by_clause: Option<&super::ast::GroupByClause>,
         ops: &mut Vec<QueryOp>,
     ) -> Result<()> {
+        if let Some(agg) = self.try_convert_aggregate(return_clause, group_by_clause)? {
+            ops.push(agg);
+            return Ok(());
+        }
+
         let projection = self.convert_return(return_clause)?;
         if !projection.is_empty() {
             ops.push(QueryOp::Project(projection));
@@ -460,6 +466,68 @@ impl AstConverter {
             ops.push(QueryOp::Distinct);
         }
         Ok(())
+    }
+
+    fn try_convert_aggregate(
+        &self,
+        return_clause: &ReturnClause,
+        group_by_clause: Option<&super::ast::GroupByClause>,
+    ) -> Result<Option<QueryOp>> {
+        let mut aggregates = Vec::new();
+        let mut has_aggregate = false;
+        for (idx, item) in return_clause.items.iter().enumerate() {
+            if let Expression::FunctionCall { name, args } = &item.expression {
+                let upper = name.to_uppercase();
+                let function = match upper.as_str() {
+                    "COUNT" => super::ir::AggregateFunction::Count,
+                    "SUM" => super::ir::AggregateFunction::Sum,
+                    "AVG" => super::ir::AggregateFunction::Avg,
+                    "MIN" => super::ir::AggregateFunction::Min,
+                    "MAX" => super::ir::AggregateFunction::Max,
+                    _ => continue,
+                };
+                has_aggregate = true;
+                let property = args.first().and_then(|expr| match expr {
+                    Expression::Property(prop) => Some(prop.property.clone()),
+                    Expression::Identifier(s) if s != "*" => Some(s.clone()),
+                    _ => None,
+                });
+                let alias = item
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| format!("agg_{}", idx + 1));
+                aggregates.push(super::ir::AggregateExpr {
+                    function,
+                    property,
+                    alias,
+                });
+            }
+        }
+
+        if !has_aggregate && group_by_clause.is_none() {
+            return Ok(None);
+        }
+
+        let mut group_by = Vec::new();
+        if let Some(group) = group_by_clause {
+            for expr in &group.items {
+                match expr {
+                    Expression::Property(prop) => group_by.push(prop.property.clone()),
+                    Expression::Identifier(name) => group_by.push(name.clone()),
+                    _ => {
+                        return Err(Error::Query(QueryError::SyntaxError {
+                            message: "GROUP BY currently supports only property or alias"
+                                .to_string(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        Ok(Some(QueryOp::Aggregate {
+            group_by,
+            aggregates,
+        }))
     }
 
     fn convert_pagination(

--- a/src/query/converter.rs
+++ b/src/query/converter.rs
@@ -510,13 +510,35 @@ impl AstConverter {
 
         let mut group_by = Vec::new();
         if let Some(group) = group_by_clause {
+            let alias_map: std::collections::HashMap<_, _> = return_clause
+                .items
+                .iter()
+                .filter_map(|item| item.alias.as_ref().map(|a| (a.as_str(), &item.expression)))
+                .collect();
+
             for expr in &group.items {
                 match expr {
-                    Expression::Property(prop) => group_by.push(prop.property.clone()),
-                    Expression::Identifier(name) => group_by.push(name.clone()),
+                    Expression::Property(prop) => group_by.push(super::ir::GroupByExpr {
+                        alias: prop.property.clone(),
+                        expr: super::ir::GroupExpr::Property(prop.property.clone()),
+                    }),
+                    Expression::Identifier(name) => {
+                        if let Some(mapped) = alias_map.get(name.as_str()) {
+                            group_by.push(self.convert_group_expression(mapped, name)?);
+                        } else {
+                            group_by.push(super::ir::GroupByExpr {
+                                alias: name.clone(),
+                                expr: super::ir::GroupExpr::Property(name.clone()),
+                            });
+                        }
+                    }
+                    Expression::FunctionCall { .. } => {
+                        let alias = format!("group_{}", group_by.len() + 1);
+                        group_by.push(self.convert_group_expression(expr, &alias)?);
+                    }
                     _ => {
                         return Err(Error::Query(QueryError::SyntaxError {
-                            message: "GROUP BY currently supports only property or alias"
+                            message: "GROUP BY supports property, alias, or time.window(...)"
                                 .to_string(),
                         }));
                     }
@@ -528,6 +550,46 @@ impl AstConverter {
             group_by,
             aggregates,
         }))
+    }
+
+    fn convert_group_expression(
+        &self,
+        expr: &Expression,
+        alias: &str,
+    ) -> Result<super::ir::GroupByExpr> {
+        match expr {
+            Expression::Property(prop) => Ok(super::ir::GroupByExpr {
+                alias: alias.to_string(),
+                expr: super::ir::GroupExpr::Property(prop.property.clone()),
+            }),
+            Expression::FunctionCall { name, args } if name.eq_ignore_ascii_case("time.window") => {
+                let window_arg = args.first().ok_or_else(|| {
+                    Error::Query(QueryError::SyntaxError {
+                        message: "time.window(...) requires one duration argument".to_string(),
+                    })
+                })?;
+                let duration = match window_arg {
+                    Expression::Literal(super::ast::PropertyValue::String(s)) => {
+                        parse_window_duration(s)?
+                    }
+                    _ => {
+                        return Err(Error::Query(QueryError::SyntaxError {
+                            message: "time.window(...) expects a string literal duration"
+                                .to_string(),
+                        }));
+                    }
+                };
+                Ok(super::ir::GroupByExpr {
+                    alias: alias.to_string(),
+                    expr: super::ir::GroupExpr::TimeWindow {
+                        duration_micros: duration,
+                    },
+                })
+            }
+            _ => Err(Error::Query(QueryError::SyntaxError {
+                message: "Unsupported GROUP BY expression".to_string(),
+            })),
+        }
     }
 
     fn convert_pagination(
@@ -1163,6 +1225,33 @@ pub fn parse_query_with_params(
     converter.convert(&ast)
 }
 
+fn parse_window_duration(text: &str) -> Result<i64> {
+    let parts: Vec<&str> = text.split_whitespace().collect();
+    if parts.len() != 2 {
+        return Err(Error::Query(QueryError::SyntaxError {
+            message: format!("Invalid time.window duration '{}'", text),
+        }));
+    }
+    let qty = parts[0].parse::<i64>().map_err(|_| {
+        Error::Query(QueryError::SyntaxError {
+            message: format!("Invalid duration quantity in '{}'", text),
+        })
+    })?;
+    let unit_micros = match parts[1].to_ascii_lowercase().as_str() {
+        "second" | "seconds" => 1_000_000,
+        "minute" | "minutes" => 60 * 1_000_000,
+        "hour" | "hours" => 60 * 60 * 1_000_000,
+        "day" | "days" => 24 * 60 * 60 * 1_000_000,
+        "week" | "weeks" => 7 * 24 * 60 * 60 * 1_000_000,
+        _ => {
+            return Err(Error::Query(QueryError::SyntaxError {
+                message: format!("Unsupported duration unit '{}'", parts[1]),
+            }));
+        }
+    };
+    Ok(qty.saturating_mul(unit_micros))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1254,6 +1343,50 @@ mod tests {
         assert!(skip_op.is_some());
         if let Some(QueryOp::Skip(n)) = skip_op {
             assert_eq!(*n, 5);
+        }
+    }
+
+    #[test]
+    fn test_convert_group_by_alias_maps_to_property() {
+        let ast = Parser::parse("MATCH (n) RETURN n.category AS cat, COUNT(*) AS cnt GROUP BY cat")
+            .expect("parse");
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).expect("convert");
+
+        let agg = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::Aggregate { .. }))
+            .expect("aggregate op");
+        if let QueryOp::Aggregate { group_by, .. } = agg {
+            assert_eq!(group_by.len(), 1);
+            assert!(matches!(
+                group_by[0].expr,
+                super::ir::GroupExpr::Property(ref p) if p == "category"
+            ));
+            assert_eq!(group_by[0].alias, "cat");
+        }
+    }
+
+    #[test]
+    fn test_convert_group_by_time_window() {
+        let ast = Parser::parse(
+            "MATCH (n) RETURN time.window('1 day') AS day, COUNT(*) AS cnt GROUP BY day",
+        )
+        .expect("parse");
+        let converter = AstConverter::new();
+        let query = converter.convert(&ast).expect("convert");
+
+        let agg = query
+            .ops
+            .iter()
+            .find(|op| matches!(op, QueryOp::Aggregate { .. }))
+            .expect("aggregate op");
+        if let QueryOp::Aggregate { group_by, .. } = agg {
+            assert!(matches!(
+                group_by[0].expr,
+                super::ir::GroupExpr::TimeWindow { duration_micros } if duration_micros == 86_400_000_000
+            ));
         }
     }
 

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -5,7 +5,7 @@
 
 use parking_lot::RwLock;
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BinaryHeap, HashSet, VecDeque};
 use std::sync::Arc;
 
 #[cfg(feature = "observability")]
@@ -16,8 +16,8 @@ use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
 use crate::core::vector::cosine_similarity;
-use crate::core::{NodeId, Timestamp};
-use crate::query::ir::{Direction, Predicate, PredicateValue};
+use crate::core::{NodeId, Timestamp, VersionId};
+use crate::query::ir::{AggregateExpr, AggregateFunction, Direction, Predicate, PredicateValue};
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 
@@ -1343,6 +1343,169 @@ impl ResultIterator for ProvenanceFilterIterator {
 pub struct ProjectIterator {
     input: Box<dyn ResultIterator>,
     properties: Vec<String>,
+}
+
+/// Iterator for grouped aggregation.
+pub struct AggregateIterator {
+    rows: std::vec::IntoIter<QueryRow>,
+}
+
+impl AggregateIterator {
+    pub fn new(
+        mut input: Box<dyn ResultIterator>,
+        group_by: Vec<String>,
+        aggregates: Vec<AggregateExpr>,
+    ) -> Result<Self> {
+        #[derive(Clone)]
+        struct AggState {
+            count: usize,
+            sum: f64,
+            min: Option<PropertyValue>,
+            max: Option<PropertyValue>,
+        }
+
+        let mut groups: BTreeMap<String, (Vec<(String, PropertyValue)>, Vec<AggState>)> =
+            BTreeMap::new();
+
+        while let Some(row) = input.next() {
+            let row = row?;
+            let node = match row.entity {
+                EntityResult::Node(n) => n,
+                _ => continue,
+            };
+
+            let mut group_values = Vec::with_capacity(group_by.len());
+            let mut key = String::new();
+            for g in &group_by {
+                let val = node
+                    .properties
+                    .get(g)
+                    .cloned()
+                    .unwrap_or(PropertyValue::Null);
+                key.push_str(&format!("|{:?}", val));
+                group_values.push((g.clone(), val));
+            }
+
+            let entry = groups.entry(key).or_insert_with(|| {
+                let states = aggregates
+                    .iter()
+                    .map(|_| AggState {
+                        count: 0,
+                        sum: 0.0,
+                        min: None,
+                        max: None,
+                    })
+                    .collect();
+                (group_values, states)
+            });
+
+            for (idx, agg) in aggregates.iter().enumerate() {
+                let state = &mut entry.1[idx];
+                match agg.function {
+                    AggregateFunction::Count => {
+                        if let Some(prop) = &agg.property {
+                            if node.properties.get(prop).is_some() {
+                                state.count += 1;
+                            }
+                        } else {
+                            state.count += 1;
+                        }
+                    }
+                    AggregateFunction::Sum | AggregateFunction::Avg => {
+                        if let Some(prop) = &agg.property {
+                            if let Some(val) = node.properties.get(prop) {
+                                match val {
+                                    PropertyValue::Int(i) => {
+                                        state.sum += *i as f64;
+                                        state.count += 1;
+                                    }
+                                    PropertyValue::Float(f) => {
+                                        state.sum += *f;
+                                        state.count += 1;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                    AggregateFunction::Min => {
+                        if let Some(prop) = &agg.property {
+                            if let Some(val) = node.properties.get(prop).cloned() {
+                                if state
+                                    .min
+                                    .as_ref()
+                                    .is_none_or(|m| format!("{:?}", val) < format!("{:?}", m))
+                                {
+                                    state.min = Some(val);
+                                }
+                            }
+                        }
+                    }
+                    AggregateFunction::Max => {
+                        if let Some(prop) = &agg.property {
+                            if let Some(val) = node.properties.get(prop).cloned() {
+                                if state
+                                    .max
+                                    .as_ref()
+                                    .is_none_or(|m| format!("{:?}", val) > format!("{:?}", m))
+                                {
+                                    state.max = Some(val);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let label = GLOBAL_INTERNER.intern("AggregationResult")?;
+        let version_id = VersionId::new(1)?;
+        let mut out = Vec::with_capacity(groups.len());
+        for (idx, (_k, (group_vals, states))) in groups.into_iter().enumerate() {
+            let mut builder = crate::core::PropertyMapBuilder::new();
+            for (k, v) in group_vals {
+                builder = builder.insert(&k, v);
+            }
+            for (agg, state) in aggregates.iter().zip(states.iter()) {
+                let value = match agg.function {
+                    AggregateFunction::Count => PropertyValue::Int(state.count as i64),
+                    AggregateFunction::Sum => PropertyValue::Float(state.sum),
+                    AggregateFunction::Avg => {
+                        if state.count == 0 {
+                            PropertyValue::Null
+                        } else {
+                            PropertyValue::Float(state.sum / state.count as f64)
+                        }
+                    }
+                    AggregateFunction::Min => state.min.clone().unwrap_or(PropertyValue::Null),
+                    AggregateFunction::Max => state.max.clone().unwrap_or(PropertyValue::Null),
+                };
+                builder = builder.insert(&agg.alias, value);
+            }
+
+            let node = Node::new(
+                NodeId::new((idx + 1) as u64)?,
+                label,
+                builder.build(),
+                version_id,
+            );
+            out.push(QueryRow::from_entity(EntityResult::Node(node)));
+        }
+
+        Ok(Self {
+            rows: out.into_iter(),
+        })
+    }
+}
+
+impl ResultIterator for AggregateIterator {
+    fn next(&mut self) -> Option<Result<QueryRow>> {
+        self.rows.next().map(Ok)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.rows.size_hint()
+    }
 }
 
 impl ProjectIterator {

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -17,7 +17,9 @@ use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
 use crate::core::vector::cosine_similarity;
 use crate::core::{NodeId, Timestamp, VersionId};
-use crate::query::ir::{AggregateExpr, AggregateFunction, Direction, Predicate, PredicateValue};
+use crate::query::ir::{
+    AggregateExpr, AggregateFunction, Direction, GroupByExpr, GroupExpr, Predicate, PredicateValue,
+};
 use crate::storage::current::CurrentStorage;
 use crate::storage::historical::HistoricalStorage;
 
@@ -1353,7 +1355,7 @@ pub struct AggregateIterator {
 impl AggregateIterator {
     pub fn new(
         mut input: Box<dyn ResultIterator>,
-        group_by: Vec<String>,
+        group_by: Vec<GroupByExpr>,
         aggregates: Vec<AggregateExpr>,
     ) -> Result<Self> {
         #[derive(Clone)]
@@ -1377,13 +1379,24 @@ impl AggregateIterator {
             let mut group_values = Vec::with_capacity(group_by.len());
             let mut key = String::new();
             for g in &group_by {
-                let val = node
-                    .properties
-                    .get(g)
-                    .cloned()
-                    .unwrap_or(PropertyValue::Null);
+                let val = match &g.expr {
+                    GroupExpr::Property(prop) => node
+                        .properties
+                        .get(prop)
+                        .cloned()
+                        .unwrap_or(PropertyValue::Null),
+                    GroupExpr::TimeWindow { duration_micros } => {
+                        if let Some(ts) = row.timestamp {
+                            let micros = ts.wallclock();
+                            let bucket = (micros / *duration_micros) * *duration_micros;
+                            PropertyValue::Int(bucket)
+                        } else {
+                            PropertyValue::Null
+                        }
+                    }
+                };
                 key.push_str(&format!("|{:?}", val));
-                group_values.push((g.clone(), val));
+                group_values.push((g.alias.clone(), val));
             }
 
             let entry = groups.entry(key).or_insert_with(|| {
@@ -1434,7 +1447,7 @@ impl AggregateIterator {
                                 if state
                                     .min
                                     .as_ref()
-                                    .is_none_or(|m| format!("{:?}", val) < format!("{:?}", m))
+                                    .is_none_or(|m| compare_property_value(&val, m).is_lt())
                                 {
                                     state.min = Some(val);
                                 }
@@ -1447,7 +1460,7 @@ impl AggregateIterator {
                                 if state
                                     .max
                                     .as_ref()
-                                    .is_none_or(|m| format!("{:?}", val) > format!("{:?}", m))
+                                    .is_none_or(|m| compare_property_value(&val, m).is_gt())
                                 {
                                     state.max = Some(val);
                                 }
@@ -1556,6 +1569,18 @@ fn predicate_to_property_value(pv: &PredicateValue) -> PropertyValue {
         PredicateValue::Int(i) => PropertyValue::Int(*i),
         PredicateValue::Float(f) => PropertyValue::Float(*f),
         PredicateValue::String(s) => PropertyValue::String(Arc::from(s.as_str())),
+    }
+}
+
+fn compare_property_value(a: &PropertyValue, b: &PropertyValue) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (PropertyValue::Int(x), PropertyValue::Int(y)) => x.cmp(y),
+        (PropertyValue::Float(x), PropertyValue::Float(y)) => x.total_cmp(y),
+        (PropertyValue::Int(x), PropertyValue::Float(y)) => (*x as f64).total_cmp(y),
+        (PropertyValue::Float(x), PropertyValue::Int(y)) => x.total_cmp(&(*y as f64)),
+        (PropertyValue::String(x), PropertyValue::String(y)) => x.cmp(y),
+        _ => Ordering::Equal,
     }
 }
 

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -336,6 +336,18 @@ impl QueryExecutor {
                     properties.clone(),
                 )))
             }
+            PhysicalOp::Aggregate {
+                input,
+                group_by,
+                aggregates,
+            } => {
+                let input_iter = self.execute_op(input)?;
+                Ok(Box::new(iterators::AggregateIterator::new(
+                    input_iter,
+                    group_by.clone(),
+                    aggregates.clone(),
+                )?))
+            }
 
             PhysicalOp::Empty => Ok(Box::new(iterators::EmptyIterator)),
             PhysicalOp::SimilarToNode {

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -160,10 +160,31 @@ pub enum QueryOp {
 
     /// General aggregation with optional grouping
     Aggregate {
-        /// Group-by property keys (or aliases)
-        group_by: Vec<String>,
+        /// Group-by expressions
+        group_by: Vec<GroupByExpr>,
         /// Aggregate functions to compute
         aggregates: Vec<AggregateExpr>,
+    },
+}
+
+/// Group-by expression descriptor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupByExpr {
+    /// Output alias/property name for this grouping column.
+    pub alias: String,
+    /// Grouping expression.
+    pub expr: GroupExpr,
+}
+
+/// Supported grouping expressions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GroupExpr {
+    /// Group by a node property value.
+    Property(String),
+    /// Group by temporal windows derived from row timestamp.
+    TimeWindow {
+        /// Window size in microseconds.
+        duration_micros: i64,
     },
 }
 

--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -157,6 +157,40 @@ pub enum QueryOp {
 
     /// Project specific properties
     Project(Vec<String>),
+
+    /// General aggregation with optional grouping
+    Aggregate {
+        /// Group-by property keys (or aliases)
+        group_by: Vec<String>,
+        /// Aggregate functions to compute
+        aggregates: Vec<AggregateExpr>,
+    },
+}
+
+/// Supported aggregate functions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AggregateFunction {
+    /// Count rows or non-null property values.
+    Count,
+    /// Sum numeric property values.
+    Sum,
+    /// Average numeric property values.
+    Avg,
+    /// Minimum property value.
+    Min,
+    /// Maximum property value.
+    Max,
+}
+
+/// An aggregate expression in a query.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AggregateExpr {
+    /// Aggregate function to apply.
+    pub function: AggregateFunction,
+    /// Optional input property (`None` for `COUNT(*)`).
+    pub property: Option<String>,
+    /// Output alias for this aggregate column.
+    pub alias: String,
 }
 
 /// Specifies how deep to traverse in graph operations.

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -44,6 +44,16 @@ pub enum Token {
     Distinct,
     /// The `COUNT` keyword, used to count results.
     Count,
+    /// The `SUM` keyword.
+    Sum,
+    /// The `AVG` keyword.
+    Avg,
+    /// The `MIN` keyword.
+    Min,
+    /// The `MAX` keyword.
+    Max,
+    /// The `GROUP` keyword, used in `GROUP BY`.
+    Group,
     /// The `ASC` keyword, used for ascending order.
     Asc,
     /// The `DESC` keyword, used for descending order.
@@ -184,6 +194,11 @@ impl fmt::Display for Token {
             Token::Skip => write!(f, "SKIP"),
             Token::Distinct => write!(f, "DISTINCT"),
             Token::Count => write!(f, "COUNT"),
+            Token::Sum => write!(f, "SUM"),
+            Token::Avg => write!(f, "AVG"),
+            Token::Min => write!(f, "MIN"),
+            Token::Max => write!(f, "MAX"),
+            Token::Group => write!(f, "GROUP"),
             Token::Asc => write!(f, "ASC"),
             Token::Desc => write!(f, "DESC"),
             Token::And => write!(f, "AND"),
@@ -785,6 +800,11 @@ impl<'a> Lexer<'a> {
             "SKIP" => Token::Skip,
             "DISTINCT" => Token::Distinct,
             "COUNT" => Token::Count,
+            "SUM" => Token::Sum,
+            "AVG" => Token::Avg,
+            "MIN" => Token::Min,
+            "MAX" => Token::Max,
+            "GROUP" => Token::Group,
             "ASC" => Token::Asc,
             "DESC" => Token::Desc,
             "AND" => Token::And,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -178,6 +178,7 @@ impl Parser {
     ///           rank_clause?
     ///           where_clause?
     ///           return_clause?
+    ///           group_by_clause?
     ///           order_clause?
     ///           skip_clause?
     ///           limit_clause?
@@ -208,6 +209,11 @@ impl Parser {
         // Parse optional RETURN clause
         if let Some(return_clause) = self.parse_return_clause()? {
             query = query.with_return(return_clause);
+        }
+
+        // Parse optional GROUP BY clause
+        if let Some(group_by) = self.parse_group_by_clause()? {
+            query = query.with_group_by(group_by);
         }
 
         // Parse optional ORDER BY clause
@@ -1096,15 +1102,45 @@ impl Parser {
     fn parse_expression(&mut self) -> Result<Expression, ParseError> {
         match self.current() {
             Some(Token::Identifier(_)) => {
-                // Could be property access (n.prop) or just identifier (n)
+                // Could be function call, property access (n.prop), or identifier (n)
                 let ident = self.parse_identifier()?;
+                if self.check(&Token::LeftParen) {
+                    self.advance(); // (
+                    let mut args = Vec::new();
+                    if !self.check(&Token::RightParen) {
+                        args.push(self.parse_expression()?);
+                        while self.check(&Token::Comma) {
+                            self.advance();
+                            args.push(self.parse_expression()?);
+                        }
+                    }
+                    self.expect(&Token::RightParen)?;
+                    return Ok(Expression::FunctionCall { name: ident, args });
+                }
                 if self.check(&Token::Dot) {
                     self.advance();
                     let prop = self.parse_identifier()?;
-                    Ok(Expression::Property(PropertyAccess {
-                        variable: ident,
-                        property: prop,
-                    }))
+                    if self.check(&Token::LeftParen) {
+                        self.advance(); // (
+                        let mut args = Vec::new();
+                        if !self.check(&Token::RightParen) {
+                            args.push(self.parse_expression()?);
+                            while self.check(&Token::Comma) {
+                                self.advance();
+                                args.push(self.parse_expression()?);
+                            }
+                        }
+                        self.expect(&Token::RightParen)?;
+                        Ok(Expression::FunctionCall {
+                            name: format!("{ident}.{prop}"),
+                            args,
+                        })
+                    } else {
+                        Ok(Expression::Property(PropertyAccess {
+                            variable: ident,
+                            property: prop,
+                        }))
+                    }
                 } else {
                     // Just an identifier - a variable reference
                     Ok(Expression::Identifier(ident))
@@ -1114,6 +1150,30 @@ impl Parser {
                 let param = p.clone();
                 self.advance();
                 Ok(Expression::Parameter(param))
+            }
+            Some(Token::Count | Token::Sum | Token::Avg | Token::Min | Token::Max) => {
+                let fn_name = match self.current() {
+                    Some(Token::Count) => "COUNT",
+                    Some(Token::Sum) => "SUM",
+                    Some(Token::Avg) => "AVG",
+                    Some(Token::Min) => "MIN",
+                    Some(Token::Max) => "MAX",
+                    _ => unreachable!(),
+                }
+                .to_string();
+                self.advance();
+                self.expect(&Token::LeftParen)?;
+                let arg = if self.check(&Token::Star) {
+                    self.advance();
+                    Expression::Identifier("*".to_string())
+                } else {
+                    self.parse_expression()?
+                };
+                self.expect(&Token::RightParen)?;
+                Ok(Expression::FunctionCall {
+                    name: fn_name,
+                    args: vec![arg],
+                })
             }
             _ => self.parse_literal_expression(),
         }
@@ -1175,26 +1235,6 @@ impl Parser {
             false
         };
 
-        // Check for COUNT
-        if self.check(&Token::Count) {
-            self.advance();
-            self.expect(&Token::LeftParen)?;
-            let arg = if self.check(&Token::Star) {
-                self.advance();
-                // Represent COUNT(*) with a special identifier
-                Expression::Identifier("*".to_string())
-            } else {
-                self.parse_expression()?
-            };
-            self.expect(&Token::RightParen)?;
-
-            let items = vec![ReturnItem::new(Expression::FunctionCall {
-                name: "COUNT".to_string(),
-                args: vec![arg],
-            })];
-            return Ok(Some(ReturnClause { items, distinct }));
-        }
-
         let mut items = vec![self.parse_return_item()?];
 
         while self.check(&Token::Comma) {
@@ -1203,6 +1243,23 @@ impl Parser {
         }
 
         Ok(Some(ReturnClause { items, distinct }))
+    }
+
+    fn parse_group_by_clause(&mut self) -> Result<Option<GroupByClause>, ParseError> {
+        if !self.check(&Token::Group) {
+            return Ok(None);
+        }
+
+        self.advance(); // GROUP
+        self.expect(&Token::By)?;
+
+        let mut items = vec![self.parse_expression()?];
+        while self.check(&Token::Comma) {
+            self.advance();
+            items.push(self.parse_expression()?);
+        }
+
+        Ok(Some(GroupByClause { items }))
     }
 
     fn parse_return_item(&mut self) -> Result<ReturnItem, ParseError> {
@@ -1862,6 +1919,23 @@ mod tests {
         } else {
             panic!("Expected return clause");
         }
+    }
+
+    #[test]
+    fn test_parse_return_multiple_aggregates() {
+        let query =
+            Parser::parse("MATCH (n) RETURN SUM(n.amount) AS total, AVG(n.amount) AS avg").unwrap();
+        let ret = query.return_clause.expect("expected return clause");
+        assert_eq!(ret.items.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_group_by() {
+        let query =
+            Parser::parse("MATCH (n) RETURN n.category AS cat, COUNT(*) AS cnt GROUP BY cat")
+                .unwrap();
+        assert!(query.group_by.is_some());
+        assert_eq!(query.group_by.expect("group by").items.len(), 1);
     }
 
     #[test]

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -10,7 +10,7 @@ use crate::core::NodeId;
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::index::vector::DistanceMetric;
 
-use super::ir::{AggregateExpr, Direction, Predicate, TraversalDepth};
+use super::ir::{AggregateExpr, Direction, GroupByExpr, Predicate, TraversalDepth};
 
 /// A logical query plan represented as a tree of operations.
 #[derive(Debug, Clone, PartialEq)]
@@ -290,7 +290,7 @@ pub enum UnaryOp {
     /// Grouped aggregation
     Aggregate {
         /// Group-by keys
-        group_by: Vec<String>,
+        group_by: Vec<GroupByExpr>,
         /// Aggregate expressions
         aggregates: Vec<AggregateExpr>,
     },

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -10,7 +10,7 @@ use crate::core::NodeId;
 use crate::core::temporal::{TimeRange, Timestamp};
 use crate::index::vector::DistanceMetric;
 
-use super::ir::{Direction, Predicate, TraversalDepth};
+use super::ir::{AggregateExpr, Direction, Predicate, TraversalDepth};
 
 /// A logical query plan represented as a tree of operations.
 #[derive(Debug, Clone, PartialEq)]
@@ -286,6 +286,14 @@ pub enum UnaryOp {
 
     /// Count results (aggregate)
     Count,
+
+    /// Grouped aggregation
+    Aggregate {
+        /// Group-by keys
+        group_by: Vec<String>,
+        /// Aggregate expressions
+        aggregates: Vec<AggregateExpr>,
+    },
 }
 
 /// Binary operations that combine two inputs.

--- a/src/query/planner/cost.rs
+++ b/src/query/planner/cost.rs
@@ -436,6 +436,7 @@ impl CostModel {
             PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input }
             | PhysicalOp::Count { input }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::Materialize { input }
             | PhysicalOp::TemporalTrack { input, .. } => self.estimate(input, stats),
 
@@ -502,6 +503,7 @@ impl CostModel {
                 (self.estimate_cardinality(input, stats) as f64 * DEFAULT_DISTINCT_RATIO) as usize
             }
             PhysicalOp::Count { .. } => 1,
+            PhysicalOp::Aggregate { input, .. } => self.estimate_cardinality(input, stats).max(1),
             PhysicalOp::HashJoin { left, right, .. } => {
                 // Assume default join selectivity of cross product
                 let left_card = self.estimate_cardinality(left, stats);

--- a/src/query/planner/mod.rs
+++ b/src/query/planner/mod.rs
@@ -399,6 +399,17 @@ impl QueryPlanner {
 
             QueryOp::Project(props) => Ok(LogicalOp::unary(UnaryOp::Project(props.clone()), input)),
 
+            QueryOp::Aggregate {
+                group_by,
+                aggregates,
+            } => Ok(LogicalOp::unary(
+                UnaryOp::Aggregate {
+                    group_by: group_by.clone(),
+                    aggregates: aggregates.clone(),
+                },
+                input,
+            )),
+
             QueryOp::Sort { key, descending } => Ok(LogicalOp::unary(
                 UnaryOp::Sort {
                     key: key.clone(),
@@ -441,6 +452,7 @@ impl QueryPlanner {
             QueryOp::Sort { .. } => "Sort",
             QueryOp::RankBySimilarity { .. } => "RankBySimilarity",
             QueryOp::GetEdges { .. } => "GetEdges",
+            QueryOp::Aggregate { .. } => "Aggregate",
             _ => "Operation",
         };
 
@@ -743,6 +755,15 @@ impl QueryPlanner {
 
             UnaryOp::Count => Ok(PhysicalOp::Count {
                 input: Box::new(input),
+            }),
+
+            UnaryOp::Aggregate {
+                group_by,
+                aggregates,
+            } => Ok(PhysicalOp::Aggregate {
+                input: Box::new(input),
+                group_by: group_by.clone(),
+                aggregates: aggregates.clone(),
             }),
 
             UnaryOp::TemporalTrack { time_range } => Ok(PhysicalOp::TemporalTrack {

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use crate::core::NodeId;
 use crate::core::temporal::{TimeRange, Timestamp};
 
-use super::super::ir::{Direction, Predicate};
+use super::super::ir::{AggregateExpr, Direction, Predicate};
 use super::super::plan::{SortKey, TemporalContext};
 use super::cost::Cost;
 
@@ -560,6 +560,16 @@ pub enum PhysicalOp {
         input: Box<PhysicalOp>,
     },
 
+    /// Grouped aggregation
+    Aggregate {
+        /// Input operator
+        input: Box<PhysicalOp>,
+        /// Group-by keys
+        group_by: Vec<String>,
+        /// Aggregate expressions
+        aggregates: Vec<AggregateExpr>,
+    },
+
     /// Track temporal changes
     TemporalTrack {
         /// Input operator
@@ -603,6 +613,7 @@ impl PhysicalOp {
             PhysicalOp::Project { .. } => "Project",
             PhysicalOp::Distinct { .. } => "Distinct",
             PhysicalOp::Count { .. } => "Count",
+            PhysicalOp::Aggregate { .. } => "Aggregate",
             PhysicalOp::TemporalTrack { .. } => "TemporalTrack",
             PhysicalOp::Materialize { .. } => "Materialize",
             PhysicalOp::Empty => "Empty",
@@ -648,6 +659,7 @@ impl PhysicalOp {
             | PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. } => 1 + input.depth(),
 
@@ -831,6 +843,7 @@ impl PhysicalOp {
             | PhysicalOp::Project { input, .. }
             | PhysicalOp::Distinct { input, .. }
             | PhysicalOp::Count { input, .. }
+            | PhysicalOp::Aggregate { input, .. }
             | PhysicalOp::TemporalTrack { input, .. }
             | PhysicalOp::Materialize { input, .. } => Some(input),
             _ => None,

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use crate::core::NodeId;
 use crate::core::temporal::{TimeRange, Timestamp};
 
-use super::super::ir::{AggregateExpr, Direction, Predicate};
+use super::super::ir::{AggregateExpr, Direction, GroupByExpr, Predicate};
 use super::super::plan::{SortKey, TemporalContext};
 use super::cost::Cost;
 
@@ -565,7 +565,7 @@ pub enum PhysicalOp {
         /// Input operator
         input: Box<PhysicalOp>,
         /// Group-by keys
-        group_by: Vec<String>,
+        group_by: Vec<GroupByExpr>,
         /// Aggregate expressions
         aggregates: Vec<AggregateExpr>,
     },


### PR DESCRIPTION
### Motivation
- Add server-side temporal aggregation and grouping so users can compute `COUNT`, `SUM`, `AVG`, `MIN`, and `MAX` over query results and group by time or properties instead of client-side post-processing. 
- Provide initial plumbing for `time.window(...)` style dotted function calls so temporal bucketing can be layered on the planner in a future pass.

### Description
- Extend lexer and parser to recognize aggregation keywords and `GROUP BY`, add function-call parsing (including dotted calls like `time.window`) and support aggregate function syntax in `RETURN` (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`). (`src/query/lexer.rs`, `src/query/parser.rs`, `src/query/ast.rs`).
- Add `GroupByClause` to the AST and a `group_by` field on `QueryAst` with builder support (`with_group_by`). (`src/query/ast.rs`).
- Add IR and planner representations for aggregation: `QueryOp::Aggregate`, `AggregateFunction`, and `AggregateExpr`; wire into logical and physical planning as a `UnaryOp::Aggregate` → `PhysicalOp::Aggregate`. (`src/query/ir.rs`, `src/query/plan.rs`, `src/query/planner/mod.rs`, `src/query/planner/physical.rs`).
- Convert `RETURN` + optional `GROUP BY` into either normal projection or a single `Aggregate` `QueryOp` via `AstConverter::try_convert_aggregate`. (`src/query/converter.rs`).
- Implement execution for grouped aggregation via a new `AggregateIterator` that consumes input rows, groups by specified keys, computes aggregates (COUNT/SUM/AVG/MIN/MAX) and emits synthetic result nodes containing group values and aggregate columns; plug the iterator into the executor for `PhysicalOp::Aggregate`. (`src/query/executor/iterators.rs`, `src/query/executor/mod.rs`).
- Update cost model and cardinality estimates to account for aggregation operators. (`src/query/planner/cost.rs`).
- Add parser tests to validate multi-aggregate `RETURN` parsing and `GROUP BY` parsing. (`src/query/parser.rs` tests).

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo check -q` successfully to ensure the tree typechecks.
- Ran `cargo clippy --all-targets --all-features -- -D warnings`, which did not complete successfully in this environment due to an external dependency download failure for `ort-sys` (proxy 403), not due to the implemented changes themselves.
- Started `cargo test`; test execution began but did not complete within the available session/time constraints (some parser unit tests added and validated locally during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb4bf7c020832ab7fdabb3b09d4026)