### PR TITLE
⚡ Bolt: Optimize ProjectIterator property interning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize String Interning in ProjectIterator**
+**Learning:** `ProjectIterator::next` was calling `node.properties.get(prop)` and `new_props.try_insert(prop, val.clone())` where `prop` was a `String`. Both `get` and `try_insert` internally call `GLOBAL_INTERNER.intern(key)`, resulting in two interner lookups (which involve hashing and potentially locks/atomics) for every single projected property on every single row processed.
+**Action:** Pre-intern the property strings in `ProjectIterator::new` and store them as `Vec<PropertyKey>`. Then use `get_by_interned_key` and `try_insert_by_key` in the `next()` loop to completely eliminate interner lookups in the hot path.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -1480,18 +1480,33 @@ impl ResultIterator for ProvenanceFilterIterator {
 }
 
 /// Iterator for projecting specific properties from query results.
+use crate::core::property::PropertyKey;
+/// Iterator for projecting specific properties from query results.
 pub struct ProjectIterator {
     input: Box<dyn ResultIterator>,
-    properties: Vec<String>,
+    properties: Vec<PropertyKey>,
 }
 
 impl ProjectIterator {
     /// Create a new ProjectIterator that projects specific properties from the results.
+    ///
+    /// ⚡ Bolt Optimization: Properties are pre-interned during construction.
+    /// This eliminates repeated String -> InternedString lookups for every
+    /// property on every single row processed during projection.
     pub fn new(input: Box<dyn ResultIterator>, mut properties: Vec<String>) -> Self {
         // Deduplicate properties to prevent errors when projecting same property multiple times
         properties.sort();
         properties.dedup();
-        ProjectIterator { input, properties }
+
+        let interned_properties = properties
+            .into_iter()
+            .filter_map(|p| GLOBAL_INTERNER.intern(&p).ok())
+            .collect();
+
+        ProjectIterator {
+            input,
+            properties: interned_properties,
+        }
     }
 }
 
@@ -1501,9 +1516,9 @@ impl ResultIterator for ProjectIterator {
             Some(Ok(mut row)) => {
                 if let Some(node) = row.entity.as_node() {
                     let mut new_props = crate::core::PropertyMapBuilder::new();
-                    for prop in &self.properties {
-                        if let Some(val) = node.properties.get(prop) {
-                            new_props = match new_props.try_insert(prop, val.clone()) {
+                    for prop_key in &self.properties {
+                        if let Some(val) = node.properties.get_by_interned_key(prop_key) {
+                            new_props = match new_props.try_insert_by_key(*prop_key, val.clone()) {
                                 Ok(p) => p,
                                 Err(e) => return Some(Err(e)),
                             };


### PR DESCRIPTION
💡 **What:** The `ProjectIterator` was changed to store `Vec<PropertyKey>` instead of `Vec<String>`. The property strings are pre-interned in the constructor, and the `next()` method was updated to use `get_by_interned_key` and `try_insert_by_key`.
🎯 **Why:** Previously, `ProjectIterator::next` called `node.properties.get(prop)` and `new_props.try_insert(prop, ...)`. Both of these methods take a string slice and internally call the `GLOBAL_INTERNER` to look up or insert the string. This resulted in two interner lookups (involving hashing and potentially synchronization) per property, per row processed. For queries returning millions of rows, this overhead is significant.
📊 **Impact:** Reduces `GLOBAL_INTERNER` lookups in the hot path to exactly zero. Eliminates all string hashing and potential lock contention during row projection.
🔬 **Measurement:** Execute a query that projects properties over a large dataset and observe reduced CPU utilization in the query executor.

---
*PR created automatically by Jules for task [384957461930189214](https://jules.google.com/task/384957461930189214) started by @madmax983*