### PR TITLE
🎻 Bard: [documentation update] for core ID and property APIs

### DIFF
--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -272,12 +272,22 @@ impl fmt::Display for EntityId {
     }
 }
 
+/// Convert a `NodeId` into an `EntityId`.
+///
+/// This provides a convenient way to upgrade a specific node identifier
+/// into the more generic `EntityId` enum when working with APIs that can
+/// accept either nodes or edges.
 impl From<NodeId> for EntityId {
     fn from(id: NodeId) -> Self {
         EntityId::Node(id)
     }
 }
 
+/// Convert an `EdgeId` into an `EntityId`.
+///
+/// This provides a convenient way to upgrade a specific edge identifier
+/// into the more generic `EntityId` enum when working with APIs that can
+/// accept either nodes or edges.
 impl From<EdgeId> for EntityId {
     fn from(id: EdgeId) -> Self {
         EntityId::Edge(id)
@@ -1736,6 +1746,10 @@ mod sentinel_id_generator_tests {
 
 use std::str::FromStr;
 
+/// Try to construct a `NodeId` from a raw `u64`.
+///
+/// This performs the same validation as [`NodeId::new`], ensuring the value
+/// does not exceed [`MAX_VALID_ID`].
 impl TryFrom<u64> for NodeId {
     type Error = StorageError;
 
@@ -1744,6 +1758,10 @@ impl TryFrom<u64> for NodeId {
     }
 }
 
+/// Try to parse a `NodeId` from a string representation.
+///
+/// The string must contain a valid base-10 integer that is less than or
+/// equal to [`MAX_VALID_ID`].
 impl FromStr for NodeId {
     type Err = StorageError;
 
@@ -1756,6 +1774,10 @@ impl FromStr for NodeId {
     }
 }
 
+/// Try to construct an `EdgeId` from a raw `u64`.
+///
+/// This performs the same validation as [`EdgeId::new`], ensuring the value
+/// does not exceed [`MAX_VALID_ID`].
 impl TryFrom<u64> for EdgeId {
     type Error = StorageError;
 
@@ -1764,6 +1786,10 @@ impl TryFrom<u64> for EdgeId {
     }
 }
 
+/// Try to parse an `EdgeId` from a string representation.
+///
+/// The string must contain a valid base-10 integer that is less than or
+/// equal to [`MAX_VALID_ID`].
 impl FromStr for EdgeId {
     type Err = StorageError;
 
@@ -1776,6 +1802,10 @@ impl FromStr for EdgeId {
     }
 }
 
+/// Try to construct a `VersionId` from a raw `u64`.
+///
+/// This performs the same validation as [`VersionId::new`], ensuring the value
+/// does not exceed [`MAX_VALID_ID`].
 impl TryFrom<u64> for VersionId {
     type Error = StorageError;
 
@@ -1784,6 +1814,10 @@ impl TryFrom<u64> for VersionId {
     }
 }
 
+/// Try to parse a `VersionId` from a string representation.
+///
+/// The string must contain a valid base-10 integer that is less than or
+/// equal to [`MAX_VALID_ID`].
 impl FromStr for VersionId {
     type Err = StorageError;
 
@@ -1796,6 +1830,10 @@ impl FromStr for VersionId {
     }
 }
 
+/// Try to construct a `TxId` from a raw `u64`.
+///
+/// Unlike other ID types, `TxId` currently does not enforce the [`MAX_VALID_ID`] limit,
+/// so this conversion cannot fail.
 impl TryFrom<u64> for TxId {
     type Error = StorageError;
 
@@ -1804,6 +1842,9 @@ impl TryFrom<u64> for TxId {
     }
 }
 
+/// Try to parse a `TxId` from a string representation.
+///
+/// The string must contain a valid base-10 integer.
 impl FromStr for TxId {
     type Err = StorageError;
 

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -1055,30 +1055,37 @@ impl fmt::Debug for PropertyValue {
 }
 
 // Convenient From implementations
+/// Convert a `bool` into a `PropertyValue`.
 impl From<bool> for PropertyValue {
     fn from(b: bool) -> Self {
         PropertyValue::Bool(b)
     }
 }
 
+/// Convert an `i64` into a `PropertyValue`.
 impl From<i64> for PropertyValue {
     fn from(i: i64) -> Self {
         PropertyValue::Int(i)
     }
 }
 
+/// Convert an `i32` into a `PropertyValue`.
 impl From<i32> for PropertyValue {
     fn from(i: i32) -> Self {
         PropertyValue::Int(i as i64)
     }
 }
 
+/// Convert an `f64` into a `PropertyValue`.
 impl From<f64> for PropertyValue {
     fn from(f: f64) -> Self {
         PropertyValue::Float(f)
     }
 }
 
+/// Convert a `String` into a `PropertyValue`.
+///
+/// This avoids unnecessary memory allocations.
 impl From<String> for PropertyValue {
     fn from(s: String) -> Self {
         // Use Arc::from(s) directly to avoid unnecessary allocation.
@@ -1090,12 +1097,16 @@ impl From<String> for PropertyValue {
     }
 }
 
+/// Convert a `&str` into a `PropertyValue`.
 impl From<&str> for PropertyValue {
     fn from(s: &str) -> Self {
         PropertyValue::String(Arc::from(s))
     }
 }
 
+/// Convert a `Vec<u8>` into a `PropertyValue`.
+///
+/// This avoids unnecessary memory allocations.
 impl From<Vec<u8>> for PropertyValue {
     fn from(b: Vec<u8>) -> Self {
         // Use Arc::from(b) directly to avoid unnecessary allocation.
@@ -1107,18 +1118,21 @@ impl From<Vec<u8>> for PropertyValue {
     }
 }
 
+/// Convert a `&[u8]` into a `PropertyValue`.
 impl From<&[u8]> for PropertyValue {
     fn from(b: &[u8]) -> Self {
         PropertyValue::Bytes(Arc::from(b))
     }
 }
 
+/// Convert a `Vec<PropertyValue>` into a `PropertyValue`.
 impl From<Vec<PropertyValue>> for PropertyValue {
     fn from(v: Vec<PropertyValue>) -> Self {
         PropertyValue::Array(Arc::new(v))
     }
 }
 
+/// Convert a `Vec<f32>` into a `PropertyValue`.
 impl From<Vec<f32>> for PropertyValue {
     fn from(v: Vec<f32>) -> Self {
         // Use v.into() to reuse the Vec's buffer, avoiding allocation and copy
@@ -1126,12 +1140,14 @@ impl From<Vec<f32>> for PropertyValue {
     }
 }
 
+/// Convert a `&[f32]` into a `PropertyValue`.
 impl From<&[f32]> for PropertyValue {
     fn from(v: &[f32]) -> Self {
         PropertyValue::Vector(Arc::from(v))
     }
 }
 
+/// Convert a `SparseVec` into a `PropertyValue`.
 impl From<SparseVec> for PropertyValue {
     fn from(sv: SparseVec) -> Self {
         PropertyValue::SparseVector(Arc::new(sv))
@@ -1551,12 +1567,14 @@ impl fmt::Debug for PropertyMap {
     }
 }
 
+/// Create an empty `PropertyMap`.
 impl Default for PropertyMap {
     fn default() -> Self {
         Self::new()
     }
 }
 
+/// Create a `PropertyMap` from an iterator of key-value pairs.
 impl FromIterator<(PropertyKey, PropertyValue)> for PropertyMap {
     fn from_iter<I: IntoIterator<Item = (PropertyKey, PropertyValue)>>(iter: I) -> Self {
         let iter = iter.into_iter();
@@ -1779,6 +1797,7 @@ impl PropertyMapBuilder {
     }
 }
 
+/// Create a new, empty `PropertyMapBuilder`.
 impl Default for PropertyMapBuilder {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
📖 Chapter: Documented missing core API structures in `src/core/id.rs` and `src/core/property.rs`.
💡 Insight: Explained the purpose and provided clarification for `TryFrom<u64>`, `FromStr` and general `From` implementations across ID types and `PropertyValue` to improve developer experience.
🧪 Example: Added extensive doc comments to `NodeId`, `EdgeId`, `VersionId`, `TxId`, `EntityId`, `PropertyValue`, `PropertyMap`, and `PropertyMapBuilder` to clearly show how they convert and initialize, ensuring zero-cost abstraction warnings where applicable.
🖼️ Preview: Documentation is now visible and clean via `cargo doc`.

---
*PR created automatically by Jules for task [15482637243122924354](https://jules.google.com/task/15482637243122924354) started by @madmax983*