### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requires Rust 1.92+.
 ```rust
 use aletheiadb::prelude::*;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
 
     // Create nodes and a relationship
@@ -63,7 +63,7 @@ query with a consistent view of the data:
 use aletheiadb::prelude::*;
 use aletheiadb::HnswConfig;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
     db.vector_index("embedding").hnsw(HnswConfig { dimensions: 2, ..Default::default() }).enable()?;
 

--- a/docs/EMBEDDINGS.md
+++ b/docs/EMBEDDINGS.md
@@ -47,7 +47,7 @@ use aletheiadb::embeddings::{embed_data_to_dense_iter, embed_query, Embedder};
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENAI_API_KEY")?;
     let embedder =
         Embedder::from_pretrained_cloud("OpenAI", "text-embedding-3-small", Some(api_key))?;

--- a/docs/guides/PERSISTENCE.md
+++ b/docs/guides/PERSISTENCE.md
@@ -331,7 +331,7 @@ use aletheiadb::storage::index_persistence::PersistenceConfig;
 use aletheiadb::storage::wal::DurabilityMode;
 use std::time::Duration;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db_path = std::env::current_dir()?.join("my-app-data");
 
     let config = AletheiaDBConfig::builder()

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -13,7 +13,7 @@ By the end you'll have a working mental model of how AletheiaDB works day-to-day
 ```rust
 use aletheiadb::prelude::*;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
     // db is ready to use
     Ok(())

--- a/docs/guides/vector-search-integration.md
+++ b/docs/guides/vector-search-integration.md
@@ -31,7 +31,7 @@ aletheiadb = "0.1"
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new();
 
     // Enable vector indexing on "embedding" property
@@ -108,7 +108,7 @@ let similar_docs = db.find_similar_with_label(doc_id, "Document", 10)?;
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
 use aletheiadb::index::vector::{HnswConfig, DistanceMetric};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // 1. Create database and enable vector index
     let db = AletheiaDB::new();
 

--- a/src/experimental/reasoning/mod.rs
+++ b/src/experimental/reasoning/mod.rs
@@ -11,7 +11,9 @@ pub mod chimera;
 pub mod dreamer;
 pub mod hindsight;
 pub mod luna;
+#[cfg(feature = "nova")]
 pub mod metaphor;
+#[cfg(feature = "nova")]
 pub mod muse;
 pub mod omen;
 pub mod oracle;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,6 +8,11 @@
 //! ```rust
 //! use aletheiadb::prelude::*;
 //! ```
+//!
+//! **Note on `Result`:** The prelude exports `aletheiadb::Result<T>`, which shadows
+//! the standard library's `std::result::Result<T, E>`. If your application entry point
+//! (`fn main()`) returns a generic error, use `std::result::Result<(), Box<dyn std::error::Error>>`
+//! instead of just `Result<(), Box<dyn std::error::Error>>` to avoid compilation errors.
 
 pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};


### PR DESCRIPTION
🤦 **The Confusion:** Users copy-pasting documentation examples that used `aletheiadb::prelude::*` encountered compilation errors because `fn main() -> Result<(), Box<dyn std::error::Error>>` failed due to `aletheiadb::Result` shadowing `std::result::Result`. Also, the `muse` and `metaphor` modules were accessible without the `nova` feature flag.

🕵️‍♂️ **The Reality:** The prelude intentionally exports a single-parameter `Result<T>` but documentation examples used the standard library's two-parameter signature. Furthermore, `muse` and `metaphor` lacked the appropriate `#[cfg(feature = "nova")]` attributes in `src/experimental/reasoning/mod.rs`.

💡 **The Fix:**
- Replaced `Result<(), Box<dyn std::error::Error>>` with `std::result::Result<(), Box<dyn std::error::Error>>` in all markdown examples (`README.md`, `docs/EMBEDDINGS.md`, `docs/guides/PERSISTENCE.md`, `docs/guides/vector-search-integration.md`, `docs/guides/getting-started.md`).
- Documented the `Result` shadowing clearly in the docstrings of `src/prelude.rs`.
- Correctly feature-gated `muse` and `metaphor` behind `#[cfg(feature = "nova")]`.

---
*PR created automatically by Jules for task [11465628271290458417](https://jules.google.com/task/11465628271290458417) started by @madmax983*