### PR TITLE
⚡ Bolt: Optimize cosine similarity in VectorRerankIterator and hybrid search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Clamp on NaN Panic**
+**Learning:** `f32::clamp` panics if called on `NaN`. When performing math operations like vector similarity that might result in `NaN` or `Inf` (e.g., division by zero from zero-length vectors), you must guard against division by zero *before* clamping, or check `.is_finite()` first.
+**Action:** Always handle zero cases manually or verify `.is_finite()` before applying `.clamp(-1.0, 1.0)`.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -15,7 +15,7 @@ use crate::core::error::Result;
 use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
-use crate::core::vector::cosine_similarity;
+use crate::core::vector::{dot_product, magnitude, normalize};
 use crate::core::{NodeId, Timestamp};
 use crate::query::ir::{Direction, Predicate, PredicateValue};
 use crate::storage::current::CurrentStorage;
@@ -1236,9 +1236,10 @@ impl Ord for ScoredRow {
 
 /// Iterator for vector reranking.
 pub struct VectorRerankIterator {
+    /// ⚡ Bolt optimization: Storing the normalized embedding avoids recomputing its magnitude for every candidate row.
+    normalized_embedding: Arc<[f32]>,
     sorted: Option<std::vec::IntoIter<Reverse<ScoredRow>>>,
     input: Option<Box<dyn ResultIterator>>,
-    embedding: Arc<[f32]>,
     k: usize,
     _current: Arc<CurrentStorage>,
     /// Vector property name, or None if no vector index is configured
@@ -1264,10 +1265,12 @@ impl VectorRerankIterator {
         // Use explicit property if provided, otherwise get default from storage
         let vector_property = property_key.or_else(|| current.get_vector_property_name());
 
+        let normalized_embedding = Arc::from(normalize(&embedding).into_boxed_slice());
+
         VectorRerankIterator {
             sorted: None,
             input: Some(input),
-            embedding,
+            normalized_embedding,
             k,
             _current: current,
             vector_property,
@@ -1281,10 +1284,14 @@ impl VectorRerankIterator {
         let PropertyValue::Vector(vec) = node.properties.get(vector_property)? else {
             return None;
         };
-        let similarity = cosine_similarity(&self.embedding, vec).ok()?;
+        let mag_vec = magnitude(vec);
+        if mag_vec == 0.0 {
+            return None; // Reject zero-length vectors
+        }
+        let similarity = dot_product(&self.normalized_embedding, vec).ok()? / mag_vec;
         // Reject NaN/Inf values - these indicate invalid input (e.g., zero-length vectors)
         if similarity.is_finite() {
-            Some(similarity)
+            Some(similarity.clamp(-1.0, 1.0))
         } else {
             #[cfg(feature = "observability")]
             tracing::debug!(

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -29,7 +29,7 @@
 
 use crate::core::error::Result;
 use crate::core::id::NodeId;
-use crate::core::vector::{cosine_similarity, validate_vector};
+use crate::core::vector::{dot_product, magnitude, normalize, validate_vector};
 use crate::query::traits::GraphView;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
@@ -122,6 +122,9 @@ pub fn traverse_and_rank<G: GraphView + ?Sized>(
     // Validate target embedding
     validate_vector(target_embedding)?;
 
+    // ⚡ Bolt optimization: Pre-normalize target to avoid recomputing magnitude for every candidate
+    let normalized_target = normalize(target_embedding);
+
     // Check that start node exists
     let _start_node = db.get_node(start)?;
 
@@ -160,8 +163,14 @@ pub fn traverse_and_rank<G: GraphView + ?Sized>(
         };
 
         // Compute cosine similarity
-        match cosine_similarity(target_embedding, embedding) {
-            Ok(similarity) => {
+        let mag_vec = magnitude(embedding);
+        if mag_vec == 0.0 {
+            continue; // Skip zero-length vectors to match cosine_similarity NaN rejection
+        }
+
+        match dot_product(&normalized_target, embedding) {
+            Ok(dot) => {
+                let similarity = (dot / mag_vec).clamp(-1.0, 1.0);
                 let candidate = ScoredCandidate::new(target_id, similarity);
 
                 if top_k_heap.len() < k {


### PR DESCRIPTION
💡 What: Optimized `VectorRerankIterator` and `hybrid_search_bfs` to normalize the query vector once upfront and compute similarity using `dot_product(normalized_query, candidate) / magnitude(candidate)` instead of `cosine_similarity`.
🎯 Why: `cosine_similarity` recomputes the magnitude of both vectors every time. Since the query vector is constant during reranking, computing its magnitude for every candidate row is redundant overhead.
📊 Impact: Eliminates repeated magnitude calculation (O(N) operations per candidate) for the query vector, reducing CPU overhead during vector reranking and hybrid search.
🔬 Measurement: Run `cargo bench` or profile queries that utilize the vector reranker.

---
*PR created automatically by Jules for task [14899364627606806579](https://jules.google.com/task/14899364627606806579) started by @madmax983*