### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Averages across 30–212 datapoints of continuous CI runs:
 
 ## Feature Flags
 
+> ⚠️ **REQUIRES FEATURE NOVA**: Experimental features like `NarrativeGenerator` and `story_demo` require the `nova` feature flag to compile!
+
 All features are off by default except `config-toml`.
 
 | Flag | What it enables |


### PR DESCRIPTION
🤦 **The Confusion:** "Tried to run the `story_demo`. Compiler said `NarrativeGenerator` not found."
🕵️ **The Reality:** "Turns out I needed to enable feature `nova`."
💡 **The Fix:** "Add a huge banner in README saying 'REQUIRES FEATURE NOVA'."

---
*PR created automatically by Jules for task [12583018231951998450](https://jules.google.com/task/12583018231951998450) started by @madmax983*