### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/core/vector/sparse.rs
+++ b/src/core/vector/sparse.rs
@@ -696,6 +696,53 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_validate_value_exhaustive() {
+        // Valid positive and negative values
+        assert!(SparseVec::validate_value(1.0).is_ok());
+        assert!(SparseVec::validate_value(-1.0).is_ok());
+
+        // Zero value should return InvalidSparseVector
+        let result = SparseVec::validate_value(0.0);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Vector(VectorError::InvalidSparseVector { reason })) => {
+                assert!(reason.contains("zero value"));
+            }
+            _ => panic!("Expected InvalidSparseVector error"),
+        }
+
+        // NaN should return ContainsNaN
+        let result = SparseVec::validate_value(f32::NAN);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Vector(VectorError::ContainsNaN { count })) => {
+                assert_eq!(count, 1);
+            }
+            _ => panic!("Expected ContainsNaN error"),
+        }
+
+        // Infinity should return ContainsInfinity
+        let result = SparseVec::validate_value(f32::INFINITY);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Vector(VectorError::ContainsInfinity { count })) => {
+                assert_eq!(count, 1);
+            }
+            _ => panic!("Expected ContainsInfinity error"),
+        }
+
+        // Negative Infinity should return ContainsInfinity
+        let result = SparseVec::validate_value(f32::NEG_INFINITY);
+        assert!(result.is_err());
+        match result {
+            Err(crate::core::error::Error::Vector(VectorError::ContainsInfinity { count })) => {
+                assert_eq!(count, 1);
+            }
+            _ => panic!("Expected ContainsInfinity error"),
+        }
+    }
+
+    #[test]
     fn test_sparse_vec_new_invalid_inputs() {
         // Table-driven tests for invalid sparse vector construction
         struct TestCase {


### PR DESCRIPTION
🎯 Target: `src/core/vector/sparse.rs` -> `SparseVec::validate_value`
💣 Risk: `SparseVec::validate_value` checks for `NaN`, `Infinity`, and `0.0`. While existing tests verify these paths implicitly when constructing invalid `SparseVec` instances, they do not explicitly ensure that valid values (`1.0`, `-1.0`) pass validation without errors. A mutation replacing `val == 0.0` with `val != 0.0` could cause all non-zero values to throw an error silently without explicit coverage.
🧪 Strategy: Added `test_validate_value_exhaustive` to explicitly test all edge cases of `SparseVec::validate_value` (`1.0`, `-1.0`, `0.0`, `f32::NAN`, `f32::INFINITY`, `f32::NEG_INFINITY`) asserting `is_ok()` and checking for the correct `Result::Err` variants.
🔬 Verification: `cargo test --lib core::vector::sparse::tests::test_validate_value_exhaustive`

---
*PR created automatically by Jules for task [931227406855138053](https://jules.google.com/task/931227406855138053) started by @madmax983*