### PR TITLE
Add comprehensive temporal state space tests for issue #153

### DIFF
--- a/tests/temporal_state_space.proptest-regressions
+++ b/tests/temporal_state_space.proptest-regressions
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4bfcc33d44c8794573bf72e65ee75a291953623bc7de4cb04478a6c3c802de3f # shrinks to update_count = 1
+cc df438c5df8ef4028273151108018cea227ca6415270154d6302d486125f6f1c0 # shrinks to s1 = 1000000, e1 = 1000000, s2 = 1000000, e2 = 1000000, qv = 1000000, qt = 1000000
+cc b79507c3ca05a2b00077aae1b83a76bdf33a43c24d29a2210ebb727944b08590 # shrinks to update_count = 1
+cc cd391f84588dd0a471fe5613361b16d0e35c1a0adb9903698e3f337014dd7ee9 # shrinks to ops = [Update { value: 0 }]

--- a/tests/temporal_state_space.rs
+++ b/tests/temporal_state_space.rs
@@ -24,7 +24,9 @@
 
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::property::PropertyMapBuilder;
-use aletheiadb::{AletheiaDB, BiTemporalInterval, Error, TimeRange, Timestamp, WriteOps, time};
+use aletheiadb::{
+    AletheiaDB, BiTemporalInterval, Error, TimeRange, Timestamp, WriteOps, WriteTransaction, time,
+};
 use proptest::prelude::*;
 
 // ============================================================================
@@ -440,22 +442,23 @@ fn exhaustive_three_operation_orderings() {
     // --- Multiple updates spanning the anchor boundary ---
     {
         let db = AletheiaDB::new().unwrap();
-        let id = db
+
+        // Use commit_with_timestamp() so each checkpoint is exactly the HLC
+        // time of the write — no sleep required, cross-platform safe.
+        let mut create_tx: WriteTransaction = db.write_transaction().unwrap();
+        let id = create_tx
             .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
-
-        let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, time::now())];
+        let ts0 = create_tx.commit_with_timestamp().unwrap();
+        let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, ts0)];
 
         // 15 updates → crosses the default anchor_interval of 10
         for i in 1..=15i64 {
-            std::thread::sleep(std::time::Duration::from_micros(10));
-            db.write(|tx| {
-                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
-                Ok::<_, Error>(())
-            })
-            .unwrap();
-            std::thread::sleep(std::time::Duration::from_micros(10));
-            checkpoints.push((i, time::now()));
+            let mut tx: WriteTransaction = db.write_transaction().unwrap();
+            tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())
+                .unwrap();
+            let ts = tx.commit_with_timestamp().unwrap();
+            checkpoints.push((i, ts));
         }
 
         assert!(check_tx_time_monotonicity(&db, id), "anchor-span: inv 1");
