### PR TITLE
⚡ Bolt: Zero-allocation SQL parser scanning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,7 @@
 **Optimize Tokenization in Temporal Parser**
 **Learning:** `tokenize_temporal_keywords` in `src/sql/temporal_parser.rs` previously copied substrings by manually advancing through a `char_indices().collect::<Vec<_>>()` and creating a `String` inside loops (`let word: String = chars[start..i].iter().map(|(_, c)| c).collect()`). This resulted in a heap allocation for every word parsed.
 **Action:** Used `sql.char_indices().peekable()` instead of collecting it. Leveraged `.len_utf8()` to calculate byte boundaries on the fly without allocations. Used a string slice `&sql[start..end]` to avoid `String` allocation for every word parsed, making parsing `0-cost` for non-matching tokens.
+
+**Optimize zero-allocation SQL token scanning**
+**Learning:** Functions scanning for tokens outside of SQL string literals were heavily allocating intermediate `Vec<char>` and `String` candidates inside tight loops, leading to O(N) memory allocation and copy overhead on every call. `char_indices().peekable()` alongside `eq_ignore_ascii_case()` completely avoids these intermediate allocations.
+**Action:** When scanning strings for substrings or keywords, avoid `.chars().collect::<Vec<_>>()` and `to_uppercase()`. Instead, use `char_indices().peekable()` to track byte offsets and test candidates using string slices (`&sql[byte_offset..byte_offset + len]`) combined with `.eq_ignore_ascii_case()`.

