### PR TITLE
⚡ Bolt: Optimize empty PropertyMap allocations

### DIFF
--- a/src/core/property/map.rs
+++ b/src/core/property/map.rs
@@ -7,7 +7,9 @@ use crate::core::property::value::PropertyValue;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::BuildHasherDefault;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+static EMPTY_PROPERTY_MAP: OnceLock<PropertyMap> = OnceLock::new();
 
 ///
 /// The underlying HashMap is wrapped in an Arc, making clones very cheap
@@ -38,6 +40,19 @@ pub struct PropertyMap {
 }
 
 impl PropertyMap {
+    /// Returns a globally shared empty property map.
+    ///
+    /// ⚡ Bolt Optimization: Using this instead of `PropertyMap::new()` or `Default::default()`
+    /// avoids allocating a new `Arc<HashMap>` on the heap for empty property maps.
+    pub fn empty() -> Self {
+        EMPTY_PROPERTY_MAP
+            .get_or_init(|| PropertyMap {
+                inner: Arc::new(HashMap::with_hasher(BuildHasherDefault::default())),
+                cached_size: 4, // 4 bytes for the count field (0)
+            })
+            .clone()
+    }
+
     /// Create a new empty property map.
     pub fn new() -> Self {
         PropertyMap {
@@ -425,7 +440,7 @@ impl fmt::Debug for PropertyMap {
 
 impl Default for PropertyMap {
     fn default() -> Self {
-        Self::new()
+        Self::empty()
     }
 }
 

--- a/src/core/property/tests.rs
+++ b/src/core/property/tests.rs
@@ -2578,4 +2578,25 @@ mod sentry_tests {
             "semantically_equal should treat NaN as equal"
         );
     }
+
+    #[test]
+    fn test_property_map_empty_shares_allocation() {
+        let map1 = PropertyMap::empty();
+        let map2 = PropertyMap::empty();
+        let map3 = PropertyMap::default();
+
+        // ⚡ Bolt Optimization test: verify that empty maps share the same Arc allocation
+        assert!(
+            Arc::ptr_eq(&map1.inner, &map2.inner),
+            "PropertyMap::empty() should share the same Arc allocation"
+        );
+        assert!(
+            Arc::ptr_eq(&map1.inner, &map3.inner),
+            "PropertyMap::default() should share the same Arc allocation as empty()"
+        );
+
+        assert_eq!(map1.len(), 0);
+        assert_eq!(map2.len(), 0);
+        assert_eq!(map3.len(), 0);
+    }
 }


### PR DESCRIPTION
💡 **What:**
Introduced a `PropertyMap::empty()` method that returns a clone of a globally shared static instance (using `std::sync::OnceLock`). Updated `impl Default for PropertyMap` to call this new method rather than `PropertyMap::new()`.

🎯 **Why:**
During query execution, `QueryResults::collect_structured` builds results by inspecting node IDs. When full nodes are not requested or not available, it pads the properties array using `Default::default()`. Previously, every call to `PropertyMap::default()` or `PropertyMap::new()` allocated a brand new `Arc<HashMap>` on the heap. For queries returning thousands of node IDs without properties, this resulted in thousands of unnecessary identical heap allocations.

📊 **Impact:**
Eliminates one `Arc<HashMap>` heap allocation for every empty `PropertyMap` created via `Default` or `empty()`. This substantially improves memory efficiency and performance when collecting structured results for large datasets, especially for vector search or ID-only projections.

🔬 **Measurement:**
Run `cargo bench` or specifically profile memory allocations during `collect_structured` on large result sets. Additionally, a new unit test `test_property_map_empty_shares_allocation` was added in `src/core/property/tests.rs` to explicitly verify that `Arc::ptr_eq` remains true for multiple default/empty instances.

---
*PR created automatically by Jules for task [14406343505526986559](https://jules.google.com/task/14406343505526986559) started by @madmax983*