### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -5,28 +5,28 @@
 //!
 //! # Prerequisites
 //!
-//! This feature is experimental and requires the `nova` feature flag.
+//! This feature is experimental and requires the `semantic-temporal` feature flag.
 //!
 //! ## Running this example
 //!
 //! ```bash
-//! cargo run --features nova --example story_demo
+//! cargo run --features semantic-temporal --example story_demo
 //! ```
 //!
 //! ## Using in your project
 //!
-//! Add the `nova` feature to your `Cargo.toml`:
+//! Add the `semantic-temporal` feature to your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
-//! aletheiadb = { version = "0.1", features = ["nova"] }
+//! aletheiadb = { version = "0.1", features = ["semantic-temporal"] }
 //! ```
 
 use aletheiadb::AletheiaDB;
 use aletheiadb::WriteOps;
-// ⚠️ REQUIRES FEATURE 'NOVA' IN CARGO.TOML
+// ⚠️ REQUIRES FEATURE 'SEMANTIC-TEMPORAL' IN CARGO.TOML
 // [dependencies]
-// aletheiadb = { version = "0.1", features = ["nova"] }
+// aletheiadb = { version = "0.1", features = ["semantic-temporal"] }
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
 use aletheiadb::properties;
 

--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -45,6 +45,11 @@ pub struct NarrativeGenerator<'a> {
 )]
 /// Generates human-readable summaries of temporal graph mutations.
 ///
+/// # Panics
+///
+/// This struct is a stub because the `semantic-temporal` feature is disabled.
+/// Attempting to use any of its methods will result in a runtime panic.
+///
 /// # Why?
 /// When analyzing a `BiTemporalInterval`, users often need to understand
 /// the sequence of events (e.g., "Alice liked the post, then Bob deleted it").


### PR DESCRIPTION
🤦‍♂️ **The Confusion:** Tried to run the `story_demo`. The comments said to use `--features nova`, but Cargo complained that `semantic-temporal` was required. Also, the `NarrativeGenerator` docs for the disabled-feature stub didn't have a clear `Panics` warning on the struct itself.
🕵️‍♂️ **The Reality:** `Cargo.toml` requires `semantic-temporal` for the example, not `nova`. The `NarrativeGenerator` stub only warned about panics on its methods, leaving the struct docs looking normal.
💡 **The Fix:** Updated the comments in `examples/story_demo.rs` to use `semantic-temporal` and added a `Panics` section to the disabled `NarrativeGenerator` struct documentation.

---
*PR created automatically by Jules for task [8121629942537669111](https://jules.google.com/task/8121629942537669111) started by @madmax983*