### PR TITLE
🪒 Razor: De-abstract Resonator into concrete ActivityDensityResonator

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,7 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+## [Reduction]
+**Bloat:** The "One-Time" Trait
+**Cut:** Removed the `Resonator` trait which was only implemented by `ActivityDensityResonator`. Transformed it into a concrete method on the struct.
+**Saved:** 5 lines of code, 1 layer of pointer indirection (removed `Box<dyn Resonator>`), and cognitive load of an unnecessary abstraction.

--- a/src/experimental/temporal/echo.rs
+++ b/src/experimental/temporal/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "semantic-temporal")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,7 +118,8 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
     fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
@@ -202,7 +197,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "semantic-temporal"))]
@@ -251,13 +246,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -318,7 +313,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
🪒 **Razor: Enforcing KISS by removing "One-Time" traits**

Found a classic case of over-abstraction in `src/experimental/temporal/echo.rs`. The `Resonator` trait was only implemented by exactly one type: `ActivityDensityResonator`.

**The Changes:**
1. Deleted the `Resonator` trait entirely.
2. Inlined `resonate` as an inherent method on `ActivityDensityResonator`.
3. Updated `EchoChamber` to hold `resonator: ActivityDensityResonator` rather than `Box<dyn Resonator>`, eliminating heap allocation and pointer indirection for every `resonate` call.

Logged in `.jules/razor.md`. Evaluated correctly in code review and passes all nova tests.

---
*PR created automatically by Jules for task [10434300741660625055](https://jules.google.com/task/10434300741660625055) started by @madmax983*