### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ All features are off by default except `config-toml`.
 aletheiadb = { version = "0.1", features = ["nova", "semantic-search"] }
 ```
 
+> ⚠️ **REQUIRES FEATURE NOVA** ⚠️
+> If you are trying to run experimental examples like `story_demo`, they will fail to compile unless you explicitly enable the `nova` feature:
+> ```bash
+> cargo run --example story_demo --features nova
+> ```
+
 ---
 
 ## Documentation


### PR DESCRIPTION
Added a prominent warning in the README.md clarifying that experimental examples like `story_demo` require the `nova` feature to compile and run. This improves Developer Experience by preventing errors when running examples directly from the documentation.

---
*PR created automatically by Jules for task [14349129409577919514](https://jules.google.com/task/14349129409577919514) started by @madmax983*