### PR TITLE
⚡ Bolt: Replace Vec::new() with Vec::with_capacity(n) in hot loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -73,3 +73,7 @@
 **[Optimize Migration Candidates Vec Pre-allocation]**
 **Learning:** In `identify_node_candidates` and `identify_edge_candidates`, initializing `all_candidates` and `final_candidates` with `Vec::new()` causes unnecessary intermediate heap reallocations during large data migrations because the maximum required capacity is already known from the `versions` map and the filtered `all_candidates` vector.
 **Action:** Always pre-allocate vectors using `Vec::with_capacity(n)` when the target collection size or its upper bound is known in advance, particularly on hot paths like data migration.
+
+**Pre-allocating Vec Capacities in Hot Paths**
+**Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
+**Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -744,7 +744,7 @@ impl Parser {
     fn parse_property_map(&mut self) -> Result<PropertyMap, ParseError> {
         self.expect(&Token::LeftBrace)?;
 
-        let mut props = Vec::new();
+        let mut props = Vec::with_capacity(4); // ⚡ Bolt Optimization: Pre-allocate capacity for property map to avoid initial heap reallocations during parsing.
 
         if !self.check(&Token::RightBrace) {
             loop {
@@ -1049,7 +1049,7 @@ impl Parser {
     fn parse_in_predicate(&mut self, expr: Expression) -> Result<PredicateExpr, ParseError> {
         self.advance();
         self.expect(&Token::LeftBracket)?;
-        let mut values = Vec::new();
+        let mut values = Vec::with_capacity(8); // ⚡ Bolt Optimization: Pre-allocate capacity for IN predicate list to avoid initial heap reallocations during parsing.
         if !self.check(&Token::RightBracket) {
             loop {
                 values.push(self.parse_property_value()?);

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -267,7 +267,7 @@ impl OperationReordering {
     /// Collect all consecutive filters from a filter chain.
     /// Returns (filters, base) where filters are in top-to-bottom order.
     fn collect_filters(&self, op: &LogicalOp) -> (Vec<Predicate>, LogicalOp) {
-        let mut filters = Vec::new();
+        let mut filters = Vec::with_capacity(4); // ⚡ Bolt Optimization: Pre-allocate capacity for query filter lists to prevent multiple reallocations during logical plan extraction.
         let mut current = op;
 
         while let LogicalOp::Unary {

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -586,7 +586,7 @@ impl FlushCoordinator {
     /// Returns a list of (segment_id, metadata) for all segments that have
     /// metadata files. Segments without metadata are not included.
     pub fn list_segments_with_metadata(&self) -> Vec<(u64, SegmentMetadata)> {
-        let mut segments = Vec::with_capacity(16); // ⚡ Bolt Optimization: Pre-allocate space for WAL segment paths to prevent small heap reallocations when reading directories.
+        let mut segments = Vec::with_capacity(16); // ⚡ Bolt Optimization: Pre-allocate space for WAL segment metadata to prevent small heap reallocations when reading directories.
 
         if let Ok(entries) = std::fs::read_dir(&self.config.wal_dir) {
             for entry in entries.flatten() {

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -586,7 +586,7 @@ impl FlushCoordinator {
     /// Returns a list of (segment_id, metadata) for all segments that have
     /// metadata files. Segments without metadata are not included.
     pub fn list_segments_with_metadata(&self) -> Vec<(u64, SegmentMetadata)> {
-        let mut segments = Vec::new();
+        let mut segments = Vec::with_capacity(16); // ⚡ Bolt Optimization: Pre-allocate space for WAL segment paths to prevent small heap reallocations when reading directories.
 
         if let Ok(entries) = std::fs::read_dir(&self.config.wal_dir) {
             for entry in entries.flatten() {

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -121,7 +121,7 @@ pub fn read_entries_from_dir_with_cipher(
     let mut entries = Vec::new();
 
     // Find all WAL segments
-    let mut segments = Vec::new();
+    let mut segments = Vec::with_capacity(16); // ⚡ Bolt Optimization: Pre-allocate space for WAL segment paths to prevent small heap reallocations when reading directories.
     if let Ok(dir_entries) = std::fs::read_dir(wal_dir) {
         for entry in dir_entries.flatten() {
             if let Some(name) = entry.file_name().to_str()


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(n)` in hot-paths for query parsing, planning, and WAL operations.
🎯 Why: `Vec::new()` causes dynamic heap reallocations (e.g. 0 -> 4 -> 8 -> 16) as elements are pushed in a loop.
📊 Impact: Eliminates multiple heap allocations per query parsing, filter aggregation, and WAL directory scans.
🔬 Measurement: Run `cargo bench` and observe improvements in parser and planner hot loops, or verify via `cargo clippy` and `cargo test`.

---
*PR created automatically by Jules for task [15783653150659075341](https://jules.google.com/task/15783653150659075341) started by @madmax983*