### PR TITLE
⚔️ Elenchus: `query::planner::rules` Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,17 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[OperationReordering Mutants: Propagation and Estimations]**
+**Module:** `src/query/planner/rules/operation_reordering.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Mutants survived replacing logical `||` with `&&` when propagating the `changed` boolean up the `LogicalOp` tree in both `Join` and other binary operations. The `apply` method's `Result::Ok` packaging was also not explicitly tested, and the `estimate_cardinality` method lacked structural coverage across all `ScanOp` variants and basic unary/empty operations.
+**Evidence:** `cargo mutants` output showed >30 surviving mutants centered on `changed` propagation (`left_changed || right_changed`), `apply` method returns, and `estimate_cardinality` math. The tests only implicitly checked high-level behavior, not structural propagation and estimation mapping.
+**Recommendation:** Added explicit tests verifying `changed` boolean propagation (`test_reorder_binary_changed_propagation`, `test_reorder_join_changed_propagation`), `apply()` returns (`test_apply_no_change_returns_none`), and `estimate_cardinality()` behavior across all variants to lock down expected logic.
+
+**[FilterScanFusion Mutants: Binary changed Propagation]**
+**Module:** `src/query/planner/rules/filter_scan_fusion.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Similar to `OperationReordering`, `FilterScanFusion::fuse` failed to fail tests when replacing logical `||` with `&&` for the `changed` boolean propagation in `LogicalOp::Binary`. The `apply` method itself and `name` method also lacked explicit validation.
+**Evidence:** Tests checked specific fusions but not the propagation of state upwards through unmodified container structures like `BinaryOp::Union` when one side fused and the other didn't.
+**Recommendation:** Strengthened tests with `test_fuse_binary_changed_propagation` to explicitly assert the boolean logic for nested `LogicalOp::Binary` returns, as well as `apply` tests.

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -242,4 +242,72 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().temporal_context.is_some());
     }
+
+    // ==================== Mutant Killers ====================
+    #[test]
+    fn test_filter_scan_fusion_name() {
+        let rule = FilterScanFusion;
+        assert_eq!(rule.name(), "filter-scan-fusion");
+    }
+
+    #[test]
+    fn test_apply_no_change_returns_none() {
+        let rule = FilterScanFusion;
+        let stats = Statistics::new();
+        let plan = LogicalPlan::new(LogicalOp::Empty);
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_apply_with_change_returns_some() {
+        let rule = FilterScanFusion;
+        let stats = Statistics::new();
+        // A plan that WILL be optimized
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("id", 42)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("User".to_string()),
+                estimated_rows: Some(100),
+            }),
+        ));
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_fuse_binary_changed_propagation() {
+        let rule = FilterScanFusion;
+
+        let op = LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            // Left child WILL change
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("id", 42)),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: Some("User".to_string()),
+                    estimated_rows: Some(100),
+                }),
+            ),
+            // Right child is Empty
+            LogicalOp::Empty,
+        );
+        let (_, changed) = rule.fuse(&op).unwrap();
+        assert!(changed);
+
+        let op2 = LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            LogicalOp::Empty,
+            // Right child WILL change
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("id", 42)),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: Some("User".to_string()),
+                    estimated_rows: Some(100),
+                }),
+            ),
+        );
+        let (_, changed2) = rule.fuse(&op2).unwrap();
+        assert!(changed2);
+    }
 }

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -1185,4 +1185,300 @@ mod tests {
             Predicate::Or(vec![Predicate::eq("a", 1), Predicate::eq("b", 2)])
         );
     }
