### PR TITLE
Add check_node_label hot-path API for label-filtered vector search

### DIFF
--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -308,8 +308,7 @@ impl CurrentIndexes {
     pub fn check_node_label(&self, id: NodeId, expected: InternedString) -> bool {
         self.nodes
             .get(&id)
-            .map(|entry| entry.value().label == expected)
-            .unwrap_or(false)
+            .is_some_and(|entry| entry.value().label == expected)
     }
 
     /// Get the endpoints (source, target) of an edge without cloning.

--- a/src/index/current.rs
+++ b/src/index/current.rs
@@ -296,6 +296,22 @@ impl CurrentIndexes {
         self.nodes.get(&id).map(|entry| entry.value().label)
     }
 
+    /// Check whether a node's label equals the given interned string, without cloning.
+    ///
+    /// This is the preferred hot-path API for label-filtered vector search (Issue #339).
+    /// It avoids the `Option`-wrapping overhead of `get_node_label` when only a boolean
+    /// answer is needed, saving a branch and keeping the closure passed to the HNSW
+    /// filter as minimal as possible.
+    ///
+    /// Returns `false` if the node does not exist.
+    #[inline]
+    pub fn check_node_label(&self, id: NodeId, expected: InternedString) -> bool {
+        self.nodes
+            .get(&id)
+            .map(|entry| entry.value().label == expected)
+            .unwrap_or(false)
+    }
+
     /// Get the endpoints (source, target) of an edge without cloning.
     ///
     /// This is a convenience method for the common case of getting an edge's
@@ -2022,5 +2038,68 @@ mod zero_copy_access_tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&EdgeId::new(1).unwrap()));
         assert!(ids.contains(&EdgeId::new(2).unwrap()));
+    }
+
+    // ========================================================================
+    // Tests for check_node_label (Issue #339)
+    // ========================================================================
+
+    /// check_node_label returns true when the node exists and its label matches.
+    #[test]
+    fn test_check_node_label_matches() {
+        let indexes = CurrentIndexes::new();
+        let node = create_test_node(1, "Person");
+        indexes.insert_node(node);
+
+        let person_label = GLOBAL_INTERNER.intern("Person").unwrap();
+        assert!(indexes.check_node_label(NodeId::new(1).unwrap(), person_label));
+    }
+
+    /// check_node_label returns false when the node exists but its label differs.
+    #[test]
+    fn test_check_node_label_mismatch() {
+        let indexes = CurrentIndexes::new();
+        let node = create_test_node(1, "Person");
+        indexes.insert_node(node);
+
+        let company_label = GLOBAL_INTERNER.intern("Company").unwrap();
+        assert!(!indexes.check_node_label(NodeId::new(1).unwrap(), company_label));
+    }
+
+    /// check_node_label returns false for a node that does not exist.
+    #[test]
+    fn test_check_node_label_nonexistent() {
+        let indexes = CurrentIndexes::new();
+
+        let person_label = GLOBAL_INTERNER.intern("Person").unwrap();
+        assert!(!indexes.check_node_label(NodeId::new(999).unwrap(), person_label));
+    }
+
+    /// check_node_label is consistent with get_node_label for the same node.
+    #[test]
+    fn test_check_node_label_consistent_with_get_node_label() {
+        let indexes = CurrentIndexes::new();
+        let node = create_test_node(5, "Document");
+        indexes.insert_node(node);
+
+        let doc_label = GLOBAL_INTERNER.intern("Document").unwrap();
+        let other_label = GLOBAL_INTERNER.intern("Article").unwrap();
+
+        // check_node_label should agree with manual get_node_label comparison
+        let node_id = NodeId::new(5).unwrap();
+        let via_get = indexes
+            .get_node_label(node_id)
+            .map(|l| l == doc_label)
+            .unwrap_or(false);
+        assert_eq!(indexes.check_node_label(node_id, doc_label), via_get);
+
+        let via_get_other = indexes
+            .get_node_label(node_id)
+            .map(|l| l == other_label)
+            .unwrap_or(false);
+        assert_eq!(
+            indexes.check_node_label(node_id, other_label),
+            via_get_other
+        );
     }
 }

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -2203,13 +2203,8 @@ impl CurrentStorage {
             let mut results = Vec::with_capacity(candidate_count);
 
             for (node_id, similarity) in candidate_results {
-                // HOT PATH: Use zero-copy label lookup to avoid cloning entire Node
-                if self
-                    .indexes
-                    .get_node_label(node_id)
-                    .map(|l| l == label_id)
-                    .unwrap_or(false)
-                {
+                // HOT PATH: check_node_label avoids cloning Node and Option overhead (Issue #339)
+                if self.indexes.check_node_label(node_id, label_id) {
                     results.push((node_id, similarity));
                 }
             }


### PR DESCRIPTION
## Summary
Introduces a new `check_node_label` method to optimize label-filtered vector search by avoiding unnecessary `Option`-wrapping overhead and reducing closure complexity in the HNSW filter hot path.

## Key Changes
- **New API**: Added `check_node_label(id, expected)` method to `CurrentIndexes` that returns a boolean directly instead of `Option<InternedString>`
  - Marked `#[inline]` for hot-path optimization
  - Returns `false` for non-existent nodes instead of `None`
  - Avoids cloning and reduces branching in filter closures

- **Updated call site**: Replaced manual `get_node_label().map()` pattern in `CurrentStorage::vector_search_with_label_filter` with the new `check_node_label` call

- **Comprehensive tests**: Added four test cases covering:
  - Label match scenario
  - Label mismatch scenario
  - Non-existent node handling
  - Consistency verification against `get_node_label`

## Implementation Details
The new method is a thin wrapper around the existing `DashMap::get` that directly compares labels without materializing an `Option`, reducing the overhead in the hot path of label-filtered vector search operations (Issue #339).

https://claude.ai/code/session_01PXUJpqcvoJW1EMtU3Lyqtn