### PR TITLE
🗺️ Atlas: [architectural change] Break TxId Dependency Cycle

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -90,3 +90,6 @@
 ## 2026-06-21 - Splitting Redb Cold Storage Blob
 **Tangle:** `src/storage/redb_cold_storage.rs` was over 4100 lines long, a "Blob" module holding both core cold storage logic and over 2000 lines of tests. It made navigation and understanding the core operations difficult.
 **Blueprint:** Refactored into a `src/storage/redb_cold_storage/` module. Kept the core data definitions and implementation in `mod.rs` (reduced to ~2000 lines) and moved all tests to `tests.rs` (~2000 lines), maintaining the `#[cfg(test)]` block functionality but with better physical separation.
+## 2026-06-25 - Breaking TxId Dependency Cycle
+**Tangle:** The `api` module depended on `core::id::TxId`, but re-exported it from `api::transaction::types::TxId`. Code across the repository, including tests, was importing the `api` version instead of the `core` domain primitive. This violated strict layering and created tight coupling between `core` types and `api` representations.
+**Blueprint:** Removed `TxId` re-export from `api::transaction::types` entirely. Updated `api::transaction::mod` to explicitly re-export `crate::core::id::TxId` instead of routing through `types`. Refactored tests like `havoc_visibility_race.rs` to import the core domain primitive directly.

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -65,8 +65,9 @@ pub mod visibility;
 pub mod write;
 pub mod write_buffer;
 
+pub use crate::core::id::TxId;
 pub use read_tx::ReadTransaction;
-pub use types::{TxId, TxMetadata, TxState};
+pub use types::{TxMetadata, TxState};
 pub use visibility::{CompressionStats, TransactionSnapshot, TxVisibilityManager};
 pub use write::WriteTransaction;
 pub use write_buffer::{BufferedWrite, WriteBuffer};

--- a/src/api/transaction/types.rs
+++ b/src/api/transaction/types.rs
@@ -9,9 +9,9 @@
 //! 2.  `Preparing`: The transaction is validating operations before commit.
 //! 3.  `Committed` or `Aborted`: Terminal states indicating success or failure.
 
+use crate::core::id::TxId;
 use crate::core::temporal::Timestamp;
 // Re-export TxId from core to break dependency cycles
-pub use crate::core::id::TxId;
 
 /// Transaction state
 ///

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -4,7 +4,7 @@
 //! which ensures that each transaction sees a consistent snapshot of the database
 //! from the time it started.
 
-use crate::api::transaction::types::TxId;
+use crate::core::id::TxId;
 use crate::core::temporal::Timestamp;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};

--- a/tests/havoc/havoc_visibility_race.rs
+++ b/tests/havoc/havoc_visibility_race.rs
@@ -1,5 +1,5 @@
-use aletheiadb::api::transaction::types::TxId;
 use aletheiadb::api::transaction::visibility::TxVisibilityManager;
+use aletheiadb::core::id::TxId;
 use std::sync::{Arc, Barrier};
 use std::thread;
 


### PR DESCRIPTION
Broke a dependency cycle where `api::transaction::types` was re-exporting `TxId` from `core`, causing downstream code and tests to import the `api` version instead of the core domain primitive.

🕸️ Tangle: The `api` module depended on `core::id::TxId`, but re-exported it. This violated strict layering.
📐 Blueprint: Removed `TxId` re-export from `api::transaction::types` entirely. Updated `api::transaction::mod` to explicitly re-export `crate::core::id::TxId`. Refactored tests to import the core domain primitive directly.
🧱 Stability: Enforces strict unidirectional dependencies from core to api.
🔬 Verification: Ran `cargo test --lib --all-features core::id` and `cargo test --lib --all-features api::transaction` to ensure tests passed.

---
*PR created automatically by Jules for task [17477240575818681790](https://jules.google.com/task/17477240575818681790) started by @madmax983*