### PR TITLE
🪒 Razor: Flatten single-implementation abstractions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,14 +1,4 @@
 ## [Reduction]
-**Bloat:** `FileColdStorage` (Redundant, inferior implementation of `ColdStorage` trait).
-**Cut:** Deleted `FileColdStorage` struct, implementation, and tests.
-**Saved:** ~200 lines of code + cognitive load of maintaining two cold storage backends.
-
-## [Reduction]
-**Bloat:** `ColdStorage` trait (Single-implementation abstraction used only by `RedbColdStorage`).
-**Cut:** Deleted the `ColdStorage` trait and `cold_storage.rs` module. Refactored all consumers to use the concrete `RedbColdStorage` struct directly.
-**Saved:** ~300 lines of boilerplate (trait definitions, mock implementations, duplicate imports) + removed dynamic dispatch overhead.
-
-## [Reduction]
-**Bloat:** `StorageSnapshot` and `FieldHolder` traits.
-**Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
-**Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+**Bloat:** [The `Resonator` trait in `src/experimental/temporal/echo.rs` (a single-implementation trait) and the `DenseEmbeddingError` enum in `src/embeddings/mod.rs` (a single-variant enum)]
+**Cut:** [Replaced the `Box<dyn Resonator>` trait object with the concrete `ActivityDensityResonator` struct directly in `EchoChamber`. Refactored `DenseEmbeddingError` from a 1-variant enum into a concrete unit struct `pub struct DenseEmbeddingError;`.]
+**Saved:** [Unnecessary dynamic dispatch, cognitive load of indirection, and abstract type verbosity.]

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -33,16 +33,11 @@ pub struct DenseEmbedData {
 
 /// Error returned when an upstream embedding result is not dense.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum DenseEmbeddingError {
-    /// A multi-vector embedding cannot be represented as a single dense vector.
-    NotDense,
-}
+pub struct DenseEmbeddingError;
 
 impl fmt::Display for DenseEmbeddingError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotDense => formatter.write_str("embedding result is not a dense vector"),
-        }
+        formatter.write_str("embedding result is not a dense vector")
     }
 }
 
@@ -93,6 +88,6 @@ fn embed_data_to_dense(data: EmbedData) -> Result<DenseEmbedData, DenseEmbedding
 fn embedding_result_to_dense(result: EmbeddingResult) -> Result<Vec<f32>, DenseEmbeddingError> {
     match result {
         EmbeddingResult::DenseVector(vector) => Ok(vector),
-        EmbeddingResult::MultiVector(_) => Err(DenseEmbeddingError::NotDense),
+        EmbeddingResult::MultiVector(_) => Err(DenseEmbeddingError),
     }
 }

--- a/src/experimental/temporal/echo.rs
+++ b/src/experimental/temporal/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "semantic-temporal")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,7 +118,7 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
+impl ActivityDensityResonator {
     fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
@@ -202,7 +196,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "semantic-temporal"))]
@@ -251,13 +245,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -318,7 +312,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );

--- a/tests/embeddings_reexport.rs
+++ b/tests/embeddings_reexport.rs
@@ -45,7 +45,7 @@ fn to_dense_iter_rejects_multi_vectors() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap_err();
 
-    assert_eq!(error, DenseEmbeddingError::NotDense);
+    assert_eq!(error, DenseEmbeddingError);
 }
 
 #[test]


### PR DESCRIPTION
* **Bloat:** The `Resonator` trait in `src/experimental/temporal/echo.rs` was a single-implementation trait, adding unnecessary dynamic dispatch (`Box<dyn Resonator>`) and abstraction. The `DenseEmbeddingError` in `src/embeddings/mod.rs` was a 1-variant enum (`NotDense`), adding unnecessary pattern matching and verbosity.
* **Cut:** Replaced the `Box<dyn Resonator>` trait object with the concrete `ActivityDensityResonator` struct directly in `EchoChamber`. Refactored `DenseEmbeddingError` from a 1-variant enum into a concrete unit struct `pub struct DenseEmbeddingError;`. Updated all `Display` implementations, constructors, and tests.
* **Saved:** Removed unnecessary dynamic dispatch, cognitive load of indirection, and abstract type verbosity. Code is simpler, more direct, and easier for juniors to read. Passed the Grandma Test.

---
*PR created automatically by Jules for task [177486169945215879](https://jules.google.com/task/177486169945215879) started by @madmax983*