### PR TITLE
👺 Havoc: Fix vector_parser out of bounds string slice panics

### DIFF
--- a/.jules/havoc.md
+++ b/.jules/havoc.md
@@ -1,0 +1,9 @@
+**SQL Vector Parser String Slicing Panic**
+**Trigger:** `let s = "'"`
+**Stack Trace:**
+```
+thread 'test_converter_sql_fuzz' panicked at src/sql/vector_parser.rs:513:11:
+begin <= end (1 <= 0) when slicing `'`
+```
+**Reproduction:** Run `cargo test --test havoc_sql` with random/mean string generation targeting `aletheiadb::sql::parse_sql`.
+**Comment:** You assumed the string would have a matching closing quote, but an empty pair of quotes like `''` or a single quote `'` would trigger out of bounds indexing. You were wrong.

--- a/src/sql/vector_parser.rs
+++ b/src/sql/vector_parser.rs
@@ -461,8 +461,10 @@ fn split_args(args: &str) -> Result<Vec<String>, SqlError> {
 /// Remove surrounding single or double quotes from a string literal.
 fn unquote_string(s: &str) -> Result<String, SqlError> {
     let s = s.trim();
-    if s.len() >= 2 && ((s.starts_with('\'') && s.ends_with('\'')) || (s.starts_with('"') && s.ends_with('"'))) {
-        Ok(s[1..s.len() - 1].to_string())
+    if let Some(inner) = s.strip_prefix('\'').and_then(|s| s.strip_suffix('\''))
+        .or_else(|| s.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+    {
+        Ok(inner.to_string())
     } else {
         Err(SqlError::ParseError(format!(
             "Expected quoted string, got: '{}'",

--- a/src/sql/vector_parser.rs
+++ b/src/sql/vector_parser.rs
@@ -461,7 +461,7 @@ fn split_args(args: &str) -> Result<Vec<String>, SqlError> {
 /// Remove surrounding single or double quotes from a string literal.
 fn unquote_string(s: &str) -> Result<String, SqlError> {
     let s = s.trim();
-    if (s.starts_with('\'') && s.ends_with('\'')) || (s.starts_with('"') && s.ends_with('"')) {
+    if s.len() >= 2 && ((s.starts_with('\'') && s.ends_with('\'')) || (s.starts_with('"') && s.ends_with('"'))) {
         Ok(s[1..s.len() - 1].to_string())
     } else {
         Err(SqlError::ParseError(format!(
@@ -509,7 +509,7 @@ fn parse_vector_literal(s: &str) -> Result<Vec<f32>, SqlError> {
     };
 
     // Strip surrounding single quotes
-    let s = if s.starts_with('\'') && s.ends_with('\'') {
+    let s = if s.starts_with('\'') && s.ends_with('\'') && s.len() >= 2 {
         &s[1..s.len() - 1]
     } else {
         s
@@ -796,6 +796,7 @@ mod tests {
             extract_vector_clauses("SELECT * FROM Documents WHERE SIMILAR_TO(embedding, $query)");
         assert!(result.is_err());
     }
+
 
     // ========================================================================
     // No Vector Clauses

--- a/tests/havoc_sql.rs
+++ b/tests/havoc_sql.rs
@@ -1,0 +1,45 @@
+use aletheiadb::sql::{parse_sql, SqlParser};
+use proptest::prelude::*;
+
+// A really mean generator that biases towards operators and single quotes
+fn sql_mean_fuzz_strategy() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        proptest::sample::select(&[
+            "SELECT", "FROM", "WHERE", "ORDER BY", "LIMIT", "MATCH", "FOR SYSTEM_TIME AS OF",
+            "=", "<", ">", "AND", "OR", "NOT", "(", ")", "[", "]", "'", "\"", ",", ".", "*",
+            "nodes", "edges", "1", "0.5", "TRUE", "FALSE", "NULL", "::vector", "<=>", "<->",
+            "\n", "\t", " ", "A", "B", "_", "-", "a", "b", "''", "'''", "''''", "'''::vector",
+            "'''<=>'''"
+        ][..]),
+        0..100
+    ).prop_map(|v| v.join(""))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn test_parser_mean_fuzz(s in sql_mean_fuzz_strategy()) {
+        let _ = SqlParser::parse_multiple(&s);
+    }
+
+    #[test]
+    fn test_converter_mean_fuzz(s in sql_mean_fuzz_strategy()) {
+        let _ = parse_sql(&s);
+    }
+}
+
+// We use purely random printable characters and all unicode combinations
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn test_parser_fuzz_random(s in ".*") {
+        let _ = SqlParser::parse_multiple(&s);
+    }
+
+    #[test]
+    fn test_converter_fuzz_random(s in ".*") {
+        let _ = parse_sql(&s);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** 
An input string like `"'"` (a single quote without a closing pair) supplied to `unquote_string` and vector literal logic caused an out of bounds panic during byte slice indexing since `s.len()` was `1` and subtracting `1` created an invalid slice bound of `1..0`.

📉 **The Stack Trace:**
```
thread 'test_converter_sql_fuzz' panicked at src/sql/vector_parser.rs:513:11:
begin <= end (1 <= 0) when slicing `'`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

🧪 **Reproduction:**
Run `cargo test --all-features --test havoc_sql` with random Unicode generation against the `parse_sql` and `SqlParser::parse_multiple` endpoints.

😈 **Comment:**
You assumed a quoted string would always have at least two characters (the open and close quotes). You were wrong. I added a `s.len() >= 2` bounds check to gracefully handle this garbage data instead of panicking.

---
*PR created automatically by Jules for task [14742897449965543408](https://jules.google.com/task/14742897449965543408) started by @madmax983*