### PR TITLE
🗣️ Echo: Gracefully handle NarrativeGenerator feature omissions

### DIFF
--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -193,7 +193,6 @@ pub mod telepathy;
 #[cfg(feature = "nova")]
 /// Temporal Diff Engine for computing snapshot differences.
 pub mod temporal_diff;
-#[cfg(feature = "nova")]
 /// Temporal narrative generator for natural language history logs.
 pub mod temporal_narrative;
 

--- a/src/experimental/temporal_narrative.rs
+++ b/src/experimental/temporal_narrative.rs
@@ -157,28 +157,23 @@ impl<'a> NarrativeGenerator<'a> {
 impl<'a> NarrativeGenerator<'a> {
     /// Create a new narrative generator.
     ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
+    /// # Why?
+    /// This is a fallback implementation that allows code to compile when the `nova` feature
+    /// is not enabled. It provides a dummy instance that will gracefully return an error
+    /// when its methods are called, rather than panicking upon initialization.
     #[allow(unused_variables)]
-    #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
+        Self {
+            _marker: std::marker::PhantomData,
+        }
     }
 
     /// Generate a narrative for a specific node.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
-    #[track_caller]
     pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
+        Err(crate::core::error::Error::other(
+            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml.",
+        ))
     }
 }
 
@@ -306,27 +301,20 @@ mod stub_tests {
     use super::*;
 
     #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
+    fn test_stub_new() {
         let db = AletheiaDB::new().unwrap();
-        // This should panic
+        // This should not panic
         let _ = NarrativeGenerator::new(&db);
     }
 
     #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
-        // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
-            _marker: std::marker::PhantomData,
-        };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
+    fn test_stub_generate_error() {
+        let db = AletheiaDB::new().unwrap();
+        let generator = NarrativeGenerator::new(&db);
+        let res = generator.generate_node_narrative(NodeId::new(0).unwrap());
+
+        assert!(res.is_err());
+        let err_msg = res.unwrap_err().to_string();
+        assert!(err_msg.contains("NarrativeGenerator requires the 'nova' feature"));
     }
 }

--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -1083,11 +1083,7 @@ impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
             1.0
         };
 
-        let target_per_node = if node_count > 0 {
-            total_vectors / node_count
-        } else {
-            0
-        };
+        let target_per_node = total_vectors.checked_div(node_count).unwrap_or(0);
 
         let vectors_to_move: usize = sizes
             .iter()

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -911,7 +911,7 @@ impl MigrationService {
             });
         } else {
             // Age mode: sort by age (oldest first) to prioritize older versions
-            candidates.sort_by(|a, b| b.age.cmp(&a.age));
+            candidates.sort_by_key(|b| std::cmp::Reverse(b.age));
         }
     }
 


### PR DESCRIPTION
**🗣️ Echo: Getting Started example is broken**

🤦 **The Confusion:** 
Blindly copy-pasting the `story_demo` code from the README results in the app compiling successfully (if `nova` is not explicitly enabled in `Cargo.toml`), but crashing with a runtime panic upon executing `NarrativeGenerator::new(&db)`.

🕵️ **The Reality:** 
The `NarrativeGenerator` is gated behind the `nova` feature flag. The `src/experimental/temporal_narrative.rs` file provided a fallback implementation (when `nova` is missing) that intentionally panicked to provide an error message. Furthermore, because `mod temporal_narrative` in `src/experimental/mod.rs` was fully gated by `#[cfg(feature = "nova")]`, the fallback code and its tests were actually dead code and completely unreachable. 

💡 **The Fix:** 
- Removed the `#[cfg(feature = "nova")]` constraint from `pub mod temporal_narrative;` in `src/experimental/mod.rs` so the module (and its fallback) is always parsed.
- Updated the fallback `NarrativeGenerator::new` to return a dummy instance containing a `PhantomData` marker instead of panicking.
- Added a `# Why?` docstring explanation to `new` to avoid tautological comments per Bard persona guidelines.
- Updated the fallback `NarrativeGenerator::generate_node_narrative` to gracefully return `Result::Err` with the required `nova` feature error message instead of panicking.
- Updated the fallback tests in `stub_tests` module to assert the non-panicking initialization and the graceful error propagation.
- Verified test behavior executes correctly by running tests both with default features and `--no-default-features`.

---
*PR created automatically by Jules for task [9371236509359210617](https://jules.google.com/task/9371236509359210617) started by @madmax983*