### PR TITLE
⚔️ Elenchus: TimeRange Overlaps Mutation Gaps Fix

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -339,3 +339,9 @@
 **Finding:** The FNV-1a fallback tests for `IdentityHasher` (`test_identity_hasher_write_fallback_fnv` and `test_identity_hasher_write_fallback_fnv_dirty`) were tautological. They exactly mirrored the source implementation by reconstructing the FNV-1a multiplication and XOR sequence to generate their `expected` values. This meant they only asserted that "the code is the code" and provided no independent verification that the hashing logic was correct or consistent with standard FNV-1a.
 **Evidence:** The original tests explicitly copied the sequence `expected ^= 1; expected = expected.wrapping_mul(FNV_PRIME);` which exactly mirrors the `write` loop. Any mutation altering `FNV_PRIME` or the operation order would survive if the same change was incorrectly made to the test or if it was inherently flawed.
 **Recommendation:** Refactored the tests to use independently pre-computed integer constants as the `expected` values (the Oracle Problem solution). This ensures the implementation matches the ground truth rather than itself.
+**[TimeRange Overlaps Mutation Gaps]**
+**Module:** `src/core/temporal.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Mutants replacing the logical operators in `TimeRange::overlaps` (`||` to `&&` in the empty check, `&&` to `||` in the bounds check) and inequality operators (`<` to `<=`, etc.) were surviving due to incomplete bounds and disjoint range testing.
+**Evidence:** The mutant analysis output `mutants.txt` showed multiple `overlaps` mutants surviving, such as replacing `||` with `&&` or `<` with `<=`.
+**Recommendation:** Added tests explicitly verifying logic bounds with disjoint ranges (`test_sentry_overlaps_disjoint_logic`) and a dedicated test verifying when both ranges are empty (`test_sentry_overlaps_both_empty_mutant`).

--- a/src/core/temporal.rs
+++ b/src/core/temporal.rs
@@ -1977,6 +1977,62 @@ mod sentry_tests {
     }
 
     #[test]
+    fn test_sentry_overlaps_both_empty_mutant() {
+        // 🛡️ Sentry Test: Verify overlaps() returns false when BOTH ranges are empty
+        // This specifically targets the mutant that changes `||` to `&&` in the empty check:
+        // `if self.is_empty() && other.is_empty()`
+
+        let empty1 = TimeRange::at(150.into());
+        let empty2 = TimeRange::at(150.into());
+        let empty3 = TimeRange::at(200.into());
+
+        assert!(
+            !empty1.overlaps(&empty2),
+            "Two empty ranges should not overlap, even if at the same timestamp"
+        );
+
+        assert!(
+            !empty1.overlaps(&empty3),
+            "Two empty ranges at different timestamps should not overlap"
+        );
+    }
+
+    #[test]
+    fn test_sentry_overlaps_disjoint_logic() {
+        // 🛡️ Sentry Test: Verify overlaps() bounds logic
+        // This targets mutants that change bounds checking logic in overlaps.
+        // mutant: replace `<` with `<=` or `<` with `==`
+        let r1 = TimeRange::new(100.into(), 200.into()).unwrap();
+        let r2 = TimeRange::new(200.into(), 300.into()).unwrap();
+        assert!(!r1.overlaps(&r2));
+        assert!(!r2.overlaps(&r1));
+
+        let disjoint_left = TimeRange::new(50.into(), 80.into()).unwrap();
+        let disjoint_right = TimeRange::new(350.into(), 400.into()).unwrap();
+
+        // mutant: replace `&&` with `||`
+        // 100 < 80 (false) && 50 < 200 (true) => false
+        // If ||, it would be true.
+        assert!(!r1.overlaps(&disjoint_left));
+
+        // 100 < 400 (true) && 350 < 200 (false) => false
+        // If ||, it would be true.
+        assert!(!r1.overlaps(&disjoint_right));
+
+        let contained = TimeRange::new(120.into(), 180.into()).unwrap();
+        let contains = TimeRange::new(50.into(), 250.into()).unwrap();
+        let overlaps_left = TimeRange::new(50.into(), 150.into()).unwrap();
+        let overlaps_right = TimeRange::new(150.into(), 250.into()).unwrap();
+
+        // Check overlapping cases to ensure we didn't break functionality
+        // and to catch mutants that always return false or replace true with false
+        assert!(r1.overlaps(&contained));
+        assert!(r1.overlaps(&contains));
+        assert!(r1.overlaps(&overlaps_left));
+        assert!(r1.overlaps(&overlaps_right));
+    }
+
+    #[test]
     fn test_sentry_overlaps_empty_range_inside_non_empty() {
         // 🛡️ Sentry Test: Verify overlaps() returns false when one range is empty, even if inside the other
         // This targets the || mutant in is_empty() checks


### PR DESCRIPTION
⚔️ Elenchus: TimeRange Overlaps Mutation Gaps Fix

Summary: Overall mutation-readiness assessment of the temporal module `overlaps` method revealed surviving mutants due to incomplete logic bounding tests, such as replacing `||` with `&&` in empty checks or bounds checking.

Verdict table:
| Test | Verdict | Reason |
| ---- | ------- | ------ |
| `test_sentry_overlaps_both_empty_mutant` | 🟢 Acquitted | Verified the specific case of both ranges being empty, preventing `||` to `&&` mutation. |
| `test_sentry_overlaps_disjoint_logic` | 🟢 Acquitted | Verified disjoint boundary overlaps, protecting logical bounds checks and operators. |

Priority fixes:
1.  **Overlaps Empty Logic**: The `overlaps` method had mutants surviving where the empty check `if self.is_empty() || other.is_empty()` could be replaced with `&&`. Fixed by adding `test_sentry_overlaps_both_empty_mutant`.
2.  **Overlaps Bounds Logic**: The boundary checking bounds `self.start < other.end && other.start < self.end` had surviving mutants replacing `<` with `<=` or `<` with `==` and `&&` with `||`. Fixed by explicitly testing disjoint bounds with `test_sentry_overlaps_disjoint_logic`.

Missing coverage: Addressed the surviving mutation coverage gaps for `TimeRange::overlaps`.

---
*PR created automatically by Jules for task [846974421600145959](https://jules.google.com/task/846974421600145959) started by @madmax983*