### PR TITLE
⚡ Bolt: Optimize candidate freshness scoring in semantic search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Iterating HashMap mutations safely]**
+**Learning:** Collecting `.keys().cloned().collect()` into a Vec just to do `.entry(id).and_modify(...)` is an anti-pattern. While it dodges immediate borrow checker complaints (since iterating and modifying the same structure isn't allowed simultaneously via immutable methods), it introduces a heap allocation and a secondary O(1) hash lookup per iteration.
+**Action:** Use `.iter_mut()` instead. It allows in-place mutation of values while iterating over the `HashMap`, eliminating the `Vec` allocation and the double lookup without fighting the borrow checker.

--- a/src/semantic_search/fishing.rs
+++ b/src/semantic_search/fishing.rs
@@ -187,9 +187,8 @@ impl<'a> FishingRod<'a> {
 
             // We need to fetch nodes to check timestamps.
             // Collect all candidate IDs
-            let all_candidates: Vec<NodeId> = candidate_scores.keys().cloned().collect();
-
-            for node_id in all_candidates {
+            // Iterate directly over mutable scores to avoid Vec allocation and double lookups
+            for (&node_id, score) in candidate_scores.iter_mut() {
                 // Not collapsing if to keep it simple and compatible with potentially older rust versions
                 // or just to be explicit. But clippy complained, so let's try to satisfy it without let_chains
                 // if they are experimental (as per memory), but `if let && let` is stable?
@@ -205,9 +204,7 @@ impl<'a> FishingRod<'a> {
                         let age_hours = age_seconds / 3600.0;
                         let freshness_score = 1.0 / (1.0 + age_hours);
 
-                        candidate_scores.entry(node_id).and_modify(|s| {
-                            *s += freshness_score * config.freshness_weight;
-                        });
+                        *score += freshness_score * config.freshness_weight;
                     }
                 }
             }


### PR DESCRIPTION
💡 **What:** Eliminated an intermediate `Vec` allocation (`all_candidates`) and a secondary `HashMap` lookup (`candidate_scores.entry(node_id).and_modify(...)`) during the freshness scoring phase in `src/semantic_search/fishing.rs`. Replaced it with a direct `.iter_mut()` loop over the scores map.

🎯 **Why:** The previous logic collected all keys into a vector to avoid a borrow-checker conflict when modifying values in the map. This introduced an unnecessary O(n) heap allocation and an extra O(1) hash lookup per node. `.iter_mut()` safely avoids the borrow checker issue while performing the exact same logic in-place.

📊 **Impact:** Removes 1 `Vec` heap allocation per freshness evaluation and eliminates N hash map lookups. Minor speed boost for queries on dense/large graphs.

🔬 **Measurement:** Run `cargo bench semantic_search` to verify standard latency improvements, or `cargo test semantic_search` to guarantee functional equivalence.

---
*PR created automatically by Jules for task [14117646427539569816](https://jules.google.com/task/14117646427539569816) started by @madmax983*