### PR TITLE
🎻 Bard: Fix broken intra-doc links in clock and http config

### DIFF
--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`crate::config::AletheiaDBConfig`] this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`Self::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: The Simulation and HTTP Modules
💡 Insight: Fixed broken intra-doc links that caused `cargo doc` warnings. `AletheiaDBConfig` was missing a `crate::config::` prefix since it's out of scope in `http::config`, and `jump_to` in `clock.rs` lacked a `Self::` prefix.
🧪 Example: Run `cargo rustdoc --lib --all-features -- -W missing_docs` to verify that there are no longer warnings about broken intra-doc links for `jump_to` and `AletheiaDBConfig`.
🖼️ Preview: Documentation for `SimulationClock::advance_by` and `ServerConfig::data_dir` now correctly link to their targets.

---
*PR created automatically by Jules for task [12887869527466059827](https://jules.google.com/task/12887869527466059827) started by @madmax983*