### PR TITLE
refactor: De-abstract single-implementation traits (Razor)

### DIFF
--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -182,38 +182,6 @@ impl std::error::Error for DistributedError {}
 // Distributed Vector Client Trait
 // ============================================================================
 
-/// Trait for communicating with remote vector index nodes.
-///
-/// This trait abstracts the network communication, allowing for different
-/// implementations (HTTP, gRPC, in-process mock for testing).
-pub trait VectorNodeClient: Send + Sync + fmt::Debug {
-    /// Get the node ID this client connects to.
-    fn node_id(&self) -> u16;
-
-    /// Check if the connection is healthy.
-    fn is_healthy(&self) -> bool;
-
-    /// Add a vector to the remote index.
-    fn add(&self, id: NodeId, vector: &[f32]) -> Result<()>;
-
-    /// Remove a vector from the remote index.
-    fn remove(&self, id: NodeId) -> Result<()>;
-
-    /// Search for k-nearest neighbors on the remote index.
-    fn search(&self, query: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>>;
-
-    /// Get the number of vectors on the remote index.
-    fn len(&self) -> Result<usize>;
-
-    /// Check if the remote index is empty.
-    fn is_empty(&self) -> Result<bool> {
-        self.len().map(|len| len == 0)
-    }
-
-    /// Perform a health check.
-    fn health_check(&self) -> Result<()>;
-}
-
 // ============================================================================
 // Circuit Breaker for Nodes
 // ============================================================================
@@ -275,7 +243,7 @@ impl Default for CircuitBreakerConfig {
 /// Circuit breaker for a single node connection.
 ///
 /// The `NodeCircuitBreaker` tracks failures and successes of requests to a remote node
-/// (typically represented by a [`VectorNodeClient`]). If failures exceed the configured
+/// (typically represented by a `MockVectorNodeClient`). If failures exceed the configured
 /// threshold, it transitions to an `Open` state, failing fast. After a timeout, it transitions
 /// to a `HalfOpen` state to test if the node has recovered.
 ///
@@ -461,7 +429,7 @@ impl NodeCircuitBreaker {
 
 /// A connection to a remote vector index node.
 ///
-/// The `NodeConnection` wraps a [`VectorNodeClient`] with a [`NodeCircuitBreaker`]
+/// The `NodeConnection` wraps a `MockVectorNodeClient` with a `NodeCircuitBreaker`
 /// and tracks basic metrics (requests, failures). It acts as the primary interface
 /// for executing requests against a specific node in a distributed index.
 ///
@@ -485,9 +453,9 @@ impl NodeCircuitBreaker {
 /// # #[cfg(not(feature = "semantic-search"))]
 /// # fn main() {}
 /// ```
-pub struct NodeConnection<C: VectorNodeClient> {
+pub struct NodeConnection {
     /// The client for this node.
-    client: Arc<C>,
+    client: Arc<MockVectorNodeClient>,
     /// Circuit breaker for this node.
     circuit_breaker: NodeCircuitBreaker,
     /// Total requests made to this node.
@@ -496,7 +464,7 @@ pub struct NodeConnection<C: VectorNodeClient> {
     failure_count: AtomicU64,
 }
 
-impl<C: VectorNodeClient> fmt::Debug for NodeConnection<C> {
+impl fmt::Debug for NodeConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NodeConnection")
             .field("node_id", &self.client.node_id())
@@ -507,9 +475,9 @@ impl<C: VectorNodeClient> fmt::Debug for NodeConnection<C> {
     }
 }
 
-impl<C: VectorNodeClient> NodeConnection<C> {
+impl NodeConnection {
     /// Create a new node connection.
-    pub fn new(client: Arc<C>, circuit_config: CircuitBreakerConfig) -> Self {
+    pub fn new(client: Arc<MockVectorNodeClient>, circuit_config: CircuitBreakerConfig) -> Self {
         Self {
             client,
             circuit_breaker: NodeCircuitBreaker::new(circuit_config),
@@ -519,6 +487,7 @@ impl<C: VectorNodeClient> NodeConnection<C> {
     }
 
     /// Get the node ID.
+    /// Get the node ID this client connects to.
     pub fn node_id(&self) -> u16 {
         self.client.node_id()
     }
@@ -536,7 +505,7 @@ impl<C: VectorNodeClient> NodeConnection<C> {
     /// Execute an operation with circuit breaker protection.
     pub fn execute<T, F>(&self, f: F) -> Result<T>
     where
-        F: FnOnce(&C) -> Result<T>,
+        F: FnOnce(&MockVectorNodeClient) -> Result<T>,
     {
         self.request_count.fetch_add(1, Ordering::Relaxed);
 
@@ -888,7 +857,7 @@ pub struct RebalanceStats {
 /// a scatter-gather pattern.
 ///
 /// See [`DistributedVectorConfig`] for configuring the topology, and
-/// [`VectorNodeClient`] for the required abstraction to interface with remote nodes.
+/// `MockVectorNodeClient` for the required abstraction to interface with remote nodes.
 ///
 /// # Examples
 ///
@@ -913,14 +882,14 @@ pub struct RebalanceStats {
 /// # #[cfg(not(feature = "semantic-search"))]
 /// # fn main() {}
 /// ```
-pub struct DistributedVectorIndex<C: VectorNodeClient> {
+pub struct DistributedVectorIndex {
     /// Configuration.
     config: DistributedVectorConfig,
     /// Node connections.
-    nodes: Vec<Arc<NodeConnection<C>>>,
+    nodes: Vec<Arc<NodeConnection>>,
 }
 
-impl<C: VectorNodeClient> fmt::Debug for DistributedVectorIndex<C> {
+impl fmt::Debug for DistributedVectorIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DistributedVectorIndex")
             .field("dimensions", &self.config.dimensions)
@@ -931,7 +900,7 @@ impl<C: VectorNodeClient> fmt::Debug for DistributedVectorIndex<C> {
     }
 }
 
-impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
+impl DistributedVectorIndex {
     /// Create a new distributed vector index from an existing list of clients.
     ///
     /// # Arguments
@@ -942,7 +911,7 @@ impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
     /// # Errors
     ///
     /// Returns an error if configuration is invalid.
-    pub fn new(config: DistributedVectorConfig, clients: Vec<Arc<C>>) -> Result<Self> {
+    pub fn new(config: DistributedVectorConfig, clients: Vec<Arc<MockVectorNodeClient>>) -> Result<Self> {
         config.validate()?;
 
         if clients.len() != config.nodes.len() {
@@ -953,7 +922,7 @@ impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
             ))));
         }
 
-        let nodes: Vec<Arc<NodeConnection<C>>> = clients
+        let nodes: Vec<Arc<NodeConnection>> = clients
             .into_iter()
             .zip(config.nodes.iter())
             .map(|(client, node_config)| {
@@ -1003,7 +972,7 @@ impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
     }
 
     /// Get a reference to a specific node connection.
-    pub fn get_node(&self, index: usize) -> Option<&Arc<NodeConnection<C>>> {
+    pub fn get_node(&self, index: usize) -> Option<&Arc<NodeConnection>> {
         self.nodes.get(index)
     }
 
@@ -1108,7 +1077,7 @@ impl<C: VectorNodeClient + 'static> DistributedVectorIndex<C> {
     }
 }
 
-impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
+impl VectorIndex for DistributedVectorIndex {
     fn add(&self, id: NodeId, vector: &[f32]) -> Result<()> {
         validate_vector(vector)?;
 
@@ -1242,7 +1211,7 @@ impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
         // Memory usage is distributed across nodes
         // Return local metadata overhead only
         std::mem::size_of::<Self>()
-            + self.nodes.len() * std::mem::size_of::<Arc<NodeConnection<C>>>()
+            + self.nodes.len() * std::mem::size_of::<Arc<NodeConnection>>()
     }
 
     fn quantization(&self) -> Quantization {
@@ -1256,7 +1225,7 @@ impl<C: VectorNodeClient + 'static> VectorIndex for DistributedVectorIndex<C> {
 
 /// Mock client for testing distributed vector operations.
 ///
-/// `MockVectorNodeClient` implements the [`VectorNodeClient`] trait in-memory
+/// `MockVectorNodeClient` is an in-memory client
 /// without actually performing any network I/O. It tracks vectors in a local hash map
 /// and implements simple distance calculations, making it ideal for unit testing
 /// [`DistributedVectorIndex`] logic.
@@ -1353,18 +1322,18 @@ impl MockVectorNodeClient {
             ),
         }
     }
-}
-
-impl VectorNodeClient for MockVectorNodeClient {
-    fn node_id(&self) -> u16 {
+    /// Get the node ID this client connects to.
+    pub fn node_id(&self) -> u16 {
         self.node_id
     }
 
-    fn is_healthy(&self) -> bool {
+    /// Check if the connection is healthy.
+    pub fn is_healthy(&self) -> bool {
         self.healthy.load(Ordering::SeqCst)
     }
 
-    fn add(&self, id: NodeId, vector: &[f32]) -> Result<()> {
+    /// Add a vector to the remote index.
+    pub fn add(&self, id: NodeId, vector: &[f32]) -> Result<()> {
         self.check_fail()?;
 
         if !self.is_healthy() {
@@ -1385,7 +1354,8 @@ impl VectorNodeClient for MockVectorNodeClient {
         Ok(())
     }
 
-    fn remove(&self, id: NodeId) -> Result<()> {
+    /// Remove a vector from the remote index.
+    pub fn remove(&self, id: NodeId) -> Result<()> {
         self.check_fail()?;
 
         if !self.is_healthy() {
@@ -1399,7 +1369,8 @@ impl VectorNodeClient for MockVectorNodeClient {
         Ok(())
     }
 
-    fn search(&self, query: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>> {
+    /// Find k most similar vectors on this remote node.
+    pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<(NodeId, f32)>> {
         self.check_fail()?;
 
         if !self.is_healthy() {
@@ -1421,7 +1392,8 @@ impl VectorNodeClient for MockVectorNodeClient {
         Ok(results)
     }
 
-    fn len(&self) -> Result<usize> {
+    /// Get the number of vectors on this node.
+    pub fn len(&self) -> Result<usize> {
         self.check_fail()?;
 
         if !self.is_healthy() {
@@ -1434,7 +1406,8 @@ impl VectorNodeClient for MockVectorNodeClient {
         Ok(self.vectors.read().unwrap().len())
     }
 
-    fn health_check(&self) -> Result<()> {
+    /// Health check for tests
+    pub fn health_check(&self) -> Result<()> {
         self.check_fail()?;
 
         if self.is_healthy() {
@@ -1446,7 +1419,14 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))))
         }
     }
+    /// Is empty
+    pub fn is_empty(&self) -> Result<bool> {
+        Ok(self.len()? == 0)
+    }
+
 }
+
+
 
 // ============================================================================
 // Tests
@@ -1915,7 +1895,7 @@ mod tests {
 
     #[test]
     fn test_merge_results_empty() {
-        let results = DistributedVectorIndex::<MockVectorNodeClient>::merge_results(vec![], 10);
+        let results = DistributedVectorIndex::merge_results(vec![], 10);
         assert!(results.is_empty());
     }
 
@@ -1927,7 +1907,7 @@ mod tests {
             (NodeId::new(3).unwrap(), 0.7),
         ]];
 
-        let merged = DistributedVectorIndex::<MockVectorNodeClient>::merge_results(node_results, 2);
+        let merged = DistributedVectorIndex::merge_results(node_results, 2);
         assert_eq!(merged.len(), 2);
         assert_eq!(merged[0].0, NodeId::new(1).unwrap());
         assert_eq!(merged[1].0, NodeId::new(2).unwrap());
@@ -1946,7 +1926,7 @@ mod tests {
             ],
         ];
 
-        let merged = DistributedVectorIndex::<MockVectorNodeClient>::merge_results(node_results, 3);
+        let merged = DistributedVectorIndex::merge_results(node_results, 3);
         assert_eq!(merged.len(), 3);
         // Should be sorted: 0.9, 0.85, 0.7
         assert_eq!(merged[0].0, NodeId::new(1).unwrap());

--- a/src/index/vector/mod.rs
+++ b/src/index/vector/mod.rs
@@ -827,5 +827,5 @@ pub use distributed::{
     CircuitBreakerConfig as DistributedCircuitBreakerConfig, CircuitState, DistributedError,
     DistributedIndexStats, DistributedVectorConfig, DistributedVectorIndex, MockVectorNodeClient,
     NodeCircuitBreaker, NodeConnection, NodeConnectionStats, RECOMMENDED_IMBALANCE_THRESHOLD,
-    RebalanceStats, RoutingStrategy, VectorNodeClient, VectorNodeConfig,
+    RebalanceStats, RoutingStrategy, VectorNodeConfig,
 };


### PR DESCRIPTION
This PR enforces the KISS and YAGNI principles by aggressively removing single-implementation traits in the codebase to eliminate unnecessary abstraction and indirection layers.

Key changes:
- `Resonator` trait deleted, `EchoChamber` now directly uses the concrete `ActivityDensityResonator`.
- `SemanticRule` trait converted to an Enum, `Sentinel` now directly uses pattern matching over rule variants instead of `Box<dyn SemanticRule>`.
- `VectorNodeClient` trait deleted, and generics stripped from `DistributedVectorIndex` and `NodeConnection` to bind them concretely to `MockVectorNodeClient`.
- Refactorings logged in `.jules/razor.md`.

---
*PR created automatically by Jules for task [12037063953567504908](https://jules.google.com/task/12037063953567504908) started by @madmax983*