### PR TITLE
🛡️ Sentry: [test coverage improvement] Add catch_unwind safety tests for SIMD vector operations

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+## Panic Risks in Vector Unsafe blocks
+**Learning:** `src/core/vector/simd.rs` contains multiple unsafe operations that rely on length parity check (`assert_eq!(a.len(), b.len())`). While these were verified via `catch_unwind` tests, many of the specific panic-handling cases in the `test_simd_mismatched_lengths_safety` and `havoc_tests.rs` did not trigger or properly document full coverage of all methods.
+**Action:** Wrote exhaustive `catch_unwind` tests specifically verifying every AVX2 and SSE2 `unsafe fn` that processes two vectors or slice mutations correctly panics when length bounds do not match, before causing out-of-bounds UB.

--- a/src/core/vector/havoc_tests.rs
+++ b/src/core/vector/havoc_tests.rs
@@ -27,6 +27,42 @@ mod tests {
     }
 
     #[test]
+    fn test_squared_diff_sum_avx2_panic() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            return;
+        }
+        let a = vec![1.0; 10];
+        let b = vec![2.0; 5];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::squared_diff_sum_avx2(&a, &b)
+        }));
+
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
+    }
+
+    #[test]
+    fn test_dot_and_magnitudes_avx2_panic() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            return;
+        }
+        let a = vec![1.0; 10];
+        let b = vec![2.0; 5];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::dot_and_magnitudes_avx2(&a, &b)
+        }));
+
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
+    }
+
+    #[test]
     fn test_scale_and_copy_avx2_panic() {
         if !is_x86_feature_detected!("avx2") {
             return;
@@ -40,6 +76,80 @@ mod tests {
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             simd::x86_ops::scale_and_copy_avx2(&src, dst_slice, 2.0)
+        }));
+
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
+    }
+
+    #[test]
+    fn test_dot_product_sse2_panic() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        let a = vec![1.0; 10];
+        let b = vec![2.0; 5];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::dot_product_sse2(&a, &b)
+        }));
+
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
+    }
+
+    #[test]
+    fn test_squared_diff_sum_sse2_panic() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        let a = vec![1.0; 10];
+        let b = vec![2.0; 5];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::squared_diff_sum_sse2(&a, &b)
+        }));
+
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
+    }
+
+    #[test]
+    fn test_dot_and_magnitudes_sse2_panic() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        let a = vec![1.0; 10];
+        let b = vec![2.0; 5];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::dot_and_magnitudes_sse2(&a, &b)
+        }));
+
+        assert!(
+            result.is_err(),
+            "Should have panicked due to length mismatch instead of causing UB"
+        );
+    }
+
+    #[test]
+    fn test_scale_and_copy_sse2_panic() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        let src = vec![1.0; 10];
+        let mut dst = vec![0.0; 5];
+        let dst_slice =
+            unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut MaybeUninit<f32>, 5) };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            simd::x86_ops::scale_and_copy_sse2(&src, dst_slice, 2.0)
         }));
 
         assert!(

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2969,59 +2969,6 @@ fn test_dot_product_sum_mismatch_panics() {
 }
 
 #[test]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn test_simd_mismatched_lengths_safety() {
-    let a = vec![1.0; 8];
-    let b = vec![1.0; 9];
-
-    // Test SSE2 if available (baseline for x86_64)
-    if is_x86_feature_detected!("sse2") {
-        let result = std::panic::catch_unwind(|| unsafe {
-            super::simd::x86_ops::dot_and_magnitudes_sse2(&a, &b)
-        });
-        assert!(
-            result.is_err(),
-            "SSE2 dot_and_magnitudes should panic on mismatch"
-        );
-
-        let result =
-            std::panic::catch_unwind(|| unsafe { super::simd::x86_ops::dot_product_sse2(&a, &b) });
-        assert!(result.is_err(), "SSE2 dot_product should panic on mismatch");
-
-        let result = std::panic::catch_unwind(|| unsafe {
-            super::simd::x86_ops::squared_diff_sum_sse2(&a, &b)
-        });
-        assert!(
-            result.is_err(),
-            "SSE2 squared_diff_sum should panic on mismatch"
-        );
-    }
-
-    // Test AVX2 if available
-    if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
-        let result = std::panic::catch_unwind(|| unsafe {
-            super::simd::x86_ops::dot_and_magnitudes_avx2(&a, &b)
-        });
-        assert!(
-            result.is_err(),
-            "AVX2 dot_and_magnitudes should panic on mismatch"
-        );
-
-        let result =
-            std::panic::catch_unwind(|| unsafe { super::simd::x86_ops::dot_product_avx2(&a, &b) });
-        assert!(result.is_err(), "AVX2 dot_product should panic on mismatch");
-
-        let result = std::panic::catch_unwind(|| unsafe {
-            super::simd::x86_ops::squared_diff_sum_avx2(&a, &b)
-        });
-        assert!(
-            result.is_err(),
-            "AVX2 squared_diff_sum should panic on mismatch"
-        );
-    }
-}
-
-#[test]
 fn test_sparse_squared_euclidean_distance_edge_cases() {
     struct TestCase {
         name: &'static str,


### PR DESCRIPTION
🎯 **Target:** AVX2 and SSE2 unsafe functions in `src/core/vector/simd.rs` (`dot_product_avx2`, `dot_product_sse2`, `dot_and_magnitudes_avx2`, `dot_and_magnitudes_sse2`, `squared_diff_sum_avx2`, `squared_diff_sum_sse2`, `scale_and_copy_avx2`, `scale_and_copy_sse2`).

💣 **Risk:** These `unsafe fn` functions process floating-point operations over memory arrays without bounds checking within their loops. They rely on the `assert_eq!(a.len(), b.len())` precondition to guarantee safety. If the precondition were bypassed or broken, it would lead to out-of-bounds reads/writes (Undefined Behavior).

🧪 **Strategy:** Extracted the previously singular `test_simd_mismatched_lengths_safety` from `tests.rs` into granular unit tests within `src/core/vector/havoc_tests.rs`. Added tests for *all* specific AVX2 and SSE2 vector methods taking two vector slices. Each test asserts that passing vectors of differing lengths immediately panics, verifying the panic boundary handles bad arguments explicitly before triggering UB. Used `std::panic::catch_unwind` with `std::panic::AssertUnwindSafe`.

🔬 **Verification:** `cargo test --lib core::vector::havoc_tests`

---
*PR created automatically by Jules for task [10622485029538933952](https://jules.google.com/task/10622485029538933952) started by @madmax983*