### PR TITLE
⚖️ Elenchus: query::planner Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[Query Planner Weak Assertions]**
+**Module:** `aletheiadb::query::planner::rules` (`filter_scan_fusion` and `limit_pushdown`)
+**Severity:** 🟡 Suspect
+**Finding:** The unit tests and doc tests for `FilterScanFusion` and `LimitPushdown` used weak assertions such as `assert!(result.is_some())` and `assert!(matches!(...))` that only verified the presence of an expected AST node type, but completely ignored the inner properties (e.g. `value` inside `PropertyScan` or the inner children of a propagated limit tree).
+**Evidence:** These were classic "Alibi Tests" - coverage showed them executing, but `cargo mutants` would have survived trivial changes to the implementation because the tests didn't assert full structural equality on the optimized tree.
+**Recommendation:** Refactored all tests in these modules to construct a full `expected_plan` manually and use `assert_eq!(result, Some(expected_plan))` for strict structural verification, eliminating the blind spots.

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -57,10 +57,16 @@ use super::{OptimizationRule, Statistics};
 /// let optimized_plan = rule.apply(&plan, &stats)?.unwrap(); // unwraps if `changed == true`
 ///
 /// // 3. The rule fuses them into a single PropertyScan
-/// assert!(matches!(
-///     optimized_plan.root,
-///     LogicalOp::Scan(ScanOp::PropertyScan { .. })
-/// ));
+/// let expected_plan = LogicalPlan {
+///     root: LogicalOp::Scan(ScanOp::PropertyScan {
+///         label: "Person".into(),
+///         key: "name".into(),
+///         value: PredicateValue::String("Alice".into()),
+///     }),
+///     temporal_context: None,
+///     hints: Default::default(),
+/// };
+/// assert_eq!(optimized_plan, expected_plan);
 /// # Ok(())
 /// # }
 /// ```
@@ -173,17 +179,14 @@ mod tests {
             }),
         ));
 
-        let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some(), "Should fuse Filter+NodeScan");
+        let expected_plan = LogicalPlan::new(LogicalOp::Scan(ScanOp::PropertyScan {
+            label: "Person".to_string(),
+            key: "name".to_string(),
+            value: crate::query::ir::PredicateValue::String("Alice".to_string()),
+        }));
 
-        let new_plan = result.unwrap();
-        match &new_plan.root {
-            LogicalOp::Scan(ScanOp::PropertyScan { label, key, .. }) => {
-                assert_eq!(label, "Person");
-                assert_eq!(key, "name");
-            }
-            other => panic!("Expected PropertyScan, got {:?}", other),
-        }
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert_eq!(result, Some(expected_plan), "Should fuse Filter+NodeScan");
     }
 
     #[test]

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -63,14 +63,22 @@ use super::{OptimizationRule, Statistics};
 /// let optimized_plan = rule.apply(&plan, &stats)?.unwrap(); // unwraps if `changed == true`
 ///
 /// // 3. The rule preserves the outer Limit but ALSO pushes it down to VectorRank
-/// if let LogicalOp::Unary { op: UnaryOp::Limit(10), input } = optimized_plan.root {
-///     assert!(matches!(
-///         *input,
-///         LogicalOp::Unary { op: UnaryOp::VectorRank { top_k: Some(10), .. }, .. }
-///     ));
-/// } else {
-///     panic!("Expected Limit operator at root");
-/// }
+/// let expected_plan = LogicalPlan {
+///     root: LogicalOp::unary(
+///         UnaryOp::Limit(10),
+///         LogicalOp::unary(
+///             UnaryOp::VectorRank {
+///                 embedding: vec![0.1_f32, 0.2_f32].into(),
+///                 top_k: Some(10),
+///                 property_key: None,
+///             },
+///             LogicalOp::Scan(ScanOp::NodeScan { label: Some("Person".into()), estimated_rows: Some(100) })
+///         )
+///     ),
+///     temporal_context: None,
+///     hints: Default::default(),
+/// };
+/// assert_eq!(optimized_plan, expected_plan);
 /// # Ok(())
 /// # }
 /// ```
