### PR TITLE
🛡️ Sentry: Map RwLock PoisonError in Mock clients

### DIFF
--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -1315,11 +1315,16 @@ impl MockVectorNodeClient {
 
     /// Make the next operation fail.
     pub fn fail_next(&self, error: impl Into<String>) {
-        *self.fail_next.write().unwrap() = Some(error.into());
+        let mut fail_guard = self.fail_next.write().unwrap_or_else(|e| e.into_inner());
+        *fail_guard = Some(error.into());
     }
 
     fn check_fail(&self) -> Result<()> {
-        if let Some(err) = self.fail_next.write().unwrap().take() {
+        let mut fail_guard = self
+            .fail_next
+            .write()
+            .map_err(|_| Error::Vector(VectorError::IndexError("Lock poisoned".into())))?;
+        if let Some(err) = fail_guard.take() {
             return Err(Error::Vector(VectorError::IndexError(err)));
         }
         Ok(())
@@ -1381,7 +1386,11 @@ impl VectorNodeClient for MockVectorNodeClient {
             }));
         }
 
-        self.vectors.write().unwrap().insert(id, vector.to_vec());
+        let mut vectors_guard = self
+            .vectors
+            .write()
+            .map_err(|_| Error::Vector(VectorError::IndexError("Lock poisoned".into())))?;
+        vectors_guard.insert(id, vector.to_vec());
         Ok(())
     }
 
@@ -1395,7 +1404,11 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))));
         }
 
-        self.vectors.write().unwrap().remove(&id);
+        let mut vectors_guard = self
+            .vectors
+            .write()
+            .map_err(|_| Error::Vector(VectorError::IndexError("Lock poisoned".into())))?;
+        vectors_guard.remove(&id);
         Ok(())
     }
 
@@ -1409,7 +1422,10 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))));
         }
 
-        let vectors = self.vectors.read().unwrap();
+        let vectors = self
+            .vectors
+            .read()
+            .map_err(|_| Error::Vector(VectorError::IndexError("Lock poisoned".into())))?;
         let mut results: Vec<(NodeId, f32)> = vectors
             .iter()
             .map(|(id, vec)| (*id, self.compute_similarity(query, vec)))
@@ -1431,7 +1447,11 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))));
         }
 
-        Ok(self.vectors.read().unwrap().len())
+        Ok(self
+            .vectors
+            .read()
+            .map_err(|_| Error::Vector(VectorError::IndexError("Lock poisoned".into())))?
+            .len())
     }
 
     fn health_check(&self) -> Result<()> {
@@ -2547,5 +2567,55 @@ mod tests {
         assert!(!index.needs_rebalancing(RECOMMENDED_IMBALANCE_THRESHOLD));
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests_poisoning {
+    use super::*;
+
+    #[test]
+    fn test_mock_vector_node_client_poison_graceful_degradation() {
+        let client = MockVectorNodeClient::new(0, 128, DistanceMetric::Cosine);
+
+        // Intentionally poison the vectors lock
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = client.vectors.write().unwrap();
+            panic!("Poisoning the vectors lock");
+        });
+
+        // Ensure methods mapped correctly without panicking
+        let id = NodeId::new(1).unwrap();
+        let vec = vec![0.1f32; 128];
+        let add_res = client.add(id, &vec);
+        assert!(
+            matches!(add_res, Err(Error::Vector(VectorError::IndexError(msg))) if msg == "Lock poisoned")
+        );
+
+        let remove_res = client.remove(id);
+        assert!(
+            matches!(remove_res, Err(Error::Vector(VectorError::IndexError(msg))) if msg == "Lock poisoned")
+        );
+
+        let search_res = client.search(&vec, 10);
+        assert!(
+            matches!(search_res, Err(Error::Vector(VectorError::IndexError(msg))) if msg == "Lock poisoned")
+        );
+
+        let len_res = client.len();
+        assert!(
+            matches!(len_res, Err(Error::Vector(VectorError::IndexError(msg))) if msg == "Lock poisoned")
+        );
+
+        // Intentionally poison the fail_next lock
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = client.fail_next.write().unwrap();
+            panic!("Poisoning the fail_next lock");
+        });
+
+        let check_res = client.check_fail();
+        assert!(
+            matches!(check_res, Err(Error::Vector(VectorError::IndexError(msg))) if msg == "Lock poisoned")
+        );
     }
 }

