### PR TITLE
⚔️ Elenchus: [src/core/property] Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[PropertyMap isEmpty Coverage Gap]**
+**Module:** `src/core/property.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The `PropertyMap::is_empty` method was tested with `assert!(map.is_empty())` on newly created maps, but there were no assertions verifying that `!map.is_empty()` after inserting items. This allowed a mutant replacing `is_empty` with `return true;` to survive the test suite.
+**Evidence:** `cargo mutants` revealed that `replace PropertyMap::is_empty -> bool with true` survived.
+**Recommendation:** Added `assert!(!map.is_empty());` in `test_property_map_builder` after populating the map to ensure the implementation is not tautologically returning `true`.

--- a/src/core/property/tests.rs
+++ b/src/core/property/tests.rs
@@ -194,6 +194,7 @@ fn test_property_map_builder() {
         .build();
 
     assert_eq!(map.len(), 3);
+    assert!(!map.is_empty());
     assert_eq!(
         map.get("name").and_then(|v: &PropertyValue| v.as_str()),
         Some("Alice")
@@ -254,6 +255,7 @@ fn test_properties_macro() {
     };
 
     assert_eq!(map.len(), 3);
+    assert!(!map.is_empty());
     assert_eq!(
         map.get("name").and_then(|v: &PropertyValue| v.as_str()),
         Some("Bob")
@@ -1562,6 +1564,7 @@ fn test_concurrent_property_map_creation() {
 
                 let map = builder.build();
                 assert_eq!(map.len(), 3);
+                assert!(!map.is_empty());
                 assert_eq!(
                     map.get("shared_key_1")
                         .and_then(|v: &PropertyValue| v.as_str()),


### PR DESCRIPTION
**Summary:** 
A mutation testing audit of `src/core/property` revealed a blind spot in the testing of `PropertyMap::is_empty()`.

**Verdict table:**
| Test / Method | Verdict | Reason |
| --- | --- | --- |
| `test_property_map_builder` | 🟡 Suspect | Failed to verify `!map.is_empty()` after insertion. |
| `test_property_map_creation` | 🟢 Acquitted | Correctly verified `is_empty` on empty maps. |

**Priority fixes:**
1.  **`PropertyMap::is_empty()`**: Added `assert!(!map.is_empty())` to `test_property_map_builder` to ensure the map correctly identifies as non-empty after items are inserted. This successfully killed the mutation `replace PropertyMap::is_empty -> bool with true`.

**Missing coverage:**
No major missing coverage detected in this specific analysis phase beyond the boolean assertion gaps.

---
*PR created automatically by Jules for task [18208763886769620938](https://jules.google.com/task/18208763886769620938) started by @madmax983*