### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/DX_AUDIT_REPORT_ECHO_AQL.md
+++ b/DX_AUDIT_REPORT_ECHO_AQL.md
@@ -1,0 +1,7 @@
+# 🗣️ Echo: Getting Started example is broken
+
+🤦 **The Confusion:** Tried to run the `Query Language (AQL)` example from the README. The compiler failed with "method not found in `AletheiaDB`" for `execute_aql`.
+
+🕵️ **The Reality:** The `execute_aql` function is gated behind the `cypher` feature flag in `AletheiaDB`. The example in the README doesn't mention this requirement.
+
+💡 **The Fix:** Add a huge banner in the README's AQL section saying 'REQUIRES FEATURE CYPHER'.

--- a/README.md
+++ b/README.md
@@ -704,6 +704,10 @@ AletheiaDB supports a Cypher-like query language with temporal and vector extens
 You can execute these directly using the `execute_aql` method:
 
 ```rust
+// ⚠️ REQUIRES FEATURE: cypher
+// [dependencies]
+// aletheiadb = { version = "0.1", features = ["cypher"] }
+
 use aletheiadb::prelude::*;
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
# 🗣️ Echo: Getting Started example is broken

🤦 **The Confusion:** Tried to run the `Query Language (AQL)` example from the README. The compiler failed with "method not found in `AletheiaDB`" for `execute_aql`.

🕵️ **The Reality:** The `execute_aql` function is gated behind the `cypher` feature flag in `AletheiaDB`. The example in the README doesn't mention this requirement.

💡 **The Fix:** Added a huge banner in the README's AQL section saying 'REQUIRES FEATURE: cypher' and included a `DX_AUDIT_REPORT_ECHO_AQL.md` documenting the issue.

---
*PR created automatically by Jules for task [11767274702348814671](https://jules.google.com/task/11767274702348814671) started by @madmax983*