### PR TITLE
⚡ Bolt: Optimize ring buffer drain with Vec::with_capacity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Optimize Ring Buffer Drain with `Vec::with_capacity`]**
+**Learning:** In a lock-free ring buffer, the `drain()` method is continuously called by the consumer (flush thread) and dynamically collects `PendingEntry` items into a new `Vec`. Using `Vec::new()` causes multiple heap allocations depending on how many items are ready.
+**Action:** Use an existing `len_approx()` or similar unsynchronized counter to estimate the number of ready items, and use `Vec::with_capacity(approx_len)` to pre-allocate exact (or nearly exact) capacity. Fall back to `Vec::new()` when the estimated length is 0 to remain zero-allocation when empty.

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -694,7 +694,14 @@ impl WalRingBuffer {
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate capacity using len_approx() to
+        // avoid intermediate heap reallocations during hot path drainage.
+        let approx_len = self.len_approx();
+        let mut entries = if approx_len > 0 {
+            Vec::with_capacity(approx_len)
+        } else {
+            Vec::new()
+        };
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
💡 **What:** Modifies the `drain()` method in the lock-free ring buffer (`src/storage/wal/ring_buffer.rs`) to pre-allocate capacity for the `entries` Vector using `self.len_approx()`, falling back to `Vec::new()` only when empty.
🎯 **Why:** The `drain()` method is continuously called by the background flush thread (the consumer). Initializing the collection vector with `Vec::new()` caused repeated intermediate heap reallocations (0 -> 4 -> 8 -> 16 etc.) as pending entries were collected.
📊 **Impact:** Eliminates intermediate heap allocations during the extremely hot path of draining the concurrent Write-Ahead Log.
🔬 **Measurement:** Verify with `cargo test --lib -- storage::wal`.

---
*PR created automatically by Jules for task [12904222584677955552](https://jules.google.com/task/12904222584677955552) started by @madmax983*