### PR TITLE
⚡ Bolt: [performance improvement] optimize take_n vector pre-allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize Vector Pre-allocation with size_hint**
+**Learning:** In `take_n`, the capacity size can safely be constrained by the upper bound of the `size_hint` of the iterator to avoid arbitrarily large allocations that won't be filled.
+**Action:** Always constrain pre-allocation sizes to realistic maximums where `size_hint` allows (e.g. `n.min(upper.unwrap_or(n))`).

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -290,7 +290,11 @@ impl QueryResults {
     /// **Why?** When you only need a handful of answers from an unbounded traversal
     /// or massive dataset, this stops execution early.
     pub fn take_n(mut self, n: usize) -> Result<Vec<QueryRow>> {
-        let mut results = Vec::with_capacity(n);
+        // ⚡ Bolt Optimization: Bound the pre-allocated capacity by the iterator's size hint
+        // to prevent large allocations when taking many items from a small stream.
+        let (_, upper) = self.iterator.size_hint();
+        let capacity = n.min(upper.unwrap_or(n));
+        let mut results = Vec::with_capacity(capacity);
         for _ in 0..n {
             match self.iterator.next() {
                 Some(Ok(row)) => results.push(row),


### PR DESCRIPTION
💡 What: Bound `Vec::with_capacity` in `QueryResults::take_n` to the iterator's `size_hint` upper bound.

🎯 Why: Calling `take_n` on an iterator with a small stream of items using a large `n` (e.g. `LIMIT 10000` on a 5-item stream) allocated unused vector memory upfront.

📊 Impact: Prevents memory overallocation during large `take_n` queries over small data streams.

🔬 Measurement: Cargo tests passed and verify semantics hold while eliminating the unused heap allocation capacity.

---
*PR created automatically by Jules for task [3703293316977942001](https://jules.google.com/task/3703293316977942001) started by @madmax983*