### PR TITLE
⚖️ Elenchus: [query::planner::rules::predicate_pushdown] Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -308,9 +308,9 @@
 ## [Predicate Pushdown Weak Assertions]
 **Module:** `src/query/planner/rules/predicate_pushdown.rs`
 **Severity:** 🟢 Acquitted
-**Finding:** The doc test example in `src/query/planner/rules/predicate_pushdown.rs` contained a weak assertion using `matches!`, which failed to verify the full AST structure after optimization. Furthermore, several unit tests (`test_push_filter_below_vector_rank_no_limit`, `test_push_filter_below_sort`, `test_binary_op_recursion_logic`, and `test_binary_op_partial_optimization`) included redundant and weak `assert!(result.is_some())` assertions.
+**Finding:** The doc test example in `src/query/planner/rules/predicate_pushdown.rs` contained a weak assertion using `matches!`, which failed to verify the full AST structure after optimization. Furthermore, several unit tests (`test_apply_changed`, `test_push_filter_below_vector_rank_no_limit`, `test_push_filter_below_sort`, `test_binary_op_recursion_logic`, and `test_binary_op_partial_optimization`) included redundant and weak `assert!(result.is_some())` assertions.
 **Evidence:** The doc test used `assert!(matches!(optimized_plan.root, LogicalOp::Unary { op: UnaryOp::Sort { .. }, input: _ }));`, only verifying the root node type. The unit tests redundantly asserted `is_some()` before checking equality.
-**Recommendation:** Fixed the doc test to use an exact `expected_plan` and `assert_eq!(optimized_plan, expected_plan)` for complete structural verification (condensing the tree into single line structure to avoid Codecov issues). Updated the four unit tests to replace `assert!(result.is_some())` and `assert_eq!(result.unwrap(), expected_plan)` with a single robust `assert_eq!(result, Some(expected_plan))` check.
+**Recommendation:** Fixed the doc test to use an exact `expected_plan` and `assert_eq!(optimized_plan, expected_plan)` for complete structural verification (condensing the tree into single line structure to avoid Codecov issues). Updated the five unit tests to replace `assert!(result.is_some())` and `assert_eq!(result.unwrap(), expected_plan)` with a single robust `assert_eq!(result, Some(expected_plan))` check.
 
 **[Property Serialization Verification]**
 **Module:** `aletheiadb::core::property`

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -579,7 +579,17 @@ mod sentry_tests {
             ),
         ));
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Sort {
+                key: SortKey::Property("a".to_string()),
+                descending: true,
+            },
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("a", 1)),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]


### PR DESCRIPTION
Summary: Audited `src/query/planner/rules/predicate_pushdown.rs` and strengthened weak existence assertions (`assert!(result.is_some())`) into structural equality assertions (`assert_eq!(result, Some(expected_plan))`).

Verdict table:
- `test_apply_changed`: 🟡 Suspect -> 🟢 Acquitted (Replaced `is_some` with `assert_eq!`)

Priority fixes:
- Replaced `assert!(result.is_some())` in `test_apply_changed` with a rigid `assert_eq!` that checks the precise LogicalPlan generated by the planner after pushdown.

Missing coverage:
- N/A

---
*PR created automatically by Jules for task [7536634203791588363](https://jules.google.com/task/7536634203791588363) started by @madmax983*