### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -191,6 +191,22 @@ pub trait ReadOps {
     ///
     /// - **Time**: O(degree) to collect visible edges
     /// - **Space**: Allocates a new `Vec` containing all edge IDs
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, core::NodeId, api::transaction::ReadOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// # let tx = db.read_transaction()?;
+    /// # let node_id = NodeId::new(1)?;
+    /// let edges = tx.get_incoming_edges(node_id);
+    /// for edge_id in edges {
+    ///     let edge = tx.get_edge(edge_id)?;
+    ///     println!("<- {}", edge.source);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId>;
 
     /// Get outgoing edges with a specific label.
@@ -206,6 +222,22 @@ pub trait ReadOps {
     ///
     /// - **Time**: O(degree) scan with label filtering
     /// - **Space**: Allocates a new `Vec` containing matching edge IDs
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, core::NodeId, api::transaction::ReadOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// # let tx = db.read_transaction()?;
+    /// # let node_id = NodeId::new(1)?;
+    /// let edges = tx.get_outgoing_edges_with_label(node_id, "KNOWS");
+    /// for edge_id in edges {
+    ///     let edge = tx.get_edge(edge_id)?;
+    ///     println!("Knows -> {}", edge.target);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId>;
 
     /// Get the approximate number of nodes in the database.

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -711,6 +711,17 @@ impl TxVisibilityManager {
     ///
     /// This provides detailed information about compression ratio,
     /// memory usage, and memory savings.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use aletheiadb::api::transaction::TxVisibilityManager;
+    /// let visibility_manager = TxVisibilityManager::new();
+    /// let stats = visibility_manager.get_compression_stats();
+    ///
+    /// println!("Compression ratio: {:.2}x", stats.compression_ratio);
+    /// println!("Memory savings: {} bytes", stats.memory_savings_bytes);
+    /// ```
     pub fn get_compression_stats(&self) -> CompressionStats {
         let committed = self
             .committed

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -720,7 +720,7 @@ impl TxVisibilityManager {
     /// let stats = visibility_manager.get_compression_stats();
     ///
     /// println!("Compression ratio: {:.2}x", stats.compression_ratio);
-    /// println!("Memory savings: {} bytes", stats.memory_savings_bytes);
+    /// println!("Memory savings: {} bytes", stats.memory_saved_bytes);
     /// ```
     pub fn get_compression_stats(&self) -> CompressionStats {
         let committed = self

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -323,6 +323,20 @@ impl WriteBuffer {
     }
 
     /// Get the buffered write for a node, if any
+    /// # Example
+    ///
+    /// ```rust
+    /// # use aletheiadb::api::transaction::{WriteBuffer, BufferedWrite};
+    /// # use aletheiadb::core::NodeId;
+    /// # use aletheiadb::core::property::PropertyMapBuilder;
+    /// let mut buffer = WriteBuffer::new();
+    /// let node_id = NodeId::new(1).unwrap();
+    /// let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+    /// buffer.add(BufferedWrite::CreateNode { id: node_id, label: "Person".to_string(), properties: props }).unwrap();
+    ///
+    /// let write = buffer.get_node_write(node_id);
+    /// assert!(write.is_some());
+    /// ```
     pub fn get_node_write(&self, node_id: NodeId) -> Option<&BufferedWrite> {
         self.modified_nodes
             .get(&node_id)
@@ -330,6 +344,22 @@ impl WriteBuffer {
     }
 
     /// Get the buffered write for an edge, if any
+    /// # Example
+    ///
+    /// ```rust
+    /// # use aletheiadb::api::transaction::{WriteBuffer, BufferedWrite};
+    /// # use aletheiadb::core::{EdgeId, NodeId};
+    /// # use aletheiadb::core::property::PropertyMapBuilder;
+    /// let mut buffer = WriteBuffer::new();
+    /// let edge_id = EdgeId::new(1).unwrap();
+    /// let source = NodeId::new(10).unwrap();
+    /// let target = NodeId::new(20).unwrap();
+    /// let props = PropertyMapBuilder::new().insert("weight", 0.5).build();
+    /// buffer.add(BufferedWrite::CreateEdge { id: edge_id, source, target, label: "KNOWS".to_string(), properties: props }).unwrap();
+    ///
+    /// let write = buffer.get_edge_write(edge_id);
+    /// assert!(write.is_some());
+    /// ```
     pub fn get_edge_write(&self, edge_id: EdgeId) -> Option<&BufferedWrite> {
         self.modified_edges
             .get(&edge_id)

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -327,12 +327,21 @@ impl WriteBuffer {
     ///
     /// ```rust
     /// # use aletheiadb::api::transaction::{WriteBuffer, BufferedWrite};
-    /// # use aletheiadb::core::NodeId;
+    /// # use aletheiadb::core::{NodeId, VersionId};
     /// # use aletheiadb::core::property::PropertyMapBuilder;
+    /// # use aletheiadb::core::interning::InternedString;
+    /// # use aletheiadb::core::temporal::time;
     /// let mut buffer = WriteBuffer::new();
     /// let node_id = NodeId::new(1).unwrap();
+    /// let version_id = VersionId::new(1).unwrap();
     /// let props = PropertyMapBuilder::new().insert("name", "Alice").build();
-    /// buffer.add(BufferedWrite::CreateNode { id: node_id, label: "Person".to_string(), properties: props }).unwrap();
+    /// buffer.add(BufferedWrite::CreateNode {
+    ///     node_id,
+    ///     version_id,
+    ///     label: InternedString::from_raw(1),
+    ///     properties: props,
+    ///     valid_from: time::now()
+    /// }).unwrap();
     ///
     /// let write = buffer.get_node_write(node_id);
     /// assert!(write.is_some());
@@ -348,14 +357,25 @@ impl WriteBuffer {
     ///
     /// ```rust
     /// # use aletheiadb::api::transaction::{WriteBuffer, BufferedWrite};
-    /// # use aletheiadb::core::{EdgeId, NodeId};
+    /// # use aletheiadb::core::{EdgeId, NodeId, VersionId};
     /// # use aletheiadb::core::property::PropertyMapBuilder;
+    /// # use aletheiadb::core::interning::InternedString;
+    /// # use aletheiadb::core::temporal::time;
     /// let mut buffer = WriteBuffer::new();
     /// let edge_id = EdgeId::new(1).unwrap();
+    /// let version_id = VersionId::new(1).unwrap();
     /// let source = NodeId::new(10).unwrap();
     /// let target = NodeId::new(20).unwrap();
     /// let props = PropertyMapBuilder::new().insert("weight", 0.5).build();
-    /// buffer.add(BufferedWrite::CreateEdge { id: edge_id, source, target, label: "KNOWS".to_string(), properties: props }).unwrap();
+    /// buffer.add(BufferedWrite::CreateEdge {
+    ///     edge_id,
+    ///     version_id,
+    ///     source,
+    ///     target,
+    ///     label: InternedString::from_raw(2),
+    ///     properties: props,
+    ///     valid_from: time::now()
+    /// }).unwrap();
     ///
     /// let write = buffer.get_edge_write(edge_id);
     /// assert!(write.is_some());


### PR DESCRIPTION
📖 **Chapter:** The `api::transaction` module getters.
💡 **Insight:** Several `get_*` methods across `ReadOps`, `WriteBuffer`, and `TxVisibilityManager` were missing explicit `# Examples` blocks, leading to "Black Box" or "Getters" docs that didn't provide a copy-pasteable hero's journey.
🧪 **Example:** Added 5 executable doctests that compile successfully and demonstrate how to fetch incoming edges, query visibility stats, and extract buffered writes.
🖼️ **Preview:** Docs now render beautifully in HTML when running `cargo doc --open`.

---
*PR created automatically by Jules for task [4504235420492051040](https://jules.google.com/task/4504235420492051040) started by @madmax983*