### PR TITLE
🛡️ Sentry: [SparseVector serialized size coverage]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -26,3 +26,7 @@
 **[Temporal TimeRange Max Timestamp and Deserialize Mutants]**
 **Learning:** `cargo mutants` revealed missing test coverage for `MAX_VALID_TIMESTAMP` bounds checking in open ranges (`TimeRange::from` and `TimeRange::at`), empty range overlap edge cases (`TimeRange::overlaps` short-circuit behavior), and deserialization stringency (`BiTemporalInterval::deserialize` exact consumed length checking against buffer size `> 48`).
 **Action:** Added targeted unit tests checking `#[should_panic]` when `MAX_VALID_TIMESTAMP` is exceeded, explicitly testing overlap between empty point-ranges within larger non-empty ranges, and appending excess bytes to binary formats to verify exact parser length consumption limits.
+
+## SparseVector Size Serialization Gap
+**Learning:** When a new variant like `SparseVector` is added to an enum (like `PropertyValue`) with a manual recursive size predictor (`serialized_size_recursive`), it is critical to explicitly add it to the table-driven serialization size tests (e.g. `test_serialized_size_matches_actual`). Missing this coverage can lead to silent regressions where the predicted size under-allocates or over-allocates the serialization buffer, potentially causing panics.
+**Action:** Always cross-reference enum definitions against serialization table tests to guarantee 100% variant coverage when implementing custom size tracking.

--- a/plan.md
+++ b/plan.md
@@ -1,3 +1,0 @@
-1. Make sure to commit the `.jules/bolt.md` learning if applicable.
-2. Complete pre-commit checks: testing, verification, review, and reflection.
-3. Submit a pull request.

--- a/src/core/property.rs
+++ b/src/core/property.rs
@@ -3240,6 +3240,12 @@ mod tests {
                 1 + 4 + 9 + (1 + 4 + 6), // tag + count + (tag + int) + (tag + len + "nested")
             ),
             (PropertyValue::vector([1.0f32, 2.0, 3.0]), 1 + 4 + 12), // tag + len + 3 * 4 bytes
+            (
+                PropertyValue::SparseVector(Arc::new(
+                    crate::core::vector::SparseVec::new(vec![0, 2], vec![1.0, 3.0], 5).unwrap(),
+                )),
+                1 + 4 + 4 + (2 * 8), // tag (1) + dim (4) + nnz (4) + indices/values (2 * 8 bytes)
+            ),
         ];
 
         for (value, expected_size) in values {


### PR DESCRIPTION
🎯 **Target:** `src/core/property.rs` -> `test_serialized_size_matches_actual` and `PropertyValue::SparseVector`.

💣 **Risk:** The `test_serialized_size_matches_actual` test was incomplete. It did not cover the newly added `PropertyValue::SparseVector` variant. If `serialized_size_recursive` drifted from the actual byte length output of `serialize_into`, it could cause severe, silent data corruption or panics during buffer pre-allocation in production.

🧪 **Strategy:** Added the missing `PropertyValue::SparseVector` instance to the table-driven test cases alongside a manual, deterministic footprint calculation (`1 + 4 + 4 + (2 * 8)`) to enforce parity between the predictor and the actual serializer.

🔬 **Verification:** Run `cargo test -p aletheiadb --lib core::property::tests::test_serialized_size_matches_actual`

---
*PR created automatically by Jules for task [13548418821898495617](https://jules.google.com/task/13548418821898495617) started by @madmax983*