### PR TITLE
⚡ Bolt: Optimize Semantic Navigator Hasher

### DIFF
--- a/src/semantic_search/semantic_navigator.rs
+++ b/src/semantic_search/semantic_navigator.rs
@@ -50,10 +50,12 @@
 
 use crate::AletheiaDB;
 use crate::core::error::{Error, Result};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::vector::cosine_similarity;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
+use std::hash::BuildHasherDefault;
 
 /// A navigator that finds semantically meaningful paths through the graph.
 ///
@@ -157,11 +159,17 @@ impl<'a> SemanticNavigator<'a> {
             node: start,
         });
 
-        let mut came_from: HashMap<NodeId, NodeId> = HashMap::new();
-        let mut g_score: HashMap<NodeId, f32> = HashMap::new();
+        // We use IdentityHasher here for significant performance gains during graph traversal.
+        // NodeId is already a uniformly distributed unique integer, so using the default SipHash
+        // is unnecessary overhead. Bypassing it speeds up the A* search considerably.
+        let mut came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
+        let mut g_score: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
         g_score.insert(start, 0.0);
 
-        let mut f_score: HashMap<NodeId, f32> = HashMap::new();
+        let mut f_score: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
         // h(start) = 1.0 - sim(start, end)
         // We know start has a vector.
         let h_start = 1.0 - cosine_similarity(&_start_vec, &end_vec)?;
@@ -238,7 +246,7 @@ impl<'a> SemanticNavigator<'a> {
 
     fn reconstruct_path(
         &self,
-        came_from: HashMap<NodeId, NodeId>,
+        came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>>,
         mut current: NodeId,
     ) -> Vec<NodeId> {
         let mut total_path = vec![current];


### PR DESCRIPTION
💡 What: Switched the default SipHash hasher in `came_from`, `g_score`, and `f_score` HashMaps to `IdentityHasher` within the `semantic_navigator::find_path` method.

🎯 Why: These HashMaps are keyed by `NodeId`, which is a sequentially or randomly generated 64-bit unsigned integer that is already uniformly distributed. Hashing it cryptographically with `SipHash` inside an A* traversal loop adds completely unnecessary overhead.

📊 Impact: Reduces CPU hashing cycles to near-zero for every visited node during a semantic path search, significantly improving throughput for large graph traversals.

🔬 Measurement: Run `cargo test --lib semantic_search` and verify tests pass.

---
*PR created automatically by Jules for task [13358285840946138377](https://jules.google.com/task/13358285840946138377) started by @madmax983*