### PR TITLE
⚔️ Elenchus: query::executor::iterators Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[TraversalIterator Missing Tests Addressed]**
+**Module:** `src/query/executor/iterators.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** As noted previously, `TraversalIterator` lacked direct unit tests for cycle suppression and input isolation.
+**Evidence:** The implementation had complex BFS logic with node isomorphism (`self.visited.insert(target)`) that was only tested implicitly through integration tests.
+**Recommendation:** Added `sentry_tests` in `src/query/executor/iterators.rs` with `test_traversal_iterator_cycle_suppression` and `test_traversal_iterator_input_isolation` to explicitly verify the internal logic of the iterator.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -3469,3 +3469,144 @@ mod tests {
         assert!(iter.next().is_none());
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use crate::AletheiaDB;
+    use crate::Direction;
+    use crate::query::executor::iterators::{ResultIterator, TraversalIterator};
+    use crate::query::executor::results::{EntityResult, QueryRow};
+
+    // Need a dummy iterator for input
+    struct DummyIterator {
+        nodes: std::vec::IntoIter<crate::core::NodeId>,
+    }
+
+    impl ResultIterator for DummyIterator {
+        fn next(&mut self) -> Option<crate::Result<QueryRow>> {
+            self.nodes.next().map(|id| {
+                let label = crate::core::interning::GLOBAL_INTERNER
+                    .intern("Test")
+                    .unwrap();
+                Ok(QueryRow {
+                    entity: EntityResult::Node(crate::core::Node {
+                        id,
+                        label: label.clone(),
+                        properties: crate::core::property::PropertyMap::default(),
+                        current_version: crate::core::VersionId::new_unchecked(0),
+                        metadata: crate::core::version::VersionMetadata {
+                            created_by_tx: crate::core::id::TxId::new(0),
+                            commit_timestamp: None,
+                        },
+                    }),
+                    path: None,
+                    score: None,
+                    timestamp: None,
+                })
+            })
+        }
+    }
+
+    #[test]
+    fn test_traversal_iterator_cycle_suppression() {
+        let db = AletheiaDB::new().unwrap();
+        let a_id = db
+            .create_node("Node", crate::PropertyMapBuilder::new().build())
+            .unwrap();
+        let b_id = db
+            .create_node("Node", crate::PropertyMapBuilder::new().build())
+            .unwrap();
+
+        db.create_edge(
+            a_id,
+            b_id,
+            "KNOWS",
+            crate::PropertyMapBuilder::new().build(),
+        )
+        .unwrap();
+        db.create_edge(
+            b_id,
+            a_id,
+            "KNOWS",
+            crate::PropertyMapBuilder::new().build(),
+        )
+        .unwrap();
+
+        let input = Box::new(DummyIterator {
+            nodes: vec![a_id].into_iter(),
+        });
+
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Outgoing,
+            None,
+            2,
+            db.current.clone(),
+            db.historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+
+        // It's depth 2.
+        // from a_id (0) -> b_id (1) -> a_id is already visited.
+        // We only yield at target depth (2). Since depth 2 is empty, it returns 0 elements.
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_traversal_iterator_input_isolation() {
+        let db = AletheiaDB::new().unwrap();
+        let a_id = db
+            .create_node("Node", crate::PropertyMapBuilder::new().build())
+            .unwrap();
+        let b_id = db
+            .create_node("Node", crate::PropertyMapBuilder::new().build())
+            .unwrap();
+        let c_id = db
+            .create_node("Node", crate::PropertyMapBuilder::new().build())
+            .unwrap();
+
+        db.create_edge(
+            a_id,
+            c_id,
+            "KNOWS",
+            crate::PropertyMapBuilder::new().build(),
+        )
+        .unwrap();
+        db.create_edge(
+            b_id,
+            c_id,
+            "KNOWS",
+            crate::PropertyMapBuilder::new().build(),
+        )
+        .unwrap();
+
+        // Input provides both A and B
+        let input = Box::new(DummyIterator {
+            nodes: vec![a_id, b_id].into_iter(),
+        });
+
+        let mut iter = TraversalIterator::new(
+            input,
+            Direction::Outgoing,
+            None,
+            1,
+            db.current.clone(),
+            db.historical.clone(),
+            None,
+        );
+
+        let mut results = Vec::new();
+        while let Some(Ok(row)) = iter.next() {
+            results.push(row.entity.node_id().unwrap());
+        }
+
+        // It should yield C twice (once for path from A, once for path from B).
+        // Since visited is cleared per input node.
+        assert_eq!(results.len(), 2);
+    }
+}


### PR DESCRIPTION
Add explicit unit tests to `src/query/executor/iterators.rs` to cover cycle suppression and input isolation in `TraversalIterator`. This addresses the gap identified in the `.jules/elenchus.md` journal.

---
*PR created automatically by Jules for task [13892239464059330288](https://jules.google.com/task/13892239464059330288) started by @madmax983*