### PR TITLE
⚔️ Elenchus: Strengthen Assertions Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[Assertion Weakness Class]**
+**Module:** `tests/generic_error_types.rs`, `tests/hlc_tests.rs`
+**Severity:** 🟡 Suspect
+**Finding:** A recurring class of weak assertions `assert!(result.is_ok())` without directly asserting the result structure/values. This proves existence but not correctness, allowing mutations returning incorrect but OK values to pass.
+**Evidence:** Found 7 instances in `generic_error_types.rs` checking `result.is_ok()` separately from `result.unwrap()`, and instances in `hlc_tests.rs` doing the same.
+**Recommendation:** Refactored these tests to use `assert_eq!(result, Ok(expected))` for strong, single-step structural equality checks.

--- a/tests/generic_error_types.rs
+++ b/tests/generic_error_types.rs
@@ -42,8 +42,7 @@ fn test_read_with_custom_error_type() {
             .ok_or(RepositoryError::NotFound) // Custom error
     });
 
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "Alice");
+    assert_eq!(result, Ok("Alice".to_string()));
 }
 
 #[test]
@@ -67,8 +66,7 @@ fn test_read_with_custom_error_not_found() {
             .ok_or(RepositoryError::NotFound)
     });
 
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), RepositoryError::NotFound);
+    assert_eq!(result, Err(RepositoryError::NotFound));
 }
 
 #[test]
@@ -101,8 +99,7 @@ fn test_write_with_custom_error_type() {
         Ok("Bob".to_string())
     });
 
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "Bob");
+    assert_eq!(result, Ok("Bob".to_string()));
 }
 
 #[test]
@@ -140,13 +137,10 @@ fn test_write_with_validation_error() {
             .to_string())
     });
 
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        RepositoryError::ValidationFailed(msg) => {
-            assert_eq!(msg, "Must be at least 18");
-        }
-        _ => panic!("Expected ValidationFailed error"),
-    }
+    assert_eq!(
+        result,
+        Err(RepositoryError::ValidationFailed("Must be at least 18".to_string()))
+    );
 }
 
 #[test]
@@ -171,8 +165,7 @@ fn test_write_with_timestamp_error() {
         Ok(name)
     });
 
-    assert!(result.is_ok());
-    let (name, _timestamp) = result.unwrap();
+    let (name, _timestamp) = result.expect("Expected Ok result");
     assert_eq!(name, "Diana");
 }
 
@@ -196,8 +189,7 @@ fn test_write_with_options_error() {
         Ok(10)
     });
 
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), 10);
+    assert_eq!(result, Ok(10));
 }
 
 #[test]
@@ -279,8 +271,5 @@ fn test_chained_operations_with_custom_errors() {
         Ok((name.to_string(), age))
     });
 
-    assert!(result.is_ok());
-    let (name, age) = result.unwrap();
-    assert_eq!(name, "Frank");
-    assert_eq!(age, 30);
+    assert_eq!(result, Ok(("Frank".to_string(), 30)));
 }

--- a/tests/hlc_tests.rs
+++ b/tests/hlc_tests.rs
@@ -23,8 +23,9 @@ fn test_evaluate_clock_skew_exact_boundaries() {
 
     // Should be OK (exact boundary allowed)
     let result = evaluate_clock_skew(current, frontier_exact, None, false);
-    assert!(
-        result.is_ok(),
+    assert_eq!(
+        result.as_ref().map(|d| d.drift_us),
+        Ok(-300_000_000),
         "Exact backward drift limit should be allowed, got {:?}",
         result
     );
@@ -46,8 +47,9 @@ fn test_evaluate_clock_skew_exact_boundaries() {
     let frontier_forward_exact = current - max_forward;
 
     let result = evaluate_clock_skew(current, frontier_forward_exact, Some(max_forward), false);
-    assert!(
-        result.is_ok(),
+    assert_eq!(
+        result.as_ref().map(|d| d.drift_us),
+        Ok(100_000),
         "Exact forward jump limit should be allowed, got {:?}",
         result
     );
@@ -67,11 +69,11 @@ fn test_evaluate_clock_skew_exact_boundaries() {
 fn test_new_validates_wallclock() {
     // Valid wallclock should succeed
     let valid = HybridTimestamp::new(1_000_000, 0);
-    assert!(valid.is_ok());
+    assert_eq!(valid.map(|t| (t.wallclock(), t.logical())), Ok((1_000_000, 0)));
 
     // MAX_VALID_TIMESTAMP should succeed
     let at_max = HybridTimestamp::new(MAX_VALID_TIMESTAMP, 0);
-    assert!(at_max.is_ok());
+    assert_eq!(at_max.map(|t| (t.wallclock(), t.logical())), Ok((MAX_VALID_TIMESTAMP, 0)));
 
     // Wallclock exceeding MAX_VALID_TIMESTAMP should fail
     let invalid = HybridTimestamp::new(MAX_VALID_TIMESTAMP + 1, 0);
@@ -183,8 +185,9 @@ fn test_deserialize_validates_wallclock() {
     valid_buffer.extend_from_slice(&logical.to_le_bytes());
 
     let result = HybridTimestamp::deserialize(&valid_buffer);
-    assert!(
-        result.is_ok(),
+    assert_eq!(
+        result.map(|(t, _)| t.wallclock()),
+        Ok(MAX_VALID_TIMESTAMP),
         "deserialize should accept wallclock <= MAX_VALID_TIMESTAMP"
     );
 
@@ -206,8 +209,9 @@ fn test_deserialize_validates_wallclock() {
     sentinel_buffer_zero.extend_from_slice(&0u32.to_le_bytes());
 
     let result = HybridTimestamp::deserialize(&sentinel_buffer_zero);
-    assert!(
-        result.is_ok(),
+    assert_eq!(
+        result.map(|(t, _)| (t.wallclock(), t.logical())),
+        Ok((i64::MAX, 0)),
         "deserialize should accept i64::MAX with zero logical counter as TIMESTAMP_MAX sentinel"
     );
 }


### PR DESCRIPTION
Summary:
Overall mutation-readiness assessment of the generic error types and HLC tests modules revealed a class of weak assertions (`assert!(result.is_ok())`). This PR audits and strengthens these tests to perform structural equality checks.

Verdict table:
| Module/Test | Classification | Reason |
| :--- | :--- | :--- |
| `generic_error_types.rs` | 🟡 SUSPECT | Checked `is_ok()` separately from value mapping, proving existence but not correct structural evaluation. |
| `hlc_tests.rs` | 🟡 SUSPECT | Checked `is_ok()` without explicitly verifying clock skew boundary logic matches or expected drift numbers. |

Priority fixes:
1. `generic_error_types.rs`: Replaced separate `assert!(result.is_ok())` and `result.unwrap()` statements with unified `assert_eq!(result, Ok(expected))` patterns.
2. `hlc_tests.rs`: Refactored `evaluate_clock_skew_exact_boundaries` to map and assert exact expected `drift_us` (e.g. `Ok(-300_000_000)` and `Ok(100_000)`) instead of `is_ok()`.
3. `hlc_tests.rs`: Refactored deserialization boundary tests to map and check the exact wallclock value parsed, ensuring `MAX_VALID_TIMESTAMP` parsing explicitly succeeds.

Missing coverage:
- Future audits should target any remaining integration tests (like `tiered_storage_reconstruction.rs`) relying on `is_some()` assertions combined with later validation steps to unify them into stronger structural checks where feasible.

---
*PR created automatically by Jules for task [14442905260555975834](https://jules.google.com/task/14442905260555975834) started by @madmax983*