### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ test_output_*.txt
 mutants.out/
 mutants.out.old/
 echo_project/
+echo_test_project/target

--- a/DX_REPORT_ECHO_EXAMPLES.md
+++ b/DX_REPORT_ECHO_EXAMPLES.md
@@ -1,0 +1,20 @@
+# 🗣️ Echo: Getting Started examples in README are broken
+
+## 🤦 The Confusion
+I copied the code blocks from `README.md` into my own project to see how to use AletheiaDB, and multiple examples wouldn't even compile!
+- The "Transactions" example threw errors about missing variables (`alice_id` wasn't defined) and `Result` type alias conflicts.
+- The "Graph Sharding" example threw errors because it didn't have a `main` function to wrap the statements, so `let` wasn't allowed for global scope.
+- The "Tiered Storage" example threw errors because it returned `Result` from the global scope without being in a function.
+- The "Embedding Generation (Optional)" example threw errors because `service.embed_batch(&documents).await?` needed type annotations for `embeddings` because it was being zipped with `documents` which has an unknown type at that point.
+- The "Production Observability (Optional)" example threw a warning about an unused variable `db`.
+
+## 🕵️ The Reality
+The code blocks were written as snippets instead of compilable, standalone examples. Rust requires a `main` function for executable programs, and `Result` type aliases can conflict if not fully qualified or correctly used.
+
+## 💡 The Fix
+I directly modified the `README.md` to ensure the examples compile successfully. Specifically:
+- Added a `main` function wrapper and `alice_id` to the "Transactions" example, and prefixed the result with `_` to avoid unused variable warnings.
+- Added a `main` function wrapper to the "Graph Sharding" example.
+- Added a `main` function wrapper to the "Tiered Storage" example.
+- Added explicit type annotations `Vec<Vec<f32>>` to `embeddings` in the "Embedding Generation" example.
+- Prefixed `db` with an underscore (`_db`) in the "Production Observability" example to prevent the warning.

--- a/README.md
+++ b/README.md
@@ -758,18 +758,20 @@ use aletheiadb::storage::sharding::{
     ShardConfig, ShardDefinition, ShardCoordinator,
 };
 
-// Define shard topology
-let config = ShardConfig::new(vec![
-    ShardDefinition::new(0, "shard0:9000", vec!["Person", "User"]),
-    ShardDefinition::new(1, "shard1:9000", vec!["Place", "Location"]),
-    ShardDefinition::new(2, "shard2:9000", vec!["Event", "Activity"]),
-]);
+fn main() {
+    // Define shard topology
+    let config = ShardConfig::new(vec![
+        ShardDefinition::new(0, "shard0:9000", vec!["Person", "User"]),
+        ShardDefinition::new(1, "shard1:9000", vec!["Place", "Location"]),
+        ShardDefinition::new(2, "shard2:9000", vec!["Event", "Activity"]),
+    ]);
 
-// Create coordinator
-let coordinator = ShardCoordinator::new(config);
+    // Create coordinator
+    let coordinator = ShardCoordinator::new(config);
 
-// Route queries to appropriate shards
-let _shard = coordinator.router().route_node("Person");
+    // Route queries to appropriate shards
+    let _shard = coordinator.router().route_node("Person");
+}
 ```
 
 See **[docs/guides/sharding-guide.md](docs/guides/sharding-guide.md)** for complete guide.
@@ -783,20 +785,24 @@ use aletheiadb::{AletheiaDB, config::AletheiaDBConfig};
 use aletheiadb::config::HistoricalConfigBuilder;
 use std::time::Duration;
 
-// Configure cold storage via the unified config builder
-let config = AletheiaDBConfig::builder()
-    .historical(
-        HistoricalConfigBuilder::new()
-            .enable_cold_storage(true)
-            .cold_storage_path("data/cold.redb")
-            .migration_age_threshold(Duration::from_secs(3600)) // 1 hour
-            .max_hot_versions(1000)
-            .build(),
-    )
-    .build();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Configure cold storage via the unified config builder
+    let config = AletheiaDBConfig::builder()
+        .historical(
+            HistoricalConfigBuilder::new()
+                .enable_cold_storage(true)
+                .cold_storage_path("data/cold.redb")
+                .migration_age_threshold(Duration::from_secs(3600)) // 1 hour
+                .max_hot_versions(1000)
+                .build(),
+        )
+        .build();
 
-// Cold storage automatically initialized!
-let _db = AletheiaDB::with_unified_config(config)?;
+    // Cold storage automatically initialized!
+    let _db = AletheiaDB::with_unified_config(config)?;
+
+    Ok(())
+}
 ```
 
 See **[docs/guides/tiered-storage-guide.md](docs/guides/tiered-storage-guide.md)** for complete guide.
@@ -810,17 +816,24 @@ For complex operations involving multiple updates, use explicit transactions.
 ```rust
 use aletheiadb::prelude::*;
 
-// Explicit read transaction
-let result = db.read(|tx| {
-    tx.get_node(alice_id).map(|node| node.label.clone())
-})?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = AletheiaDB::new()?;
+    let alice_id = db.create_node("Person", PropertyMap::new())?;
 
-// Explicit write transaction with multiple operations
-db.write(|tx| {
-    let node1 = tx.create_node("Event", PropertyMap::new())?;
-    let node2 = tx.create_node("Event", PropertyMap::new())?;
-    tx.create_edge(node1, node2, "FOLLOWS", PropertyMap::new())
-})?;
+    // Explicit read transaction
+    let _result = db.read(|tx| {
+        tx.get_node(alice_id).map(|node| node.label.clone())
+    })?;
+
+    // Explicit write transaction with multiple operations
+    db.write(|tx| {
+        let node1 = tx.create_node("Event", PropertyMap::new())?;
+        let node2 = tx.create_node("Event", PropertyMap::new())?;
+        tx.create_edge(node1, node2, "FOLLOWS", PropertyMap::new())
+    })?;
+
+    Ok(())
+}
 ```
 
 ### Embedding Generation (Optional)
@@ -847,7 +860,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "AletheiaDB is a bi-temporal graph database",
         "It tracks both valid time and transaction time",
     ];
