### PR TITLE
🪒 Razor: De-abstract traits in experimental modules

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,18 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `Resonator` trait (Single-implementation abstraction used only by `ActivityDensityResonator`).
+**Cut:** Deleted the `Resonator` trait. Refactored `EchoChamber` to use the concrete `ActivityDensityResonator` struct directly.
+**Saved:** ~10 lines of trait definition + dynamic dispatch overhead in `EchoChamber`.
+
+## [Reduction]
+**Bloat:** `SemanticRule` trait (Abstraction over `VectorBanRule` and `NumericRangeRule`).
+**Cut:** Replaced the `SemanticRule` trait with a `SemanticRule` enum containing variants for the two concrete rules.
+**Saved:** Removed dynamic dispatch overhead `Box<dyn SemanticRule>` and flattened the abstraction layer.
+
+## [Reduction]
+**Bloat:** `PropagationModel` trait (Single-implementation abstraction used only by `LinearPropagation`).
+**Cut:** Deleted the `PropagationModel` trait. Refactored `Sybil` to use the concrete `LinearPropagation` struct directly.
+**Saved:** ~20 lines of trait definition + trait bound complexity in `Sybil::simulate`.

--- a/src/experimental/characterization/sybil.rs
+++ b/src/experimental/characterization/sybil.rs
@@ -44,25 +44,6 @@ use std::collections::HashMap;
 /// Maps NodeId -> Vector (state).
 pub type PropagationState = HashMap<NodeId, Vec<f32>>;
 
-/// Defines how a node updates its state based on its neighbors.
-pub trait PropagationModel {
-    /// Calculate the next state for a node.
-    ///
-    /// # Arguments
-    /// * `node_id` - The node being updated.
-    /// * `current_self` - The node's current vector (if any).
-    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
-    ///
-    /// # Returns
-    /// The new vector state for the node.
-    fn next_state(
-        &self,
-        node_id: NodeId,
-        current_self: Option<&[f32]>,
-        neighbors: &[(NodeId, &[f32])],
-    ) -> Option<Vec<f32>>;
-}
-
 /// A simple linear propagation model.
 /// New State = (1 - alpha) * Old State + alpha * Average(Neighbor States)
 pub struct LinearPropagation {
@@ -79,10 +60,17 @@ impl LinearPropagation {
             alpha: alpha.clamp(0.0, 1.0),
         }
     }
-}
 
-impl PropagationModel for LinearPropagation {
-    fn next_state(
+    /// Calculate the next state for a node.
+    ///
+    /// # Arguments
+    /// * `node_id` - The node being updated.
+    /// * `current_self` - The node's current vector (if any).
+    /// * `neighbors` - List of (NodeId, Neighbor Vector) tuples.
+    ///
+    /// # Returns
+    /// The new vector state for the node.
+    pub fn next_state(
         &self,
         _node_id: NodeId,
         current_self: Option<&[f32]>,
@@ -156,10 +144,10 @@ impl<'a> Sybil<'a> {
     /// * `property_name` - The vector property to use as the "meme".
     /// * `model` - The propagation logic.
     /// * `steps` - Number of iterations.
-    pub fn simulate<M: PropagationModel>(
+    pub fn simulate(
         &self,
         property_name: &str,
-        model: &M,
+        model: &LinearPropagation,
         steps: usize,
     ) -> Result<PropagationState> {
         // Step 1: Load Initial State

--- a/src/experimental/diagnostics/sentinel.rs
+++ b/src/experimental/diagnostics/sentinel.rs
@@ -33,15 +33,27 @@ use crate::core::property::PropertyMap;
 use crate::core::vector::cosine_similarity;
 
 /// A rule that validates a PropertyMap.
-pub trait SemanticRule {
+pub enum SemanticRule {
+    /// A rule that bans vectors similar to a set of forbidden vectors.
+    VectorBan(VectorBanRule),
+    /// A rule that enforces a logical condition on a numeric property.
+    NumericRange(NumericRangeRule),
+}
+
+impl SemanticRule {
     /// Validate the given properties.
     /// Returns Ok if valid, Err with a reason if invalid.
-    fn validate(&self, props: &PropertyMap) -> Result<()>;
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
+        match self {
+            SemanticRule::VectorBan(rule) => rule.validate(props),
+            SemanticRule::NumericRange(rule) => rule.validate(props),
+        }
+    }
 }
 
 /// The Sentinel validates data against a set of rules.
 pub struct Sentinel {
-    rules: Vec<Box<dyn SemanticRule>>,
+    rules: Vec<SemanticRule>,
 }
 
 impl Sentinel {
@@ -51,7 +63,7 @@ impl Sentinel {
     }
 
     /// Add a rule to the Sentinel.
-    pub fn add_rule(&mut self, rule: Box<dyn SemanticRule>) {
+    pub fn add_rule(&mut self, rule: SemanticRule) {
         self.rules.push(rule);
     }
 
@@ -106,8 +118,9 @@ impl VectorBanRule {
     }
 }
 
-impl SemanticRule for VectorBanRule {
-    fn validate(&self, props: &PropertyMap) -> Result<()> {
+impl VectorBanRule {
+    /// Validate the given properties against the VectorBanRule.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         // If the property doesn't exist or isn't a vector, we skip validation (or should we fail?)
         // Let's be lenient: if no vector is provided, the rule doesn't apply.
         // Unless it's a required field, which is a different rule (SchemaRule).
@@ -188,8 +201,9 @@ impl NumericRangeRule {
     }
 }
 
-impl SemanticRule for NumericRangeRule {
-    fn validate(&self, props: &PropertyMap) -> Result<()> {
+impl NumericRangeRule {
+    /// Validate the given properties against the NumericRangeRule.
+    pub fn validate(&self, props: &PropertyMap) -> Result<()> {
         let val = match props.get(&self.property_name) {
             Some(v) => v,
             None => return Ok(()),
@@ -329,11 +343,11 @@ mod tests {
         // Rule 1: Ban toxic vectors
         let mut ban_rule = VectorBanRule::new("embedding", 0.8);
         ban_rule.add_banned_vector(vec![1.0, 0.0]).unwrap();
-        sentinel.add_rule(Box::new(ban_rule));
+        sentinel.add_rule(SemanticRule::VectorBan(ban_rule));
 
         // Rule 2: Age must be >= 18
         let range_rule = NumericRangeRule::new("age").min(18.0);
-        sentinel.add_rule(Box::new(range_rule));
+        sentinel.add_rule(SemanticRule::NumericRange(range_rule));
 
         // Valid Insert
         let valid = PropertyMapBuilder::new()

--- a/src/experimental/temporal/echo.rs
+++ b/src/experimental/temporal/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -202,7 +197,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "semantic-temporal"))]
@@ -251,13 +246,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -318,7 +313,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
Following the Razor persona guidelines, this PR flattens unnecessary trait abstractions within the `experimental` modules:
- Replaced the single-implementation `Resonator` trait with the concrete `ActivityDensityResonator` struct in `echo.rs`.
- Replaced the multi-implementation `SemanticRule` trait with a `SemanticRule` enum in `sentinel.rs`, removing `Box<dyn Trait>` overhead.
- Replaced the single-implementation `PropagationModel` trait with the concrete `LinearPropagation` struct in `sybil.rs`.

All changes were verified with `cargo check --lib --features nova`, `cargo clippy`, and tests pass. The `.jules/razor.md` journal has been updated.

---
*PR created automatically by Jules for task [11736853817050188126](https://jules.google.com/task/11736853817050188126) started by @madmax983*