### PR TITLE
🎻 Bard: Fixed broken intra-doc links in http config and simulation clock

### DIFF
--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`AletheiaDBConfig`](crate::AletheiaDBConfig) this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`jump_to`](Self::jump_to) for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: `http::config` and `simulation::clock` modules
💡 Insight: Fixed broken intra-doc links to `AletheiaDBConfig` and `jump_to`.
🧪 Example: N/A, links were fixed.
🖼️ Preview: Documentation renders properly without warnings.

---
*PR created automatically by Jules for task [2448850661551680155](https://jules.google.com/task/2448850661551680155) started by @madmax983*