### PR TITLE
⚡ Bolt: Optimize WalRingBuffer::drain by pre-allocating result Vec capacity

### DIFF
--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -694,7 +694,12 @@ impl WalRingBuffer {
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate Vec capacity based on available entries to prevent intermediate heap reallocations.
+        let write_pos = self.write_pos.load(Ordering::Relaxed);
+        let read_pos = self.read_pos.load(Ordering::Relaxed);
+        let available = write_pos.saturating_sub(read_pos) as usize;
+        let capacity = available.min(self.capacity);
+        let mut entries = Vec::with_capacity(capacity);
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
💡 What: Replaced `let mut entries = Vec::new();` with `let mut entries = Vec::with_capacity(capacity);` in `WalRingBuffer::drain()`, dynamically calculating the capacity based on the difference between the current write and read positions.

🎯 Why: In high-throughput concurrent logging environments like the WAL, repeatedly draining pending entries into a dynamically resizing `Vec` causes unnecessary intermediate heap reallocations (e.g., allocating capacity for 0, then 4, 8, 16, etc. elements). Pre-allocating the vector size avoids these allocations since the maximum number of items to be drained can be precisely estimated upfront.

📊 Impact: Reduces heap allocations for every single flush cycle of the `WalRingBuffer`. This contributes to a more consistent latency profile during heavy write workloads.

🔬 Measurement: Verified the safety and correctness by ensuring all `cargo test --lib -- storage::wal::ring_buffer` tests pass and `cargo clippy` emits no warnings. The calculation safely defaults to `0` capacity via `saturating_sub` in edge cases.

---
*PR created automatically by Jules for task [10206099554289048937](https://jules.google.com/task/10206099554289048937) started by @madmax983*