### PR TITLE
Add #[must_use] attribute to Result-returning methods

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -299,6 +299,7 @@ impl WriteTransaction {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn commit(self) -> Result<()> {
         self.commit_with_timestamp().map(|_| ())
     }
@@ -331,6 +332,7 @@ impl WriteTransaction {
     /// - **Async**: Returns after flush to OS cache (background thread syncs)
     /// - **GroupCommit**: Waits for batch fsync (ACID + high throughput)
     /// - **AsyncBatched**: Returns after flush to OS cache, batched fsync in background (<100µs latency)
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn commit_with_timestamp(mut self) -> Result<Timestamp> {
         self.commit_with_timestamp_inner().record_error_metric()
     }
@@ -613,6 +615,7 @@ impl WriteTransaction {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn rollback(mut self) -> Result<()> {
         if self.state == TxState::Committed {
             return Err(TransactionError::AlreadyCommitted {

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -273,6 +273,7 @@ impl WriteBuffer {
     ///
     /// assert_eq!(buffer.len(), 1);
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn add(&mut self, write: BufferedWrite) -> Result<()> {
         // Check capacity limit (DoS protection)
         if self.operations.len() >= self.max_operations {

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 impl AletheiaDB {
     /// Get statistics about the historical storage.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn historical_stats(&self) -> Result<HistoricalStats> {
         Ok(self.historical.read().stats())
     }
@@ -44,6 +45,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn persist_indexes(&self) -> Result<()> {
         let result = (|| {
             use crate::storage::index_persistence::formats::IndexManifest;

--- a/src/db/admin.rs
+++ b/src/db/admin.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 impl AletheiaDB {
     /// Get statistics about the historical storage.
-    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    #[must_use = "the historical statistics value must be used"]
     pub fn historical_stats(&self) -> Result<HistoricalStats> {
         Ok(self.historical.read().stats())
     }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -111,6 +111,7 @@ impl AletheiaDB {
     /// # Errors
     ///
     /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn new() -> Result<Self> {
         Self::with_config(AnchorConfig::default())
     }
@@ -120,6 +121,7 @@ impl AletheiaDB {
     /// # Errors
     ///
     /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_config(config: AnchorConfig) -> Result<Self> {
         Self::with_full_config(config, crate::config::WalConfig::default())
     }
@@ -149,6 +151,7 @@ impl AletheiaDB {
     ///     .build();
     /// let db = AletheiaDB::with_wal_config(wal_config)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_wal_config(wal_config: crate::config::WalConfig) -> Result<Self> {
         Self::with_full_config(AnchorConfig::default(), wal_config)
     }
@@ -175,6 +178,7 @@ impl AletheiaDB {
     ///
     /// let db = AletheiaDB::with_unified_config(config)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_unified_config(config: AletheiaDBConfig) -> Result<Self> {
         let result = (|| {
             let durability_mode = config.wal.durability_mode;
@@ -398,6 +402,7 @@ impl AletheiaDB {
     /// # Errors
     ///
     /// Returns an error if WAL initialization fails (e.g., cannot create WAL directory).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_full_config(
         anchor_config: AnchorConfig,
         wal_config: crate::config::WalConfig,

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -34,6 +34,7 @@ impl AletheiaDB {
     /// # See Also
     ///
     /// * [`write`](Self::write) - For batched write operations.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         self.write(|tx| tx.create_node(label, properties))
     }
@@ -64,6 +65,7 @@ impl AletheiaDB {
     /// # See Also
     ///
     /// * [`write`](Self::write) - For batched write operations.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_edge(
         &self,
         source: NodeId,
@@ -77,6 +79,7 @@ impl AletheiaDB {
     /// Get the current state of a node.
     ///
     /// This uses the fast path (current storage) for O(1) lookup.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node(&self, node_id: NodeId) -> Result<Node> {
         self.current.get_node(node_id).record_error_metric()
     }
@@ -99,6 +102,7 @@ impl AletheiaDB {
     /// write lock on the same shard (e.g., `update_node`, `delete_node`) within the closure.
     /// Doing so will cause a deadlock (lock re-entrancy hazard).
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_node<F, R>(&self, id: NodeId, f: F) -> Result<R>
     where
         F: FnOnce(&Node) -> R,
@@ -107,6 +111,7 @@ impl AletheiaDB {
     }
 
     /// Get the current state of an edge.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge(&self, edge_id: EdgeId) -> Result<Edge> {
         self.current.get_edge(edge_id).record_error_metric()
     }
@@ -168,6 +173,7 @@ impl AletheiaDB {
     /// - **Zero-copy**: Only reads and returns the target NodeId (8 bytes)
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_target(&self, edge_id: EdgeId) -> Result<NodeId> {
         self.current.get_edge_target(edge_id).record_error_metric()
     }
@@ -179,6 +185,7 @@ impl AletheiaDB {
     /// - **Zero-copy**: Only reads and returns the source NodeId (8 bytes)
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_source(&self, edge_id: EdgeId) -> Result<NodeId> {
         self.current.get_edge_source(edge_id).record_error_metric()
     }

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -31,6 +31,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn execute_aql(&self, query_string: &str) -> Result<QueryResults> {
         let query = crate::query::parse_query(query_string)?;
         self.execute_query(query)
@@ -108,6 +109,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn execute_query(&self, query: Query) -> Result<QueryResults> {
         let result = (|| {
             #[cfg(feature = "observability")]
@@ -163,6 +165,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn traverse_and_rank(
         &self,
         source: NodeId,
@@ -214,6 +217,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_at_time(
         &self,
         embedding: &[f32],
@@ -273,6 +277,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn traverse_and_rank_at_time(
         &self,
         source: NodeId,
@@ -325,6 +330,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn execute_cypher(&self, query_string: &str) -> Result<QueryResults> {
         let query = crate::cypher::parse_cypher(query_string)?;
         self.execute_query(query)
@@ -362,6 +368,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn execute_cypher_with_params(
         &self,
         query_string: &str,

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -89,6 +89,7 @@ impl AletheiaDB {
     ///
     /// Uses the temporal index for O(log n) candidate lookup, then verifies
     /// visibility with historical storage (handles closed intervals from deletions).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node_at_time(
         &self,
         node_id: NodeId,
@@ -108,6 +109,7 @@ impl AletheiaDB {
     ///
     /// Uses the temporal index for O(log n) candidate lookup, then verifies
     /// visibility with historical storage (handles closed intervals from deletions).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_at_time(
         &self,
         edge_id: EdgeId,
@@ -198,6 +200,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_nodes_at_time(
         &self,
         node_ids: &[NodeId],
@@ -283,6 +286,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edges_at_time(
         &self,
         edge_ids: &[EdgeId],
@@ -322,6 +326,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node_at_valid_time(&self, node_id: NodeId, valid_time: Timestamp) -> Result<Node> {
         let tx_time = time::now();
         self.get_node_at_time(node_id, valid_time, tx_time)
@@ -347,6 +352,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node_at_transaction_time(
         &self,
         node_id: NodeId,
@@ -373,6 +379,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node_history(&self, node_id: NodeId) -> Result<EntityHistory> {
         self.historical
             .read()
@@ -397,6 +404,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node_at_version(&self, node_id: NodeId, version_number: u64) -> Result<Node> {
         self.historical
             .read()
@@ -427,6 +435,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn diff_node_versions(
         &self,
         node_id: NodeId,
@@ -442,6 +451,7 @@ impl AletheiaDB {
     /// Get an edge at a specific valid time.
     ///
     /// Query by valid time only (transaction time defaults to now).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_at_valid_time(&self, edge_id: EdgeId, valid_time: Timestamp) -> Result<Edge> {
         let transaction_time = time::now();
         self.get_edge_at_time(edge_id, valid_time, transaction_time)
@@ -450,6 +460,7 @@ impl AletheiaDB {
     /// Get an edge at a specific transaction time.
     ///
     /// Query by transaction time only (valid time defaults to now).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_at_transaction_time(
         &self,
         edge_id: EdgeId,
@@ -462,6 +473,7 @@ impl AletheiaDB {
     /// Get the complete version history of an edge.
     ///
     /// Returns all versions in chronological order (oldest first).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_history(&self, edge_id: EdgeId) -> Result<EntityHistory> {
         self.historical
             .read()
@@ -472,6 +484,7 @@ impl AletheiaDB {
     /// Compute the difference between two versions of an edge.
     ///
     /// Shows which properties were added, removed, or modified.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn diff_edge_versions(
         &self,
         edge_id: EdgeId,

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -104,6 +104,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn read_transaction(&self) -> Result<ReadTransaction> {
         let result = (|| {
             let tx_id = self.tx_id_gen.next();
@@ -207,6 +208,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn write_transaction(&self) -> Result<WriteTransaction> {
         let result = (|| {
             let tx_id = self.tx_id_gen.next();
@@ -435,6 +437,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn write_transaction_with_options(
         &self,
         options: WriteOptions,

--- a/src/db/vector.rs
+++ b/src/db/vector.rs
@@ -33,6 +33,7 @@ impl AletheiaDB {
     /// # Errors
     ///
     /// Returns an error if vector indexing is already enabled.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn enable_vector_index(&self, property_name: &str, config: HnswConfig) -> Result<()> {
         #[cfg(feature = "observability")]
         let _span =
@@ -80,6 +81,7 @@ impl AletheiaDB {
     /// Returns an error if:
     /// - Temporal vector indexing is already enabled
     /// - The historical storage lock is poisoned
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn enable_temporal_vector_index(
         &self,
         property_name: &str,
@@ -294,6 +296,7 @@ impl AletheiaDB {
     /// - No vector index is enabled for the specified property
     /// - Query node is not found
     /// - Query node does not have the specified vector property
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_in(
         &self,
         property_name: &str,
@@ -332,6 +335,7 @@ impl AletheiaDB {
     /// Returns an error if:
     /// - No vector index is enabled for the specified property
     /// - Embedding dimensions don't match the index configuration
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn search_vectors_in(
         &self,
         property_name: &str,
@@ -372,6 +376,7 @@ impl AletheiaDB {
     /// - Vector index is not enabled
     /// - Query node is not found
     /// - Query node does not have the indexed vector property
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar(&self, query_node_id: NodeId, k: usize) -> Result<Vec<(NodeId, f32)>> {
         #[cfg(feature = "observability")]
         let _span = crate::observability::vector_search_span("find_similar", "").entered();
@@ -397,6 +402,7 @@ impl AletheiaDB {
     /// // Find similar Person nodes only
     /// let similar_people = db.find_similar_with_label(person_id, "Person", 10)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_with_label(
         &self,
         query_node_id: NodeId,
@@ -442,6 +448,7 @@ impl AletheiaDB {
     ///     println!("Node {:?} has similarity {}", node_id, similarity);
     /// }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_by_embedding(
         &self,
         embedding: &[f32],
@@ -488,6 +495,7 @@ impl AletheiaDB {
     ///     5
     /// )?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_by_embedding_with_label(
         &self,
         embedding: &[f32],
@@ -515,6 +523,7 @@ impl AletheiaDB {
     /// * `query_vector` - The query embedding vector
     /// * `k` - Maximum number of results to return
     /// * `predicate` - A closure that takes a `NodeId` and returns `true` if the node should be included
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_with_predicate<F>(
         &self,
         property_name: &str,
@@ -568,6 +577,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_as_of(
         &self,
         embedding: &[f32],
@@ -621,6 +631,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_as_of_in(
         &self,
         property_name: &str,
@@ -688,6 +699,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn track_drift_in(
         &self,
         property_name: &str,
@@ -744,6 +756,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn semantic_evolution_in(
         &self,
         property_name: &str,
@@ -808,6 +821,7 @@ impl AletheiaDB {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_drift_in(
         &self,
         property_name: &str,

--- a/src/db/vector_builder.rs
+++ b/src/db/vector_builder.rs
@@ -146,6 +146,7 @@ impl<'a> VectorIndexBuilder<'a> {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn enable(self) -> Result<()> {
         let hnsw_config = self
             .hnsw_config

--- a/src/db/vector_builder.rs
+++ b/src/db/vector_builder.rs
@@ -36,6 +36,7 @@ use crate::index::vector::temporal::TemporalVectorConfig;
 /// # Ok(())
 /// # }
 /// ```
+#[must_use = "VectorIndexBuilder does nothing unless .enable() is called"]
 pub struct VectorIndexBuilder<'a> {
     db: &'a AletheiaDB,
     property_name: String,

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -196,6 +196,7 @@ impl CurrentStorage {
     /// // Index body embeddings (1536 dimensions) - different property, OK!
     /// storage.enable_vector_index("body_embedding", config_1536)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn enable_vector_index(&self, property_name: &str, config: HnswConfig) -> Result<()> {
         // Check property limit before attempting to add
         if self.vector_indexes.len() >= DEFAULT_MAX_VECTOR_PROPERTIES {
@@ -419,6 +420,7 @@ impl CurrentStorage {
     /// Create a node with the given label and properties.
     ///
     /// Returns the ID of the newly created node.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -440,6 +442,7 @@ impl CurrentStorage {
     /// Create an edge between two nodes.
     ///
     /// Returns the ID of the newly created edge.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_edge(
         &self,
         source: NodeId,
@@ -478,6 +481,7 @@ impl CurrentStorage {
     }
 
     /// Get a node by ID.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node(&self, id: NodeId) -> Result<Node> {
         self.indexes
             .get_node(id)
@@ -502,6 +506,7 @@ impl CurrentStorage {
     /// write lock on the same shard (e.g., `update_node`, `delete_node`) within the closure.
     /// Doing so will cause a deadlock (lock re-entrancy hazard).
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn with_node<F, R>(&self, id: NodeId, f: F) -> Result<R>
     where
         F: FnOnce(&Node) -> R,
@@ -512,6 +517,7 @@ impl CurrentStorage {
     }
 
     /// Get an edge by ID.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge(&self, id: EdgeId) -> Result<Edge> {
         self.indexes
             .get_edge(id)
@@ -533,6 +539,7 @@ impl CurrentStorage {
     /// - **Zero-copy**: Only reads and returns the target NodeId (8 bytes)
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_target(&self, id: EdgeId) -> Result<NodeId> {
         self.indexes
             .get_edge_target(id)
@@ -546,6 +553,7 @@ impl CurrentStorage {
     /// - **Zero-copy**: Only reads and returns the source NodeId (8 bytes)
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_source(&self, id: EdgeId) -> Result<NodeId> {
         self.indexes
             .get_edge_source(id)
@@ -559,6 +567,7 @@ impl CurrentStorage {
     /// - **Zero-copy**: Only reads and returns two NodeIds (16 bytes)
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_endpoints(&self, id: EdgeId) -> Result<(NodeId, NodeId)> {
         self.indexes
             .get_edge_endpoints(id)
@@ -572,6 +581,7 @@ impl CurrentStorage {
     /// - **Zero-copy**: Only reads and returns the label (8 bytes)
     /// - **No allocation**: Does not clone Edge or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_edge_label(&self, id: EdgeId) -> Result<InternedString> {
         self.indexes
             .get_edge_label(id)
@@ -585,6 +595,7 @@ impl CurrentStorage {
     /// - **Zero-copy**: Only reads and returns the label (8 bytes)
     /// - **No allocation**: Does not clone Node or PropertyMap
     #[inline]
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn get_node_label(&self, id: NodeId) -> Result<InternedString> {
         self.indexes
             .get_node_label(id)
@@ -602,6 +613,7 @@ impl CurrentStorage {
     ///
     /// Only use this method if you explicitly need to preserve edges for some
     /// specialized use case (e.g., maintaining edge history for audit purposes).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn delete_node(&self, id: NodeId) -> Result<Node> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -621,6 +633,7 @@ impl CurrentStorage {
     }
 
     /// Delete an edge.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn delete_edge(&self, id: EdgeId) -> Result<Edge> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -640,6 +653,7 @@ impl CurrentStorage {
 
     /// Insert a node directly (used by WriteTransaction).
     /// Does not generate IDs - caller must provide them.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn insert_node_direct(&self, node: Node, timestamp: Timestamp) -> Result<()> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -660,6 +674,7 @@ impl CurrentStorage {
 
     /// Insert an edge directly (used by WriteTransaction).
     /// Does not generate IDs or rebuild adjacency - caller must handle.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn insert_edge_direct(&self, edge: Edge) -> Result<()> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -668,6 +683,7 @@ impl CurrentStorage {
     }
 
     /// Update a node directly (used by WriteTransaction).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn update_node_direct(&self, node: Node, timestamp: Timestamp) -> Result<()> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -706,6 +722,7 @@ impl CurrentStorage {
     }
 
     /// Update an edge directly (used by WriteTransaction).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn update_edge_direct(&self, edge: Edge) -> Result<()> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -715,6 +732,7 @@ impl CurrentStorage {
     }
 
     /// Delete a node directly (used by WriteTransaction).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn delete_node_direct(&self, id: NodeId, timestamp: Timestamp) -> Result<()> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -732,6 +750,7 @@ impl CurrentStorage {
     }
 
     /// Delete an edge directly (used by WriteTransaction).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn delete_edge_direct(&self, id: EdgeId) -> Result<()> {
         // Synchronize with snapshot creation
         let _lock = self.snapshot_lock.read();
@@ -1140,6 +1159,7 @@ impl CurrentStorage {
     /// - Query node is not found
     /// - Query node does not have the indexed vector property
     /// - The property is not a vector
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar(&self, query_node_id: NodeId, k: usize) -> Result<Vec<(NodeId, f32)>> {
         let (prop_name, index, _) = self.get_vector_index_internal(None)?;
         let query_vector = self.get_node_vector(query_node_id, &prop_name)?;
@@ -1150,6 +1170,7 @@ impl CurrentStorage {
     ///
     /// Returns a list of (NodeId, score) pairs sorted by similarity (highest first).
     /// Only nodes with the specified label are returned. The query node is excluded.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_with_label(
         &self,
         query_node_id: NodeId,
@@ -1180,6 +1201,7 @@ impl CurrentStorage {
     /// Returns an error if:
     /// - Vector index is not enabled
     /// - Embedding dimensions don't match the indexed property
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_by_embedding(
         &self,
         embedding: &[f32],
@@ -1211,6 +1233,7 @@ impl CurrentStorage {
     /// Returns an error if:
     /// - Vector index is not enabled
     /// - Embedding dimensions don't match the indexed property
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_by_embedding_with_label(
         &self,
         embedding: &[f32],
@@ -1242,6 +1265,7 @@ impl CurrentStorage {
     /// Returns an error if:
     /// - No vector index is enabled for the specified property
     /// - Embedding dimensions don't match the indexed property
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_by_embedding_in(
         &self,
         property_name: &str,
@@ -1263,6 +1287,7 @@ impl CurrentStorage {
     /// * `embedding` - The query embedding vector
     /// * `label` - Only return nodes with this label
     /// * `k` - Maximum number of results to return
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_by_embedding_in_with_label(
         &self,
         property_name: &str,
@@ -1286,6 +1311,7 @@ impl CurrentStorage {
     /// * `query` - The query embedding vector
     /// * `k` - Maximum number of results to return
     /// * `predicate` - A closure that takes a `NodeId` and returns `true` if the node should be included
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_with_predicate<F>(
         &self,
         property_name: &str,
@@ -1338,6 +1364,7 @@ impl CurrentStorage {
     /// // Search body embeddings (different property, potentially different results)
     /// let similar_body = storage.find_similar_in("body_embedding", node_id, 10)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_in(
         &self,
         property_name: &str,
@@ -1353,6 +1380,7 @@ impl CurrentStorage {
     /// Search a specific property's vector index with a raw embedding.
     ///
     /// Equivalent to [`find_similar_by_embedding_in`](Self::find_similar_by_embedding_in).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn search_vectors_in(
         &self,
         property_name: &str,
@@ -1390,6 +1418,7 @@ impl CurrentStorage {
     /// let temporal_config = TemporalVectorConfig::default_with_hnsw(hnsw_config);
     /// storage.enable_temporal_vector_index("embedding", temporal_config)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn enable_temporal_vector_index(
         &self,
         property_name: &str,
@@ -1497,6 +1526,7 @@ impl CurrentStorage {
     /// let timestamp = 1234567890000000; // microseconds since epoch
     /// let results = storage.find_similar_as_of(&query_embedding, 10, timestamp)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_as_of(
         &self,
         embedding: &[f32],
@@ -1543,6 +1573,7 @@ impl CurrentStorage {
     /// let timestamp = 1234567890000000;
     /// let results = storage.find_similar_as_of_in("content_embedding", &query_embedding, 10, timestamp)?;
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_as_of_in(
         &self,
         property_name: &str,
@@ -1590,6 +1621,7 @@ impl CurrentStorage {
     /// - Temporal vector index is not enabled
     /// - The property name doesn't match the indexed property
     /// - Reference embedding dimensions don't match
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn track_drift_in(
         &self,
         property_name: &str,
@@ -1616,6 +1648,7 @@ impl CurrentStorage {
     /// Get the semantic evolution of a node's embedding over time in a specific property.
     ///
     /// Returns the actual embedding vectors at each snapshot timestamp.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn semantic_evolution_in(
         &self,
         property_name: &str,
@@ -1642,6 +1675,7 @@ impl CurrentStorage {
     ///
     /// Scans all nodes and identifies those whose embeddings have changed
     /// by more than the specified threshold over the time range.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_drift_in(
         &self,
         property_name: &str,
@@ -1693,6 +1727,7 @@ impl CurrentStorage {
     ///     println!("At timestamp {}: {} similar nodes", timestamp, similar_nodes.len());
     /// }
     /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_similar_in_range(
         &self,
         embedding: &[f32],
@@ -1714,6 +1749,7 @@ impl CurrentStorage {
     ///
     /// This should be called after committing a transaction to trigger snapshot
     /// creation based on the configured strategy.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn on_temporal_vector_transaction(&self) -> Result<()> {
         let state = self.temporal_vector_index_state.read();
         if let Some(index) = &state.index {


### PR DESCRIPTION
## Summary

This PR adds the `#[must_use]` attribute to all public methods that return `Result<T>` across the codebase. This compiler lint helps prevent silent failures by warning developers when they ignore error results from fallible operations.

## Changes

- Added `#[must_use = "this Result must be used; ignoring errors can lead to silent failures"]` attribute to:
  - **Storage operations** (`src/storage/current/mod.rs`): Vector indexing, node/edge CRUD operations, temporal vector operations, and similarity search methods
  - **Database operations** (`src/db/ops.rs`): Node/edge creation and retrieval methods
  - **Query execution** (`src/db/query.rs`): AQL, Cypher, and custom query execution methods
  - **Temporal operations** (`src/db/temporal.rs`): Time-based node/edge retrieval and history methods
  - **Vector search** (`src/db/vector.rs`): Similarity search and drift tracking methods
  - **Configuration** (`src/db/config.rs`): Database initialization methods
  - **Transactions** (`src/db/transaction.rs`, `src/api/transaction/write/mod.rs`): Transaction creation and commit/rollback methods
  - **Administrative operations** (`src/db/admin.rs`): Statistics and persistence methods
  - **Write buffer** (`src/api/transaction/write_buffer.rs`): Buffer operations
  - **Vector builder** (`src/db/vector_builder.rs`): Index building methods

## Implementation Details

The attribute uses a descriptive message to guide developers toward proper error handling. This is a non-breaking change that only affects compile-time warnings—existing code will continue to work but will now receive lint warnings if error results are ignored.

https://claude.ai/code/session_01TbgC8JPKBqgccqCAhiRpyT