### PR TITLE
🎻 Bard: Fix broken intra-doc links

### DIFF
--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`crate::AletheiaDBConfig`] this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`Self::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: Configuration and Simulation
💡 Insight: Fixed broken intra-doc links that were causing `cargo doc` warnings. Qualified `AletheiaDBConfig` with `crate::` and `jump_to` with `Self::` to ensure proper rustdoc resolution.
🧪 Example: Verified via `cargo doc --no-deps` which now completes with 0 warnings.
🖼️ Preview: Documentation for `to_unified_config` and `advance_by` now correctly links to target items.

---
*PR created automatically by Jules for task [14518907606250903550](https://jules.google.com/task/14518907606250903550) started by @madmax983*