### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -102,7 +102,7 @@ impl AletheiaDB {
                     crate::core::error::VectorError::IndexError(
                         "HNSW configuration is required when no vector index exists. \
                      Use TemporalVectorConfig::default_with_hnsw() to provide one, \
-                     or enable the vector index first with enable_vector_index()."
+                     or enable the vector index first with db.vector_index(\"...\").hnsw(...).enable()."
                             .to_string(),
                     ),
                 ));

--- a/src/experimental/fishing.rs
+++ b/src/experimental/fishing.rs
@@ -124,7 +124,7 @@ impl<'a> FishingRod<'a> {
                     } else {
                         return Err(crate::core::error::Error::Vector(
                             crate::core::error::VectorError::IndexError(
-                                "No vector indexes configured. Call enable_vector_index() first."
+                                "No vector indexes configured. Call db.vector_index(\"...\").hnsw(...).enable() first."
                                     .to_string(),
                             ),
                         ));

--- a/src/query/executor/mod.rs
+++ b/src/query/executor/mod.rs
@@ -400,7 +400,7 @@ impl QueryExecutor {
         // 1. Validate that property_key matches the indexed property
         let indexed_property = self.current.get_indexed_property_name().ok_or_else(|| {
             crate::core::error::Error::Query(crate::core::error::QueryError::ExecutionError {
-                message: "No vector index is enabled. Call enable_vector_index() first."
+                message: "No vector index is enabled. Call db.vector_index(\"...\").hnsw(...).enable() first."
                     .to_string(),
             })
         })?;

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2139,7 +2139,7 @@ impl CurrentStorage {
         } else {
             self.get_default_vector_property_name().ok_or_else(|| {
                 crate::core::error::Error::Vector(crate::core::error::VectorError::IndexError(
-                    "Vector index is not enabled. Call enable_vector_index() first.".to_string(),
+                    "Vector index is not enabled. Call db.vector_index(\"...\").hnsw(...).enable() first.".to_string(),
                 ))
             })?
         };


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the examples from the README.md and the `IndexNotFound` and related error messages use the old API `db.enable_vector_index(..., config)` which confused me immensely when trying to set up vector indexing.

🕵️ **The Reality:** Several files (`src/experimental/fishing.rs`, `src/query/executor/mod.rs`, `src/storage/current/mod.rs`, `src/db/vector.rs`) were still hardcoding hints pointing to the old API (`enable_vector_index()`).

💡 **The Fix:** Changed the hint messages in those files to use the modern fluent API: `Call db.vector_index(\"...\").hnsw(...).enable() first.`.

---
*PR created automatically by Jules for task [18261833865403587330](https://jules.google.com/task/18261833865403587330) started by @madmax983*