+
+    // ==================== Mutant Killers ====================
+    #[test]
+    fn test_operation_reordering_name() {
+        let rule = OperationReordering;
+        assert_eq!(rule.name(), "operation-reordering");
+    }
+
+    #[test]
+    fn test_apply_no_change_returns_none() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+        let plan = LogicalPlan::new(LogicalOp::Empty);
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_apply_with_change_returns_some() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+        // A plan that WILL be optimized
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "id".to_string(),
+                right_key: "ref_id".to_string(),
+            },
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("LargeTable".to_string()),
+                estimated_rows: Some(10000),
+            }),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("SmallTable".to_string()),
+                estimated_rows: Some(100),
+            }),
+        ));
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_estimate_cardinality_empty() {
+        let rule = OperationReordering;
+        assert_eq!(rule.estimate_cardinality(&LogicalOp::Empty), 0);
+    }
+
+    #[test]
+    fn test_estimate_cardinality_unary_limit() {
+        let rule = OperationReordering;
+        let op = LogicalOp::unary(UnaryOp::Limit(50), LogicalOp::Empty);
+        assert_eq!(rule.estimate_cardinality(&op), 50);
+    }
+
+    #[test]
+    fn test_estimate_cardinality_unary_other() {
+        let rule = OperationReordering;
+        let op = LogicalOp::unary(
+            UnaryOp::Skip(10),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: Some(200),
+            }),
+        );
+        assert_eq!(rule.estimate_cardinality(&op), 200);
+    }
+
+    #[test]
+    fn test_estimate_cardinality_binary() {
+        let rule = OperationReordering;
+        let op = LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: Some(100),
+            }),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: Some(200),
+            }),
+        );
+        // (100 * 200 * 0.1) = 2000
+        assert_eq!(rule.estimate_cardinality(&op), 2000);
+    }
+
+    #[test]
+    fn test_estimate_cardinality_scans() {
+        let rule = OperationReordering;
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::NodeLookup(vec![
+                NodeId::new(1).unwrap()
+            ]))),
+            1
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: None
+            })),
+            DEFAULT_NODE_SCAN_CARDINALITY
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::VectorSearch {
+                k: 15,
+                property_key: Some("".to_string()),
+                metric: crate::index::vector::DistanceMetric::Cosine,
+                label_filter: None,
+                embedding: vec![].into()
+            })),
+            15
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::TemporalNodeLookup {
+                node_ids: vec![NodeId::new(1).unwrap(), NodeId::new(2).unwrap()],
+                valid_time: 0.into(),
+                transaction_time: 0.into()
+            })),
+            2
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::TemporalVectorSearch {
+                k: 25,
+                property_key: Some("".to_string()),
+                timestamp: 0.into(),
+                embedding: vec![].into()
+            })),
+            25
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::SimilarToNode {
+                k: 35,
+                source_node: NodeId::new(1).unwrap(),
+                property_key: "".to_string(),
+                label_filter: None
+            })),
+            35
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::PropertyScan {
+                label: "".to_string(),
+                key: "".to_string(),
+                value: crate::query::ir::PredicateValue::Int(0)
+            })),
+            DEFAULT_PROPERTY_SCAN_CARDINALITY
+        );
+        assert_eq!(
+            rule.estimate_cardinality(&LogicalOp::Scan(ScanOp::EdgeScan {
+                edge_type: None,
+                estimated_rows: None
+            })),
+            DEFAULT_EDGE_SCAN_CARDINALITY
+        );
+    }
+
+    #[test]
+    fn test_reorder_binary_changed_propagation() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        let op = LogicalOp::binary(
+            BinaryOp::Union,
+            // Left child is a non-optimal join that WILL be changed
+            LogicalOp::binary(
+                BinaryOp::Join {
+                    left_key: "a".to_string(),
+                    right_key: "b".to_string(),
+                },
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(1000),
+                }),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(10),
+                }),
+            ),
+            // Right child is optimal (Empty)
+            LogicalOp::Empty,
+        );
+        let (_, changed) = rule.reorder(&op, &stats).unwrap();
+        assert!(
+            changed,
+            "changed should propagate from left child in binary op"
+        );
+
+        let op2 = LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Empty,
+            // Right child is a non-optimal join that WILL be changed
+            LogicalOp::binary(
+                BinaryOp::Join {
+                    left_key: "a".to_string(),
+                    right_key: "b".to_string(),
+                },
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(1000),
+                }),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(10),
+                }),
+            ),
+        );
+        let (_, changed2) = rule.reorder(&op2, &stats).unwrap();
+        assert!(
+            changed2,
+            "changed should propagate from right child in binary op"
+        );
+    }
+
+    #[test]
+    fn test_reorder_join_changed_propagation() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        // Join where left child will change, but size is already optimal (left is small, right is large)
+        let op = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "a".to_string(),
+                right_key: "b".to_string(),
+            },
+            // Left child will change
+            LogicalOp::binary(
+                BinaryOp::Join {
+                    left_key: "c".to_string(),
+                    right_key: "d".to_string(),
+                },
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(10),
+                }),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(2),
+                }),
+            ),
+            // Right child is Large, so left < right and they don't swap
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: Some(10000),
+            }),
+        );
+
+        let (_, changed) = rule.reorder(&op, &stats).unwrap();
+        assert!(
+            changed,
+            "changed should propagate from left child in join op"
+        );
+
+        // Join where right child will change, but size is already optimal
+        let op2 = LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "a".to_string(),
+                right_key: "b".to_string(),
+            },
+            // Left child is small
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: Some(10),
+            }),
+            // Right child will change, and its size will still be larger than left
+            LogicalOp::binary(
+                BinaryOp::Join {
+                    left_key: "c".to_string(),
+                    right_key: "d".to_string(),
+                },
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(10000),
+                }),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(2000),
+                }),
+            ),
+        );
+
+        let (_, changed2) = rule.reorder(&op2, &stats).unwrap();
+        assert!(
+            changed2,
+            "changed should propagate from right child in join op"
+        );
+    }
+
+    #[test]
+    fn test_filters_equal_method() {
+        let rule = OperationReordering;
+        let op1 = LogicalOp::Empty;
+        let op2 = LogicalOp::Empty;
+        let op3 = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(10),
+        });
+        assert!(rule.filters_equal(&op1, &op2));
+        assert!(!rule.filters_equal(&op1, &op3));
+    }
 }