--- a/src/sql/match_parser.rs
+++ b/src/sql/match_parser.rs
@@ -132,53 +132,63 @@ pub fn extract_match_clauses(sql: &str) -> Result<ExtractedMatch, SqlError> {
 /// Find a keyword in SQL that is NOT inside a string literal.
 ///
 /// Returns the byte offset of the first character of the keyword, or None.
+/// ⚡ Bolt Optimization: Uses `char_indices().peekable()` and `eq_ignore_ascii_case`
+/// instead of `.chars().collect::<Vec<_>>()` and allocating new Strings,
+/// completely eliminating multiple O(N) heap allocations for the SQL string on every call.
 fn find_keyword_outside_strings(sql: &str, keyword: &str) -> Option<usize> {
-    let sql_upper = sql.to_uppercase();
-    let keyword_upper = keyword.to_uppercase();
-    let keyword_len = keyword_upper.chars().count();
+    let keyword_len = keyword.len();
+    let mut chars_iter = sql.char_indices().peekable();
 
-    let mut i = 0;
-    let chars: Vec<char> = sql.chars().collect();
-    let upper_chars: Vec<char> = sql_upper.chars().collect();
-
-    while i < chars.len() {
+    while let Some((byte_offset, c)) = chars_iter.next() {
         // Skip string literals
-        if chars[i] == '\'' {
-            i += 1;
-            while i < chars.len() {
-                if chars[i] == '\'' {
+        if c == '\'' {
+            while let Some(&(_, next_c)) = chars_iter.peek() {
+                chars_iter.next();
+                if next_c == '\'' {
                     // Check for escaped quote ''
-                    if i + 1 < chars.len() && chars[i + 1] == '\'' {
-                        i += 2;
-                    } else {
-                        i += 1;
-                        break;
+                    let is_escaped = chars_iter.peek().map(|&(_, c)| c == '\'').unwrap_or(false);
+                    if is_escaped {
+                        chars_iter.next();
+                        continue;
                     }
-                } else {
-                    i += 1;
+                    break;
                 }
             }
             continue;
         }
 
         // Check if we have the keyword at this position
-        if i + keyword_len <= upper_chars.len() {
-            let candidate: String = upper_chars[i..i + keyword_len].iter().collect();
-            if candidate == keyword_upper {
-                // Ensure it's a word boundary (not part of a larger identifier)
-                let before_ok = i == 0 || !chars[i - 1].is_alphanumeric() && chars[i - 1] != '_';
-                let after_ok = i + keyword_len >= chars.len()
-                    || !chars[i + keyword_len].is_alphanumeric() && chars[i + keyword_len] != '_';
-
-                if before_ok && after_ok {
-                    // Calculate byte offset
-                    let byte_offset: usize = sql.chars().take(i).map(|c| c.len_utf8()).sum();
-                    return Some(byte_offset);
+        let candidate_opt = sql.get(byte_offset..byte_offset + keyword_len);
+        let is_match = candidate_opt.map(|c| c.eq_ignore_ascii_case(keyword)).unwrap_or(false);
+        if is_match {
+            // Ensure it's a word boundary (not part of a larger identifier)
+            let before_ok = byte_offset == 0 || {
+                if let Some(before_str) = sql.get(..byte_offset) {
+                    if let Some(before_char) = before_str.chars().next_back() {
+                        !before_char.is_alphanumeric() && before_char != '_'
+                    } else {
+                        true
+                    }
+                } else {
+                    false
                 }
+            };
+            let after_ok = byte_offset + keyword_len >= sql.len() || {
+                if let Some(after_str) = sql.get(byte_offset + keyword_len..) {
+                    if let Some(after_char) = after_str.chars().next() {
+                        !after_char.is_alphanumeric() && after_char != '_'
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            };
+
+            if before_ok && after_ok {
+                return Some(byte_offset);
             }
         }
-
-        i += 1;
     }
 
     None

--- a/src/sql/vector_parser.rs
+++ b/src/sql/vector_parser.rs
@@ -298,50 +298,43 @@ fn cleanup_where_true(sql: &mut String) {
 
 /// Find a substring outside of single-quoted string literals.
 /// Returns the byte position of the first match, or None.
+/// ⚡ Bolt Optimization: Uses `char_indices().peekable()` instead of `.chars().collect::<Vec<_>>()`
+/// and `eq_ignore_ascii_case` instead of allocating new Strings and using `to_uppercase()`,
+/// completely eliminating multiple O(N) heap allocations for the SQL string on every call.
 fn find_outside_strings(sql: &str, needle: &str) -> Option<usize> {
-    let chars: Vec<char> = sql.chars().collect();
-    let needle_chars: Vec<char> = needle.chars().collect();
-    let needle_len = needle_chars.len();
+    let needle_len = needle.len();
+    let mut chars_iter = sql.char_indices().peekable();
 
-    let mut i = 0;
-    while i < chars.len() {
+    while let Some((byte_offset, c)) = chars_iter.next() {
         // Skip single-quoted strings
-        if chars[i] == '\'' {
-            i += 1;
-            while i < chars.len() {
-                if chars[i] == '\'' {
-                    if i + 1 < chars.len() && chars[i + 1] == '\'' {
-                        i += 2; // escaped quote
-                    } else {
-                        i += 1;
-                        break;
+        if c == '\'' {
+            while let Some(&(_, next_c)) = chars_iter.peek() {
+                chars_iter.next();
+                if next_c == '\'' {
+                    let is_escaped = chars_iter.peek().map(|&(_, c)| c == '\'').unwrap_or(false);
+                    if is_escaped {
+                        chars_iter.next(); // Escaped quote
+                        continue;
                     }
-                } else {
-                    i += 1;
+                    break; // End of string
                 }
             }
             continue;
         }
 
         // Check for needle match
-        if i + needle_len <= chars.len() {
-            let candidate: String = chars[i..i + needle_len].iter().collect();
+        if let Some(candidate) = sql.get(byte_offset..byte_offset + needle_len) {
             if candidate == needle {
-                // Convert char index to byte offset
-                let byte_offset: usize = chars[..i].iter().map(|c| c.len_utf8()).sum();
                 return Some(byte_offset);
             }
             // Also check case-insensitive for keyword-like needles (not operators)
             if !needle.starts_with('<')
                 && !needle.starts_with('>')
-                && candidate.to_uppercase() == needle.to_uppercase()
+                && candidate.eq_ignore_ascii_case(needle)
             {
-                let byte_offset: usize = chars[..i].iter().map(|c| c.len_utf8()).sum();
                 return Some(byte_offset);
             }
         }
-
-        i += 1;
     }
 
     None


### PR DESCRIPTION
💡 What: Replaced eager `Vec<char>` and intermediate `String` collection loops in SQL parsing functions (`find_outside_strings` and `find_keyword_outside_strings`) with zero-allocation `char_indices().peekable()` iterators and safe string slicing (`.get`) combined with `eq_ignore_ascii_case`.
🎯 Why: Searching for keywords or operator sequences in SQL queries required full O(N) allocations for characters, plus inner loop allocations for candidate strings. This caused massive allocator thrashing on every parser invocation.
📊 Impact: Removes multiple heap allocations (`Vec` and `String`) for the SQL string on every single call to these hot-path parser scanner functions.
🔬 Measurement: Run `cargo clippy` and `cargo test` to verify correctness without panics on multi-byte characters.

---
*PR created automatically by Jules for task [16655381790066698379](https://jules.google.com/task/16655381790066698379) started by @madmax983*