--- a/src/storage/sharding/network.rs
+++ b/src/storage/sharding/network.rs
@@ -683,72 +683,99 @@ impl MockShardClient {
 
     /// Set whether the client is healthy.
     pub fn set_healthy(&self, healthy: bool) {
-        *self.healthy.write().unwrap() = healthy;
+        let mut h = self.healthy.write().unwrap_or_else(|e| e.into_inner());
+        *h = healthy;
     }
 
     /// Set the prepare response.
     pub fn set_prepare_response(&self, response: PrepareResponse) {
-        *self.prepare_response.write().unwrap() = Some(response);
+        let mut r = self
+            .prepare_response
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        *r = Some(response);
     }
 
     /// Set the commit response.
     pub fn set_commit_response(&self, response: CommitResponse) {
-        *self.commit_response.write().unwrap() = Some(response);
+        let mut r = self
+            .commit_response
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        *r = Some(response);
     }
 
     /// Set the abort response.
     pub fn set_abort_response(&self, response: AbortResponse) {
-        *self.abort_response.write().unwrap() = Some(response);
+        let mut r = self
+            .abort_response
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        *r = Some(response);
     }
 
     /// Set the query response.
     pub fn set_query_response(&self, response: Vec<u8>) {
-        *self.query_response.write().unwrap() = response;
+        let mut r = self
+            .query_response
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        *r = response;
     }
 
     /// Set the shard state.
     pub fn set_state(&self, state: ShardState) {
-        *self.state.write().unwrap() = state;
+        let mut s = self.state.write().unwrap_or_else(|e| e.into_inner());
+        *s = state;
     }
 
     /// Set simulated latency.
     pub fn set_latency(&self, latency: Duration) {
-        *self.latency.write().unwrap() = latency;
+        let mut l = self.latency.write().unwrap_or_else(|e| e.into_inner());
+        *l = latency;
     }
 
     /// Make the next call fail with the given error.
     pub fn fail_next(&self, error: NetworkError) {
-        *self.fail_next.write().unwrap() = Some(error);
+        let mut f = self.fail_next.write().unwrap_or_else(|e| e.into_inner());
+        *f = Some(error);
     }
 
     /// Get call count for a method.
     pub fn call_count(&self, method: &str) -> usize {
         self.call_counts
             .read()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .get(method)
             .copied()
             .unwrap_or(0)
     }
 
     fn increment_call(&self, method: &str) {
-        let mut counts = self.call_counts.write().unwrap();
+        let mut counts = self.call_counts.write().unwrap_or_else(|e| e.into_inner());
         *counts.entry(method.to_string()).or_insert(0) += 1;
     }
 
     fn check_fail(&self) -> NetworkResult<()> {
-        let mut fail = self.fail_next.write().unwrap();
+        let mut fail = self
+            .fail_next
+            .write()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?;
         if let Some(err) = fail.take() {
             return Err(err);
         }
         Ok(())
     }
 
-    fn simulate_latency(&self) {
-        let latency = *self.latency.read().unwrap();
+    fn simulate_latency(&self) -> NetworkResult<()> {
+        let latency = *self
+            .latency
+            .read()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?;
         if latency > Duration::ZERO {
             std::thread::sleep(latency);
         }
+        Ok(())
     }
 }
 
@@ -758,7 +785,7 @@ impl ShardClient for MockShardClient {
     }
 
     fn is_healthy(&self) -> bool {
-        *self.healthy.read().unwrap()
+        self.healthy.read().map(|h| *h).unwrap_or(false)
     }
 
     fn prepare(
@@ -774,11 +801,11 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
+        self.simulate_latency()?;
 
         self.prepare_response
             .read()
-            .unwrap()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
             .clone()
             .ok_or(NetworkError::ProtocolError("No response configured".into()))
     }
@@ -795,11 +822,11 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
+        self.simulate_latency()?;
 
         self.commit_response
             .read()
-            .unwrap()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
             .clone()
             .ok_or(NetworkError::ProtocolError("No response configured".into()))
     }
@@ -812,11 +839,11 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
+        self.simulate_latency()?;
 
         self.abort_response
             .read()
