### PR TITLE
🪒 Razor: [De-Abstract Resonator trait]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `Resonator` trait (Single-implementation trait used only by `ActivityDensityResonator`).
+**Cut:** Deleted the `Resonator` trait. Refactored `EchoChamber` to use the concrete `ActivityDensityResonator` struct directly.
+**Saved:** ~10 lines of trait definition + dynamic dispatch overhead + generic bounds.

--- a/src/experimental/echo.rs
+++ b/src/experimental/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "nova")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -202,7 +197,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "nova"))]
@@ -251,13 +246,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -318,7 +313,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
### 🪒 Razor: De-Abstract `Resonator` trait

This PR removes the single-implementation `Resonator` trait from `src/experimental/echo.rs` and replaces it with concrete usage of `ActivityDensityResonator`.

**Bloat:** `Resonator` trait (Single-implementation trait used only by `ActivityDensityResonator`).
**Cut:** Deleted the `Resonator` trait. Refactored `EchoChamber` to use the concrete `ActivityDensityResonator` struct directly.
**Saved:** ~10 lines of trait definition + dynamic dispatch overhead + generic bounds.

#### Steps
1. Deleted `Resonator` trait.
2. Moved `resonate` method to `ActivityDensityResonator` implementation.
3. Updated `EchoChamber` to store `ActivityDensityResonator` directly instead of a `Box<dyn Resonator>`.
4. Updated tests and removed obsolete imports in doctests.
5. Recorded the change in `.jules/razor.md`.

---
*PR created automatically by Jules for task [7088825786422173749](https://jules.google.com/task/7088825786422173749) started by @madmax983*