### PR TITLE
👺 Havoc: Prevent Overflow Panic in TxVisibilityManager

### DIFF
--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -300,11 +300,11 @@ impl CompressedCommitLog {
             while i + run_length < entries.len() {
                 let (next_tx, next_ts) = entries[i + run_length];
                 let expected_tx = TxId::new(end_tx.as_u64() + 1);
-                let expected_ts_wallclock = end_ts.wallclock() + 1;
+                let expected_ts_wallclock = end_ts.wallclock().checked_add(1);
 
                 // Check if both tx_id and timestamp increment by 1
                 // Note: We compare wallclock values since logical component should be 0
-                if next_tx == expected_tx && next_ts.wallclock() == expected_ts_wallclock {
+                if next_tx == expected_tx && Some(next_ts.wallclock()) == expected_ts_wallclock {
                     end_tx = next_tx;
                     end_ts = next_ts;
                     run_length += 1;

--- a/tests/sentry_epoch_overflow.rs
+++ b/tests/sentry_epoch_overflow.rs
@@ -1,0 +1,32 @@
+use aletheiadb::api::transaction::visibility::TxVisibilityManager;
+use aletheiadb::core::id::TxId;
+use aletheiadb::core::Timestamp;
+
+#[test]
+fn sentry_epoch_overflow_diff_ts() {
+    let mgr = TxVisibilityManager::new();
+
+    // Create an epoch with max offset to cause i64 overflow during linear interpolation
+    mgr.register_active(TxId::new(0));
+    mgr.register_commit(TxId::new(0), Timestamp::from(i64::MAX));
+
+    mgr.register_active(TxId::new(10));
+    mgr.register_commit(TxId::new(10), Timestamp::from(i64::MAX));
+
+    for i in 1..9 {
+        mgr.register_active(TxId::new(i));
+        mgr.register_commit(TxId::new(i), Timestamp::from(i64::MAX));
+    }
+
+    // Compress to create epoch
+    mgr.compress_commit_log();
+
+    // Try to get visible timestamp for something in middle
+    let snap = mgr.capture_snapshot(Timestamp::from(10));
+    let visible = mgr.is_visible(&snap, TxId::new(5));
+
+    // We mainly assert that the above operations did not panic.
+    // The timestamp for TxId 5 is i64::MAX, which is > the snapshot timestamp 10,
+    // so it should NOT be visible.
+    assert!(!visible);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Sequential timestamps near i64::MAX cause overflow.
📉 **The Stack Trace:** attempt to add with overflow.
🧪 **Reproduction:** Run cargo test --test sentry_epoch_overflow.
😈 **Comment:** Time does not stop.

---
*PR created automatically by Jules for task [10661119027941766255](https://jules.google.com/task/10661119027941766255) started by @madmax983*