### PR TITLE
⚡ Bolt: Pre-allocate vectors in migration candidates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -70,3 +70,6 @@
 **SIMD optimization for vector math**
 **Learning:** Manual iterator combinations for vector math (e.g., zip().map().sum() and sqrt()) do not reliably auto-vectorize and miss out on SIMD extensions like AVX2/FMA. This is a common performance bottleneck in hot paths (like in Prophet's vector similarity calculation).
 **Action:** Use SIMD-optimized functions from crate::core::vector (such as cosine_similarity) instead of manual iterator-based math for vector operations in hot paths. This can yield significant performance gains (e.g., ~20x speedup for 1536-dimensional vectors).
+**[Optimize Migration Candidates Vec Pre-allocation]**
+**Learning:** In `identify_node_candidates` and `identify_edge_candidates`, initializing `all_candidates` and `final_candidates` with `Vec::new()` causes unnecessary intermediate heap reallocations during large data migrations because the maximum required capacity is already known from the `versions` map and the filtered `all_candidates` vector.
+**Action:** Always pre-allocate vectors using `Vec::with_capacity(n)` when the target collection size or its upper bound is known in advance, particularly on hot paths like data migration.

--- a/src/storage/migration.rs
+++ b/src/storage/migration.rs
@@ -1277,7 +1277,8 @@ impl MigrationService {
     ) -> Vec<MigrationCandidate> {
         // Track how many candidates we've selected per node
         let mut candidates_per_node: FastHashMap<NodeId, usize> = FastHashMap::default();
-        let mut all_candidates = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate vectors using known capacity to avoid intermediate heap reallocations during migration.
+        let mut all_candidates = Vec::with_capacity(versions.len());
 
         // Get current wallclock time in milliseconds since UNIX epoch
         let current_wallclock_ms = SystemTime::now()
@@ -1314,7 +1315,8 @@ impl MigrationService {
         self.sort_candidates_by_policy(&mut all_candidates);
 
         // Filter candidates to ensure min_hot_versions remain
-        let mut final_candidates = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate vectors using known capacity to avoid intermediate heap reallocations during migration.
+        let mut final_candidates = Vec::with_capacity(all_candidates.len());
         for candidate in all_candidates {
             // Get node_id from the original version
             let node_id = versions.get(&candidate.version_id).map(|v| v.node_id);
@@ -1359,7 +1361,8 @@ impl MigrationService {
     ) -> Vec<MigrationCandidate> {
         // Track how many candidates we've selected per edge
         let mut candidates_per_edge: FastHashMap<EdgeId, usize> = FastHashMap::default();
-        let mut all_candidates = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate vectors using known capacity to avoid intermediate heap reallocations during migration.
+        let mut all_candidates = Vec::with_capacity(versions.len());
 
         // Get current wallclock time in milliseconds since UNIX epoch
         let current_wallclock_ms = SystemTime::now()
@@ -1395,7 +1398,8 @@ impl MigrationService {
         self.sort_candidates_by_policy(&mut all_candidates);
 
         // Filter candidates to ensure min_hot_versions remain
-        let mut final_candidates = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate vectors using known capacity to avoid intermediate heap reallocations during migration.
+        let mut final_candidates = Vec::with_capacity(all_candidates.len());
         for candidate in all_candidates {
             let edge_id = versions.get(&candidate.version_id).map(|v| v.edge_id);
             if let Some(edge_id) = edge_id {


### PR DESCRIPTION
💡 What: Pre-allocated `all_candidates` and `final_candidates` vectors with `Vec::with_capacity` in `identify_node_candidates` and `identify_edge_candidates` using the known size of `versions` and `all_candidates`.
🎯 Why: To eliminate unnecessary heap memory reallocations during large data migrations where many nodes or edges are scanned for tiering/eviction.
📊 Impact: Reduces heap reallocations during node and edge migrations, improving performance and reducing allocator overhead.
🔬 Measurement: Run `cargo test --lib storage` to verify correctness.

---
*PR created automatically by Jules for task [17787064050996682437](https://jules.google.com/task/17787064050996682437) started by @madmax983*