### PR TITLE
⚡ Bolt: Avoid clone on QueryRow property extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,6 @@
 **[Zero-Cost Lexer Lookahead]**
 **Learning:** `Peekable::clone()` is not a zero-cost abstraction when parsing strings, especially since it clones the underlying iterator state on every single token. For simple ASCII characters (like `-`, `/`, `*`, `0`..`9`), `input.as_bytes().get(idx + 1)` is much faster and completely avoids heap allocations and iterator cloning overhead.
 **Action:** When doing lookaheads in a lexer over a `String` or `&str`, prefer slicing the underlying byte array `as_bytes()` if the characters you're looking for are strictly single-byte ASCII.
+**[QueryRow Entity Extraction]**
+**Learning:** Destructuring a struct (like `QueryRow`) and pattern matching directly on its owned components (`EntityResult`) inside a loop completely eliminates the need for expensive heap allocations caused by intermediate `.clone()` calls on nested data structures like HashMaps (properties). Rust's move semantics are the ultimate zero-cost abstraction for consuming data iterators.
+**Action:** When mapping over iterators or structs that are fully consumed, never use `as_ref().map(|x| x.clone())`. Instead, destructure the container and take ownership by value.

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -682,33 +682,45 @@ impl QueryResults {
         };
 
         for row in rows {
-            // Extract node ID
-            if let Some(node_id) = row.entity.node_id() {
-                nodes.push(node_id);
-                // Extract properties if we are collecting them
-                if let Some(ref mut props) = properties {
-                    let map = row
-                        .entity
-                        .as_node()
-                        .map(|n| n.properties.clone())
-                        .unwrap_or_default();
-                    props.push(map);
+            let QueryRow {
+                entity,
+                score,
+                path,
+                timestamp,
+            } = row;
+
+            // ⚡ Bolt Optimization: Consumes the entity directly by value instead of cloning
+            // properties map via `as_node().map(|n| n.properties.clone())`. This eliminates
+            // one large heap allocation per row during result structurization.
+            match entity {
+                EntityResult::Node(n) => {
+                    nodes.push(n.id);
+                    if let Some(ref mut props) = properties {
+                        props.push(n.properties);
+                    }
                 }
+                EntityResult::NodeId(id) => {
+                    nodes.push(id);
+                    if let Some(ref mut props) = properties {
+                        props.push(Default::default());
+                    }
+                }
+                _ => {} // Ignore edges, etc.
             }
 
             // Extract or pad scores
             if let Some(ref mut s) = scores {
-                s.push(row.score.unwrap_or(0.0));
+                s.push(score.unwrap_or(0.0));
             }
 
             // Extract or pad paths
             if let Some(ref mut p) = paths {
-                p.push(row.path.unwrap_or_default());
+                p.push(path.unwrap_or_default());
             }
 
             // Extract or pad versions
             if let Some(ref mut v) = versions {
-                if let Some(timestamp) = row.timestamp {
+                if let Some(timestamp) = timestamp {
                     // Safely convert timestamp (i64) to VersionId (u64)
                     // Negative timestamps are clamped to 0
                     // Phase 2: Use wallclock component for version ID


### PR DESCRIPTION
💡 What: Refactored `QueryResults::collect_structured()` to destructure `QueryRow` and consume its `entity` field by value via pattern matching, eliminating a `.clone()` call on node properties.
🎯 Why: Iterating over query results and converting them to a structured format is a hot path. The previous implementation used `row.entity.as_node().map(|n| n.properties.clone())`, which forced a heap allocation for every node's property map, even though the `QueryRow` is consumed immediately after.
📊 Impact: Reduces heap allocations by 1 per returned node row. For a query returning 10,000 nodes, this prevents 10,000 unnecessary HashMap/PropertyMap clones, significantly reducing memory pressure and improving structurization throughput.
🔬 Measurement: Run `cargo test --offline --lib query::executor::results` to ensure semantic equivalence. Run `cargo bench` (or a targeted benchmark) to observe reduced allocation overhead during result collection.

---
*PR created automatically by Jules for task [16880614619813099562](https://jules.google.com/task/16880614619813099562) started by @madmax983*