### PR TITLE
🛡️ Sentry: observer.rs test coverage improvement

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,11 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+
+## StorageEvent Enum Variants Coverage Gap
+**Learning:** `test_event_timestamp` and `is_anchor_event` in `src/core/observer.rs` were only testing the `NodeAnchorCreated` variant, leaving `EdgeAnchorCreated`, `NodeVersionCreated`, and `EdgeVersionCreated` completely untested. This represents a significant coverage gap where refactoring the `StorageEvent` enum fields could easily break `timestamp()` or `is_anchor_event()` logic without triggering any test failures.
+**Action:** When writing tests for methods on an Enum (especially large match statements or macros like `matches!`), always ensure there is a table-driven or exhaustive test case that explicitly exercises every single variant, especially when the variants contain similar or overlapping data fields.
+
+## notify_observers Error Handling Gap
+**Learning:** The `notify_observers` function handles errors from observers by safely matching on `Error::Vector` and logging it differently than other errors. However, this specific error matching path was completely untested. `sentry_error_does_not_block_subsequent_observers` only used `Error::Other`.
+**Action:** When a function explicitly matches on and handles specific error variants differently (even just for logging), always write tests that intentionally return those exact error variants (like `VectorError::InvalidVector`) from mocks to ensure the error handling logic itself does not panic or misbehave, and that the execution loop continues as expected.

--- a/src/core/observer.rs
+++ b/src/core/observer.rs
@@ -528,13 +528,65 @@ mod tests {
 
     #[test]
     fn test_event_timestamp() {
-        let event = StorageEvent::NodeAnchorCreated {
+        let events = vec![
+            StorageEvent::NodeAnchorCreated {
+                version_id: VersionId::new(1).unwrap(),
+                node_id: NodeId::new(1).unwrap(),
+                timestamp: 12345.into(),
+            },
+            StorageEvent::EdgeAnchorCreated {
+                version_id: VersionId::new(1).unwrap(),
+                edge_id: crate::core::id::EdgeId::new(1).unwrap(),
+                timestamp: 12345.into(),
+            },
+            StorageEvent::NodeVersionCreated {
+                version_id: VersionId::new(2).unwrap(),
+                node_id: NodeId::new(1).unwrap(),
+                timestamp: 12345.into(),
+                is_anchor: false,
+            },
+            StorageEvent::EdgeVersionCreated {
+                version_id: VersionId::new(2).unwrap(),
+                edge_id: crate::core::id::EdgeId::new(1).unwrap(),
+                timestamp: 12345.into(),
+                is_anchor: false,
+            },
+        ];
+
+        for event in events {
+            assert_eq!(event.timestamp().wallclock(), 12345);
+        }
+    }
+
+    #[test]
+    fn test_is_anchor_event() {
+        let anchor1 = StorageEvent::NodeAnchorCreated {
             version_id: VersionId::new(1).unwrap(),
             node_id: NodeId::new(1).unwrap(),
-            timestamp: 12345.into(),
+            timestamp: 1000.into(),
+        };
+        let anchor2 = StorageEvent::EdgeAnchorCreated {
+            version_id: VersionId::new(1).unwrap(),
+            edge_id: crate::core::id::EdgeId::new(1).unwrap(),
+            timestamp: 1000.into(),
+        };
+        let version1 = StorageEvent::NodeVersionCreated {
+            version_id: VersionId::new(2).unwrap(),
+            node_id: NodeId::new(1).unwrap(),
+            timestamp: 2000.into(),
+            is_anchor: false,
+        };
+        let version2 = StorageEvent::EdgeVersionCreated {
+            version_id: VersionId::new(2).unwrap(),
+            edge_id: crate::core::id::EdgeId::new(1).unwrap(),
+            timestamp: 2000.into(),
+            is_anchor: false,
         };
 
-        assert_eq!(event.timestamp().wallclock(), 12345);
+        assert!(anchor1.is_anchor_event());
+        assert!(anchor2.is_anchor_event());
+        assert!(!version1.is_anchor_event());
+        assert!(!version2.is_anchor_event());
     }
 
     #[test]
@@ -633,6 +685,54 @@ mod sentry_tests {
         fn interested_in(&self, _event: &StorageEvent) -> bool {
             self.interested
         }
+    }
+
+    struct VectorErrorObserver {
+        call_count: AtomicUsize,
+    }
+
+    impl StorageObserver for VectorErrorObserver {
+        fn on_event(&self, _event: &StorageEvent) -> Result<()> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Err(crate::core::error::Error::Vector(
+                crate::core::error::VectorError::InvalidVector {
+                    reason: "Test vector error".to_string(),
+                },
+            ))
+        }
+    }
+
+    #[test]
+    fn test_sentry_vector_error_does_not_block_subsequent_observers() {
+        // 🛡️ Sentry Test: Verify that Vector errors specifically are handled gracefully
+        let vector_failing = Arc::new(VectorErrorObserver {
+            call_count: AtomicUsize::new(0),
+        });
+        let success = Arc::new(TrackingObserver::new(true, false));
+
+        let observers: Vec<Observer> = vec![
+            Arc::clone(&vector_failing) as Observer,
+            Arc::clone(&success) as Observer,
+        ];
+
+        let event = StorageEvent::NodeAnchorCreated {
+            version_id: VersionId::new(1).unwrap(),
+            node_id: NodeId::new(1).unwrap(),
+            timestamp: 1000.into(),
+        };
+
+        notify_observers(&observers, &event);
+
+        assert_eq!(
+            vector_failing.call_count.load(Ordering::SeqCst),
+            1,
+            "Failing vector observer should be called"
+        );
+        assert_eq!(
+            success.count(),
+            1,
+            "Subsequent observer SHOULD be called despite previous vector error"
+        );
     }
 
     #[test]


### PR DESCRIPTION
🎯 **Target:** `src/core/observer.rs` functions `StorageEvent::timestamp()`, `StorageEvent::is_anchor_event()`, and `notify_observers()`.

💣 **Risk:** 
1. `test_event_timestamp` and `is_anchor_event` only tested the `NodeAnchorCreated` variant, leaving the other 3 variants untested and prone to regression if enum fields were refactored.
2. `notify_observers` explicitly matches on `Error::Vector` to provide specialized logging, but this code path was never exercised by tests, creating a risk that this specific error handling logic could crash or halt the observer chain.

🧪 **Strategy:** 
- Used table-driven tests for `timestamp()` and `is_anchor_event()` to check all four variants (`NodeAnchorCreated`, `EdgeAnchorCreated`, `NodeVersionCreated`, `EdgeVersionCreated`).
- Wrote a new `VectorErrorObserver` mock that intentionally returns a `VectorError` and verified that `notify_observers` properly catches it and continues execution to the next observer in the loop.

🔬 **Verification:** 
`cargo test --lib core::observer`

*(Sentry persona)*

---
*PR created automatically by Jules for task [16035758008487616193](https://jules.google.com/task/16035758008487616193) started by @madmax983*