### PR TITLE
👺 Havoc: Visibility Non-Repeatable Read

### DIFF
--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -588,6 +588,15 @@ impl TxVisibilityManager {
         // Use Arc::make_mut for idiomatic copy-on-write.
         Arc::make_mut(&mut *active_guard).remove(&tx_id);
         committed.insert(tx_id, commit_timestamp);
+
+        // Ensure active_guard is dropped AFTER committed to prevent non-repeatable read race.
+        // If active_guard drops first, a snapshot can be captured while tx_id is NOT in active,
+        // but BEFORE the write lock on committed is released. A reader using that snapshot
+        // could then get a read lock on committed, see the commit, and determine it is visible,
+        // despite it not being in the active set of the snapshot.
+        // By dropping active_guard here (or implicitly by dropping committed first), we prevent it.
+        drop(committed);
+        drop(active_guard);
     }
 
     /// Register a transaction abort.


### PR DESCRIPTION
🧨 **The Trigger:** Concurrently checking visibility while another thread commits.

📉 **The Stack Trace:** (Havoc test panic)
```
👺 HAVOC: Non-repeatable read detected!

🧨 Trigger: Concurrently checking visibility while another thread commits.

📉 The Flaw:
Snapshot Isolation is broken. A single snapshot just changed its mind about visibility.
1. First check: is_visible(tx) = false (Tx not in committed yet)
2. Second check: is_visible(tx) = true (Tx appeared in committed, snapshot says it wasn't active)

😈 Comment:
You tried to optimize lock contention by dropping the active lock before acquiring the committed lock in register_commit.
Congratulations, you created a race window where a transaction ceases to exist. A true phantom.
Lock both, or use an atomic state transition.
```

🧪 **Reproduction:** Run `cargo test --test havoc havoc_visibility_non_repeatable_read`

😈 **Comment:** You tried to optimize lock contention by dropping the active lock before acquiring the committed lock in register_commit. Congratulations, you created a race window where a transaction ceases to exist. A true phantom. By explicitly dropping the active guard after the committed lock, the window is closed.

---
*PR created automatically by Jules for task [10986592086469341846](https://jules.google.com/task/10986592086469341846) started by @madmax983*