### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,10 +853,10 @@ use aletheiadb::{AletheiaDB, properties};
 use aletheiadb::embeddings::{EmbeddingService, providers::openai::*};
 use std::sync::Arc;
 
-// Note: Requires `tokio` dependency in Cargo.toml
+// Note: Requires `tokio = { version = "1", features = ["full"] }` in Cargo.toml
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    // Enable in Cargo.toml: features = ["embedding-openai"]
+    // Enable in Cargo.toml: aletheiadb = { version = "0.1", features = ["embedding-openai"] }
 
     // 1. Create embedding service
     let config = OpenAIConfig::from_env(OpenAIModel::TextEmbedding3Small)?;


### PR DESCRIPTION
🤦‍♂️ **The Confusion:** The "Embedding Generation (Optional)" example in the `README.md` fails to compile out of the box because it uses the `#[tokio::main]` macro but does not explicitly instruct the user to include `tokio = { version = "1", features = ["full"] }` in `Cargo.toml`. Instead, it vaguely says `// Note: Requires tokio dependency in Cargo.toml`. This causes friction for users trying to copy-paste the example.

🕵️‍♂️ **The Reality:** The macro expansion for `#[tokio::main]` requires the `rt` and `macros` features from the `tokio` crate, which are typically pulled in via the `"full"` feature flag. Additionally, it requires explicitly defining `aletheiadb = { version = "0.1", features = ["embedding-openai"] }`.

💡 **The Fix:** Updated the comment block above the "Embedding Generation" example to explicitly spell out the required `tokio` dependency with its features, as well as the exact `aletheiadb` configuration needed.

---
*PR created automatically by Jules for task [10109244966965442576](https://jules.google.com/task/10109244966965442576) started by @madmax983*