### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,10 +700,21 @@ cargo run --bin aletheia -- daemon stop
 
 ### Query Language (AQL)
 
+> ⚠️ **IMPORTANT: REQUIRES FEATURE 'CYPHER'**
+>
+> AQL functionality requires the `cypher` feature flag.
+> **You MUST add this to your `Cargo.toml` or the code will not compile:**
+>
+> ```toml
+> [dependencies]
+> aletheiadb = { version = "0.1", features = ["cypher"] }
+> ```
+
 AletheiaDB supports a Cypher-like query language with temporal and vector extensions.
 You can execute these directly using the `execute_aql` method:
 
 ```rust
+// ⚠️ REQUIRES FEATURE: cypher
 use aletheiadb::prelude::*;
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
@@ -836,6 +847,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Enable in Cargo.toml: features = ["embedding-openai"]
+    // Note: Requires `OPENAI_API_KEY` environment variable to be set!
 
     // 1. Create embedding service
     let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;


### PR DESCRIPTION
🤦 **The Confusion:** 
New users trying to run the Getting Started examples from the `README.md` face two immediate friction points:
1. The "Query Language (AQL)" example uses `execute_aql()`, but fails to compile with "method not found" because it silently requires the `cypher` feature.
2. The "Embedding Generation" example compiles if `tokio` is added, but crashes at runtime because `OpenAIConfig::from_env()` implicitly requires the `OPENAI_API_KEY` environment variable to be set.

🕵️‍♂️ **The Reality:** 
Users just want to copy-paste examples to see the database working. Hidden dependencies like feature flags and environment variables guarantee a frustrating first experience. If they have to search the source code or guess why an example doesn't compile or run, we've failed them.

💡 **The Fix:** 
*   Added a prominent warning banner directly above the AQL example clarifying that the `cypher` feature must be enabled in `Cargo.toml`.
*   Added an explicit comment in the Embedding Generation example noting that the `OPENAI_API_KEY` environment variable must be set.

---
*PR created automatically by Jules for task [4337290240380613545](https://jules.google.com/task/4337290240380613545) started by @madmax983*