### PR TITLE
🎻 Bard: [documentation update] Fix unresolved intra-doc links

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -26,7 +26,7 @@
 //! - `ALETHEIADB_CORS_PERMISSIVE`: Set to "true" to allow any origin (default: false)
 //! - `ALETHEIADB_CORS_ORIGINS`: Comma-separated list of allowed origins
 //! - `ALETHEIADB_CONFIG`: Path to a TOML config file consumed by
-//!   [`AletheiaDBConfig::from_toml_file`]. Takes precedence over
+//!   [`AletheiaDBConfig::from_toml_file`](aletheiadb::config::AletheiaDBConfig::from_toml_file). Takes precedence over
 //!   `ALETHEIADB_DATA_DIR`.
 //! - `ALETHEIADB_DATA_DIR`: Directory for WAL + index persistence. When set,
 //!   the server persists state across restarts. When unset (and `ALETHEIADB_CONFIG`

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`AletheiaDBConfig`](crate::config::AletheiaDBConfig) this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -7,8 +7,8 @@
 //! # Wiring
 //!
 //! Install state once at startup via
-//! [`autumn_web::app().on_startup(...)`](autumn_web::prelude::app) and an
-//! [`AppState::insert_extension`](autumn_web::prelude::AppState::insert_extension)
+//! `` `autumn_web::app().on_startup(...)` `` and an
+//! `` `AppState::insert_extension` ``
 //! call. Handlers then receive it through the [`AppState`] extractor defined
 //! in this module, which reads the extension out of autumn's own state.
 

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`jump_to`](Self::jump_to) for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 **Chapter:** The Unresolved Links
💡 **Insight:** Intra-doc links referencing cross-crate modules (`server.rs` to library internals), unavailable external crates (`autumn_web`), or improperly scoped inner references (`jump_to`) generated compilation warnings. I resolved these to satisfy `cargo doc` natively, converting unresolvable links to clean backticks.
🧪 **Example:** Modified `src/bin/server.rs`, `src/http/config.rs`, `src/http/state.rs`, and `src/simulation/clock.rs`.
🖼️ **Preview:** `cargo doc --no-deps --document-private-items --workspace --all-features` now runs entirely warning-free!

---
*PR created automatically by Jules for task [9473268704388642506](https://jules.google.com/task/9473268704388642506) started by @madmax983*