### PR TITLE
⚡ Bolt: Iterator chaining over unnecessary vector allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -54,3 +54,7 @@
 **[Zero-Cost Lexer Lookahead]**
 **Learning:** `Peekable::clone()` is not a zero-cost abstraction when parsing strings, especially since it clones the underlying iterator state on every single token. For simple ASCII characters (like `-`, `/`, `*`, `0`..`9`), `input.as_bytes().get(idx + 1)` is much faster and completely avoids heap allocations and iterator cloning overhead.
 **Action:** When doing lookaheads in a lexer over a `String` or `&str`, prefer slicing the underlying byte array `as_bytes()` if the characters you're looking for are strictly single-byte ASCII.
+
+**[Iterator chaining over unnecessary vector allocation]**
+**Learning:** Collecting iterators into intermediate vectors (`.collect::<Vec<_>>().extend(...)`) to combine them is an anti-pattern. The standard library provides `.chain()` which merges iterators directly with zero heap allocations and is functionally equivalent.
+**Action:** When merging multiple collections or iterators, always consider `.chain()` instead of intermediate `Vec` collections. This prevents redundant memory allocations and overhead.

--- a/src/experimental/horizon.rs
+++ b/src/experimental/horizon.rs
@@ -111,21 +111,22 @@ impl<'a> HorizonEngine<'a> {
                 }
 
                 // Get all neighbors (both outgoing and incoming for true semantic reach)
-                let mut neighbors = tx
+                let outgoing = tx
                     .get_outgoing_edges(current_node_id)
                     .into_iter()
-                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target))
-                    .collect::<Vec<_>>();
+                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target));
 
                 let incoming = tx
                     .get_incoming_edges(current_node_id)
                     .into_iter()
-                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source))
-                    .collect::<Vec<_>>();
+                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source));
 
-                neighbors.extend(incoming);
+                // ⚡ Bolt optimization: Use `.chain()` instead of intermediate `.collect::<Vec<_>>()`
+                // followed by `.extend()`. This merges the two edge iterators dynamically, avoiding
+                // two unnecessary heap allocations per explored node on the hot path of the BFS traversal.
+                let all_neighbors = outgoing.chain(incoming);
 
-                for neighbor_id in neighbors {
+                for neighbor_id in all_neighbors {
                     if visited.contains(&neighbor_id) {
                         continue;
                     }


### PR DESCRIPTION
💡 **What:** Replaced intermediate vector allocation (`.collect::<Vec<_>>().extend(...)`) with dynamic iterator merging using `.chain()`.
🎯 **Why:** Merging edge iterators with `.collect::<Vec<_>>()` forced two unnecessary heap allocations per explored node inside the inner loop of the `HorizonEngine` BFS algorithm.
📊 **Impact:** Reduces heap allocations and overhead dynamically on the hot path. 
🔬 **Measurement:** Test by running `cargo test --lib --all-features experimental::horizon::tests::test_horizon_mapping -- --exact`.

---
*PR created automatically by Jules for task [5260753522994645557](https://jules.google.com/task/5260753522994645557) started by @madmax983*