### PR TITLE
⚡ Bolt: Remove unnecessary clone of ShardResult array

### DIFF
--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -406,7 +406,7 @@ impl<C: ShardClient> QueryExecutor<C> {
 
         self.queries_executed.fetch_add(1, Ordering::Relaxed);
 
-        let shards_succeeded = results.len();
+        let shards_succeeded = results.len(); // Optimization note
 
         Ok(QueryResult {
             query_id: query.id,

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -406,13 +406,15 @@ impl<C: ShardClient> QueryExecutor<C> {
 
         self.queries_executed.fetch_add(1, Ordering::Relaxed);
 
+        let shards_succeeded = results.len();
+
         Ok(QueryResult {
             query_id: query.id,
             data: aggregated,
-            shard_results: results.clone(),
+            shard_results: results,
             total_time,
             shards_queried: target_shards.len(),
-            shards_succeeded: results.len(),
+            shards_succeeded,
             total_results,
         })
     }


### PR DESCRIPTION
💡 What: Removed an unnecessary `.clone()` call on the `results` vector in `src/storage/sharding/executor.rs` during query result aggregation.
🎯 Why: The original code cloned the entire `results` vector (which contains potentially large `Vec<u8>` arrays in `ShardResult` instances) merely because `results.len()` was called on the subsequent line during struct initialization. This led to a use-after-move scenario that the `.clone()` bypassed. By extracting `results.len()` into a temporary variable (`shards_succeeded`) beforehand, we can safely move `results` into the `QueryResult` struct.
📊 Impact: Completely eliminates an O(N) heap allocation and data clone of shard result payloads per distributed query execution.
🔬 Measurement: Run `cargo test --lib storage::sharding::executor` and `cargo check`. No functionality is changed, only the ownership transition is improved.

---
*PR created automatically by Jules for task [5750880072872452040](https://jules.google.com/task/5750880072872452040) started by @madmax983*