### PR TITLE
⚔️ Elenchus: Fix WAL Batch LSN Gaps

### DIFF
--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -406,6 +406,19 @@ impl ConcurrentWal {
             return Ok(Vec::new());
         }
 
+        // Pre-validate all operations to ensure they don't exceed the max entry size.
+        // This prevents partial batch failures which would cause gaps in the LSN sequence.
+        for operation in &operations {
+            let estimated_capacity = super::estimate_entry_capacity(operation);
+            if estimated_capacity > super::entry::MAX_WAL_ENTRY_SIZE {
+                return Err(Error::Storage(StorageError::CapacityExceeded {
+                    resource: "WAL entry size".to_string(),
+                    current: estimated_capacity,
+                    limit: super::entry::MAX_WAL_ENTRY_SIZE,
+                }));
+            }
+        }
+
         let count = operations.len() as u64;
 
         // Defensive check: ensure count > 0 to prevent panic in allocate_batch
@@ -461,6 +474,19 @@ impl ConcurrentWal {
         // Handle empty batch early
         if operations.is_empty() {
             return Ok((Vec::new(), Vec::new()));
+        }
+
+        // Pre-validate all operations to ensure they don't exceed the max entry size.
+        // This prevents partial batch failures which would cause gaps in the LSN sequence.
+        for operation in &operations {
+            let estimated_capacity = super::estimate_entry_capacity(operation);
+            if estimated_capacity > super::entry::MAX_WAL_ENTRY_SIZE {
+                return Err(Error::Storage(StorageError::CapacityExceeded {
+                    resource: "WAL entry size".to_string(),
+                    current: estimated_capacity,
+                    limit: super::entry::MAX_WAL_ENTRY_SIZE,
+                }));
+            }
         }
 
         let count = operations.len() as u64;

--- a/tests/havoc/wal.rs
+++ b/tests/havoc/wal.rs
@@ -6,5 +6,3 @@ mod havoc_flush_race;
 mod havoc_loom_ring_buffer;
 #[path = "havoc_ring_buffer_torture.rs"]
 mod havoc_ring_buffer_torture;
-#[path = "havoc_wal_gaps.rs"]
-mod havoc_wal_gaps;

--- a/tests/sentry_wal_gaps.rs
+++ b/tests/sentry_wal_gaps.rs
@@ -114,3 +114,59 @@ fn test_sentry_wal_batch_gaps() {
     );
     println!("🛡️ SENTRY SUCCESS: LSNs are contiguous. Batch validation prevented gaps.");
 }
+
+#[test]
+fn test_sentry_wal_batch_with_handles_gaps() {
+    let dir = tempdir().unwrap();
+    let config = ConcurrentWalConfig::new(dir.path());
+    let wal = ConcurrentWal::new(config).unwrap();
+
+    // 1. Create a batch: [Valid, Huge (Invalid), Valid]
+    let ops = vec![test_operation(1), huge_operation(2), test_operation(3)];
+
+    // 2. Append batch with handles - should fail
+    let result = wal.append_batch_with_handles(ops);
+    assert!(
+        result.is_err(),
+        "Batch append with handles should fail due to size limit"
+    );
+
+    let err = result.unwrap_err();
+    println!("Append batch with handles error (expected): {}", err);
+    assert!(
+        err.to_string().contains("CapacityExceeded") || err.to_string().contains("WAL entry size")
+    );
+
+    // 3. Append another valid operation successfully
+    let lsn_after = wal.append_async(test_operation(4)).unwrap();
+    println!("Appended valid op after failure, LSN: {:?}", lsn_after);
+
+    // 4. Drain and inspect LSNs
+    let entries = wal.drain_all();
+    let lsns: Vec<u64> = entries.iter().map(|e| e.lsn.0).collect();
+
+    // 5. Verify atomicity
+    assert!(
+        !lsns.contains(&1) || lsn_after.0 == 1,
+        "LSN 1 should belong to the valid operation, not the failed batch"
+    );
+    assert!(
+        lsns.contains(&lsn_after.0),
+        "LSN after batch should be present"
+    );
+
+    // Prove contiguity
+    let mut contiguous = true;
+    for i in 0..lsns.len().saturating_sub(1) {
+        if lsns[i + 1] != lsns[i] + 1 {
+            contiguous = false;
+            break;
+        }
+    }
+
+    assert!(
+        contiguous,
+        "LSN sequence should be contiguous, but found gaps: {:?}",
+        lsns
+    );
+}

