### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,16 @@ let _result = db.read(|tx| {
 
 ### Embedding Generation (Optional)
 
+> ⚠️ **IMPORTANT: REQUIRES FEATURE 'embedding-openai'**
+>
+> Experimental features like **Embedding Generation** require the `embedding-openai` feature flag.
+> **You MUST add this to your `Cargo.toml` or the code will not compile:**
+>
+> ```toml
+> [dependencies]
+> aletheiadb = { version = "0.1", features = ["embedding-openai"] }
+> ```
+
 AletheiaDB includes an optional embedding generation system for semantic search:
 
 ```rust


### PR DESCRIPTION
🤦‍♂️ **The Confusion:** "Tried to run the `Embedding Generation` example. Compiler said `could not find embeddings in aletheiadb` and failed to compile."

🕵️‍♂️ **The Reality:** "Turns out I needed to enable feature `embedding-openai` in Cargo.toml."

💡 **The Fix:** "Add a huge banner in README saying 'REQUIRES FEATURE embedding-openai' above the example."

---
*PR created automatically by Jules for task [8414327203109815788](https://jules.google.com/task/8414327203109815788) started by @madmax983*