### PR TITLE
⚡ Bolt: Optimize WalRingBuffer::drain to pre-allocate vector capacity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Ring Buffer Drain Pre-allocation]
+**Learning:** When draining a concurrent ring buffer, you can pre-allocate the results vector size by calculating the difference between atomic `write_pos` and `read_pos` to avoid reallocation overhead. However, in concurrent environments, you MUST load `read_pos` *before* `write_pos`. If `write_pos` is loaded first, and both advance concurrently before `read_pos` is loaded, the resulting subtraction can underflow (or wrap around to a massive number), causing an OOM panic when initializing the vector capacity. Bounding the capacity by the buffer's max capacity is also a necessary safety net.
+**Action:** Always load the lagging pointer/index (`read_pos`) before the leading pointer/index (`write_pos`) when estimating concurrent sizes, and bound capacity calculations by a known maximum.

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -694,7 +694,14 @@ impl WalRingBuffer {
     /// A vector of pending entries ready for flushing. May be empty if
     /// no entries are available.
     pub fn drain(&self) -> Vec<PendingEntry> {
-        let mut entries = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate capacity by calculating the difference
+        // between write and read positions.
+        // MUST load read_pos before write_pos to prevent integer underflow races
+        // during concurrent drains. Bound by capacity to handle wraparounds.
+        let read = self.read_pos.load(Ordering::Relaxed);
+        let write = self.write_pos.load(Ordering::Relaxed);
+        let cap = std::cmp::min(self.capacity, write.wrapping_sub(read) as usize);
+        let mut entries = Vec::with_capacity(cap);
 
         loop {
             let pos = self.read_pos.load(Ordering::Relaxed);


### PR DESCRIPTION
💡 **What:** Replaced the default `Vec::new()` heap allocation in `WalRingBuffer::drain` with `Vec::with_capacity(cap)`. The capacity is calculated dynamically by finding the difference between the concurrent `write_pos` and `read_pos` atomics, explicitly loading `read_pos` before `write_pos` to avoid underflow race conditions, and clamping the result to the ring buffer's max capacity.
🎯 **Why:** `WalRingBuffer::drain` is called continuously by the flush coordinator to gather entries to be written to disk. Using `Vec::new()` causes the vector to dynamically resize (and reallocate memory) on the heap multiple times as entries are pulled from the buffer. Pre-allocating the known chunk size avoids these intermediate reallocations entirely.
📊 **Impact:** Reduces heap reallocations during every flush cycle of the WAL by initializing the result vector with the precise size needed to hold all pending entries.
🔬 **Measurement:** Verify by running the WAL ring buffer tests: `cargo test --lib storage::wal::ring_buffer`

---
*PR created automatically by Jules for task [7712152115857364381](https://jules.google.com/task/7712152115857364381) started by @madmax983*