### PR TITLE
🎻 Bard: Contextual `# Why?` documentation for Iterators and Experimental modules

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -100,3 +100,6 @@
 ## 2025-03-05 - The Case of the Silent Shard Rebalancer
 **Confusion:** The `src/storage/sharding/rebalance.rs` and `src/storage/sharding/rpc_client.rs` modules lacked any executable examples or context about *why* specific structures existed. Users trying to understand or manually trigger cluster migrations had to read the source code of `RebalanceManager` and guess how it interacts with `MigrationPlan`.
 **Clarification:** Added comprehensive module-level documentation and struct-level `# The Spark` and `# The Details` sections with executable `///` doctests.
+## 2025-03-05 - The Danger of Tautological Documentation
+**Confusion:** The instruction to explain *what* and *why* for public functions was misinterpreted as "add a comment to everything", resulting in tautological noise (e.g., `/// Creates a new TraversalIterator.` for `TraversalIterator::new()`).
+**Clarification:** Strict adherence to the `🚫 Never do: Write comments that simply repeat the function name` rule is required. When documenting basic constructor methods, instead of writing "Creates X", always include a `# Why?` section explaining the architectural context (e.g., "Why? This is used for `NodeLookup` physical operations where the query planner has already resolved exact node IDs").

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -224,6 +224,8 @@ impl StringInterner {
     ///
     /// - **For read-only access**: Use [`resolve_with`](Self::resolve_with) to avoid Arc cloning.
     /// - **When an owned Arc is needed**: Use this method (`resolve`).
+    ///
+    /// Resolves an interned string to an owned `Arc<str>`.
     #[deprecated(
         since = "0.1.0",
         note = "Use resolve_with() for read-only access; use resolve() only when an owned Arc<str> is strictly required"

--- a/src/encryption/config.rs
+++ b/src/encryption/config.rs
@@ -17,6 +17,12 @@ use crate::encryption::factory::Algorithm;
     feature = "config-toml",
     serde(tag = "type", rename_all = "snake_case")
 )]
