### PR TITLE
🗺️ Atlas: Implement Facade pattern by hiding internal modules in sharding and embeddings

### DIFF
--- a/examples/embedding_comparison.rs
+++ b/examples/embedding_comparison.rs
@@ -25,7 +25,10 @@
 #![cfg(feature = "embedding-all")]
 
 use aletheiadb::embeddings::EmbeddingService;
-use aletheiadb::embeddings::providers::{huggingface::*, ollama::*, onnx::*, openai::*};
+use aletheiadb::embeddings::providers::{
+    HuggingFaceConfig, HuggingFaceProvider, OllamaConfig, OllamaProvider, OnnxConfig, OnnxProvider,
+    OpenAIConfig, OpenAIModel, OpenAIProvider,
+};
 use std::sync::Arc;
 use std::time::Instant;
 

--- a/examples/embedding_huggingface.rs
+++ b/examples/embedding_huggingface.rs
@@ -18,7 +18,7 @@
 #![cfg(feature = "embedding-huggingface")]
 
 use aletheiadb::embeddings::EmbeddingService;
-use aletheiadb::embeddings::providers::huggingface::*;
+use aletheiadb::embeddings::providers::{HuggingFaceConfig, HuggingFaceProvider};
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use std::sync::Arc;
 

--- a/examples/embedding_ollama.rs
+++ b/examples/embedding_ollama.rs
@@ -17,7 +17,7 @@
 #![cfg(feature = "embedding-ollama")]
 
 use aletheiadb::embeddings::EmbeddingService;
-use aletheiadb::embeddings::providers::ollama::*;
+use aletheiadb::embeddings::providers::{OllamaConfig, OllamaProvider};
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use std::sync::Arc;
 

--- a/examples/embedding_onnx.rs
+++ b/examples/embedding_onnx.rs
@@ -17,7 +17,7 @@
 #![cfg(feature = "embedding-onnx")]
 
 use aletheiadb::embeddings::EmbeddingService;
-use aletheiadb::embeddings::providers::onnx::*;
+use aletheiadb::embeddings::providers::{OnnxConfig, OnnxProvider};
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use std::sync::Arc;
 

--- a/examples/embedding_openai.rs
+++ b/examples/embedding_openai.rs
@@ -22,7 +22,7 @@
 #![cfg(feature = "embedding-openai")]
 
 use aletheiadb::embeddings::EmbeddingService;
-use aletheiadb::embeddings::providers::openai::*;
+use aletheiadb::embeddings::providers::{OpenAIConfig, OpenAIModel, OpenAIProvider};
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use std::sync::Arc;
 

--- a/src/embeddings/providers/mod.rs
+++ b/src/embeddings/providers/mod.rs
@@ -4,13 +4,25 @@
 //! for various embedding services and local models.
 
 #[cfg(feature = "embedding-openai")]
-pub mod openai;
+mod openai;
 
 #[cfg(feature = "embedding-huggingface")]
-pub mod huggingface;
+mod huggingface;
 
 #[cfg(feature = "embedding-onnx")]
-pub mod onnx;
+mod onnx;
 
 #[cfg(feature = "embedding-ollama")]
-pub mod ollama;
+mod ollama;
+
+#[cfg(feature = "embedding-openai")]
+pub use openai::{OpenAIConfig, OpenAIModel, OpenAIProvider};
+
+#[cfg(feature = "embedding-huggingface")]
+pub use huggingface::{HuggingFaceConfig, HuggingFaceProvider};
+
+#[cfg(feature = "embedding-onnx")]
+pub use onnx::{OnnxConfig, OnnxModel, OnnxProvider};
+
+#[cfg(feature = "embedding-ollama")]
+pub use ollama::{OllamaConfig, OllamaProvider};

