### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -96,3 +96,7 @@
 ## 2024-04-07 - [QueryResults API Confusion]
 **Confusion:** The query execution API was opaque, returning raw struct definitions for `QueryResults`, `QueryResult`, and `QueryRow` without context. Users were likely confused about when to use the lazy iterator versus the eagerly evaluated batch objects, and how context like scores, paths, and timestamps fit into rows instead of raw nodes.
 **Clarification:** Added module-level documentation (`//!`) to explain the "Journey of a Result" from planner to materialized structures. Supplemented struct definitions with `///` comments explaining the *why* (e.g. "Why? Use this when the expected result set is small"). Also added executable doctests for `consume_results`, `QueryRow::from_entity`, and `QueryRow::with_score`.
+
+## 2025-03-05 - The Case of the Silent Shard Rebalancer
+**Confusion:** The `src/storage/sharding/rebalance.rs` and `src/storage/sharding/rpc_client.rs` modules lacked any executable examples or context about *why* specific structures existed. Users trying to understand or manually trigger cluster migrations had to read the source code of `RebalanceManager` and guess how it interacts with `MigrationPlan`.
+**Clarification:** Added comprehensive module-level documentation and struct-level `# The Spark` and `# The Details` sections with executable `///` doctests.

--- a/src/storage/sharding/rebalance.rs
+++ b/src/storage/sharding/rebalance.rs
@@ -1,7 +1,17 @@
 //! Shard rebalancing implementation.
 //!
+//! # The Abstract
 //! Handles online data migration between shards when they become unbalanced
-//! or when new shards are added to the cluster.
+//! or when new shards are added to the cluster. This module orchestrates
+//! the lifecycle of a migration, from planning through dual-write dual-commit
+//! phases to the final cutover.
+//!
+//! # The Hero's Journey
+//! When a shard grows too large (exceeding its `imbalance_threshold`), the
+//! `RebalanceManager` drafts a `MigrationPlan`. This plan transitions through
+//! states like `DualWrite` and `Copying`, meticulously tracking its progress
+//! via `MigrationProgress` so that operators can monitor cluster health in
+//! real-time.
 
 use super::config::RebalanceConfig;
 use super::types::{ShardId, ShardState};
@@ -50,6 +60,27 @@ impl fmt::Display for MigrationState {
 }
 
 /// Progress of a migration operation.
