### PR TITLE
👺 Havoc: Fix Spurious Wakeups in Flush Coordinator Condvar

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -892,9 +892,7 @@ impl FlushSignal {
 
         let (_guard, _result) = self
             .condvar
-            .wait_timeout_while(guard, timeout, |_| {
-                !self.requested.load(Ordering::Acquire)
-            })
+            .wait_timeout_while(guard, timeout, |_| !self.requested.load(Ordering::Acquire))
             .unwrap_or_else(|e| e.into_inner());
 
         // Only return true if actually requested, regardless of spurious wakeups

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -890,13 +890,11 @@ impl FlushSignal {
     pub fn wait_for_request(&self, timeout: Duration) -> bool {
         let guard = self.mutex.lock().unwrap_or_else(|e| e.into_inner());
 
-        if self.requested.load(Ordering::Acquire) {
-            return true;
-        }
-
         let (_guard, _result) = self
             .condvar
-            .wait_timeout(guard, timeout)
+            .wait_timeout_while(guard, timeout, |_| {
+                !self.requested.load(Ordering::Acquire)
+            })
             .unwrap_or_else(|e| e.into_inner());
 
         // Only return true if actually requested, regardless of spurious wakeups

--- a/tests/havoc/havoc_wal_spurious_wakeup.rs
+++ b/tests/havoc/havoc_wal_spurious_wakeup.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use std::thread;
+use aletheiadb::storage::wal::flush_coordinator::FlushSignal;
+
+#[test]
+fn havoc_wal_spurious_wakeup() {
+    let signal = Arc::new(FlushSignal::new());
+
+    let signal_clone = Arc::clone(&signal);
+
+    let t = thread::spawn(move || {
+        let start = Instant::now();
+        // The thread waits for 2 seconds
+        let result = signal_clone.wait_for_request(Duration::from_secs(2));
+        let elapsed = start.elapsed();
+        (result, elapsed)
+    });
+
+    // Give it a moment to enter wait
+    thread::sleep(Duration::from_millis(50));
+
+    // Simulating spurious wakeup by manually requesting a flush BUT we swap it back instantly.
+    // Actually, wait_for_request says: "Handles spurious wakeups by checking the actual requested flag."
+    // Let's invoke request_flush() then IMMEDIATELY take_request() so the flag is false when the thread wakes up.
+    signal.request_flush();
+    signal.take_request();
+
+    let (was_requested, elapsed) = t.join().unwrap();
+
+    // Because wait_for_request doesn't loop, it wakes up from the condvar, checks `requested` (which is false), and returns false immediately!
+    // It should have slept for ~2 seconds.
+    assert!(!was_requested, "Spurious wakeup correctly resulted in false");
+
+    if elapsed < Duration::from_secs(1) {
+        panic!("👺 HAVOC SUCCESS: Spurious wakeup caused premature return! Elapsed: {:?}. The condvar didn't loop until timeout.", elapsed);
+    }
+}

--- a/tests/havoc/havoc_wal_spurious_wakeup.rs
+++ b/tests/havoc/havoc_wal_spurious_wakeup.rs
@@ -1,7 +1,7 @@
-use aletheiadb::storage::wal::flush_coordinator::FlushSignal;
 use std::sync::Arc;
-use std::thread;
 use std::time::{Duration, Instant};
+use std::thread;
+use aletheiadb::storage::wal::flush_coordinator::FlushSignal;
 
 #[test]
 fn havoc_wal_spurious_wakeup() {

--- a/tests/havoc/havoc_wal_spurious_wakeup.rs
+++ b/tests/havoc/havoc_wal_spurious_wakeup.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-use std::thread;
 use aletheiadb::storage::wal::flush_coordinator::FlushSignal;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 #[test]
 fn havoc_wal_spurious_wakeup() {
@@ -30,9 +30,15 @@ fn havoc_wal_spurious_wakeup() {
 
     // Because wait_for_request doesn't loop, it wakes up from the condvar, checks `requested` (which is false), and returns false immediately!
     // It should have slept for ~2 seconds.
-    assert!(!was_requested, "Spurious wakeup correctly resulted in false");
+    assert!(
+        !was_requested,
+        "Spurious wakeup correctly resulted in false"
+    );
 
     if elapsed < Duration::from_secs(1) {
-        panic!("👺 HAVOC SUCCESS: Spurious wakeup caused premature return! Elapsed: {:?}. The condvar didn't loop until timeout.", elapsed);
+        panic!(
+            "👺 HAVOC SUCCESS: Spurious wakeup caused premature return! Elapsed: {:?}. The condvar didn't loop until timeout.",
+            elapsed
+        );
     }
 }

--- a/tests/havoc/wal.rs
+++ b/tests/havoc/wal.rs
@@ -8,3 +8,5 @@ mod havoc_loom_ring_buffer;
 mod havoc_ring_buffer_torture;
 #[path = "havoc_wal_gaps.rs"]
 mod havoc_wal_gaps;
+#[path = "havoc_wal_spurious_wakeup.rs"]
+mod havoc_wal_spurious_wakeup;


### PR DESCRIPTION
🧨 **The Trigger:** 
A condvar `wait_timeout` was implemented without a condition loop. Any spurious wakeup (or a quick `request_flush` followed by a `take_request`) would cause the waiting thread to wake up, see the flag as `false`, and immediately return `false` instead of going back to sleep to fulfill the timeout contract.

📉 **The Stack Trace:** 
```
thread 'havoc_suites::wal::havoc_wal_spurious_wakeup::havoc_wal_spurious_wakeup' panicked at tests/havoc/havoc_wal_spurious_wakeup.rs:36:9:
👺 HAVOC SUCCESS: Spurious wakeup caused premature return! Elapsed: 50.201449ms. The condvar didn't loop until timeout.
```

🧪 **Reproduction:** 
Run `cargo test --test havoc havoc_wal_spurious_wakeup` on the commit before this fix.

😈 **Comment:** 
"You thought `wait_timeout` was a sleep. It's not. The condvar woke up, saw the flag was false, and just gave up. I made it loop with `wait_timeout_while`. You're welcome."

---
*PR created automatically by Jules for task [4104511067303657365](https://jules.google.com/task/4104511067303657365) started by @madmax983*