### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -73,3 +73,6 @@
 **[Optimize Migration Candidates Vec Pre-allocation]**
 **Learning:** In `identify_node_candidates` and `identify_edge_candidates`, initializing `all_candidates` and `final_candidates` with `Vec::new()` causes unnecessary intermediate heap reallocations during large data migrations because the maximum required capacity is already known from the `versions` map and the filtered `all_candidates` vector.
 **Action:** Always pre-allocate vectors using `Vec::with_capacity(n)` when the target collection size or its upper bound is known in advance, particularly on hot paths like data migration.
+**Pre-allocating Vecs for transaction state**
+**Learning:** Collecting iterators into `Vec` inside a hot transaction path like `apply.rs` can cause multiple allocations due to organic resizing.
+**Action:** Use `Vec::with_capacity(n)` and an explicit loop when the size `n` is known upfront, especially if handling `Result` mapping across an iterator.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -437,10 +437,11 @@ pub(crate) fn apply_changes(tx: &WriteTransaction, commit_timestamp: Timestamp) 
         .count();
 
     let mut tombstone_ids = if num_deletes > 0 {
-        let ids: Result<Vec<u64>> = (0..num_deletes)
-            .map(|_| tx.version_id_gen.next().map_err(Into::into))
-            .collect();
-        ids?.into_iter()
+        let mut ids = Vec::with_capacity(num_deletes);
+        for _ in 0..num_deletes {
+            ids.push(tx.version_id_gen.next()?);
+        }
+        ids.into_iter()
     } else {
         Vec::new().into_iter()
     };


### PR DESCRIPTION
💡 What: Replaced the chained `.collect::<Result<Vec<_>, _>>().into_iter()` inside `apply.rs` (which performs organic resizing as elements are generated) with an explicitly capacity-sized `Vec::with_capacity` populated via a `for` loop.
🎯 Why: Collecting iterators inside hot transaction paths (like applying writes/deletes) that map over results causes unpredictable and unoptimized allocations if size hints are lost. The array size (`num_deletes`) was known prior to collection.
📊 Impact: Removes multiple intermediate heap reallocations per transaction containing deletions.
🔬 Measurement: Run `cargo test --lib --all-features -- apply`.

---
*PR created automatically by Jules for task [3014741425194021899](https://jules.google.com/task/3014741425194021899) started by @madmax983*