### PR TITLE
🎻 Bard: [documentation update] Add executable doctests for transaction APIs

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -4,3 +4,6 @@
 ## 2024-04-10 - [Intra-doc links for conditionally-compiled or non-existent items]
 **Confusion:** Using standard intra-doc links (`[item]`) for items that are either conditionally compiled (like feature-gated experimental modules) or don't resolve properly in the dependency tree causes `rustdoc::broken_intra_doc_links` warnings.
 **Clarification:** Changed intra-doc links to standard markdown backticks (`` `item` ``) for items like `` `crate::semantic_search` ``, `` `reasoning` ``, `` `temporal` ``, `` `diagnostics` ``, `` `characterization` ``, `` `mosaic` ``, and `` `autumn_web::prelude::app` `` to satisfy rustdoc while still keeping the documentation clean and readable.
+## 2025-02-12 - [Formatting Documentation with Derive Attributes]
+**Confusion:** When adding documentation to an existing struct or enum that has a `#[derive(...)]` attribute, inserting the `///` comments after the `#[derive(...)]` macro splits the documentation block in the source code. While `rustdoc` concatenates them, it creates messy source files.
+**Clarification:** Always ensure that all `///` doc comments are placed strictly *above* any `#[...]` attributes on structs, enums, or functions to maintain clean and readable source hygiene.

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -80,6 +80,21 @@ use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::temporal::Timestamp;
 
 /// Common read operations available in all transaction types
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::{AletheiaDB, core::NodeId, api::transaction::ReadOps};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let db = AletheiaDB::new()?;
+/// let tx = db.read_transaction()?;
+/// let node_id = NodeId::new(1)?;
+/// if let Ok(node) = tx.get_node(node_id) {
+///     println!("Found node with label: {}", node.label);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub trait ReadOps {
     /// Get a node by ID.
     ///
