### PR TITLE
⚡ Bolt: [performance improvement] Optimize semantic search traversal allocations

### DIFF
--- a/src/semantic_search/fishing.rs
+++ b/src/semantic_search/fishing.rs
@@ -147,7 +147,9 @@ impl<'a> FishingRod<'a> {
 
         // Step 2: Spread the Net (Graph Traversal)
         if config.depth > 0 {
-            let mut neighbors: Vec<(NodeId, NodeId)> = Vec::new(); // (neighbor, source)
+            // ⚡ Bolt Optimization: Pre-allocate capacity for neighbors vector to prevent
+            // heap reallocations during graph traversal step of semantic search.
+            let mut neighbors: Vec<(NodeId, NodeId)> = Vec::with_capacity(school.len() * 4); // (neighbor, source)
 
             for (source_node, _) in school.iter() {
                 let edges = if let Some(ref labels) = config.edge_labels {


### PR DESCRIPTION
💡 **What:**
Optimized the memory allocation strategy during the semantic search graph traversal step in `src/semantic_search/fishing.rs` (`FishingRod::cast` method). We now pre-allocate capacity for the `neighbors` vector based on a heuristic of the initial `school` size.

🎯 **Why:**
During the "Spread the Net" graph traversal step, the engine pushes edges into a continuously growing `neighbors` vector. Using `Vec::new()` causes multiple O(log N) heap re-allocations as the traversal encounters more edges.

📊 **Impact:**
Reduces intermediate heap re-allocations when collecting nodes in semantic search graph traversals, slightly improving performance for wide searches.

🔬 **Measurement:**
Run `cargo test -p aletheiadb --lib semantic_search::fishing` to verify correct behavior remains intact. Use a profiler on a dense graph to see the reduction in allocations.

---
*PR created automatically by Jules for task [9018757176972065495](https://jules.google.com/task/9018757176972065495) started by @madmax983*