### PR TITLE
🪒 Razor: De-abstract Resonator trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,14 +1,4 @@
 ## [Reduction]
-**Bloat:** `FileColdStorage` (Redundant, inferior implementation of `ColdStorage` trait).
-**Cut:** Deleted `FileColdStorage` struct, implementation, and tests.
-**Saved:** ~200 lines of code + cognitive load of maintaining two cold storage backends.
-
-## [Reduction]
-**Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
-**Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
-**Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
-
-## [Reduction]
-**Bloat:** `StorageSnapshot` and `FieldHolder` traits.
-**Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
-**Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+**Bloat:** The `Resonator` trait in `src/experimental/echo.rs` was a single-implementation trait representing speculative generality. `ActivityDensityResonator` was the only implementor, yet the `EchoChamber` API used dynamic dispatch (`Box<dyn Resonator>`) and generics.
+**Cut:** Removed the `Resonator` trait entirely. Promoted `ActivityDensityResonator` to be the concrete type used by `EchoChamber` and replaced all `Box<dyn Resonator>` usages with direct instances of `ActivityDensityResonator`.
+**Saved:** ~20 lines of code, removed dynamic dispatch overhead, and eliminated mental overhead of tracking a trait that only has one implementation.

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -81,13 +81,7 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
-/// A resonator that measures activity density over a fixed time window.
+/// A resonator that measures activity density over a fixed time window to generate temporal fingerprints from entity history.
 ///
 /// # The Details
 /// It looks at the "Last N" microseconds of history and bins updates into
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -196,7 +191,7 @@ impl Resonator for ActivityDensityResonator {
 /// ```
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -239,13 +234,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -306,7 +301,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
🪒 **Razor: De-abstract Resonator trait**

**Problem:**
The `src/experimental/echo.rs` module defined a `Resonator` trait that was only implemented by a single struct (`ActivityDensityResonator`). This violates the KISS principle by introducing unnecessary abstraction, generic bounds (`<R: Resonator>`), and dynamic dispatch (`Box<dyn Resonator>`) for something that is only ever used as a single concrete type.

**Solution:**
- Removed the `Resonator` trait completely.
- Updated `ActivityDensityResonator` to implement the `resonate` method directly.
- Updated `EchoChamber` to use `ActivityDensityResonator` concretely instead of storing a `Box<dyn Resonator>`.
- Updated `EchoChamber::with_resonator` to accept the concrete struct rather than generic types.
- Fixed documentation and tests to use the concrete struct.
- Documented the reduction in `.jules/razor.md`.

This simplifies the API, reduces mental overhead, and slightly improves performance by removing a heap allocation and dynamic dispatch.

---
*PR created automatically by Jules for task [11441568845608536329](https://jules.google.com/task/11441568845608536329) started by @madmax983*