### PR TITLE
[codex] Fix 0.1.0 release readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,16 +91,19 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --bin aletheia --target ${{ matrix.target }}
 
       - name: Create archive
         shell: bash
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            7z a ${{ matrix.artifact_name }}.zip ./target/${{ matrix.target }}/release/aletheiadb.exe
+            archive_name="${{ matrix.artifact_name }}.zip"
+            7z a "$archive_name" ./target/${{ matrix.target }}/release/aletheia.exe
           else
-            tar czf ${{ matrix.artifact_name }}.tar.gz -C ./target/${{ matrix.target }}/release aletheiadb
+            archive_name="${{ matrix.artifact_name }}.tar.gz"
+            tar czf "$archive_name" -C ./target/${{ matrix.target }}/release aletheia
           fi
+          echo "ARCHIVE_NAME=$archive_name" >> "$GITHUB_ENV"
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -108,8 +111,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./${{ matrix.artifact_name }}.*
-          asset_name: ${{ matrix.artifact_name }}
+          asset_path: ./${{ env.ARCHIVE_NAME }}
+          asset_name: ${{ env.ARCHIVE_NAME }}
           asset_content_type: application/octet-stream
 
   publish-crate:
@@ -125,4 +128,3 @@ jobs:
 
       - name: Publish to crates.io
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        continue-on-error: true # Don't fail if already published

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,6 @@ fail-under-functions = 75.0
 
 # Exclude certain files from coverage
 exclude = [
-    "src/main.rs",
     "src/bin/**",
     "benches/**",
     "tests/**",

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1119,6 +1119,7 @@ mod tests {
 
     #[cfg(feature = "observability")]
     #[test]
+    #[serial_test::serial]
     fn test_result_ext_records_storage_metric_once() {
         crate::observability::METRICS.reset();
 

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2211,6 +2211,7 @@ fn poison_mutex<T>(mutex: &std::sync::Arc<std::sync::Mutex<T>>) {
 
 #[cfg(feature = "observability")]
 #[test]
+#[serial_test::serial]
 fn test_create_node_transaction_error_counted_once_when_lock_poisoned() {
     crate::observability::METRICS.reset();
     let db = AletheiaDB::new().unwrap();
@@ -2226,6 +2227,7 @@ fn test_create_node_transaction_error_counted_once_when_lock_poisoned() {
 
 #[cfg(feature = "observability")]
 #[test]
+#[serial_test::serial]
 fn test_vector_builder_duplicate_enable_counts_error_once() {
     use crate::index::vector::{DistanceMetric, HnswConfig};
 
@@ -2246,6 +2248,7 @@ fn test_vector_builder_duplicate_enable_counts_error_once() {
 
 #[cfg(feature = "observability")]
 #[test]
+#[serial_test::serial]
 fn test_read_closure_db_error_counts_once() {
     crate::observability::METRICS.reset();
     let db = AletheiaDB::new().unwrap();
@@ -2263,6 +2266,7 @@ fn test_read_closure_db_error_counts_once() {
 
 #[cfg(feature = "observability")]
 #[test]
+#[serial_test::serial]
 fn test_write_commit_error_counts_once() {
     crate::observability::METRICS.reset();
     let db = AletheiaDB::new().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,0 @@
-//! The AletheiaDB binary.
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/semantic_search/semantic_navigator.rs
+++ b/src/semantic_search/semantic_navigator.rs
@@ -261,12 +261,20 @@ mod tests {
 
     fn create_test_db() -> (AletheiaDB, tempfile::TempDir) {
         let dir = tempdir().unwrap();
+        let wal_path = dir.path().join("wal");
+        let data_path = dir.path().join("data");
+        std::fs::create_dir_all(&wal_path).unwrap();
+        std::fs::create_dir_all(&data_path).unwrap();
+
+        let persistence_config = crate::storage::index_persistence::PersistenceConfig {
+            data_dir: data_path,
+            enabled: false,
+            ..Default::default()
+        };
+
         let config = AletheiaDBConfig::builder()
-            .wal(
-                WalConfigBuilder::new()
-                    .wal_dir(dir.path().join("wal"))
-                    .build(),
-            )
+            .wal(WalConfigBuilder::new().wal_dir(wal_path).build())
+            .persistence(persistence_config)
             .build();
         let db = AletheiaDB::with_unified_config(config).unwrap();
         (db, dir)

--- a/src/semantic_search/tapestry.rs
+++ b/src/semantic_search/tapestry.rs
@@ -108,12 +108,20 @@ mod tests {
 
     fn create_test_db() -> (AletheiaDB, tempfile::TempDir) {
         let dir = tempdir().unwrap();
+        let wal_path = dir.path().join("wal");
+        let data_path = dir.path().join("data");
+        std::fs::create_dir_all(&wal_path).unwrap();
+        std::fs::create_dir_all(&data_path).unwrap();
+
+        let persistence_config = crate::storage::index_persistence::PersistenceConfig {
+            data_dir: data_path,
+            enabled: false,
+            ..Default::default()
+        };
+
         let config = AletheiaDBConfig::builder()
-            .wal(
-                WalConfigBuilder::new()
-                    .wal_dir(dir.path().join("wal"))
-                    .build(),
-            )
+            .wal(WalConfigBuilder::new().wal_dir(wal_path).build())
+            .persistence(persistence_config)
             .build();
         let db = AletheiaDB::with_unified_config(config).unwrap();
         (db, dir)

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -1,0 +1,44 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn release_workflow_archives_real_cli_binary() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("release workflow should be readable");
+
+    assert!(
+        workflow.contains("release/aletheia.exe"),
+        "Windows release artifact should archive the real aletheia CLI"
+    );
+    assert!(
+        workflow.contains("release aletheia"),
+        "Unix release artifact should archive the real aletheia CLI"
+    );
+    assert!(
+        !workflow.contains("release/aletheiadb.exe"),
+        "release workflow must not archive the placeholder default binary"
+    );
+}
+
+#[test]
+fn release_workflow_does_not_mask_publish_failure() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("release workflow should be readable");
+
+    assert!(
+        !workflow.contains("continue-on-error: true"),
+        "crates.io publish failures must fail the release workflow"
+    );
+}
+
+#[test]
+fn package_does_not_ship_placeholder_default_binary() {
+    let main_path = Path::new("src/main.rs");
+    if main_path.exists() {
+        let main_rs = fs::read_to_string(main_path).expect("src/main.rs should be readable");
+        assert!(
+            !main_rs.contains("Hello, world!"),
+            "default package binary must not be the Cargo hello-world template"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the 0.1.0 release path so the GitHub release archives the real `aletheia` CLI instead of the placeholder `aletheiadb` binary. Also removes the hello-world default binary, makes crates.io publish failures fail the release workflow, and adds regression coverage for the release workflow.

## Root Cause

The release workflow built all default binaries and archived `target/.../release/aletheiadb`, but `src/main.rs` was still the Cargo template binary that only printed `Hello, world!`. The functional CLI lives in `src/bin/aletheia.rs`.

The all-features semantic-search failures came from tests using a temp WAL directory while leaving index persistence pointed at the repo-local default `data/`, which allowed stale persisted index state to leak into tests.

The observability metrics failure came from tests resetting and reading the global metrics singleton concurrently.

## Changes

- Build and archive `aletheia` explicitly in the release workflow.
- Upload release assets by exact archive filename instead of wildcard.
- Remove `continue-on-error: true` from `cargo publish`.
- Delete placeholder `src/main.rs` and remove its stale coverage exclude entry.
- Add `tests/release_workflow.rs` to lock the release artifact behavior.
- Isolate semantic-search test DB persistence to temp dirs and disable persistence in those helpers.
- Mark global observability metrics tests with `serial_test::serial`.

## Validation

CPU-throttled targeted checks:

- `cargo test --test release_workflow`
- `cargo test -j 2 --features semantic-search --lib semantic_search::semantic_navigator::tests -- --nocapture`
- `cargo test -j 2 --features semantic-search --lib semantic_search::tapestry::tests::test_tapestry_weave -- --exact --nocapture`
- `cargo test -j 1 --no-default-features --features observability --lib counted_once -- --nocapture`
- `cargo test -j 1 --no-default-features --features observability --lib counts_error_once -- --nocapture`
- `cargo test -j 1 --no-default-features --features observability --lib db_error_counts_once -- --nocapture`
- `cargo test -j 1 --no-default-features --features observability --lib test_write_commit_error_counts_once -- --nocapture`
- `cargo test -j 1 --no-default-features --features observability --lib test_result_ext_records_storage_metric_once -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo build -j 1 --release --bin aletheia`
- `target\\release\\aletheia.exe --help`
- `.git`-free temp copy: `cargo package --allow-dirty --no-verify --offline`

Note: direct `cargo package` inside this local repository still fails in Cargo's git-status layer with `slotmap turned out to be too small`; packaging from a `.git`-free temp copy succeeds offline, so this appears tied to local Git metadata rather than package contents.