--- a/tests/sentry_wal_gaps.rs
+++ b/tests/sentry_wal_gaps.rs
@@ -54,7 +54,7 @@ fn huge_operation(id: u64) -> WalOperation {
 }
 
 #[test]
-fn test_havoc_wal_batch_gaps() {
+fn test_sentry_wal_batch_gaps() {
     let dir = tempdir().unwrap();
     let config = ConcurrentWalConfig::new(dir.path());
     let wal = ConcurrentWal::new(config).unwrap();
@@ -85,48 +85,32 @@ fn test_havoc_wal_batch_gaps() {
 
     println!("Drained LSNs: {:?}", lsns);
 
-    // 5. Verify the wreckage: Gaps in LSN sequence
-    // Expected: LSN 1 (from first op in batch) MIGHT be there?
-    // No, `append_batch` loop:
-    // 1. Allocates 3 LSNs (current, current+1, current+2).
-    // 2. Loop idx=0: Serialize (ok), Append (ok). LSN 1 written.
-    // 3. Loop idx=1: Serialize (fail), Return Err.
-    // 4. Loop idx=2: Never executed.
-
-    // So LSN 1 should be written.
-    // LSN 2 was allocated but serialization failed.
-    // LSN 3 was allocated but loop aborted.
-    // Next LSN allocated by `append_async` should be 4.
-
-    // So we expect LSNs: [1, 4]
-    // Gap: 2, 3 are missing.
+    // 5. Verify atomicity: No partial batches and no LSN gaps
+    // Since we pre-validate the batch, the entire batch should be rejected before
+    // any LSNs are allocated. The next valid operation should receive LSN 1.
 
     assert!(
-        lsns.contains(&1),
-        "LSN 1 should be present (written before failure)"
+        !lsns.contains(&1) || lsn_after.0 == 1,
+        "LSN 1 should belong to the valid operation, not the failed batch"
     );
-    assert!(
-        !lsns.contains(&2),
-        "LSN 2 should be missing (failed serialization)"
-    );
-    assert!(!lsns.contains(&3), "LSN 3 should be missing (aborted loop)");
     assert!(
         lsns.contains(&lsn_after.0),
         "LSN after batch should be present"
     );
 
-    // Prove non-contiguity
+    // Prove contiguity
     let mut contiguous = true;
-    for i in 0..lsns.len() - 1 {
+    for i in 0..lsns.len().saturating_sub(1) {
         if lsns[i + 1] != lsns[i] + 1 {
             contiguous = false;
             break;
         }
     }
 
-    if !contiguous {
-        println!("👺 HAVOC SUCCESS: Found gaps in LSN sequence! System is fragile.");
-    } else {
-        panic!("Boring. LSNs are contiguous. Failed to break it.");
-    }
+    assert!(
+        contiguous,
+        "LSN sequence should be contiguous, but found gaps: {:?}",
+        lsns
+    );
+    println!("🛡️ SENTRY SUCCESS: LSNs are contiguous. Batch validation prevented gaps.");
 }


### PR DESCRIPTION
Fixes a vulnerability identified by the Elenchus persona where a partial failure during WAL batch appending would cause gaps in the LSN sequence, thereby blocking `WalRingBuffer` progression. We now validate sizes before allocating `LSNs`. Havoc test was converted to a Sentry test.

---
*PR created automatically by Jules for task [8132717613662985723](https://jules.google.com/task/8132717613662985723) started by @madmax983*