### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -96,3 +96,6 @@
 ## 2024-04-07 - [QueryResults API Confusion]
 **Confusion:** The query execution API was opaque, returning raw struct definitions for `QueryResults`, `QueryResult`, and `QueryRow` without context. Users were likely confused about when to use the lazy iterator versus the eagerly evaluated batch objects, and how context like scores, paths, and timestamps fit into rows instead of raw nodes.
 **Clarification:** Added module-level documentation (`//!`) to explain the "Journey of a Result" from planner to materialized structures. Supplemented struct definitions with `///` comments explaining the *why* (e.g. "Why? Use this when the expected result set is small"). Also added executable doctests for `consume_results`, `QueryRow::from_entity`, and `QueryRow::with_score`.
+## 2024-04-12 - Documenting AletheiaDB
+**Confusion:** The `ShardConnection` constructor needs `ShardId::new(...).unwrap()` instead of `ShardId(...)` or `ShardId::new_unchecked(...)` because the tuple fields and the `new_unchecked` method are private.
+**Clarification:** Updated doctests to use `ShardId::new(1).unwrap()` explicitly.

--- a/plan.md
+++ b/plan.md
@@ -1,3 +1,0 @@
-1. Make sure to commit the `.jules/bolt.md` learning if applicable.
-2. Complete pre-commit checks: testing, verification, review, and reflection.
-3. Submit a pull request.

--- a/src/experimental/temporal_diff.rs
+++ b/src/experimental/temporal_diff.rs
@@ -10,8 +10,20 @@ use crate::core::property::PropertyMap;
 use crate::core::temporal::Timestamp;
 use std::collections::HashMap;
 
-/// A report of changes between two timestamps.
+/// A report detailing the changes between two timestamps.
 #[derive(Debug, Clone)]
+///
+/// # Examples
+/// ```
+/// use aletheiadb::experimental::temporal_diff::DiffReport;
+/// use aletheiadb::core::temporal::Timestamp;
+///
+/// let report = DiffReport {
+///     t1: Timestamp::from(0),
+///     t2: Timestamp::from(100),
+///     changes: vec![],
+/// };
+/// ```
 pub struct DiffReport {
     /// The first timestamp (baseline).
     pub t1: Timestamp,
@@ -66,8 +78,24 @@ pub enum ChangeType {
     },
 }
 
-/// Difference in properties.
+/// Represents the difference between two property maps.
 #[derive(Debug, Clone, Default)]
