### PR TITLE
🗺️ Atlas: Disambiguate duplicate struct names to fix "Leak" smell

### DIFF
--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -27,7 +27,7 @@ use aletheiadb::WriteOps;
 // ⚠️ REQUIRES FEATURE 'NOVA' IN CARGO.TOML
 // [dependencies]
 // aletheiadb = { version = "0.1", features = ["nova"] }
-use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
+use aletheiadb::experimental::temporal_narrative::TemporalNarrativeGenerator;
 use aletheiadb::properties;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // 3. Generate Narrative
-    let generator = NarrativeGenerator::new(&db);
+    let generator = TemporalNarrativeGenerator::new(&db);
     let narrative = generator.generate_node_narrative(node_id)?;
 
     for event in narrative {

--- a/src/experimental/chronos.rs
+++ b/src/experimental/chronos.rs
@@ -1,4 +1,4 @@
-//! Chronos: Temporal Graph Analysis & Pathfinding.
+//! ChronosEngine: Temporal Graph Analysis & Pathfinding.
 //!
 //! This module implements tools for analyzing the graph's evolution over time
 //! and navigating it at specific historical snapshots.
@@ -29,7 +29,7 @@
 //! # {
 //! use aletheiadb::{AletheiaDB, properties, ReadOps, WriteOps, Error};
 //! use aletheiadb::core::temporal::time;
-//! use aletheiadb::experimental::chronos::Chronos;
+//! use aletheiadb::experimental::chronos::ChronosEngine;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let db = AletheiaDB::new()?;
@@ -60,8 +60,8 @@
 //!     Ok::<_, Error>(())
 //! })?;
 //!
-//! // 3. Analyze history with Chronos
-//! let chronos = Chronos::new(&db);
+//! // 3. Analyze history with ChronosEngine
+//! let chronos = ChronosEngine::new(&db);
 //!
 //! // At T2 (present), the path is broken
 //! let path_now = chronos.find_path_at_time(alice, charlie, time::now(), time::now())?;
@@ -71,7 +71,7 @@
 //! let path_then = chronos.find_path_at_time(alice, charlie, t1, t1)?;
 //! assert_eq!(path_then.unwrap(), vec![alice, bob, charlie]);
 //!
-//! println!("🕵️ Chronos confirmed: The connection existed in the past!");
+//! println!("🕵️ ChronosEngine confirmed: The connection existed in the past!");
 //! # Ok(())
 //! # }
 //! # }
@@ -88,22 +88,22 @@ use std::collections::{HashSet, VecDeque};
 
 #[cfg(feature = "nova")]
 /// The Time Lord of the Graph.
-pub struct Chronos<'a> {
+pub struct ChronosEngine<'a> {
     db: &'a AletheiaDB,
 }
 
 #[cfg(not(feature = "nova"))]
 /// The Time Lord of the Graph.
 #[deprecated(
-    note = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    note = "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
-pub struct Chronos<'a> {
+pub struct ChronosEngine<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }
 
 #[cfg(feature = "nova")]
