### PR TITLE
⚡ Bolt: Combine O(N) filter iterations in rebalance.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,6 @@
 **Optimize Tokenization in Temporal Parser**
 **Learning:** `tokenize_temporal_keywords` in `src/sql/temporal_parser.rs` previously copied substrings by manually advancing through a `char_indices().collect::<Vec<_>>()` and creating a `String` inside loops (`let word: String = chars[start..i].iter().map(|(_, c)| c).collect()`). This resulted in a heap allocation for every word parsed.
 **Action:** Used `sql.char_indices().peekable()` instead of collecting it. Leveraged `.len_utf8()` to calculate byte boundaries on the fly without allocations. Used a string slice `&sql[start..end]` to avoid `String` allocation for every word parsed, making parsing `0-cost` for non-matching tokens.
+**Optimize filter passes over collections**
+**Learning:** Found two O(N) chained `.iter().filter().collect()` passes iterating over `shard_states` in `src/storage/sharding/rebalance.rs` to separate elements into `overloaded` and `underloaded` vectors. The float threshold math was also being recalculated per item inside the closures.
+**Action:** Replace multiple sequential `.filter().collect()` passes with a single `for` loop that hoists invariant math outside the loop and uses `push()` with mutually exclusive `if / else if` branches to partition the data in exactly one pass.

--- a/src/storage/sharding/rebalance.rs
+++ b/src/storage/sharding/rebalance.rs
@@ -427,19 +427,21 @@ impl RebalanceManager {
         let avg_nodes = total_nodes / shard_states.len() as u64;
 
         // Find overloaded and underloaded shards
-        let mut overloaded: Vec<&ShardState> = shard_states
-            .iter()
-            .filter(|s| {
-                s.node_count as f64 > avg_nodes as f64 * (1.0 + self.config.imbalance_threshold)
-            })
-            .collect();
+        // ⚡ Bolt Optimization: Combines two O(N) `.filter().collect()` passes into a single loop
+        // over `shard_states`, correctly hoisting float math outside of the loop.
+        let mut overloaded = Vec::new();
+        let mut underloaded = Vec::new();
+        let upper_threshold = avg_nodes as f64 * (1.0 + self.config.imbalance_threshold);
+        let lower_threshold = avg_nodes as f64 * (1.0 - self.config.imbalance_threshold);
 
-        let mut underloaded: Vec<&ShardState> = shard_states
-            .iter()
-            .filter(|s| {
-                (s.node_count as f64) < avg_nodes as f64 * (1.0 - self.config.imbalance_threshold)
-            })
-            .collect();
+        for s in shard_states {
+            let count = s.node_count as f64;
+            if count > upper_threshold {
+                overloaded.push(s);
+            } else if count < lower_threshold {
+                underloaded.push(s);
+            }
+        }
 
         // Sort by severity
         overloaded.sort_by_key(|s| std::cmp::Reverse(s.node_count));


### PR DESCRIPTION
💡 **What:** Replaced two sequential `O(N)` `iter().filter().collect()` passes with a single `for` loop in `src/storage/sharding/rebalance.rs`, calculating `overloaded` and `underloaded` shard states simultaneously.
🎯 **Why:** The previous approach required two full iterations over `shard_states` and redundantly performed the same floating-point threshold calculations (e.g., `avg_nodes as f64 * (1.0 + self.config.imbalance_threshold)`) inside the filter closures for every item. By hoisting these invariant calculations outside the loop and partitioning the data in one pass, we eliminate unnecessary compute and iteration overhead.
📊 **Impact:** Reduces iteration count by 50% and eliminates redundant floating-point math during sharding rebalance planning. Memory usage is similar but slightly improved by pre-allocating `Vec::new()` without invoking `.collect()`, which drops exact size hints when `.filter()` is used in the chain.
🔬 **Measurement:** Run `cargo test --lib` (specifically `storage::sharding::rebalance::tests`) to verify functional equivalence. Profile migration planning with a large number of simulated shards.

---
*PR created automatically by Jules for task [2173281262822626245](https://jules.google.com/task/2173281262822626245) started by @madmax983*