### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -34,3 +34,7 @@
 ## ProjectIterator try_insert unwrapping
 **Learning:** `unwrap()` inside iterator implementations (like `ProjectIterator::next`) poses a significant panic risk when handling properties, especially dynamically sized ones where recursion depth limits can be exceeded or insertion errors can occur. In a database context, panics inside iterators will crash the entire query process rather than just returning an error to the client.
 **Action:** Always gracefully handle property insertion errors using `match` or `?` and propagate them down the iterator pipeline instead of unwrapping, allowing the query to fail safely. Added tests mocking a `try_insert` failure by using an invalid property state.
+
+## Cypher Lexer Panic on Unexpected EOF
+**Learning:** `unwrap()` inside the `CypherLexer::read_string` method poses a panic risk if `advance()` returns `None` after a quote is seemingly expected (e.g., if lexer state changes or during fuzzing). This bypasses the resilient `CypherError` error handling path.
+**Action:** Replaced `unwrap()` with a `match` block that gracefully returns `CypherError::LexError` on EOF. Always ensure that lexer/parser read functions use proper error propagation instead of panicking on unexpected input ends, even if internal invariants supposedly guarantee character presence.

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -500,7 +500,15 @@ impl<'a> CypherLexer<'a> {
     // -----------------------------------------------------------------------
 
     fn read_string(&mut self, start: usize) -> Result<Token, CypherError> {
-        let (_, quote) = self.advance().unwrap(); // consume opening quote
+        let (_, quote) = match self.advance() {
+            Some(res) => res,
+            None => {
+                return Err(CypherError::LexError {
+                    position: start,
+                    message: "Unexpected EOF at start of string literal".to_string(),
+                });
+            }
+        }; // consume opening quote
         let mut value = String::new();
 
         loop {
@@ -694,6 +702,19 @@ impl<'a> CypherLexer<'a> {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    #[test]
+    fn string_literal_unexpected_eof_start() {
+        // Technically, `read_string` should only be called if `advance()` has peeking chars,
+        // but testing the resilient error path prevents panics.
+        let mut lexer = CypherLexer {
+            input: "",
+            chars: "".char_indices().peekable(),
+            position: 0,
+        };
+        let result = lexer.read_string(0);
+        assert!(matches!(result, Err(CypherError::LexError { .. })));
+    }
 
     #[test]
     fn keyword_lookup_exhaustive() {


### PR DESCRIPTION
🎯 **Target:** `CypherLexer::read_string` function in `src/cypher/lexer.rs`

💣 **Risk:** The previous implementation used `self.advance().unwrap()` to consume the opening quote of a string literal. While this is normally protected by preceding checks, any change to internal invariants or state during fuzzing/mutations could trigger a panic, bypassing the `CypherError` resilient error handling framework and potentially crashing the database thread during query parsing.

🧪 **Strategy:** 
1. Replaced the `unwrap()` with a graceful `match` block that returns a `CypherError::LexError` on `None`.
2. Added the `string_literal_unexpected_eof_start` unit test inside the `unit_tests` module to explicitly trigger this failure path and verify no panic occurs.

🔭 **Verification:** `cargo test --lib cypher` (and `cargo clippy --all-targets --all-features -- -D warnings` ran cleanly).

---
*PR created automatically by Jules for task [5290108862497057288](https://jules.google.com/task/5290108862497057288) started by @madmax983*