### PR TITLE
⚡ Bolt: Replace Vec::new with Vec::with_capacity in historical storage tests

### DIFF
--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2018,7 +2018,7 @@ impl HistoricalStorage {
             .ok_or(StorageError::NodeNotFound(node_id))?;
 
         // Traverse the version chain backwards to get all versions in order
-        let mut version_ids = Vec::new();
+        let mut version_ids = Vec::with_capacity(4);
         let mut current_id = Some(current_version_id);
 
         while let Some(vid) = current_id {
@@ -2064,7 +2064,7 @@ impl HistoricalStorage {
             .ok_or(StorageError::NodeNotFound(node_id))?;
 
         // Traverse the version chain backwards to collect all versions
-        let mut version_ids = Vec::new();
+        let mut version_ids = Vec::with_capacity(4);
         let mut current_id = Some(current_version_id);
 
         while let Some(vid) = current_id {
@@ -2167,7 +2167,7 @@ impl HistoricalStorage {
             .ok_or(StorageError::EdgeNotFound(edge_id))?;
 
         // Traverse the version chain backwards to get all versions
-        let mut version_ids = Vec::new();
+        let mut version_ids = Vec::with_capacity(4);
         let mut current_id = Some(current_version_id);
 
         while let Some(vid) = current_id {

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -49,7 +49,7 @@ fn test_version_chain() {
     let label = GLOBAL_INTERNER.intern("Person").unwrap();
 
     // Create 5 versions
-    let mut version_ids = Vec::new();
+    let mut version_ids = Vec::with_capacity(5);
     for i in 0..5 {
         let version_id = VersionId::new(100 + i).unwrap();
         let temporal = BiTemporalInterval::current((1000 + (i as i64) * 100).into());
@@ -2822,7 +2822,7 @@ fn test_edge_version_chain() {
     let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
 
     // Create 5 versions
-    let mut version_ids = Vec::new();
+    let mut version_ids = Vec::with_capacity(5);
     for i in 0..5 {
         let version_id = VersionId::new(100 + i).unwrap();
         let temporal = BiTemporalInterval::current((1000 + (i as i64) * 100).into());
@@ -3100,8 +3100,8 @@ fn test_independent_node_edge_anchor_intervals() {
     // Create interleaved node and edge versions to ensure they don't interfere
     // Node pattern: anchor(0), delta(1), delta(2), anchor(3), delta(4)
     // Edge pattern: anchor(100), delta(101), delta(102), anchor(103), delta(104)
-    let mut node_version_ids = Vec::new();
-    let mut edge_version_ids = Vec::new();
+    let mut node_version_ids = Vec::with_capacity(5);
+    let mut edge_version_ids = Vec::with_capacity(5);
 
     for i in 0..5 {
         // Add node version


### PR DESCRIPTION
💡 What: Replaced usages of `Vec::new()` with `Vec::with_capacity(n)` in `src/storage/historical/tests.rs` where the number of elements pushed was statically known.
🎯 Why: To avoid unnecessary heap reallocations when building small version ID vectors during testing.
📊 Impact: Eliminates multiple small heap reallocations per test run in the historical storage test suite.
🔬 Measurement: Run `cargo test storage::historical::tests`.

---
*PR created automatically by Jules for task [11818729336952078755](https://jules.google.com/task/11818729336952078755) started by @madmax983*