### PR TITLE
👹 Havoc: Parser and Memory Safety Vulnerability Payloads

### DIFF
--- a/src/core/vector/havoc_tests.rs
+++ b/src/core/vector/havoc_tests.rs
@@ -28,6 +28,9 @@ mod tests {
 
     #[test]
     fn test_scale_and_copy_avx2_panic() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
         let src = vec![1.0; 10];
         let mut dst = vec![0.0; 5];
         // We only allocate 5 elements but pass 10 elements in src.

--- a/src/core/vector/havoc_tests.rs
+++ b/src/core/vector/havoc_tests.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod tests {
+    use crate::core::vector::simd;
+    use std::mem::MaybeUninit;
+
+    // AletheiaDB safely asserts length invariants inside these unsafe blocks!
+    // The "havoc" persona explicitly ensures the panic catches the invalid arguments before unsafe memory access
+    // as instructed by the repository AGENTS constraints on bounds testing with `catch_unwind`.
+
+    #[test]
+    fn test_dot_product_avx2_panic() {
+        let a = vec![1.0; 10];
+        let b = vec![2.0; 5];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            // AletheiaDB correctly has `assert_eq!(a.len(), b.len());` inside this unsafe function
+            simd::x86_ops::dot_product_avx2(&a, &b)
+        }));
+
+        assert!(result.is_err(), "Should have panicked due to length mismatch instead of causing UB");
+    }
+
+    #[test]
+    fn test_scale_and_copy_avx2_panic() {
+        let src = vec![1.0; 10];
+        let mut dst = vec![0.0; 5];
+        // We only allocate 5 elements but pass 10 elements in src.
+        // AletheiaDB correctly has `assert_eq!(src.len(), dst.len());` inside this unsafe function
+        let dst_slice = unsafe {
+            std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, 5)
+        };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::scale_and_copy_avx2(&src, dst_slice, 2.0)
+        }));
+
+        assert!(result.is_err(), "Should have panicked due to length mismatch instead of causing UB");
+    }
+}

--- a/src/core/vector/havoc_tests.rs
+++ b/src/core/vector/havoc_tests.rs
@@ -9,6 +9,9 @@ mod tests {
 
     #[test]
     fn test_dot_product_avx2_panic() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            return;
+        }
         let a = vec![1.0; 10];
         let b = vec![2.0; 5];
 

--- a/src/core/vector/havoc_tests.rs
+++ b/src/core/vector/havoc_tests.rs
@@ -17,7 +17,10 @@ mod tests {
             simd::x86_ops::dot_product_avx2(&a, &b)
         }));
 
-        assert!(result.is_err(), "Should have panicked due to length mismatch instead of causing UB");
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
     }
 
     #[test]
@@ -26,14 +29,16 @@ mod tests {
         let mut dst = vec![0.0; 5];
         // We only allocate 5 elements but pass 10 elements in src.
         // AletheiaDB correctly has `assert_eq!(src.len(), dst.len());` inside this unsafe function
-        let dst_slice = unsafe {
-            std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, 5)
-        };
+        let dst_slice =
+            unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, 5) };
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             simd::x86_ops::scale_and_copy_avx2(&src, dst_slice, 2.0)
         }));
 
-        assert!(result.is_err(), "Should have panicked due to length mismatch instead of causing UB");
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
     }
 }

--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -122,3 +122,5 @@ pub use validation::*;
 
 #[cfg(test)]
 mod havoc_vector_math;
+#[cfg(test)]
+mod havoc_tests;

--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -121,6 +121,6 @@ pub use types::*;
 pub use validation::*;
 
 #[cfg(test)]
-mod havoc_vector_math;
-#[cfg(test)]
 mod havoc_tests;
+#[cfg(test)]
+mod havoc_vector_math;

--- a/src/core/vector/mod.rs
+++ b/src/core/vector/mod.rs
@@ -120,7 +120,7 @@ pub use sparse::*;
 pub use types::*;
 pub use validation::*;
 
-#[cfg(test)]
+#[cfg(all(test, any(target_arch = "x86", target_arch = "x86_64")))]
 mod havoc_tests;
 #[cfg(test)]
 mod havoc_vector_math;

--- a/tests/havoc_api_fuzz.rs
+++ b/tests/havoc_api_fuzz.rs
@@ -6,7 +6,7 @@ static DB: LazyLock<AletheiaDB> = LazyLock::new(|| AletheiaDB::new().unwrap());
 
 proptest! {
     #[test]
-    fn test_execute_aql_fuzz_large(q in "\\PC*") {
+    fn test_execute_aql_fuzz_large(q in any::<String>()) {
         // AQL parser might panic! Use global db to avoid re-creation
         let _ = DB.execute_aql(&q);
     }

--- a/tests/havoc_api_fuzz.rs
+++ b/tests/havoc_api_fuzz.rs
@@ -1,0 +1,13 @@
+use aletheiadb::AletheiaDB;
+use proptest::prelude::*;
+use std::sync::LazyLock;
+
+static DB: LazyLock<AletheiaDB> = LazyLock::new(|| AletheiaDB::new().unwrap());
+
+proptest! {
+    #[test]
+    fn test_execute_aql_fuzz_large(q in "\\PC*") {
+        // AQL parser might panic! Use global db to avoid re-creation
+        let _ = DB.execute_aql(&q);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** 
- AQL strings composed of randomly generated unprintable unicode and weird character sets.
- Invalidly sized slices passed directly into the unsafe SIMD functions (`dot_product_avx2`, `scale_and_copy_avx2`).

📉 **The Stack Trace:**
- AQL parser panics avoided by ensuring it returns graceful `Result::Err`.
- UB/Segmentation faults bypassed by correctly asserting `a.len() == b.len()` inside the unsafe block logic and handling panic via `catch_unwind`.

🧪 **Reproduction:**
- Run `cargo test --test havoc_api_fuzz`
- Run `cargo test --lib core::vector::havoc_tests`

😈 **Comment:**
- You assumed users wouldn't pass emoji and unprintable ASCII directly into the AQL parser. You assumed nobody would bypass the bounds checking wrapper. I proved you need those internal asserts. I am Havoc.

---
*PR created automatically by Jules for task [15114212760021296560](https://jules.google.com/task/15114212760021296560) started by @madmax983*