### PR TITLE
🪒 Razor: De-abstract Resonator trait to concrete struct

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+
+## [Reduction]
+**Bloat:** `Resonator` trait in `src/experimental/temporal/echo.rs` (Single-implementation trait used only by `ActivityDensityResonator`).
+**Cut:** Deleted the `Resonator` trait. Refactored `ActivityDensityResonator` to implement `resonate` directly and updated `EchoChamber` to use the concrete struct instead of dynamic dispatch via `Box<dyn Resonator>`.
+**Saved:** ~20 lines of boilerplate, removed dynamic dispatch overhead, simplified object creation.

--- a/src/experimental/temporal/echo.rs
+++ b/src/experimental/temporal/echo.rs
@@ -81,12 +81,6 @@ impl TemporalFingerprint {
     }
 }
 
-/// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -98,7 +92,7 @@ pub trait Resonator {
 /// ```
 /// # #[cfg(feature = "semantic-temporal")]
 /// # fn main() {
-/// use aletheiadb::experimental::echo::{ActivityDensityResonator, Resonator};
+/// use aletheiadb::experimental::echo::ActivityDensityResonator;
 ///
 /// let resonator = ActivityDensityResonator {
 ///     window_size_us: 3600 * 1_000_000, // 1 hour
@@ -124,8 +118,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -202,7 +197,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "semantic-temporal"))]
@@ -251,13 +246,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -318,7 +313,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
## What
De-abstracted the single-implementation `Resonator` trait in `src/experimental/temporal/echo.rs` into its concrete implementation `ActivityDensityResonator`.

## Why
This implements the "Keep It Simple, Stupid" (KISS) principle by deleting speculative generality. The `Resonator` trait had exactly one implementation, making the abstraction unnecessary and introducing unneeded dynamic dispatch via `Box<dyn Resonator>`. 

## How
1. Removed `pub trait Resonator` from `echo.rs`.
2. Changed the `impl Resonator for ActivityDensityResonator` block to just `impl ActivityDensityResonator` and made the `resonate` method public.
3. Updated `EchoChamber` to hold `ActivityDensityResonator` directly by value.
4. Updated `EchoChamber::with_resonator` to accept the concrete type.
5. Adjusted all associated tests to pass without the trait.
6. Added an entry to `.jules/razor.md` documenting this simplification.

## Verification
- Ran `cargo check --lib --features nova` successfully.
- Ran `cargo test --lib --features nova echo` successfully.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` successfully.

---
*PR created automatically by Jules for task [14544425437434455417](https://jules.google.com/task/14544425437434455417) started by @madmax983*