### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -4,3 +4,6 @@
 ## 2024-04-10 - [Intra-doc links for conditionally-compiled or non-existent items]
 **Confusion:** Using standard intra-doc links (`[item]`) for items that are either conditionally compiled (like feature-gated experimental modules) or don't resolve properly in the dependency tree causes `rustdoc::broken_intra_doc_links` warnings.
 **Clarification:** Changed intra-doc links to standard markdown backticks (`` `item` ``) for items like `` `crate::semantic_search` ``, `` `reasoning` ``, `` `temporal` ``, `` `diagnostics` ``, `` `characterization` ``, `` `mosaic` ``, and `` `autumn_web::prelude::app` `` to satisfy rustdoc while still keeping the documentation clean and readable.
+## 2024-05-03 - [The Missing Documentations of the db internals]
+**Confusion:** Many core public functions and structures within the `src/db` submodules were missing module level documentation (`//!`), making it hard for users to quickly get the concept of what each file does.
+**Clarification:** I added module-level `//!` documentation to all files under `src/db` that were missing them (`admin.rs`, `config.rs`, `ops.rs`, `query.rs`, `temporal.rs`, `transaction.rs`, `vector.rs`, `vector_builder.rs`) as well as `src/experimental/temporal/temporal_narrative.rs`. This provides a "Abstract" of what the file does before listing "how".

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -1,3 +1,6 @@
+//! Administrative and test-only helper methods.
+//!
+//! Provides internal statistics, test visibility, and database maintenance operations.
 use crate::api::transaction::visibility::CompressionStats;
 use crate::core::error::{PersistenceErrorKind, Result, ResultExt, StorageError};
 use crate::core::temporal::Timestamp;

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -1,3 +1,6 @@
+//! Database configuration and initialization.
+//!
+//! Provides the `AletheiaDB::new()` and `with_config` entry points for the database.
 use crate::api::transaction::TxVisibilityManager;
 use crate::config::AletheiaDBConfig;
 use crate::core::error::{Result, ResultExt, StorageError};

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -1,6 +1,6 @@
 //! Database configuration and initialization.
 //!
-//! Provides the `AletheiaDB::new()` and `with_config` entry points for the database.
+//! Provides AletheiaDB initialization methods, including AletheiaDB::new() and AletheiaDB::with_unified_config().
 use crate::api::transaction::TxVisibilityManager;
 use crate::config::AletheiaDBConfig;
 use crate::core::error::{Result, ResultExt, StorageError};

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -1,3 +1,6 @@
+//! Basic graph operations for creating and reading nodes and edges.
+//!
+//! Contains convenience methods for the most common graph operations.
 use crate::api::transaction::WriteOps;
 use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -1,3 +1,6 @@
+//! Query builder and execution entry points.
+//!
+//! Provides access to the query planner, AQL execution, and hybrid search methods.
 use crate::core::error::{Result, ResultExt};
 use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -1,3 +1,6 @@
+//! Temporal query operations for bi-temporal data.
+//!
+//! Methods for querying historical states of the graph using valid and transaction times.
 use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId, VersionId};

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -1,3 +1,6 @@
+//! Transaction management methods.
+//!
+//! Provides closures and manual transaction control for both read and write operations.
 use crate::api::transaction::{ReadTransaction, WriteTransaction};
 use crate::core::error::{Result, ResultExt, TransactionError};
 use crate::core::hlc::HybridTimestamp;

--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -1,3 +1,6 @@
+//! Vector index management and search operations.
+//!
+//! Methods for creating vector indexes, semantic search, and similarity tracking.
 use crate::core::error::{Result, ResultExt};
 use crate::core::id::NodeId;
 use crate::core::temporal::Timestamp;

--- a/src/db/vector_builder.rs
+++ b/src/db/vector_builder.rs
@@ -1,3 +1,6 @@
+//! Builder pattern for creating vector indexes.
+//!
+//! Provides `VectorIndexBuilder` to configure HNSW and temporal vector indexes.
 use crate::core::error::{Error, Result};
 use crate::db::AletheiaDB;
 use crate::index::vector::hnsw::HnswConfig;

--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -1,3 +1,6 @@
+//! Experimental module for generating human-readable narratives from temporal history.
+//!
+//! Converts raw graph mutations into readable event summaries.
 use crate::AletheiaDB;
 #[cfg(feature = "semantic-temporal")]
 use crate::core::GLOBAL_INTERNER;


### PR DESCRIPTION
📖 Chapter: The `db` and `experimental` modules.
💡 Insight: Added missing module-level `//!` documentation to `admin.rs`, `config.rs`, `ops.rs`, `query.rs`, `temporal.rs`, `transaction.rs`, `vector.rs`, `vector_builder.rs`, and `temporal_narrative.rs` to provide an "Abstract" of what each file does before diving into the implementation details. This clears up the "Black Box" confusion for the `src/db/` directory.
🧪 Example: Checked generation via `cargo doc --no-deps`.
🖼️ Preview: Documentation is now visible at the top of the module pages in standard cargo docs.

---
*PR created automatically by Jules for task [17863892043042281712](https://jules.google.com/task/17863892043042281712) started by @madmax983*