### PR TITLE
⚖️ Elenchus: query::planner::rules Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[LogicalPlan Mutants - Boolean Logic Escapes]**
+**Module:** `src/query/planner/rules/limit_pushdown.rs`, `operation_reordering.rs`, `predicate_pushdown.rs`, `filter_scan_fusion.rs`
+**Severity:** 🟡 Suspect
+**Finding:** `cargo mutants` revealed missing test coverage for the boolean propagation logic `changed || other_condition` and `left_changed || right_changed` within the query optimizer's tree-walking `push_down`, `reorder`, and `fuse` methods. Specifically, changing `||` to `&&` in these statements survived, meaning tests weren't verifying scenarios where one child changed while the other didn't, or where an inner node changed but the outer node properties did not.
+**Evidence:** `replace || with && in LimitPushdown::push_down`, `replace || with && in OperationReordering::reorder`, `replace || with && in PredicatePushdown::push_down`, and `replace || with && in FilterScanFusion::fuse` all generated surviving mutants.
+**Recommendation:** Added exhaustive `elenchus_tests` modules to each file, specifically crafting scenarios that set exactly one side of the boolean OR conditions to true (e.g., `left_changed=false, right_changed=true`, or `input_changed=true, new_top_k==top_k`). These explicitly lock the required union boolean propagation behavior.

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -243,3 +243,32 @@ mod tests {
         assert!(result.unwrap().temporal_context.is_some());
     }
 }
+
+#[cfg(test)]
+mod elenchus_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::ir::Predicate;
+    use crate::query::plan::{BinaryOp, ScanOp, UnaryOp};
+
+    #[test]
+    fn test_filter_scan_fusion_right_changed() {
+        let rule = FilterScanFusion;
+
+        let left = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: Some(10),
+            }),
+        );
+
+        let op = LogicalOp::binary(BinaryOp::Union, left, right);
+        let (_new_op, changed) = rule.fuse(&op).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true due to right side fusion in Union"
+        );
+    }
+}

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -543,3 +543,87 @@ mod sentry_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod elenchus_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::plan::{BinaryOp, ScanOp, UnaryOp};
+
+    #[test]
+    fn test_limit_changed_true_effective_eq() {
+        let rule = LimitPushdown;
+
+        // Logical plan: Limit(10, VectorRank(None))
+        let op = LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::unary(
+                UnaryOp::VectorRank {
+                    embedding: vec![0.1f32].into(),
+                    top_k: None,
+                    property_key: None,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        );
+
+        let (_new_op, changed) = rule.push_down(&op, None).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true because inner VectorRank changed top_k from None to Some(10)"
+        );
+    }
+
+    #[test]
+    fn test_vector_rank_changed_true_top_k_eq() {
+        let rule = LimitPushdown;
+
+        // Logical plan: VectorRank(Some(10), VectorRank(None))
+        // The outer VectorRank has top_k = Some(10). Inner has None.
+        // wait, we can just do VectorRank(Some(10), Limit(10, Scan(..)) wait no, limit gets pushed down.
+        // Let's do VectorRank(Some(10), Binary( Union, Limit(10, Limit(20, Scan)), Scan ))
+        // Outer VectorRank top_k = Some(10). Inner changes.
+        let op = LogicalOp::unary(
+            UnaryOp::VectorRank {
+                embedding: vec![0.1f32].into(),
+                top_k: Some(10),
+                property_key: None,
+            },
+            LogicalOp::unary(
+                UnaryOp::Limit(10),
+                LogicalOp::unary(
+                    UnaryOp::Limit(20),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        );
+        let (_new_op, changed) = rule.push_down(&op, None).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true because inner Limit was optimized"
+        );
+    }
+
+    #[test]
+    fn test_binary_op_right_changed() {
+        let rule = LimitPushdown;
+
+        // BinaryOp( Union, Scan, Limit(10, Limit(20, Scan)) )
+        // left_changed = false, right_changed = true.
+        let left = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+        let right = LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::unary(
+                UnaryOp::Limit(20),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        );
+
+        let op = LogicalOp::binary(BinaryOp::Union, left, right);
+        let (_new_op, changed) = rule.push_down(&op, None).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true because right child changed"
+        );
+    }
+}

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -1186,3 +1186,135 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod elenchus_tests {
+    use super::*;
+
+    use crate::query::ir::Predicate;
+    use crate::query::plan::{BinaryOp, ScanOp, UnaryOp};
+
+    #[test]
+    fn test_operation_reordering_changed_true_filters_equal_true() {
+        // We want to hit the mutant: replace || with && in OperationReordering::reorder
+        // In the binary join case: changed = left_changed || right_changed || swapped;
+        // Let's test left_changed = true, right_changed = false, swapped = false.
+
+        let rule = OperationReordering;
+        let stats = Statistics::default();
+
+        // Left: Filter(A) -> Filter(B) -> Scan (will be reordered to Filter(B) -> Filter(A) -> Scan)
+        // Right: Scan (no change)
+        // Left and Right sizes: Left is 1000 * 0.1 * 0.1 = 10, Right is 1000.
+        // wait, we don't want swapped=true. We want right_card >= left_card.
+        // 1000 >= 10, so swapped=false.
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("rare", "value")),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("common", "value")),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(10),
+                }),
+            ),
+        );
+        let right = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(100),
+        });
+
+        // Setup stats to make sure "rare" is more selective than "common".
+        // rare: 0.1, common: 0.2
+        stats.update_property_stats("rare", 10);
+        stats.update_property_stats("common", 5);
+
+        let op = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "id".to_string(),
+                right_key: "ref_id".to_string(),
+            },
+            left,
+            right,
+        );
+
+        let (_new_op, changed) = rule.reorder(&op, &stats).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true due to left side reordering"
+        );
+    }
+
+    #[test]
+    fn test_operation_reordering_right_changed() {
+        let rule = OperationReordering;
+        let stats = Statistics::default();
+
+        let left = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(10),
+        });
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("rare", "value")),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("common", "value")),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(100),
+                }),
+            ),
+        );
+
+        stats.update_property_stats("rare", 10);
+        stats.update_property_stats("common", 5);
+
+        let op = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "id".to_string(),
+                right_key: "ref_id".to_string(),
+            },
+            left,
+            right,
+        );
+
+        let (_new_op, changed) = rule.reorder(&op, &stats).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true due to right side reordering"
+        );
+    }
+
+    #[test]
+    fn test_binary_op_non_join_reordering() {
+        // Testing LogicalOp::Binary (non-join)
+        // returns changed = left_changed || right_changed
+
+        let rule = OperationReordering;
+        let stats = Statistics::default();
+
+        let left = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(10),
+        });
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("rare", "value")),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("common", "value")),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(100),
+                }),
+            ),
+        );
+
+        stats.update_property_stats("rare", 10);
+        stats.update_property_stats("common", 5);
+
+        let op = LogicalOp::binary(BinaryOp::Union, left, right);
+        let (_new_op, changed) = rule.reorder(&op, &stats).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true due to right side reordering in Union"
+        );
+    }
+}

