### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,11 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+
+## QueryBuilder valid_time_between panic
+**Learning:** Fluent builder APIs (like `QueryBuilder::valid_time_between`) often hide `.unwrap()` calls to maintain a clean `-> Self` signature. However, when these methods process dynamic user input (like timestamps), this introduces a severe panic risk.
+**Action:** Always inspect builder methods that accept dynamic bounds or parameters. Refactor them to return `Result<Self, Error>` instead of panicking, and add `#[should_panic]` or `assert!(res.is_err())` test cases to verify the boundary conditions.
+
+## HTTP server apply_autumn_env unsafe block
+**Learning:** Setup functions that bridge configuration into environment variables often use `unsafe { std::env::set_var(...) }` to avoid UB in newer Rust editions. These blocks are critical and often lack test coverage because they touch global state.
+**Action:** Write unit tests for environment manipulation logic, using the `#[serial]` macro (from `serial_test`) to ensure parallel test runners do not suffer from race conditions or flaky failures.

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -313,6 +313,41 @@ fn build_cors_layer(cors: &CorsConfig) -> CorsLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    #[test]
+    #[serial]
+    fn test_apply_autumn_env_sets_variables() {
+        let cors = CorsConfig::restrictive()
+            .allow_origin("https://example.com")
+            .allow_origin("https://another.com");
+
+        let config = ServerConfig::builder()
+            .host("127.0.0.1")
+            .port(8080)
+            .cors(cors)
+            .build();
+
+        unsafe {
+            apply_autumn_env(&config);
+        }
+
+        assert_eq!(std::env::var("AUTUMN_SERVER__HOST").unwrap(), "127.0.0.1");
+        assert_eq!(std::env::var("AUTUMN_SERVER__PORT").unwrap(), "8080");
+        assert_eq!(
+            std::env::var("AUTUMN_CORS__ALLOWED_ORIGINS").unwrap(),
+            "https://example.com,https://another.com"
+        );
+        assert_eq!(
+            std::env::var("AUTUMN_CORS__ALLOWED_METHODS").unwrap(),
+            "GET"
+        );
+        assert_eq!(
+            std::env::var("AUTUMN_CORS__ALLOWED_HEADERS").unwrap(),
+            "content-type"
+        );
+        assert_eq!(std::env::var("AUTUMN_CORS__MAX_AGE").unwrap(), "3600");
+    }
+
     use crate::http::config::RateLimitConfig;
 
     #[test]

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -641,17 +641,20 @@ impl<S: QueryState> QueryBuilder<S> {
     /// ```ignore
     /// // "Who did Alice know during Q1 2024?"
     /// let results = db.query()
-    ///     .valid_time_between(jan_1, mar_31)
+    ///     .valid_time_between(jan_1, mar_31)?
     ///     .start(alice_id)
     ///     .traverse("KNOWS")
     ///     .execute(&db)?;
     /// ```
-    #[must_use]
-    pub fn valid_time_between(mut self, start: Timestamp, end: Timestamp) -> Self {
+    pub fn valid_time_between(
+        mut self,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Result<Self, crate::core::error::TemporalError> {
         let mut ctx = self.temporal_context.take().unwrap_or_default();
-        ctx.valid_time_between = Some(TimeRange::between(start, end).unwrap());
+        ctx.valid_time_between = Some(TimeRange::between(start, end)?);
         self.temporal_context = Some(ctx);
-        self
+        Ok(self)
     }
 
     /// Set temporal context: query across a transaction time range.
@@ -669,16 +672,19 @@ impl<S: QueryState> QueryBuilder<S> {
     /// ```ignore
     /// // "What did we learn about Alice during Q1 2024?"
     /// let results = db.query()
-    ///     .transaction_time_between(jan_1, mar_31)
+    ///     .transaction_time_between(jan_1, mar_31)?
     ///     .start(alice_id)
     ///     .execute(&db)?;
     /// ```
-    #[must_use]
-    pub fn transaction_time_between(mut self, start: Timestamp, end: Timestamp) -> Self {
+    pub fn transaction_time_between(
+        mut self,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Result<Self, crate::core::error::TemporalError> {
         let mut ctx = self.temporal_context.take().unwrap_or_default();
-        ctx.transaction_time_between = Some(TimeRange::between(start, end).unwrap());
+        ctx.transaction_time_between = Some(TimeRange::between(start, end)?);
         self.temporal_context = Some(ctx);
-        self
+        Ok(self)
     }
 
     /// Set temporal context: query across a valid time range.
@@ -690,8 +696,11 @@ impl<S: QueryState> QueryBuilder<S> {
     ///
     /// Prefer using [`valid_time_between()`](Self::valid_time_between) or
     /// [`transaction_time_between()`](Self::transaction_time_between) for clarity.
-    #[must_use]
-    pub fn between(self, start: Timestamp, end: Timestamp) -> Self {
+    pub fn between(
+        self,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Result<Self, crate::core::error::TemporalError> {
         self.valid_time_between(start, end)
     }
 
@@ -1111,6 +1120,26 @@ impl FindSimilarBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AletheiaDB;
+    use crate::core::hlc::HybridTimestamp;
+    #[test]
+    fn test_valid_time_between_errors_on_invalid_range() {
+        let db = AletheiaDB::new().unwrap();
+        let ts1 = HybridTimestamp::new(2000, 0).unwrap();
+        let ts2 = HybridTimestamp::new(1000, 0).unwrap();
+        let res = db.query().valid_time_between(ts1, ts2);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_transaction_time_between_errors_on_invalid_range() {
+        let db = AletheiaDB::new().unwrap();
+        let ts1 = HybridTimestamp::new(2000, 0).unwrap();
+        let ts2 = HybridTimestamp::new(1000, 0).unwrap();
+        let res = db.query().transaction_time_between(ts1, ts2);
+        assert!(res.is_err());
+    }
+
     use crate::core::NodeId;
 
     fn test_node_id() -> NodeId {
@@ -1181,6 +1210,7 @@ mod tests {
     fn test_temporal_between() {
         let query = QueryBuilder::new()
             .between(1000.into(), 2000.into())
+            .unwrap()
             .start(test_node_id())
             .build();
 
@@ -1581,6 +1611,7 @@ mod tests {
 
         let query = QueryBuilder::new()
             .valid_time_between(start, end)
+            .unwrap()
             .start(test_node_id())
             .build();
 
@@ -1603,6 +1634,7 @@ mod tests {
 
         let query = QueryBuilder::new()
             .transaction_time_between(start, end)
+            .unwrap()
             .start(test_node_id())
             .build();
 
@@ -1704,6 +1736,7 @@ mod tests {
         let query = QueryBuilder::new()
             .as_of_valid_time(point_ts)
             .transaction_time_between(range_start, range_end)
+            .unwrap()
             .start(test_node_id())
             .build();
 

--- a/tests/hybrid_query.rs
+++ b/tests/hybrid_query.rs
@@ -638,7 +638,12 @@ mod temporal_vector_tests {
         let end_time = now();
 
         // Query using between() range
-        let query = db.query().between(start_time, end_time).start(node).build();
+        let query = db
+            .query()
+            .between(start_time, end_time)
+            .unwrap()
+            .start(node)
+            .build();
 
         assert!(query.is_temporal(), "Query should have temporal context");
 


### PR DESCRIPTION
🎯 Target:
- `src/http/server.rs`: Added test coverage for the `apply_autumn_env` function and its `unsafe` block modifying environment variables.
- `src/query/builder.rs`: Refactored `valid_time_between` and `transaction_time_between` to return `Result` and eliminated panics on invalid input.

💣 Risk:
- `apply_autumn_env`: Environment variable manipulation inside an `unsafe` block lacked rigorous correctness testing, risking misconfiguration regressions.
- `QueryBuilder`: Calling `valid_time_between` or `transaction_time_between` with an invalid temporal range (e.g. `start > end`) previously triggered a hidden `.unwrap()` panic, crashing the query thread on dynamic user input.

🧪 Strategy:
- Wrote a dedicated unit test for `apply_autumn_env` using `#[serial]` to prevent race conditions during global state manipulation.
- Refactored `valid_time_between` and `transaction_time_between` to return `Result<Self, TemporalError>` instead of panicking, and updated the builder chain.
- Added explicit unit tests verifying that invalid time ranges correctly return errors.

🔭 Verification:
- Run `cargo test --lib http::server::tests`
- Run `cargo test --lib query::builder::tests`
- Run `cargo test --test hybrid_query`

---
*PR created automatically by Jules for task [11499106047511809359](https://jules.google.com/task/11499106047511809359) started by @madmax983*