-impl<'a> Chronos<'a> {
-    /// Create a new Chronos instance.
+impl<'a> ChronosEngine<'a> {
+    /// Create a new ChronosEngine instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self { db }
     }
@@ -323,8 +323,8 @@ impl<'a> Chronos<'a> {
 
 #[cfg(not(feature = "nova"))]
 #[allow(deprecated)]
-impl<'a> Chronos<'a> {
-    /// Create a new Chronos instance.
+impl<'a> ChronosEngine<'a> {
+    /// Create a new ChronosEngine instance.
     ///
     /// # Panics
     ///
@@ -333,7 +333,7 @@ impl<'a> Chronos<'a> {
     #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
         panic!(
-            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
@@ -352,7 +352,7 @@ impl<'a> Chronos<'a> {
         tx_time: Timestamp,
     ) -> Result<Option<Vec<NodeId>>> {
         panic!(
-            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
@@ -365,7 +365,7 @@ impl<'a> Chronos<'a> {
     #[track_caller]
     pub fn node_volatility(&self, node_id: NodeId, window: TimeRange) -> Result<f32> {
         panic!(
-            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
@@ -378,7 +378,7 @@ impl<'a> Chronos<'a> {
     #[track_caller]
     pub fn path_stability(&self, path: &[EdgeId], window: TimeRange) -> Result<f32> {
         panic!(
-            "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 }
@@ -420,7 +420,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(10));
         let t3 = time::now();
 
-        let chronos = Chronos::new(&db);
+        let chronos = ChronosEngine::new(&db);
 
         // Path should exist at T2 (between creation and deletion?)
         // Create edge happened "at" some time between t1 and t2 (when create_edge returned).
@@ -460,7 +460,7 @@ mod tests {
 
         let t_end = time::now();
 
-        let chronos = Chronos::new(&db);
+        let chronos = ChronosEngine::new(&db);
         let window = TimeRange::new(t_start, t_end).unwrap();
 
         let vol = chronos.node_volatility(node, window).unwrap();
@@ -482,19 +482,19 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_new() {
         let db = AletheiaDB::new().unwrap();
-        let _ = Chronos::new(&db);
+        let _ = ChronosEngine::new(&db);
     }
 
     #[test]
     #[should_panic(
-        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_find_path_at_time() {
-        let chronos = Chronos {
+        let chronos = ChronosEngine {
             _marker: std::marker::PhantomData,
         };
         let _ = chronos.find_path_at_time(
@@ -507,10 +507,10 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_node_volatility() {
-        let chronos = Chronos {
+        let chronos = ChronosEngine {
             _marker: std::marker::PhantomData,
         };
         let _ = chronos.node_volatility(
@@ -525,10 +525,10 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "Chronos requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "ChronosEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_path_stability() {
-        let chronos = Chronos {
+        let chronos = ChronosEngine {
             _marker: std::marker::PhantomData,
         };
         let _ = chronos.path_stability(

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -180,11 +180,11 @@ impl Resonator for ActivityDensityResonator {
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
 /// use aletheiadb::AletheiaDB;
-/// use aletheiadb::experimental::echo::EchoChamber;
+/// use aletheiadb::experimental::echo::EchoChamberEngine;
 /// use aletheiadb::core::id::NodeId;
 ///
 /// let db = AletheiaDB::new().unwrap();
-/// let chamber = EchoChamber::new(&db);
+/// let chamber = EchoChamberEngine::new(&db);
 ///
 /// let target_node = NodeId::new(1).unwrap();
 /// let candidates = vec![NodeId::new(2).unwrap(), NodeId::new(3).unwrap()];
@@ -194,7 +194,7 @@ impl Resonator for ActivityDensityResonator {
 /// # #[cfg(not(feature = "nova"))]
 /// # fn main() {}
 /// ```
-pub struct EchoChamber<'a> {
+pub struct EchoChamberEngine<'a> {
     db: &'a AletheiaDB,
     resonator: Box<dyn Resonator>,
 }
@@ -212,11 +212,11 @@ pub struct EchoChamber<'a> {
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
 /// use aletheiadb::AletheiaDB;
-/// use aletheiadb::experimental::echo::EchoChamber;
+/// use aletheiadb::experimental::echo::EchoChamberEngine;
 /// use aletheiadb::core::id::NodeId;
 ///
 /// let db = AletheiaDB::new().unwrap();
-/// let chamber = EchoChamber::new(&db);
+/// let chamber = EchoChamberEngine::new(&db);
 ///
 /// let target_node = NodeId::new(1).unwrap();
 /// let candidates = vec![NodeId::new(2).unwrap(), NodeId::new(3).unwrap()];
@@ -227,15 +227,15 @@ pub struct EchoChamber<'a> {
 /// # fn main() {}
 /// ```
 #[deprecated(
-    note = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    note = "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
-pub struct EchoChamber<'a> {
+pub struct EchoChamberEngine<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }
 
 #[cfg(feature = "nova")]
-impl<'a> EchoChamber<'a> {
-    /// Create a new EchoChamber with default settings.
+impl<'a> EchoChamberEngine<'a> {
+    /// Create a new EchoChamberEngine with default settings.
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
@@ -243,7 +243,7 @@ impl<'a> EchoChamber<'a> {
         }
     }
 
-    /// Configure the EchoChamber with a custom resonator.
+    /// Configure the EchoChamberEngine with a custom resonator.
     pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
         self.resonator = Box::new(resonator);
         self
@@ -285,8 +285,8 @@ impl<'a> EchoChamber<'a> {
 
 #[cfg(not(feature = "nova"))]
 #[allow(deprecated)]
-impl<'a> EchoChamber<'a> {
-    /// Create a new EchoChamber with default settings.
+impl<'a> EchoChamberEngine<'a> {
+    /// Create a new EchoChamberEngine with default settings.
     ///
     /// # Panics
     ///
@@ -295,11 +295,11 @@ impl<'a> EchoChamber<'a> {
     #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
         panic!(
-            "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
-    /// Configure the EchoChamber with a custom resonator.
+    /// Configure the EchoChamberEngine with a custom resonator.
     ///
     /// # Panics
     ///
@@ -308,7 +308,7 @@ impl<'a> EchoChamber<'a> {
     #[track_caller]
     pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
         panic!(
-            "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
@@ -321,7 +321,7 @@ impl<'a> EchoChamber<'a> {
     #[track_caller]
     pub fn find_echoes(&self, target: NodeId, candidates: &[NodeId]) -> Result<Vec<(NodeId, f32)>> {
         panic!(
-            "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 }
@@ -416,7 +416,7 @@ mod tests {
             num_bins: 10,
         };
 
-        let chamber = EchoChamber::new(&db).with_resonator(resonator);
+        let chamber = EchoChamberEngine::new(&db).with_resonator(resonator);
 
         // Find echoes for Node A among B and C
         let echoes = chamber.find_echoes(node_a, &[node_b, node_c]).unwrap();
@@ -454,19 +454,19 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_new() {
         let db = AletheiaDB::new().unwrap();
-        let _ = EchoChamber::new(&db);
+        let _ = EchoChamberEngine::new(&db);
     }
 
     #[test]
     #[should_panic(
-        expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_with_resonator() {
-        let chamber = EchoChamber {
+        let chamber = EchoChamberEngine {
             _marker: std::marker::PhantomData,
         };
         // We need a dummy resonator. Since Resonator trait is public but ActivityDensityResonator is only stubbed out...
@@ -479,10 +479,10 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "EchoChamberEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_find_echoes() {
-        let chamber = EchoChamber {
+        let chamber = EchoChamberEngine {
             _marker: std::marker::PhantomData,
         };
         let _ = chamber.find_echoes(NodeId::new(0).unwrap(), &[]);

--- a/src/experimental/gestalt.rs
+++ b/src/experimental/gestalt.rs
@@ -9,7 +9,7 @@
 //! "Find a \[Person ~ 'Engineer'\] connected to a \[Company ~ 'Startup'\] via \[WORKS_FOR\]."
 //!
 //! # Concepts
-//! - **Pattern**: A template subgraph with constraints.
+//! - **GestaltPattern**: A template subgraph with constraints.
 //! - **Anchor**: A node in the pattern with a vector constraint, used to seed the search.
 //! - **Match**: A concrete subgraph in the database that satisfies the pattern.
 
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 
 /// A node in the pattern graph.
 #[derive(Debug, Clone)]
-pub struct PatternNode {
+pub struct GestaltPatternNode {
     /// The ID of the node within the pattern (0, 1, 2...).
     pub id: usize,
     /// Optional label constraint (exact match).
@@ -42,7 +42,7 @@ pub struct VectorConstraint {
 
 /// An edge in the pattern graph.
 #[derive(Debug, Clone)]
-pub struct PatternEdge {
+pub struct GestaltPatternEdge {
     /// The source pattern node ID.
     pub source: usize,
     /// The target pattern node ID.
@@ -63,10 +63,10 @@ pub struct PatternEdge {
 /// Building a pattern to find a specific sub-graph structure:
 ///
 /// ```
-/// use aletheiadb::experimental::gestalt::Pattern;
+/// use aletheiadb::experimental::gestalt::GestaltPattern;
 ///
 /// # fn main() {
-/// let mut pattern = Pattern::new();
+/// let mut pattern = GestaltPattern::new();
 ///
 /// // Create a starting node constraint.
 /// // We're looking for a Person matching this embedding concept:
@@ -86,14 +86,14 @@ pub struct PatternEdge {
 /// # }
 /// ```
 #[derive(Debug, Clone, Default)]
-pub struct Pattern {
+pub struct GestaltPattern {
     /// Nodes in the pattern.
-    pub nodes: Vec<PatternNode>,
+    pub nodes: Vec<GestaltPatternNode>,
     /// Edges in the pattern.
-    pub edges: Vec<PatternEdge>,
+    pub edges: Vec<GestaltPatternEdge>,
 }
 
-impl Pattern {
+impl GestaltPattern {
     /// Create a new, empty pattern.
     pub fn new() -> Self {
         Self::default()
@@ -104,7 +104,7 @@ impl Pattern {
     /// Returns the internal index of the new node, which can be used to connect edges.
     pub fn add_node(&mut self, label: Option<String>) -> usize {
         let id = self.nodes.len();
-        self.nodes.push(PatternNode {
+        self.nodes.push(GestaltPatternNode {
             id,
             label,
             vector_constraint: None,
@@ -127,7 +127,7 @@ impl Pattern {
         threshold: f32,
     ) -> usize {
         let id = self.nodes.len();
-        self.nodes.push(PatternNode {
+        self.nodes.push(GestaltPatternNode {
             id,
             label,
             vector_constraint: Some(VectorConstraint {
@@ -142,10 +142,10 @@ impl Pattern {
     /// Add a directed edge between two previously added nodes.
     ///
     /// The `source` and `target` IDs must correspond to nodes already created
-    /// via [`add_node`](Pattern::add_node) or [`add_semantic_node`](Pattern::add_semantic_node).
+    /// via [`add_node`](GestaltPattern::add_node) or [`add_semantic_node`](GestaltPattern::add_semantic_node).
     /// If invalid IDs are used, an error will be returned when [`GestaltMatcher::find_matches`] evaluates the pattern.
     pub fn add_edge(&mut self, source: usize, target: usize, label: Option<String>) {
-        self.edges.push(PatternEdge {
+        self.edges.push(GestaltPatternEdge {
             source,
             target,
             label,
@@ -159,7 +159,7 @@ impl Pattern {
         for edge in &self.edges {
             if edge.source >= node_count || edge.target >= node_count {
                 return Err(crate::core::error::Error::other(format!(
-                    "Pattern edge references invalid node ID: {} -> {}",
+                    "GestaltPattern edge references invalid node ID: {} -> {}",
                     edge.source, edge.target
                 )));
             }
@@ -171,9 +171,9 @@ impl Pattern {
 /// A concrete match found in the database.
 #[derive(Debug, Clone)]
 pub struct Match {
-    /// Mapping from Pattern Node ID -> Database Node ID.
+    /// Mapping from GestaltPattern Node ID -> Database Node ID.
     pub nodes: HashMap<usize, NodeId>,
-    /// Mapping from Pattern Edge (index) -> Database Edge ID.
+    /// Mapping from GestaltPattern Edge (index) -> Database Edge ID.
     pub edges: HashMap<usize, EdgeId>,
     /// The average similarity score of all vector constraints in this match.
     pub score: f32,
@@ -181,7 +181,7 @@ pub struct Match {
 
 /// The Gestalt Engine for semantic sub-graph matching.
 ///
-/// This engine is responsible for executing a [`Pattern`] query against an [`AletheiaDB`] instance.
+/// This engine is responsible for executing a [`GestaltPattern`] query against an [`AletheiaDB`] instance.
 /// It uses a "backtracking search" strategy, beginning at the "anchor" node (the node with
 /// the semantic constraint) and traversing outward to verify the structural constraints.
 pub struct GestaltMatcher<'a> {
@@ -197,14 +197,14 @@ impl<'a> GestaltMatcher<'a> {
     /// Find occurrences of the pattern in the database up to a specified limit.
     ///
     /// The returned `Vec<Match>` will contain the concrete `NodeId` and `EdgeId` mappings
-    /// from the database that satisfy the [`Pattern`].
+    /// from the database that satisfy the [`GestaltPattern`].
     ///
     /// # Errors
     ///
     /// Returns an error if:
-    /// - The [`Pattern`] is invalid (e.g., edges point to non-existent nodes).
-    /// - The [`Pattern`] does not contain at least one node with a `vector_constraint` (anchor).
-    pub fn find_matches(&self, pattern: &Pattern, limit: usize) -> Result<Vec<Match>> {
+    /// - The [`GestaltPattern`] is invalid (e.g., edges point to non-existent nodes).
+    /// - The [`GestaltPattern`] does not contain at least one node with a `vector_constraint` (anchor).
+    pub fn find_matches(&self, pattern: &GestaltPattern, limit: usize) -> Result<Vec<Match>> {
         pattern.validate()?;
 
         if pattern.nodes.is_empty() {
@@ -273,7 +273,7 @@ impl<'a> GestaltMatcher<'a> {
     // Recursive backtracking to complete the match.
     fn backtrack(
         &self,
-        pattern: &Pattern,
+        pattern: &GestaltPattern,
         current_match: &mut Match,
         results: &mut Vec<Match>,
         limit: usize,
@@ -303,7 +303,7 @@ impl<'a> GestaltMatcher<'a> {
             // Find candidates for this node
             // Candidates must be neighbors of the mapped nodes that connect to it.
             // 1. Identify constraints from existing mappings.
-            // E.g. Pattern: 0 -> 1. 0 is mapped to A. 1 must be a neighbor of A.
+            // E.g. GestaltPattern: 0 -> 1. 0 is mapped to A. 1 must be a neighbor of A.
 
             let candidates = self.find_candidates_for_node(pattern, next_idx, current_match)?;
 
@@ -333,7 +333,7 @@ impl<'a> GestaltMatcher<'a> {
                 }
             }
         } else {
-            // Pattern might be disconnected?
+            // GestaltPattern might be disconnected?
             // If we have unmapped nodes but can't reach them from mapped ones,
             // we'd need to pick a new anchor for the disconnected component.
             // For MVP, we assume connected patterns or fail.
@@ -344,7 +344,7 @@ impl<'a> GestaltMatcher<'a> {
         Ok(())
     }
 
-    fn pick_next_node(&self, pattern: &Pattern, current_match: &Match) -> Option<usize> {
+    fn pick_next_node(&self, pattern: &GestaltPattern, current_match: &Match) -> Option<usize> {
         // Find an unmapped pattern node that is connected to a mapped pattern node
         for edge in &pattern.edges {
             let s_mapped = current_match.nodes.contains_key(&edge.source);
@@ -362,7 +362,7 @@ impl<'a> GestaltMatcher<'a> {
 
     fn find_candidates_for_node(
         &self,
-        pattern: &Pattern,
+        pattern: &GestaltPattern,
         target_idx: usize,
         current_match: &Match,
     ) -> Result<Vec<NodeId>> {
@@ -457,7 +457,11 @@ impl<'a> GestaltMatcher<'a> {
         }
     }
 
-    fn check_node_constraints(&self, node_id: NodeId, pattern_node: &PatternNode) -> Result<bool> {
+    fn check_node_constraints(
+        &self,
+        node_id: NodeId,
+        pattern_node: &GestaltPatternNode,
+    ) -> Result<bool> {
         // Label check
         if !self.check_node_label(node_id, &pattern_node.label)? {
             return Ok(false);
@@ -483,7 +487,7 @@ impl<'a> GestaltMatcher<'a> {
         Ok(true)
     }
 
-    fn verify_edges(&self, pattern: &Pattern, current_match: &mut Match) -> Result<bool> {
+    fn verify_edges(&self, pattern: &GestaltPattern, current_match: &mut Match) -> Result<bool> {
         // Ensure all pattern edges exist in the database between the mapped nodes
         for (i, edge) in pattern.edges.iter().enumerate() {
             let u = current_match.nodes[&edge.source];
@@ -512,7 +516,7 @@ impl<'a> GestaltMatcher<'a> {
         Ok(true)
     }
 
-    fn calculate_score(&self, pattern: &Pattern, current_match: &Match) -> Result<f32> {
+    fn calculate_score(&self, pattern: &GestaltPattern, current_match: &Match) -> Result<f32> {
         let mut total_score = 0.0;
         let mut count = 0;
 
@@ -594,12 +598,12 @@ mod tests {
         db.create_edge(e, f, "WORKS_FOR", Default::default())
             .unwrap();
 
-        // Pattern:
+        // GestaltPattern:
         // Node 0: [1, 0] (Sim > 0.9)
         // Node 1: [0, 1] (Sim > 0.9)
         // Edge 0 -> 1 (WORKS_FOR)
 
-        let mut pattern = Pattern::new();
+        let mut pattern = GestaltPattern::new();
         let p0 = pattern.add_semantic_node(
             Some("Person".to_string()),
             "vec".to_string(),

--- a/src/experimental/graph_context.rs
+++ b/src/experimental/graph_context.rs
@@ -58,7 +58,7 @@ use crate::AletheiaDB;
 use crate::core::error::Result;
 use crate::core::id::NodeId;
 use crate::core::interning::{GLOBAL_INTERNER, InternedString};
-use crate::experimental::temporal_narrative::NarrativeGenerator;
+use crate::experimental::temporal_narrative::TemporalNarrativeGenerator;
 use std::fmt::Write;
 
 /// Builder for generating a rich context description of a node.
@@ -175,7 +175,7 @@ impl<'a> GraphContextBuilder<'a> {
 
         // 3. Evolution (History)
         writeln!(&mut output, "\n## Evolution").unwrap();
-        let generator = NarrativeGenerator::new(self.db);
+        let generator = TemporalNarrativeGenerator::new(self.db);
         match generator.generate_node_narrative(self.center_node) {
             Ok(events) => {
                 if events.is_empty() {

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -1,8 +1,8 @@
-//! Sherlock: Temporal Pattern Matching Engine.
+//! SherlockEngine: Temporal Pattern Matching Engine.
 //!
 //! "It is a capital mistake to theorize before one has data."
 //!
-//! Sherlock allows you to define "Mysteries" (Temporal Patterns) and investigate
+//! SherlockEngine allows you to define "Mysteries" (Temporal Patterns) and investigate
 //! the graph history to find "Deductions" (Matches).
 //!
 //! It answers questions like:
@@ -11,8 +11,8 @@
 //!
 //! # Concepts
 //! - **Clue**: A specific condition to look for (e.g., Property Change).
-//! - **Mystery**: A sequence of Clues with time constraints.
-//! - **Deduction**: A concrete sequence of events that matches the Mystery.
+//! - **SherlockMystery**: A sequence of Clues with time constraints.
+//! - **Deduction**: A concrete sequence of events that matches the SherlockMystery.
 
 use crate::AletheiaDB;
 use crate::core::error::Result;
@@ -48,18 +48,18 @@ pub enum Clue {
 }
 
 #[cfg(feature = "nova")]
-/// A Mystery defines the pattern to search for.
+/// A SherlockMystery defines the pattern to search for.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::experimental::sherlock::{Mystery, Clue};
+/// use aletheiadb::experimental::sherlock::{SherlockMystery, Clue};
 /// use aletheiadb::core::property::PropertyValue;
 /// use std::time::Duration;
 ///
-/// let mystery = Mystery::new(Duration::from_secs(60))
+/// let mystery = SherlockMystery::new(Duration::from_secs(60))
 ///     .add_clue(Clue::PropertyState {
 ///         key: "status".to_string(),
 ///         value: Some(PropertyValue::from("Pending")),
@@ -69,7 +69,7 @@ pub enum Clue {
 /// # fn main() {}
 /// ```
 #[derive(Debug, Clone)]
-pub struct Mystery {
+pub struct SherlockMystery {
     /// The sequence of clues to find.
     pub clues: Vec<Clue>,
     /// Maximum time allowed between the first and last clue.
@@ -77,17 +77,17 @@ pub struct Mystery {
 }
 
 #[cfg(not(feature = "nova"))]
-/// A Mystery defines the pattern to search for.
+/// A SherlockMystery defines the pattern to search for.
 #[deprecated(
-    note = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    note = "SherlockMystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
-pub struct Mystery {
+pub struct SherlockMystery {
     _marker: std::marker::PhantomData<Duration>,
 }
 
 #[cfg(feature = "nova")]
-impl Mystery {
-    /// Create a new Mystery builder.
+impl SherlockMystery {
+    /// Create a new SherlockMystery builder.
     pub fn new(time_window: Duration) -> Self {
         Self {
             clues: Vec::new(),
@@ -104,8 +104,8 @@ impl Mystery {
 
 #[cfg(not(feature = "nova"))]
 #[allow(deprecated)]
-impl Mystery {
-    /// Create a new Mystery builder.
+impl SherlockMystery {
+    /// Create a new SherlockMystery builder.
     ///
     /// # Panics
     ///
@@ -114,7 +114,7 @@ impl Mystery {
     #[track_caller]
     pub fn new(time_window: Duration) -> Self {
         panic!(
-            "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "SherlockMystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
@@ -127,7 +127,7 @@ impl Mystery {
     #[track_caller]
     pub fn add_clue(self, clue: Clue) -> Self {
         panic!(
-            "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "SherlockMystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 }
@@ -155,7 +155,7 @@ pub struct Deduction {
 }
 
 #[cfg(feature = "nova")]
-/// The Sherlock Engine.
+/// The SherlockEngine Engine.
 ///
 /// # Examples
 ///
@@ -163,7 +163,7 @@ pub struct Deduction {
 /// # #[cfg(feature = "nova")]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use aletheiadb::AletheiaDB;
-/// use aletheiadb::experimental::sherlock::{Sherlock, Mystery, Clue};
+/// use aletheiadb::experimental::sherlock::{SherlockEngine, SherlockMystery, Clue};
 /// use aletheiadb::core::property::{PropertyValue, PropertyMapBuilder};
 /// use aletheiadb::api::transaction::WriteOps;
 /// use std::time::Duration;
@@ -180,8 +180,8 @@ pub struct Deduction {
 ///     PropertyMapBuilder::new().insert("status", "Completed").build()
 /// ))?;
 ///
-/// let sherlock = Sherlock::new(&db);
-/// let mystery = Mystery::new(Duration::from_secs(60))
+/// let sherlock = SherlockEngine::new(&db);
+/// let mystery = SherlockMystery::new(Duration::from_secs(60))
 ///     .add_clue(Clue::PropertyState {
 ///         key: "status".to_string(),
 ///         value: Some(PropertyValue::from("Pending")),
@@ -198,29 +198,33 @@ pub struct Deduction {
 /// # #[cfg(not(feature = "nova"))]
 /// # fn main() {}
 /// ```
-pub struct Sherlock<'a> {
+pub struct SherlockEngine<'a> {
     #[allow(dead_code)]
     db: &'a AletheiaDB,
 }
 
 #[cfg(not(feature = "nova"))]
-/// The Sherlock Engine.
+/// The SherlockEngine Engine.
 #[deprecated(
-    note = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    note = "SherlockEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
-pub struct Sherlock<'a> {
+pub struct SherlockEngine<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }
 
 #[cfg(feature = "nova")]
-impl<'a> Sherlock<'a> {
-    /// Create a new Sherlock instance.
+impl<'a> SherlockEngine<'a> {
+    /// Create a new SherlockEngine instance.
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self { db }
     }
 
-    /// Investigate a specific node for the given Mystery.
-    pub fn investigate(&self, node_id: NodeId, mystery: &Mystery) -> Result<Vec<Deduction>> {
+    /// Investigate a specific node for the given SherlockMystery.
+    pub fn investigate(
+        &self,
+        node_id: NodeId,
+        mystery: &SherlockMystery,
+    ) -> Result<Vec<Deduction>> {
         let history = self.db.get_node_history(node_id)?;
         let mut deductions = Vec::new();
 
@@ -329,8 +333,8 @@ impl<'a> Sherlock<'a> {
 
 #[cfg(not(feature = "nova"))]
 #[allow(deprecated)]
-impl<'a> Sherlock<'a> {
-    /// Create a new Sherlock instance.
+impl<'a> SherlockEngine<'a> {
+    /// Create a new SherlockEngine instance.
     ///
     /// # Panics
     ///
@@ -339,20 +343,24 @@ impl<'a> Sherlock<'a> {
     #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
         panic!(
-            "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "SherlockEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
-    /// Investigate a specific node for the given Mystery.
+    /// Investigate a specific node for the given SherlockMystery.
     ///
     /// # Panics
     ///
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn investigate(&self, node_id: NodeId, mystery: &Mystery) -> Result<Vec<Deduction>> {
+    pub fn investigate(
+        &self,
+        node_id: NodeId,
+        mystery: &SherlockMystery,
+    ) -> Result<Vec<Deduction>> {
         panic!(
-            "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "SherlockEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 }
@@ -397,11 +405,11 @@ mod tests {
         })
         .unwrap();
 
-        let sherlock = Sherlock::new(&db);
+        let sherlock = SherlockEngine::new(&db);
 
-        // Mystery: Pending -> Delivered (skipping Shipped is allowed if order preserved? No, we just look for A then B)
+        // SherlockMystery: Pending -> Delivered (skipping Shipped is allowed if order preserved? No, we just look for A then B)
         // Let's look for Pending -> Shipped -> Delivered
-        let mystery = Mystery::new(Duration::from_secs(1))
+        let mystery = SherlockMystery::new(Duration::from_secs(1))
             .add_clue(Clue::PropertyState {
                 key: "status".to_string(),
                 value: Some(PropertyValue::from("Pending")),
@@ -441,10 +449,10 @@ mod tests {
         })
         .unwrap();
 
-        let sherlock = Sherlock::new(&db);
+        let sherlock = SherlockEngine::new(&db);
 
-        // Mystery: A -> B within 10ms (Should Fail)
-        let impossible_mystery = Mystery::new(Duration::from_millis(10))
+        // SherlockMystery: A -> B within 10ms (Should Fail)
+        let impossible_mystery = SherlockMystery::new(Duration::from_millis(10))
             .add_clue(Clue::PropertyState {
                 key: "state".to_string(),
                 value: Some(PropertyValue::from("A")),
@@ -460,8 +468,8 @@ mod tests {
             "Should not match due to time constraint"
         );
 
-        // Mystery: A -> B within 500ms (Should Pass)
-        let possible_mystery = Mystery::new(Duration::from_millis(500))
+        // SherlockMystery: A -> B within 500ms (Should Pass)
+        let possible_mystery = SherlockMystery::new(Duration::from_millis(500))
             .add_clue(Clue::PropertyState {
                 key: "state".to_string(),
                 value: Some(PropertyValue::from("A")),
@@ -485,27 +493,27 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "SherlockEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_new() {
         let db = AletheiaDB::new().unwrap();
-        let _ = Sherlock::new(&db);
+        let _ = SherlockEngine::new(&db);
     }
 
     #[test]
     #[should_panic(
-        expected = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "SherlockMystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_mystery() {
-        let _ = Mystery::new(Duration::from_secs(1));
+        let _ = SherlockMystery::new(Duration::from_secs(1));
     }
 
     #[test]
     #[should_panic(
-        expected = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "SherlockMystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_add_clue() {
-        let mystery = Mystery {
+        let mystery = SherlockMystery {
             _marker: std::marker::PhantomData,
         };
         let clue = Clue::PropertyState {
@@ -517,13 +525,13 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "SherlockEngine requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_investigate() {
-        let sherlock = Sherlock {
+        let sherlock = SherlockEngine {
             _marker: std::marker::PhantomData,
         };
-        let mystery = Mystery {
+        let mystery = SherlockMystery {
             _marker: std::marker::PhantomData,
         };
         let _ = sherlock.investigate(NodeId::new(0).unwrap(), &mystery);

--- a/src/experimental/temporal_narrative.rs
+++ b/src/experimental/temporal_narrative.rs
@@ -25,21 +25,21 @@ pub struct NarrativeEvent {
 
 /// Generator for creating natural language narratives from temporal history.
 #[cfg(feature = "nova")]
-pub struct NarrativeGenerator<'a> {
+pub struct TemporalNarrativeGenerator<'a> {
     db: &'a AletheiaDB,
 }
 
 #[cfg(not(feature = "nova"))]
 /// Generator for creating natural language narratives from temporal history.
 #[deprecated(
-    note = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+    note = "TemporalNarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
-pub struct NarrativeGenerator<'a> {
+pub struct TemporalNarrativeGenerator<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }
 
 #[cfg(feature = "nova")]
-impl<'a> NarrativeGenerator<'a> {
+impl<'a> TemporalNarrativeGenerator<'a> {
     /// Create a new narrative generator.
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self { db }
@@ -142,7 +142,7 @@ impl<'a> NarrativeGenerator<'a> {
 
 #[cfg(not(feature = "nova"))]
 #[allow(deprecated)]
-impl<'a> NarrativeGenerator<'a> {
+impl<'a> TemporalNarrativeGenerator<'a> {
     /// Create a new narrative generator.
     ///
     /// # Panics
@@ -152,7 +152,7 @@ impl<'a> NarrativeGenerator<'a> {
     #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
         panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "TemporalNarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 
@@ -165,7 +165,7 @@ impl<'a> NarrativeGenerator<'a> {
     #[track_caller]
     pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
         panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+            "TemporalNarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
     }
 }
@@ -199,7 +199,7 @@ mod tests {
         .unwrap();
 
         // 3. Generate Narrative
-        let generator = NarrativeGenerator::new(&db);
+        let generator = TemporalNarrativeGenerator::new(&db);
         let narrative = generator.generate_node_narrative(node_id).unwrap();
 
         assert_eq!(narrative.len(), 2);
@@ -264,7 +264,7 @@ mod tests {
         .unwrap();
 
         // 3. Generate Narrative
-        let generator = NarrativeGenerator::new(&db);
+        let generator = TemporalNarrativeGenerator::new(&db);
         let narrative = generator.generate_node_narrative(node_id).unwrap();
 
         assert_eq!(narrative.len(), 2);
@@ -295,23 +295,23 @@ mod stub_tests {
 
     #[test]
     #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "TemporalNarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_new() {
         let db = AletheiaDB::new().unwrap();
         // This should panic
-        let _ = NarrativeGenerator::new(&db);
+        let _ = TemporalNarrativeGenerator::new(&db);
     }
 
     #[test]
     #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
+        expected = "TemporalNarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
     )]
     fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
+        // Construct a fake TemporalNarrativeGenerator to test method panic
+        // Safety: TemporalNarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
         // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
+        let generator: TemporalNarrativeGenerator<'_> = TemporalNarrativeGenerator {
             _marker: std::marker::PhantomData,
         };
         // This should panic

--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -231,7 +231,7 @@ pub enum CircuitState {
 
 /// Configuration for circuit breaker.
 ///
-/// The `CircuitBreakerConfig` defines the thresholds and durations for the
+/// The `DistributedCircuitBreakerConfig` defines the thresholds and durations for the
 /// [`NodeCircuitBreaker`] to transition between `Closed`, `Open`, and `HalfOpen` states.
 /// It helps prevent cascading failures in a distributed setup when remote nodes are unresponsive.
 ///
@@ -240,10 +240,10 @@ pub enum CircuitState {
 /// ```rust
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::index::vector::distributed::CircuitBreakerConfig;
+/// use aletheiadb::index::vector::distributed::DistributedCircuitBreakerConfig;
 /// use std::time::Duration;
 ///
-/// let config = CircuitBreakerConfig {
+/// let config = DistributedCircuitBreakerConfig {
 ///     failure_threshold: 5,
 ///     open_duration: Duration::from_secs(30),
 ///     success_threshold: 3,
@@ -253,7 +253,7 @@ pub enum CircuitState {
 /// # fn main() {}
 /// ```
 #[derive(Debug, Clone)]
-pub struct CircuitBreakerConfig {
+pub struct DistributedCircuitBreakerConfig {
     /// Number of failures before opening circuit.
     pub failure_threshold: usize,
     /// Duration to keep circuit open.
@@ -262,7 +262,7 @@ pub struct CircuitBreakerConfig {
     pub success_threshold: usize,
 }
 
-impl Default for CircuitBreakerConfig {
+impl Default for DistributedCircuitBreakerConfig {
     fn default() -> Self {
         Self {
             failure_threshold: DEFAULT_FAILURE_THRESHOLD,
@@ -284,9 +284,9 @@ impl Default for CircuitBreakerConfig {
 /// ```rust
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::index::vector::distributed::{CircuitBreakerConfig, NodeCircuitBreaker, CircuitState};
+/// use aletheiadb::index::vector::distributed::{DistributedCircuitBreakerConfig, NodeCircuitBreaker, CircuitState};
 ///
-/// let config = CircuitBreakerConfig::default();
+/// let config = DistributedCircuitBreakerConfig::default();
 /// let breaker = NodeCircuitBreaker::new(config);
 ///
 /// // Initially, the circuit is closed and allows requests
@@ -298,7 +298,7 @@ impl Default for CircuitBreakerConfig {
 /// ```
 #[derive(Debug)]
 pub struct NodeCircuitBreaker {
-    config: CircuitBreakerConfig,
+    config: DistributedCircuitBreakerConfig,
     state: RwLock<CircuitState>,
     failure_count: AtomicUsize,
     success_count: AtomicUsize,
@@ -307,7 +307,7 @@ pub struct NodeCircuitBreaker {
 
 impl NodeCircuitBreaker {
     /// Create a new circuit breaker.
-    pub fn new(config: CircuitBreakerConfig) -> Self {
+    pub fn new(config: DistributedCircuitBreakerConfig) -> Self {
         Self {
             config,
             state: RwLock::new(CircuitState::Closed),
@@ -471,13 +471,13 @@ impl NodeCircuitBreaker {
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
 /// use aletheiadb::index::vector::distributed::{
-///     MockVectorNodeClient, NodeConnection, CircuitBreakerConfig
+///     MockVectorNodeClient, NodeConnection, DistributedCircuitBreakerConfig
 /// };
 /// use aletheiadb::index::vector::DistanceMetric;
 /// use std::sync::Arc;
 ///
 /// let client = Arc::new(MockVectorNodeClient::new(0, 384, DistanceMetric::Cosine));
-/// let connection = NodeConnection::new(client, CircuitBreakerConfig::default());
+/// let connection = NodeConnection::new(client, DistributedCircuitBreakerConfig::default());
 ///
 /// assert_eq!(connection.node_id(), 0);
 /// assert!(connection.is_available());
@@ -509,7 +509,7 @@ impl<C: VectorNodeClient> fmt::Debug for NodeConnection<C> {
 
 impl<C: VectorNodeClient> NodeConnection<C> {
     /// Create a new node connection.
-    pub fn new(client: Arc<C>, circuit_config: CircuitBreakerConfig) -> Self {
+    pub fn new(client: Arc<C>, circuit_config: DistributedCircuitBreakerConfig) -> Self {
         Self {
             client,
             circuit_breaker: NodeCircuitBreaker::new(circuit_config),
@@ -630,7 +630,7 @@ impl NodeConnectionStats {
 /// Configuration for a single vector node.
 ///
 /// The `VectorNodeConfig` describes how to connect to a specific remote node,
-/// including its endpoint, timeout settings, and specific [`CircuitBreakerConfig`].
+/// including its endpoint, timeout settings, and specific [`DistributedCircuitBreakerConfig`].
 ///
 /// # Examples
 ///
@@ -657,7 +657,7 @@ pub struct VectorNodeConfig {
     /// Request timeout.
     pub timeout: Duration,
     /// Circuit breaker configuration.
-    pub circuit_breaker: CircuitBreakerConfig,
+    pub circuit_breaker: DistributedCircuitBreakerConfig,
 }
 
 impl VectorNodeConfig {
@@ -667,7 +667,7 @@ impl VectorNodeConfig {
             node_id,
             endpoint: endpoint.into(),
             timeout: DEFAULT_TIMEOUT,
-            circuit_breaker: CircuitBreakerConfig::default(),
+            circuit_breaker: DistributedCircuitBreakerConfig::default(),
         }
     }
 
@@ -678,7 +678,7 @@ impl VectorNodeConfig {
     }
 
     /// Set the circuit breaker configuration.
-    pub fn with_circuit_breaker(mut self, config: CircuitBreakerConfig) -> Self {
+    pub fn with_circuit_breaker(mut self, config: DistributedCircuitBreakerConfig) -> Self {
         self.circuit_breaker = config;
         self
     }
@@ -1770,7 +1770,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_opens_on_failures() {
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 3,
             open_duration: Duration::from_millis(100),
             success_threshold: 2,
@@ -1790,7 +1790,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_half_open_transition() {
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 1,
             open_duration: Duration::from_millis(10),
             success_threshold: 1,
@@ -1807,7 +1807,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_closes_from_half_open() {
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 1,
             open_duration: Duration::from_millis(10),
             success_threshold: 2,
@@ -2267,7 +2267,7 @@ mod tests {
 
     #[test]
     fn test_circuit_breaker_remaining_time() {
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 1,
             open_duration: Duration::from_secs(60),
             success_threshold: 1,
@@ -2297,7 +2297,7 @@ mod tests {
         let client = Arc::new(MockVectorNodeClient::new(0, 4, DistanceMetric::Cosine));
         let connection = NodeConnection::new(
             client,
-            CircuitBreakerConfig {
+            DistributedCircuitBreakerConfig {
                 failure_threshold: 1,
                 open_duration: Duration::from_secs(60),
                 success_threshold: 1,
@@ -2316,7 +2316,7 @@ mod tests {
     #[test]
     fn test_node_connection_debug() {
         let client = Arc::new(MockVectorNodeClient::new(0, 4, DistanceMetric::Cosine));
-        let connection = NodeConnection::new(client, CircuitBreakerConfig::default());
+        let connection = NodeConnection::new(client, DistributedCircuitBreakerConfig::default());
 
         let debug_str = format!("{:?}", connection);
         assert!(debug_str.contains("NodeConnection"));
@@ -2413,7 +2413,7 @@ mod tests {
     fn test_circuit_breaker_concurrent_failures() {
         use std::thread;
 
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 10,
             open_duration: Duration::from_secs(60),
             success_threshold: 3,
@@ -2445,7 +2445,7 @@ mod tests {
     fn test_circuit_breaker_concurrent_success_failure_mix() {
         use std::thread;
 
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 5,
             open_duration: Duration::from_millis(10),
             success_threshold: 2,
@@ -2495,7 +2495,7 @@ mod tests {
     fn test_circuit_breaker_concurrent_state_checks() {
         use std::thread;
 
-        let config = CircuitBreakerConfig {
+        let config = DistributedCircuitBreakerConfig {
             failure_threshold: 3,
             open_duration: Duration::from_millis(50),
             success_threshold: 2,

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -824,8 +824,8 @@ pub mod distributed;
 
 // Re-export distributed types for convenience
 pub use distributed::{
-    CircuitBreakerConfig as DistributedCircuitBreakerConfig, CircuitState, DistributedError,
-    DistributedIndexStats, DistributedVectorConfig, DistributedVectorIndex, MockVectorNodeClient,
-    NodeCircuitBreaker, NodeConnection, NodeConnectionStats, RECOMMENDED_IMBALANCE_THRESHOLD,
-    RebalanceStats, RoutingStrategy, VectorNodeClient, VectorNodeConfig,
+    CircuitState, DistributedCircuitBreakerConfig, DistributedError, DistributedIndexStats,
+    DistributedVectorConfig, DistributedVectorIndex, MockVectorNodeClient, NodeCircuitBreaker,
+    NodeConnection, NodeConnectionStats, RECOMMENDED_IMBALANCE_THRESHOLD, RebalanceStats,
+    RoutingStrategy, VectorNodeClient, VectorNodeConfig,
 };

--- a/src/storage/sharding/config.rs
+++ b/src/storage/sharding/config.rs
@@ -233,7 +233,7 @@ impl Default for ShardConfig {
 
 /// Configuration for shard rebalancing.
 #[derive(Debug, Clone)]
-pub struct RebalanceConfig {
+pub struct ShardRebalanceConfig {
     /// Trigger rebalancing when size variance exceeds this threshold.
     /// Value is a ratio (e.g., 0.3 = 30% imbalance triggers rebalancing).
     pub imbalance_threshold: f64,
@@ -253,7 +253,7 @@ pub struct RebalanceConfig {
     pub migration_retries: u32,
 }
 
-impl RebalanceConfig {
+impl ShardRebalanceConfig {
     /// Create a new rebalance configuration with default values.
     pub fn new() -> Self {
         Self::default()
@@ -289,7 +289,7 @@ impl RebalanceConfig {
     }
 }
 
-impl Default for RebalanceConfig {
+impl Default for ShardRebalanceConfig {
     fn default() -> Self {
         Self {
             imbalance_threshold: 0.3, // 30%
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_config_defaults() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         assert!((config.imbalance_threshold - 0.3).abs() < 0.001);
         assert_eq!(config.batch_size, 10_000);
         assert!(config.auto_rebalance);
@@ -424,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_config_builders() {
-        let config = RebalanceConfig::new()
+        let config = ShardRebalanceConfig::new()
             .with_imbalance_threshold(0.5)
             .with_batch_size(5000)
             .with_auto_rebalance(false);
@@ -436,16 +436,16 @@ mod tests {
 
     #[test]
     fn test_rebalance_config_threshold_clamping() {
-        let config = RebalanceConfig::new().with_imbalance_threshold(1.5);
+        let config = ShardRebalanceConfig::new().with_imbalance_threshold(1.5);
         assert!((config.imbalance_threshold - 1.0).abs() < 0.001);
 
-        let config = RebalanceConfig::new().with_imbalance_threshold(-0.5);
+        let config = ShardRebalanceConfig::new().with_imbalance_threshold(-0.5);
         assert!((config.imbalance_threshold - 0.0).abs() < 0.001);
     }
 
     #[test]
     fn test_rebalance_config_should_rebalance() {
-        let config = RebalanceConfig::new().with_imbalance_threshold(0.3);
+        let config = ShardRebalanceConfig::new().with_imbalance_threshold(0.3);
 
         // Below threshold
         assert!(!config.should_rebalance(0.2));

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -43,7 +43,7 @@
 //! method replays the pending decisions from the log, ensuring that all participants
 //! eventually reach a consistent state.
 
-use super::config::{RebalanceConfig, ShardConfig};
+use super::config::{ShardConfig, ShardRebalanceConfig};
 use super::persistent_commit_log::{CommitLogConfig, PersistentCommitLog};
 use super::router::{ShardRouter, TraversalPlan};
 use super::transaction::{DistributedTransaction, DistributedTxError, TransactionPhase};
@@ -63,14 +63,14 @@ use crate::core::hlc::MAX_BACKWARD_DRIFT_US;
 
 /// Result of recovery operation.
 #[derive(Debug, Clone)]
-pub struct RecoveryResult {
+pub struct ShardRecoveryResult {
     /// Transactions that were successfully recovered.
     pub recovered: Vec<TxId>,
     /// Transactions that failed recovery and were dead-lettered.
     pub dead_lettered: Vec<DeadLetteredTransaction>,
 }
 
-impl RecoveryResult {
+impl ShardRecoveryResult {
     /// Check if recovery was fully successful (no dead letters).
     pub fn is_complete(&self) -> bool {
         self.dead_lettered.is_empty()
@@ -230,7 +230,7 @@ pub struct ShardCoordinator {
     /// Metrics per shard.
     metrics: RwLock<HashMap<ShardId, Arc<ShardMetrics>>>,
     /// Rebalance configuration.
-    rebalance_config: RebalanceConfig,
+    rebalance_config: ShardRebalanceConfig,
     /// Timeout for transaction operations.
     transaction_timeout: Duration,
     /// Dead letter queue for transactions that failed recovery.
@@ -278,7 +278,7 @@ impl ShardCoordinator {
             commit_clock: Mutex::new(time::now()),
             commit_clock_observed_at: Mutex::new(Instant::now()),
             metrics: RwLock::new(metrics),
-            rebalance_config: RebalanceConfig::default(),
+            rebalance_config: ShardRebalanceConfig::default(),
             transaction_timeout,
             dead_letter_queue: RwLock::new(HashMap::new()),
         };
@@ -290,7 +290,7 @@ impl ShardCoordinator {
     }
 
     /// Create a coordinator with custom rebalance config.
-    pub fn with_rebalance_config(mut self, config: RebalanceConfig) -> Self {
+    pub fn with_rebalance_config(mut self, config: ShardRebalanceConfig) -> Self {
         self.rebalance_config = config;
         self
     }
@@ -877,10 +877,10 @@ impl ShardCoordinator {
     ///
     /// # Returns
     ///
-    /// A `RecoveryResult` containing:
+    /// A `ShardRecoveryResult` containing:
     /// *   `recovered`: List of `TxId`s that were successfully completed.
     /// *   `dead_lettered`: List of transactions that failed after max retries and require manual intervention.
-    pub fn recover_pending_transactions(&self) -> RecoveryResult {
+    pub fn recover_pending_transactions(&self) -> ShardRecoveryResult {
         let decisions = {
             let log = self.commit_log.read().expect("Commit log lock poisoned");
             log.pending_commits()
@@ -965,7 +965,7 @@ impl ShardCoordinator {
             }
         }
 
-        RecoveryResult {
+        ShardRecoveryResult {
             recovered,
             dead_lettered,
         }
@@ -1377,18 +1377,18 @@ mod tests {
         assert!(metrics.is_some());
     }
 
-    // ==================== RecoveryResult Tests ====================
+    // ==================== ShardRecoveryResult Tests ====================
 
     #[test]
     fn test_recovery_result_is_complete() {
-        let result = RecoveryResult {
+        let result = ShardRecoveryResult {
             recovered: vec![TxId::new(1), TxId::new(2)],
             dead_lettered: vec![],
         };
         assert!(result.is_complete());
         assert_eq!(result.dead_letter_count(), 0);
 
-        let result_with_dead = RecoveryResult {
+        let result_with_dead = ShardRecoveryResult {
             recovered: vec![TxId::new(1)],
             dead_lettered: vec![DeadLetteredTransaction {
                 tx_id: TxId::new(2),
@@ -1433,7 +1433,7 @@ mod tests {
     #[test]
     fn test_coordinator_with_rebalance_config() {
         let config = test_config();
-        let rebalance_config = RebalanceConfig {
+        let rebalance_config = ShardRebalanceConfig {
             imbalance_threshold: 0.5,
             batch_size: 500,
             max_concurrent_migrations: 2,
@@ -1576,7 +1576,7 @@ mod tests {
 
     #[test]
     fn test_recovery_result_debug() {
-        let result = RecoveryResult {
+        let result = ShardRecoveryResult {
             recovered: vec![TxId::new(1)],
             dead_lettered: vec![],
         };

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -238,7 +238,7 @@ pub struct ShardResult {
 
 /// Aggregated result from all shards.
 #[derive(Debug, Clone)]
-pub struct QueryResult {
+pub struct ShardQueryResult {
     /// Query ID.
     pub query_id: u64,
     /// Aggregated data.
@@ -255,7 +255,7 @@ pub struct QueryResult {
     pub total_results: usize,
 }
 
-impl QueryResult {
+impl ShardQueryResult {
     /// Check if all shards succeeded.
     pub fn is_complete(&self) -> bool {
         self.shards_queried == self.shards_succeeded
@@ -273,7 +273,7 @@ impl QueryResult {
 
 /// Distributed query executor.
 #[derive(Debug)]
-pub struct QueryExecutor<C: ShardClient> {
+pub struct ShardedQueryExecutor<C: ShardClient> {
     /// Configuration.
     config: ExecutorConfig,
     /// Shard clients indexed by shard ID.
@@ -288,7 +288,7 @@ pub struct QueryExecutor<C: ShardClient> {
     queries_failed: AtomicU64,
 }
 
-impl<C: ShardClient> QueryExecutor<C> {
+impl<C: ShardClient> ShardedQueryExecutor<C> {
     /// Create a new query executor.
     pub fn new(config: ExecutorConfig, router: ShardRouter) -> Self {
         Self {
@@ -329,7 +329,7 @@ impl<C: ShardClient> QueryExecutor<C> {
     ///   are marked as `pending` in the timeout error (or silently omitted if results are returned).
     ///
     /// This means the order of `target_shards` matters: earlier shards are prioritized.
-    pub fn execute(&self, query: DistributedQuery) -> ExecutorResult<QueryResult> {
+    pub fn execute(&self, query: DistributedQuery) -> ExecutorResult<ShardQueryResult> {
         let start = Instant::now();
         let timeout = query.timeout.unwrap_or(self.config.default_timeout);
 
@@ -406,7 +406,7 @@ impl<C: ShardClient> QueryExecutor<C> {
 
         self.queries_executed.fetch_add(1, Ordering::Relaxed);
 
-        Ok(QueryResult {
+        Ok(ShardQueryResult {
             query_id: query.id,
             data: aggregated,
             shard_results: results.clone(),
@@ -423,7 +423,7 @@ impl<C: ShardClient> QueryExecutor<C> {
         _start_node: NodeId,
         start_label: &str,
         target_labels: &[&str],
-    ) -> ExecutorResult<QueryResult> {
+    ) -> ExecutorResult<ShardQueryResult> {
         let plan = self.router.route_traversal(start_label, target_labels);
 
         // Build query from traversal plan
@@ -446,8 +446,8 @@ impl<C: ShardClient> QueryExecutor<C> {
     }
 
     /// Get executor statistics.
-    pub fn stats(&self) -> ExecutorStats {
-        ExecutorStats {
+    pub fn stats(&self) -> ShardExecutorStats {
+        ShardExecutorStats {
             queries_executed: self.queries_executed.load(Ordering::Relaxed),
             queries_failed: self.queries_failed.load(Ordering::Relaxed),
             registered_clients: self.clients.len(),
@@ -597,7 +597,7 @@ impl<C: ShardClient> QueryExecutor<C> {
 
 /// Statistics for the query executor.
 #[derive(Debug, Clone)]
-pub struct ExecutorStats {
+pub struct ShardExecutorStats {
     /// Total queries executed.
     pub queries_executed: u64,
     /// Total queries failed.
@@ -606,7 +606,7 @@ pub struct ExecutorStats {
     pub registered_clients: usize,
 }
 
-impl ExecutorStats {
+impl ShardExecutorStats {
     /// Calculate success rate.
     pub fn success_rate(&self) -> f64 {
         let total = self.queries_executed + self.queries_failed;
@@ -679,11 +679,11 @@ mod tests {
         assert_eq!(query.aggregation, AggregationStrategy::Sum);
     }
 
-    // ==================== QueryResult Tests ====================
+    // ==================== ShardQueryResult Tests ====================
 
     #[test]
     fn test_query_result_complete() {
-        let result = QueryResult {
+        let result = ShardQueryResult {
             query_id: 1,
             data: vec![],
             shard_results: vec![],
@@ -699,7 +699,7 @@ mod tests {
 
     #[test]
     fn test_query_result_partial() {
-        let result = QueryResult {
+        let result = ShardQueryResult {
             query_id: 1,
             data: vec![],
             shard_results: vec![],
@@ -713,12 +713,12 @@ mod tests {
         assert!((result.success_rate() - 0.666).abs() < 0.01);
     }
 
-    // ==================== QueryExecutor Tests ====================
+    // ==================== ShardedQueryExecutor Tests ====================
 
     #[test]
     fn test_executor_creation() {
-        let executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         assert_eq!(executor.stats().registered_clients, 0);
         assert_eq!(executor.stats().queries_executed, 0);
@@ -726,8 +726,8 @@ mod tests {
 
     #[test]
     fn test_executor_register_client() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client = Arc::new(MockShardClient::new(make_shard_id(0)));
         executor.register_client(make_shard_id(0), client);
@@ -737,8 +737,8 @@ mod tests {
 
     #[test]
     fn test_executor_unregister_client() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client = Arc::new(MockShardClient::new(make_shard_id(0)));
         executor.register_client(make_shard_id(0), client);
@@ -749,8 +749,8 @@ mod tests {
 
     #[test]
     fn test_executor_no_shards() {
-        let executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let query = DistributedQuery::new(1, vec![]);
         let result = executor.execute(query);
@@ -760,8 +760,8 @@ mod tests {
 
     #[test]
     fn test_executor_single_shard_success() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client = Arc::new(MockShardClient::new(make_shard_id(0)));
         executor.register_client(make_shard_id(0), client);
@@ -776,8 +776,8 @@ mod tests {
 
     #[test]
     fn test_executor_multiple_shards_success() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         for i in 0..3 {
             let client = Arc::new(MockShardClient::new(make_shard_id(i)));
@@ -797,8 +797,8 @@ mod tests {
 
     #[test]
     fn test_executor_partial_failure() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
         let client1 = Arc::new(MockShardClient::new(make_shard_id(1)));
@@ -820,8 +820,8 @@ mod tests {
             allow_partial_results: true,
             ..Default::default()
         };
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(config, test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(config, test_router());
 
         let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
         let client1 = Arc::new(MockShardClient::new(make_shard_id(1)));
@@ -840,8 +840,8 @@ mod tests {
 
     #[test]
     fn test_executor_all_failed() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
         client0.set_healthy(false);
@@ -858,8 +858,8 @@ mod tests {
 
     #[test]
     fn test_aggregation_concat() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
         let client1 = Arc::new(MockShardClient::new(make_shard_id(1)));
@@ -877,8 +877,8 @@ mod tests {
 
     #[test]
     fn test_aggregation_merge_nodes() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
         // Simulate client0 returning some data
@@ -903,8 +903,8 @@ mod tests {
 
     #[test]
     fn test_aggregation_count() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client = Arc::new(MockShardClient::new(make_shard_id(0)));
         executor.register_client(make_shard_id(0), client);
@@ -919,8 +919,8 @@ mod tests {
 
     #[test]
     fn test_aggregation_by_shard() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client0 = Arc::new(MockShardClient::new(make_shard_id(0)));
         let client1 = Arc::new(MockShardClient::new(make_shard_id(1)));
@@ -985,8 +985,8 @@ mod tests {
         use crate::storage::sharding::router::{TraversalPlan, TraversalStep};
         use std::collections::HashSet;
 
-        let executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let mut plan = TraversalPlan {
             start_shard: make_shard_id(0),
@@ -1063,12 +1063,12 @@ mod tests {
         assert_eq!(serialized.capacity(), serialized.len());
     }
 
-    // ==================== ExecutorStats Tests ====================
+    // ==================== ShardExecutorStats Tests ====================
 
     #[test]
     fn test_executor_stats() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client = Arc::new(MockShardClient::new(make_shard_id(0)));
         executor.register_client(make_shard_id(0), client);
@@ -1085,8 +1085,8 @@ mod tests {
 
     #[test]
     fn test_executor_stats_with_failures() {
-        let mut executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let mut executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let client = Arc::new(MockShardClient::new(make_shard_id(0)));
         client.set_healthy(false);
@@ -1102,8 +1102,8 @@ mod tests {
 
     #[test]
     fn test_query_id_generation() {
-        let executor: QueryExecutor<MockShardClient> =
-            QueryExecutor::new(ExecutorConfig::default(), test_router());
+        let executor: ShardedQueryExecutor<MockShardClient> =
+            ShardedQueryExecutor::new(ExecutorConfig::default(), test_router());
 
         let id1 = executor.next_query_id();
         let id2 = executor.next_query_id();

--- a/src/storage/sharding/migration.rs
+++ b/src/storage/sharding/migration.rs
@@ -427,7 +427,7 @@ impl<C: ShardClient> MigrationExecutor<C> {
     }
 
     /// Execute a migration plan.
-    pub fn execute(&self, plan: &mut MigrationPlan) -> MigrationResult<MigrationStats> {
+    pub fn execute(&self, plan: &mut MigrationPlan) -> MigrationResult<ShardMigrationStats> {
         let start = Instant::now();
         let migration_id = plan.id;
 
@@ -473,7 +473,7 @@ impl<C: ShardClient> MigrationExecutor<C> {
             flags.remove(&migration_id);
         }
 
-        Ok(MigrationStats {
+        Ok(ShardMigrationStats {
             migration_id,
             total_time: start.elapsed(),
             batches_transferred: copy_stats.batches,
@@ -496,8 +496,8 @@ impl<C: ShardClient> MigrationExecutor<C> {
     }
 
     /// Get executor statistics.
-    pub fn stats(&self) -> ExecutorStats {
-        ExecutorStats {
+    pub fn stats(&self) -> ShardMigrationExecutorStats {
+        ShardMigrationExecutorStats {
             batches_transferred: self.batches_transferred.load(Ordering::Relaxed),
             bytes_transferred: self.bytes_transferred.load(Ordering::Relaxed),
             active_migrations: self.cancellation_flags.read().map(|f| f.len()).unwrap_or(0),
@@ -685,7 +685,7 @@ struct CopyStats {
 
 /// Statistics from a migration.
 #[derive(Debug, Clone)]
-pub struct MigrationStats {
+pub struct ShardMigrationStats {
     /// Migration ID.
     pub migration_id: u64,
     /// Total time taken.
@@ -704,7 +704,7 @@ pub struct MigrationStats {
 
 /// Executor statistics.
 #[derive(Debug, Clone)]
-pub struct ExecutorStats {
+pub struct ShardMigrationExecutorStats {
     /// Total batches transferred.
     pub batches_transferred: u64,
     /// Total bytes transferred.
@@ -932,11 +932,11 @@ mod tests {
         assert!(!executor.cancel(999));
     }
 
-    // ==================== MigrationStats Tests ====================
+    // ==================== ShardMigrationStats Tests ====================
 
     #[test]
     fn test_migration_stats() {
-        let stats = MigrationStats {
+        let stats = ShardMigrationStats {
             migration_id: 1,
             total_time: Duration::from_secs(10),
             batches_transferred: 100,
@@ -1093,11 +1093,11 @@ mod tests {
         assert!(debug.contains("batch_retries"));
     }
 
-    // ==================== ExecutorStats Tests ====================
+    // ==================== ShardMigrationExecutorStats Tests ====================
 
     #[test]
     fn test_executor_stats_default() {
-        let stats = ExecutorStats {
+        let stats = ShardMigrationExecutorStats {
             batches_transferred: 0,
             bytes_transferred: 0,
             active_migrations: 0,

--- a/src/storage/sharding/mod.rs
+++ b/src/storage/sharding/mod.rs
@@ -58,15 +58,17 @@ pub mod transaction;
 pub mod types;
 
 // Re-export commonly used types
-pub use config::{RebalanceConfig, ShardConfig, ShardDefinition, ShardDiscovery};
-pub use coordinator::{DeadLetteredTransaction, RecoveryResult, ShardConnection, ShardCoordinator};
+pub use config::{ShardConfig, ShardDefinition, ShardDiscovery, ShardRebalanceConfig};
+pub use coordinator::{
+    DeadLetteredTransaction, ShardConnection, ShardCoordinator, ShardRecoveryResult,
+};
 pub use executor::{
     AggregationStrategy, DistributedQuery, ExecutorConfig, ExecutorError, ExecutorResult,
-    ExecutorStats, QueryExecutor, QueryResult, ShardResult,
+    ShardExecutorStats, ShardQueryResult, ShardResult, ShardedQueryExecutor,
 };
 pub use migration::{
     DualWriteRouter, MigrationConfig, MigrationError, MigrationExecutor, MigrationResult,
-    MigrationStats, RoutingToken,
+    RoutingToken, ShardMigrationStats,
 };
 pub use network::{
     CircuitBreaker, CircuitBreakerConfig, CircuitState, ConnectionPool, MigrationBatch,
@@ -77,7 +79,7 @@ pub use persistent_commit_log::{
     CommitLogConfig, CommitLogEntry, CommitLogError, CommitLogResult, CommitLogStats, EntryType,
     PersistentCommitLog,
 };
-pub use rebalance::{MigrationPlan, MigrationProgress, MigrationState, RebalanceManager};
+pub use rebalance::{MigrationPlan, MigrationState, RebalanceManager, ShardMigrationProgress};
 pub use router::{ShardRouter, TraversalPlan, TraversalStep};
 pub use rpc_client::{ClientStats, HttpShardClient, RpcConfig};
 pub use simulation::{EdgeCutAnalysis, ShardingSimulation, SimulationResult};

--- a/src/storage/sharding/rebalance.rs
+++ b/src/storage/sharding/rebalance.rs
@@ -3,7 +3,7 @@
 //! Handles online data migration between shards when they become unbalanced
 //! or when new shards are added to the cluster.
 
-use super::config::RebalanceConfig;
+use super::config::ShardRebalanceConfig;
 use super::types::{ShardId, ShardState};
 use crate::core::id::NodeId;
 use std::collections::{HashMap, VecDeque};
@@ -51,7 +51,7 @@ impl fmt::Display for MigrationState {
 
 /// Progress of a migration operation.
 #[derive(Debug, Clone)]
-pub struct MigrationProgress {
+pub struct ShardMigrationProgress {
     /// Total nodes to migrate.
     pub total_nodes: u64,
     /// Nodes migrated so far.
@@ -70,7 +70,7 @@ pub struct MigrationProgress {
     pub estimated_completion: Option<Instant>,
 }
 
-impl MigrationProgress {
+impl ShardMigrationProgress {
     /// Create a new progress tracker.
     pub fn new(total_nodes: u64, total_edges: u64) -> Self {
         Self {
@@ -143,7 +143,7 @@ pub struct MigrationPlan {
     /// Current state of the migration.
     pub state: MigrationState,
     /// Progress tracking.
-    pub progress: MigrationProgress,
+    pub progress: ShardMigrationProgress,
     /// When this plan was created.
     pub created_at: Instant,
     /// Priority (higher = more urgent).
@@ -197,7 +197,7 @@ impl MigrationPlan {
             labels_to_migrate: labels,
             nodes_to_migrate: None,
             state: MigrationState::Planned,
-            progress: MigrationProgress::new(estimated_nodes, estimated_edges),
+            progress: ShardMigrationProgress::new(estimated_nodes, estimated_edges),
             created_at: Instant::now(),
             priority: 1,
             reason,
@@ -221,7 +221,7 @@ impl MigrationPlan {
             labels_to_migrate: Vec::new(),
             nodes_to_migrate: Some(nodes),
             state: MigrationState::Planned,
-            progress: MigrationProgress::new(num_nodes, estimated_edges),
+            progress: ShardMigrationProgress::new(num_nodes, estimated_edges),
             created_at: Instant::now(),
             priority: 1,
             reason,
@@ -372,7 +372,7 @@ impl std::error::Error for RebalanceError {}
 /// Manager for coordinating shard rebalancing operations.
 pub struct RebalanceManager {
     /// Configuration for rebalancing.
-    config: RebalanceConfig,
+    config: ShardRebalanceConfig,
     /// Queue of planned migrations.
     migration_queue: VecDeque<MigrationPlan>,
     /// Currently active migrations.
@@ -389,7 +389,7 @@ pub struct RebalanceManager {
 
 impl RebalanceManager {
     /// Create a new rebalance manager.
-    pub fn new(config: RebalanceConfig) -> Self {
+    pub fn new(config: ShardRebalanceConfig) -> Self {
         Self {
             config,
             migration_queue: VecDeque::new(),
@@ -664,7 +664,7 @@ mod tests {
 
     #[test]
     fn test_migration_progress() {
-        let mut progress = MigrationProgress::new(100, 200);
+        let mut progress = ShardMigrationProgress::new(100, 200);
         assert_eq!(progress.percentage(), 0.0);
         assert!(!progress.is_complete());
 
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn test_migration_progress_error_tracking() {
-        let mut progress = MigrationProgress::new(100, 100);
+        let mut progress = ShardMigrationProgress::new(100, 100);
         assert_eq!(progress.errors, 0);
 
         progress.record_error();
@@ -800,7 +800,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_creation() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let manager = RebalanceManager::new(config);
 
         assert_eq!(manager.active_count(), 0);
@@ -810,7 +810,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_plan_rebalance() {
-        let config = RebalanceConfig::new().with_imbalance_threshold(0.3);
+        let config = ShardRebalanceConfig::new().with_imbalance_threshold(0.3);
         let mut manager = RebalanceManager::new(config);
 
         let states = vec![make_shard_state(0, 1000), make_shard_state(1, 100)];
@@ -826,7 +826,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_cooldown() {
-        let config = RebalanceConfig::new().with_cooldown(Duration::from_secs(3600));
+        let config = ShardRebalanceConfig::new().with_cooldown(Duration::from_secs(3600));
         let mut manager = RebalanceManager::new(config);
 
         let states = vec![make_shard_state(0, 1000), make_shard_state(1, 100)];
@@ -850,7 +850,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_queue_migration() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         let plan1 = MigrationPlan::new(
@@ -887,7 +887,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_start_migration() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         let plan = MigrationPlan::new(
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_max_concurrent() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         // Queue multiple migrations
@@ -945,7 +945,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_advance_migration() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         let plan = MigrationPlan::new(
@@ -976,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_update_progress() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         let plan = MigrationPlan::new(
@@ -1001,7 +1001,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_fail_migration() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         let plan = MigrationPlan::new(
@@ -1026,7 +1026,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_cancel_migration() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let mut manager = RebalanceManager::new(config);
 
         // Cancel from queue
@@ -1083,7 +1083,7 @@ mod tests {
 
     #[test]
     fn test_rebalance_manager_debug() {
-        let config = RebalanceConfig::new();
+        let config = ShardRebalanceConfig::new();
         let manager = RebalanceManager::new(config);
         let debug = format!("{:?}", manager);
         assert!(debug.contains("RebalanceManager"));


### PR DESCRIPTION
🕸️ **Tangle**: 
Various structs across the codebase shared identical generic names (e.g. `QueryExecutor`, `QueryResult`, `RebalanceConfig`, `MigrationStats`, `ExecutorStats`, `Pattern`), resulting in compiler ambiguity during imports and leaking domain logic across module boundaries.

📐 **Blueprint**: 
Renamed these duplicated structs to use domain-specific names enforcing strict boundaries. For example:
- `QueryExecutor` in `sharding` -> `ShardedQueryExecutor`
- `QueryResult` in `sharding` -> `ShardQueryResult`
- `MigrationProgress` in `sharding` -> `ShardMigrationProgress`
- `RebalanceConfig` -> `ShardRebalanceConfig`
- `CircuitBreakerConfig` -> `DistributedCircuitBreakerConfig`
- `Pattern` in `gestalt.rs` -> `GestaltPattern`
- Disambiguated experimental components (`Chronos` -> `ChronosEngine`, `Sherlock` -> `SherlockEngine`).

Note: Attempted to disambiguate `Config` aliases in the `honeycomb`/`prometheus` observability modules but halted that specific attempt as it required excessive structural alterations that broke tightly coupled internal type aliases. Prioritizing safe boundary enforcement for core/sharding logic.

🧱 **Stability**: 
Reduced naming ambiguity; zero logical alterations. 

🔬 **Verification**: 
Confirmed cleanly compiles with `cargo check --all-targets --all-features` and tests pass without regressions.

---
*PR created automatically by Jules for task [9576059335224914132](https://jules.google.com/task/9576059335224914132) started by @madmax983*