### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vector capacity during float list parsing

### DIFF
--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -443,7 +443,10 @@ impl Parser {
     }
 
     fn parse_float_list(&mut self) -> Result<Vec<f32>, ParseError> {
-        let mut values = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate capacity for typical vector embeddings.
+        // Most embeddings are at least 128 dimensions. Pre-allocating avoids
+        // O(log N) heap reallocations during parsing of large arrays.
+        let mut values = Vec::with_capacity(128);
 
         loop {
             let value = match self.current() {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -443,10 +443,7 @@ impl Parser {
     }
 
     fn parse_float_list(&mut self) -> Result<Vec<f32>, ParseError> {
-        // ⚡ Bolt Optimization: Pre-allocate capacity for typical vector embeddings.
-        // Most embeddings are at least 128 dimensions. Pre-allocating avoids
-        // O(log N) heap reallocations during parsing of large arrays.
-        let mut values = Vec::with_capacity(128);
+        let mut values = Vec::with_capacity(128); // ⚡ Bolt Optimization: Pre-allocate capacity for typical vector embeddings to avoid O(log N) heap reallocations during parsing of large arrays.
 
         loop {
             let value = match self.current() {


### PR DESCRIPTION
💡 **What**: The optimization changes `Vec::new()` to `Vec::with_capacity(128)` inside the `parse_float_list` function of the query parser (`src/query/parser.rs`).

🎯 **Why**: This function parses lists of floating-point numbers which, in the context of AletheiaDB, are almost exclusively used to represent vector embeddings. Vector embeddings are typically large (e.g., 128, 384, 1536 dimensions). Because `Vec::new()` creates a vector with a capacity of 0, pushing 128+ floats requires multiple automatic heap reallocations (0 -> 4 -> 8 -> 16 -> 32 -> 64 -> 128), which is an O(log N) penalty during a hot parsing path.

📊 **Impact**: This reduces the number of heap allocations and memory copies during the parsing of array literals inside the Cypher/SQL queries. It pre-allocates 512 bytes on the heap instantly. This improves the performance of ingestion pipelines sending vector embeddings inline.

🔬 **Measurement**: Verified the logic is sound. We can measure this by running heavy ingestion workloads inserting nodes with literal vectors and tracking memory allocators or measuring the parsing throughput via `cargo bench`. Tests were verified via `cargo test --lib query::parser`.

---
*PR created automatically by Jules for task [833012301462653677](https://jules.google.com/task/833012301462653677) started by @madmax983*