### PR TITLE
⚡ Bolt: Pre-allocate WalRingBuffer drain vector

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -694,7 +694,9 @@ impl WalRingBuffer {
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        // ⚡ Bolt: Eliminate repeated heap allocations when draining
+        // high-throughput buffers by pre-allocating the vector capacity.
+        let mut entries = Vec::with_capacity(self.len_approx());
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
💡 What: Pre-allocate `entries` vector capacity in `WalRingBuffer::drain()` using `self.len_approx()`.

🎯 Why: The `drain()` method handles high-throughput extraction of pending WAL entries from the concurrent ring buffer. Initializing it with `Vec::new()` causes repeated standard heap reallocations (0 -> 4 -> 8 -> 16 -> 32) during the `try_claim` loop. Since we already track the approximate bounds of the ring buffer, we can ask for the memory exactly once.

📊 Impact: Eliminates multiple dynamic heap allocations per flush cycle.

🔬 Measurement: Run `cargo test storage::wal::ring_buffer`.

---
*PR created automatically by Jules for task [5950822221703358339](https://jules.google.com/task/5950822221703358339) started by @madmax983*