### PR TITLE
⚡ Bolt: Optimize tombstone ID pre-allocation in write transactions

### DIFF
--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -456,10 +456,13 @@ pub(crate) fn apply_changes(tx: &WriteTransaction, commit_timestamp: Timestamp) 
         .count();
 
     let mut tombstone_ids = if num_deletes > 0 {
-        let ids: Result<Vec<u64>> = (0..num_deletes)
-            .map(|_| tx.version_id_gen.next().map_err(Into::into))
-            .collect();
-        ids?.into_iter()
+        // ⚡ Bolt Optimization: Pre-allocate the vector for tombstone IDs to prevent
+        // intermediate heap reallocations during write transaction commits.
+        let mut ids = Vec::with_capacity(num_deletes);
+        for _ in 0..num_deletes {
+            ids.push(tx.version_id_gen.next()?);
+        }
+        ids.into_iter()
     } else {
         Vec::new().into_iter()
     };


### PR DESCRIPTION
💡 What: The optimization implemented in `apply_changes()` replaces a `.collect::<Result<Vec<u64>>>()?.into_iter()` call used for pre-generating `tombstone_ids` with a manually pre-allocated vector using `Vec::with_capacity(num_deletes)`.

🎯 Why: The previous `.collect()` on a `Map` iterator that produces `Result` values cannot precisely guarantee the underlying vector's final capacity allocation, causing potential intermediate heap reallocations as it grows. Because write transaction commits are on a hot path, we want to remove these implicit heap reallocations.

📊 Impact: Reduces intermediate heap allocations for large batch deletion write transactions from O(log N) resizes to O(1) single allocation, making write transaction processing more deterministic and faster.

🔬 Measurement: Run `cargo bench` and observe improvements in batch transaction deletion benchmarks, or manually verify by comparing allocation profiling traces during massive node/edge deletion workloads.

---
*PR created automatically by Jules for task [1888541517284258483](https://jules.google.com/task/1888541517284258483) started by @madmax983*