### PR TITLE
⚡ Bolt: Avoid string allocations when parsing Cypher literals and derive Copy for TokenKind

### DIFF
--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -21,7 +21,8 @@ use super::CypherError;
 ///
 /// Covers keywords, operators, symbols, literals, parameters, identifiers,
 /// and the end-of-input marker.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// ⚡ Bolt: Derived `Copy` to avoid cloning token kinds during parsing.
 pub enum TokenKind {
     // -- Keywords: clauses --------------------------------------------------
     /// `MATCH`

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -221,8 +221,8 @@ impl CypherParser {
         self.expect(TokenKind::LParen)?;
 
         let variable = if self.at(TokenKind::Identifier) {
-            let tok = self.advance().clone();
-            Some(tok.text)
+            let tok = self.advance();
+            Some(tok.text.clone())
         } else {
             None
         };
@@ -266,8 +266,8 @@ impl CypherParser {
         self.expect(TokenKind::LBracket)?;
 
         let variable = if self.at(TokenKind::Identifier) {
-            let tok = self.advance().clone();
-            Some(tok.text)
+            let tok = self.advance();
+            Some(tok.text.clone())
         } else {
             None
         };
@@ -539,7 +539,7 @@ impl CypherParser {
     /// primary := value | var '.' prop | '(' expr ')' | func_call | var
     /// ```
     fn parse_primary_expr(&mut self) -> Result<CypherExpr, CypherError> {
-        match self.peek().kind.clone() {
+        match self.peek().kind {
             // Parenthesized sub-expression
             TokenKind::LParen => {
                 self.advance();
@@ -551,8 +551,8 @@ impl CypherParser {
             // Identifier: could be variable, property access, dot-qualified function call,
             // or simple function call
             TokenKind::Identifier => {
-                let name_tok = self.advance().clone();
-                let name = name_tok.text;
+                let name_tok = self.advance();
+                let name = name_tok.text.clone();
 
                 if self.at(TokenKind::Dot) {
                     // Could be property access: var.prop
@@ -597,7 +597,7 @@ impl CypherParser {
             | TokenKind::Sum
             | TokenKind::Min
             | TokenKind::Max => {
-                let name_tok = self.advance().clone();
+                let name_tok = self.advance();
                 let name = name_tok.text.to_uppercase();
                 self.expect(TokenKind::LParen)?;
                 let args = self.parse_function_args()?;
@@ -777,26 +777,26 @@ impl CypherParser {
 
     /// Parse a single literal value or parameter.
     fn parse_value(&mut self) -> Result<CypherValue, CypherError> {
-        match self.peek().kind.clone() {
+        match self.peek().kind {
             TokenKind::IntegerLiteral => {
-                let tok = self.advance().clone();
-                let n: i64 = tok
+                let n: i64 = self
+                    .advance()
                     .text
                     .parse()
                     .map_err(|_| self.error("invalid integer literal"))?;
                 Ok(CypherValue::Int(n))
             }
             TokenKind::FloatLiteral => {
-                let tok = self.advance().clone();
-                let f: f64 = tok
+                let f: f64 = self
+                    .advance()
                     .text
                     .parse()
                     .map_err(|_| self.error("invalid float literal"))?;
                 Ok(CypherValue::Float(f))
             }
             TokenKind::StringLiteral => {
-                let tok = self.advance().clone();
-                Ok(CypherValue::String(tok.text))
+                let tok = self.advance();
+                Ok(CypherValue::String(tok.text.clone()))
             }
             TokenKind::True => {
                 self.advance();
@@ -811,8 +811,8 @@ impl CypherParser {
                 Ok(CypherValue::Null)
             }
             TokenKind::Parameter => {
-                let tok = self.advance().clone();
-                Ok(CypherValue::Parameter(tok.text))
+                let tok = self.advance();
+                Ok(CypherValue::Parameter(tok.text.clone()))
             }
             _ => Err(self.error(&format!("expected value, found {:?}", self.peek().kind))),
         }

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -789,10 +789,11 @@ impl CypherParser {
             }
             TokenKind::FloatLiteral => {
                 let f: f64 = self
-                    .advance()
+                    .peek()
                     .text
                     .parse()
                     .map_err(|_| self.error("invalid float literal"))?;
+                self.advance();
                 Ok(CypherValue::Float(f))
             }
             TokenKind::StringLiteral => {

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -780,10 +780,11 @@ impl CypherParser {
         match self.peek().kind {
             TokenKind::IntegerLiteral => {
                 let n: i64 = self
-                    .advance()
+                    .peek()
                     .text
                     .parse()
                     .map_err(|_| self.error("invalid integer literal"))?;
+                self.advance();
                 Ok(CypherValue::Int(n))
             }
             TokenKind::FloatLiteral => {


### PR DESCRIPTION
💡 What: Added `Copy` to `TokenKind` and stopped cloning `Token` and `Token::text` to avoid unnecessary heap allocations when parsing literal values.
🎯 Why: Lexing and parsing Cypher literals was cloning strings unecessarily when they could be borrowed and parsed directly as a slice, and token kind didn't need to be cloned since it is a simple primitive Enum.
📊 Impact: Removes heap allocations entirely for numerical parsing and `TokenKind` `.clone()` calls during `peek()`, lowering the overall memory allocations during Cypher parsing.
🔬 Measurement: Run `cargo test --lib --all-features -- cypher::` to verify logic hasn't changed.

---
*PR created automatically by Jules for task [10889582252040878541](https://jules.google.com/task/10889582252040878541) started by @madmax983*