### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -166,33 +166,38 @@ AletheiaDB stores dense vector embeddings as node properties and indexes them
 with HNSW for fast k-NN search. Enable the index before inserting nodes.
 
 ```rust
-use aletheiadb::{AletheiaDB, HnswConfig, DistanceMetric};
+use aletheiadb::prelude::*;
+use aletheiadb::{HnswConfig, DistanceMetric};
 
-let db = AletheiaDB::new()?;
+fn main() -> Result<()> {
+    let db = AletheiaDB::new()?;
 
-// Enable HNSW indexing on the "embedding" property
-db.vector_index("embedding")
-    .hnsw(HnswConfig::new(384, DistanceMetric::Cosine))
-    .enable()?;
+    // Enable HNSW indexing on the "embedding" property
+    db.vector_index("embedding")
+        .hnsw(HnswConfig::new(384, DistanceMetric::Cosine))
+        .enable()?;
 
-let v1 = vec![0.1f32; 384];
-let v2 = vec![0.9f32; 384]; // very different from v1
+    let v1 = vec![0.1f32; 384];
+    let v2 = vec![0.9f32; 384]; // very different from v1
 
-let doc1 = db.create_node("Document", properties! {
-    "title"     => "Intro to Rust",
-    "embedding" => &v1[..],
-})?;
+    let doc1 = db.create_node("Document", properties! {
+        "title"     => "Intro to Rust",
+        "embedding" => &v1[..],
+    })?;
 
-let _doc2 = db.create_node("Document", properties! {
-    "title"     => "Advanced Rust",
-    "embedding" => &v2[..],
-})?;
+    let _doc2 = db.create_node("Document", properties! {
+        "title"     => "Advanced Rust",
+        "embedding" => &v2[..],
+    })?;
 
-// Find the 10 nodes most similar to doc1
-// (doc1 itself is excluded from results)
-let similar = db.find_similar(doc1, 10)?;
-for (node_id, score) in similar {
-    println!("Node {:?} similarity: {:.3}", node_id, score);
+    // Find the 10 nodes most similar to doc1
+    // (doc1 itself is excluded from results)
+    let similar = db.find_similar(doc1, 10)?;
+    for (node_id, score) in similar {
+        println!("Node {:?} similarity: {:.3}", node_id, score);
+    }
+
+    Ok(())
 }
 ```
 
@@ -203,23 +208,31 @@ for (node_id, score) in similar {
 All three dimensions can be combined in a single query:
 
 ```rust
+use aletheiadb::prelude::*;
 use aletheiadb::time;
 
-let query_embedding = vec![0.1f32; 384];
-let t = time::now();
+fn main() -> Result<()> {
+    let db = AletheiaDB::new()?;
+    let alice_id = db.create_node("Person", properties! { "name" => "Alice" })?;
 
-// "Who does Alice know (graph), ranked by semantic similarity to my embedding
-//  (vector), as of a specific point in time (temporal)?"
-let results = db.query()
-    .as_of(t, t)                                      // temporal
-    .start(alice_id)                                  // graph: start node
-    .traverse("KNOWS")                                // graph: hop
-    .rank_by_similarity(&query_embedding, 10)         // vector: re-rank
-    .execute(&db)?;
+    let query_embedding = vec![0.1f32; 384];
+    let t = time::now();
 
-for row in results {
-    let row = row?;
-    println!("Found {:?} with score {:?}", row.entity, row.score);
+    // "Who does Alice know (graph), ranked by semantic similarity to my embedding
+    //  (vector), as of a specific point in time (temporal)?"
+    let results = db.query()
+        .as_of(t, t)                                      // temporal
+        .start(alice_id)                                  // graph: start node
+        .traverse("KNOWS")                                // graph: hop
+        .rank_by_similarity(&query_embedding, 10)         // vector: re-rank
+        .execute(&db)?;
+
+    for row in results {
+        let row = row?;
+        println!("Found {:?} with score {:?}", row.entity, row.score);
+    }
+
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
🤦 **The Confusion:** 
While reading the `docs/guides/getting-started.md`, a user copying the code snippets for Vector Search and Hybrid Queries directly into a fresh `main.rs` file encountered compilation errors. Specifically, the compiler complained about missing `properties` macros and undefined references to `db` or `alice_id` because the snippets lacked necessary imports and initialization boilerplate. 
 
🕵️‍♂️ **The Reality:** 
The code snippets were written under the assumption that the user was continuously appending to the same `main.rs` block from earlier steps. However, according to the strict DX audit "README Run" standard, every copy-paste example should be self-contained and independently compilable.

💡 **The Fix:** 
Updated the code blocks in `docs/guides/getting-started.md` by wrapping them within fully formed `fn main() -> Result<()> { ... }` blocks, adding the necessary `use aletheiadb::prelude::*;` imports, and ensuring `db` setup and context variables are clearly defined in the example scope.

---
*PR created automatically by Jules for task [7609587720302494190](https://jules.google.com/task/7609587720302494190) started by @madmax983*