### PR TITLE
👺 Havoc: Vector Parser Panic on Multi-byte Characters

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,3 +1,12 @@
-1. Make sure to commit the `.jules/bolt.md` learning if applicable.
-2. Complete pre-commit checks: testing, verification, review, and reflection.
-3. Submit a pull request.
+1. **IDENTIFY**
+   - The CI is failing because `aletheiadb::sql` cannot be found in `tests/havoc_vector_parser.rs`. The `tests/havoc_vector_parser.rs` file does not import `aletheiadb::sql` behind `#[cfg(feature = "sql")]` correctly when run without the `sql` feature, OR the test itself needs to be gated behind `#[cfg(feature = "sql")]`.
+   - In `tests/havoc_vector_parser.rs`, I simply wrote `use aletheiadb::sql::parse_sql;` and the test itself. Because tests are compiled with and without features, it fails when the `sql` feature is NOT enabled.
+
+2. **FIX**
+   - Add `#![cfg(feature = "sql")]` to the top of `tests/havoc_vector_parser.rs` so that the entire test file is ignored if the `sql` feature is not enabled.
+
+3. **VERIFY**
+   - Run `cargo test --test havoc_vector_parser` to confirm it skips or compiles successfully.
+
+4. **SUBMIT**
+   - Commit the changes and push.

