### PR TITLE
🗣️ Echo: Fix getting started and hybrid query examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,26 @@ Requires Rust 1.92+.
 ```rust
 use aletheiadb::prelude::*;
 
-let db = AletheiaDB::new()?;
+fn main() -> Result<()> {
+    let db = AletheiaDB::new()?;
 
-// Create nodes and a relationship
-let alice = db.create_node("Person", properties! { "name" => "Alice" })?;
-let bob   = db.create_node("Person", properties! { "name" => "Bob"   })?;
-db.create_edge(alice, bob, "KNOWS", properties! {})?;
+    // Create nodes and a relationship
+    let alice = db.create_node("Person", properties! { "name" => "Alice" })?;
+    let bob   = db.create_node("Person", properties! { "name" => "Bob"   })?;
+    db.create_edge(alice, bob, "KNOWS", properties! {})?;
 
-// Snapshot the time before an update
-let before = aletheiadb::time::now();
+    // Snapshot the time before an update
+    let before = aletheiadb::time::now();
 
-// Update Alice
-db.write(|tx| tx.update_node(alice, properties! { "role" => "engineer" }))?;
+    // Update Alice
+    db.write(|tx| tx.update_node(alice, properties! { "role" => "engineer" }))?;
 
-// Time-travel: what did Alice look like before the update?
-let past = db.get_node_at_time(alice, before, before)?;
-assert!(past.properties.get("role").is_none());
+    // Time-travel: what did Alice look like before the update?
+    let past = db.get_node_at_time(alice, before, before)?;
+    assert!(past.properties.get("role").is_none());
+
+    Ok(())
+}
 ```
 
 See the [Getting Started guide](docs/guides/getting-started.md) for a full walkthrough.
@@ -56,12 +60,27 @@ Graph traversal, vector ranking, and temporal snapshots compose into a single
 query with a consistent view of the data:
 
 ```rust
-let results = db.query()
-    .as_of(valid_time, tx_time)              // temporal: point-in-time snapshot
-    .start(alice_id)                         // graph: starting node
-    .traverse("KNOWS")                       // graph: follow edges
-    .rank_by_similarity(&query_embedding, 10) // vector: re-rank by similarity
-    .execute(&db)?;
+use aletheiadb::prelude::*;
+use aletheiadb::HnswConfig;
+
+fn main() -> Result<()> {
+    let db = AletheiaDB::new()?;
+    db.vector_index("embedding").hnsw(HnswConfig { dimensions: 2, ..Default::default() }).enable()?;
+
+    let alice = db.create_node("Person", properties! { "name" => "Alice" })?;
+    let query_embedding = vec![0.1, 0.2];
+    let valid_time = aletheiadb::time::now();
+    let tx_time = aletheiadb::time::now();
+
+    let _results = db.query()
+        .as_of(valid_time, tx_time)              // temporal: point-in-time snapshot
+        .start(alice)                            // graph: starting node
+        .traverse("KNOWS")                       // graph: follow edges
+        .rank_by_similarity(&query_embedding, 10) // vector: re-rank by similarity
+        .execute(&db)?;
+
+    Ok(())
+}
 ```
 
 See the [Hybrid Query guide](docs/guides/hybrid-query-guide.md).


### PR DESCRIPTION
🤦 **The Confusion:**
Tried to run the `Getting Started` and `Hybrid Queries` examples in `README.md` by copy-pasting them into a fresh `main.rs`. They both failed! The first failed to compile when placed in a standard `main()` because the `prelude` exports `aletheiadb::Result<T>` which conflicts with `std::result::Result<(), Box<dyn Error>>`. The second crashed at runtime because it lacked the required vector index initialization.

🕵️ **The Reality:**
Documentation examples must be foolproof and executable as provided without implicit setup steps or uninstantiated variable bindings.

💡 **The Fix:**
Wrapped the examples into complete, runnable `fn main() -> Result<()> { ... }` blocks. Added the missing `db.vector_index("embedding").hnsw(HnswConfig { dimensions: 2, ..Default::default() }).enable()?;` initialization and variable assignments to the Hybrid Queries example.

---
*PR created automatically by Jules for task [14684847068740475852](https://jules.google.com/task/14684847068740475852) started by @madmax983*