### PR TITLE
⚡ Bolt: Replace Vec::new() with Vec::with_capacity() in WalRingBuffer::drain

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -694,7 +694,8 @@ impl WalRingBuffer {
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate vector using len_approx() to prevent heap reallocations when draining high-throughput queues.
+        let mut entries = Vec::with_capacity(self.len_approx());
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(self.len_approx())` in `WalRingBuffer::drain`.
🎯 Why: Draining the WAL RingBuffer under high load can produce many entries. Using an un-sized `Vec` leads to multiple consecutive heap allocations as the vector grows.
📊 Impact: Reduces heap reallocations during flush coordination, lowering latency in the hot path.
🔬 Measurement: Run `cargo bench` if available or the specific test `cargo test storage::wal::ring_buffer` to verify correctness and see performance impact under load.

---
*PR created automatically by Jules for task [11901152282142146880](https://jules.google.com/task/11901152282142146880) started by @madmax983*