--- a/src/query/planner/rules/predicate_pushdown.rs
+++ b/src/query/planner/rules/predicate_pushdown.rs
@@ -704,3 +704,37 @@ mod sentry_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod elenchus_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::ir::Predicate;
+    use crate::query::plan::{BinaryOp, ScanOp, UnaryOp};
+
+    #[test]
+    fn test_predicate_pushdown_right_changed() {
+        // We want to test `left_changed || right_changed` for BinaryOp.
+        // Let's make right_changed = true, left_changed = false.
+
+        let rule = PredicatePushdown;
+        let left = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("rare", "value")),
+            LogicalOp::unary(
+                UnaryOp::Sort {
+                    key: crate::query::plan::SortKey::Property("age".into()),
+                    descending: true,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        );
+
+        let op = LogicalOp::binary(BinaryOp::Union, left, right);
+        let (_new_op, changed) = rule.push_down(&op).unwrap();
+        assert!(
+            changed,
+            "Expected changed to be true due to right side reordering in Union"
+        );
+    }
+}


### PR DESCRIPTION
**⚖️ Elenchus: query::planner::rules Test Quality Audit**

### 🤦 **The Vulnerability**
`cargo mutants` identified a pattern of surviving mutations within the query planner's rule application. Specifically, the boolean logic used to propagate state changes up the AST (e.g., `left_changed || right_changed` or `changed || effective_limit != *n`) was not explicitly verified. Replacing `||` with `&&` in the source code survived because existing tests always either caused both sides of the condition to be true or neither side to be true. There were no explicit tests asserting scenarios where exactly one side of the binary operation was modified.

### 🕵️‍♂️ **The Reality**
This blind spot meant that the optimizer could silently drop successful nested optimizations if the root operation didn't also change, potentially resulting in sub-optimal execution plans being deployed.

### 💡 **The Fix**
Added `elenchus_tests` modules to each affected planner rule (`LimitPushdown`, `OperationReordering`, `PredicatePushdown`, `FilterScanFusion`). These modules contain highly targeted test cases that explicitly construct LogicalPlans where exactly one branch or inner operation undergoes an optimization change, strictly enforcing the union boolean propagation and killing all remaining `replace || with &&` mutants. Updated `.jules/elenchus.md` to document this critical gap and solution.

---
*PR created automatically by Jules for task [2030176386296574777](https://jules.google.com/task/2030176386296574777) started by @madmax983*