### PR TITLE
👺 Havoc: Parser Fuzzing Suite

### DIFF
--- a/tests/havoc/mod.rs
+++ b/tests/havoc/mod.rs
@@ -1,6 +1,7 @@
 mod concurrency;
 mod config;
 pub mod havoc_visibility_race;
+mod parser_dos;
 mod property;
 mod vector;
 mod wal;

--- a/tests/havoc/parser_dos.rs
+++ b/tests/havoc/parser_dos.rs
@@ -1,0 +1,22 @@
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    #[test]
+    fn fuzz_aql_parser(s in ".*") {
+        let _ = aletheiadb::query::parser::Parser::parse(&s);
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn fuzz_cypher_parser(s in ".*") {
+        let _ = aletheiadb::cypher::parse_cypher(&s);
+    }
+
+    #[cfg(feature = "sql")]
+    #[test]
+    fn fuzz_sql_parser(s in ".*") {
+        let _ = aletheiadb::sql::parse_sql(&s);
+    }
+}


### PR DESCRIPTION
Added a new fuzzing test suite for the query parsers (AQL, Cypher, SQL) using `proptest`.

### 🧨 The Trigger
Aggressively throwing random strings (including control characters via the `.*` regex) at the public `parse` and `parse_*` methods of the AQL, Cypher, and SQL parsers.

### 📉 The Stack Trace
N/A - The parsers successfully handled the garbage input without panicking during the current proptest run.

### 🧪 Reproduction
Run `cargo test -p aletheiadb --test havoc --all-features -- parser_dos`

### 😈 Comment
The parsers survived the initial onslaught of garbage strings. However, this test harness provides a foundation for future, more targeted fuzzing (e.g., deeply nested ASTs or specific adversarial syntax structures) to find deeper weaknesses.


---
*PR created automatically by Jules for task [17240064789674780408](https://jules.google.com/task/17240064789674780408) started by @madmax983*