+///
+/// # The Spark
+/// Migrating gigabytes of graph data takes time. We need a way to track
+/// exactly how far along the operation is, so operators aren't left guessing
+/// if the cluster is stalled.
+///
+/// # The Details
+/// This struct continuously updates its estimates based on the current transfer
+/// rate. It tracks both nodes and edges separately, as edge migrations often
+/// involve complex cross-shard updates.
+///
+/// # Examples
+/// ```
+/// use aletheiadb::storage::sharding::rebalance::MigrationProgress;
+///
+/// let mut progress = MigrationProgress::new(1000, 5000);
+/// progress.update(100, 500, 1024 * 1024); // 100 nodes, 500 edges, 1MB
+///
+/// assert_eq!(progress.percentage(), 10.0);
+/// assert!(!progress.is_complete());
+/// ```
 #[derive(Debug, Clone)]
 pub struct MigrationProgress {
     /// Total nodes to migrate.
@@ -128,6 +159,34 @@ impl MigrationProgress {
 }
 
 /// A plan for migrating data between shards.
+///
+/// # The Spark
+/// A migration is not a single atomic action; it's a state machine. The
+/// `MigrationPlan` captures the intent (who, what, where) and orchestrates
+/// the safe transition of data between a source and a target.
+///
+/// # The Details
+/// Every plan executes a careful choreography: Dual Write -> Background Copy ->
+/// Verify -> Cutover. This ensures zero downtime and strong consistency during
+/// the cluster rebalancing phase.
+///
+/// # Examples
+/// ```
+/// use aletheiadb::storage::sharding::types::ShardId;
+/// use aletheiadb::storage::sharding::rebalance::{MigrationPlan, MigrationReason, MigrationState};
+///
+/// let plan = MigrationPlan::new(
+///     1,
+///     ShardId::new(0).unwrap(),
+///     ShardId::new(1).unwrap(),
+///     vec!["User".to_string()],
+///     1000,
+///     5000,
+///     MigrationReason::Imbalance,
+/// );
+///
+/// assert_eq!(plan.state, MigrationState::Planned);
+/// ```
 #[derive(Debug, Clone)]
 pub struct MigrationPlan {
     /// Unique identifier for this migration.
@@ -370,6 +429,27 @@ impl fmt::Display for RebalanceError {
 impl std::error::Error for RebalanceError {}
 
 /// Manager for coordinating shard rebalancing operations.
+///
+/// # The Spark
+/// A cluster with unbalanced shards leads to hot spots and tail latency degradation.
+/// The `RebalanceManager` acts as the traffic controller, detecting these hot spots
+/// and scheduling migrations to return the cluster to equilibrium.
+///
+/// # The Details
+/// It maintains queues of planned, active, and completed migrations, enforcing
+/// concurrency limits (`max_concurrent_migrations`) to prevent rebalancing storms
+/// from degrading regular query performance.
+///
+/// # Examples
+/// ```
+/// use aletheiadb::storage::sharding::config::RebalanceConfig;
+/// use aletheiadb::storage::sharding::rebalance::RebalanceManager;
+///
+/// let config = RebalanceConfig::new().with_imbalance_threshold(0.15); // 15% deviation
+/// let mut manager = RebalanceManager::new(config);
+///
+/// assert_eq!(manager.active_count(), 0);
+/// ```
 pub struct RebalanceManager {
     /// Configuration for rebalancing.
     config: RebalanceConfig,

--- a/src/storage/sharding/rpc_client.rs
+++ b/src/storage/sharding/rpc_client.rs
@@ -41,6 +41,30 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Configuration for RPC client.
+///
+/// # The Spark
+/// Shard-to-shard communication over a network is inherently unreliable. The
+/// `RpcConfig` allows operators to tune how resilient the system should be to
+/// transient network partitions and latency spikes during distributed transactions.
+///
+/// # The Details
+/// Includes settings for request timeouts and retry logic with exponential backoff.
+/// In production, `timeout` should typically be set lower than the 2PC coordinator
+/// timeout to prevent cascading failures.
+///
+/// # Examples
+/// ```
+/// use aletheiadb::storage::sharding::rpc_client::RpcConfig;
+/// use std::time::Duration;
+///
+/// let config = RpcConfig {
+///     endpoint: "http://shard1:9000".to_string(),
+///     timeout: Duration::from_secs(5),
+///     max_retries: 3,
+///     ..Default::default()
+/// };
+/// assert_eq!(config.max_retries, 3);
+/// ```
 #[derive(Debug, Clone)]
 pub struct RpcConfig {
     /// Base endpoint URL (e.g., "http://shard0:9000").
@@ -83,9 +107,18 @@ impl Default for RpcConfig {
 /// connection health tracking, and comprehensive error handling.
 ///
 /// # Thread Safety
+/// HTTP-based implementation of the ShardClient trait.
 ///
-/// This client is thread-safe and can be shared across multiple threads.
-/// Internal state is protected by atomic operations and RwLocks.
+/// # The Spark
+/// In a sharded environment, nodes must coordinate to execute distributed queries
+/// and Two-Phase Commit (2PC) transactions. The `HttpShardClient` abstracts away
+/// the network complexity, making a remote shard look like a local resource.
+///
+/// # The Details
+/// This client uses `reqwest` internally and implements the `ShardClient` trait
+/// to send `Prepare`, `Commit`, and `Abort` signals. It handles network retries
+/// automatically based on its `RpcConfig`. It is thread-safe and designed to be
+/// shared via `Arc`. Internal state is protected by atomic operations and RwLocks.
 ///
 /// # Protocol
 ///
@@ -99,6 +132,19 @@ impl Default for RpcConfig {
 /// - `POST /api/v1/migration/receive` - Receive migration batch
 /// - `POST /api/v1/migration/extract` - Extract migration batch
 /// - `GET /api/v1/health` - Health check
+///
+/// # Examples
+/// ```ignore
+/// use aletheiadb::storage::sharding::types::ShardId;
+/// use aletheiadb::storage::sharding::rpc_client::{HttpShardClient, RpcConfig};
+///
+/// let shard_id = ShardId::new(1).unwrap();
+/// let config = RpcConfig::default();
+///
+/// // In a real app, this connects to the remote shard's HTTP API
+/// let client = HttpShardClient::new(shard_id, config).unwrap();
+/// let state = client.get_state().unwrap();
+/// ```
 pub struct HttpShardClient {
     /// Shard ID this client connects to.
     shard_id: ShardId,


### PR DESCRIPTION
📖 Chapter: The Sharding and RPC Client Modules

💡 Insight: 
The `src/storage/sharding/rebalance.rs` and `src/storage/sharding/rpc_client.rs` modules contained critical distributed system logic but lacked executable examples or contextual narrative. Users trying to understand or manually trigger cluster migrations had to read the source code of `RebalanceManager` and `HttpShardClient` and guess how they interacted with `MigrationPlan` and `RpcConfig`. I have added comprehensive module-level documentation (`//!`) to explain the "Hero's Journey" of migrations and 2PC transactions. I supplemented struct definitions with `///` comments containing `# The Spark` (Why does this exist?) and `# The Details` (How does it work?) sections.

🧪 Example:
Added 4 executable `///` doctests demonstrating the usage of `MigrationProgress`, `MigrationPlan`, `RebalanceManager`, and `RpcConfig`, ensuring the examples compile correctly.

🖼️ Preview:
Documentation now clearly separates the intent of a distributed operation from its technical details, preventing the silent failure patterns discussed in the journal. Tests and docs check out correctly.

---
*PR created automatically by Jules for task [15574234583209649323](https://jules.google.com/task/15574234583209649323) started by @madmax983*