### PR TITLE
Expand HTTP API surface with bulk CRUD and bulk query endpoints

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -39,6 +39,7 @@ const MAX_DEEP_PAGINATION: usize = 10_000;
 const MAX_NEIGHBOR_LIMIT: usize = 1_000;
 const MAX_EXEC_RESULTS: usize = 10_000;
 const MAX_BULK_ITEMS: usize = 1_000;
+const MAX_BULK_EXEC_TOTAL_ROWS: usize = 20_000;
 
 /// Health check response.
 #[derive(Debug, Serialize)]
@@ -527,7 +528,8 @@ async fn handle_bulk_execute_query(
     validate_bulk_size(&queries, "queries")?;
     blocking(move || {
         let mut all_results = Vec::with_capacity(queries.len());
-        for query_item in queries {
+        let mut total_rows = 0usize;
+        for (idx, query_item) in queries.into_iter().enumerate() {
             let parsed_query = if let Some(params_json) = query_item.parameters {
                 let params =
                     json_to_parameter_map(&params_json).map_err(AletheiaHttpError::BadRequest)?;
@@ -546,6 +548,16 @@ async fn handle_bulk_execute_query(
                     query_row_to_json(row).map_err(AletheiaHttpError::Internal)
                 })
                 .collect::<Result<Vec<_>, AletheiaHttpError>>()?;
+
+            total_rows = total_rows.saturating_add(rows.len());
+            if total_rows > MAX_BULK_EXEC_TOTAL_ROWS {
+                return Err(AletheiaHttpError::BadRequest(format!(
+                    "Bulk query result budget exceeded at query {}: total rows {} > {}",
+                    idx + 1,
+                    total_rows,
+                    MAX_BULK_EXEC_TOTAL_ROWS
+                )));
+            }
 
             all_results.push(json!({
                 "query": query_item.query,

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -15,6 +15,7 @@
 //! }
 //! ```
 
+use crate::api::transaction::WriteOps;
 use crate::core::NodeId;
 use crate::http::converters::{
     interned_to_string, json_to_parameter_map, json_to_property_map, property_map_to_json,
@@ -37,6 +38,7 @@ use std::sync::Arc;
 const MAX_DEEP_PAGINATION: usize = 10_000;
 const MAX_NEIGHBOR_LIMIT: usize = 1_000;
 const MAX_EXEC_RESULTS: usize = 10_000;
+const MAX_BULK_ITEMS: usize = 1_000;
 
 /// Health check response.
 #[derive(Debug, Serialize)]
@@ -75,6 +77,18 @@ pub enum QueryRequest {
         label: String,
         properties: Option<HashMap<String, Value>>,
     },
+    /// Create many nodes atomically in one transaction.
+    BulkCreateNodes { nodes: Vec<CreateNodeInput> },
+    /// Fetch many nodes by ID.
+    BulkGetNodes { node_ids: Vec<u64> },
+    /// Update many nodes atomically in one transaction.
+    BulkUpdateNodes { updates: Vec<UpdateNodeInput> },
+    /// Delete many nodes atomically in one transaction.
+    BulkDeleteNodes {
+        node_ids: Vec<u64>,
+        #[serde(default)]
+        cascade: bool,
+    },
     /// Find neighbors (either direction) of a node. Paginated, deduped.
     FindNeighbors {
         node_id: u64,
@@ -88,6 +102,29 @@ pub enum QueryRequest {
         query: String,
         parameters: Option<HashMap<String, Value>>,
     },
+    /// Execute many AQL queries in sequence and return per-query rows.
+    BulkExecuteQuery { queries: Vec<ExecuteQueryInput> },
+}
+
+/// Payload for node creation inside a bulk request.
+#[derive(Debug, Deserialize)]
+pub struct CreateNodeInput {
+    label: String,
+    properties: Option<HashMap<String, Value>>,
+}
+
+/// Payload for node update inside a bulk request.
+#[derive(Debug, Deserialize)]
+pub struct UpdateNodeInput {
+    node_id: u64,
+    properties: Option<HashMap<String, Value>>,
+}
+
+/// Payload for query execution inside a bulk request.
+#[derive(Debug, Deserialize)]
+pub struct ExecuteQueryInput {
+    query: String,
+    parameters: Option<HashMap<String, Value>>,
 }
 
 /// Wrapper for all JSON responses: `{ success: bool, data?: ..., error?: ... }`.
@@ -337,6 +374,189 @@ async fn handle_execute_query(
     .await
 }
 
+fn convert_node_for_response(node: crate::core::graph::Node) -> Result<Value, AletheiaHttpError> {
+    let props_json = property_map_to_json(&node.properties).map_err(AletheiaHttpError::Internal)?;
+    Ok(json!({
+        "id": node.id.as_u64(),
+        "label": interned_to_string(node.label),
+        "properties": props_json,
+    }))
+}
+
+fn validate_bulk_size<T>(items: &[T], name: &str) -> Result<(), AletheiaHttpError> {
+    if items.is_empty() {
+        return Err(AletheiaHttpError::BadRequest(format!(
+            "{name} cannot be empty"
+        )));
+    }
+    if items.len() > MAX_BULK_ITEMS {
+        return Err(AletheiaHttpError::BadRequest(format!(
+            "{name} exceeds max size of {MAX_BULK_ITEMS}"
+        )));
+    }
+    Ok(())
+}
+
+async fn handle_bulk_create_nodes(
+    db: Arc<crate::AletheiaDB>,
+    nodes: Vec<CreateNodeInput>,
+) -> Result<Value, AletheiaHttpError> {
+    validate_bulk_size(&nodes, "nodes")?;
+    blocking(move || {
+        let created_ids = db
+            .write(|tx| {
+                let mut ids = Vec::with_capacity(nodes.len());
+                for node in &nodes {
+                    let props = match &node.properties {
+                        Some(p) => json_to_property_map(p)
+                            .map_err(|e| crate::core::error::Error::other(e.to_string()))?,
+                        None => crate::core::PropertyMap::new(),
+                    };
+                    ids.push(tx.create_node(&node.label, props)?);
+                }
+                Ok::<_, crate::core::error::Error>(ids)
+            })
+            .map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+
+        let mut created = Vec::with_capacity(created_ids.len());
+        for id in created_ids {
+            let node = db
+                .get_node(id)
+                .map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
+            created.push(convert_node_for_response(node)?);
+        }
+        Ok(Value::Array(created))
+    })
+    .await
+}
+
+async fn handle_bulk_get_nodes(
+    db: Arc<crate::AletheiaDB>,
+    node_ids: Vec<u64>,
+) -> Result<Value, AletheiaHttpError> {
+    validate_bulk_size(&node_ids, "node_ids")?;
+    blocking(move || {
+        let mut found = Vec::with_capacity(node_ids.len());
+        let mut missing = Vec::new();
+
+        for node_id in node_ids {
+            let nid =
+                NodeId::new(node_id).map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+            match db.get_node(nid) {
+                Ok(node) => found.push(convert_node_for_response(node)?),
+                Err(_) => missing.push(node_id),
+            }
+        }
+
+        Ok(json!({
+            "nodes": found,
+            "missing_node_ids": missing,
+        }))
+    })
+    .await
+}
+
+async fn handle_bulk_update_nodes(
+    db: Arc<crate::AletheiaDB>,
+    updates: Vec<UpdateNodeInput>,
+) -> Result<Value, AletheiaHttpError> {
+    validate_bulk_size(&updates, "updates")?;
+    blocking(move || {
+        let updated_ids = db
+            .write(|tx| {
+                let mut ids = Vec::with_capacity(updates.len());
+                for update in &updates {
+                    let node_id = NodeId::new(update.node_id)?;
+                    let props = match &update.properties {
+                        Some(p) => json_to_property_map(p)
+                            .map_err(|e| crate::core::error::Error::other(e.to_string()))?,
+                        None => crate::core::PropertyMap::new(),
+                    };
+                    tx.update_node(node_id, props)?;
+                    ids.push(node_id);
+                }
+                Ok::<_, crate::core::error::Error>(ids)
+            })
+            .map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+
+        let mut updated = Vec::with_capacity(updated_ids.len());
+        for id in updated_ids {
+            let node = db
+                .get_node(id)
+                .map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
+            updated.push(convert_node_for_response(node)?);
+        }
+        Ok(Value::Array(updated))
+    })
+    .await
+}
+
+async fn handle_bulk_delete_nodes(
+    db: Arc<crate::AletheiaDB>,
+    node_ids: Vec<u64>,
+    cascade: bool,
+) -> Result<Value, AletheiaHttpError> {
+    validate_bulk_size(&node_ids, "node_ids")?;
+    blocking(move || {
+        let deleted_count = db
+            .write(|tx| {
+                for node_id in &node_ids {
+                    let nid = NodeId::new(*node_id)?;
+                    if cascade {
+                        tx.delete_node_cascade(nid)?;
+                    } else {
+                        tx.delete_node(nid)?;
+                    }
+                }
+                Ok::<_, crate::core::error::Error>(node_ids.len())
+            })
+            .map_err(|e| AletheiaHttpError::BadRequest(e.to_string()))?;
+
+        Ok(json!({
+            "deleted_count": deleted_count,
+            "cascade": cascade,
+        }))
+    })
+    .await
+}
+
+async fn handle_bulk_execute_query(
+    db: Arc<crate::AletheiaDB>,
+    queries: Vec<ExecuteQueryInput>,
+) -> Result<Value, AletheiaHttpError> {
+    validate_bulk_size(&queries, "queries")?;
+    blocking(move || {
+        let mut all_results = Vec::with_capacity(queries.len());
+        for query_item in queries {
+            let parsed_query = if let Some(params_json) = query_item.parameters {
+                let params =
+                    json_to_parameter_map(&params_json).map_err(AletheiaHttpError::BadRequest)?;
+                parse_query_with_params(&query_item.query, params)
+                    .map_err(|e| AletheiaHttpError::QueryParse(e.to_string()))?
+            } else {
+                parse_query(&query_item.query).map_err(|e| classify_query_error(e.to_string()))?
+            };
+
+            let rows = db
+                .execute_query(parsed_query)
+                .map_err(|e| classify_query_error(e.to_string()))?
+                .take(MAX_EXEC_RESULTS)
+                .map(|row_result| {
+                    let row = row_result.map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
+                    query_row_to_json(row).map_err(AletheiaHttpError::Internal)
+                })
+                .collect::<Result<Vec<_>, AletheiaHttpError>>()?;
+
+            all_results.push(json!({
+                "query": query_item.query,
+                "rows": rows,
+            }));
+        }
+        Ok(Value::Array(all_results))
+    })
+    .await
+}
+
 /// Heuristic: parser errors → 400, everything else → 500.
 fn classify_query_error(msg: String) -> AletheiaHttpError {
     let lowered = msg.to_lowercase();
@@ -360,6 +580,12 @@ pub async fn handle_query(
             handle_create_node(db, label, properties).await?
         }
         QueryRequest::GetNode { node_id } => handle_get_node(db, node_id).await?,
+        QueryRequest::BulkCreateNodes { nodes } => handle_bulk_create_nodes(db, nodes).await?,
+        QueryRequest::BulkGetNodes { node_ids } => handle_bulk_get_nodes(db, node_ids).await?,
+        QueryRequest::BulkUpdateNodes { updates } => handle_bulk_update_nodes(db, updates).await?,
+        QueryRequest::BulkDeleteNodes { node_ids, cascade } => {
+            handle_bulk_delete_nodes(db, node_ids, cascade).await?
+        }
         QueryRequest::FindNode {
             label,
             properties,
@@ -373,6 +599,9 @@ pub async fn handle_query(
         } => handle_find_neighbors(db, node_id, limit, offset).await?,
         QueryRequest::ExecuteQuery { query, parameters } => {
             handle_execute_query(db, query, parameters).await?
+        }
+        QueryRequest::BulkExecuteQuery { queries } => {
+            handle_bulk_execute_query(db, queries).await?
         }
     };
 

--- a/tests/http_api.rs
+++ b/tests/http_api.rs
@@ -183,3 +183,88 @@ async fn pagination_and_neighbor_deduplication() {
         .count();
     assert_eq!(n2_count, 1, "neighbor should appear exactly once");
 }
+
+#[tokio::test]
+async fn bulk_crud_and_bulk_query_endpoints_work() {
+    let (client, db) = client_with_db();
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_create_nodes",
+            "nodes": [
+                { "label": "Person", "properties": { "name": "Alice" } },
+                { "label": "Person", "properties": { "name": "Bob" } }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "bulk_create_nodes failed: {body}");
+    let created = body["data"].as_array().expect("created array");
+    assert_eq!(created.len(), 2);
+    let alice_id = created[0]["id"].as_u64().expect("alice id");
+    let bob_id = created[1]["id"].as_u64().expect("bob id");
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_get_nodes",
+            "node_ids": [alice_id, bob_id, 999_999_u64]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "bulk_get_nodes failed: {body}");
+    assert_eq!(body["data"]["nodes"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        body["data"]["missing_node_ids"].as_array().unwrap().len(),
+        1
+    );
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_update_nodes",
+            "updates": [
+                { "node_id": alice_id, "properties": { "name": "Alice Updated", "age": 30 } },
+                { "node_id": bob_id, "properties": { "name": "Bob Updated" } }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "bulk_update_nodes failed: {body}");
+    let updated = body["data"].as_array().unwrap();
+    assert_eq!(updated.len(), 2);
+    assert_eq!(updated[0]["properties"]["name"], "Alice Updated");
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_execute_query",
+            "queries": [
+                { "query": "MATCH (n:Person) RETURN n" },
+                { "query": "MATCH (n:Person) WHERE n.name = \"Alice Updated\" RETURN n" }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "bulk_execute_query failed: {body}");
+    let grouped = body["data"].as_array().unwrap();
+    assert_eq!(grouped.len(), 2);
+    assert!(grouped[0]["rows"].as_array().unwrap().len() >= 2);
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_delete_nodes",
+            "node_ids": [alice_id, bob_id]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "bulk_delete_nodes failed: {body}");
+    assert_eq!(body["data"]["deleted_count"], 2);
+
+    assert!(
+        db.get_node(aletheiadb::core::NodeId::new(alice_id).unwrap())
+            .is_err()
+    );
+}

--- a/tests/http_api.rs
+++ b/tests/http_api.rs
@@ -268,3 +268,41 @@ async fn bulk_crud_and_bulk_query_endpoints_work() {
             .is_err()
     );
 }
+
+#[tokio::test]
+async fn bulk_execute_query_enforces_total_row_budget() {
+    let (client, db) = client_with_db();
+
+    for i in 0..40_i64 {
+        db.create_node(
+            "BudgetTest",
+            aletheiadb::core::PropertyMapBuilder::new()
+                .insert("idx", i)
+                .build(),
+        )
+        .unwrap();
+    }
+
+    let mut queries = Vec::new();
+    for _ in 0..600 {
+        queries.push(json!({ "query": "MATCH (n:BudgetTest) RETURN n" }));
+    }
+
+    let (status, body) = post_query(
+        &client,
+        &json!({
+            "operation": "bulk_execute_query",
+            "queries": queries
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 400, "expected request-level row budget rejection");
+    assert_eq!(body["success"], false);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("result budget exceeded")
+    );
+}


### PR DESCRIPTION
### Motivation

- Provide batch-oriented HTTP primitives so clients can fetch, mutate, and query many entities with fewer roundtrips and atomic semantics.
- Support high-throughput import/ingest and multi-query workflows via the existing `/query` polymorphic endpoint while protecting the server from DoS via size caps.

### Description

- Added new `QueryRequest` variants: `bulk_create_nodes`, `bulk_get_nodes`, `bulk_update_nodes`, `bulk_delete_nodes` (with optional `cascade`), and `bulk_execute_query` and corresponding DTOs `CreateNodeInput`, `UpdateNodeInput`, and `ExecuteQueryInput`.
- Implemented handlers `handle_bulk_create_nodes`, `handle_bulk_get_nodes`, `handle_bulk_update_nodes`, `handle_bulk_delete_nodes`, and `handle_bulk_execute_query`, reusing the existing `blocking` helper and mapping storage errors into `AletheiaHttpError` responses.
- Enforced safety caps with `MAX_BULK_ITEMS` and `validate_bulk_size`, added `convert_node_for_response` to centralize JSON formatting, and used `db.write(|tx| ...)` (via `WriteOps`) to ensure atomic bulk mutations.
- Wired the new handlers into the `/query` dispatcher and added an integration test (`tests/http_api.rs`) that exercises end-to-end bulk create/get/update/query/delete flows.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo clippy --all-targets --features http-server -- -D warnings` which completed successfully for the `http-server` feature matrix.
- Ran `cargo test --test http_api --features http-server` and all tests passed (`4` tests passed, `0` failed).
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it failed in this environment due to an external prebuilt binary download error (`ort-sys` download returned HTTP 403), so full all-features linting could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaadb47994832a95eb8b1ebce79498)