### PR TITLE
🗣️ Echo: Nova's story feature example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Averages across 30–212 datapoints of continuous CI runs:
 
 ## Feature Flags
 
+> **⚠️ REQUIRES FEATURE NOVA**: Experimental modules like the Narrative Generator require the `nova` feature.
+
 All features are off by default except `config-toml`.
 
 | Flag | What it enables |

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -92,9 +92,7 @@ pub mod reasoning;
 #[cfg(feature = "semantic-reasoning")]
 pub use reasoning::*;
 
-#[cfg(feature = "semantic-temporal")]
 pub mod temporal;
-#[cfg(feature = "semantic-temporal")]
 pub use temporal::*;
 
 #[cfg(feature = "semantic-diagnostics")]

--- a/src/experimental/temporal/mod.rs
+++ b/src/experimental/temporal/mod.rs
@@ -6,13 +6,21 @@
 //!
 //! Experimental — gated by `features = ["semantic-temporal"]` (or the `nova` umbrella).
 
+#[cfg(feature = "semantic-temporal")]
 pub mod ariadne;
+#[cfg(feature = "semantic-temporal")]
 pub mod aura;
+#[cfg(feature = "semantic-temporal")]
 pub mod chronos;
+#[cfg(feature = "semantic-temporal")]
 pub mod echo;
+#[cfg(feature = "semantic-temporal")]
 pub mod kairos;
+#[cfg(feature = "semantic-temporal")]
 pub mod mnemosyne;
+#[cfg(feature = "semantic-temporal")]
 pub mod sherlock;
+#[cfg(feature = "semantic-temporal")]
 pub mod temporal_diff;
 /// Temporal narrative generator: natural-language history logs from version diffs.
 pub mod temporal_narrative;


### PR DESCRIPTION
* 🤦 **The Confusion:** "Tried to run the `story_demo`. Compiler said `NarrativeGenerator` not found."
* 🕵️ **The Reality:** "Turns out I needed to enable feature `nova`. The compiler error was unhelpful because the deprecation stub was hidden behind the feature gate."
* 💡 **The Fix:** "Exposed the stub unconditionally so the compiler correctly warns users to add `nova` to their Cargo.toml, and added a huge banner in README saying 'REQUIRES FEATURE NOVA'."

---
*PR created automatically by Jules for task [3169497990145272398](https://jules.google.com/task/3169497990145272398) started by @madmax983*