### PR TITLE
🛡️ Sentry: Cypher lexer test coverage improvement

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -34,3 +34,6 @@
 ## ProjectIterator try_insert unwrapping
 **Learning:** `unwrap()` inside iterator implementations (like `ProjectIterator::next`) poses a significant panic risk when handling properties, especially dynamically sized ones where recursion depth limits can be exceeded or insertion errors can occur. In a database context, panics inside iterators will crash the entire query process rather than just returning an error to the client.
 **Action:** Always gracefully handle property insertion errors using `match` or `?` and propagate them down the iterator pipeline instead of unwrapping, allowing the query to fail safely. Added tests mocking a `try_insert` failure by using an invalid property state.
+**[Lexer Safety and Edge Cases]**
+**Learning:** Found multiple unteminated or invalid token edge cases in `cypher/lexer.rs` that were missing tests (e.g. `! ` instead of `!=`, unterminated strings, invalid numerical characters like `1a`). Also noted that numbers parsed as floats immediately followed by letters without space could panic further down. Added checks `filter(|&&(_, ch)| ch.is_alphabetic())` directly within the numbers match block to fix.
+**Action:** Always write failure cases for parsers and lexers to ensure `unwrap_err` states match expected errors without panics or OOB string slices.

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -601,6 +601,12 @@ impl<'a> CypherLexer<'a> {
             .unwrap_or(self.input.len());
         let text = &self.input[start..end];
 
+        // Ensure that a number doesn't immediately flow into an alphabetic
+        // character unless it's a known suffix (which Cypher doesn't currently use)
+        if let Some(&(_, ch)) = self.chars.peek().filter(|&&(_, ch)| ch.is_alphabetic()) {
+            return Err(self.lex_error(end, format!("Unexpected character: '{}'", ch)));
+        }
+
         let kind = if is_float {
             TokenKind::FloatLiteral
         } else {
@@ -745,5 +751,58 @@ mod unit_tests {
                 "{kw} should be a keyword, not an identifier"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_sentry {
+    use super::*;
+
+    #[test]
+    fn test_lexer_unterminated_string() {
+        let err = CypherLexer::tokenize("\"unterminated").unwrap_err();
+        assert!(err.to_string().contains("Unterminated string literal"));
+        let err = CypherLexer::tokenize("'unterminated").unwrap_err();
+        assert!(err.to_string().contains("Unterminated string literal"));
+    }
+
+    #[test]
+    fn test_lexer_bang_without_equals() {
+        let err = CypherLexer::tokenize("!").unwrap_err();
+        assert!(err.to_string().contains("Expected '=' after '!'"));
+        let err = CypherLexer::tokenize("! ").unwrap_err();
+        assert!(err.to_string().contains("Expected '=' after '!'"));
+    }
+
+    #[test]
+    fn test_lexer_empty_parameter() {
+        let err = CypherLexer::tokenize("$").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Expected parameter name after '$'")
+        );
+        let err = CypherLexer::tokenize("$ ").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Expected parameter name after '$'")
+        );
+    }
+
+    #[test]
+    fn test_lexer_escape_sequence_unterminated() {
+        let err = CypherLexer::tokenize("\"test\\").unwrap_err();
+        assert!(err.to_string().contains("Unterminated string literal"));
+    }
+
+    #[test]
+    fn test_lexer_invalid_character() {
+        let err = CypherLexer::tokenize("~").unwrap_err();
+        assert!(err.to_string().contains("Unexpected character: '~'"));
+    }
+
+    #[test]
+    fn test_lexer_number_invalid() {
+        let err = CypherLexer::tokenize("1a").unwrap_err();
+        assert!(err.to_string().contains("Unexpected character: 'a'"));
     }
 }


### PR DESCRIPTION
🎯 **Target:** Function `cypher::lexer` being tested.
💣 **Risk:** Avoid `unwrap` and potential malformed out-of-bounds operations parsing numbers and strings.
🧪 **Strategy:** Add tests for expected errors and filter check for numbers flowing directly into unspaced alphabetic chars. 
🔬 **Verification:** Run `cargo test --features cypher --lib cypher::lexer::tests_sentry`.

---
*PR created automatically by Jules for task [14928299231332269751](https://jules.google.com/task/14928299231332269751) started by @madmax983*