### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/docs/guides/hybrid-query-guide.md
+++ b/docs/guides/hybrid-query-guide.md
@@ -485,7 +485,7 @@ Predicate::gt("score", 0.5f64)        // f64
 ### Common Errors
 
 ```rust
-use aletheiadb::utils::error::{Error, StorageError, VectorError};
+use aletheiadb::core::error::{Error, StorageError, VectorError};
 
 match results.next() {
     Some(Ok(row)) => { /* process row */ }


### PR DESCRIPTION
🤦 **The Confusion:** The 'Hybrid Query Guide' documentation shows an error handling example that imports from an invalid module path (`utils::error`), which causes a compiler error if copied into code. 
🕵️ **The Reality:** The error types were actually moved to the core module (`core::error`). 
💡 **The Fix:** Update the documentation to use the correct import path (`aletheiadb::core::error::{Error, StorageError, VectorError}`).

---
*PR created automatically by Jules for task [12014462462158750602](https://jules.google.com/task/12014462462158750602) started by @madmax983*