### PR TITLE
🛡️ Sentry: Verify scale_and_copy boundary panics

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,7 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+
+**[SIMD scale_and_copy Bounds Check Panic]**
+**Learning:** `unsafe` SIMD functions that write to uninitialized memory slices (like `scale_and_copy`) must have explicit length checks (e.g., `assert_eq!(src.len(), dst.len())`). Missing explicit test coverage for these boundary panics leaves a gap where a regression could silently drop the check and cause memory corruption.
+**Action:** Always verify boundary checks for `unsafe` SIMD memory writes by creating a smaller `dst` slice using `unsafe { std::slice::from_raw_parts_mut(..., len) }` and executing the function inside `std::panic::catch_unwind` to guarantee the length mismatch panics before undefined behavior occurs.

--- a/src/core/vector/sentry_safety_tests.rs
+++ b/src/core/vector/sentry_safety_tests.rs
@@ -101,3 +101,23 @@ fn test_scale_and_copy_large_vector() {
         assert_eq!(*val, (i as f32) * 2.0);
     }
 }
+
+#[test]
+fn test_scale_and_copy_panics_on_length_mismatch() {
+    let src = vec![1.0; 17];
+    let mut dst = vec![0.0; 17];
+
+    // Create a smaller dst slice
+    let small_dst = unsafe {
+        std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut std::mem::MaybeUninit<f32>, 16)
+    };
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        scale_and_copy(&src, small_dst, 2.0);
+    }));
+
+    assert!(
+        result.is_err(),
+        "scale_and_copy should panic when src and dst lengths mismatch"
+    );
+}


### PR DESCRIPTION
🎯 Target: `scale_and_copy` in `src/core/vector/simd.rs` and its use in operations.
💣 Risk: Missing length mismatch check testing means a regression in `unsafe` SIMD code bounds checking could lead to memory corruption or undefined behavior.
🧪 Strategy: Ensure `scale_and_copy` correctly panics when called with unmatching length slices using a manually created smaller pointer slice and `catch_unwind`.
🔬 Verification: `cargo test -p aletheiadb --lib core::vector::sentry_safety_tests::test_scale_and_copy_panics_on_length_mismatch`

---
*PR created automatically by Jules for task [5665771077985770451](https://jules.google.com/task/5665771077985770451) started by @madmax983*