### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,16 +810,17 @@ For complex operations involving multiple updates, use explicit transactions.
 ```rust
 use aletheiadb::prelude::*;
 
-// Explicit read transaction
-let result = db.read(|tx| {
-    tx.get_node(alice_id).map(|node| node.label.clone())
-})?;
-
 // Explicit write transaction with multiple operations
-db.write(|tx| {
+let (node1_id, _) = db.write(|tx| -> Result<(NodeId, NodeId)> {
     let node1 = tx.create_node("Event", PropertyMap::new())?;
     let node2 = tx.create_node("Event", PropertyMap::new())?;
-    tx.create_edge(node1, node2, "FOLLOWS", PropertyMap::new())
+    tx.create_edge(node1, node2, "FOLLOWS", PropertyMap::new())?;
+    Ok((node1, node2))
+})?;
+
+// Explicit read transaction
+let _result = db.read(|tx| {
+    tx.get_node(node1_id).map(|node| node.label.clone())
 })?;
 ```
 
@@ -834,7 +835,7 @@ use std::sync::Arc;
 
 // Note: Requires `tokio` dependency in Cargo.toml
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Enable in Cargo.toml: features = ["embedding-openai"]
 
     // 1. Create embedding service

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ For complex operations involving multiple updates, use explicit transactions.
 use aletheiadb::prelude::*;
 
 // Explicit write transaction with multiple operations
+let db = AletheiaDB::new().unwrap();
 let (node1_id, _) = db.write(|tx| -> Result<(NodeId, NodeId)> {
     let node1 = tx.create_node("Event", PropertyMap::new())?;
     let node2 = tx.create_node("Event", PropertyMap::new())?;


### PR DESCRIPTION
* 🤦 **The Confusion:** Tried to run the examples in `README.md` by pasting them into a fresh `main.rs`, and they failed to compile due to shadowed `Result` type (`aletheiadb::prelude::*` brings a custom `Result` in scope, while the docs used the `std` one) and undefined variables (`alice_id`).
* 🕵️ **The Reality:** The provided `db.read` block used an undefined `alice_id`. The provided `db.write` block yielded a generic inference error unless a return type was provided to tell Rust the exact `E` type.
* 💡 **The Fix:** Updated the example in `README.md` to properly define `NodeId`s during the write transaction, assigned the `db.write` closure a proper return type, and used the explicit `std::result::Result` in the main function signatures. Verified these changes compile via `cargo check` in an isolated environment.

---
*PR created automatically by Jules for task [9196490277064059280](https://jules.google.com/task/9196490277064059280) started by @madmax983*