### PR TITLE
⚡ Bolt: Optimize PropertyMapBuilder with capacity pre-allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -73,3 +73,7 @@
 **[Optimize Migration Candidates Vec Pre-allocation]**
 **Learning:** In `identify_node_candidates` and `identify_edge_candidates`, initializing `all_candidates` and `final_candidates` with `Vec::new()` causes unnecessary intermediate heap reallocations during large data migrations because the maximum required capacity is already known from the `versions` map and the filtered `all_candidates` vector.
 **Action:** Always pre-allocate vectors using `Vec::with_capacity(n)` when the target collection size or its upper bound is known in advance, particularly on hot paths like data migration.
+
+**Optimize PropertyMapBuilder Pre-allocation**
+**Learning:** Initializing `PropertyMapBuilder::new()` without specifying capacity and then inserting multiple properties sequentially (e.g. in `ProjectIterator`) triggers unnecessary intermediate hashmap reallocations as properties are projected.
+**Action:** Added `PropertyMapBuilder::with_capacity(capacity)` and replaced `PropertyMapBuilder::new()` in mapping projections where the target property length (`self.properties.len()`) is known in advance, preventing hashmap rehashing overhead during large query result projections.

--- a/src/core/property/map.rs
+++ b/src/core/property/map.rs
@@ -482,6 +482,14 @@ impl PropertyMapBuilder {
         }
     }
 
+    /// Create a builder with the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        PropertyMapBuilder {
+            map: HashMap::with_capacity_and_hasher(capacity, BuildHasherDefault::default()),
+            current_size: 4, // Count field
+        }
+    }
+
     /// Create a builder from an existing PropertyMap.
     ///
     /// This will clone the underlying HashMap if the Arc has multiple references,

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1500,7 +1500,8 @@ impl ResultIterator for ProjectIterator {
         match self.input.next() {
             Some(Ok(mut row)) => {
                 if let Some(node) = row.entity.as_node() {
-                    let mut new_props = crate::core::PropertyMapBuilder::new();
+                    let mut new_props =
+                        crate::core::PropertyMapBuilder::with_capacity(self.properties.len());
                     for prop in &self.properties {
                         if let Some(val) = node.properties.get(prop) {
                             new_props = match new_props.try_insert(prop, val.clone()) {


### PR DESCRIPTION
💡 What: Added `PropertyMapBuilder::with_capacity` to explicitly set `HashMap` capacity, and updated `ProjectIterator` to use it with `self.properties.len()`.
🎯 Why: Iteratively inserting projected properties into a `PropertyMapBuilder::new()` forces intermediate, unnecessary hashmap reallocations as elements are added, degrading query performance.
📊 Impact: Avoids arbitrary heap allocations and O(N) reallocation overhead during query execution for each individual result row when explicitly projecting node properties.
🔬 Measurement: Verified with `cargo test --lib --all-features query::executor::iterators` to ensure semantic preservation.

---
*PR created automatically by Jules for task [6619813274142618422](https://jules.google.com/task/6619813274142618422) started by @madmax983*