### PR TITLE
test: strengthen BinaryOp recursion logic testing in planner rules

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[Planner Rules BinaryOp Weak Assertions]**
+**Module:** `src/query/planner/rules/filter_scan_fusion.rs` and `src/query/planner/rules/operation_reordering.rs`
+**Severity:** 🟢 Acquitted (Strengthened)
+**Finding:** Both `FilterScanFusion` and `OperationReordering` had similar structural blindspots to `LimitPushdown` where `cargo mutants` could mutate the `left_changed || right_changed` logic in the `BinaryOp` match arm to `&&` and the tests would pass.
+**Evidence:** `cargo mutants` run against `FilterScanFusion` and `OperationReordering` showed that tests didn't explicitly check partial optimizations inside a `LogicalOp::Binary` branch propagating the `changed = true` flag.
+**Recommendation:** Added `test_binary_op_recursion_logic` sentry tests to both modules explicitly verifying that a `LogicalOp::Binary` returns a `changed = true` (by unwrapping the result appropriately in `apply` which checks `if changed`) when only one of its branches changes.

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -242,4 +242,42 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().temporal_context.is_some());
     }
+
+    #[test]
+    fn test_binary_op_recursion_logic() {
+        use crate::query::plan::BinaryOp;
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let left_op = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        let right_op = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Other".to_string()),
+            estimated_rows: None,
+        });
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left_op, right_op));
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Scan(ScanOp::PropertyScan {
+                label: "Person".to_string(),
+                key: "name".to_string(),
+                value: crate::query::ir::PredicateValue::String("Alice".to_string()),
+            }),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Other".to_string()),
+                estimated_rows: None,
+            }),
+        ));
+
+        assert_eq!(result, Some(expected_plan));
+    }
 }

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -1185,4 +1185,59 @@ mod tests {
             Predicate::Or(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
         );
     }
+
+    #[test]
+    fn test_binary_op_recursion_logic() {
+        use crate::query::plan::BinaryOp;
+        let rule = OperationReordering;
+        let stats = Statistics::new();
+
+        let left_scan = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Large".to_string()),
+            estimated_rows: Some(10000),
+        });
+
+        let right_scan = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Small".to_string()),
+            estimated_rows: Some(100),
+        });
+
+        let join_op = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "author".to_string(),
+                right_key: "id".to_string(),
+            },
+            left_scan.clone(),
+            right_scan.clone(),
+        );
+
+        let other_scan = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Other".to_string()),
+            estimated_rows: None,
+        });
+
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            join_op,
+            other_scan.clone(),
+        ));
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_join = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "id".to_string(), // Swapped keys
+                right_key: "author".to_string(),
+            },
+            right_scan.clone(),
+            left_scan.clone(),
+        );
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            expected_join,
+            other_scan,
+        ));
+
+        assert_eq!(result, Some(expected_plan));
+    }
 }


### PR DESCRIPTION
This PR addresses a testing blindspot in the query planner rules. Specifically, the `left_changed || right_changed` logic inside the `BinaryOp` match arm of both `FilterScanFusion` and `OperationReordering` was weak and could be mutated to `&&` without failing existing tests.

Changes:
* Added `test_binary_op_recursion_logic` to `FilterScanFusion` and `OperationReordering` to explicitly verify partial optimization propagation.
* Updated `.jules/elenchus.md` with the verdict and evidence.

---
*PR created automatically by Jules for task [8101238090459293613](https://jules.google.com/task/8101238090459293613) started by @madmax983*