--- a/src/storage/sharding/mod.rs
+++ b/src/storage/sharding/mod.rs
@@ -80,7 +80,9 @@ pub use persistent_commit_log::{
 pub use rebalance::{MigrationPlan, MigrationProgress, MigrationState, RebalanceManager};
 pub use router::{ShardRouter, TraversalPlan, TraversalStep};
 pub use rpc_client::{ClientStats, HttpShardClient, RpcConfig};
-pub use simulation::{EdgeCutAnalysis, ShardingSimulation, SimulationResult};
+pub use simulation::{
+    EdgeCutAnalysis, EdgeTypeConfig, ShardingSimulation, SimulationResult, StorageAnalysis,
+};
 #[allow(deprecated)]
 pub use transaction::TwoPhaseCommitLog;
 pub use transaction::{DistributedTransaction, ParticipantState, TransactionPhase};

--- a/src/storage/sharding/mod.rs
+++ b/src/storage/sharding/mod.rs
@@ -44,18 +44,18 @@
 //! # }
 //! ```
 
-pub mod config;
-pub mod coordinator;
-pub mod executor;
-pub mod migration;
-pub mod network;
-pub mod persistent_commit_log;
-pub mod rebalance;
-pub mod router;
-pub mod rpc_client;
-pub mod simulation;
-pub mod transaction;
-pub mod types;
+mod config;
+mod coordinator;
+mod executor;
+mod migration;
+mod network;
+mod persistent_commit_log;
+mod rebalance;
+mod router;
+mod rpc_client;
+mod simulation;
+mod transaction;
+mod types;
 
 // Re-export commonly used types
 pub use config::{RebalanceConfig, ShardConfig, ShardDefinition, ShardDiscovery};

--- a/src/storage/sharding/rpc_client.rs
+++ b/src/storage/sharding/rpc_client.rs
@@ -16,7 +16,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use aletheiadb::storage::sharding::rpc_client::{HttpShardClient, RpcConfig};
+//! use aletheiadb::storage::sharding::{HttpShardClient, RpcConfig};
 //!
 //! let config = RpcConfig {
 //!     endpoint: "http://shard0:9000".to_string(),

--- a/src/storage/sharding/simulation.rs
+++ b/src/storage/sharding/simulation.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 /// # Examples
 ///
 /// ```rust
-/// use aletheiadb::storage::sharding::simulation::SimulationResult;
+/// use aletheiadb::storage::sharding::SimulationResult;
 ///
 /// let result = SimulationResult::new(1000, 5000, 4);
 /// assert_eq!(result.total_nodes, 1000);
@@ -78,7 +78,7 @@ impl SimulationResult {
 /// # Examples
 ///
 /// ```rust
-/// use aletheiadb::storage::sharding::simulation::EdgeCutAnalysis;
+/// use aletheiadb::storage::sharding::EdgeCutAnalysis;
 ///
 /// let analysis = EdgeCutAnalysis::new(200, 800);
 /// assert_eq!(analysis.cross_shard_ratio, 0.2); // 200 / (200 + 800)
@@ -194,7 +194,7 @@ impl LatencyEstimates {
 /// # Examples
 ///
 /// ```rust
-/// use aletheiadb::storage::sharding::simulation::StorageAnalysis;
+/// use aletheiadb::storage::sharding::StorageAnalysis;
 ///
 /// // 1000 nodes, 5000 edges, 500 cross-shard edges
 /// let analysis = StorageAnalysis::calculate(1000, 5000, 500);
@@ -265,7 +265,7 @@ pub struct SimulationConfig {
 /// # Examples
 ///
 /// ```rust
-/// use aletheiadb::storage::sharding::simulation::EdgeTypeConfig;
+/// use aletheiadb::storage::sharding::EdgeTypeConfig;
 ///
 /// let config = EdgeTypeConfig {
 ///     source_label: "User".to_string(),

--- a/tests/regressions/tx_id_recovery_collision.rs
+++ b/tests/regressions/tx_id_recovery_collision.rs
@@ -1,7 +1,7 @@
 use aletheiadb::core::id::TxId;
-use aletheiadb::storage::sharding::config::{ShardConfig, ShardDefinition};
-use aletheiadb::storage::sharding::coordinator::ShardCoordinator;
-use aletheiadb::storage::sharding::types::ShardId;
+use aletheiadb::storage::sharding::ShardCoordinator;
+use aletheiadb::storage::sharding::ShardId;
+use aletheiadb::storage::sharding::{ShardConfig, ShardDefinition};
 use tempfile::TempDir;
 
 #[test]

--- a/tests/reproduce_log_corruption.rs
+++ b/tests/reproduce_log_corruption.rs
@@ -1,6 +1,6 @@
 use aletheiadb::core::id::TxId;
-use aletheiadb::storage::sharding::persistent_commit_log::{CommitLogConfig, PersistentCommitLog};
-use aletheiadb::storage::sharding::types::ShardId;
+use aletheiadb::storage::sharding::ShardId;
+use aletheiadb::storage::sharding::{CommitLogConfig, PersistentCommitLog};
 use std::fs::OpenOptions;
 use std::io::Write;
 

--- a/tests/sentry_shard_recovery.rs
+++ b/tests/sentry_shard_recovery.rs
@@ -1,6 +1,6 @@
-use aletheiadb::storage::sharding::config::{ShardConfig, ShardDefinition};
-use aletheiadb::storage::sharding::coordinator::ShardCoordinator;
-use aletheiadb::storage::sharding::types::ShardId;
+use aletheiadb::storage::sharding::ShardCoordinator;
+use aletheiadb::storage::sharding::ShardId;
+use aletheiadb::storage::sharding::{ShardConfig, ShardDefinition};
 use std::time::Duration;
 use tempfile::TempDir;
 


### PR DESCRIPTION
**🕸️ Tangle:**
The `storage::sharding` and `embeddings::providers` modules were leaking internal module organization. In `storage/sharding/mod.rs` and `embeddings/providers/mod.rs`, child modules were declared as `pub mod`. This exposed both top-level items (via `pub use`) AND the full internal module structures, creating a redundant and sprawling API surface ("The Leak" / "The Bloat" / "The Sprawl").

**📐 Blueprint:**
Refactored `storage::sharding` and `embeddings::providers` by changing the visibility of child modules from `pub mod` to private `mod`. To implement a strict Facade pattern, explicit `pub use` statements were added in `embeddings/providers/mod.rs` to re-export necessary configuration and provider structs. This guarantees the public API remains flat and clean, strictly enforcing domain boundaries.

**🧱 Stability:**
The patch drastically reduces API surface area by properly encapsulating internal structure while explicitly exposing required configurations to consumers via a controlled interface. Code builds correctly and all integrations were verified.

**🔬 Verification:**
Ran `cargo clippy`, fixed downstream compilation errors inside examples and tests that were implicitly importing via private module paths, and verified successfully with `cargo test`.

---
*PR created automatically by Jules for task [15819816798689548140](https://jules.google.com/task/15819816798689548140) started by @madmax983*