### PR TITLE
⚡ Bolt: Pre-allocate Vec in RingBuffer drain

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -694,7 +694,8 @@ impl WalRingBuffer {
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        // ⚡ Bolt: Pre-allocate vector to eliminate multiple heap reallocations when draining high-throughput WAL buffers.
+        let mut entries = Vec::with_capacity(self.len_approx());
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(self.len_approx())` in the WAL ring buffer `drain` method.
🎯 Why: To eliminate multiple heap reallocations during high-throughput WAL operations.
📊 Impact: Reduces memory allocation overhead significantly when draining many entries.
🔬 Measurement: Run `cargo test storage::wal::ring_buffer` to verify behavior remains correct.

---
*PR created automatically by Jules for task [1551363191806910571](https://jules.google.com/task/1551363191806910571) started by @madmax983*