### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/experimental/reasoning/hindsight.rs
+++ b/src/experimental/reasoning/hindsight.rs
@@ -27,7 +27,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 ///
 /// This structure holds all the virtual modifications (additions, updates, deletions)
 /// that are applied as an overlay on top of the base database state.
-
 #[derive(Debug, Clone)]
 pub struct Scenario {
     /// Nodes added in this scenario.
@@ -77,7 +76,6 @@ impl Scenario {
 ///
 /// This allows you to inspect exactly what changes would be made if the scenario
 /// were committed to the actual database.
-
 #[derive(Debug, Clone)]
 pub struct HindsightDiff {
     /// Nodes added in this scenario.


### PR DESCRIPTION
📖 Chapter: Fixed broken documentation

🔦 Insight: The previous attempts to fix documentation caused missing_doc warnings because empty lines existed between the doc comments and the struct declarations.

🧪 Example: Removed empty lines between `/// ...` and `#[derive(...)]` in `hindsight.rs`.

🖼️ Preview: All cargo doc and clippy warnings are fixed.

---
*PR created automatically by Jules for task [8151538022593269783](https://jules.google.com/task/8151538022593269783) started by @madmax983*