### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations in Horizon BFS

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,7 @@
 **[Zero-Cost Lexer Lookahead]**
 **Learning:** `Peekable::clone()` is not a zero-cost abstraction when parsing strings, especially since it clones the underlying iterator state on every single token. For simple ASCII characters (like `-`, `/`, `*`, `0`..`9`), `input.as_bytes().get(idx + 1)` is much faster and completely avoids heap allocations and iterator cloning overhead.
 **Action:** When doing lookaheads in a lexer over a `String` or `&str`, prefer slicing the underlying byte array `as_bytes()` if the characters you're looking for are strictly single-byte ASCII.
+**Removed Vec allocations with Iterator Chaining**\n**Learning:** Gathering iterators using  just to iterate over their combination causes unnecessary heap allocations inside tight loops (like a BFS traversal).\n**Action:** Use  to lazily iterate over multiple sources directly and maintain zero-cost abstractions.
+**Removed Vec allocations with Iterator Chaining**
+**Learning:** Gathering iterators using `.collect::<Vec<_>>()` just to iterate over their combination causes unnecessary heap allocations inside tight loops (like a BFS traversal).
+**Action:** Use `.chain()` to lazily iterate over multiple sources directly and maintain zero-cost abstractions.

--- a/src/experimental/horizon.rs
+++ b/src/experimental/horizon.rs
@@ -111,21 +111,19 @@ impl<'a> HorizonEngine<'a> {
                 }
 
                 // Get all neighbors (both outgoing and incoming for true semantic reach)
-                let mut neighbors = tx
+                let outgoing = tx
                     .get_outgoing_edges(current_node_id)
                     .into_iter()
-                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target))
-                    .collect::<Vec<_>>();
+                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target));
 
                 let incoming = tx
                     .get_incoming_edges(current_node_id)
                     .into_iter()
-                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source))
-                    .collect::<Vec<_>>();
+                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source));
 
-                neighbors.extend(incoming);
-
-                for neighbor_id in neighbors {
+                // Bolt Optimization: Chain incoming and outgoing iterators directly
+                // to eliminate two intermediate Vec allocations per node during BFS.
+                for neighbor_id in outgoing.chain(incoming) {
                     if visited.contains(&neighbor_id) {
                         continue;
                     }


### PR DESCRIPTION
💡 What: Replaced two intermediate `.collect::<Vec<_>>()` calls with `.chain()` in the `HorizonEngine::map_horizon` BFS traversal.
🎯 Why: The previous implementation unnecessarily allocated two vectors per traversed node just to combine incoming and outgoing edges for the loop, which introduced heap allocation overhead inside a hot path.
📊 Impact: Eliminates two heap allocations per node visited during the BFS traversal, improving traversal speed and reducing memory pressure without changing behavior.
🔬 Measurement: Verify there are no regressions by running `cargo test --all-features experimental::horizon`.

---
*PR created automatically by Jules for task [16839224830015327574](https://jules.google.com/task/16839224830015327574) started by @madmax983*