### PR TITLE
🪒 Razor: De-abstract `Resonator` trait in echo module

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** The "One-Time" Trait `Resonator` in `src/experimental/echo.rs` was only implemented by one struct (`ActivityDensityResonator`).
+**Cut:** Removed the `Resonator` trait entirely, implementing the `resonate` method directly on `ActivityDensityResonator`, and using the concrete struct in `EchoChamber` instead of dynamic dispatch (`Box<dyn Resonator>`).
+**Saved:** Unnecessary trait abstraction, trait bounds, dynamic dispatch overhead, and cognitive load for a single-use pattern.

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -196,7 +191,7 @@ impl Resonator for ActivityDensityResonator {
 /// ```
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -239,13 +234,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -306,7 +301,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );
@@ -469,9 +464,7 @@ mod stub_tests {
         let chamber = EchoChamber {
             _marker: std::marker::PhantomData,
         };
-        // We need a dummy resonator. Since Resonator trait is public but ActivityDensityResonator is only stubbed out...
-        // Actually ActivityDensityResonator is not gated?
-        // Let's check the code above. ActivityDensityResonator struct definition is NOT gated.
+        // ActivityDensityResonator struct definition is NOT gated.
         // So we can use it.
         let resonator = ActivityDensityResonator::default();
         let _ = chamber.with_resonator(resonator);


### PR DESCRIPTION
This PR enforces the KISS principle by eliminating a "One-Time" trait abstraction within the experimental modules.

## Changes Made
- Deleted the `Resonator` trait in `src/experimental/echo.rs`.
- Moved the `resonate` method directly onto the single implementing struct, `ActivityDensityResonator`.
- Refactored `EchoChamber` to hold an `ActivityDensityResonator` directly instead of allocating a `Box<dyn Resonator>`.
- Updated all related methods (`new`, `with_resonator`), doctests, and test suites.
- Added a journal entry to `.jules/razor.md` detailing the reduction.

## Impact
- Reduced cognitive load by deleting boilerplate.
- Removed the overhead of dynamic dispatch (`Box<dyn>`).
- Simplifies the architecture.

---
*PR created automatically by Jules for task [12219345995979711596](https://jules.google.com/task/12219345995979711596) started by @madmax983*