### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -12,6 +12,9 @@ use crate::storage::current::{IncomingEdgesIter, OutgoingEdgesIter};
 impl AletheiaDB {
     /// Create a node with the given label and properties.
     ///
+    /// Why? This is the primary entry point for populating the database. It encapsulates the underlying
+    /// complexity of transaction management and ID generation so users can quickly store new entities.
+    ///
     /// This is a convenience method that internally uses a write transaction.
     /// For multiple operations, prefer using `write()` or `write_transaction()`.
     ///
@@ -40,6 +43,9 @@ impl AletheiaDB {
     }
 
     /// Create an edge between two nodes.
+    ///
+    /// Why? Relationships are fundamental to a graph database. This function provides a straightforward
+    /// way to establish connections between existing nodes without managing transaction boundaries manually.
     ///
     /// This is a convenience method that internally uses a write transaction.
     /// For multiple operations, prefer using `write()` or `write_transaction()`.

--- a/src/index/vector/sparse.rs
+++ b/src/index/vector/sparse.rs
@@ -591,7 +591,27 @@ impl SparseVectorIndex {
         self.vectors.contains_key(&id)
     }
 
-    /// Gets the sparse vector for a node ID, if it exists.
+    /// Retrieves the sparse vector representation for a given node ID.
+    ///
+    /// Why? This is essential for operations that need to directly inspect or re-index
+    /// the exact non-zero dimensions and values of a node's sparse representation.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use aletheiadb::core::id::NodeId;
+    /// # use aletheiadb::index::vector::sparse::{SparseVectorIndex, SparseIndexConfig};
+    /// # use aletheiadb::core::vector::SparseVec;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let config = SparseIndexConfig::new(100);
+    /// let index = SparseVectorIndex::new(config)?;
+    /// let doc = SparseVec::new(vec![0, 10], vec![1.0, 2.5], 100)?;
+    /// let node_id = NodeId::new(42)?;
+    /// index.add(node_id, &doc)?;
+    ///
+    /// let retrieved = index.get(node_id).expect("Vector should exist");
+    /// assert_eq!(retrieved.indices().len(), 2);
+    /// # Ok(()) }
+    /// ```
     #[must_use]
     pub fn get(&self, id: NodeId) -> Option<Arc<SparseVec>> {
         self.vectors.get(&id).map(|v| Arc::clone(&v.vector))

--- a/src/storage/wal/durability.rs
+++ b/src/storage/wal/durability.rs
@@ -270,9 +270,9 @@ impl DurabilityMode {
         })
     }
 
-    /// Returns the default GroupCommit configuration (2ms, 200 transactions).
+    /// Retrieves the default GroupCommit configuration (2ms, 200 transactions).
     ///
-    /// This provides a good balance between latency and throughput for
+    /// Why? This provides a good balance between latency and throughput for
     /// typical OLTP workloads, offering ACID guarantees with much better
     /// performance than Synchronous mode.
     ///
@@ -347,9 +347,9 @@ impl DurabilityMode {
         })
     }
 
-    /// Returns the default AsyncBatched configuration (10ms, 100 transactions).
+    /// Retrieves the default AsyncBatched configuration (10ms, 100 transactions).
     ///
-    /// This provides very low latency (<100µs) with efficient batching,
+    /// Why? This provides very low latency (<100µs) with efficient batching,
     /// suitable for high-throughput applications that can tolerate a small
     /// data loss window on crash.
     ///


### PR DESCRIPTION
📖 Chapter: Refined the documentation for sparse vector index fetching and core graph operations.
🔦 Insight: Added missing `Why?` explanations to `create_node`, `create_edge`, and multiple `DurabilityMode` implementations, shifting them away from useless 'Getter' descriptions.
🧪 Example: Added a fully executable `Doc Test` example to `SparseVectorIndex::get` to show actual instantiation and fetching of sparse vectors.
🖼️ Preview: Tested with `cargo doc` rendering perfectly. All tests and clippy pass cleanly.

---
*PR created automatically by Jules for task [9588409227940054907](https://jules.google.com/task/9588409227940054907) started by @madmax983*