### PR TITLE
🔭 Vantage: Spec for SQL:2011 Temporal Syntax

### DIFF
--- a/docs/specs/VANTAGE_SPEC_SQL_2011_TEMPORAL_SYNTAX.md
+++ b/docs/specs/VANTAGE_SPEC_SQL_2011_TEMPORAL_SYNTAX.md
@@ -1,0 +1,13 @@
+# 🔭 Vantage: Spec for SQL:2011 Temporal Syntax
+
+👤 **User Story:**
+As a Database Administrator familiar with standard relational databases, I want to use SQL:2011 standard temporal syntax (like `SYSTEM_TIME AS OF` and `FOR SYSTEM_TIME BETWEEN`), so that I can easily migrate existing temporal queries to AletheiaDB without learning a completely new proprietary query language.
+
+✅ **Acceptance Criteria:**
+- Must support the standard `FOR SYSTEM_TIME AS OF <timestamp>` clause for point-in-time queries.
+- Must support the standard `FOR SYSTEM_TIME FROM <start> TO <end>` and `FOR SYSTEM_TIME BETWEEN <start> AND <end>` clauses for range queries.
+- Must seamlessly integrate with the existing Cypher-like AST/IR pipeline without breaking current AQL semantics.
+
+🚫 **Out of Scope:**
+- Application-time (Valid Time) SQL:2011 syntax (only System Time / Transaction Time is targeted for Phase 1).
+- Full SQL standard compliance beyond the temporal extensions.


### PR DESCRIPTION
👤 **User Story:**
As a Database Administrator familiar with standard relational databases, I want to use SQL:2011 standard temporal syntax (like `SYSTEM_TIME AS OF` and `FOR SYSTEM_TIME BETWEEN`), so that I can easily migrate existing temporal queries to AletheiaDB without learning a completely new proprietary query language.

✅ **Acceptance Criteria:**
- Must support the standard `FOR SYSTEM_TIME AS OF <timestamp>` clause for point-in-time queries.
- Must support the standard `FOR SYSTEM_TIME FROM <start> TO <end>` and `FOR SYSTEM_TIME BETWEEN <start> AND <end>` clauses for range queries.
- Must seamlessly integrate with the existing Cypher-like AST/IR pipeline without breaking current AQL semantics.

🚫 **Out of Scope:**
- Application-time (Valid Time) SQL:2011 syntax (only System Time / Transaction Time is targeted for Phase 1).
- Full SQL standard compliance beyond the temporal extensions.

---
*PR created automatically by Jules for task [9377794659201056242](https://jules.google.com/task/9377794659201056242) started by @madmax983*