### PR TITLE
⚡ Bolt: Use IdentityHasher for A* Pathfinding maps in Semantic Navigator

### DIFF
--- a/src/semantic_search/semantic_navigator.rs
+++ b/src/semantic_search/semantic_navigator.rs
@@ -50,10 +50,12 @@
 
 use crate::AletheiaDB;
 use crate::core::error::{Error, Result};
+use crate::core::hasher::IdentityHasher;
 use crate::core::id::NodeId;
 use crate::core::vector::cosine_similarity;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
+use std::hash::BuildHasherDefault;
 
 /// A navigator that finds semantically meaningful paths through the graph.
 ///
@@ -157,11 +159,18 @@ impl<'a> SemanticNavigator<'a> {
             node: start,
         });
 
-        let mut came_from: HashMap<NodeId, NodeId> = HashMap::new();
-        let mut g_score: HashMap<NodeId, f32> = HashMap::new();
+        // ⚡ Bolt: Use `IdentityHasher` instead of the default SipHash.
+        // `NodeId` is already a unique wrapper over `u64`. In pathfinding (like A*),
+        // we perform thousands of map insertions and lookups. Bypassing SipHash eliminates
+        // unnecessary hashing overhead on already-unique integer keys.
+        let mut came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
+        let mut g_score: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
         g_score.insert(start, 0.0);
 
-        let mut f_score: HashMap<NodeId, f32> = HashMap::new();
+        let mut f_score: HashMap<NodeId, f32, BuildHasherDefault<IdentityHasher>> =
+            HashMap::default();
         // h(start) = 1.0 - sim(start, end)
         // We know start has a vector.
         let h_start = 1.0 - cosine_similarity(&_start_vec, &end_vec)?;
@@ -238,7 +247,7 @@ impl<'a> SemanticNavigator<'a> {
 
     fn reconstruct_path(
         &self,
-        came_from: HashMap<NodeId, NodeId>,
+        came_from: HashMap<NodeId, NodeId, BuildHasherDefault<IdentityHasher>>,
         mut current: NodeId,
     ) -> Vec<NodeId> {
         let mut total_path = vec![current];


### PR DESCRIPTION
💡 **What**: Replaced the default `SipHash` hasher with `IdentityHasher` for the `came_from`, `g_score`, and `f_score` HashMaps in `SemanticNavigator::find_path()`.
🎯 **Why**: The keys in these maps are `NodeId`s, which internally represent unique `u64` integers. Cryptographic hashing via `SipHash` is unnecessary for these uniquely identifiable integers, especially in hot paths like A* pathfinding where thousands of map insertions and lookups occur per query.
📊 **Impact**: Expected to reduce hashing overhead and slightly improve the performance of A* pathfinding in the Semantic Navigator without breaking any existing behavior or compromising memory safety.
🔬 **Measurement**: Verified the pathfinding behavior holds true by running `cargo test --lib --all-features semantic_search::semantic_navigator`. More robust benchmarks would demonstrate exactly how many cpu cycles were saved during large graph traversals.

---
*PR created automatically by Jules for task [10674300317718781186](https://jules.google.com/task/10674300317718781186) started by @madmax983*