### PR TITLE
🎻 Bard: Add OPENAI_API_KEY environment variable documentation

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -96,3 +96,6 @@
 ## 2024-04-07 - [QueryResults API Confusion]
 **Confusion:** The query execution API was opaque, returning raw struct definitions for `QueryResults`, `QueryResult`, and `QueryRow` without context. Users were likely confused about when to use the lazy iterator versus the eagerly evaluated batch objects, and how context like scores, paths, and timestamps fit into rows instead of raw nodes.
 **Clarification:** Added module-level documentation (`//!`) to explain the "Journey of a Result" from planner to materialized structures. Supplemented struct definitions with `///` comments explaining the *why* (e.g. "Why? Use this when the expected result set is small"). Also added executable doctests for `consume_results`, `QueryRow::from_entity`, and `QueryRow::with_score`.
+## 2026-04-09 - [Hidden Dependency in OpenAIConfig]
+**Confusion:** Users copy-pasting the `OpenAIConfig::from_env` example would experience runtime panics if the `OPENAI_API_KEY` environment variable was not set.
+**Clarification:** Added an explicit comment `// Note: The OPENAI_API_KEY environment variable is required.` before the calls in `src/embeddings/mod.rs`, `src/embeddings/providers/openai.rs`, and `src/embeddings/service.rs`.

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -16,6 +16,7 @@
 //! use aletheiadb::embeddings::{EmbeddingService, providers::openai::*};
 //! use std::sync::Arc;
 //!
+//! // Note: The OPENAI_API_KEY environment variable is required.
 //! let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
 //! let provider = Arc::new(OpenAIProvider::new(config)?);
 //! let service = EmbeddingService::new(provider);

--- a/src/embeddings/providers/openai.rs
+++ b/src/embeddings/providers/openai.rs
@@ -11,6 +11,7 @@
 //! use aletheiadb::embeddings::{EmbeddingService, providers::openai::*};
 //! use std::sync::Arc;
 //!
+//! // Note: The OPENAI_API_KEY environment variable is required.
 //! let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
 //! let provider = Arc::new(OpenAIProvider::new(config)?);
 //! let service = EmbeddingService::new(provider);
@@ -96,6 +97,7 @@ impl OpenAIConfig {
     /// # Example
     ///
     /// ```ignore
+    /// // Note: The OPENAI_API_KEY environment variable is required.
     /// let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
     /// ```
     pub fn from_env(model: OpenAIModel) -> Result<Self, EmbeddingError> {
@@ -179,6 +181,7 @@ impl OpenAIProvider {
     /// # Example
     ///
     /// ```ignore
+    /// // Note: The OPENAI_API_KEY environment variable is required.
     /// let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
     /// let provider = OpenAIProvider::new(config)?;
     /// ```

--- a/src/embeddings/service.rs
+++ b/src/embeddings/service.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 /// use aletheiadb::embeddings::{EmbeddingService, providers::openai::*};
 /// use std::sync::Arc;
 ///
+/// // Note: The OPENAI_API_KEY environment variable is required.
 /// let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
 /// let provider = Arc::new(OpenAIProvider::new(config)?);
 /// let service = EmbeddingService::new(provider);


### PR DESCRIPTION
📖 Chapter: Embeddings module documentation
🔦 Insight: Users copy-pasting the `OpenAIConfig::from_env` example would experience runtime panics if the `OPENAI_API_KEY` environment variable was not set.
🧪 Example: Added an explicit comment `// Note: The OPENAI_API_KEY environment variable is required.` before the calls in `src/embeddings/mod.rs`, `src/embeddings/providers/openai.rs`, and `src/embeddings/service.rs`.
🖼️ Preview: 
```rust
// Note: The OPENAI_API_KEY environment variable is required.
let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;
```

---
*PR created automatically by Jules for task [5867242433821911720](https://jules.google.com/task/5867242433821911720) started by @madmax983*