### PR TITLE
⚡ Bolt: Optimize pathfinding vector pre-allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@
 **[Optimize Vec allocations with Vec::with_capacity and exact size hints]**
 **Learning:** In Rust, replacing an idiomatic `.collect::<Vec<_>>()` chain with a manual `for` loop and `Vec::with_capacity()` is often a de-optimization. Iterators implementing `ExactSizeIterator` or `TrustedLen` (e.g., from slices or `std::vec::IntoIter`) automatically pre-allocate perfect capacity and elide bounds checks during `.collect()`. However, when `.filter(...)` is introduced into an iterator chain, the exact size hint is lost, causing `.collect()` to dynamically reallocate.
 **Action:** When filtering a collection of known maximum size into a `Vec`, manually pre-allocate `Vec::with_capacity(collection.len())` and use a `for` loop (or `.extend()`) to avoid all intermediate heap reallocations.
+
+**Optimize pathfinding neighbor vectors with pre-allocation**
+**Learning:** In A* semantic pathfinding logic, `neighbors` and `neighbor_edges` vectors are correctly reused across loop iterations (`.clear()`). However, initializing them with `Vec::new()` before the loop means the first time they are populated, they incur multiple heap reallocations (0 -> 4 -> 8 -> 16 -> 32 capacity).
+**Action:** Always initialize reusable collection vectors in algorithms like A* with `Vec::with_capacity()` based on an expected average branching factor (e.g. 32) to avoid these initial reallocations.

--- a/src/query/semantic_pathfinding.rs
+++ b/src/query/semantic_pathfinding.rs
@@ -207,7 +207,9 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
         });
 
         // Reuse allocation across iterations
-        let mut neighbors = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate capacity for an average branching factor of 32
+        // to avoid multiple heap reallocations (0 -> 4 -> 8 -> 16 -> 32) on the first node expansion.
+        let mut neighbors = Vec::with_capacity(32);
 
         while let Some(State { cost, node, depth }) = pq.pop() {
             if node == end {
@@ -342,7 +344,9 @@ impl<'a, G: GraphView + ?Sized> SemanticPathfinder<'a, G> {
         });
 
         // Reuse allocation across iterations
-        let mut neighbor_edges = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate capacity for an average branching factor of 32
+        // to avoid multiple heap reallocations (0 -> 4 -> 8 -> 16 -> 32) on the first node expansion.
+        let mut neighbor_edges = Vec::with_capacity(32);
 
         while let Some(State { cost, node, depth }) = pq.pop() {
             if node == end {


### PR DESCRIPTION
💡 What: Pre-allocated `neighbors` and `neighbor_edges` vectors in semantic A* pathfinding to an initial capacity of 32.
🎯 Why: While the vectors are correctly cleared and reused across iterations, initializing them with `Vec::new()` causes multiple heap reallocations (0 -> 4 -> 8 -> 16 -> 32) when the first node is expanded.
📊 Impact: Eliminates several unnecessary heap reallocations and memory moves per pathfinding query execution.
🔬 Measurement: Run `cargo test -p aletheiadb --lib query::semantic_pathfinding` or execute pathfinding queries via `QueryBuilder`.

---
*PR created automatically by Jules for task [9222172850923697360](https://jules.google.com/task/9222172850923697360) started by @madmax983*