### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/docs/guides/hybrid-query-guide.md
+++ b/docs/guides/hybrid-query-guide.md
@@ -256,7 +256,7 @@ for row in results {
 "What documents were similar to this query in 2023?"
 
 ```rust
-let timestamp_2023 = 1672531200000000; // 2023-01-01 in microseconds
+let timestamp_2023 = Timestamp::new(1672531200000000, 0).unwrap(); // 2023-01-01 in microseconds
 
 let results = db.query()
     .as_of(timestamp_2023, timestamp_2023)

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,4 +19,5 @@ pub use crate::core::temporal::{BiTemporalInterval, TimeRange, Timestamp, time};
 // Re-export the properties! macro. It is exported at the crate root because of #[macro_export],
 // so we re-export it from there.
 pub use crate::properties;
+pub use crate::query::Predicate;
 pub use crate::storage::wal::{DurabilityMode, WriteOptions};


### PR DESCRIPTION
🗣️ Echo DX Audit Fixes

This PR fixes multiple DX/Compilation issues encountered during the "README Run" of `hybrid-query-guide.md`:

1.  **Import Scan Failure:** The examples heavily rely on `Predicate` for filtering, but `Predicate` was missing from `aletheiadb::prelude::*`. This has been fixed.
2.  **Friction Point (Type Mismatch):** The example passed an `i64` integer directly to `.as_of()`, which strictly requires a `Timestamp`. The example has been updated to use `Timestamp::new(1672531200000000, 0).unwrap()`.

---
*PR created automatically by Jules for task [8669051722683231612](https://jules.google.com/task/8669051722683231612) started by @madmax983*