### PR DESCRIPTION
**Summary:**
This PR fortifies the query planner optimization rules (`OperationReordering` and `FilterScanFusion`) against mutation evasion. By adding highly specific unit tests, we've locked down behaviors surrounding nested structural updates (propagating `changed` flags) and explicit output cardinality calculations.

**Verdict table:**

| Module / Function | Verdict | Reason |
| :--- | :--- | :--- |
| `operation_reordering::reorder` | 🟡 Suspect (Fixed) | Allowed mutations from `||` to `&&` when propagating boolean logic up complex `BinaryOp` nodes. |
| `operation_reordering::estimate_cardinality` | 🟡 Suspect (Fixed) | Lacked exhaustive structural checks across all scan variants and unary operators, meaning arbitrary mathematical mutations survived. |
| `operation_reordering::apply` | 🟡 Suspect (Fixed) | Survived missing changes, returning `Ok(None)` falsely or `Ok(Some(..))` falsely. |
| `filter_scan_fusion::fuse` | 🟡 Suspect (Fixed) | Same boolean propagation gap as reordering inside binary logic trees. |

**Priority fixes:**
1. **`test_reorder_binary_changed_propagation` & `test_reorder_join_changed_propagation`**: Force validation that when a child node (either left or right) mutates, that boolean reliably bubbles to the parent tree, completely defeating the `||` to `&&` mutations.
2. **`test_estimate_cardinality_scans`**: Mapped every single scan operation variant against expected bounds, ensuring that any mutation to hardcoded cost constants or mathematical estimations results in a panic.
3. **`test_apply_*` coverage**: Verified the direct output shapes from rule execution, forcing failures if `Ok(None)` / `Ok(Some)` logic swaps.

**Missing coverage addressed:**
Tests missing from explicit `name()` verification to comprehensive matching have all been filled to cover the gaps.

---
*PR created automatically by Jules for task [17153073895598553368](https://jules.google.com/task/17153073895598553368) started by @madmax983*