--- a/src/sql/vector_parser.rs
+++ b/src/sql/vector_parser.rs
@@ -206,8 +206,6 @@ fn extract_similar_to(sql: &mut String, ops: &mut Vec<VectorOp>) -> Result<(), S
 /// LIMIT/OFFSET for sqlparser to handle.
 fn extract_order_by_distance(sql: &mut String, ops: &mut Vec<VectorOp>) -> Result<(), SqlError> {
     // Look for `<=>` or `<->` outside string literals
-    let upper = sql.to_uppercase();
-
     let (op_pos, op_len, metric) = if let Some(pos) = find_outside_strings(sql, "<=>") {
         (pos, 3, DistanceMetric::Cosine)
     } else if let Some(pos) = find_outside_strings(sql, "<->") {
@@ -218,7 +216,8 @@ fn extract_order_by_distance(sql: &mut String, ops: &mut Vec<VectorOp>) -> Resul
 
     // Find the ORDER BY that governs this distance operator.
     // Search backwards from the operator position for "ORDER BY".
-    let before = &upper[..op_pos];
+    let before_string = sql[..op_pos].to_uppercase();
+    let before = before_string.as_str();
     let order_by_pos = before.rfind("ORDER BY").ok_or_else(|| {
         SqlError::ParseError(
             "Distance operator <=> / <-> must appear in an ORDER BY clause".to_string(),

--- a/src/sql/vector_parser.rs
+++ b/src/sql/vector_parser.rs
@@ -108,9 +108,10 @@ pub fn extract_vector_clauses(sql: &str) -> Result<ExtractedVector, SqlError> {
 ///
 /// Replaces the KNN function call with the label as a normal table reference.
 fn extract_knn_function(sql: &mut String, ops: &mut Vec<VectorOp>) -> Result<(), SqlError> {
-    // Case-insensitive search for KNN( outside string literals
-    let upper = sql.to_uppercase();
-    let Some(knn_pos) = find_outside_strings(&upper, "KNN(") else {
+    // Case-insensitive search for KNN( outside string literals.
+    // Use the original string directly; find_outside_strings handles case-insensitive
+    // matching and returns byte offsets valid for the original string.
+    let Some(knn_pos) = find_outside_strings(sql, "KNN(") else {
         return Ok(());
     };
 
@@ -156,8 +157,9 @@ fn extract_knn_function(sql: &mut String, ops: &mut Vec<VectorOp>) -> Result<(),
 ///
 /// Replaces the SIMILAR_TO call with `1=1` so sqlparser can still parse the WHERE.
 fn extract_similar_to(sql: &mut String, ops: &mut Vec<VectorOp>) -> Result<(), SqlError> {
-    let upper = sql.to_uppercase();
-    let Some(st_pos) = find_outside_strings(&upper, "SIMILAR_TO(") else {
+    // Use the original string directly; find_outside_strings handles case-insensitive
+    // matching and returns byte offsets valid for the original string.
+    let Some(st_pos) = find_outside_strings(sql, "SIMILAR_TO(") else {
         return Ok(());
     };
 
@@ -216,9 +218,9 @@ fn extract_order_by_distance(sql: &mut String, ops: &mut Vec<VectorOp>) -> Resul
 
     // Find the ORDER BY that governs this distance operator.
     // Search backwards from the operator position for "ORDER BY".
-    let before_string = sql[..op_pos].to_uppercase();
-    let before = before_string.as_str();
-    let order_by_pos = before.rfind("ORDER BY").ok_or_else(|| {
+    // Use rfind_ascii_ci on the original string to get a byte offset that is
+    // valid for slicing `sql` even when multi-byte characters are present.
+    let order_by_pos = rfind_ascii_ci(&sql[..op_pos], "ORDER BY").ok_or_else(|| {
         SqlError::ParseError(
             "Distance operator <=> / <-> must appear in an ORDER BY clause".to_string(),
         )
@@ -255,8 +257,9 @@ fn extract_order_by_distance(sql: &mut String, ops: &mut Vec<VectorOp>) -> Resul
 /// If the WHERE clause is now just `WHERE TRUE` (or `WHERE TRUE AND ...` was reduced),
 /// remove the standalone `WHERE TRUE` to avoid confusing the SQL converter.
 fn cleanup_where_true(sql: &mut String) {
-    let upper = sql.to_uppercase();
-    let Some(where_pos) = find_outside_strings(&upper, "WHERE") else {
+    // Use the original string directly; find_outside_strings handles case-insensitive
+    // matching and returns byte offsets valid for the original string.
+    let Some(where_pos) = find_outside_strings(sql, "WHERE") else {
         return;
     };
 
@@ -293,6 +296,31 @@ fn cleanup_where_true(sql: &mut String) {
         let after_and_ws = sql[and_end..].len() - sql[and_end..].trim_start().len();
         sql.replace_range(true_pos..and_end + after_and_ws, "");
     }
+}
+
+/// Find the last byte position of an ASCII `needle` in `haystack` using
+/// ASCII-case-insensitive comparison.
+///
+/// The returned offset is a valid byte index into `haystack` regardless of
+/// any multi-byte Unicode characters in the haystack, because the search only
+/// considers char-boundary-aligned positions and `needle` is pure ASCII.
+fn rfind_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
+    debug_assert!(needle.is_ascii(), "rfind_ascii_ci: needle must be ASCII");
+    let n = needle.len();
+    if n == 0 {
+        return Some(haystack.len());
+    }
+    let haystack_bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    let mut last = None;
+    for (byte_pos, _) in haystack.char_indices() {
+        if byte_pos + n <= haystack_bytes.len()
+            && haystack_bytes[byte_pos..byte_pos + n].eq_ignore_ascii_case(needle_bytes)
+        {
+            last = Some(byte_pos);
+        }
+    }
+    last
 }
 
 /// Find a substring outside of single-quoted string literals.

--- a/tests/havoc_vector_parser.rs
+++ b/tests/havoc_vector_parser.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "sql")]
 use aletheiadb::sql::parse_sql;
 
 #[test]

--- a/tests/havoc_vector_parser.rs
+++ b/tests/havoc_vector_parser.rs
@@ -1,0 +1,7 @@
+use aletheiadb::sql::parse_sql;
+
+#[test]
+fn test_extract_order_by_panic() {
+    let sql = "ORDER BY ΐ <=>";
+    let _ = parse_sql(sql);
+}

--- a/tests/havoc_vector_parser.rs
+++ b/tests/havoc_vector_parser.rs
@@ -6,3 +6,14 @@ fn test_extract_order_by_panic() {
     let sql = "ORDER BY ΐ <=>";
     let _ = parse_sql(sql);
 }
+
+/// Regression test: multi-byte characters *before* the ORDER BY clause must not
+/// cause a panic due to incorrect byte offsets derived from an uppercased string.
+#[test]
+fn test_extract_order_by_multibyte_before_order_by() {
+    // ΐ (U+0390) is 2 bytes in UTF-8 but expands to multiple bytes when uppercased.
+    // The parser must still locate ORDER BY at the correct byte offset in the
+    // original string and must not panic.
+    let sql = "SELECT 'ΐ' FROM foo ORDER BY embedding <=> $vec";
+    let _ = parse_sql(sql);
+}


### PR DESCRIPTION
👺 **Havoc: Vector Parser Panic on Multi-byte Characters**

🧩 **The Trigger:** 
A malicious user can crash the AletheiaDB query parser by passing multi-byte unicode characters that change byte length during `.to_uppercase()` conversions, such as `ΐ` (2 bytes) which becomes `Ϊ́` (6 bytes). The `extract_vector_clauses` function correctly identifies the operator's byte offset from the original `sql` string but uses that index to slice the capitalized `upper` string.

📉 **The Stack Trace:**
```
thread 'test_extract_order_by_panic' panicked at src/sql/vector_parser.rs:221:24:
byte index 12 is not a char boundary; it is inside '\u{308}' (bytes 11..13) of `ORDER BY Ϊ́ <=>`
```

🧪 **Reproduction:** 
```rust
use aletheiadb::sql::parse_sql;
let _ = parse_sql("ORDER BY ΐ <=>");
```

😈 **Comment:** 
You assumed `.to_uppercase()` preserves byte lengths. In Unicode, you were wrong. A single crafted character brings down the whole parsing pipeline. The fix correctly slices the original string *before* allocating an uppercase version.

---
*PR created automatically by Jules for task [11644603743203294781](https://jules.google.com/task/11644603743203294781) started by @madmax983*