### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -43,10 +43,10 @@
 //!
 //! | Flag | What it gates | Modules |
 //! |------|---------------|---------|
-//! | `reasoning` (`semantic-reasoning`) | Prediction, synthesis, counterfactuals | prophet, dreamer, omen, oracle, hindsight, muse, luna, metaphor, synergy, chimera, alchemy |
-//! | `temporal` (`semantic-temporal`) | Bi-temporal + semantic | sherlock, chronos, echo, kairos, temporal_narrative, temporal_diff, aura, mnemosyne, ariadne |
-//! | `diagnostics` (`semantic-diagnostics`) | Anomaly, validation, health | dissonance, sentinel, fossil, tremor, polygraph, wormhole, ripple, entanglement, thermos, paradox |
-//! | `characterization` (`semantic-characterization`) | Describe concepts + export | archetype, prism, gravity, sybil, synapse, kaleidoscope, papyrus, graph_context, wildfire |
+//! | [reasoning] (semantic-reasoning) | Prediction, synthesis, counterfactuals | prophet, dreamer, omen, oracle, hindsight, muse, luna, metaphor, synergy, chimera, alchemy |
+//! | [temporal] (semantic-temporal) | Bi-temporal + semantic | sherlock, chronos, echo, kairos, temporal_narrative, temporal_diff, aura, mnemosyne, ariadne |
+//! | [diagnostics] (semantic-diagnostics) | Anomaly, validation, health | dissonance, sentinel, fossil, tremor, polygraph, wormhole, ripple, entanglement, thermos, paradox |
+//! | [characterization] (semantic-characterization) | Describe concepts + export | archetype, prism, gravity, sybil, synapse, kaleidoscope, papyrus, graph_context, wildfire |
 //!
 //! For convenience, every submodule is re-exported at this module's path —
 //! existing code using `aletheiadb::experimental::sherlock::Sherlock` keeps

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -17,7 +17,7 @@
 //! - 🚩 **Opt-in**: You must explicitly enable them.
 //!
 //! Once a category proves itself, it graduates to a top-level stable feature
-//! (see [`crate::semantic_search`] for the first graduation).
+//! (see `crate::semantic_search` for the first graduation).
 //!
 //! # Enabling Nova
 //!
@@ -43,10 +43,10 @@
 //!
 //! | Flag | What it gates | Modules |
 //! |------|---------------|---------|
-//! | [`reasoning`] (`semantic-reasoning`) | Prediction, synthesis, counterfactuals | prophet, dreamer, omen, oracle, hindsight, muse, luna, metaphor, synergy, chimera, alchemy |
-//! | [`temporal`] (`semantic-temporal`) | Bi-temporal + semantic | sherlock, chronos, echo, kairos, temporal_narrative, temporal_diff, aura, mnemosyne, ariadne |
-//! | [`diagnostics`] (`semantic-diagnostics`) | Anomaly, validation, health | dissonance, sentinel, fossil, tremor, polygraph, wormhole, ripple, entanglement, thermos, paradox |
-//! | [`characterization`] (`semantic-characterization`) | Describe concepts + export | archetype, prism, gravity, sybil, synapse, kaleidoscope, papyrus, graph_context, wildfire |
+//! | `reasoning` (`semantic-reasoning`) | Prediction, synthesis, counterfactuals | prophet, dreamer, omen, oracle, hindsight, muse, luna, metaphor, synergy, chimera, alchemy |
+//! | `temporal` (`semantic-temporal`) | Bi-temporal + semantic | sherlock, chronos, echo, kairos, temporal_narrative, temporal_diff, aura, mnemosyne, ariadne |
+//! | `diagnostics` (`semantic-diagnostics`) | Anomaly, validation, health | dissonance, sentinel, fossil, tremor, polygraph, wormhole, ripple, entanglement, thermos, paradox |
+//! | `characterization` (`semantic-characterization`) | Describe concepts + export | archetype, prism, gravity, sybil, synapse, kaleidoscope, papyrus, graph_context, wildfire |
 //!
 //! For convenience, every submodule is re-exported at this module's path —
 //! existing code using `aletheiadb::experimental::sherlock::Sherlock` keeps

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -17,7 +17,7 @@
 //! - 🚩 **Opt-in**: You must explicitly enable them.
 //!
 //! Once a category proves itself, it graduates to a top-level stable feature
-//! (see `crate::semantic_search` for the first graduation).
+//! (see [crate::semantic_search] for the first graduation).
 //!
 //! # Enabling Nova
 //!


### PR DESCRIPTION
📖 Chapter: The Experimental module docs.
🔦 Insight: Fixed broken intra-doc links in `src/experimental/mod.rs` (`[`reasoning`]`, `[`temporal`]`, etc) that broke `cargo doc` due to being feature flags instead of valid Rust items. Switched to standard Markdown inline code (`` `reasoning` ``).
🧪 Example: N/A (just fixed links).
🖼️ Preview: Links render properly and doc build passes with `RUSTDOCFLAGS="-D warnings"`.

---
*PR created automatically by Jules for task [14114296221426752983](https://jules.google.com/task/14114296221426752983) started by @madmax983*