### PR TITLE
⚡ Bolt: [PropertyMapBuilder capacity allocation optimization]

### DIFF
--- a/src/bin/aletheia.rs
+++ b/src/bin/aletheia.rs
@@ -519,7 +519,7 @@ fn json_to_property_map(raw: &str) -> Result<PropertyMap, String> {
         .as_object()
         .ok_or_else(|| "properties JSON must be an object".to_string())?;
 
-    let mut map = PropertyMapBuilder::new();
+    let mut map = PropertyMapBuilder::with_capacity(object.len());
     for (key, value) in object {
         let converted = json_to_property_value(value)?;
         map = map.insert(key, converted);

--- a/src/core/property/map.rs
+++ b/src/core/property/map.rs
@@ -476,8 +476,16 @@ pub struct PropertyMapBuilder {
 impl PropertyMapBuilder {
     /// Create a new builder with an empty map.
     pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Create a new builder with a pre-allocated capacity.
+    ///
+    /// ⚡ Bolt: Pre-allocating the HashMap avoids multiple reallocation and rehashing
+    /// operations when building a PropertyMap where the number of properties is known.
+    pub fn with_capacity(capacity: usize) -> Self {
         PropertyMapBuilder {
-            map: HashMap::with_hasher(BuildHasherDefault::default()),
+            map: HashMap::with_capacity_and_hasher(capacity, BuildHasherDefault::default()),
             current_size: 4, // Count field
         }
     }

--- a/src/core/property/tests.rs
+++ b/src/core/property/tests.rs
@@ -2579,3 +2579,13 @@ mod sentry_tests {
         );
     }
 }
+
+#[test]
+fn test_property_map_builder_with_capacity() {
+    let builder = PropertyMapBuilder::with_capacity(10);
+    assert!(builder.map.capacity() >= 10);
+
+    let builder = builder.insert("key1", 42i64);
+    let map = builder.build();
+    assert_eq!(map.get("key1").unwrap(), &PropertyValue::Int(42));
+}

--- a/src/http/converters.rs
+++ b/src/http/converters.rs
@@ -135,7 +135,7 @@ fn property_value_to_json_recursive(
 pub fn json_to_property_map(
     json: &HashMap<String, serde_json::Value>,
 ) -> Result<PropertyMap, String> {
-    let mut builder = PropertyMapBuilder::new();
+    let mut builder = PropertyMapBuilder::with_capacity(json.len());
     for (key, value) in json {
         let pv = json_to_property_value(value)?;
         builder = builder


### PR DESCRIPTION
💡 What: Added `PropertyMapBuilder::with_capacity` method and updated JSON translation calls (e.g. `aletheia.rs` and `converters.rs`) to pre-allocate the map size correctly when translating parsed JSON maps to internal representations.
🎯 Why: Creating a `PropertyMapBuilder` natively invokes `HashMap::new()` which creates an empty map. Upon parsing large JSON payloads, inserting dynamically resizes and reallocates the underlying array multiple times, causing unnecessary CPU overhead and heap pressure during ingestion operations.
📊 Impact: Eliminates multiple redundant `HashMap` resizing and rehashing operations per `PropertyMap` created from JSON payloads, directly reducing the time and allocations required for property ingestion.
🔬 Measurement: Run `cargo test --lib --all-features core::property::tests::test_property_map_builder_with_capacity` and `cargo test --lib --all-features http::converters::tests` to verify correct behavior. Benchmark ingestion speeds on large graphs to profile allocation counts.

---
*PR created automatically by Jules for task [2393288986243541631](https://jules.google.com/task/2393288986243541631) started by @madmax983*