### PR TITLE
⚡ Bolt: Remove heap allocations in query lexers via zero-cost case-insensitive macro

### DIFF
--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -1,0 +1,28 @@
+/// A macro for performing case-insensitive string matching without memory allocation.
+///
+/// This macro expands to a series of `if else if` statements using `eq_ignore_ascii_case`,
+/// which avoids the need to call `to_uppercase()` or `to_lowercase()` and allocate a new `String`
+/// just for comparison.
+///
+/// # Example
+/// ```rust
+/// use aletheiadb::core::macros::match_ignore_ascii_case;
+///
+/// let text = "MaTcH";
+/// let result = match_ignore_ascii_case!(text,
+///     "MATCH" => 1,
+///     "WHERE" => 2,
+///     _ => 3
+/// );
+/// assert_eq!(result, 1);
+/// ```
+#[macro_export]
+macro_rules! match_ignore_ascii_case {
+    ( $text:expr, $( $s:literal => $v:expr ),+ , _ => $fallback:expr ) => {
+        if false { unreachable!() }
+        $( else if $text.eq_ignore_ascii_case($s) { $v } )+
+        else { $fallback }
+    }
+}
+
+pub use match_ignore_ascii_case;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,6 +27,8 @@
 
 pub mod error;
 pub mod graph;
+/// Performance optimization macros.
+pub mod macros;
 pub mod hasher;
 pub mod history;
 pub mod hlc;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,13 +27,13 @@
 
 pub mod error;
 pub mod graph;
-/// Performance optimization macros.
-pub mod macros;
 pub mod hasher;
 pub mod history;
 pub mod hlc;
 pub mod id;
 pub mod interning;
+/// Performance optimization macros.
+pub mod macros;
 pub mod observer;
 pub mod property;
 pub mod temporal;

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -12,6 +12,7 @@
 //! - **Always ends with `Eof`**: the token stream is always terminated.
 
 use super::CypherError;
+use crate::core::macros::match_ignore_ascii_case;
 
 // ---------------------------------------------------------------------------
 // Token types
@@ -629,7 +630,7 @@ impl<'a> CypherLexer<'a> {
             .unwrap_or(self.input.len());
         let text = &self.input[start..end];
 
-        let kind = match text.to_uppercase().as_str() {
+        let kind = match_ignore_ascii_case!(text,
             // Clauses
             "MATCH" => TokenKind::Match,
             "OPTIONAL" => TokenKind::OptionalMatch,
@@ -684,8 +685,8 @@ impl<'a> CypherLexer<'a> {
             "VALID_TIME" => TokenKind::ValidTime,
 
             // Not a keyword
-            _ => TokenKind::Identifier,
-        };
+            _ => TokenKind::Identifier
+        );
 
         Ok(Token::new(kind, text, start))
     }

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -4,6 +4,7 @@
 //! This is the first stage of parsing - converting raw text into structured tokens
 //! that the parser can work with.
 
+use crate::core::macros::match_ignore_ascii_case;
 use std::fmt;
 
 /// A token in the AQL language.
@@ -775,7 +776,7 @@ impl<'a> Lexer<'a> {
         let text = &self.input[start_pos..end_pos];
 
         // Check for keywords (case-insensitive)
-        let token = match text.to_uppercase().as_str() {
+        let token = match_ignore_ascii_case!(text,
             "MATCH" => Token::Match,
             "WHERE" => Token::Where,
             "RETURN" => Token::Return,
@@ -813,8 +814,8 @@ impl<'a> Lexer<'a> {
             "COSINE" => Token::Cosine,
             "EUCLIDEAN" => Token::Euclidean,
             "DOT_PRODUCT" => Token::DotProduct,
-            _ => Token::Identifier(text.to_string()),
-        };
+            _ => Token::Identifier(text.to_string())
+        );
 
         Ok(token)
     }


### PR DESCRIPTION
💡 What: Replaced `to_uppercase()` match blocks with a new `match_ignore_ascii_case!` macro using `.eq_ignore_ascii_case()`.
🎯 Why: Lexers were needlessly allocating Strings on the heap for every token to do case-insensitive comparisons against keywords.
📊 Impact: Removes one heap allocation per keyword token parsed in both Cypher and Query lexers.
🔬 Measurement: Run `cargo test query::lexer` and `cargo test cypher::lexer`.

---
*PR created automatically by Jules for task [7632866381176039877](https://jules.google.com/task/7632866381176039877) started by @madmax983*