@@ -641,20 +644,19 @@ fn check_all_eight_temporal_invariants() {
     // Inv 7 & 8: Anchor/Delta Completeness – reconstruction across anchor boundary
     {
         let db = AletheiaDB::new().unwrap();
-        let id = db
+        let mut create_tx: WriteTransaction = db.write_transaction().unwrap();
+        let id = create_tx
             .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
+        let ts0 = create_tx.commit_with_timestamp().unwrap();
 
-        let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, time::now())];
+        let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, ts0)];
         for i in 1..=15i64 {
-            std::thread::sleep(std::time::Duration::from_micros(10));
-            db.write(|tx| {
-                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
-                Ok::<_, Error>(())
-            })
-            .unwrap();
-            std::thread::sleep(std::time::Duration::from_micros(10));
-            checkpoints.push((i, time::now()));
+            let mut tx: WriteTransaction = db.write_transaction().unwrap();
+            tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())
+                .unwrap();
+            let ts = tx.commit_with_timestamp().unwrap();
+            checkpoints.push((i, ts));
         }
 
         for (expected, ts) in &checkpoints {

--- a/tests/temporal_state_space.rs
+++ b/tests/temporal_state_space.rs
@@ -53,33 +53,86 @@ fn operation_sequence(max_ops: usize) -> impl Strategy<Value = Vec<TemporalOpera
 
 // ============================================================================
 // Invariant checkers
-// RED phase: each function calls `todo!()` so tests fail until implemented.
+// GREEN phase: fully implemented.
 // ============================================================================
 
 /// Invariant 1 – Transaction time is monotonically non-decreasing across versions.
-fn check_tx_time_monotonicity(_db: &AletheiaDB, _node_id: NodeId) -> bool {
-    todo!("RED – tx_time monotonicity checker not yet implemented")
+///
+/// For every consecutive pair of versions (older, newer) returned by
+/// `get_node_history`, the transaction_time start of newer must be ≥ that of older.
+fn check_tx_time_monotonicity(db: &AletheiaDB, node_id: NodeId) -> bool {
+    let history = match db.get_node_history(node_id) {
+        Ok(h) => h,
+        Err(_) => return true, // no history to check; trivially satisfied
+    };
+    if history.versions.len() < 2 {
+        return true;
+    }
+    for pair in history.versions.windows(2) {
+        let prev_tx = pair[0].temporal.transaction_time().start();
+        let curr_tx = pair[1].temporal.transaction_time().start();
+        if curr_tx < prev_tx {
+            return false;
+        }
+    }
+    true
 }
 
 /// Invariant 2 – Version numbers are strictly increasing.
-fn check_version_numbers_increasing(_db: &AletheiaDB, _node_id: NodeId) -> bool {
-    todo!("RED – version number ordering checker not yet implemented")
+///
+/// Each successive version must have a strictly greater `version_number`.
+fn check_version_numbers_increasing(db: &AletheiaDB, node_id: NodeId) -> bool {
+    let history = match db.get_node_history(node_id) {
+        Ok(h) => h,
+        Err(_) => return true,
+    };
+    if history.versions.len() < 2 {
+        return true;
+    }
+    for pair in history.versions.windows(2) {
+        if pair[1].version_number <= pair[0].version_number {
+            return false;
+        }
+    }
+    true
 }
 
 /// Invariant 3 – All stored time ranges satisfy start <= end.
-fn check_time_range_validity(_db: &AletheiaDB, _node_id: NodeId) -> bool {
-    todo!("RED – time range validity checker not yet implemented")
+///
+/// Every version's valid_time and transaction_time must be structurally
+/// valid: `range.start() <= range.end()`.
+fn check_time_range_validity(db: &AletheiaDB, node_id: NodeId) -> bool {
+    let history = match db.get_node_history(node_id) {
+        Ok(h) => h,
+        Err(_) => return true,
+    };
+    for v in &history.versions {
+        let vt = v.temporal.valid_time();
+        let tt = v.temporal.transaction_time();
+        if vt.start() > vt.end() || tt.start() > tt.end() {
+            return false;
+        }
+    }
+    true
 }
 
 /// Invariant 4 – Visibility is consistent with individual dimension checks.
 ///
 /// `visible_at(vt, tt)  ⟺  is_valid_at(vt) AND is_recorded_at(tt)`
+///
+/// This is the fundamental bi-temporal visibility law: a fact is only visible
+/// at a query point (valid_time=vt, tx_time=tt) when *both* dimensions are
+/// simultaneously satisfied.
 fn check_visibility_consistency(
-    _interval: BiTemporalInterval,
-    _vt: Timestamp,
-    _tt: Timestamp,
+    interval: BiTemporalInterval,
+    vt: Timestamp,
+    tt: Timestamp,
 ) -> bool {
-    todo!("RED – visibility consistency checker not yet implemented")
+    let visible = interval.is_visible_at(vt, tt);
+    let valid = interval.is_valid_at(vt);
+    let recorded = interval.is_recorded_at(tt);
+    // Bi-conditional: visible iff (valid AND recorded)
+    visible == (valid && recorded)
 }
 
 // ============================================================================

--- a/tests/temporal_state_space.rs
+++ b/tests/temporal_state_space.rs
@@ -465,11 +465,16 @@ fn exhaustive_three_operation_orderings() {
         );
         assert!(check_time_range_validity(&db, id), "anchor-span: inv 3");
 
-        // Every historical value must be reconstructable via anchor + delta chain.
+        // Every historical value must be reconstructable via anchor + delta chain,
+        // and the reconstructed node must carry the exact expected property value.
         for (expected, ts) in &checkpoints {
-            assert!(
-                db.get_node_at_time(id, *ts, *ts).is_ok(),
-                "anchor-span: v={expected} not reconstructable at its snapshot time"
+            let node = db
+                .get_node_at_time(id, *ts, *ts)
+                .unwrap_or_else(|_| panic!("anchor-span: v={expected} not reconstructable"));
+            assert_eq!(
+                node.get_property("v").and_then(|v| v.as_int()),
+                Some(*expected),
+                "anchor-span: v={expected} reconstructed with wrong value"
             );
         }
     }
@@ -653,9 +658,13 @@ fn check_all_eight_temporal_invariants() {
         }
 
         for (expected, ts) in &checkpoints {
-            assert!(
-                db.get_node_at_time(id, *ts, *ts).is_ok(),
-                "inv 7/8: v={expected} must be reconstructable across anchor/delta boundary"
+            let node = db
+                .get_node_at_time(id, *ts, *ts)
+                .unwrap_or_else(|_| panic!("inv 7/8: v={expected} not reconstructable"));
+            assert_eq!(
+                node.get_property("v").and_then(|v| v.as_int()),
+                Some(*expected),
+                "inv 7/8: v={expected} reconstructed with wrong value"
             );
         }
     }

--- a/tests/temporal_state_space.rs
+++ b/tests/temporal_state_space.rs
@@ -1,24 +1,26 @@
 //! State space exploration tests for temporal invariants (issue #153).
 //!
-//! Implements property-based testing and exhaustive small-n enumeration to
-//! verify the 8 core temporal invariants of AletheiaDB beyond line coverage.
+//! Supplements line/branch coverage with property-based and exhaustive
+//! small-n enumeration to verify AletheiaDB's 8 core temporal invariants
+//! across a wide range of operation sequences and timestamp combinations.
 //!
-//! # TDD Structure
-//! - **RED phase** (this commit): invariant checkers are stubs that `todo!()`,
-//!   causing every test to fail.
-//! - **GREEN phase** (next commit): invariant checkers fully implemented;
-//!   all tests pass.
-//! - **REFACTOR phase**: code organisation and edge-case expansion.
+//! # Phase 1 – Property-based tests (proptest)
+//! Each test exercises one or more invariants over randomly-generated
+//! inputs, ensuring correctness across thousands of state combinations.
 //!
-//! # Invariants under test
-//! 1. **Transaction Time Monotonicity** – `tx_time(v_n) >= tx_time(v_{n-1})`
-//! 2. **Version Number Ordering** – `version_number(v_n) > version_number(v_{n-1})`
-//! 3. **Time Range Validity** – `start <= end` for every stored range
-//! 4. **Visibility Consistency** – `visible_at(vt, tt) ⟺ valid_at(vt) ∧ recorded_at(tt)`
-//! 5. **Overlap Symmetry** – `r1.overlaps(r2) == r2.overlaps(r1)`
-//! 6. **Contains-Range Reflexivity** – `r.contains_range(r) == true`
-//! 7. **Half-Open Interval Semantics** – end is exclusive
-//! 8. **Temporal Isolation** – time-travel sees consistent snapshot values
+//! # Phase 2 – Exhaustive small-n enumeration
+//! Deterministically exercises every semantically distinct lifecycle
+//! ordering for a single entity and all relevant timestamp orderings.
+//!
+//! # Invariants verified
+//! 1. **Tx-time monotonicity** – `tx_time(v_n) >= tx_time(v_{n-1})`
+//! 2. **Version number ordering** – `version_number(v_n) > version_number(v_{n-1})`
+//! 3. **Time range validity** – `start <= end` for every stored range
+//! 4. **Visibility consistency** – `visible_at(vt,tt) ⟺ valid_at(vt) ∧ recorded_at(tt)`
+//! 5. **Overlap symmetry** – `r1.overlaps(r2) == r2.overlaps(r1)`
+//! 6. **Contains-range reflexivity** – `r.contains_range(r) == true`
+//! 7. **Half-open interval semantics** – end timestamp is always exclusive
+//! 8. **Temporal isolation** – time-travel yields consistent snapshot values
 
 use aletheiadb::core::id::NodeId;
 use aletheiadb::core::property::PropertyMapBuilder;
@@ -30,6 +32,8 @@ use proptest::prelude::*;
 // ============================================================================
 
 /// A post-creation operation that can be applied to a node in sequence.
+///
+/// Used by proptest strategies to generate realistic node lifecycles.
 #[derive(Debug, Clone)]
 enum TemporalOperation {
     Update { value: i64 },
@@ -44,95 +48,65 @@ fn temporal_operation_strategy() -> impl Strategy<Value = TemporalOperation> {
 }
 
 /// Generates a non-empty sequence of operations to apply after an initial Create.
-///
-/// The sequence always starts with at least one Update, and may optionally end
-/// with a Delete.  This mirrors the realistic node lifecycle.
 fn operation_sequence(max_ops: usize) -> impl Strategy<Value = Vec<TemporalOperation>> {
     proptest::collection::vec(temporal_operation_strategy(), 1..=max_ops)
 }
 
 // ============================================================================
-// Invariant checkers
-// GREEN phase: fully implemented.
+// Invariant checker functions
+//
+// Each function embodies one or more of the 8 invariants and returns `true`
+// when the invariant holds.  `get_node_history` errors (e.g., after deletion)
+// are treated as an empty history: invariants are trivially satisfied.
 // ============================================================================
 
 /// Invariant 1 – Transaction time is monotonically non-decreasing across versions.
-///
-/// For every consecutive pair of versions (older, newer) returned by
-/// `get_node_history`, the transaction_time start of newer must be ≥ that of older.
 fn check_tx_time_monotonicity(db: &AletheiaDB, node_id: NodeId) -> bool {
     let history = match db.get_node_history(node_id) {
         Ok(h) => h,
-        Err(_) => return true, // no history to check; trivially satisfied
+        Err(_) => return true,
     };
-    if history.versions.len() < 2 {
-        return true;
-    }
-    for pair in history.versions.windows(2) {
+    history.versions.windows(2).all(|pair| {
         let prev_tx = pair[0].temporal.transaction_time().start();
         let curr_tx = pair[1].temporal.transaction_time().start();
-        if curr_tx < prev_tx {
-            return false;
-        }
-    }
-    true
+        curr_tx >= prev_tx
+    })
 }
 
 /// Invariant 2 – Version numbers are strictly increasing.
-///
-/// Each successive version must have a strictly greater `version_number`.
 fn check_version_numbers_increasing(db: &AletheiaDB, node_id: NodeId) -> bool {
     let history = match db.get_node_history(node_id) {
         Ok(h) => h,
         Err(_) => return true,
     };
-    if history.versions.len() < 2 {
-        return true;
-    }
-    for pair in history.versions.windows(2) {
-        if pair[1].version_number <= pair[0].version_number {
-            return false;
-        }
-    }
-    true
+    history
+        .versions
+        .windows(2)
+        .all(|pair| pair[1].version_number > pair[0].version_number)
 }
 
-/// Invariant 3 – All stored time ranges satisfy start <= end.
-///
-/// Every version's valid_time and transaction_time must be structurally
-/// valid: `range.start() <= range.end()`.
+/// Invariant 3 – All stored time ranges satisfy `start <= end`.
 fn check_time_range_validity(db: &AletheiaDB, node_id: NodeId) -> bool {
     let history = match db.get_node_history(node_id) {
         Ok(h) => h,
         Err(_) => return true,
     };
-    for v in &history.versions {
+    history.versions.iter().all(|v| {
         let vt = v.temporal.valid_time();
         let tt = v.temporal.transaction_time();
-        if vt.start() > vt.end() || tt.start() > tt.end() {
-            return false;
-        }
-    }
-    true
+        vt.start() <= vt.end() && tt.start() <= tt.end()
+    })
 }
 
 /// Invariant 4 – Visibility is consistent with individual dimension checks.
 ///
-/// `visible_at(vt, tt)  ⟺  is_valid_at(vt) AND is_recorded_at(tt)`
-///
-/// This is the fundamental bi-temporal visibility law: a fact is only visible
-/// at a query point (valid_time=vt, tx_time=tt) when *both* dimensions are
-/// simultaneously satisfied.
+/// `visible_at(vt, tt)  ⟺  is_valid_at(vt) ∧ is_recorded_at(tt)`
 fn check_visibility_consistency(
     interval: BiTemporalInterval,
     vt: Timestamp,
     tt: Timestamp,
 ) -> bool {
-    let visible = interval.is_visible_at(vt, tt);
-    let valid = interval.is_valid_at(vt);
-    let recorded = interval.is_recorded_at(tt);
-    // Bi-conditional: visible iff (valid AND recorded)
-    visible == (valid && recorded)
+    interval.is_visible_at(vt, tt) == (interval.is_valid_at(vt) && interval.is_recorded_at(tt))
 }
 
 // ============================================================================
@@ -142,18 +116,17 @@ fn check_visibility_consistency(
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(200))]
 
-    // Invariant 1 & 2 – after N updates, tx_time is monotone and versions are ordered
+    /// Invariants 1 & 2: After N updates, tx_time is monotone and versions are ordered.
     #[test]
     fn prop_tx_time_monotonicity_after_updates(update_count in 1usize..=8) {
         let db = AletheiaDB::new().unwrap();
-
-        let props = PropertyMapBuilder::new().insert("v", 0i64).build();
-        let node_id = db.create_node("TestNode", props).unwrap();
+        let node_id = db
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
+            .unwrap();
 
         for i in 1..=(update_count as i64) {
-            let p = PropertyMapBuilder::new().insert("v", i).build();
             db.write(|tx| {
-                tx.update_node(node_id, p)?;
+                tx.update_node(node_id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
@@ -161,28 +134,27 @@ proptest! {
 
         prop_assert!(
             check_tx_time_monotonicity(&db, node_id),
-            "Invariant 1 violated after {} updates",
+            "Inv 1 violated after {} updates",
             update_count
         );
         prop_assert!(
             check_version_numbers_increasing(&db, node_id),
-            "Invariant 2 violated after {} updates",
+            "Inv 2 violated after {} updates",
             update_count
         );
     }
 
-    // Invariant 3 – time ranges stored by the database are always valid
+    /// Invariant 3: Every stored time range satisfies start <= end.
     #[test]
     fn prop_time_ranges_always_valid(update_count in 1usize..=6) {
         let db = AletheiaDB::new().unwrap();
-
-        let props = PropertyMapBuilder::new().insert("v", 0i64).build();
-        let node_id = db.create_node("N", props).unwrap();
+        let node_id = db
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
+            .unwrap();
 
         for i in 1..=(update_count as i64) {
-            let p = PropertyMapBuilder::new().insert("v", i).build();
             db.write(|tx| {
-                tx.update_node(node_id, p)?;
+                tx.update_node(node_id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
@@ -190,12 +162,12 @@ proptest! {
 
         prop_assert!(
             check_time_range_validity(&db, node_id),
-            "Invariant 3 violated after {} updates",
+            "Inv 3 violated after {} updates",
             update_count
         );
     }
 
-    // Invariant 4 – BiTemporalInterval visibility ⟺ both dimensions satisfied
+    /// Invariant 4: BiTemporalInterval visibility ⟺ both dimensions satisfied.
     #[test]
     fn prop_visibility_consistency(
         s1 in 1_000_000i64..=400_000_000i64,
@@ -205,6 +177,7 @@ proptest! {
         qv in 1_000_000i64..=400_000_000i64,
         qt in 1_000_000i64..=400_000_000i64,
     ) {
+        // Ensure start <= end for both ranges.
         let (s1, e1) = if s1 <= e1 { (s1, e1) } else { (e1, s1) };
         let (s2, e2) = if s2 <= e2 { (s2, e2) } else { (e2, s2) };
 
@@ -221,14 +194,14 @@ proptest! {
 
         prop_assert!(
             check_visibility_consistency(interval, qv.into(), qt.into()),
-            "Invariant 4 violated: visible={}, valid_at={}, recorded_at={}",
+            "Inv 4 violated: visible={}, valid_at={}, recorded_at={}",
             interval.is_visible_at(qv.into(), qt.into()),
             interval.is_valid_at(qv.into()),
             interval.is_recorded_at(qt.into())
         );
     }
 
-    // Invariant 5 – TimeRange.overlaps() is symmetric
+    /// Invariant 5: TimeRange.overlaps() is symmetric.
     #[test]
     fn prop_overlap_symmetry(
         s1 in 1_000_000i64..=400_000_000i64,
@@ -251,13 +224,13 @@ proptest! {
         prop_assert_eq!(
             r1.overlaps(&r2),
             r2.overlaps(&r1),
-            "Invariant 5 violated: overlap not symmetric for {:?} vs {:?}",
+            "Inv 5 violated: overlap not symmetric for {:?} vs {:?}",
             r1,
             r2
         );
     }
 
-    // Invariant 6 – TimeRange.contains_range() is reflexive
+    /// Invariant 6: TimeRange.contains_range() is reflexive.
     #[test]
     fn prop_contains_range_reflexivity(
         s in 1_000_000i64..=400_000_000i64,
@@ -272,12 +245,12 @@ proptest! {
 
         prop_assert!(
             range.contains_range(&range),
-            "Invariant 6 violated: range does not contain itself: {:?}",
+            "Inv 6 violated: range does not contain itself: {:?}",
             range
         );
     }
 
-    // Invariant 7 – Half-open interval: end is exclusive, end-1 is inclusive
+    /// Invariant 7: End of a TimeRange is always exclusive.
     #[test]
     fn prop_closed_range_excludes_end(
         s in 1_000_000i64..=100_000_000i64,
@@ -287,33 +260,32 @@ proptest! {
 
         prop_assert!(
             !range.contains(e.into()),
-            "Invariant 7 violated: range {:?} contains its exclusive end {}",
-            range, e
+            "Inv 7 violated: range {:?} contains its exclusive end",
+            range
         );
         prop_assert!(
             range.contains((e - 1).into()),
-            "Invariant 7 violated: range {:?} does not contain end-1={}",
-            range,
-            e - 1
+            "Inv 7 violated: range {:?} does not contain end-1",
+            range
         );
     }
 
-    // Invariant 8 – Temporal isolation: operation sequences preserve invariants
+    /// Invariants 1–3: Any operation sequence preserves version chain invariants.
     #[test]
-    fn prop_operation_sequence_preserves_invariants(
-        ops in operation_sequence(6)
-    ) {
+    fn prop_operation_sequence_preserves_invariants(ops in operation_sequence(6)) {
         let db = AletheiaDB::new().unwrap();
-
-        let props = PropertyMapBuilder::new().insert("v", 0i64).build();
-        let node_id = db.create_node("N", props).unwrap();
+        let node_id = db
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
+            .unwrap();
 
         for op in &ops {
             match op {
                 TemporalOperation::Update { value } => {
-                    let p = PropertyMapBuilder::new().insert("v", *value).build();
                     let _ = db.write(|tx| {
-                        tx.update_node(node_id, p)?;
+                        tx.update_node(
+                            node_id,
+                            PropertyMapBuilder::new().insert("v", *value).build(),
+                        )?;
                         Ok::<_, Error>(())
                     });
                 }
@@ -326,20 +298,19 @@ proptest! {
             }
         }
 
-        // After any combination of operations, the version chain invariants must hold.
         prop_assert!(
             check_tx_time_monotonicity(&db, node_id),
-            "Invariant 1 violated after sequence {:?}",
+            "Inv 1 violated after sequence {:?}",
             ops
         );
         prop_assert!(
             check_version_numbers_increasing(&db, node_id),
-            "Invariant 2 violated after sequence {:?}",
+            "Inv 2 violated after sequence {:?}",
             ops
         );
         prop_assert!(
             check_time_range_validity(&db, node_id),
-            "Invariant 3 violated after sequence {:?}",
+            "Inv 3 violated after sequence {:?}",
             ops
         );
     }
@@ -351,47 +322,32 @@ proptest! {
 
 /// Exhaustively tests all semantically distinct 3-operation lifecycle orderings.
 ///
-/// For a single entity, the possible sequences that matter are:
-///   Create → Update           (normal update)
-///   Create → Delete           (immediate delete)
-///   Create → Update → Delete  (full lifecycle)
-///   Create → Update × N       (multiple versions, spanning anchor boundary)
+/// Covers:
+/// - Create → Update
+/// - Create → Delete
+/// - Create → Update → Delete (full lifecycle)
+/// - Create → Update × 15 (multiple versions, spanning the default anchor boundary)
 #[test]
 fn exhaustive_three_operation_orderings() {
     // --- Create then Update ---
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 1i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 1i64).build())
             .unwrap();
 
         db.write(|tx| {
-            tx.update_node(
-                id,
-                PropertyMapBuilder::new().insert("v", 2i64).build(),
-            )?;
+            tx.update_node(id, PropertyMapBuilder::new().insert("v", 2i64).build())?;
             Ok::<_, Error>(())
         })
         .unwrap();
 
-        assert!(
-            check_tx_time_monotonicity(&db, id),
-            "Create→Update: tx_time monotonicity (inv 1)"
-        );
-        assert!(
-            check_version_numbers_increasing(&db, id),
-            "Create→Update: version numbers increasing (inv 2)"
-        );
-        assert!(
-            check_time_range_validity(&db, id),
-            "Create→Update: time range validity (inv 3)"
-        );
+        assert!(check_tx_time_monotonicity(&db, id), "C→U: inv 1");
+        assert!(check_version_numbers_increasing(&db, id), "C→U: inv 2");
+        assert!(check_time_range_validity(&db, id), "C→U: inv 3");
 
         let history = db.get_node_history(id).unwrap();
-        assert_eq!(history.versions.len(), 2, "Create→Update: expected 2 versions");
+        assert_eq!(history.versions.len(), 2, "C→U: expected 2 versions");
         assert_eq!(
             history
                 .versions
@@ -401,7 +357,7 @@ fn exhaustive_three_operation_orderings() {
                 .get("v")
                 .and_then(|v| v.as_int()),
             Some(2),
-            "Create→Update: latest version should carry v=2"
+            "C→U: latest version should carry v=2"
         );
     }
 
@@ -409,10 +365,7 @@ fn exhaustive_three_operation_orderings() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 1i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 1i64).build())
             .unwrap();
 
         std::thread::sleep(std::time::Duration::from_micros(100));
@@ -425,15 +378,14 @@ fn exhaustive_three_operation_orderings() {
         })
         .unwrap();
 
-        // Current query must fail after deletion.
         assert!(
             db.get_node(id).is_err(),
-            "Create→Delete: node should not be accessible after deletion"
+            "C→D: node inaccessible after deletion"
         );
-        // Time-travel to before deletion must succeed.
         assert!(
-            db.get_node_at_time(id, t_after_create, t_after_create).is_ok(),
-            "Create→Delete: time-travel before deletion should succeed"
+            db.get_node_at_time(id, t_after_create, t_after_create)
+                .is_ok(),
+            "C→D: time-travel before deletion succeeds"
         );
     }
 
@@ -441,10 +393,7 @@ fn exhaustive_three_operation_orderings() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 1i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 1i64).build())
             .unwrap();
 
         std::thread::sleep(std::time::Duration::from_micros(100));
@@ -452,10 +401,7 @@ fn exhaustive_three_operation_orderings() {
         std::thread::sleep(std::time::Duration::from_micros(100));
 
         db.write(|tx| {
-            tx.update_node(
-                id,
-                PropertyMapBuilder::new().insert("v", 2i64).build(),
-            )?;
+            tx.update_node(id, PropertyMapBuilder::new().insert("v", 2i64).build())?;
             Ok::<_, Error>(())
         })
         .unwrap();
@@ -470,24 +416,23 @@ fn exhaustive_three_operation_orderings() {
         })
         .unwrap();
 
-        // Current query fails.
         assert!(
             db.get_node(id).is_err(),
-            "C→U→D: node should not exist after deletion"
+            "C→U→D: node inaccessible after deletion"
         );
-        // Time-travel to after create (before update) → v=1.
+
         let node_v1 = db.get_node_at_time(id, t_v1, t_v1).unwrap();
         assert_eq!(
             node_v1.get_property("v").and_then(|v| v.as_int()),
             Some(1),
-            "C→U→D: time-travel before update should give v=1"
+            "C→U→D: time-travel before update yields v=1"
         );
-        // Time-travel to after update (before delete) → v=2.
+
         let node_v2 = db.get_node_at_time(id, t_v2, t_v2).unwrap();
         assert_eq!(
             node_v2.get_property("v").and_then(|v| v.as_int()),
             Some(2),
-            "C→U→D: time-travel after update should give v=2"
+            "C→U→D: time-travel after update yields v=2"
         );
     }
 
@@ -495,10 +440,7 @@ fn exhaustive_three_operation_orderings() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 0i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
 
         let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, time::now())];
@@ -506,9 +448,8 @@ fn exhaustive_three_operation_orderings() {
         // 15 updates → crosses the default anchor_interval of 10
         for i in 1..=15i64 {
             std::thread::sleep(std::time::Duration::from_micros(10));
-            let p = PropertyMapBuilder::new().insert("v", i).build();
             db.write(|tx| {
-                tx.update_node(id, p)?;
+                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
@@ -516,108 +457,96 @@ fn exhaustive_three_operation_orderings() {
             checkpoints.push((i, time::now()));
         }
 
-        assert!(
-            check_tx_time_monotonicity(&db, id),
-            "Multi-update: tx_time monotonicity across anchor boundary (inv 1)"
-        );
+        assert!(check_tx_time_monotonicity(&db, id), "anchor-span: inv 1");
         assert!(
             check_version_numbers_increasing(&db, id),
-            "Multi-update: version numbers increasing (inv 2)"
+            "anchor-span: inv 2"
         );
-        assert!(
-            check_time_range_validity(&db, id),
-            "Multi-update: time range validity (inv 3)"
-        );
+        assert!(check_time_range_validity(&db, id), "anchor-span: inv 3");
 
-        // Verify reconstruction of every version via anchor + delta chain.
+        // Every historical value must be reconstructable via anchor + delta chain.
         for (expected, ts) in &checkpoints {
-            let node = db.get_node_at_time(id, *ts, *ts);
             assert!(
-                node.is_ok(),
-                "Multi-update: version v={} not reconstructable at its snapshot time",
-                expected
+                db.get_node_at_time(id, *ts, *ts).is_ok(),
+                "anchor-span: v={expected} not reconstructable at its snapshot time"
             );
         }
     }
 }
 
 /// Exhaustively tests all timestamp-ordering cases for BiTemporalInterval visibility.
+///
+/// Uses three ordered reference points t1 < t2 < t3 and checks all
+/// combinations of (valid_time_query, tx_time_query) against an interval
+/// with valid time [t1, t3) and transaction time [t2, ∞).
 #[test]
 fn exhaustive_timestamp_visibility_orderings() {
-    // Reference timestamps: t1 < t2 < t3 (seconds since epoch)
     let t1 = time::from_secs(100);
     let t2 = time::from_secs(200);
     let t3 = time::from_secs(300);
     let before_t1 = time::from_secs(50);
 
-    // Interval valid from t1..t3, recorded from t2..current
-    let interval = BiTemporalInterval::new(
-        TimeRange::new(t1, t3).unwrap(),
-        TimeRange::from(t2),
-    );
+    let interval = BiTemporalInterval::new(TimeRange::new(t1, t3).unwrap(), TimeRange::from(t2));
 
-    // Before valid time start → not visible regardless of tx_time
+    // Before valid time start — not visible regardless of tx_time.
     assert!(
         !interval.is_visible_at(before_t1, t3),
-        "Not visible before valid time start"
+        "not visible before valid-time start"
     );
-    // Valid time ok, but before transaction time start → not visible
+
+    // Valid time ok, but before transaction time start — not visible.
     assert!(
         !interval.is_visible_at(t2, t1),
-        "Not visible when tx_time before recording start"
+        "not visible when tx_time precedes recording"
     );
-    // Both dimensions satisfied → visible
+
+    // Both dimensions satisfied — visible.
     assert!(
         interval.is_visible_at(t2, t3),
-        "Visible when both dimensions satisfied"
+        "visible when both dimensions satisfied"
     );
     assert!(
         interval.is_visible_at(t1, t3),
-        "Visible at valid time start when tx_time satisfied"
-    );
-    // End of valid range is exclusive → not visible
-    assert!(
-        !interval.is_visible_at(t3, t3),
-        "Not visible at exclusive valid-time end"
+        "visible at valid-time start when tx satisfied"
     );
 
-    // Open interval (current in both dimensions)
+    // End of valid range is exclusive — not visible at t3.
+    assert!(
+        !interval.is_visible_at(t3, t3),
+        "exclusive valid-time end not visible"
+    );
+
+    // Open-ended interval (both dimensions current from t1).
     let open = BiTemporalInterval::current(t1);
     assert!(
         open.is_visible_at(t2, t2),
-        "Open interval: visible at any future point"
+        "open interval: visible at any future point"
     );
     assert!(
         !open.is_visible_at(before_t1, before_t1),
-        "Open interval: not visible before start"
+        "open interval: not visible before start"
     );
 }
 
-/// Systematically verifies all 8 temporal invariants with concrete scenarios.
+/// Systematically verifies all 8 temporal invariants with targeted scenarios.
 #[test]
 fn check_all_eight_temporal_invariants() {
     // Inv 1: Transaction Time Monotonicity
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 0i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
         for i in 1..=5i64 {
             db.write(|tx| {
-                tx.update_node(
-                    id,
-                    PropertyMapBuilder::new().insert("v", i).build(),
-                )?;
+                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
         }
         assert!(
             check_tx_time_monotonicity(&db, id),
-            "Inv 1: tx_time monotonicity"
+            "inv 1: tx_time monotonicity"
         );
     }
 
@@ -625,24 +554,18 @@ fn check_all_eight_temporal_invariants() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 0i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
         for i in 1..=5i64 {
             db.write(|tx| {
-                tx.update_node(
-                    id,
-                    PropertyMapBuilder::new().insert("v", i).build(),
-                )?;
+                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
         }
         assert!(
             check_version_numbers_increasing(&db, id),
-            "Inv 2: version number ordering"
+            "inv 2: version number ordering"
         );
     }
 
@@ -650,24 +573,18 @@ fn check_all_eight_temporal_invariants() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 0i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
         for i in 1..=5i64 {
             db.write(|tx| {
-                tx.update_node(
-                    id,
-                    PropertyMapBuilder::new().insert("v", i).build(),
-                )?;
+                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
         }
         assert!(
             check_time_range_validity(&db, id),
-            "Inv 3: all stored time ranges valid"
+            "inv 3: all stored time ranges valid"
         );
     }
 
@@ -689,7 +606,7 @@ fn check_all_eight_temporal_invariants() {
         let tx_now = time::now();
         assert!(
             db.get_node_at_time(id, before_valid, tx_now).is_err(),
-            "Inv 4: entity not visible before valid_from"
+            "inv 4: entity not visible before valid_from"
         );
     }
 
@@ -697,10 +614,7 @@ fn check_all_eight_temporal_invariants() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 1i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 1i64).build())
             .unwrap();
 
         std::thread::sleep(std::time::Duration::from_micros(100));
@@ -715,15 +629,15 @@ fn check_all_eight_temporal_invariants() {
 
         assert!(
             db.get_node_at_time(id, t_alive, t_alive).is_ok(),
-            "Inv 5: time-travel before deletion must succeed"
+            "inv 5: time-travel before deletion must succeed"
         );
         assert!(
             db.get_node(id).is_err(),
-            "Inv 5: current access after deletion must fail"
+            "inv 5: current access after deletion must fail"
         );
     }
 
-    // Inv 6: Visibility Consistency (direct BiTemporalInterval checks)
+    // Inv 6: Visibility Consistency – direct BiTemporalInterval checks
     {
         let vt_start = time::from_secs(100);
         let vt_end = time::from_secs(200);
@@ -740,11 +654,11 @@ fn check_all_eight_temporal_invariants() {
 
         assert!(
             check_visibility_consistency(interval, vt_inside, tt_satisfied),
-            "Inv 6: visibility consistent when both dims satisfied"
+            "inv 6: consistent when both dims satisfied"
         );
         assert!(
             check_visibility_consistency(interval, vt_inside, tt_before),
-            "Inv 6: visibility consistent when tx_time not satisfied"
+            "inv 6: consistent when tx_time not satisfied"
         );
     }
 
@@ -752,20 +666,14 @@ fn check_all_eight_temporal_invariants() {
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
-            .create_node(
-                "N",
-                PropertyMapBuilder::new().insert("v", 0i64).build(),
-            )
+            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
             .unwrap();
 
         let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, time::now())];
         for i in 1..=15i64 {
             std::thread::sleep(std::time::Duration::from_micros(10));
             db.write(|tx| {
-                tx.update_node(
-                    id,
-                    PropertyMapBuilder::new().insert("v", i).build(),
-                )?;
+                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
                 Ok::<_, Error>(())
             })
             .unwrap();
@@ -774,11 +682,9 @@ fn check_all_eight_temporal_invariants() {
         }
 
         for (expected, ts) in &checkpoints {
-            let node = db.get_node_at_time(id, *ts, *ts);
             assert!(
-                node.is_ok(),
-                "Inv 7/8: version v={} should be reconstructable across anchor/delta boundary",
-                expected
+                db.get_node_at_time(id, *ts, *ts).is_ok(),
+                "inv 7/8: v={expected} must be reconstructable across anchor/delta boundary"
             );
         }
     }

--- a/tests/temporal_state_space.rs
+++ b/tests/temporal_state_space.rs
@@ -279,22 +279,23 @@ proptest! {
             .unwrap();
 
         for op in &ops {
-            match op {
-                TemporalOperation::Update { value } => {
-                    let _ = db.write(|tx| {
-                        tx.update_node(
-                            node_id,
-                            PropertyMapBuilder::new().insert("v", *value).build(),
-                        )?;
-                        Ok::<_, Error>(())
-                    });
-                }
-                TemporalOperation::Delete => {
-                    let _ = db.write(|tx| {
-                        tx.delete_node(node_id)?;
-                        Ok::<_, Error>(())
-                    });
-                }
+            let res = match op {
+                TemporalOperation::Update { value } => db.write(|tx| {
+                    tx.update_node(
+                        node_id,
+                        PropertyMapBuilder::new().insert("v", *value).build(),
+                    )?;
+                    Ok::<_, Error>(())
+                }),
+                TemporalOperation::Delete => db.write(|tx| {
+                    tx.delete_node(node_id)?;
+                    Ok::<_, Error>(())
+                }),
+            };
+            if res.is_err() {
+                // Expected for sequences like update-after-delete; stop here and
+                // check invariants on the state reached before the failure.
+                break;
             }
         }
 
@@ -531,7 +532,7 @@ fn exhaustive_timestamp_visibility_orderings() {
 /// Systematically verifies all 8 temporal invariants with targeted scenarios.
 #[test]
 fn check_all_eight_temporal_invariants() {
-    // Inv 1: Transaction Time Monotonicity
+    // Inv 1, 2 & 3: Transaction Time Monotonicity, Version Number Ordering, Time Range Validity
     {
         let db = AletheiaDB::new().unwrap();
         let id = db
@@ -548,40 +549,10 @@ fn check_all_eight_temporal_invariants() {
             check_tx_time_monotonicity(&db, id),
             "inv 1: tx_time monotonicity"
         );
-    }
-
-    // Inv 2: Version Number Ordering
-    {
-        let db = AletheiaDB::new().unwrap();
-        let id = db
-            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
-            .unwrap();
-        for i in 1..=5i64 {
-            db.write(|tx| {
-                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
-                Ok::<_, Error>(())
-            })
-            .unwrap();
-        }
         assert!(
             check_version_numbers_increasing(&db, id),
             "inv 2: version number ordering"
         );
-    }
-
-    // Inv 3: Time Range Validity
-    {
-        let db = AletheiaDB::new().unwrap();
-        let id = db
-            .create_node("N", PropertyMapBuilder::new().insert("v", 0i64).build())
-            .unwrap();
-        for i in 1..=5i64 {
-            db.write(|tx| {
-                tx.update_node(id, PropertyMapBuilder::new().insert("v", i).build())?;
-                Ok::<_, Error>(())
-            })
-            .unwrap();
-        }
         assert!(
             check_time_range_validity(&db, id),
             "inv 3: all stored time ranges valid"

--- a/tests/temporal_state_space.rs
+++ b/tests/temporal_state_space.rs
@@ -1,0 +1,732 @@
+//! State space exploration tests for temporal invariants (issue #153).
+//!
+//! Implements property-based testing and exhaustive small-n enumeration to
+//! verify the 8 core temporal invariants of AletheiaDB beyond line coverage.
+//!
+//! # TDD Structure
+//! - **RED phase** (this commit): invariant checkers are stubs that `todo!()`,
+//!   causing every test to fail.
+//! - **GREEN phase** (next commit): invariant checkers fully implemented;
+//!   all tests pass.
+//! - **REFACTOR phase**: code organisation and edge-case expansion.
+//!
+//! # Invariants under test
+//! 1. **Transaction Time Monotonicity** – `tx_time(v_n) >= tx_time(v_{n-1})`
+//! 2. **Version Number Ordering** – `version_number(v_n) > version_number(v_{n-1})`
+//! 3. **Time Range Validity** – `start <= end` for every stored range
+//! 4. **Visibility Consistency** – `visible_at(vt, tt) ⟺ valid_at(vt) ∧ recorded_at(tt)`
+//! 5. **Overlap Symmetry** – `r1.overlaps(r2) == r2.overlaps(r1)`
+//! 6. **Contains-Range Reflexivity** – `r.contains_range(r) == true`
+//! 7. **Half-Open Interval Semantics** – end is exclusive
+//! 8. **Temporal Isolation** – time-travel sees consistent snapshot values
+
+use aletheiadb::core::id::NodeId;
+use aletheiadb::core::property::PropertyMapBuilder;
+use aletheiadb::{AletheiaDB, BiTemporalInterval, Error, TimeRange, Timestamp, WriteOps, time};
+use proptest::prelude::*;
+
+// ============================================================================
+// Test infrastructure: TemporalOperation generators
+// ============================================================================
+
+/// A post-creation operation that can be applied to a node in sequence.
+#[derive(Debug, Clone)]
+enum TemporalOperation {
+    Update { value: i64 },
+    Delete,
+}
+
+fn temporal_operation_strategy() -> impl Strategy<Value = TemporalOperation> {
+    prop_oneof![
+        any::<i64>().prop_map(|v| TemporalOperation::Update { value: v }),
+        Just(TemporalOperation::Delete),
+    ]
+}
+
+/// Generates a non-empty sequence of operations to apply after an initial Create.
+///
+/// The sequence always starts with at least one Update, and may optionally end
+/// with a Delete.  This mirrors the realistic node lifecycle.
+fn operation_sequence(max_ops: usize) -> impl Strategy<Value = Vec<TemporalOperation>> {
+    proptest::collection::vec(temporal_operation_strategy(), 1..=max_ops)
+}
+
+// ============================================================================
+// Invariant checkers
+// RED phase: each function calls `todo!()` so tests fail until implemented.
+// ============================================================================
+
+/// Invariant 1 – Transaction time is monotonically non-decreasing across versions.
+fn check_tx_time_monotonicity(_db: &AletheiaDB, _node_id: NodeId) -> bool {
+    todo!("RED – tx_time monotonicity checker not yet implemented")
+}
+
+/// Invariant 2 – Version numbers are strictly increasing.
+fn check_version_numbers_increasing(_db: &AletheiaDB, _node_id: NodeId) -> bool {
+    todo!("RED – version number ordering checker not yet implemented")
+}
+
+/// Invariant 3 – All stored time ranges satisfy start <= end.
+fn check_time_range_validity(_db: &AletheiaDB, _node_id: NodeId) -> bool {
+    todo!("RED – time range validity checker not yet implemented")
+}
+
+/// Invariant 4 – Visibility is consistent with individual dimension checks.
+///
+/// `visible_at(vt, tt)  ⟺  is_valid_at(vt) AND is_recorded_at(tt)`
+fn check_visibility_consistency(
+    _interval: BiTemporalInterval,
+    _vt: Timestamp,
+    _tt: Timestamp,
+) -> bool {
+    todo!("RED – visibility consistency checker not yet implemented")
+}
+
+// ============================================================================
+// Phase 1: Property-based tests
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    // Invariant 1 & 2 – after N updates, tx_time is monotone and versions are ordered
+    #[test]
+    fn prop_tx_time_monotonicity_after_updates(update_count in 1usize..=8) {
+        let db = AletheiaDB::new().unwrap();
+
+        let props = PropertyMapBuilder::new().insert("v", 0i64).build();
+        let node_id = db.create_node("TestNode", props).unwrap();
+
+        for i in 1..=(update_count as i64) {
+            let p = PropertyMapBuilder::new().insert("v", i).build();
+            db.write(|tx| {
+                tx.update_node(node_id, p)?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+
+        prop_assert!(
+            check_tx_time_monotonicity(&db, node_id),
+            "Invariant 1 violated after {} updates",
+            update_count
+        );
+        prop_assert!(
+            check_version_numbers_increasing(&db, node_id),
+            "Invariant 2 violated after {} updates",
+            update_count
+        );
+    }
+
+    // Invariant 3 – time ranges stored by the database are always valid
+    #[test]
+    fn prop_time_ranges_always_valid(update_count in 1usize..=6) {
+        let db = AletheiaDB::new().unwrap();
+
+        let props = PropertyMapBuilder::new().insert("v", 0i64).build();
+        let node_id = db.create_node("N", props).unwrap();
+
+        for i in 1..=(update_count as i64) {
+            let p = PropertyMapBuilder::new().insert("v", i).build();
+            db.write(|tx| {
+                tx.update_node(node_id, p)?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+
+        prop_assert!(
+            check_time_range_validity(&db, node_id),
+            "Invariant 3 violated after {} updates",
+            update_count
+        );
+    }
+
+    // Invariant 4 – BiTemporalInterval visibility ⟺ both dimensions satisfied
+    #[test]
+    fn prop_visibility_consistency(
+        s1 in 1_000_000i64..=400_000_000i64,
+        e1 in 1_000_000i64..=400_000_000i64,
+        s2 in 1_000_000i64..=400_000_000i64,
+        e2 in 1_000_000i64..=400_000_000i64,
+        qv in 1_000_000i64..=400_000_000i64,
+        qt in 1_000_000i64..=400_000_000i64,
+    ) {
+        let (s1, e1) = if s1 <= e1 { (s1, e1) } else { (e1, s1) };
+        let (s2, e2) = if s2 <= e2 { (s2, e2) } else { (e2, s2) };
+
+        let vt = match TimeRange::new(s1.into(), e1.into()) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+        let tt = match TimeRange::new(s2.into(), e2.into()) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+
+        let interval = BiTemporalInterval::new(vt, tt);
+
+        prop_assert!(
+            check_visibility_consistency(interval, qv.into(), qt.into()),
+            "Invariant 4 violated: visible={}, valid_at={}, recorded_at={}",
+            interval.is_visible_at(qv.into(), qt.into()),
+            interval.is_valid_at(qv.into()),
+            interval.is_recorded_at(qt.into())
+        );
+    }
+
+    // Invariant 5 – TimeRange.overlaps() is symmetric
+    #[test]
+    fn prop_overlap_symmetry(
+        s1 in 1_000_000i64..=400_000_000i64,
+        e1 in 1_000_000i64..=400_000_000i64,
+        s2 in 1_000_000i64..=400_000_000i64,
+        e2 in 1_000_000i64..=400_000_000i64,
+    ) {
+        let (s1, e1) = if s1 <= e1 { (s1, e1) } else { (e1, s1) };
+        let (s2, e2) = if s2 <= e2 { (s2, e2) } else { (e2, s2) };
+
+        let r1 = match TimeRange::new(s1.into(), e1.into()) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+        let r2 = match TimeRange::new(s2.into(), e2.into()) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+
+        prop_assert_eq!(
+            r1.overlaps(&r2),
+            r2.overlaps(&r1),
+            "Invariant 5 violated: overlap not symmetric for {:?} vs {:?}",
+            r1,
+            r2
+        );
+    }
+
+    // Invariant 6 – TimeRange.contains_range() is reflexive
+    #[test]
+    fn prop_contains_range_reflexivity(
+        s in 1_000_000i64..=400_000_000i64,
+        e in 1_000_000i64..=400_000_000i64,
+    ) {
+        let (s, e) = if s <= e { (s, e) } else { (e, s) };
+
+        let range = match TimeRange::new(s.into(), e.into()) {
+            Ok(r) => r,
+            Err(_) => return Ok(()),
+        };
+
+        prop_assert!(
+            range.contains_range(&range),
+            "Invariant 6 violated: range does not contain itself: {:?}",
+            range
+        );
+    }
+
+    // Invariant 7 – Half-open interval: end is exclusive, end-1 is inclusive
+    #[test]
+    fn prop_closed_range_excludes_end(
+        s in 1_000_000i64..=100_000_000i64,
+        e in 100_000_001i64..=400_000_000i64,
+    ) {
+        let range = TimeRange::new(s.into(), e.into()).unwrap();
+
+        prop_assert!(
+            !range.contains(e.into()),
+            "Invariant 7 violated: range {:?} contains its exclusive end {}",
+            range, e
+        );
+        prop_assert!(
+            range.contains((e - 1).into()),
+            "Invariant 7 violated: range {:?} does not contain end-1={}",
+            range,
+            e - 1
+        );
+    }
+
+    // Invariant 8 – Temporal isolation: operation sequences preserve invariants
+    #[test]
+    fn prop_operation_sequence_preserves_invariants(
+        ops in operation_sequence(6)
+    ) {
+        let db = AletheiaDB::new().unwrap();
+
+        let props = PropertyMapBuilder::new().insert("v", 0i64).build();
+        let node_id = db.create_node("N", props).unwrap();
+
+        for op in &ops {
+            match op {
+                TemporalOperation::Update { value } => {
+                    let p = PropertyMapBuilder::new().insert("v", *value).build();
+                    let _ = db.write(|tx| {
+                        tx.update_node(node_id, p)?;
+                        Ok::<_, Error>(())
+                    });
+                }
+                TemporalOperation::Delete => {
+                    let _ = db.write(|tx| {
+                        tx.delete_node(node_id)?;
+                        Ok::<_, Error>(())
+                    });
+                }
+            }
+        }
+
+        // After any combination of operations, the version chain invariants must hold.
+        prop_assert!(
+            check_tx_time_monotonicity(&db, node_id),
+            "Invariant 1 violated after sequence {:?}",
+            ops
+        );
+        prop_assert!(
+            check_version_numbers_increasing(&db, node_id),
+            "Invariant 2 violated after sequence {:?}",
+            ops
+        );
+        prop_assert!(
+            check_time_range_validity(&db, node_id),
+            "Invariant 3 violated after sequence {:?}",
+            ops
+        );
+    }
+}
+
+// ============================================================================
+// Phase 2: Exhaustive small-n state enumeration
+// ============================================================================
+
+/// Exhaustively tests all semantically distinct 3-operation lifecycle orderings.
+///
+/// For a single entity, the possible sequences that matter are:
+///   Create → Update           (normal update)
+///   Create → Delete           (immediate delete)
+///   Create → Update → Delete  (full lifecycle)
+///   Create → Update × N       (multiple versions, spanning anchor boundary)
+#[test]
+fn exhaustive_three_operation_orderings() {
+    // --- Create then Update ---
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 1i64).build(),
+            )
+            .unwrap();
+
+        db.write(|tx| {
+            tx.update_node(
+                id,
+                PropertyMapBuilder::new().insert("v", 2i64).build(),
+            )?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+
+        assert!(
+            check_tx_time_monotonicity(&db, id),
+            "Create→Update: tx_time monotonicity (inv 1)"
+        );
+        assert!(
+            check_version_numbers_increasing(&db, id),
+            "Create→Update: version numbers increasing (inv 2)"
+        );
+        assert!(
+            check_time_range_validity(&db, id),
+            "Create→Update: time range validity (inv 3)"
+        );
+
+        let history = db.get_node_history(id).unwrap();
+        assert_eq!(history.versions.len(), 2, "Create→Update: expected 2 versions");
+        assert_eq!(
+            history
+                .versions
+                .last()
+                .unwrap()
+                .properties
+                .get("v")
+                .and_then(|v| v.as_int()),
+            Some(2),
+            "Create→Update: latest version should carry v=2"
+        );
+    }
+
+    // --- Create then Delete ---
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 1i64).build(),
+            )
+            .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let t_after_create = time::now();
+        std::thread::sleep(std::time::Duration::from_micros(100));
+
+        db.write(|tx| {
+            tx.delete_node(id)?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+
+        // Current query must fail after deletion.
+        assert!(
+            db.get_node(id).is_err(),
+            "Create→Delete: node should not be accessible after deletion"
+        );
+        // Time-travel to before deletion must succeed.
+        assert!(
+            db.get_node_at_time(id, t_after_create, t_after_create).is_ok(),
+            "Create→Delete: time-travel before deletion should succeed"
+        );
+    }
+
+    // --- Create → Update → Delete (full lifecycle) ---
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 1i64).build(),
+            )
+            .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let t_v1 = time::now();
+        std::thread::sleep(std::time::Duration::from_micros(100));
+
+        db.write(|tx| {
+            tx.update_node(
+                id,
+                PropertyMapBuilder::new().insert("v", 2i64).build(),
+            )?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let t_v2 = time::now();
+        std::thread::sleep(std::time::Duration::from_micros(100));
+
+        db.write(|tx| {
+            tx.delete_node(id)?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+
+        // Current query fails.
+        assert!(
+            db.get_node(id).is_err(),
+            "C→U→D: node should not exist after deletion"
+        );
+        // Time-travel to after create (before update) → v=1.
+        let node_v1 = db.get_node_at_time(id, t_v1, t_v1).unwrap();
+        assert_eq!(
+            node_v1.get_property("v").and_then(|v| v.as_int()),
+            Some(1),
+            "C→U→D: time-travel before update should give v=1"
+        );
+        // Time-travel to after update (before delete) → v=2.
+        let node_v2 = db.get_node_at_time(id, t_v2, t_v2).unwrap();
+        assert_eq!(
+            node_v2.get_property("v").and_then(|v| v.as_int()),
+            Some(2),
+            "C→U→D: time-travel after update should give v=2"
+        );
+    }
+
+    // --- Multiple updates spanning the anchor boundary ---
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 0i64).build(),
+            )
+            .unwrap();
+
+        let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, time::now())];
+
+        // 15 updates → crosses the default anchor_interval of 10
+        for i in 1..=15i64 {
+            std::thread::sleep(std::time::Duration::from_micros(10));
+            let p = PropertyMapBuilder::new().insert("v", i).build();
+            db.write(|tx| {
+                tx.update_node(id, p)?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+            std::thread::sleep(std::time::Duration::from_micros(10));
+            checkpoints.push((i, time::now()));
+        }
+
+        assert!(
+            check_tx_time_monotonicity(&db, id),
+            "Multi-update: tx_time monotonicity across anchor boundary (inv 1)"
+        );
+        assert!(
+            check_version_numbers_increasing(&db, id),
+            "Multi-update: version numbers increasing (inv 2)"
+        );
+        assert!(
+            check_time_range_validity(&db, id),
+            "Multi-update: time range validity (inv 3)"
+        );
+
+        // Verify reconstruction of every version via anchor + delta chain.
+        for (expected, ts) in &checkpoints {
+            let node = db.get_node_at_time(id, *ts, *ts);
+            assert!(
+                node.is_ok(),
+                "Multi-update: version v={} not reconstructable at its snapshot time",
+                expected
+            );
+        }
+    }
+}
+
+/// Exhaustively tests all timestamp-ordering cases for BiTemporalInterval visibility.
+#[test]
+fn exhaustive_timestamp_visibility_orderings() {
+    // Reference timestamps: t1 < t2 < t3 (seconds since epoch)
+    let t1 = time::from_secs(100);
+    let t2 = time::from_secs(200);
+    let t3 = time::from_secs(300);
+    let before_t1 = time::from_secs(50);
+
+    // Interval valid from t1..t3, recorded from t2..current
+    let interval = BiTemporalInterval::new(
+        TimeRange::new(t1, t3).unwrap(),
+        TimeRange::from(t2),
+    );
+
+    // Before valid time start → not visible regardless of tx_time
+    assert!(
+        !interval.is_visible_at(before_t1, t3),
+        "Not visible before valid time start"
+    );
+    // Valid time ok, but before transaction time start → not visible
+    assert!(
+        !interval.is_visible_at(t2, t1),
+        "Not visible when tx_time before recording start"
+    );
+    // Both dimensions satisfied → visible
+    assert!(
+        interval.is_visible_at(t2, t3),
+        "Visible when both dimensions satisfied"
+    );
+    assert!(
+        interval.is_visible_at(t1, t3),
+        "Visible at valid time start when tx_time satisfied"
+    );
+    // End of valid range is exclusive → not visible
+    assert!(
+        !interval.is_visible_at(t3, t3),
+        "Not visible at exclusive valid-time end"
+    );
+
+    // Open interval (current in both dimensions)
+    let open = BiTemporalInterval::current(t1);
+    assert!(
+        open.is_visible_at(t2, t2),
+        "Open interval: visible at any future point"
+    );
+    assert!(
+        !open.is_visible_at(before_t1, before_t1),
+        "Open interval: not visible before start"
+    );
+}
+
+/// Systematically verifies all 8 temporal invariants with concrete scenarios.
+#[test]
+fn check_all_eight_temporal_invariants() {
+    // Inv 1: Transaction Time Monotonicity
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 0i64).build(),
+            )
+            .unwrap();
+        for i in 1..=5i64 {
+            db.write(|tx| {
+                tx.update_node(
+                    id,
+                    PropertyMapBuilder::new().insert("v", i).build(),
+                )?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        assert!(
+            check_tx_time_monotonicity(&db, id),
+            "Inv 1: tx_time monotonicity"
+        );
+    }
+
+    // Inv 2: Version Number Ordering
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 0i64).build(),
+            )
+            .unwrap();
+        for i in 1..=5i64 {
+            db.write(|tx| {
+                tx.update_node(
+                    id,
+                    PropertyMapBuilder::new().insert("v", i).build(),
+                )?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        assert!(
+            check_version_numbers_increasing(&db, id),
+            "Inv 2: version number ordering"
+        );
+    }
+
+    // Inv 3: Time Range Validity
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 0i64).build(),
+            )
+            .unwrap();
+        for i in 1..=5i64 {
+            db.write(|tx| {
+                tx.update_node(
+                    id,
+                    PropertyMapBuilder::new().insert("v", i).build(),
+                )?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+        }
+        assert!(
+            check_time_range_validity(&db, id),
+            "Inv 3: all stored time ranges valid"
+        );
+    }
+
+    // Inv 4: Valid Time Consistency – entity not visible before its valid_from
+    {
+        let db = AletheiaDB::new().unwrap();
+        let valid_from = time::from_secs(1000);
+        let id = db
+            .write(|tx| {
+                tx.create_node_with_valid_time(
+                    "N",
+                    PropertyMapBuilder::new().insert("v", 1i64).build(),
+                    Some(valid_from),
+                )
+            })
+            .unwrap();
+
+        let before_valid = time::from_secs(500);
+        let tx_now = time::now();
+        assert!(
+            db.get_node_at_time(id, before_valid, tx_now).is_err(),
+            "Inv 4: entity not visible before valid_from"
+        );
+    }
+
+    // Inv 5: No Paradoxes – time-travel before deletion succeeds; current access fails
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 1i64).build(),
+            )
+            .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_micros(100));
+        let t_alive = time::now();
+        std::thread::sleep(std::time::Duration::from_micros(100));
+
+        db.write(|tx| {
+            tx.delete_node(id)?;
+            Ok::<_, Error>(())
+        })
+        .unwrap();
+
+        assert!(
+            db.get_node_at_time(id, t_alive, t_alive).is_ok(),
+            "Inv 5: time-travel before deletion must succeed"
+        );
+        assert!(
+            db.get_node(id).is_err(),
+            "Inv 5: current access after deletion must fail"
+        );
+    }
+
+    // Inv 6: Visibility Consistency (direct BiTemporalInterval checks)
+    {
+        let vt_start = time::from_secs(100);
+        let vt_end = time::from_secs(200);
+        let tt_start = time::from_secs(150);
+
+        let interval = BiTemporalInterval::new(
+            TimeRange::new(vt_start, vt_end).unwrap(),
+            TimeRange::from(tt_start),
+        );
+
+        let vt_inside = time::from_secs(150);
+        let tt_satisfied = time::from_secs(200);
+        let tt_before = time::from_secs(100);
+
+        assert!(
+            check_visibility_consistency(interval, vt_inside, tt_satisfied),
+            "Inv 6: visibility consistent when both dims satisfied"
+        );
+        assert!(
+            check_visibility_consistency(interval, vt_inside, tt_before),
+            "Inv 6: visibility consistent when tx_time not satisfied"
+        );
+    }
+
+    // Inv 7 & 8: Anchor/Delta Completeness – reconstruction across anchor boundary
+    {
+        let db = AletheiaDB::new().unwrap();
+        let id = db
+            .create_node(
+                "N",
+                PropertyMapBuilder::new().insert("v", 0i64).build(),
+            )
+            .unwrap();
+
+        let mut checkpoints: Vec<(i64, Timestamp)> = vec![(0, time::now())];
+        for i in 1..=15i64 {
+            std::thread::sleep(std::time::Duration::from_micros(10));
+            db.write(|tx| {
+                tx.update_node(
+                    id,
+                    PropertyMapBuilder::new().insert("v", i).build(),
+                )?;
+                Ok::<_, Error>(())
+            })
+            .unwrap();
+            std::thread::sleep(std::time::Duration::from_micros(10));
+            checkpoints.push((i, time::now()));
+        }
+
+        for (expected, ts) in &checkpoints {
+            let node = db.get_node_at_time(id, *ts, *ts);
+            assert!(
+                node.is_ok(),
+                "Inv 7/8: version v={} should be reconstructable across anchor/delta boundary",
+                expected
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds extensive property-based and exhaustive state enumeration tests to verify AletheiaDB's 8 core temporal invariants across a wide range of operation sequences and timestamp combinations. This addresses issue #153 by supplementing line/branch coverage with rigorous verification of temporal correctness.

## Key Changes
- **Phase 1 – Property-based tests (proptest)**: 8 randomized test cases exercising thousands of state combinations:
  - Transaction time monotonicity and version ordering after sequential updates
  - Time range validity (start ≤ end) across all stored ranges
  - BiTemporalInterval visibility consistency (visible_at ⟺ valid_at ∧ recorded_at)
  - TimeRange overlap symmetry and contains-range reflexivity
  - Half-open interval semantics (exclusive end timestamp)
  - Operation sequence preservation of version chain invariants

- **Phase 2 – Exhaustive small-n enumeration**: Deterministic tests covering all semantically distinct scenarios:
  - Three-operation lifecycle orderings (Create→Update, Create→Delete, Create→Update→Delete)
  - Multiple updates spanning the anchor boundary (15 updates crossing default anchor_interval of 10)
  - All timestamp-ordering cases for BiTemporalInterval visibility with reference points t1 < t2 < t3
  - Comprehensive verification of all 8 temporal invariants with targeted scenarios

- **Test infrastructure**: Helper functions for invariant checking and operation generation:
  - `TemporalOperation` enum and strategy for realistic node lifecycle generation
  - Invariant checker functions for tx-time monotonicity, version ordering, time range validity, and visibility consistency
  - Proptest regression seed file for reproducible failure cases

## Notable Implementation Details
- Graceful handling of post-deletion history access (treated as empty history with trivially satisfied invariants)
- Systematic timestamp ordering verification using three reference points to cover all visibility cases
- Anchor/delta reconstruction verification across the default 10-version anchor boundary
- Time-travel validation confirming nodes are accessible at historical timestamps but inaccessible after deletion

https://claude.ai/code/session_01FELdjXvGjX7ZMamX8atLXP