### PR TITLE
⚡ Bolt: Pre-allocate capacity in WAL ring buffer drain

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 **Optimize Checkpoint Serialization Vec Pre-allocation**
 **Learning:** Found multiple vectors (`nodes`, `edges`, `node_versions`, `edge_versions`, etc.) in `extract_graph_data_from_snapshot` and `extract_temporal_data_from_snapshot` within `src/storage/checkpoint.rs` being created without capacity, resulting in potentially multiple heap reallocations when persisting thousands or millions of entities. `clippy::unused_doc_comments` lint caught the invalid `///` doc comment usage inside function bodies.
 **Action:** Use `Vec::with_capacity(n)` instead of `Vec::new()` when initializing vectors and calculating their capacity using snapshot's `node_count`, `edge_count`, `node_version_count`, and `edge_version_count` methods. Use standard `//` for inline comments to avoid unused doc comment warnings.
+**Pre-allocate capacity in WAL ring buffer drain**
+**Learning:** Draining a `WalRingBuffer` with `Vec::new()` creates unnecessary heap allocations and memory copies when flushing high-throughput WAL entries to disk.
+**Action:** Use `Vec::with_capacity(self.len_approx())` to pre-allocate capacity based on the buffer's approximate length, eliminating reallocations during bursts of pending entries.

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -693,8 +693,9 @@ impl WalRingBuffer {
     ///
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
+    /// ⚡ Bolt Optimization: Use len_approx() to pre-allocate capacity and avoid Vec reallocations during high-throughput WAL flushes.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        let mut entries = Vec::with_capacity(self.len_approx());
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
* 💡 What: Changed `Vec::new()` to `Vec::with_capacity(self.len_approx())` in `drain()`.
* 🎯 Why: During high-throughput bursts, `drain()` is called to gather all pending entries for flushing to disk. Without capacity pre-allocation, the returned `Vec` repeatedly reallocates. `len_approx()` provides a nearly exact count since it's the only consumer draining.
* 📊 Impact: Eliminates multiple heap reallocations (and corresponding memory copies) per flush cycle when there are multiple pending entries.
* 🔬 Measurement: Run `cargo bench` and observe improvements in WAL flushing latency.

---
*PR created automatically by Jules for task [18185460698488212778](https://jules.google.com/task/18185460698488212778) started by @madmax983*