@@ -254,21 +262,12 @@ mod tests {
             ),
         ));
 
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        ));
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
-
-        let new_plan = result.unwrap();
-        // Should be Limit(5, Scan) - no nested limit
-        match &new_plan.root {
-            LogicalOp::Unary {
-                op: UnaryOp::Limit(n),
-                input,
-            } => {
-                assert_eq!(*n, 5);
-                assert!(matches!(input.as_ref(), LogicalOp::Scan(_)));
-            }
-            _ => panic!("Expected Limit"),
-        }
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]
@@ -289,26 +288,19 @@ mod tests {
             ),
         ));
 
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::unary(
+                UnaryOp::VectorRank {
+                    embedding: Arc::from([0.1f32; 4].as_slice()),
+                    top_k: Some(5),
+                    property_key: None,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
-
-        let new_plan = result.unwrap();
-        // VectorRank should have top_k=5 now
-        match &new_plan.root {
-            LogicalOp::Unary {
-                op: UnaryOp::Limit(_),
-                input,
-            } => match input.as_ref() {
-                LogicalOp::Unary {
-                    op: UnaryOp::VectorRank { top_k, .. },
-                    ..
-                } => {
-                    assert_eq!(*top_k, Some(5));
-                }
-                _ => panic!("Expected VectorRank"),
-            },
-            _ => panic!("Expected Limit"),
-        }
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]
@@ -363,8 +355,18 @@ mod tests {
             ),
         ));
 
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::unary(
+                UnaryOp::Project(vec!["name".to_string()]),
+                LogicalOp::unary(
+                    UnaryOp::Limit(5),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        ));
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]
@@ -404,8 +406,17 @@ mod tests {
             ),
             LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
         ));
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            LogicalOp::unary(
+                UnaryOp::Limit(10),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+        ));
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]


### PR DESCRIPTION
**Summary**
This PR addresses weak test assertions in the `query::planner::rules` modules, specifically targeting `FilterScanFusion` and `LimitPushdown`. The previous tests utilized `assert!(result.is_some())` and `matches!(...)` macros which only verified the presence and outer boundary of the AST nodes, acting as "Alibi Tests." These tests have been completely rewritten to construct full `expected_plan` trees and use strict structural equality checks (`assert_eq!`) to eliminate blind spots and ensure mutation resistance.

**Verdict Table**
| Module | Verdict | Reason |
|---|---|---|
| `query::planner::rules::filter_scan_fusion` | 🟡 Suspect -> 🟢 Acquitted | Used weak `matches!` assertions missing property value verification. Fixed with strict equality. |
| `query::planner::rules::limit_pushdown` | 🟡 Suspect -> 🟢 Acquitted | Used weak `is_some()` and partial `matches!` failing to verify inner limits. Fixed with strict equality. |

**Priority Fixes**
1.  **FilterScanFusion `test_fuses_eq_filter_on_labeled_scan` & doc test**: Replaced `matches!` with a manually constructed `LogicalPlan` to guarantee that the `PropertyScan` accurately merged the `label`, `key`, and `value` fields.
2.  **LimitPushdown binary & unary op propagation tests**: Replaced simplistic `is_some()` and panic-based matching branches with exhaustive AST equality to ensure `Limit` propagated down precisely to `VectorRank` and left sibling nodes untouched in `BinaryOp`.
3.  **Doc Tests**: Synchronized the documentation tests in both modules to use explicit `expected_plan` setups and `assert_eq!` validation.

**Missing coverage**
No new logic was implemented, but the robustness of the existing tests has been significantly fortified to resist mutations. Future checks should ensure new rules strictly adhere to structural equality tests rather than partial property validation.

---
*PR created automatically by Jules for task [12027700488198357671](https://jules.google.com/task/12027700488198357671) started by @madmax983*