### PR TITLE
🪒 Razor: [Reduction] Remove single-implementation traits in experimental modules

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,13 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `Resonator` trait in `src/experimental/echo.rs` (Single-implementation abstraction used only by `ActivityDensityResonator`).
+**Cut:** Deleted the `Resonator` trait. Refactored `EchoChamber` to use the concrete `ActivityDensityResonator` struct directly.
+**Saved:** ~10 lines of trait definition + dynamic dispatch overhead in experimental module.
+
+## [Reduction]
+**Bloat:** `PropagationModel` trait in `src/experimental/sybil.rs` (Single-implementation abstraction used only by `LinearPropagation`).
+**Cut:** Deleted the `PropagationModel` trait. Refactored `Sybil::simulate` to use the concrete `LinearPropagation` struct directly.
+**Saved:** ~10 lines of trait definition + cognitive load of generic abstractions.

--- a/patch_echo.py
+++ b/patch_echo.py
@@ -1,0 +1,22 @@
+import sys
+
+with open("src/experimental/echo.rs", "r") as f:
+    content = f.read()
+
+to_remove = """pub trait Resonator {
+    /// Generate a fingerprint from the given history.
+    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
+}
+
+"""
+content = content.replace(to_remove, "")
+content = content.replace("impl Resonator for ActivityDensityResonator {", "impl ActivityDensityResonator {")
+content = content.replace("    fn resonate(&self", "    /// Generate a fingerprint from the given history.\n    pub fn resonate(&self")
+content = content.replace("resonator: Box<dyn Resonator>,", "resonator: ActivityDensityResonator,")
+content = content.replace("resonator: Box::new(ActivityDensityResonator::default()),", "resonator: ActivityDensityResonator::default(),")
+content = content.replace("pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {", "pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {")
+content = content.replace("self.resonator = Box::new(resonator);", "self.resonator = resonator;")
+content = content.replace("pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {", "pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {")
+
+with open("src/experimental/echo.rs", "w") as f:
+    f.write(content)

--- a/patch_sybil.py
+++ b/patch_sybil.py
@@ -1,0 +1,33 @@
+import sys
+
+with open("src/experimental/sybil.rs", "r") as f:
+    content = f.read()
+
+to_remove = """/// Trait for defining how a node's state updates based on its neighbors.
+pub trait PropagationModel {
+    /// Calculate the next state for a node.
+    ///
+    /// # Arguments
+    /// * `node_id` - The node being updated.
+    /// * `current_self` - The node's current vector (if any).
+    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
+    ///
+    /// # Returns
+    /// The new vector state for the node.
+    fn next_state(
+        &self,
+        node_id: NodeId,
+        current_self: Option<&[f32]>,
+        neighbors: &[(NodeId, &[f32])],
+    ) -> Option<Vec<f32>>;
+}
+
+"""
+content = content.replace(to_remove, "")
+content = content.replace("impl PropagationModel for LinearPropagation {", "impl LinearPropagation {")
+content = content.replace("    fn next_state(", "    pub fn next_state(")
+content = content.replace("pub fn simulate<M: PropagationModel>(", "pub fn simulate(")
+content = content.replace("model: &M,", "model: &LinearPropagation,")
+
+with open("src/experimental/sybil.rs", "w") as f:
+    f.write(content)

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -82,11 +82,6 @@ impl TemporalFingerprint {
 }
 
 /// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -124,8 +119,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -196,7 +192,7 @@ impl Resonator for ActivityDensityResonator {
 /// ```
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -239,13 +235,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -306,7 +302,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
Removed single-implementation traits `Resonator` and `PropagationModel` in experimental modules to reduce boilerplate and overhead.

---
*PR created automatically by Jules for task [4228711121215850167](https://jules.google.com/task/4228711121215850167) started by @madmax983*