### PR TITLE
⚡ Bolt: Pre-allocate HashMaps during index persistence recovery

### DIFF
--- a/src/storage/index_persistence/graph.rs
+++ b/src/storage/index_persistence/graph.rs
@@ -706,12 +706,13 @@ pub fn load_graph_index_with_delta(
 
     // 2. Handle modifications (update existing entries)
     // Convert modifications to HashMaps to reduce O(M*N) lookups to O(N+M)
-    let mut node_mods = std::collections::HashMap::new();
+    // ⚡ Bolt Optimization: Pre-allocate HashMaps to avoid re-allocations during delta recovery.
+    let mut node_mods = std::collections::HashMap::with_capacity(delta.modified_nodes.len());
     for n in delta.modified_nodes {
         node_mods.insert(n.id, n);
     }
 
-    let mut edge_mods = std::collections::HashMap::new();
+    let mut edge_mods = std::collections::HashMap::with_capacity(delta.modified_edges.len());
     for e in delta.modified_edges {
         edge_mods.insert(e.id, e);
     }


### PR DESCRIPTION
💡 What:
Pre-allocated `node_mods` and `edge_mods` `HashMap`s with their exact capacities using `.with_capacity()` during the delta recovery process (`load_graph_index_with_delta`) in `src/storage/index_persistence/graph.rs`.

🎯 Why:
The previous implementation initialized empty HashMaps using `HashMap::new()` and subsequently inserted items inside a `for` loop. Since we know the exact number of incoming modifications from `delta.modified_nodes.len()` and `delta.modified_edges.len()`, starting from an empty capacity forces the `HashMap` to re-allocate its internal buffer and re-hash existing keys multiple times as the size scales.

📊 Impact:
Eliminates intermediate memory allocations and the O(N) cost of rehashing when recovering large batches of node/edge updates from persistence index delta files. This optimizes the hot path used during node startup and log application.

🔬 Measurement:
Run `cargo test --lib --all-features -- index_persistence::graph` to verify that delta operations and uncompressed loads successfully function identically to the non-preallocated behavior.

---
*PR created automatically by Jules for task [9900341295973966506](https://jules.google.com/task/9900341295973966506) started by @madmax983*