### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/cypher/converter.rs
+++ b/src/cypher/converter.rs
@@ -17,10 +17,11 @@
 //!
 //! # Usage
 //!
-//! ```rust,ignore
+//! ```rust
 //! use aletheiadb::cypher::{parse_cypher, parse_cypher_with_params, CypherParameterValue};
 //! use std::collections::HashMap;
 //!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Simple: no parameters
 //! let query = parse_cypher("MATCH (n:Person) RETURN n")?;
 //!
@@ -28,6 +29,8 @@
 //! let mut params = HashMap::new();
 //! params.insert("name".to_string(), CypherParameterValue::String("Alice".into()));
 //! let query = parse_cypher_with_params("MATCH (n:Person {name: $name}) RETURN n", params)?;
+//! # Ok(())
+//! # }
 //! ```
 
 use std::collections::HashMap;
@@ -717,10 +720,13 @@ fn is_vector_function(name: &str) -> bool {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use aletheiadb::cypher::parse_cypher;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let query = parse_cypher("MATCH (n:Person) RETURN n")?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn parse_cypher(input: &str) -> Result<Query, CypherError> {
     let stmt = CypherParser::parse(input)?;
@@ -738,16 +744,19 @@ pub fn parse_cypher(input: &str) -> Result<Query, CypherError> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use aletheiadb::cypher::{parse_cypher_with_params, CypherParameterValue};
 /// use std::collections::HashMap;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut params = HashMap::new();
 /// params.insert("name".to_string(), CypherParameterValue::String("Alice".into()));
 /// let query = parse_cypher_with_params(
 ///     "MATCH (n:Person {name: $name}) RETURN n",
 ///     params,
 /// )?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn parse_cypher_with_params(
     input: &str,

--- a/src/cypher/mod.rs
+++ b/src/cypher/mod.rs
@@ -24,7 +24,7 @@
 //!
 //! # Quick Start
 //!
-//! ```rust,ignore
+//! ```rust
 //! use aletheiadb::cypher::CypherError;
 //!
 //! // Errors carry position information for diagnostics
@@ -32,8 +32,7 @@
 //!     position: 42,
 //!     message: "expected RETURN clause".to_string(),
 //! };
-//! println!("{err}");
-//! // => "Cypher parse error at position 42: expected RETURN clause"
+//! assert_eq!(err.to_string(), "Cypher parse error at position 42: expected RETURN clause");
 //! ```
 //!
 //! # Planned Syntax

--- a/src/sql/converter.rs
+++ b/src/sql/converter.rs
@@ -39,11 +39,14 @@ pub enum SqlParameterValue {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use aletheiadb::sql::SqlConverter;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let converter = SqlConverter::new();
 /// let query = converter.convert_sql("SELECT * FROM nodes WHERE label = 'Person'")?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct SqlConverter {
     /// Parameter bindings
@@ -742,10 +745,13 @@ impl Default for SqlConverter {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use aletheiadb::sql::parse_sql;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let query = parse_sql("SELECT * FROM nodes WHERE label = 'Person' LIMIT 10")?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn parse_sql(sql: &str) -> Result<Query, SqlError> {
     let converter = SqlConverter::new();
@@ -756,10 +762,12 @@ pub fn parse_sql(sql: &str) -> Result<Query, SqlError> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use aletheiadb::sql::{parse_sql_with_params, SqlParameterValue};
 /// use aletheiadb::query::ir::PredicateValue;
+/// use std::collections::HashMap;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut params = HashMap::new();
 /// params.insert("min_age".to_string(), SqlParameterValue::Scalar(PredicateValue::Int(21)));
 ///
@@ -767,6 +775,8 @@ pub fn parse_sql(sql: &str) -> Result<Query, SqlError> {
 ///     "SELECT * FROM nodes WHERE age > min_age",
 ///     params
 /// )?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn parse_sql_with_params(
     sql: &str,


### PR DESCRIPTION
📖 Chapter: The `cypher` and `sql` modules.
🔦 Insight: The API reference had several examples flagged with `rust,ignore`. These examples were prone to getting out of sync with code changes, risking user frustration if copy-pasted directly.
🧪 Example: Converted five `rust,ignore` documentation blocks across three files into functional, executable `cargo test --doc` examples by wrapping them with `fn main() -> Result<(), ...>`. 
🖼️ Preview: Documentation is now verifiable during build.

---
*PR created automatically by Jules for task [13517066938731925813](https://jules.google.com/task/13517066938731925813) started by @madmax983*