### PR TITLE
[codex] Fix git-cliff PR link rendering

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,7 @@ body = """
     ### {{ group | upper_first }}
     {% for commit in commits %}
         - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}\
-          {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ commit.remote.pr_url }})){% endif %}\
+          {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/madmax983/AletheiaDB/pull/{{ commit.remote.pr_number }})){% endif %}\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Summary

Fixes the remaining `git-cliff --config cliff.toml --current --strip header` render failure after PR #2855.

## Root Cause

`commit.remote.pr_number` is present for PR-linked commits, but `commit.remote.pr_url` is not part of the git-cliff template context. The template attempted to render the missing `commit.remote.pr_url` field and failed.

## Changes

- Keep the `commit.remote.pr_number` guard.
- Construct GitHub PR links directly from the configured repository URL pattern and PR number.

## Validation

- `git-cliff --config cliff.toml --current --strip header`
- `git diff --check HEAD~1..HEAD`
- `git log --oneline origin/trunk..HEAD` shows only `703b33846 Fix git-cliff PR link rendering`.