### PR TITLE
🗣️ Echo: Getting Started example has unused variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ pr_description.md
 
 # Re-include Python SDK sources (overrides "*.py" above)
 !python/**/*.py
+test_readme/

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -122,6 +122,8 @@ let (carol_id, dave_id) = db.write(|tx| -> Result<(NodeId, NodeId)> {
     tx.create_edge(carol, dave, "WORKS_WITH", properties! {})?;
     Ok((carol, dave))
 })?;
+
+println!("Created Carol: {:?} and Dave: {:?}", carol_id, dave_id);
 ```
 
 ---


### PR DESCRIPTION
🤦 **The Confusion:** When running the "README Run" by copy-pasting the examples from `docs/guides/getting-started.md` sequentially into a fresh `main.rs`, the compiler flags `carol_id` and `dave_id` as unused variables in the transaction example. This causes friction for new users.
🕵️‍♂️ **The Reality:** The variables are returned from the transaction closure but never logged or used in subsequent steps of the tutorial.
💡 **The Fix:** Added a `println!("Created Carol: {:?} and Dave: {:?}", carol_id, dave_id);` statement below the transaction block to utilize the variables legitimately without introducing confusing language-specific idioms (like underscore prefixing) to a beginner tutorial.

---
*PR created automatically by Jules for task [17596431581392034479](https://jules.google.com/task/17596431581392034479) started by @madmax983*