### PR TITLE
⚡ Bolt: [performance improvement] Optimize HistoricalStorageSnapshot iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -73,3 +73,6 @@
 **[Optimize Migration Candidates Vec Pre-allocation]**
 **Learning:** In `identify_node_candidates` and `identify_edge_candidates`, initializing `all_candidates` and `final_candidates` with `Vec::new()` causes unnecessary intermediate heap reallocations during large data migrations because the maximum required capacity is already known from the `versions` map and the filtered `all_candidates` vector.
 **Action:** Always pre-allocate vectors using `Vec::with_capacity(n)` when the target collection size or its upper bound is known in advance, particularly on hot paths like data migration.
+**[HistoricalStorageSnapshot Arc Vec Optimization]**
+**Learning:** Changing a collection of Arc references (`Vec<Arc<T>>`) into an Arc reference of a collection (`Arc<Vec<Arc<T>>>`) when read-only sharing is required drastically reduces allocator overhead during iterator creation. Iteration overhead remains similar (or improves due to cache locality), but thousands of individual heap allocations and atomic refcount operations during creation are entirely eliminated.
+**Action:** When capturing large graph structures for snapshots, prefer contiguous vectors wrapped in a single Arc rather than owned collections of individual Arc allocations inside iterators.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2922,7 +2922,7 @@ impl HistoricalStorage {
                 .map(|version| Arc::new(version.clone())),
         );
 
-        HistoricalStorageSnapshot::new(lsn, node_versions, edge_versions)
+        HistoricalStorageSnapshot::new(lsn, Arc::new(node_versions), Arc::new(edge_versions))
     }
 
     /// **Test-only helper**: Remove a node version from hot storage.

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -191,18 +191,20 @@ impl ExactSizeIterator for CurrentEdgeIterator {
 pub struct HistoricalStorageSnapshot {
     /// LSN at which snapshot was taken
     lsn: LSN,
-    /// Arc references to node versions
-    node_versions: Vec<Arc<NodeVersion>>,
-    /// Arc references to edge versions
-    edge_versions: Vec<Arc<EdgeVersion>>,
+    /// Arc references to node versions.
+    /// Wrapped in an Arc to prevent O(N) allocation overhead when creating iterators.
+    node_versions: Arc<Vec<Arc<NodeVersion>>>,
+    /// Arc references to edge versions.
+    /// Wrapped in an Arc to prevent O(N) allocation overhead when creating iterators.
+    edge_versions: Arc<Vec<Arc<EdgeVersion>>>,
 }
 
 impl HistoricalStorageSnapshot {
     /// Create a new historical snapshot.
     pub fn new(
         lsn: LSN,
-        node_versions: Vec<Arc<NodeVersion>>,
-        edge_versions: Vec<Arc<EdgeVersion>>,
+        node_versions: Arc<Vec<Arc<NodeVersion>>>,
+        edge_versions: Arc<Vec<Arc<EdgeVersion>>>,
     ) -> Self {
         Self {
             lsn,
@@ -245,7 +247,7 @@ impl HistoricalStorageSnapshot {
 
 /// Iterator over node versions in HistoricalStorageSnapshot.
 pub struct HistoricalNodeVersionIterator {
-    versions: Vec<Arc<NodeVersion>>,
+    versions: Arc<Vec<Arc<NodeVersion>>>,
     index: usize,
 }
 
@@ -276,7 +278,7 @@ impl ExactSizeIterator for HistoricalNodeVersionIterator {
 
 /// Iterator over edge versions in HistoricalStorageSnapshot.
 pub struct HistoricalEdgeVersionIterator {
-    versions: Vec<Arc<EdgeVersion>>,
+    versions: Arc<Vec<Arc<EdgeVersion>>>,
     index: usize,
 }
 


### PR DESCRIPTION
💡 What: Refactored `HistoricalStorageSnapshot` and its associated iterators (`HistoricalNodeVersionIterator` and `HistoricalEdgeVersionIterator`) to store node and edge versions as `Arc<Vec<Arc<T>>>` instead of owned `Vec<Arc<T>>`. Also updated `HistoricalStorage::create_snapshot` to wrap the populated vectors in `Arc::new()`.

🎯 Why: Previously, when iterating over versions in a `HistoricalStorageSnapshot` (e.g., during checkpointing via `snapshot.iter_node_versions()`), the `iter_*_versions` methods cloned the entire owned `Vec<Arc<T>>`. This caused an unnecessary $O(N)$ heap allocation and $N$ atomic refcount increments on the hot path for every iterator creation. 

📊 Impact: Eliminates an $O(N)$ heap allocation and $N$ atomic increment operations per iterator instantiation for historical snapshots. Iterator creation is now $O(1)$ and performs a single atomic increment. This results in significantly fewer allocations and improved memory efficiency during checkpointing.

🔬 Measurement: Run `cargo test --lib -- storage::historical` and `cargo test --lib -- storage::snapshot` to verify correctness and no regressions. Run `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [11531423688205127573](https://jules.google.com/task/11531423688205127573) started by @madmax983*