+///
+/// # Examples
+/// ```
+/// use aletheiadb::experimental::temporal_diff::PropertyDiff;
+/// use std::collections::HashMap;
+///
+/// let mut changed = HashMap::new();
+/// changed.insert("status".to_string(), ("old".to_string(), "new".to_string()));
+///
+/// let diff = PropertyDiff {
+///     added: vec!["created_at".to_string()],
+///     removed: vec![],
+///     changed,
+/// };
+/// assert!(!diff.is_empty());
+/// ```
 pub struct PropertyDiff {
     /// Keys added in the new version.
     pub added: Vec<String>,
@@ -77,7 +105,18 @@ pub struct PropertyDiff {
     pub changed: HashMap<String, (String, String)>,
 }
 
-/// The Temporal Diff Engine.
+/// Engine for computing temporal diffs on a graph.
+///
+/// # Examples
+/// ```
+/// use aletheiadb::AletheiaDB;
+/// use aletheiadb::experimental::temporal_diff::TemporalDiff;
+///
+/// fn main() {
+///     let db = AletheiaDB::new().unwrap();
+///     let engine = TemporalDiff::new(&db);
+/// }
+/// ```
 pub struct TemporalDiff<'a> {
     db: &'a AletheiaDB,
 }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -72,11 +72,30 @@ pub struct RecoveryResult {
 
 impl RecoveryResult {
     /// Check if recovery was fully successful (no dead letters).
+    ///
+    /// This is useful to determine if automated recovery finished cleanly,
+    /// or if manual intervention is required to resolve stuck transactions.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::coordinator::RecoveryResult;
+    ///
+    /// let result = RecoveryResult { recovered: vec![], dead_lettered: vec![] };
+    /// assert!(result.is_complete());
+    /// ```
     pub fn is_complete(&self) -> bool {
         self.dead_lettered.is_empty()
     }
 
     /// Get the number of transactions that required manual intervention.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::coordinator::RecoveryResult;
+    ///
+    /// let result = RecoveryResult { recovered: vec![], dead_lettered: vec![] };
+    /// assert_eq!(result.dead_letter_count(), 0);
+    /// ```
     pub fn dead_letter_count(&self) -> usize {
         self.dead_lettered.len()
     }
@@ -112,6 +131,19 @@ pub struct ShardConnection {
 
 impl ShardConnection {
     /// Create a new shard connection.
+    ///
+    /// This establishes the metadata necessary for the coordinator to
+    /// communicate with a remote shard during distributed queries and transactions.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::coordinator::ShardConnection;
+    /// use aletheiadb::storage::sharding::types::ShardId;
+    ///
+    /// let shard_id = ShardId::new(1).unwrap();
+    /// let conn = ShardConnection::new(shard_id, "127.0.0.1:8080".to_string());
+    /// assert_eq!(conn.shard_id, shard_id);
+    /// ```
     pub fn new(shard_id: ShardId, endpoint: String) -> Self {
         Self {
             shard_id,

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -130,6 +130,23 @@ pub enum EntryType {
 
 impl CommitLogEntry {
     /// Create a commit entry.
+    ///
+    /// This is used during the Two-Phase Commit protocol when all participants
+    /// have successfully voted to commit. It serves as the durable record
+    /// that the transaction should be applied, allowing recovery to succeed
+    /// even if the coordinator crashes immediately after.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::persistent_commit_log::CommitLogEntry;
+    /// use aletheiadb::core::id::TxId;
+    /// use aletheiadb::storage::sharding::types::ShardId;
+    /// use aletheiadb::core::temporal::time;
+    ///
+    /// let tx_id = TxId::new(42);
+    /// let shard = ShardId::new(1).unwrap();
+    /// let entry = CommitLogEntry::commit(1, tx_id, vec![shard], Some(time::now()));
+    /// ```
     pub fn commit(
         lsn: u64,
         tx_id: TxId,
@@ -147,6 +164,21 @@ impl CommitLogEntry {
     }
 
     /// Create an abort entry.
+    ///
+    /// This is used when a transaction fails or times out during the
+    /// prepare phase. Writing this ensures the coordinator remembers
+    /// not to commit this transaction upon recovery.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::persistent_commit_log::CommitLogEntry;
+    /// use aletheiadb::core::id::TxId;
+    /// use aletheiadb::storage::sharding::types::ShardId;
+    ///
+    /// let tx_id = TxId::new(42);
+    /// let shard = ShardId::new(1).unwrap();
+    /// let entry = CommitLogEntry::abort(2, tx_id, vec![shard]);
+    /// ```
     pub fn abort(lsn: u64, tx_id: TxId, participants: Vec<ShardId>) -> Self {
         Self {
             lsn,
@@ -159,6 +191,20 @@ impl CommitLogEntry {
     }
 
     /// Create a completion entry.
+    ///
+    /// This indicates that the 2PC protocol is fully complete for this
+    /// transaction (all shards have acknowledged the commit/abort decision).
+    /// This allows the coordinator to garbage-collect the transaction
+    /// state from memory.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::persistent_commit_log::CommitLogEntry;
+    /// use aletheiadb::core::id::TxId;
+    ///
+    /// let tx_id = TxId::new(42);
+    /// let entry = CommitLogEntry::complete(3, tx_id);
+    /// ```
     pub fn complete(lsn: u64, tx_id: TxId) -> Self {
         Self {
             lsn,
@@ -171,6 +217,17 @@ impl CommitLogEntry {
     }
 
     /// Serialize the entry to bytes.
+    ///
+    /// # Examples
+    /// ```
+    /// use aletheiadb::storage::sharding::persistent_commit_log::CommitLogEntry;
+    /// use aletheiadb::core::id::TxId;
+    ///
+    /// let tx_id = TxId::new(42);
+    /// let entry = CommitLogEntry::complete(3, tx_id);
+    /// let bytes = entry.serialize();
+    /// assert!(!bytes.is_empty());
+    /// ```
     pub fn serialize(&self) -> Vec<u8> {
         let mut data = Vec::with_capacity(64);
 


### PR DESCRIPTION
📖 Chapter: Documenting the `temporal_diff.rs`, `coordinator.rs`, and `persistent_commit_log.rs` modules.
💡 Insight: Added explanations of why structures like `CommitLogEntry::commit`, `CommitLogEntry::abort`, and `ShardConnection` exist to help guide engineers reading the API. Also documented `ShardId` initialization pain points in `.jules/bard.md`.
🧪 Example: Added multiple executable doctests across structs and methods.

---
*PR created automatically by Jules for task [8021661206218021733](https://jules.google.com/task/8021661206218021733) started by @madmax983*