### PR TITLE
⚡ Bolt: Pre-allocate `successful_results` vector in distributed search

### DIFF
--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -1168,7 +1168,8 @@ impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
             .collect();
 
         // Collect successful results
-        let mut successful_results = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate successful_results vector using results.len() to prevent intermediate heap reallocations on the happy path.
+        let mut successful_results = Vec::with_capacity(results.len());
         let mut failed_count = 0;
         let mut sample_error = String::new();
 

--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -1168,8 +1168,7 @@ impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
             .collect();
 
         // Collect successful results
-        // ⚡ Bolt Optimization: Pre-allocate successful_results vector using results.len() to prevent intermediate heap reallocations on the happy path.
-        let mut successful_results = Vec::with_capacity(results.len());
+        let mut successful_results = Vec::with_capacity(results.len()); // ⚡ Bolt Optimization: Pre-allocate successful_results vector using results.len() to prevent intermediate heap reallocations on the happy path.
         let mut failed_count = 0;
         let mut sample_error = String::new();
 


### PR DESCRIPTION
💡 **What:** Changed the initialization of `successful_results` from `Vec::new()` to `Vec::with_capacity(results.len())` in the distributed vector index search path.
🎯 **Why:** The `successful_results` vector is populated with the outcome of parallel searches across shards. On the happy path, it will store exactly `results.len()` items. Using `Vec::new()` forces multiple intermediate heap reallocations (e.g., 0 -> 4 -> 8...) as elements are pushed. Pre-allocating eliminates these overheads.
📊 **Impact:** Removes intermediate heap allocations on the hot path for distributed vector queries, improving memory efficiency and reducing allocator overhead.
🔭 **Measurement:** Run benchmark `cargo bench` or specifically monitor the allocation rate in `test_search_nodes` / `test_executor_stats_with_failures`.

---
*PR created automatically by Jules for task [12164255510092157789](https://jules.google.com/task/12164255510092157789) started by @madmax983*