### PR TITLE
🎻 Bard: Fix broken intra-doc links for AletheiaDBConfig and jump_to

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-18 - [Fixing intra-doc links]
+**Confusion:** Broken intra-doc links (`[`AletheiaDBConfig`]` and `[`jump_to`]`) triggered warnings during `cargo rustdoc --lib --all-features -- -W missing_docs`.
+**Clarification:** Fixed the links by using fully qualified paths (e.g. `[`crate::AletheiaDBConfig`]`, `[`SimulatedClock::jump_to`]`) to allow `rustdoc` to resolve them.

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`crate::AletheiaDBConfig`] this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`SimulatedClock::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: The "Missing" Link and "Broken Examples"

💡 Insight: Broken intra-doc links (`[AletheiaDBConfig]` and `[jump_to]`) were triggering warnings during `cargo rustdoc --lib --all-features -- -W missing_docs`. This is an issue as we strive for pristine `cargo doc` outputs. The links have been corrected using fully qualified paths (e.g. `[crate::AletheiaDBConfig]`, `[SimulatedClock::jump_to]`).

🧪 Example:
```rust
/// Materialize the [`crate::AletheiaDBConfig`] this server config implies.
pub fn to_unified_config(&self) -> Option<crate::AletheiaDBConfig> { ... }
```

🖼️ Preview: `cargo rustdoc --lib --all-features -- -W missing_docs` now passes with 0 generated errors about unresolved links.

---
*PR created automatically by Jules for task [16688283407283536066](https://jules.google.com/task/16688283407283536066) started by @madmax983*