### PR TITLE
🎻 Bard: Fix broken intra-doc links in http and simulation modules

### DIFF
--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`crate::config::AletheiaDBConfig`] this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`Self::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: `http::config` and `simulation::clock` modules
🔦 Insight: Fixed unresolved intra-doc links that were causing `cargo doc` warnings. Replaced `[AletheiaDBConfig]` with `[crate::config::AletheiaDBConfig]` and `[jump_to]` with `[Self::jump_to]`.
🧪 Example: N/A - pure link resolution fixes.
🖼️ Preview: `cargo rustdoc --lib --all-features -- -W missing_docs` now passes with 0 warnings.

---
*PR created automatically by Jules for task [17958010302461698871](https://jules.google.com/task/17958010302461698871) started by @madmax983*