### PR TITLE
⚡ Bolt: Optimize Vec allocations in query parser and result instantiation

### DIFF
--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -405,7 +405,8 @@ impl QueryResult {
     #[must_use]
     pub fn new() -> Self {
         QueryResult {
-            nodes: Vec::new(),
+            // ⚡ Bolt Optimization: Most queries return results, start with small capacity
+            nodes: Vec::with_capacity(16),
             properties: None,
             scores: None,
             paths: None,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -744,7 +744,7 @@ impl Parser {
     fn parse_property_map(&mut self) -> Result<PropertyMap, ParseError> {
         self.expect(&Token::LeftBrace)?;
 
-        let mut props = Vec::new();
+        let mut props = Vec::with_capacity(8); // ⚡ Bolt Optimization: Most property maps are small, pre-allocating avoids small reallocations
 
         if !self.check(&Token::RightBrace) {
             loop {
@@ -1049,7 +1049,7 @@ impl Parser {
     fn parse_in_predicate(&mut self, expr: Expression) -> Result<PredicateExpr, ParseError> {
         self.advance();
         self.expect(&Token::LeftBracket)?;
-        let mut values = Vec::new();
+        let mut values = Vec::with_capacity(4); // ⚡ Bolt Optimization: Most IN predicates have few values
         if !self.check(&Token::RightBracket) {
             loop {
                 values.push(self.parse_property_value()?);


### PR DESCRIPTION
💡 What: Replaced zero-capacity `Vec::new()` with `Vec::with_capacity()` in hot paths, specifically during `QueryResult::new()`, `parse_property_map()`, and `parse_in_predicate()`.
🎯 Why: Creating a `Vec` with `new()` starts with 0 capacity. Since queries almost always return rows, and parsed maps/predicates nearly always contain items, this forces multiple heap reallocations (resizes) as elements are immediately pushed.
📊 Impact: Reduces O(log N) heap reallocations for every query executed and parsed.
🔬 Measurement: Run `cargo test --lib query` to verify no logic regressions, and observe fewer minor page faults in profiling tools during high-throughput query parsing.

---
*PR created automatically by Jules for task [18220570683533352909](https://jules.google.com/task/18220570683533352909) started by @madmax983*