### PR TITLE
⚡ Bolt: Optimize MockIterator allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[MockIterator Vec Pre-allocation]**
+**Learning:** Found unnecessary `.collect::<Vec<_>>().into_iter()` chain in `MockIterator::new` in `src/query/executor/results.rs`. This caused an unnecessary intermediate heap allocation.
+**Action:** Replaced the `.collect` chain with a `Box<dyn Iterator>` to eliminate the heap reallocation.

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -791,13 +791,14 @@ mod tests {
 
     // Mock iterator for testing QueryResults
     struct MockIterator {
-        items: std::vec::IntoIter<Result<QueryRow>>,
+        items: Box<dyn Iterator<Item = Result<QueryRow>> + Send>,
     }
 
+    /// ⚡ Bolt Optimization: Removed intermediate `.collect::<Vec<_>>()` allocation to return an iterator directly, saving a heap reallocation during test mock setup.
     impl MockIterator {
         fn new(rows: Vec<QueryRow>) -> Self {
             MockIterator {
-                items: rows.into_iter().map(Ok).collect::<Vec<_>>().into_iter(),
+                items: Box::new(rows.into_iter().map(Ok)),
             }
         }
 
@@ -817,7 +818,7 @@ mod tests {
                 )));
             }
             MockIterator {
-                items: results.into_iter(),
+                items: Box::new(results.into_iter()),
             }
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced the `.collect::<Vec<_>>().into_iter()` chain in `MockIterator::new` (within `src/query/executor/results.rs`) with a boxed iterator `Box<dyn Iterator<Item = Result<QueryRow>> + Send>`. Added doc comments explaining the change.
🎯 **Why:** The previous implementation collected the iterator into an intermediate vector, allocating an O(N) array on the heap, only to immediately convert it back into an iterator. Returning the mapped iterator directly avoids this unnecessary data copy and heap reallocation.
📊 **Impact:** Replaces an O(N) memory allocation with an O(1) allocation for the `Box` wrapper during `MockIterator` instantiation.
🔬 **Measurement:** Verify by running `cargo test --lib query::executor::results`.

---
*PR created automatically by Jules for task [8789914857092123008](https://jules.google.com/task/8789914857092123008) started by @madmax983*