### PR TITLE
🛡️ Sentry: [SIMD scale_and_copy panic coverage]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -26,3 +26,7 @@
 **[Temporal TimeRange Max Timestamp and Deserialize Mutants]**
 **Learning:** `cargo mutants` revealed missing test coverage for `MAX_VALID_TIMESTAMP` bounds checking in open ranges (`TimeRange::from` and `TimeRange::at`), empty range overlap edge cases (`TimeRange::overlaps` short-circuit behavior), and deserialization stringency (`BiTemporalInterval::deserialize` exact consumed length checking against buffer size `> 48`).
 **Action:** Added targeted unit tests checking `#[should_panic]` when `MAX_VALID_TIMESTAMP` is exceeded, explicitly testing overlap between empty point-ranges within larger non-empty ranges, and appending excess bytes to binary formats to verify exact parser length consumption limits.
+
+**[SIMD Mismatched Lengths Panics]**
+**Learning:** Functions that write to uninitialized destination buffers (like `scale_and_copy_sse2`/`avx2`) are extremely unsafe if length checks fail. They require `assert_eq!(src.len(), dst.len())` but those checks weren't actually tested in `#[should_panic]` test blocks.
+**Action:** When validating unsafe SIMD memory slices or `MaybeUninit` blocks, explicitly ensure that the out-of-bounds/mismatched length panics are part of the `test_simd_mismatched_lengths_safety` coverage.

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -3008,7 +3008,10 @@ fn test_simd_mismatched_lengths_safety() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             super::simd::x86_ops::scale_and_copy_sse2(&a, &mut dst, 2.0)
         }));
-        assert!(result.is_err(), "SSE2 scale_and_copy should panic on mismatch");
+        assert!(
+            result.is_err(),
+            "SSE2 scale_and_copy should panic on mismatch"
+        );
     }
 
     // Test AVX2 if available
@@ -3037,7 +3040,10 @@ fn test_simd_mismatched_lengths_safety() {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             super::simd::x86_ops::scale_and_copy_avx2(&a, &mut dst, 2.0)
         }));
-        assert!(result.is_err(), "AVX2 scale_and_copy should panic on mismatch");
+        assert!(
+            result.is_err(),
+            "AVX2 scale_and_copy should panic on mismatch"
+        );
     }
 }
 

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2969,6 +2969,14 @@ fn test_dot_product_sum_mismatch_panics() {
 }
 
 #[test]
+#[should_panic]
+fn test_scale_and_copy_mismatch_panics() {
+    let a = vec![1.0, 2.0];
+    let mut b = vec![std::mem::MaybeUninit::uninit(); 3];
+    let _ = super::simd::scale_and_copy(&a, &mut b, 2.0);
+}
+
+#[test]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn test_simd_mismatched_lengths_safety() {
     let a = vec![1.0; 8];
@@ -2995,6 +3003,12 @@ fn test_simd_mismatched_lengths_safety() {
             result.is_err(),
             "SSE2 squared_diff_sum should panic on mismatch"
         );
+
+        let mut dst = vec![std::mem::MaybeUninit::uninit(); 9];
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            super::simd::x86_ops::scale_and_copy_sse2(&a, &mut dst, 2.0)
+        }));
+        assert!(result.is_err(), "SSE2 scale_and_copy should panic on mismatch");
     }
 
     // Test AVX2 if available
@@ -3018,6 +3032,12 @@ fn test_simd_mismatched_lengths_safety() {
             result.is_err(),
             "AVX2 squared_diff_sum should panic on mismatch"
         );
+
+        let mut dst = vec![std::mem::MaybeUninit::uninit(); 9];
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            super::simd::x86_ops::scale_and_copy_avx2(&a, &mut dst, 2.0)
+        }));
+        assert!(result.is_err(), "AVX2 scale_and_copy should panic on mismatch");
     }
 }
 


### PR DESCRIPTION
🎯 Target: `src/core/vector/simd.rs` specifically `scale_and_copy_avx2` and `scale_and_copy_sse2`.
💣 Risk: These internal SIMD functions perform raw unaligned `MaybeUninit` memory loads/stores and explicitly require caller bounds validation (`assert_eq!(src.len(), dst.len());`). Lacking safety tests for length mismatches creates a severe risk of buffer over-reads/overwrites and silent memory corruption if upstream functions omit bounds checks.
🧪 Strategy: Added a new `#[should_panic]` unit test for the top-level `scale_and_copy` and extended the explicitly differential `test_simd_mismatched_lengths_safety` with `catch_unwind` to verify both SSE2 and AVX2 variants panic securely before any unsafe operations execute.
🔬 Verification: `cargo test --manifest-path Cargo.toml test_simd_mismatched_lengths_safety`

---
*PR created automatically by Jules for task [16167340270354388742](https://jules.google.com/task/16167340270354388742) started by @madmax983*