+/// Configuration options for the Master Encryption Key (MEK) provider.
+///
+/// # Why?
+/// Different environments require different security postures. Development might
+/// use a file-based key, while production typically injects keys via environment variables
+/// or a KMS (Key Management Service).
 pub enum KeyProviderConfig {
     /// Load the MEK from a file on disk (hex or raw binary).
     File {

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -194,6 +194,12 @@ impl Resonator for ActivityDensityResonator {
 /// # #[cfg(not(feature = "nova"))]
 /// # fn main() {}
 /// ```
+/// A simulator for testing semantic drift and reinforcement loops.
+///
+/// # Why?
+/// In recommender systems, repeatedly suggesting content similar to a user's
+/// previous interactions creates an echo chamber. This struct simulates that
+/// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
     resonator: Box<dyn Resonator>,
@@ -229,6 +235,12 @@ pub struct EchoChamber<'a> {
 #[deprecated(
     note = "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
+/// A simulator for testing semantic drift and reinforcement loops.
+///
+/// # Why?
+/// In recommender systems, repeatedly suggesting content similar to a user's
+/// previous interactions creates an echo chamber. This struct simulates that
+/// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }

--- a/src/experimental/sherlock.rs
+++ b/src/experimental/sherlock.rs
@@ -69,6 +69,12 @@ pub enum Clue {
 /// # fn main() {}
 /// ```
 #[derive(Debug, Clone)]
+/// A deductive reasoning task over the graph topology.
+///
+/// # Why?
+/// Sherlock allows for programmatic hypothesis testing on graph structures,
+/// determining if a specific path or subgraph matches a complex logical pattern
+/// (e.g., "Is there a cycle of trust between these 5 accounts?").
 pub struct Mystery {
     /// The sequence of clues to find.
     pub clues: Vec<Clue>,
@@ -81,6 +87,12 @@ pub struct Mystery {
 #[deprecated(
     note = "Mystery requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
+/// A deductive reasoning task over the graph topology.
+///
+/// # Why?
+/// Sherlock allows for programmatic hypothesis testing on graph structures,
+/// determining if a specific path or subgraph matches a complex logical pattern
+/// (e.g., "Is there a cycle of trust between these 5 accounts?").
 pub struct Mystery {
     _marker: std::marker::PhantomData<Duration>,
 }
@@ -198,6 +210,12 @@ pub struct Deduction {
 /// # #[cfg(not(feature = "nova"))]
 /// # fn main() {}
 /// ```
+/// The deductive reasoning engine for AletheiaDB.
+///
+/// # Why?
+/// This struct orchestrates the evaluation of `Mystery` constraints against
+/// the current state of the database, utilizing a backtracking algorithm
+/// to find subgraphs that satisfy complex topological rules.
 pub struct Sherlock<'a> {
     #[allow(dead_code)]
     db: &'a AletheiaDB,
@@ -208,6 +226,12 @@ pub struct Sherlock<'a> {
 #[deprecated(
     note = "Sherlock requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
+/// The deductive reasoning engine for AletheiaDB.
+///
+/// # Why?
+/// This struct orchestrates the evaluation of `Mystery` constraints against
+/// the current state of the database, utilizing a backtracking algorithm
+/// to find subgraphs that satisfy complex topological rules.
 pub struct Sherlock<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }

--- a/src/experimental/temporal_narrative.rs
+++ b/src/experimental/temporal_narrative.rs
@@ -25,6 +25,12 @@ pub struct NarrativeEvent {
 
 /// Generator for creating natural language narratives from temporal history.
 #[cfg(feature = "nova")]
+/// Generates human-readable summaries of temporal graph mutations.
+///
+/// # Why?
+/// When analyzing a `BiTemporalInterval`, users often need to understand
+/// the sequence of events (e.g., "Alice liked the post, then Bob deleted it").
+/// This struct translates raw `VersionMetadata` into a chronological narrative.
 pub struct NarrativeGenerator<'a> {
     db: &'a AletheiaDB,
 }
@@ -34,6 +40,12 @@ pub struct NarrativeGenerator<'a> {
 #[deprecated(
     note = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
 )]
+/// Generates human-readable summaries of temporal graph mutations.
+///
+/// # Why?
+/// When analyzing a `BiTemporalInterval`, users often need to understand
+/// the sequence of events (e.g., "Alice liked the post, then Bob deleted it").
+/// This struct translates raw `VersionMetadata` into a chronological narrative.
 pub struct NarrativeGenerator<'a> {
     _marker: std::marker::PhantomData<&'a AletheiaDB>,
 }

--- a/src/index/vector/temporal/snapshot.rs
+++ b/src/index/vector/temporal/snapshot.rs
@@ -274,6 +274,11 @@ impl std::fmt::Debug for SnapshotIndex {
 }
 
 impl SnapshotIndex {
+    /// Searches the snapshot for the top `k` nearest neighbors to the `query` vector.
+    ///
+    /// # Why?
+    /// This provides a point-in-time semantic search. It routes the query to either
+    /// the fully consolidated HNSW index, or a delta-index depending on the snapshot's state.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>> {
         match self {
             SnapshotIndex::Full(index) => index.search(query, k),
@@ -281,6 +286,12 @@ impl SnapshotIndex {
         }
     }
 
+    /// Searches the snapshot for the top `k` nearest neighbors, applying a custom predicate filter.
+    ///
+    /// # Why?
+    /// Pure vector search often returns irrelevant results (e.g., matching a document from
+    /// the wrong user). This allows pre-filtering the candidate list during the HNSW traversal
+    /// to guarantee both semantic relevance and logical correctness.
     pub fn search_with_filter(
         &self,
         query: &[f32],

--- a/src/observability/backends/prometheus.rs
+++ b/src/observability/backends/prometheus.rs
@@ -102,10 +102,21 @@ pub struct PrometheusBackend;
 
 #[cfg(not(feature = "observability-prometheus"))]
 impl PrometheusBackend {
+    /// Create a fallback Prometheus backend when the feature is disabled.
+    ///
+    /// # Why?
+    /// This prevents compile errors in downstream code that blindly attempts to construct
+    /// the backend. It effectively becomes a no-op.
     pub fn new(_config: PrometheusConfig) -> Self {
         Self
     }
 
+    /// Attempt to start the Prometheus backend (always fails when disabled).
+    ///
+    /// # Why?
+    /// Calling this without the `observability-prometheus` feature flag active
+    /// acts as a fail-safe, returning an error to alert the operator that metrics
+    /// cannot be collected.
     pub fn start(self) -> Result<(), Error> {
         Err(Error::other(
             "Prometheus support not compiled in. Enable the 'observability-prometheus' feature.",

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -89,6 +89,12 @@ impl Query {
 pub trait QueryState: private::Sealed {}
 
 mod private {
+    /// Sealed trait pattern to prevent downstream crates from implementing query states.
+    ///
+    /// # Why?
+    /// The query builder relies on a strict, internal state machine (Initial -> Traversing -> Filtered).
+    /// If external users could implement this trait, they could bypass the compile-time safety checks
+    /// and construct invalid queries that panic at runtime.
     pub trait Sealed {}
 }
 

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -75,6 +75,11 @@ pub struct NodeLookupIterator {
 }
 
 impl NodeLookupIterator {
+    /// Initialize the iterator with a predefined list of node identifiers.
+    ///
+    /// # Why?
+    /// This is used for `NodeLookup` physical operations where the query
+    /// planner has already resolved exact node IDs (e.g., from an index or literal).
     pub fn new(node_ids: Vec<NodeId>, current: Arc<CurrentStorage>) -> Self {
         NodeLookupIterator {
             node_ids: node_ids.into_iter(),
@@ -440,6 +445,13 @@ pub struct BatchTemporalNodeIterator {
 impl BatchTemporalNodeIterator {
     /// Create a new batch temporal node iterator.
     ///
+    /// Initialize an iterator that resolves multiple historical nodes simultaneously.
+    ///
+    /// # Why?
+    /// Unlike the standard `TemporalNodeIterator`, this optimizes lock acquisition
+    /// by grabbing the read lock once for the entire batch. This prevents lock contention
+    /// on highly active graphs during deep historical traversals.
+    ///
     /// Acquires the historical storage lock once, reconstructs all nodes,
     /// then releases the lock and returns the iterator over results.
     ///
@@ -557,7 +569,11 @@ pub struct TemporalNodeScanIterator {
 }
 
 impl TemporalNodeScanIterator {
-    /// Create a new temporal node scan iterator.
+    /// Initialize a scanning iterator that searches historical storage.
+    ///
+    /// # Why?
+    /// This provides a fallback mechanism to find nodes in the past when temporal
+    /// indexes are either unavailable or explicitly bypassed.
     ///
     /// # Arguments
     ///
@@ -749,6 +765,12 @@ pub struct TraversalIterator {
 }
 
 impl TraversalIterator {
+    /// Initialize a Breadth-First Search (BFS) graph traversal iterator.
+    ///
+    /// # Why?
+    /// This is the core engine for `MATCH (a)-[*]->(b)` operations. It manages
+    /// a frontier of visited nodes to prevent infinite loops in cyclic graphs,
+    /// and conditionally queries the historical storage if a temporal context is present.
     pub fn new(
         input: Box<dyn ResultIterator>,
         direction: Direction,
@@ -1528,6 +1550,11 @@ pub struct PropertyScanIterator {
 }
 
 impl PropertyScanIterator {
+    /// Initialize a full-scan iterator that evaluates a property predicate against all nodes.
+    ///
+    /// # Why?
+    /// Use this as a fallback when no index is available for the requested `label` and `key`.
+    /// It eagerly loads all matching nodes into memory, so it is best used on small datasets.
     pub fn new(
         label: String,
         key: String,

--- a/src/query/plan.rs
+++ b/src/query/plan.rs
@@ -433,6 +433,7 @@ impl TemporalContext {
     /// Create a time range context (backward compatibility - uses valid_time dimension).
     ///
     /// **Deprecated**: Use `valid_time_between()` or `transaction_time_between()` for clarity.
+    /// Sets the temporal context to query data valid between the specified `TimeRange`.
     #[must_use]
     #[deprecated(
         since = "0.1.0",


### PR DESCRIPTION
📖 Chapter
The Query Execution Iterators and Experimental Modules (`src/query/executor/iterators.rs`, `src/experimental/`).

🔦 Insight
Many core types in the physical query planner lacked documentation explaining *why* they existed. For example, `BatchTemporalNodeIterator` wasn't distinguished from the standard iterator. Additionally, the experimental modules (`Sherlock`, `EchoChamber`, `NarrativeGenerator`) lacked high-level summaries of their architectural purpose.

I added detailed `# Why?` sections to these structs and constructors to bridge the gap between machine logic and human understanding, explaining the specific edge cases and performance goals (like lock contention reduction) each iterator solves.

🧪 Example
Added clear structural context for the `Sealed` trait in the query builder to prevent downstream compile-time bypasses, and explained the fallback mechanism for the `PrometheusBackend` when the observability feature is disabled.

🖼️ Preview
N/A (Backend logic structural explanations).

**Assumptions Made:**
I autonomously assumed that the feedback regarding tautological comments meant I should replace them with descriptive contextual `# Why?` sections rather than reverting them to an entirely undocumented state.

---
*PR created automatically by Jules for task [14634312554506857242](https://jules.google.com/task/14634312554506857242) started by @madmax983*