### PR TITLE
🛡️ Sentry: [test coverage improvement] cypher lexer read_string

### DIFF
--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -500,7 +500,9 @@ impl<'a> CypherLexer<'a> {
     // -----------------------------------------------------------------------
 
     fn read_string(&mut self, start: usize) -> Result<Token, CypherError> {
-        let (_, quote) = self.advance().unwrap(); // consume opening quote
+        let (_, quote) = self
+            .advance()
+            .ok_or_else(|| self.lex_error(start, "Expected opening quote".to_string()))?;
         let mut value = String::new();
 
         loop {
@@ -745,5 +747,23 @@ mod unit_tests {
                 "{kw} should be a keyword, not an identifier"
             );
         }
+    }
+    #[test]
+    fn test_read_string_unexpected_eof() {
+        // 🎯 Target: read_string EOF handling
+        // 💣 Risk: If read_string is called but advance() returns None for the quote, it used to unwrap and panic
+        let mut lexer = CypherLexer {
+            input: "",
+            chars: "".char_indices().peekable(),
+            position: 0,
+        };
+        let result = lexer.read_string(0);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .message
+                .contains("Expected opening quote")
+        );
     }
 }


### PR DESCRIPTION
🎯 **Target:** `src/cypher/lexer.rs` `CypherLexer::read_string` method.

💣 **Risk:** The method contained a hardcoded `unwrap()` when attempting to consume the expected opening quote (`let (_, quote) = self.advance().unwrap();`). While the current lexer loop guarantees this is only called when a quote character is found via `peek()`, directly invoking this function or refactoring the lexer loop could lead to a crash due to `advance()` returning `None` on unexpected EOF.

🧪 **Strategy:** Replaced the `unwrap()` call with `.ok_or_else(|| self.lex_error(start, "Expected opening quote".to_string()))?`, which safely returns a `CypherError` instead of panicking. I also added a unit test `test_read_string_unexpected_eof` that initializes a lexer with an empty string and directly invokes `read_string` to verify the error is handled gracefully. Note: `CypherLexer` does not have a `new()` associated function, so it was instantiated directly.

🔬 **Verification:**
```bash
cargo test --lib -- cypher::lexer::tests::test_read_string_unexpected_eof
cargo clippy --all-targets --all-features -- -D warnings
```

---
*PR created automatically by Jules for task [8236355425368254318](https://jules.google.com/task/8236355425368254318) started by @madmax983*