### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+**Vector validation gaps and sparse vector edge cases**
+**Learning:** Functions like `sparse_cosine_similarity` and `sparse_euclidean_distance` delegate dimension validation to their underlying dot-product or distance-sum functions but missed explicit unit test coverage of this propagation path in their respective wrapper functions. Similarly, `validate_vector_with_bounds` missed explicit standalone tests for `f32::NAN` and `f32::INFINITY` that didn't simultaneously test something else.
+**Action:** Wrote targeted `_sentry` unit tests directly covering the explicit error branches (`DimensionMismatch`, `ContainsNaN`, `ContainsInfinity`) for these wrapper functions to ensure their interface contracts are explicitly guarded.

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -3089,3 +3089,51 @@ fn test_sparse_squared_euclidean_distance_edge_cases() {
         );
     }
 }
+
+#[test]
+fn test_sparse_cosine_similarity_dimension_mismatch_sentry() {
+    let a = SparseVec::new(vec![0], vec![1.0], 5).unwrap();
+    let b = SparseVec::new(vec![0], vec![1.0], 10).unwrap();
+
+    let result = sparse_cosine_similarity(&a, &b);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        crate::core::error::Error::Vector(crate::core::error::VectorError::DimensionMismatch { .. })
+    ));
+}
+
+#[test]
+fn test_sparse_euclidean_distance_dimension_mismatch_sentry() {
+    let a = SparseVec::new(vec![0], vec![1.0], 5).unwrap();
+    let b = SparseVec::new(vec![0], vec![1.0], 10).unwrap();
+
+    let result = sparse_euclidean_distance(&a, &b);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        crate::core::error::Error::Vector(crate::core::error::VectorError::DimensionMismatch { .. })
+    ));
+}
+
+#[test]
+fn test_validate_vector_with_bounds_nan_only_sentry() {
+    let v = vec![1.0, f32::NAN];
+    let result = validate_vector_with_bounds(&v, 10);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        crate::core::error::Error::Vector(crate::core::error::VectorError::ContainsNaN { .. })
+    ));
+}
+
+#[test]
+fn test_validate_vector_with_bounds_inf_only_sentry() {
+    let v = vec![1.0, f32::INFINITY];
+    let result = validate_vector_with_bounds(&v, 10);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        crate::core::error::Error::Vector(crate::core::error::VectorError::ContainsInfinity { .. })
+    ));
+}


### PR DESCRIPTION
🎯 Target: `sparse_cosine_similarity`, `sparse_euclidean_distance` and `validate_vector_with_bounds` in `src/core/vector/sparse.rs` and `src/core/vector/validation.rs`.
💣 Risk: The similarity and distance wrapper functions relied on implicit propagation of `DimensionMismatch` from their internal dot product and distance sum computations, meaning the wrapper API contracts weren't explicitly verified. `validate_vector_with_bounds` also lacked isolated test coverage for specific NaN and Infinity validation rejections.
🧪 Strategy: Wrote specific unit tests (`test_sparse_cosine_similarity_dimension_mismatch_sentry`, `test_sparse_euclidean_distance_dimension_mismatch_sentry`, `test_validate_vector_with_bounds_nan_only_sentry`, `test_validate_vector_with_bounds_inf_only_sentry`) using `assert!(matches!(...))` to verify the exact error variants are properly returned.
🔬 Verification: `cargo test test_sparse_cosine_similarity_dimension_mismatch_sentry` and associated test names.

---
*PR created automatically by Jules for task [1121882261026741214](https://jules.google.com/task/1121882261026741214) started by @madmax983*