-    let embeddings = service.embed_batch(&documents).await?;
+    let embeddings: Vec<Vec<f32>> = service.embed_batch(&documents).await?;
 
     // 3. Store with vectors
     let db = AletheiaDB::new()?;
@@ -901,7 +914,7 @@ fn main() {
     let config = observability::Config::from_env();
     observability::init(config);
 
-    let db = aletheiadb::AletheiaDB::new().unwrap();
+    let _db = aletheiadb::AletheiaDB::new().unwrap();
 
     // Metrics automatically collected
     // Check for critical errors


### PR DESCRIPTION
🤦 **The Confusion:**
I copied the code blocks from `README.md` into my own project to see how to use AletheiaDB, and multiple examples wouldn't even compile!
- The "Transactions" example threw errors about missing variables (`alice_id` wasn't defined) and `Result` type alias conflicts.
- The "Graph Sharding" example threw errors because it didn't have a `main` function to wrap the statements, so `let` wasn't allowed for global scope.
- The "Tiered Storage" example threw errors because it returned `Result` from the global scope without being in a function.
- The "Embedding Generation (Optional)" example threw errors because `service.embed_batch(&documents).await?` needed type annotations for `embeddings` because it was being zipped with `documents` which has an unknown type at that point.
- The "Production Observability (Optional)" example threw a warning about an unused variable `db`.

🕵️ **The Reality:**
The code blocks were written as snippets instead of compilable, standalone examples. Rust requires a `main` function for executable programs, and `Result` type aliases can conflict if not fully qualified or correctly used.

💡 **The Fix:**
I directly modified the `README.md` to ensure the examples compile successfully. Specifically:
- Added a `main` function wrapper and `alice_id` to the "Transactions" example, and prefixed the result with `_` to avoid unused variable warnings.
- Added a `main` function wrapper to the "Graph Sharding" example.
- Added a `main` function wrapper to the "Tiered Storage" example.
- Added explicit type annotations `Vec<Vec<f32>>` to `embeddings` in the "Embedding Generation" example.
- Prefixed `db` with an underscore (`_db`) in the "Production Observability" example to prevent the warning.
- Ensured all tests and checks pass.

---
*PR created automatically by Jules for task [3387275023597787129](https://jules.google.com/task/3387275023597787129) started by @madmax983*