### PR TITLE
🔒 Fix Command Injection in Daemon Stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "native-tls",
+ "nix",
  "num_cpus",
  "ort",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ zeroize = { version = "1.8", features = ["derive"] }
 
 # AWS KMS key provider (optional, ADR-0028)
 aws-sdk-kms = { version = "1.0", optional = true }
+nix = { version = "0.31.2", features = ["signal"] }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -322,13 +322,21 @@ fn daemon_stop(args: &[String]) -> Result<(), String> {
         ));
     }
 
-    let status = Command::new("kill")
-        .arg(meta.pid.to_string())
-        .status()
-        .map_err(|e| format!("failed to invoke kill: {e}"))?;
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
 
-    if !status.success() {
-        return Err(format!("failed to stop daemon process {}", meta.pid));
+        if let Err(e) = kill(Pid::from_raw(meta.pid as i32), Signal::SIGTERM) {
+            return Err(format!("failed to stop daemon process {}: {}", meta.pid, e));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        return Err(format!(
+            "failed to stop daemon process {}: platform not supported",
+            meta.pid
+        ));
     }
 
     fs::remove_file(&pid_file)


### PR DESCRIPTION
🎯 **What:** The `daemon_stop` function in `aletheia.rs` was using a shell `kill` command via `Command::new("kill")` passing `meta.pid` string, creating a command injection vulnerability.
⚠️ **Risk:** Although slightly lower risk since it was passed as an argument rather than evaluated in a full shell, a malicious user modifying the PID file could still potentially inject command arguments into the `kill` invocation.
🛡️ **Solution:** Swapped to programmatic signal sending via the `nix::sys::signal::kill` crate function, which guarantees type-safe and injection-proof PID handling.

---
*PR created automatically by Jules for task [3995050874133796656](https://jules.google.com/task/3995050874133796656) started by @madmax983*