### PR TITLE
🛡️ Sentry: ProjectIterator error handling coverage

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -30,3 +30,7 @@
 ## LimitPushdown Mutants
 **Learning:** `cargo mutants` revealed missing test coverage for `LimitPushdown::push_down` in several conditions around `||`. Also limits shouldn't be blindly pushed down through filters, because limits only apply after the filter reduces the row count. Tests covering the lack of modification of binary children boundaries have also been introduced.
 **Action:** When adding rules like `LimitPushdown`, always ensure to write exhaustive structural test cases (verifying limits propagating, or explicitly stopping at operations like `Filter` or `Sort`).
+
+## ProjectIterator try_insert unwrapping
+**Learning:** `unwrap()` inside iterator implementations (like `ProjectIterator::next`) poses a significant panic risk when handling properties, especially dynamically sized ones where recursion depth limits can be exceeded or insertion errors can occur. In a database context, panics inside iterators will crash the entire query process rather than just returning an error to the client.
+**Action:** Always gracefully handle property insertion errors using `match` or `?` and propagate them down the iterator pipeline instead of unwrapping, allowing the query to fail safely. Added tests mocking a `try_insert` failure by using an invalid property state.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1481,7 +1481,10 @@ impl ResultIterator for ProjectIterator {
                     let mut new_props = crate::core::PropertyMapBuilder::new();
                     for prop in &self.properties {
                         if let Some(val) = node.properties.get(prop) {
-                            new_props = new_props.try_insert(prop, val.clone()).unwrap();
+                            new_props = match new_props.try_insert(prop, val.clone()) {
+                                Ok(p) => p,
+                                Err(e) => return Some(Err(e)),
+                            };
                         }
                     }
                     let new_node = crate::core::graph::Node::new(
@@ -2440,6 +2443,46 @@ mod tests {
 
         let res = project_iter.next().unwrap();
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_project_iterator_handles_recursion_error_gracefully() {
+        // Create a property value that fails serialized_size()
+        let mut deep_val = PropertyValue::Int(1);
+        for _ in 0..101 {
+            deep_val = PropertyValue::Array(std::sync::Arc::new(vec![deep_val.clone()]));
+        }
+
+        // We can create a Node by bypassing try_insert. Since PropertyMap uses Arc<HashMap...>, let's just make one.
+        let mut map = std::collections::HashMap::default();
+        let key = crate::core::interning::GLOBAL_INTERNER
+            .intern("deep")
+            .unwrap();
+        map.insert(key, deep_val);
+
+        let props = crate::core::PropertyMap {
+            inner: std::sync::Arc::new(map),
+            cached_size: 100, // Lie about size to avoid computing it
+        };
+
+        let node = Node::new(
+            NodeId::new(1).unwrap(),
+            crate::core::interning::GLOBAL_INTERNER
+                .intern("Test")
+                .unwrap(),
+            props,
+            crate::core::id::VersionId::new(1).unwrap(),
+        );
+
+        let row = QueryRow::from_entity(EntityResult::Node(node));
+        let mock_iter = MockIterator::from_results(vec![Ok(row)]);
+        let mut project_iter = ProjectIterator::new(Box::new(mock_iter), vec!["deep".to_string()]);
+
+        let res = project_iter.next().unwrap();
+        assert!(
+            res.is_err(),
+            "ProjectIterator should gracefully handle property insertion errors"
+        );
     }
 
     #[test]


### PR DESCRIPTION
🎯 Target: `ProjectIterator::next` in `src/query/executor/iterators.rs`.

💣 Risk: Usage of `unwrap()` when trying to project properties using `try_insert`. If a property exceeds the maximum recursion depth, or fails interning, it triggers a hard panic, crashing the query engine.

🧪 Strategy: Replaced `.unwrap()` with a `match` expression to safely propagate the error down the iterator stream as `Some(Err(e))`. Added a targeted test creating a deeply nested property to intentionally trigger a `try_insert` failure and assert the `Result::Err` is gracefully returned.

🔬 Verification: Run `cargo test --lib query::executor::iterators::tests::test_project_iterator_handles_recursion_error_gracefully`

---
*PR created automatically by Jules for task [6795288366408878379](https://jules.google.com/task/6795288366408878379) started by @madmax983*