### PR TITLE
🗣️ Echo: Fix Result shadowing and inconsistent gating

### DIFF
--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -30,7 +30,7 @@ use aletheiadb::WriteOps;
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
 use aletheiadb::properties;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
 
     // 1. Create Node

--- a/src/experimental/reasoning/mod.rs
+++ b/src/experimental/reasoning/mod.rs
@@ -11,7 +11,9 @@ pub mod chimera;
 pub mod dreamer;
 pub mod hindsight;
 pub mod luna;
+#[cfg(feature = "semantic-reasoning")]
 pub mod metaphor;
+#[cfg(feature = "semantic-reasoning")]
 pub mod muse;
 pub mod omen;
 pub mod oracle;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@
 
 pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};
-pub use crate::core::error::{Error, Result};
+pub use crate::core::error::Error;
 pub use crate::core::id::{EdgeId, NodeId, VersionId};
 pub use crate::core::interning::InternedString;
 pub use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};


### PR DESCRIPTION
🗣️ Echo: Fix `Result` shadowing and inconsistent gating

🤦 **The Confusion:** The `aletheiadb::prelude` module exported `Result`, shadowing `std::result::Result`. This caused friction when copying examples since standard `Result` needs two arguments but `aletheiadb::Result` needs one. Furthermore, `muse` and `metaphor` were accessible inconsistently compared to other experimental modules.

🕵️‍♂️ **The Reality:** The prelude was re-exporting `crate::core::error::Result`. And `muse` and `metaphor` were missing explicit feature gates in `src/experimental/reasoning/mod.rs`.

💡 **The Fix:** Removed `Result` from `src/prelude.rs` re-exports, updated `examples/story_demo.rs` to use `std::result::Result`, and added `#[cfg(feature = "semantic-reasoning")]` gating to `muse` and `metaphor` modules.

---
*PR created automatically by Jules for task [18001836023100821864](https://jules.google.com/task/18001836023100821864) started by @madmax983*