### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-06-25 - [Intra-doc links failing to resolve in `ServerConfig` and `SimulatedClock`]
+**Confusion:** Intra-doc links to `[`AletheiaDBConfig`]` in `src/http/config.rs` and `[`jump_to`]` in `src/simulation/clock.rs` caused `rustdoc::broken_intra_doc_links` warnings because they were not explicitly scoped. The compiler couldn't locate `AletheiaDBConfig` from the local scope, and `jump_to` wasn't correctly identified as an associated method of `SimulatedClock`.
+**Clarification:** I updated the intra-doc links to use explicit paths. `[`AletheiaDBConfig`]` was changed to `[`crate::config::AletheiaDBConfig`]` and `[`jump_to`]` was changed to `[`Self::jump_to`]`. This explicitly scopes the links and resolves the warnings.

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`crate::config::AletheiaDBConfig`] this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`Self::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: The `HTTP` and `Simulation` modules
🔦 Insight: Fixed `rustdoc::broken_intra_doc_links` warnings by correctly scoping `AletheiaDBConfig` to `crate::config::AletheiaDBConfig` in `src/http/config.rs` and `jump_to` to `Self::jump_to` in `src/simulation/clock.rs`.
🧪 Example: N/A (Internal documentation link fix)
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [9296086954061781923](https://jules.google.com/task/9296086954061781923) started by @madmax983*