### PR TITLE
🪒 Razor: [reduction]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,13 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `Resonator` trait (Single-implementation abstraction used only by `ActivityDensityResonator`).
+**Cut:** Deleted the `Resonator` trait and refactored `EchoChamber` to use the concrete `ActivityDensityResonator` struct directly, removing generic type parameters.
+**Saved:** ~20 lines of trait definition + cognitive load of unnecessary abstraction layers + generic parameter bloat across the module.
+
+## [Reduction]
+**Bloat:** `SemanticRule` trait (Abstraction causing `Box<dyn SemanticRule>` allocations and dynamic dispatch for just two rule types).
+**Cut:** Converted `SemanticRule` from a trait into an enum with `VectorBan` and `NumericRange` variants, moving the `validate` implementations to the concrete structs.
+**Saved:** Removed dynamic dispatch overhead + simplified `Sentinel` to hold `Vec<SemanticRule>` instead of boxed trait objects.

--- a/src/experimental/diagnostics/sentinel.rs
+++ b/src/experimental/diagnostics/sentinel.rs
@@ -18,7 +18,7 @@
 //! // Rule: Ban anything semantically similar to "Hate Speech" (vector: [1.0, 0.0])
 //! let mut ban_rule = VectorBanRule::new("embedding", 0.9);
 //! ban_rule.add_banned_vector(vec![1.0, 0.0]).unwrap();
-//! sentinel.add_rule(Box::new(ban_rule));
+//! sentinel.add_rule(SemanticRule::VectorBan(ban_rule));
 //!
 //! // This should fail validation
 //! let toxic_props = PropertyMapBuilder::new()
@@ -33,15 +33,27 @@ use crate::core::property::PropertyMap;
 use crate::core::vector::cosine_similarity;
 
 /// A rule that validates a PropertyMap.
-pub trait SemanticRule {
+pub enum SemanticRule {
+    /// A rule that bans vectors similar to a set of forbidden vectors.
+    VectorBan(VectorBanRule),
+    /// A rule that enforces a logical condition on a numeric property.
+    NumericRange(NumericRangeRule),
+}
+
+impl SemanticRule {
     /// Validate the given properties.
     /// Returns Ok if valid, Err with a reason if invalid.
-    fn validate(&self, props: &PropertyMap) -> Result<()>;
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
+        match self {
+            SemanticRule::VectorBan(rule) => rule.validate(props),
+            SemanticRule::NumericRange(rule) => rule.validate(props),
+        }
+    }
 }
 
 /// The Sentinel validates data against a set of rules.
 pub struct Sentinel {
-    rules: Vec<Box<dyn SemanticRule>>,
+    rules: Vec<SemanticRule>,
 }
 
 impl Sentinel {
@@ -51,7 +63,7 @@ impl Sentinel {
     }
 
     /// Add a rule to the Sentinel.
-    pub fn add_rule(&mut self, rule: Box<dyn SemanticRule>) {
+    pub fn add_rule(&mut self, rule: SemanticRule) {
         self.rules.push(rule);
     }
 
@@ -106,8 +118,9 @@ impl VectorBanRule {
     }
 }
 
-impl SemanticRule for VectorBanRule {
-    fn validate(&self, props: &PropertyMap) -> Result<()> {
+impl VectorBanRule {
+    /// Validate the given properties.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         // If the property doesn't exist or isn't a vector, we skip validation (or should we fail?)
         // Let's be lenient: if no vector is provided, the rule doesn't apply.
         // Unless it's a required field, which is a different rule (SchemaRule).
@@ -188,8 +201,9 @@ impl NumericRangeRule {
     }
 }
 
-impl SemanticRule for NumericRangeRule {
-    fn validate(&self, props: &PropertyMap) -> Result<()> {
+impl NumericRangeRule {
+    /// Validate the given properties.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         let val = match props.get(&self.property_name) {
             Some(v) => v,
             None => return Ok(()),
@@ -329,11 +343,11 @@ mod tests {
         // Rule 1: Ban toxic vectors
         let mut ban_rule = VectorBanRule::new("embedding", 0.8);
         ban_rule.add_banned_vector(vec![1.0, 0.0]).unwrap();
-        sentinel.add_rule(Box::new(ban_rule));
+        sentinel.add_rule(SemanticRule::VectorBan(ban_rule));
 
         // Rule 2: Age must be >= 18
         let range_rule = NumericRangeRule::new("age").min(18.0);
-        sentinel.add_rule(Box::new(range_rule));
+        sentinel.add_rule(SemanticRule::NumericRange(range_rule));
 
         // Valid Insert
         let valid = PropertyMapBuilder::new()

--- a/src/experimental/temporal/echo.rs
+++ b/src/experimental/temporal/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "semantic-temporal")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -202,7 +197,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "semantic-temporal"))]
@@ -251,13 +246,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 


### PR DESCRIPTION
This PR adheres to the Razor persona's core philosophy of ruthless essentialism by removing unnecessary abstractions.

Two primary reductions were performed:

1.  **De-Abstracted `Resonator`:** The `Resonator` trait was only implemented by `ActivityDensityResonator`. The trait was removed, and `EchoChamber` was refactored to consume the concrete `ActivityDensityResonator` struct directly, removing generic type bloat.
2.  **Flattened `SemanticRule`:** The `SemanticRule` trait was used to abstract validation logic, causing unnecessary heap allocations (`Box<dyn SemanticRule>`) and dynamic dispatch for just two rule types. It has been converted to an `enum`, improving both performance and clarity.

All relevant doc tests and unit tests have been updated and pass successfully. Public visibility modifiers were explicitly preserved during the conversion from trait implementations to inherent implementations.

---
*PR created automatically by Jules for task [17365810193531617236](https://jules.google.com/task/17365810193531617236) started by @madmax983*