### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -712,6 +712,7 @@ mod tests {
         // Both methods should work - IDs are generated successfully
         // Note: First ID may be 0 due to IdGenerator starting at 0 (known issue)
         assert!(id1.as_u64() < id2.as_u64(), "IDs should increment");
+        tx.commit().unwrap();
     }
 
     #[test]
@@ -727,6 +728,7 @@ mod tests {
         let node_id = tx
             .create_node_with_valid_time("Person", props, Some(valid_from))
             .unwrap();
+        tx.commit().unwrap();
 
         // Verify node was created with a valid ID (0 is valid!)
         assert!(node_id.as_u64() <= MAX_VALID_ID);

--- a/src/api/transaction/read_tx.rs
+++ b/src/api/transaction/read_tx.rs
@@ -525,7 +525,9 @@ mod tests {
 
         // Wait for all readers
         for handle in handles {
-            handle.join().unwrap();
+            if let Err(e) = handle.join() {
+                std::panic::resume_unwind(e);
+            }
         }
     }
 

--- a/src/api/transaction/types.rs
+++ b/src/api/transaction/types.rs
@@ -155,7 +155,10 @@ mod tests {
         // Collect all generated IDs
         let mut all_ids: Vec<TxId> = vec![];
         for handle in handles {
-            all_ids.extend(handle.join().unwrap());
+            match handle.join() {
+                Ok(ids) => all_ids.extend(ids),
+                Err(e) => std::panic::resume_unwind(e),
+            }
         }
 
         // All IDs should be unique

--- a/src/api/transaction/visibility.rs
+++ b/src/api/transaction/visibility.rs
@@ -305,7 +305,9 @@ mod tests {
             .collect();
 
         for handle in handles {
-            handle.join().unwrap();
+            if let Err(e) = handle.join() {
+                std::panic::resume_unwind(e);
+            }
         }
     }
 }

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2814,7 +2814,9 @@ mod timestamp_ordering_tests {
 
         // Wait for all threads
         for handle in handles {
-            handle.join().unwrap();
+            if let Err(e) = handle.join() {
+                std::panic::resume_unwind(e);
+            }
         }
 
         // Analyze results: sort by commit timestamp

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -663,7 +663,9 @@ mod tests {
         let result = coord.wait_for_flush(epoch);
         assert!(result.is_ok());
 
-        handle.join().unwrap();
+        if let Err(e) = handle.join() {
+            std::panic::resume_unwind(e);
+        }
     }
 
     #[test]
@@ -689,7 +691,9 @@ mod tests {
         let err = result.unwrap_err();
         assert!(err.to_string().contains("disk full"));
 
-        handle.join().unwrap();
+        if let Err(e) = handle.join() {
+            std::panic::resume_unwind(e);
+        }
     }
 
     #[test]
@@ -750,7 +754,10 @@ mod tests {
 
         // All should succeed
         for handle in handles {
-            let result = handle.join().unwrap();
+            let result = match handle.join() {
+                Ok(r) => r,
+                Err(e) => std::panic::resume_unwind(e),
+            };
             assert!(result.is_ok());
         }
     }


### PR DESCRIPTION
🎯 Target: Thread joins in `src/api/transaction/` tests and `src/storage/wal/group_commit.rs`, and transaction trait tests in `src/api/transaction/mod.rs`.
💣 Risk: `handle.join().unwrap()` hides actual thread panics (like `LockPoisoned` or logic errors) behind an unhelpful `Any` panic on the main thread, making concurrent test failures notoriously hard to debug. Also, missing transaction commits can cause tests to hang.
🧪 Strategy: Replaced `.unwrap()` on `handle.join()` with explicit `std::panic::resume_unwind(e)` to bubble up accurate stack traces and error messages. Added missing `tx.commit().unwrap()` to `test_create_node_default_delegates_to_with_valid_time` and `test_create_node_with_backdated_valid_time`.
🔬 Verification: Run `cargo test --lib test_concurrent_commits_ordered_timestamps` and other modified tests; `cargo clippy` and `cargo fmt` pass without warnings.

---
*PR created automatically by Jules for task [6534440826492723280](https://jules.google.com/task/6534440826492723280) started by @madmax983*