### PR TITLE
⚡ Bolt: Optimize BFS traversal by replacing Vec allocations with zero-cost iterator chaining

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -57,3 +57,6 @@
 **[QueryRow Entity Extraction]**
 **Learning:** Destructuring a struct (like `QueryRow`) and pattern matching directly on its owned components (`EntityResult`) inside a loop completely eliminates the need for expensive heap allocations caused by intermediate `.clone()` calls on nested data structures like HashMaps (properties). Rust's move semantics are the ultimate zero-cost abstraction for consuming data iterators.
 **Action:** When mapping over iterators or structs that are fully consumed, never use `as_ref().map(|x| x.clone())`. Instead, destructure the container and take ownership by value.
+**[Zero-cost abstraction for iterator concatenation]**
+**Learning:** In Rust, combining two iterators into a temporary vector using `.collect::<Vec<_>>()` and `.extend()` inside loops causes unnecessary intermediate heap allocations. You can chain iterators without allocations and pass the elements directly to the next loop iterator using `.chain()` which is extremely useful when aggregating items from multiple inputs.
+**Action:** Replaced `.collect::<Vec<_>>()` and `.extend()` with zero-cost chaining `outgoing.chain(incoming)` for graph edge mapping traversal.

--- a/src/experimental/horizon.rs
+++ b/src/experimental/horizon.rs
@@ -111,21 +111,18 @@ impl<'a> HorizonEngine<'a> {
                 }
 
                 // Get all neighbors (both outgoing and incoming for true semantic reach)
-                let mut neighbors = tx
+                let outgoing = tx
                     .get_outgoing_edges(current_node_id)
                     .into_iter()
-                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target))
-                    .collect::<Vec<_>>();
+                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.target));
 
                 let incoming = tx
                     .get_incoming_edges(current_node_id)
                     .into_iter()
-                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source))
-                    .collect::<Vec<_>>();
+                    .filter_map(|e| tx.get_edge(e).ok().map(|edge| edge.source));
 
-                neighbors.extend(incoming);
-
-                for neighbor_id in neighbors {
+                // ⚡ Bolt Optimization: Use zero-cost iterator `.chain()` rather than intermediate `.collect::<Vec<_>>()` calls to avoid multiple heap allocations on the hot path per iteration.
+                for neighbor_id in outgoing.chain(incoming) {
                     if visited.contains(&neighbor_id) {
                         continue;
                     }


### PR DESCRIPTION
💡 **What:** Replaced intermediate `Vec` allocations and `.extend()` calls with zero-cost iterator `.chain()` during BFS edge traversals in `src/experimental/horizon.rs`. Added the learning to `.jules/bolt.md`.
🎯 **Why:** The algorithm was unnecessarily instantiating temporary `Vec` arrays inside a highly active graph traversal `while` loop when combining outgoing and incoming neighbor edges. Iterators can natively be chained together to avoid all intermediate heap allocations entirely.
📊 **Impact:** Reduces heap allocations by a massive degree on deep semantic BFS mapping operations—saving at least two `Vec` allocations per node traversed.
🔬 **Measurement:** Run `cargo test --lib --all-features experimental::horizon::tests::test_horizon_mapping -- --exact` to verify functional correctness, and optionally profile heap allocations locally.

---
*PR created automatically by Jules for task [803025791362973676](https://jules.google.com/task/803025791362973676) started by @madmax983*