### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ AletheiaDB tracks both **valid time** (when facts were true in reality) and **tr
 
 ## Quick Start
 
+> # ⚠️ REQUIRES FEATURE NOVA
+>
+> If you are trying to use `NarrativeGenerator` or run `story_demo`, you MUST enable the `nova` feature in your `Cargo.toml`.
+
+
 ### Prerequisites
 
 - Rust 1.92+ (edition 2024)


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the `story_demo` example from the README. Compiler said `NarrativeGenerator` not found, leaving me stuck right out of the gate.
🕵️‍♂️ **The Reality:** Turns out I needed to explicitly enable the experimental `nova` feature flag in Cargo.toml.
💡 **The Fix:** Added a huge warning banner right at the top of the Quick Start section explicitly telling users they must enable the feature flag for Narrative Generation to work.

---
*PR created automatically by Jules for task [16830091632829296869](https://jules.google.com/task/16830091632829296869) started by @madmax983*