### PR TITLE
⚡ Bolt: Eliminate PropertyMap cloning in result collection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,10 @@
 **Optimize Tokenization in Temporal Parser**
 **Learning:** `tokenize_temporal_keywords` in `src/sql/temporal_parser.rs` previously copied substrings by manually advancing through a `char_indices().collect::<Vec<_>>()` and creating a `String` inside loops (`let word: String = chars[start..i].iter().map(|(_, c)| c).collect()`). This resulted in a heap allocation for every word parsed.
 **Action:** Used `sql.char_indices().peekable()` instead of collecting it. Leveraged `.len_utf8()` to calculate byte boundaries on the fly without allocations. Used a string slice `&sql[start..end]` to avoid `String` allocation for every word parsed, making parsing `0-cost` for non-matching tokens.
+**[Optimize PropertyMap cloning in Result Collection]**
+**Learning:** In AletheiaDB's query executor (`collect_structured`), iterating over owned `QueryRow`s and extracting properties via `.map(|n| n.properties.clone())` causes unnecessary and costly heap allocations for the underlying `PropertyMap` (which contains `Arc` strings and HashMaps).
+**Action:** Since the rows are consumed, use pattern matching on `row.entity` (e.g., `EntityResult::Node(n)`) to directly consume the inner `Node` and take ownership of `n.properties` without cloning.
+
+**[Avoid Vec::with_capacity for Error Paths]**
+**Learning:** Replacing `Vec::new()` with `Vec::with_capacity()` for vectors that track errors or failures (the unhappy path) is a performance anti-pattern. `Vec::new()` does not allocate heap memory until the first element is pushed, whereas `Vec::with_capacity()` forces a guaranteed heap allocation on every execution, introducing a performance regression on the happy path.
+**Action:** Only pre-allocate `Vec`s that are guaranteed or highly likely to be populated. Leave error tracking vectors as `Vec::new()`.

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -558,6 +558,8 @@ impl QueryResults {
     /// the streaming iterator directly for result sets exceeding 100K rows.
     /// ⚡ Bolt Optimization: Pre-allocates vector based on iterator's lower size bound
     /// to reduce heap allocations during collection of structured results.
+    /// Also avoids costly `.clone()` heap allocations for `PropertyMap`s by
+    /// consuming the `Node` and taking ownership of its properties directly.
     pub fn collect_structured(mut self) -> Result<QueryResult> {
         // First pass: collect all rows
         let (lower, _) = self.iterator.size_hint();
@@ -605,18 +607,21 @@ impl QueryResults {
         };
 
         for row in rows {
-            // Extract node ID
-            if let Some(node_id) = row.entity.node_id() {
-                nodes.push(node_id);
-                // Extract properties if we are collecting them
-                if let Some(ref mut props) = properties {
-                    let map = row
-                        .entity
-                        .as_node()
-                        .map(|n| n.properties.clone())
-                        .unwrap_or_default();
-                    props.push(map);
+            // Extract node ID and optionally properties
+            match row.entity {
+                EntityResult::Node(n) => {
+                    nodes.push(n.id);
+                    if let Some(ref mut props) = properties {
+                        props.push(n.properties);
+                    }
                 }
+                EntityResult::NodeId(id) => {
+                    nodes.push(id);
+                    if let Some(ref mut props) = properties {
+                        props.push(Default::default());
+                    }
+                }
+                _ => {} // Skip edges for now, as collect_structured focuses on nodes
             }
 
             // Extract or pad scores


### PR DESCRIPTION
## 💡 What
Eliminates a costly `.clone()` allocation on `PropertyMap`s when collecting structured query results.

## 🎯 Why
In `src/query/executor/results.rs`, the `collect_structured` function was iterating over owned `QueryRow`s but still cloning the underlying node properties (`n.properties.clone()`) to build the results. `PropertyMap` instances contain heap-allocated components like `HashMap`s and `Arc<String>`s, making this operation expensive for large result sets. Since the function consumes the rows, we can safely pattern match on `row.entity` and move the `PropertyMap` directly without cloning.

## 📊 Impact
Removes 1 heap allocation per returned node in `collect_structured` query executions.

## 🔬 Measurement
Run `cargo test query::executor` and observe the reduced allocation overhead in benchmark profiles.

---
*PR created automatically by Jules for task [14233660696506460601](https://jules.google.com/task/14233660696506460601) started by @madmax983*