### PR TITLE
🎻 Bard: [documentation update] Add doc-tests for transaction visibility and buffers

### DIFF
--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -21,6 +21,29 @@ use std::sync::{Arc, Mutex, PoisonError};
 /// overhead when capturing snapshots. With N concurrent transactions, cloning
 /// a HashSet containing N elements on every transaction creation was creating
 /// quadratic scaling. Arc allows cheap snapshot captures (just Arc clone).
+///
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::api::transaction::{TransactionSnapshot, TxId};
+/// use aletheiadb::core::temporal::Timestamp;
+/// use std::collections::HashSet;
+/// use std::sync::Arc;
+///
+/// let mut active = HashSet::new();
+/// active.insert(TxId::new(42));
+///
+/// let snapshot = TransactionSnapshot {
+///     snapshot_timestamp: Timestamp::from(100),
+///     active_transactions: Arc::new(active),
+/// };
+///
+/// // A version committed at timestamp 50 by TxId 10 is visible
+/// assert!(snapshot.is_visible(TxId::new(10), Some(Timestamp::from(50))));
+///
+/// // A version created by the active TxId 42 is not visible
+/// assert!(!snapshot.is_visible(TxId::new(42), Some(Timestamp::from(50))));
+/// ```
 #[derive(Debug, Clone)]
 pub struct TransactionSnapshot {
     /// Timestamp when snapshot was taken
@@ -77,6 +100,26 @@ impl TransactionSnapshot {
 /// The `active` set uses `Arc`-wrapping with copy-on-write semantics (Issue #221):
 /// snapshot capture is O(1) (just an `Arc` clone), while mutations clone only when
 /// the `Arc` is shared.
+///
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::api::transaction::{TxVisibilityManager, TxId};
+/// use aletheiadb::core::temporal::Timestamp;
+///
+/// let manager = TxVisibilityManager::new();
+///
+/// // Register a new active transaction
+/// manager.register_active(TxId::new(1));
+/// assert_eq!(manager.active_count(), 1);
+///
+/// // Capture a snapshot for a new transaction starting at timestamp 100
+/// let snapshot = manager.capture_snapshot(Timestamp::from(100));
+///
+/// // Register commit removes it from the active set
+/// manager.register_commit(TxId::new(1));
+/// assert_eq!(manager.active_count(), 0);
+/// ```
 pub struct TxVisibilityManager {
     /// Currently active (not yet committed or aborted) transactions.
     ///

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -22,6 +22,26 @@ type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<IdentityHasher>>;
 /// but not `transaction_time` (which is only known at commit time). This enables
 /// true bi-temporal semantics where valid_time can be backdated independently
 /// of when the transaction commits.
+///
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::api::transaction::BufferedWrite;
+/// use aletheiadb::core::id::{NodeId, VersionId};
+/// use aletheiadb::core::property::PropertyMapBuilder;
+/// use aletheiadb::core::temporal::Timestamp;
+/// use aletheiadb::core::interning::GLOBAL_INTERNER;
+///
+/// let write = BufferedWrite::CreateNode {
+///     node_id: NodeId::new(1).unwrap(),
+///     version_id: VersionId::new(1).unwrap(),
+///     label: GLOBAL_INTERNER.intern("Person").unwrap(),
+///     properties: PropertyMapBuilder::new().build(),
+///     valid_from: Timestamp::from(100),
+/// };
+///
+/// assert!(write.is_node_operation());
+/// ```
 #[derive(Debug, Clone)]
 pub enum BufferedWrite {
     /// Create a new node
@@ -165,6 +185,30 @@ pub const DEFAULT_MAX_OPERATIONS: usize = 50_000;
 ///
 /// Buffers all write operations in a transaction until commit time,
 /// enabling atomicity and validation before applying changes.
+///
+/// # Examples
+///
+/// ```rust
+/// use aletheiadb::api::transaction::{WriteBuffer, BufferedWrite};
+/// use aletheiadb::core::id::{NodeId, VersionId};
+/// use aletheiadb::core::property::PropertyMapBuilder;
+/// use aletheiadb::core::temporal::Timestamp;
+/// use aletheiadb::core::interning::GLOBAL_INTERNER;
+///
+/// let mut buffer = WriteBuffer::new();
+///
+/// let write = BufferedWrite::CreateNode {
+///     node_id: NodeId::new(1).unwrap(),
+///     version_id: VersionId::new(1).unwrap(),
+///     label: GLOBAL_INTERNER.intern("Person").unwrap(),
+///     properties: PropertyMapBuilder::new().build(),
+///     valid_from: Timestamp::from(100),
+/// };
+///
+/// buffer.add(write).unwrap();
+/// assert_eq!(buffer.len(), 1);
+/// assert!(buffer.has_modified_node(NodeId::new(1).unwrap()));
+/// ```
 pub struct WriteBuffer {
     /// Buffered operations in order
     operations: Vec<BufferedWrite>,


### PR DESCRIPTION
📖 Chapter: Core transaction visibility and write buffer structures.
🔦 Insight: Demonstrated exactly how to instantiate and utilize `TransactionSnapshot`, `TxVisibilityManager`, `WriteBuffer`, and `BufferedWrite`, ensuring users don't have to read the source to understand how `valid_from` timestamps or snapshot isolation mechanisms work.
🧪 Example: Added 4 executable doc-tests.
🖼️ Preview: Evaluated by `cargo doc --no-deps`.

---
*PR created automatically by Jules for task [10816514343440844409](https://jules.google.com/task/10816514343440844409) started by @madmax983*