### PR TITLE
⚡ Bolt: Use FastHashMap for NodeId keys in semantic search

### DIFF
--- a/src/semantic_search/cartographer.rs
+++ b/src/semantic_search/cartographer.rs
@@ -55,8 +55,8 @@
 //! ```
 
 use crate::core::NodeId;
+use crate::core::version::FastHashMap;
 use crate::{AletheiaDB, PropertyMapBuilder, WriteOps};
-use std::collections::HashMap;
 
 /// The result of a clustering operation.
 #[derive(Debug, Clone)]
@@ -64,7 +64,7 @@ pub struct ClusteringResult {
     /// The centroids of the clusters.
     pub centroids: Vec<Vec<f32>>,
     /// Mapping of node ID to cluster index.
-    pub assignments: HashMap<NodeId, usize>,
+    pub assignments: FastHashMap<NodeId, usize>,
 }
 
 /// The Cartographer maps the semantic landscape of the graph.
@@ -198,7 +198,7 @@ impl KMeans {
         if data.is_empty() {
             return ClusteringResult {
                 centroids: Vec::new(),
-                assignments: HashMap::new(),
+                assignments: FastHashMap::default(),
             };
         }
 
@@ -217,11 +217,11 @@ impl KMeans {
             }
         }
 
-        let mut assignments: HashMap<NodeId, usize> = HashMap::new();
+        let mut assignments: FastHashMap<NodeId, usize> = FastHashMap::default();
 
         for _iteration in 0..self.max_iterations {
             let mut changes = 0;
-            let mut new_assignments: HashMap<NodeId, usize> = HashMap::new();
+            let mut new_assignments: FastHashMap<NodeId, usize> = FastHashMap::default();
             let mut sums = vec![vec![0.0; dimensions]; effective_k];
             let mut counts = vec![0; effective_k];
 

--- a/src/semantic_search/fishing.rs
+++ b/src/semantic_search/fishing.rs
@@ -13,10 +13,10 @@
 //! - **Freshness**: Preferring recently updated information.
 
 use crate::AletheiaDB;
+use crate::core::version::FastHashMap;
 use crate::core::error::{Error, Result};
 use crate::core::id::NodeId;
 use crate::core::temporal::time;
-use std::collections::HashMap;
 
 /// Configuration for a fishing trip.
 #[derive(Debug, Clone)]
@@ -135,8 +135,8 @@ impl<'a> FishingRod<'a> {
             }
         };
 
-        let mut candidate_scores: HashMap<NodeId, f32> = HashMap::new();
-        let mut provenance: HashMap<NodeId, String> = HashMap::new();
+        let mut candidate_scores: FastHashMap<NodeId, f32> = FastHashMap::default();
+        let mut provenance: FastHashMap<NodeId, String> = FastHashMap::default();
 
         // Add the "school" (vector matches) to candidates
         for (node_id, similarity) in school.iter() {

--- a/src/semantic_search/fishing.rs
+++ b/src/semantic_search/fishing.rs
@@ -13,10 +13,10 @@
 //! - **Freshness**: Preferring recently updated information.
 
 use crate::AletheiaDB;
-use crate::core::version::FastHashMap;
 use crate::core::error::{Error, Result};
 use crate::core::id::NodeId;
 use crate::core::temporal::time;
+use crate::core::version::FastHashMap;
 
 /// Configuration for a fishing trip.
 #[derive(Debug, Clone)]

--- a/src/semantic_search/semantic_navigator.rs
+++ b/src/semantic_search/semantic_navigator.rs
@@ -49,11 +49,12 @@
 //! ```
 
 use crate::AletheiaDB;
+use crate::core::version::FastHashMap;
 use crate::core::error::{Error, Result};
 use crate::core::id::NodeId;
 use crate::core::vector::cosine_similarity;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 
 /// A navigator that finds semantically meaningful paths through the graph.
 ///
@@ -157,11 +158,11 @@ impl<'a> SemanticNavigator<'a> {
             node: start,
         });
 
-        let mut came_from: HashMap<NodeId, NodeId> = HashMap::new();
-        let mut g_score: HashMap<NodeId, f32> = HashMap::new();
+        let mut came_from: FastHashMap<NodeId, NodeId> = FastHashMap::default();
+        let mut g_score: FastHashMap<NodeId, f32> = FastHashMap::default();
         g_score.insert(start, 0.0);
 
-        let mut f_score: HashMap<NodeId, f32> = HashMap::new();
+        let mut f_score: FastHashMap<NodeId, f32> = FastHashMap::default();
         // h(start) = 1.0 - sim(start, end)
         // We know start has a vector.
         let h_start = 1.0 - cosine_similarity(&_start_vec, &end_vec)?;
@@ -238,7 +239,7 @@ impl<'a> SemanticNavigator<'a> {
 
     fn reconstruct_path(
         &self,
-        came_from: HashMap<NodeId, NodeId>,
+        came_from: FastHashMap<NodeId, NodeId>,
         mut current: NodeId,
     ) -> Vec<NodeId> {
         let mut total_path = vec![current];

--- a/src/semantic_search/semantic_navigator.rs
+++ b/src/semantic_search/semantic_navigator.rs
@@ -49,10 +49,10 @@
 //! ```
 
 use crate::AletheiaDB;
-use crate::core::version::FastHashMap;
 use crate::core::error::{Error, Result};
 use crate::core::id::NodeId;
 use crate::core::vector::cosine_similarity;
+use crate::core::version::FastHashMap;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 


### PR DESCRIPTION
💡 What: Switched `HashMap` to `FastHashMap` (which uses `IdentityHasher`) for mapping `NodeId` keys in `cartographer.rs`, `fishing.rs`, and `semantic_navigator.rs`.
🎯 Why: The default `SipHash` in `HashMap` has high hashing overhead for small integer keys like `NodeId`. Since `NodeId` provides high-quality, unique integer values, `IdentityHasher` bypasses this overhead, resulting in faster map lookups and inserts during computationally intensive semantic search operations like clustering and A* pathfinding.
📊 Impact: Eliminates unnecessary `SipHash` calculations on hot paths, improving the efficiency of clustering, candidate scoring, and graph traversal.
🔬 Measurement: Run `cargo bench` (if available for semantic search) or observe lower CPU cycles spent in hashing when profiling semantic search features.

---
*PR created automatically by Jules for task [2705451271806589739](https://jules.google.com/task/2705451271806589739) started by @madmax983*