### PR TITLE
⚡ Bolt: Pre-allocate version history vectors

### DIFF
--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,4 @@
+💡 What: Replaced `Vec::new()` with `Vec::with_capacity(version_count)` in `get_node_history`, `get_node_at_version`, and `get_edge_history` during version chain traversal.
+🎯 Why: Version chains are traversed backwards, which means the array will continually hit capacity bounds and reallocate on the heap as we trace back through historical deltas. By utilizing the O(1) cached entity version counters (`node_version_counts`, `edge_version_counts`) we can instantly pre-allocate the perfect capacity.
+📊 Impact: Completely eliminates multiple `Vec` heap reallocations when querying large entity histories, offering a zero-cost abstraction improvement.
+🔬 Measurement: Run bench `process_data` or `cargo bench storage::historical::version_retrieval` to verify reallocation reduction.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2013,7 +2013,9 @@ impl HistoricalStorage {
             .ok_or(StorageError::NodeNotFound(node_id))?;
 
         // Traverse the version chain backwards to get all versions in order
-        let mut version_ids = Vec::new();
+        let version_count = self.node_version_counts.get(&node_id).copied().unwrap_or(0);
+        // ⚡ Bolt Optimization: Pre-allocate Vec using cached version count to prevent reallocation during version chain traversal.
+        let mut version_ids = Vec::with_capacity(version_count);
         let mut current_id = Some(current_version_id);
 
         while let Some(vid) = current_id {
@@ -2058,7 +2060,9 @@ impl HistoricalStorage {
             .ok_or(StorageError::NodeNotFound(node_id))?;
 
         // Traverse the version chain backwards to collect all versions
-        let mut version_ids = Vec::new();
+        let version_count = self.node_version_counts.get(&node_id).copied().unwrap_or(0);
+        // ⚡ Bolt Optimization: Pre-allocate Vec using cached version count to prevent reallocation during version chain traversal.
+        let mut version_ids = Vec::with_capacity(version_count);
         let mut current_id = Some(current_version_id);
 
         while let Some(vid) = current_id {
@@ -2159,7 +2163,9 @@ impl HistoricalStorage {
             .ok_or(StorageError::EdgeNotFound(edge_id))?;
 
         // Traverse the version chain backwards to get all versions
-        let mut version_ids = Vec::new();
+        let version_count = self.edge_version_counts.get(&edge_id).copied().unwrap_or(0);
+        // ⚡ Bolt Optimization: Pre-allocate Vec using cached version count to prevent reallocation during version chain traversal.
+        let mut version_ids = Vec::with_capacity(version_count);
         let mut current_id = Some(current_version_id);
 
         while let Some(vid) = current_id {


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(version_count)` in `get_node_history`, `get_node_at_version`, and `get_edge_history` during version chain traversal.
🎯 Why: Version chains are traversed backwards, which means the array will continually hit capacity bounds and reallocate on the heap as we trace back through historical deltas. By utilizing the O(1) cached entity version counters (`node_version_counts`, `edge_version_counts`) we can instantly pre-allocate the perfect capacity.
📊 Impact: Completely eliminates multiple `Vec` heap reallocations when querying large entity histories, offering a zero-cost abstraction improvement.
🔬 Measurement: Run bench `process_data` or `cargo bench storage::historical::version_retrieval` to verify reallocation reduction.

---
*PR created automatically by Jules for task [2396098148538431167](https://jules.google.com/task/2396098148538431167) started by @madmax983*