-            .unwrap()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
             .clone()
             .ok_or(NetworkError::ProtocolError("No response configured".into()))
     }
@@ -829,8 +856,13 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
-        Ok(self.query_response.read().unwrap().clone())
+        self.simulate_latency()?;
+        let resp = self
+            .query_response
+            .read()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
+            .clone();
+        Ok(resp)
     }
 
     fn get_state(&self) -> NetworkResult<ShardState> {
@@ -841,8 +873,13 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
-        Ok(self.state.read().unwrap().clone())
+        self.simulate_latency()?;
+        let state = self
+            .state
+            .read()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
+            .clone();
+        Ok(state)
     }
 
     fn receive_migration_batch(&self, batch: MigrationBatch) -> NetworkResult<MigrationResponse> {
@@ -853,7 +890,7 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
+        self.simulate_latency()?;
         Ok(MigrationResponse {
             accepted: true,
             nodes_written: batch.nodes.len() as u64,
@@ -876,7 +913,7 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
+        self.simulate_latency()?;
 
         // Return empty batch (simulating end of data)
         Ok(MigrationBatch {
@@ -897,7 +934,7 @@ impl ShardClient for MockShardClient {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
 
-        self.simulate_latency();
+        self.simulate_latency()?;
         Ok(())
     }
 }
@@ -1293,5 +1330,44 @@ mod tests {
 
         client.set_healthy(false);
         assert!(client.health_check().is_err());
+    }
+}
+
+#[cfg(test)]
+mod tests_poisoning {
+    use super::*;
+
+    #[test]
+    fn test_mock_shard_client_poison_graceful_degradation() {
+        let client = MockShardClient::new(ShardId::new(1).unwrap());
+
+        // Intentionally poison the lock
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = client.healthy.write().unwrap();
+            panic!("Poisoning the healthy lock");
+        });
+
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = client.prepare_response.write().unwrap();
+            panic!("Poisoning the prepare_response lock");
+        });
+
+        // Ensure it doesn't panic, but rather handles it gracefully
+        assert!(!client.is_healthy()); // mapped to false
+
+        // Because `is_healthy` gracefully degraded to `false`,
+        // the client behaves as unavailable.
+        let result = client.prepare(TxId::new(1), &[], None);
+        assert!(matches!(result, Err(NetworkError::ShardUnavailable(_))));
+
+        // Let's also test a poisoned `prepare_response` independently.
+        let client2 = MockShardClient::new(ShardId::new(2).unwrap());
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = client2.prepare_response.write().unwrap();
+            panic!("Poisoning the prepare_response lock");
+        });
+
+        let result2 = client2.prepare(TxId::new(1), &[], None);
+        assert!(matches!(result2, Err(NetworkError::ProtocolError(msg)) if msg == "Lock poisoned"));
     }
 }


### PR DESCRIPTION
🛡️ Sentry: Map RwLock PoisonError in Mock clients

## Target
`MockVectorNodeClient` in `src/index/vector/distributed.rs`
`MockShardClient` in `src/storage/sharding/network.rs`

## Risk
Using `.unwrap()` on `RwLock` guards poses a significant availability risk in multi-threaded database systems. If a thread panics while holding the lock (e.g., during simulated tests or network faults), the lock becomes poisoned. Subsequent threads accessing the mock clients will also crash upon calling `unwrap()`, turning a localized error into a systemic crash.

## Strategy
Replaced all `.unwrap()` calls on `RwLock` results:
- For mock state setters (e.g. `set_healthy`), used `.unwrap_or_else(|e| e.into_inner())` to safely clear the poison state and proceed, which is acceptable in mock setups to allow testing to continue.
- For mock execution methods (e.g., `prepare`, `search`, `add`), explicitly mapped lock poisoning errors to domain-specific protocol errors (`NetworkError::ProtocolError` and `Error::Vector(VectorError::IndexError)`), gracefully rejecting operations instead of crashing the system.
- Added explicit unit tests verifying that panicking while holding the lock triggers graceful error degradation instead of downstream panics.

## Verification
`cargo test --lib storage::sharding::network index::vector::distributed`

---
*PR created automatically by Jules for task [5205973068012436858](https://jules.google.com/task/5205973068012436858) started by @madmax983*