### PR TITLE
⚡ Bolt: Optimize HashMap hashing in semantic search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -73,3 +73,7 @@
 **[Optimize Migration Candidates Vec Pre-allocation]**
 **Learning:** In `identify_node_candidates` and `identify_edge_candidates`, initializing `all_candidates` and `final_candidates` with `Vec::new()` causes unnecessary intermediate heap reallocations during large data migrations because the maximum required capacity is already known from the `versions` map and the filtered `all_candidates` vector.
 **Action:** Always pre-allocate vectors using `Vec::with_capacity(n)` when the target collection size or its upper bound is known in advance, particularly on hot paths like data migration.
+
+**[Semantic Search HashMap IdentityHasher]
+**Learning:** Using `HashMap::new()` relies on the default SipHash algorithm. When dealing with `NodeId`s (which are structurally small integers acting as distinct unique identifiers), SipHash introduces a major, unnecessary cryptographic hashing overhead on intensive paths like A* traversals or spreading activation.
+**Action:** Swapped `HashMap::new()` for `HashMap::with_hasher(BuildHasherDefault::default())` using `crate::core::hasher::IdentityHasher` inside `semantic_search/semantic_navigator.rs`, `telepathy.rs`, `fishing.rs`, and `cartographer.rs` to enforce O(1) hash complexity for graph algorithm lookups.


### PR DESCRIPTION
## ⚡ Bolt: Use IdentityHasher for NodeId HashMaps in semantic_search

### 💡 What
Swapped the default `SipHash` algorithm (`HashMap::new()`) for an `IdentityHasher` (`HashMap::with_hasher(BuildHasherDefault::default())`) on integer-based `NodeId` HashMaps in the `semantic_search` module.

Targeted areas:
* `semantic_navigator.rs` (A* Pathfinding: `came_from`, `g_score`, `f_score`)
* `telepathy.rs` (Spreading Activation: `vector_cache`, `seeds`, `results_map`)
* `fishing.rs` (Associative Retrieval: `candidate_scores`, `provenance`)
* `cartographer.rs` (Clustering: `assignments`, `new_assignments`)

### 🎯 Why
In AletheiaDB, `NodeId` is simply a wrapper around a unique `u64` identifier. The default Rust `HashMap` uses `SipHash`, which is a cryptographically strong hash function designed to prevent HashDoS attacks. However, on trusted internal unique identifiers like `NodeId` inside high-throughput graph algorithms (like finding paths, clustering, and spreading activation), the cryptographic overhead of `SipHash` is an unnecessary and significant CPU bottleneck. By using the `IdentityHasher` (from `crate::core::hasher`), we reduce hashing complexity from O(L) back to O(1), making map insertions and lookups blazingly fast.

### 📊 Impact
* Eliminates the cryptographic hashing penalty during graph traversals in the `semantic_search` module.
* Substantially speeds up pathfinding (A*) and spreading activation logic where thousands of internal `NodeId` lookups happen sequentially.

### 🔬 Measurement
* Run `cargo test --lib semantic_search` to verify algorithmic correctness remains untouched.

---
*PR created automatically by Jules for task [3490875036308965598](https://jules.google.com/task/3490875036308965598) started by @madmax983*