### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/docs/analysis/DX_REPORT.md
+++ b/docs/analysis/DX_REPORT.md
@@ -59,7 +59,7 @@ See `examples/echo_complaint.rs`.
 **Recommendation:** Add a comment directly in the code snippets in the README:
 ```rust
 // Requires "nova" feature in Cargo.toml
-use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
+use aletheiadb::experimental::temporal::temporal_narrative::NarrativeGenerator;
 ```
 This catches the eye during copy-paste more effectively than a blockquote above the block.
 

--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -27,7 +27,7 @@ use aletheiadb::WriteOps;
 // ⚠️ REQUIRES FEATURE 'NOVA' IN CARGO.TOML
 // [dependencies]
 // aletheiadb = { version = "0.1", features = ["nova"] }
-use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
+use aletheiadb::experimental::temporal::temporal_narrative::NarrativeGenerator;
 use aletheiadb::properties;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
🤦 **The Confusion:** "Tried to run the `story_demo`. Compiler said `NarrativeGenerator` not found."

🕵️‍♂️ **The Reality:** "Turns out the import path in `examples/story_demo.rs` and the documentation in `docs/analysis/DX_REPORT.md` was outdated and incorrect, pointing to `aletheiadb::experimental::temporal_narrative::NarrativeGenerator` instead of `aletheiadb::experimental::temporal::temporal_narrative::NarrativeGenerator`."

💡 **The Fix:** "Fixed the import path to match the current module structure so that the example compiles and runs."

---
*PR created automatically by Jules for task [12621388509951099026](https://jules.google.com/task/12621388509951099026) started by @madmax983*