@@ -276,6 +291,19 @@ pub trait ReadOps {
 }
 
 /// Write operations (only available in write transactions)
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::{AletheiaDB, properties, api::transaction::WriteOps};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let db = AletheiaDB::new()?;
+/// let mut tx = db.write_transaction()?;
+/// let node_id = tx.create_node("Person", properties! { "name" => "Alice" })?;
+/// tx.commit()?;
+/// # Ok(())
+/// # }
+/// ```
 pub trait WriteOps: ReadOps {
     /// Create a new node with optional backdated valid_from time.
     ///

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -96,6 +96,19 @@ impl ReadTransaction {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, api::transaction::ReadOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let tx = db.read_transaction()?;
+    /// let metadata = tx.metadata();
+    /// println!("Transaction ID: {:?}", metadata.tx_id);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn metadata(&self) -> TxMetadata {
         TxMetadata {
             tx_id: self.tx_id,
@@ -120,6 +133,18 @@ impl ReadTransaction {
     /// let id = tx.tx_id();
     ///
     /// println!("Running in transaction context: {:?}", id);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, api::transaction::ReadOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let tx = db.read_transaction()?;
+    /// println!("Transaction ID: {:?}", tx.tx_id());
     /// # Ok(())
     /// # }
     /// ```

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -22,6 +22,23 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock};
 /// a HashSet containing N elements on every transaction creation was creating
 /// quadratic scaling. Arc allows cheap snapshot captures (just Arc clone).
 #[derive(Debug, Clone)]
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::core::temporal::time;
+/// # use aletheiadb::api::transaction::TxId;
+/// # use aletheiadb::api::transaction::TransactionSnapshot;
+/// # use std::sync::Arc;
+/// # use std::collections::HashSet;
+/// let mut active_txs = HashSet::new();
+/// active_txs.insert(TxId::new(1));
+///
+/// let snapshot = TransactionSnapshot {
+///     snapshot_timestamp: time::now(),
+///     active_transactions: Arc::new(active_txs),
+/// };
+/// ```
 pub struct TransactionSnapshot {
     /// Timestamp when snapshot was taken
     pub snapshot_timestamp: Timestamp,
@@ -46,6 +63,24 @@ impl TransactionSnapshot {
     ///
     /// # Returns
     /// `true` if the version is visible in this snapshot, `false` otherwise
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::core::temporal::time;
+    /// # use aletheiadb::api::transaction::TxId;
+    /// # use aletheiadb::api::transaction::TransactionSnapshot;
+    /// # use std::sync::Arc;
+    /// # use std::collections::HashSet;
+    /// # let mut active_txs = HashSet::new();
+    /// # active_txs.insert(TxId::new(1));
+    /// # let snapshot = TransactionSnapshot {
+    /// #     snapshot_timestamp: time::now(),
+    /// #     active_transactions: Arc::new(active_txs),
+    /// # };
+    /// let created_tx = TxId::new(2);
+    /// let is_vis = snapshot.is_visible(created_tx, Some(time::now()));
+    /// ```
     pub fn is_visible(&self, created_by_tx: TxId, commit_timestamp: Option<Timestamp>) -> bool {
         match commit_timestamp {
             None => false, // Uncommitted version - not visible
@@ -161,6 +196,20 @@ impl EpochRange {
 
 /// Statistics about commit log compression.
 #[derive(Debug, Clone)]
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::api::transaction::CompressionStats;
+/// let stats = CompressionStats {
+///     total_transactions: 100,
+///     epoch_count: 5,
+///     exception_count: 2,
+///     memory_usage_bytes: 1024,
+///     memory_saved_bytes: 512,
+///     compression_ratio: 0.9,
+/// };
+/// ```
 pub struct CompressionStats {
     /// Total number of transactions tracked
     pub total_transactions: usize,
@@ -476,6 +525,13 @@ impl CompressedCommitLog {
 /// The `committed` field now uses `CompressedCommitLog` which applies epoch-based
 /// compression to reduce memory usage from ~24 bytes per transaction to ~0.24 bytes
 /// per transaction (100x compression) for sequential workloads.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::api::transaction::TxVisibilityManager;
+/// let visibility_manager = TxVisibilityManager::new();
+/// ```
 pub struct TxVisibilityManager {
     /// Currently active transactions, wrapped in Arc for efficient snapshot capture.
     ///

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -238,6 +238,19 @@ impl WriteTransaction {
     }
 
     /// Get transaction metadata.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, api::transaction::WriteOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let tx = db.write_transaction()?;
+    /// let metadata = tx.metadata();
+    /// println!("Transaction ID: {:?}", metadata.tx_id);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn metadata(&self) -> TxMetadata {
         TxMetadata {
             tx_id: self.tx_id,
@@ -249,6 +262,18 @@ impl WriteTransaction {
     }
 
     /// Get transaction ID.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, api::transaction::WriteOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let tx = db.write_transaction()?;
+    /// println!("Transaction ID: {:?}", tx.tx_id());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn tx_id(&self) -> TxId {
         self.tx_id
     }
@@ -331,6 +356,20 @@ impl WriteTransaction {
     /// - **Async**: Returns after flush to OS cache (background thread syncs)
     /// - **GroupCommit**: Waits for batch fsync (ACID + high throughput)
     /// - **AsyncBatched**: Returns after flush to OS cache, batched fsync in background (<100µs latency)
+    ///
+    /// ## Examples
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, properties, api::transaction::WriteOps};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let mut tx = db.write_transaction()?;
+    /// tx.create_node("Person", properties! { "name" => "Alice" })?;
+    /// let ts = tx.commit_with_timestamp()?;
+    /// println!("Committed at: {:?}", ts);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn commit_with_timestamp(mut self) -> Result<Timestamp> {
         self.commit_with_timestamp_inner().record_error_metric()
     }

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -23,6 +23,24 @@ type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<IdentityHasher>>;
 /// true bi-temporal semantics where valid_time can be backdated independently
 /// of when the transaction commits.
 #[derive(Debug, Clone)]
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::api::transaction::BufferedWrite;
+/// # use aletheiadb::core::NodeId;
+/// # use aletheiadb::core::id::VersionId;
+/// # use aletheiadb::core::temporal::time;
+/// # use aletheiadb::core::property::PropertyMapBuilder;
+/// # use aletheiadb::core::interning::{InternedString, GLOBAL_INTERNER};
+/// let write = BufferedWrite::CreateNode {
+///     node_id: NodeId::new(1).unwrap(),
+///     version_id: VersionId::new(1).unwrap(),
+///     label: GLOBAL_INTERNER.intern("Person").unwrap(),
+///     properties: PropertyMapBuilder::new().build(),
+///     valid_from: time::now(),
+/// };
+/// ```
 pub enum BufferedWrite {
     /// Create a new node
     CreateNode {
@@ -165,6 +183,13 @@ pub const DEFAULT_MAX_OPERATIONS: usize = 50_000;
 ///
 /// Buffers all write operations in a transaction until commit time,
 /// enabling atomicity and validation before applying changes.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use aletheiadb::api::transaction::WriteBuffer;
+/// let buffer = WriteBuffer::new();
+/// ```
 pub struct WriteBuffer {
     /// Buffered operations in order
     operations: Vec<BufferedWrite>,


### PR DESCRIPTION
📖 Chapter: The `Transaction` API Module
🔦 Insight: Clarified the usage of transaction operations (read and write), snapshot isolation concepts, and buffering mechanisms by adding practical code examples.
🧪 Example: Added 13 compile-tested doctests to traits and core structures across the module.
🖼️ Preview: Documentation now includes copy-pasteable examples for instantiating transactions, reading data, and modifying the graph.

---
*PR created automatically by Jules for task [7028667558566372285](https://jules.google.com/task/7028667558566372285) started by @madmax983*