### PR TITLE
Add temporal invariant violation tests and edge validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Free Disk Space (Ubuntu)
+      - name: Free disk space (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /usr/local/share/powershell /usr/share/swift \
+            /usr/local/.ghcup /usr/lib/jvm "$AGENT_TOOLSDIRECTORY" || true
+          df -h
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -72,6 +72,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm "$AGENT_TOOLSDIRECTORY" || true
+          df -h
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -91,12 +98,6 @@ jobs:
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v5
-        with:
-          path: target
-          key: ${{ runner.os }}-v2-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate coverage report
         run: cargo llvm-cov --features "config-toml,mcp-server,sharding-rpc" --lcov --output-path lcov.info

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          df -h
+
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -54,14 +61,6 @@ jobs:
           key: ${{ runner.os }}-cargo-mutants-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-mutants-
-
-      - name: Cache cargo build
-        uses: actions/cache@v5
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-mutants-target-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mutants-target-
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
@@ -134,6 +133,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          df -h
+
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
@@ -143,14 +149,6 @@ jobs:
           key: ${{ runner.os }}-cargo-mutants-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-mutants-
-
-      - name: Cache cargo build
-        uses: actions/cache@v5
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-mutants-target-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mutants-target-
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1104,12 +1104,14 @@ impl WriteOps for WriteTransaction {
             validation::validate_valid_from_future(valid_from)?;
 
             // Validate valid_from is not before the edge's own creation time
-            let historical = self.historical.read();
-            if let Some(current_version_id) = historical.get_current_edge_version(edge_id)
-                && let Some(current_version) = historical.get_edge_version(current_version_id)
-            {
-                let creation_time = current_version.temporal.valid_time().start();
-                drop(historical);
+            let creation_time = {
+                let historical = self.historical.read();
+                historical
+                    .get_current_edge_version(edge_id)
+                    .and_then(|vid| historical.get_edge_version(vid))
+                    .map(|v| v.temporal.valid_time().start())
+            };
+            if let Some(creation_time) = creation_time {
                 validation::validate_valid_from_not_before_creation(
                     &format!("edge:{}", edge_id.as_u64()),
                     creation_time,
@@ -1261,12 +1263,14 @@ impl WriteOps for WriteTransaction {
             validation::validate_valid_from_future(valid_from)?;
 
             // Validate valid_from is not before the edge's own creation time
-            let historical = self.historical.read();
-            if let Some(current_version_id) = historical.get_current_edge_version(edge_id)
-                && let Some(current_version) = historical.get_edge_version(current_version_id)
-            {
-                let creation_time = current_version.temporal.valid_time().start();
-                drop(historical);
+            let creation_time = {
+                let historical = self.historical.read();
+                historical
+                    .get_current_edge_version(edge_id)
+                    .and_then(|vid| historical.get_edge_version(vid))
+                    .map(|v| v.temporal.valid_time().start())
+            };
+            if let Some(creation_time) = creation_time {
                 validation::validate_valid_from_not_before_creation(
                     &format!("edge:{}", edge_id.as_u64()),
                     creation_time,

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1100,6 +1100,23 @@ impl WriteOps for WriteTransaction {
             let timestamp = self.start_timestamp;
             let valid_from = valid_from.unwrap_or(timestamp);
 
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
+
+            // Validate valid_from is not before the edge's own creation time
+            let historical = self.historical.read();
+            if let Some(current_version_id) = historical.get_current_edge_version(edge_id)
+                && let Some(current_version) = historical.get_edge_version(current_version_id)
+            {
+                let creation_time = current_version.temporal.valid_time().start();
+                drop(historical);
+                validation::validate_valid_from_not_before_creation(
+                    &format!("edge:{}", edge_id.as_u64()),
+                    creation_time,
+                    valid_from,
+                )?;
+            }
+
             // Buffer the write with merged properties
             self.buffer.add(super::BufferedWrite::UpdateEdge {
                 edge_id,
@@ -1239,6 +1256,23 @@ impl WriteOps for WriteTransaction {
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
             let valid_from = valid_from.unwrap_or(timestamp);
+
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
+
+            // Validate valid_from is not before the edge's own creation time
+            let historical = self.historical.read();
+            if let Some(current_version_id) = historical.get_current_edge_version(edge_id)
+                && let Some(current_version) = historical.get_edge_version(current_version_id)
+            {
+                let creation_time = current_version.temporal.valid_time().start();
+                drop(historical);
+                validation::validate_valid_from_not_before_creation(
+                    &format!("edge:{}", edge_id.as_u64()),
+                    creation_time,
+                    valid_from,
+                )?;
+            }
 
             // Buffer the write
             self.buffer.add(super::BufferedWrite::DeleteEdge {

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2912,6 +2912,119 @@ mod timestamp_ordering_tests {
             Some(5)
         );
     }
+
+    /// Test: A rollback must not advance the shared current_timestamp.
+    ///
+    /// If an uncommitted transaction were to advance the HLC frontier during
+    /// rollback, subsequent commits would see an artificially high starting
+    /// timestamp, potentially conflicting with future clock ticks.
+    #[test]
+    fn test_rollback_does_not_advance_current_timestamp() {
+        let harness = TestHarness::new();
+
+        let ts_before = *harness.current_timestamp.lock().unwrap();
+
+        // Build a transaction with work but drop it without committing (implicit rollback)
+        {
+            let mut tx = harness.create_tx();
+            tx.create_node(
+                "Test",
+                PropertyMapBuilder::new().insert("x", 1i64).build(),
+            )
+            .unwrap();
+            // tx is dropped here → rollback; current_timestamp must not change
+        }
+
+        let ts_after_rollback = *harness.current_timestamp.lock().unwrap();
+        assert_eq!(
+            ts_before, ts_after_rollback,
+            "Rollback must not advance current_timestamp"
+        );
+
+        // A subsequent commit must produce a timestamp strictly greater than ts_before
+        let mut tx2 = harness.create_tx();
+        tx2.create_node(
+            "Test",
+            PropertyMapBuilder::new().insert("x", 2i64).build(),
+        )
+        .unwrap();
+        tx2.commit().unwrap();
+
+        let ts_after_commit = *harness.current_timestamp.lock().unwrap();
+        assert!(
+            ts_after_commit > ts_before,
+            "Commit after rollback must produce timestamp > pre-rollback timestamp \
+             (before={ts_before}, after_commit={ts_after_commit})"
+        );
+    }
+
+    /// Test: Concurrent transactions that collide on wallclock are still ordered
+    /// by the logical counter embedded in the HLC timestamp.
+    ///
+    /// Two threads commit back-to-back in < 1 µs (a common occurrence under
+    /// load). The HLC monotonic guarantee means each commit gets a unique,
+    /// strictly-increasing commit timestamp regardless of wallclock resolution.
+    ///
+    /// Note: the shared `current_timestamp` reflects the LAST committed value,
+    /// so we read each node's embedded commit timestamp instead — that is the
+    /// value sealed into every committed version record.
+    #[test]
+    fn test_concurrent_commits_never_produce_equal_timestamps() {
+        let harness = Arc::new(TestHarness::new());
+        let node_ids: Arc<Mutex<Vec<crate::core::id::NodeId>>> =
+            Arc::new(Mutex::new(Vec::new()));
+
+        let threads: Vec<_> = (0..20)
+            .map(|i| {
+                let h = harness.clone();
+                let ids = node_ids.clone();
+                thread::spawn(move || {
+                    let mut tx = h.create_tx();
+                    let node_id = tx
+                        .create_node(
+                            "Test",
+                            PropertyMapBuilder::new().insert("i", i as i64).build(),
+                        )
+                        .unwrap();
+                    tx.commit().unwrap();
+
+                    ids.lock().unwrap().push(node_id);
+                })
+            })
+            .collect();
+
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        // Read the actual commit timestamp embedded in each node at commit time.
+        // This is distinct from the shared current_timestamp which is updated by
+        // every commit — reading it concurrently would produce duplicates.
+        let ids = node_ids.lock().unwrap();
+        let mut commit_timestamps: Vec<Timestamp> = ids
+            .iter()
+            .map(|&nid| {
+                harness
+                    .current
+                    .get_node(nid)
+                    .unwrap()
+                    .metadata
+                    .commit_timestamp
+                    .unwrap()
+            })
+            .collect();
+        commit_timestamps.sort();
+
+        // All per-node commit timestamps must be unique
+        for i in 1..commit_timestamps.len() {
+            assert_ne!(
+                commit_timestamps[i],
+                commit_timestamps[i - 1],
+                "Concurrent commits produced duplicate commit timestamps at index {i}: {}",
+                commit_timestamps[i]
+            );
+        }
+    }
 }
 
 mod bitemporal_validation_tests {
@@ -3178,6 +3291,148 @@ mod bitemporal_validation_tests {
             result.is_err(),
             "Should reject valid_time before entity creation"
         );
+    }
+
+    /// Test: Updating an edge with valid_time before the edge's own creation is rejected.
+    ///
+    /// This exercises ValidTimeBeforeEntityCreation for edges, complementing the
+    /// existing node test. The edge's own valid_from (not the connected nodes') is
+    /// used as the lower bound.
+    #[test]
+    fn test_update_edge_rejects_valid_time_before_edge_creation() {
+        use crate::core::error::TemporalError;
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+
+        // Create source and target nodes, then an edge
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let edge_id = tx2
+            .create_edge(src, tgt, "KNOWS", PropertyMap::new())
+            .unwrap();
+        tx2.commit().unwrap();
+
+        // Try to update the edge with a valid_time that predates its own creation
+        let before_creation = HybridTimestamp::new(1000, 0).unwrap();
+
+        let mut tx3 = harness.begin_write();
+        let result = tx3.update_edge_with_valid_time(
+            edge_id,
+            PropertyMapBuilder::new().insert("strength", 5i64).build(),
+            Some(before_creation),
+        );
+
+        assert!(result.is_err(), "Should reject valid_time before edge creation");
+        match result.unwrap_err() {
+            crate::core::error::Error::Temporal(TemporalError::ValidTimeBeforeEntityCreation {
+                ..
+            }) => {}
+            err => panic!("Expected ValidTimeBeforeEntityCreation, got: {err:?}"),
+        }
+    }
+
+    /// Test: Deleting an edge with valid_time before the edge's own creation is rejected.
+    #[test]
+    fn test_delete_edge_rejects_valid_time_before_edge_creation() {
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let edge_id = tx2
+            .create_edge(src, tgt, "KNOWS", PropertyMap::new())
+            .unwrap();
+        tx2.commit().unwrap();
+
+        let before_creation = HybridTimestamp::new(1000, 0).unwrap();
+
+        let mut tx3 = harness.begin_write();
+        let result = tx3.delete_edge_with_valid_time(edge_id, Some(before_creation));
+
+        assert!(
+            result.is_err(),
+            "Should reject valid_time before edge creation"
+        );
+    }
+
+    /// Test: The maximum valid timestamp boundary is accepted and just above is rejected.
+    ///
+    /// `HybridTimestamp::new` rejects wallclock values exceeding `MAX_VALID_TIMESTAMP`
+    /// (i64::MAX - 1000) to guard against overflow-based DoS attacks on the temporal
+    /// indexing layer. The internal `TIMESTAMP_MAX` sentinel (i64::MAX) is created only
+    /// via `new_unchecked` for use as an open-ended interval marker.
+    #[test]
+    fn test_timestamp_boundary_max_valid_timestamp() {
+        use crate::core::hlc::HybridTimestamp;
+        use crate::core::temporal::MAX_VALID_TIMESTAMP;
+
+        // Exactly at MAX_VALID_TIMESTAMP is valid
+        let at_boundary = HybridTimestamp::new(MAX_VALID_TIMESTAMP, 0);
+        assert!(
+            at_boundary.is_ok(),
+            "HybridTimestamp at MAX_VALID_TIMESTAMP must be valid, got: {at_boundary:?}"
+        );
+
+        // One above MAX_VALID_TIMESTAMP is invalid — this is the overflow guard
+        let above_boundary = HybridTimestamp::new(MAX_VALID_TIMESTAMP + 1, 0);
+        assert!(
+            above_boundary.is_err(),
+            "HybridTimestamp just above MAX_VALID_TIMESTAMP must be rejected"
+        );
+
+        // i64::MAX via the public constructor is also rejected (not a user-visible value)
+        let via_new = HybridTimestamp::new(i64::MAX, 0);
+        assert!(
+            via_new.is_err(),
+            "i64::MAX via HybridTimestamp::new must be rejected (use TIMESTAMP_MAX internally)"
+        );
+
+        // TIMESTAMP_MAX is accessible as a module-level constant and can be used
+        // in open-ended time ranges internally, but cannot be created via new()
+        let sentinel = crate::core::temporal::TIMESTAMP_MAX;
+        assert_eq!(sentinel.wallclock(), i64::MAX);
+        assert_eq!(sentinel.logical(), 0);
+    }
+
+    /// Test: Transaction with a valid_time set 1 year in future is rejected.
+    ///
+    /// The MAX_VALID_TIME_FUTURE_OFFSET_US constant limits how far ahead valid_time
+    /// can be set, preventing logical time paradoxes where recorded facts appear
+    /// to be valid arbitrarily far in the future.
+    #[test]
+    fn test_valid_time_one_year_in_future_rejected() {
+        use crate::core::error::TemporalError;
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+
+        // Use exactly 1 year + 1 second past the allowed limit
+        let over_limit_wallclock = time::now().wallclock()
+            + super::super::MAX_VALID_TIME_FUTURE_OFFSET_US
+            + 1_000_000; // +1s over limit
+
+        let over_limit_ts = HybridTimestamp::new(over_limit_wallclock, 0).unwrap();
+
+        let mut tx = harness.begin_write();
+        let result = tx.create_node_with_valid_time("Test", PropertyMap::new(), Some(over_limit_ts));
+
+        assert!(result.is_err(), "Should reject valid_time beyond the 1-year limit");
+        match result.unwrap_err() {
+            crate::core::error::Error::Temporal(TemporalError::ValidTimeTooFarInFuture {
+                ..
+            }) => {}
+            err => panic!("Expected ValidTimeTooFarInFuture, got: {err:?}"),
+        }
     }
 }
 

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -3433,6 +3433,86 @@ mod bitemporal_validation_tests {
             err => panic!("Expected ValidTimeTooFarInFuture, got: {err:?}"),
         }
     }
+
+    /// Test: Updating an edge with valid_time set more than 1 year in future is rejected.
+    #[test]
+    fn test_update_edge_rejects_far_future_valid_time() {
+        use crate::core::error::TemporalError;
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let edge_id = tx2
+            .create_edge(src, tgt, "KNOWS", PropertyMap::new())
+            .unwrap();
+        tx2.commit().unwrap();
+
+        let over_limit_wallclock =
+            time::now().wallclock() + super::super::MAX_VALID_TIME_FUTURE_OFFSET_US + 1_000_000;
+        let over_limit_ts = HybridTimestamp::new(over_limit_wallclock, 0).unwrap();
+
+        let mut tx3 = harness.begin_write();
+        let result = tx3.update_edge_with_valid_time(
+            edge_id,
+            PropertyMapBuilder::new().insert("strength", 5i64).build(),
+            Some(over_limit_ts),
+        );
+
+        assert!(
+            result.is_err(),
+            "Should reject valid_time beyond the 1-year limit"
+        );
+        match result.unwrap_err() {
+            crate::core::error::Error::Temporal(TemporalError::ValidTimeTooFarInFuture {
+                ..
+            }) => {}
+            err => panic!("Expected ValidTimeTooFarInFuture, got: {err:?}"),
+        }
+    }
+
+    /// Test: Deleting an edge with valid_time set more than 1 year in future is rejected.
+    #[test]
+    fn test_delete_edge_rejects_far_future_valid_time() {
+        use crate::core::error::TemporalError;
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let edge_id = tx2
+            .create_edge(src, tgt, "KNOWS", PropertyMap::new())
+            .unwrap();
+        tx2.commit().unwrap();
+
+        let over_limit_wallclock =
+            time::now().wallclock() + super::super::MAX_VALID_TIME_FUTURE_OFFSET_US + 1_000_000;
+        let over_limit_ts = HybridTimestamp::new(over_limit_wallclock, 0).unwrap();
+
+        let mut tx3 = harness.begin_write();
+        let result = tx3.delete_edge_with_valid_time(edge_id, Some(over_limit_ts));
+
+        assert!(
+            result.is_err(),
+            "Should reject valid_time beyond the 1-year limit"
+        );
+        match result.unwrap_err() {
+            crate::core::error::Error::Temporal(TemporalError::ValidTimeTooFarInFuture {
+                ..
+            }) => {}
+            err => panic!("Expected ValidTimeTooFarInFuture, got: {err:?}"),
+        }
+    }
 }
 
 mod find_nodes_by_property_tests {

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -2927,11 +2927,8 @@ mod timestamp_ordering_tests {
         // Build a transaction with work but drop it without committing (implicit rollback)
         {
             let mut tx = harness.create_tx();
-            tx.create_node(
-                "Test",
-                PropertyMapBuilder::new().insert("x", 1i64).build(),
-            )
-            .unwrap();
+            tx.create_node("Test", PropertyMapBuilder::new().insert("x", 1i64).build())
+                .unwrap();
             // tx is dropped here → rollback; current_timestamp must not change
         }
 
@@ -2943,11 +2940,8 @@ mod timestamp_ordering_tests {
 
         // A subsequent commit must produce a timestamp strictly greater than ts_before
         let mut tx2 = harness.create_tx();
-        tx2.create_node(
-            "Test",
-            PropertyMapBuilder::new().insert("x", 2i64).build(),
-        )
-        .unwrap();
+        tx2.create_node("Test", PropertyMapBuilder::new().insert("x", 2i64).build())
+            .unwrap();
         tx2.commit().unwrap();
 
         let ts_after_commit = *harness.current_timestamp.lock().unwrap();
@@ -2971,8 +2965,7 @@ mod timestamp_ordering_tests {
     #[test]
     fn test_concurrent_commits_never_produce_equal_timestamps() {
         let harness = Arc::new(TestHarness::new());
-        let node_ids: Arc<Mutex<Vec<crate::core::id::NodeId>>> =
-            Arc::new(Mutex::new(Vec::new()));
+        let node_ids: Arc<Mutex<Vec<crate::core::id::NodeId>>> = Arc::new(Mutex::new(Vec::new()));
 
         let threads: Vec<_> = (0..20)
             .map(|i| {
@@ -3327,7 +3320,10 @@ mod bitemporal_validation_tests {
             Some(before_creation),
         );
 
-        assert!(result.is_err(), "Should reject valid_time before edge creation");
+        assert!(
+            result.is_err(),
+            "Should reject valid_time before edge creation"
+        );
         match result.unwrap_err() {
             crate::core::error::Error::Temporal(TemporalError::ValidTimeBeforeEntityCreation {
                 ..
@@ -3417,16 +3413,19 @@ mod bitemporal_validation_tests {
         let harness = TestHarness::new();
 
         // Use exactly 1 year + 1 second past the allowed limit
-        let over_limit_wallclock = time::now().wallclock()
-            + super::super::MAX_VALID_TIME_FUTURE_OFFSET_US
-            + 1_000_000; // +1s over limit
+        let over_limit_wallclock =
+            time::now().wallclock() + super::super::MAX_VALID_TIME_FUTURE_OFFSET_US + 1_000_000; // +1s over limit
 
         let over_limit_ts = HybridTimestamp::new(over_limit_wallclock, 0).unwrap();
 
         let mut tx = harness.begin_write();
-        let result = tx.create_node_with_valid_time("Test", PropertyMap::new(), Some(over_limit_ts));
+        let result =
+            tx.create_node_with_valid_time("Test", PropertyMap::new(), Some(over_limit_ts));
 
-        assert!(result.is_err(), "Should reject valid_time beyond the 1-year limit");
+        assert!(
+            result.is_err(),
+            "Should reject valid_time beyond the 1-year limit"
+        );
         match result.unwrap_err() {
             crate::core::error::Error::Temporal(TemporalError::ValidTimeTooFarInFuture {
                 ..

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1030,7 +1030,25 @@ impl HistoricalStorage {
                 .into());
             }
 
-            let version = self.get_node_version_any_tier(current_id)?;
+            // After the first version is retrieved, a VersionNotFound on a subsequent
+            // lookup means the backward chain is broken: the ancestor (ultimately the
+            // anchor) has been removed. Return MissingAnchor rather than the generic
+            // VersionNotFound so callers can distinguish "version never existed" from
+            // "chain integrity was broken after creation".
+            let version = match self.get_node_version_any_tier(current_id) {
+                Ok(v) => v,
+                Err(crate::core::error::Error::Storage(StorageError::VersionNotFound(_)))
+                    if !version_ids.is_empty() =>
+                {
+                    let entity_id = version_ids
+                        .first()
+                        .and_then(|&vid| self.node_versions.get(&vid))
+                        .map(|v| v.node_id.to_string())
+                        .unwrap_or_else(|| format!("version {}", version_id));
+                    return Err(TemporalError::MissingAnchor { entity_id }.into());
+                }
+                Err(e) => return Err(e),
+            };
 
             let is_anchor = version.is_anchor();
             let prev_id = version.prev_version;
@@ -1128,7 +1146,23 @@ impl HistoricalStorage {
                 .into());
             }
 
-            let version = self.get_edge_version_any_tier(current_id)?;
+            // After the first version is retrieved, a VersionNotFound on a subsequent
+            // lookup means the backward chain is broken — the ancestor anchor has been
+            // removed. Return MissingAnchor rather than VersionNotFound.
+            let version = match self.get_edge_version_any_tier(current_id) {
+                Ok(v) => v,
+                Err(crate::core::error::Error::Storage(StorageError::VersionNotFound(_)))
+                    if !version_ids.is_empty() =>
+                {
+                    let entity_id = version_ids
+                        .first()
+                        .and_then(|&vid| self.edge_versions.get(&vid))
+                        .map(|v| v.edge_id.to_string())
+                        .unwrap_or_else(|| format!("version {}", version_id));
+                    return Err(TemporalError::MissingAnchor { entity_id }.into());
+                }
+                Err(e) => return Err(e),
+            };
 
             let is_anchor = version.is_anchor();
             let prev_id = version.prev_version;

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2953,6 +2953,31 @@ impl HistoricalStorage {
         self.node_property_cache.clear();
         self.node_anchor_cache.clear();
     }
+
+    /// **Test-only helper**: Remove an edge version from hot storage.
+    ///
+    /// Used in tests to simulate version migration or corruption scenarios.
+    ///
+    /// # Safety
+    /// This method directly modifies internal state and should only be used
+    /// in tests. It does not update caches or notify observers.
+    #[doc(hidden)]
+    pub fn __test_remove_edge_version(&mut self, version_id: VersionId) {
+        self.edge_versions.remove(&version_id);
+    }
+
+    /// **Test-only helper**: Clear the edge property reconstruction cache.
+    ///
+    /// Used in tests to force actual property reconstruction for edge versions
+    /// instead of returning cached values.
+    ///
+    /// # Safety
+    /// This method clears caches and should only be used in tests.
+    #[doc(hidden)]
+    pub fn __test_clear_edge_property_cache(&self) {
+        self.edge_property_cache.clear();
+        self.edge_anchor_cache.clear();
+    }
 }
 
 impl Default for HistoricalStorage {

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1043,7 +1043,7 @@ impl HistoricalStorage {
                 {
                     let entity_id = version_ids
                         .first()
-                        .and_then(|&vid| self.node_versions.get(&vid))
+                        .and_then(|&vid| self.get_node_version_any_tier(vid).ok())
                         .map(|v| v.node_id.to_string())
                         .unwrap_or_else(|| format!("version {}", version_id));
                     return Err(TemporalError::MissingAnchor { entity_id }.into());
@@ -1157,7 +1157,7 @@ impl HistoricalStorage {
                 {
                     let entity_id = version_ids
                         .first()
-                        .and_then(|&vid| self.edge_versions.get(&vid))
+                        .and_then(|&vid| self.get_edge_version_any_tier(vid).ok())
                         .map(|v| v.edge_id.to_string())
                         .unwrap_or_else(|| format!("version {}", version_id));
                     return Err(TemporalError::MissingAnchor { entity_id }.into());

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1004,7 +1004,8 @@ impl HistoricalStorage {
     /// # Returns
     /// * `Ok(PropertyMap)` - Reconstructed properties
     /// * `Err(TemporalError::MaxDepthExceeded)` - Delta chain too deep (DoS protection)
-    /// * `Err(StorageError::VersionNotFound)` - Version not found
+    /// * `Err(StorageError::VersionNotFound)` - Requested version does not exist
+    /// * `Err(TemporalError::MissingAnchor)` - An ancestor in the chain was removed
     /// * `Err(TemporalError::CorruptedVersionChain)` - Invalid chain structure
     fn reconstruct_node_properties_iterative(&self, version_id: VersionId) -> Result<PropertyMap> {
         // Collect version IDs backwards from target to anchor

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4491,3 +4491,319 @@ fn test_sentry_find_node_version_at_time_cycle_detection() {
         }
     }
 }
+
+// ============================================================================
+// Temporal Invariant Violation Tests (Issue #350)
+// ============================================================================
+//
+// These tests verify that temporal errors are detected and reported correctly.
+// They cover three categories:
+//
+// 1. Version chain corruption (CorruptedVersionChain, MissingAnchor)
+// 2. Temporal paradox detection (competing valid_time ranges)
+// 3. Historical reconstruction with broken chains
+
+#[test]
+fn test_corrupted_version_chain_delta_no_prev_version() {
+    // Verifies that a delta version with a None prev_version link is detected
+    // as a corrupted chain during property reconstruction.
+    //
+    // This exercises the error path in reconstruct_node_properties_iterative
+    // at the "Delta version has no previous version" check.
+    use crate::core::version::NodeVersion;
+
+    let mut storage = HistoricalStorage::new();
+    let node_id = NodeId::new(42).unwrap();
+    let label = GLOBAL_INTERNER.intern("CorruptTest").unwrap();
+
+    // Create a valid anchor version first
+    let v0_id = VersionId::new(1).unwrap();
+    storage
+        .add_node_version(
+            node_id,
+            v0_id,
+            1000.into(),
+            1000.into(),
+            label,
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            false,
+        )
+        .unwrap();
+
+    // Manually create a delta version then corrupt it by setting prev_version = None.
+    // This simulates a broken chain where the delta has no link back to the anchor.
+    let v1_id = VersionId::new(2).unwrap();
+    let mut v1 = NodeVersion::new_delta(
+        v1_id,
+        node_id,
+        BiTemporalInterval::current(2000.into()),
+        label,
+        &PropertyMapBuilder::new().insert("name", "Alice").build(),
+        &PropertyMapBuilder::new().insert("name", "Bob").build(),
+        v0_id,
+    );
+    v1.prev_version = None; // Deliberately corrupt: remove backward link
+
+    storage.insert_restored_node_version(v1).unwrap();
+    storage.__test_clear_property_cache();
+
+    // Reconstruction of v1 must fail with a specific corruption error
+    let result = storage.reconstruct_node_properties(v1_id);
+    assert!(result.is_err(), "Expected error for corrupted chain");
+    match result.unwrap_err() {
+        crate::core::error::Error::Temporal(crate::core::error::TemporalError::CorruptedVersionChain {
+            reason,
+            ..
+        }) => {
+            assert!(
+                reason.contains("no previous version"),
+                "Expected 'no previous version' in reason, got: {reason}"
+            );
+        }
+        err => panic!("Expected CorruptedVersionChain, got: {err:?}"),
+    }
+}
+
+#[test]
+fn test_missing_anchor_detected_after_anchor_deletion() {
+    // Verifies that when the anchor version of a node's chain is removed from
+    // storage, attempting to reconstruct a downstream delta returns MissingAnchor
+    // rather than a generic VersionNotFound.
+    //
+    // MissingAnchor is semantically more informative: it tells the caller that
+    // the chain exists but the base snapshot is gone, which is distinct from
+    // the requested version never existing at all.
+    //
+    // Chain structure: v0 (anchor) ← v1 (delta)
+    // Action: remove v0 from hot storage
+    // Expected: reconstruct(v1) → MissingAnchor, not VersionNotFound
+
+    let mut storage = HistoricalStorage::new();
+    let node_id = NodeId::new(99).unwrap();
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+
+    // Build anchor → delta chain
+    let v0_id = VersionId::new(10).unwrap();
+    storage
+        .add_node_version(
+            node_id,
+            v0_id,
+            1000.into(),
+            1000.into(),
+            label,
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            false,
+        )
+        .unwrap();
+
+    let v1_id = VersionId::new(11).unwrap();
+    storage
+        .add_node_version(
+            node_id,
+            v1_id,
+            2000.into(),
+            2000.into(),
+            label,
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+            false,
+        )
+        .unwrap();
+
+    assert!(storage.get_node_version(v1_id).unwrap().is_delta());
+    assert_eq!(
+        storage.get_node_version(v1_id).unwrap().prev_version,
+        Some(v0_id)
+    );
+
+    // Simulate anchor loss (e.g. migration to cold storage that is then unavailable)
+    storage.__test_remove_node_version(v0_id);
+    storage.__test_clear_property_cache();
+
+    let result = storage.reconstruct_node_properties(v1_id);
+    assert!(result.is_err(), "Expected error when anchor is missing");
+    match result.unwrap_err() {
+        crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
+            entity_id,
+        }) => {
+            assert!(!entity_id.is_empty(), "MissingAnchor entity_id must not be empty");
+        }
+        err => panic!("Expected MissingAnchor, got: {err:?}"),
+    }
+}
+
+#[test]
+fn test_edge_missing_anchor_detected_after_anchor_deletion() {
+    // Mirrors test_missing_anchor_detected_after_anchor_deletion for edge versions.
+    //
+    // Chain: e0 (anchor) ← e1 (delta). Remove e0. Reconstruct(e1) → MissingAnchor.
+
+    let mut storage = HistoricalStorage::new();
+    let edge_id = crate::core::id::EdgeId::new(55).unwrap();
+    let source = NodeId::new(1).unwrap();
+    let target = NodeId::new(2).unwrap();
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+
+    let e0_id = VersionId::new(20).unwrap();
+    storage
+        .add_edge_version(
+            edge_id,
+            e0_id,
+            1000.into(),
+            1000.into(),
+            label,
+            source,
+            target,
+            PropertyMapBuilder::new().insert("weight", 1i64).build(),
+            false,
+        )
+        .unwrap();
+
+    let e1_id = VersionId::new(21).unwrap();
+    storage
+        .add_edge_version(
+            edge_id,
+            e1_id,
+            2000.into(),
+            2000.into(),
+            label,
+            source,
+            target,
+            PropertyMapBuilder::new().insert("weight", 2i64).build(),
+            false,
+        )
+        .unwrap();
+
+    assert!(storage.get_edge_version(e1_id).unwrap().is_delta());
+
+    // Remove the anchor
+    storage.__test_remove_edge_version(e0_id);
+    storage.__test_clear_edge_property_cache();
+
+    let result = storage.reconstruct_edge_properties(e1_id);
+    assert!(result.is_err(), "Expected error when edge anchor is missing");
+    match result.unwrap_err() {
+        crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
+            entity_id,
+        }) => {
+            assert!(!entity_id.is_empty());
+        }
+        err => panic!("Expected MissingAnchor, got: {err:?}"),
+    }
+}
+
+#[test]
+fn test_version_chain_reconstruction_multi_hop_deltas() {
+    // Verifies correct property reconstruction across a four-version chain:
+    // v0 (anchor: name=Alice) → v1 (delta: name=Bob) → v2 (delta: name=Carol) → v3 (delta: name=Dave)
+    //
+    // The anchor_interval is set to 10 so all updates create deltas rather than new anchors.
+    let mut storage = HistoricalStorage::with_config(AnchorConfig {
+        anchor_interval: 10,
+        max_delta_chain: 100,
+    });
+
+    let node_id = NodeId::new(1).unwrap();
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+    let names = ["Alice", "Bob", "Carol", "Dave"];
+    let mut version_ids = Vec::new();
+
+    for (i, &name) in names.iter().enumerate() {
+        let vid = VersionId::new(100 + i as u64).unwrap();
+        storage
+            .add_node_version(
+                node_id,
+                vid,
+                (1000 + i as i64 * 100).into(),
+                (1000 + i as i64 * 100).into(),
+                label,
+                PropertyMapBuilder::new().insert("name", name).build(),
+                false,
+            )
+            .unwrap();
+        version_ids.push(vid);
+    }
+
+    // v0 is anchor, v1/v2/v3 are deltas (interval=10, only first is anchor)
+    assert!(storage.get_node_version(version_ids[0]).unwrap().is_anchor());
+    assert!(storage.get_node_version(version_ids[1]).unwrap().is_delta());
+    assert!(storage.get_node_version(version_ids[2]).unwrap().is_delta());
+    assert!(storage.get_node_version(version_ids[3]).unwrap().is_delta());
+
+    storage.__test_clear_property_cache();
+
+    for (i, &vid) in version_ids.iter().enumerate() {
+        let props = storage.reconstruct_node_properties(vid).unwrap();
+        assert_eq!(
+            props.get("name").and_then(|v| v.as_str()),
+            Some(names[i]),
+            "Version {i} should have name={}",
+            names[i]
+        );
+    }
+}
+
+#[test]
+fn test_competing_valid_times_stored_and_queried_by_bitemporal_interval() {
+    // Bi-temporal databases legitimately store versions with overlapping or
+    // "competing" valid_time ranges. The transaction_time dimension resolves
+    // which version was "known" at any given point.
+    //
+    // This test verifies that:
+    // 1. Two versions for the same node with different valid_from times can coexist.
+    // 2. Querying at each valid_time returns the correct version.
+    // 3. No error is returned for "competing" ranges — they are valid state.
+
+    let mut storage = HistoricalStorage::new();
+    let node_id = NodeId::new(7).unwrap();
+    let label = GLOBAL_INTERNER.intern("Event").unwrap();
+
+    // v1: valid_from=3000, recorded at tx_time=1000
+    let v1_id = VersionId::new(1).unwrap();
+    storage
+        .add_node_version(
+            node_id,
+            v1_id,
+            3000.into(), // valid_from: event started at t=3000
+            1000.into(), // tx_time: we recorded this at t=1000
+            label,
+            PropertyMapBuilder::new().insert("status", "scheduled").build(),
+            false,
+        )
+        .unwrap();
+
+    // v2: valid_from=2000, recorded at tx_time=2000 (later knowledge: event started earlier)
+    let v2_id = VersionId::new(2).unwrap();
+    storage
+        .add_node_version(
+            node_id,
+            v2_id,
+            2000.into(), // valid_from: corrected — event actually started at t=2000
+            2000.into(), // tx_time: we learned this at t=2000
+            label,
+            PropertyMapBuilder::new().insert("status", "started").build(),
+            false,
+        )
+        .unwrap();
+
+    // Both versions should exist without error
+    assert!(storage.get_node_version(v1_id).is_some());
+    assert!(storage.get_node_version(v2_id).is_some());
+
+    // As of tx_time=1500 (after v1 but before v2), only v1 was known.
+    // Query at valid_time=3500 should find v1.
+    let found = storage.find_node_version_at_time(node_id, 3500.into(), 1500.into());
+    assert_eq!(
+        found,
+        Some(v1_id),
+        "At tx_time=1500, only v1 was known for valid_time=3500"
+    );
+
+    // As of tx_time=2500 (after both versions), v2 is the latest knowledge.
+    // Query at valid_time=2500 should find v2 (valid_from=2000 covers this).
+    let found_v2 = storage.find_node_version_at_time(node_id, 2500.into(), 2500.into());
+    assert_eq!(
+        found_v2,
+        Some(v2_id),
+        "At tx_time=2500, v2 should be visible at valid_time=2500"
+    );
+}

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4614,6 +4614,17 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
         Some(v0_id)
     );
 
+    // Pre-populate the reconstruction cache so that __test_clear_property_cache
+    // becomes load-bearing: a mutant that makes it a no-op would leave the cache
+    // populated and the second reconstruct call would return Ok (cached) instead
+    // of MissingAnchor, which would fail the test below.
+    let warm = storage.reconstruct_node_properties(v1_id).unwrap();
+    assert_eq!(
+        warm.get("name").and_then(|v| v.as_str()),
+        Some("Bob"),
+        "pre-deletion reconstruction must succeed"
+    );
+
     // Simulate anchor loss (e.g. migration to cold storage that is then unavailable)
     storage.__test_remove_node_version(v0_id);
     storage.__test_clear_property_cache();
@@ -4676,6 +4687,17 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
         .unwrap();
 
     assert!(storage.get_edge_version(e1_id).unwrap().is_delta());
+
+    // Pre-populate the edge reconstruction cache so the clear step is load-bearing.
+    // A mutant that turns __test_clear_edge_property_cache into a no-op would leave
+    // the cached Ok value in place; the subsequent reconstruct would return it instead
+    // of discovering MissingAnchor, causing the assertion below to fail.
+    let warm = storage.reconstruct_edge_properties(e1_id).unwrap();
+    assert_eq!(
+        warm.get("weight").and_then(|v| v.as_int()),
+        Some(2),
+        "pre-deletion reconstruction must succeed"
+    );
 
     // Remove the anchor
     storage.__test_remove_edge_version(e0_id);

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4551,10 +4551,9 @@ fn test_corrupted_version_chain_delta_no_prev_version() {
     let result = storage.reconstruct_node_properties(v1_id);
     assert!(result.is_err(), "Expected error for corrupted chain");
     match result.unwrap_err() {
-        crate::core::error::Error::Temporal(crate::core::error::TemporalError::CorruptedVersionChain {
-            reason,
-            ..
-        }) => {
+        crate::core::error::Error::Temporal(
+            crate::core::error::TemporalError::CorruptedVersionChain { reason, .. },
+        ) => {
             assert!(
                 reason.contains("no previous version"),
                 "Expected 'no previous version' in reason, got: {reason}"
@@ -4625,7 +4624,10 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
         crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
             entity_id,
         }) => {
-            assert!(!entity_id.is_empty(), "MissingAnchor entity_id must not be empty");
+            assert!(
+                !entity_id.is_empty(),
+                "MissingAnchor entity_id must not be empty"
+            );
         }
         err => panic!("Expected MissingAnchor, got: {err:?}"),
     }
@@ -4680,7 +4682,10 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
     storage.__test_clear_edge_property_cache();
 
     let result = storage.reconstruct_edge_properties(e1_id);
-    assert!(result.is_err(), "Expected error when edge anchor is missing");
+    assert!(
+        result.is_err(),
+        "Expected error when edge anchor is missing"
+    );
     match result.unwrap_err() {
         crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
             entity_id,
@@ -4724,7 +4729,12 @@ fn test_version_chain_reconstruction_multi_hop_deltas() {
     }
 
     // v0 is anchor, v1/v2/v3 are deltas (interval=10, only first is anchor)
-    assert!(storage.get_node_version(version_ids[0]).unwrap().is_anchor());
+    assert!(
+        storage
+            .get_node_version(version_ids[0])
+            .unwrap()
+            .is_anchor()
+    );
     assert!(storage.get_node_version(version_ids[1]).unwrap().is_delta());
     assert!(storage.get_node_version(version_ids[2]).unwrap().is_delta());
     assert!(storage.get_node_version(version_ids[3]).unwrap().is_delta());
@@ -4766,7 +4776,9 @@ fn test_competing_valid_times_stored_and_queried_by_bitemporal_interval() {
             3000.into(), // valid_from: event started at t=3000
             1000.into(), // tx_time: we recorded this at t=1000
             label,
-            PropertyMapBuilder::new().insert("status", "scheduled").build(),
+            PropertyMapBuilder::new()
+                .insert("status", "scheduled")
+                .build(),
             false,
         )
         .unwrap();
@@ -4780,7 +4792,9 @@ fn test_competing_valid_times_stored_and_queried_by_bitemporal_interval() {
             2000.into(), // valid_from: corrected — event actually started at t=2000
             2000.into(), // tx_time: we learned this at t=2000
             label,
-            PropertyMapBuilder::new().insert("status", "started").build(),
+            PropertyMapBuilder::new()
+                .insert("status", "started")
+                .build(),
             false,
         )
         .unwrap();

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4629,6 +4629,16 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
     storage.__test_remove_node_version(v0_id);
     storage.__test_clear_property_cache();
 
+    // Kill the anchor-cache-clear mutation: v0 is an anchor so add_node_version put it
+    // in node_anchor_cache. After __test_clear_property_cache, the anchor cache is empty.
+    // A mutant that makes node_anchor_cache.clear() a no-op leaves v0 in the cache;
+    // reconstruct_node_properties_with_depth would then return Ok via the anchor-cache
+    // fallback instead of falling through to the iterative path that discovers the gap.
+    assert!(
+        storage.reconstruct_node_properties(v0_id).is_err(),
+        "Anchor must not be reconstructable via cache after clear and deletion"
+    );
+
     let result = storage.reconstruct_node_properties(v1_id);
     assert!(result.is_err(), "Expected error when anchor is missing");
     match result.unwrap_err() {
@@ -4688,10 +4698,9 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
 
     assert!(storage.get_edge_version(e1_id).unwrap().is_delta());
 
-    // Pre-populate the edge reconstruction cache so the clear step is load-bearing.
-    // A mutant that turns __test_clear_edge_property_cache into a no-op would leave
-    // the cached Ok value in place; the subsequent reconstruct would return it instead
-    // of discovering MissingAnchor, causing the assertion below to fail.
+    // Pre-populate the edge reconstruction cache so the primary-cache clear is load-bearing.
+    // A mutant that makes edge_property_cache.clear() a no-op leaves the cached Ok for e1;
+    // the subsequent reconstruct would return it instead of discovering MissingAnchor.
     let warm = storage.reconstruct_edge_properties(e1_id).unwrap();
     assert_eq!(
         warm.get("weight").and_then(|v| v.as_int()),
@@ -4702,6 +4711,15 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
     // Remove the anchor
     storage.__test_remove_edge_version(e0_id);
     storage.__test_clear_edge_property_cache();
+
+    // Kill the anchor-cache-clear mutation: e0 is an anchor so add_edge_version put it
+    // in edge_anchor_cache. After __test_clear_edge_property_cache, the anchor cache is
+    // empty. A mutant that makes edge_anchor_cache.clear() a no-op leaves e0 there;
+    // reconstruct_edge_properties_with_depth would return Ok via the anchor-cache fallback.
+    assert!(
+        storage.reconstruct_edge_properties(e0_id).is_err(),
+        "Edge anchor must not be reconstructable via cache after clear and deletion"
+    );
 
     let result = storage.reconstruct_edge_properties(e1_id);
     assert!(

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4645,9 +4645,12 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
         crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
             entity_id,
         }) => {
+            // entity_id must come from the version's node_id field (via
+            // get_node_version_any_tier), not the generic "version V" fallback.
+            // This assertion kills the mutation that removes the .and_then() lookup.
             assert!(
-                !entity_id.is_empty(),
-                "MissingAnchor entity_id must not be empty"
+                entity_id.starts_with("Node("),
+                "MissingAnchor entity_id must identify the node, got: {entity_id}"
             );
         }
         err => panic!("Expected MissingAnchor, got: {err:?}"),
@@ -4730,7 +4733,12 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
         crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
             entity_id,
         }) => {
-            assert!(!entity_id.is_empty());
+            // entity_id must come from the version's edge_id field (via
+            // get_edge_version_any_tier), not the generic "version V" fallback.
+            assert!(
+                entity_id.starts_with("Edge("),
+                "MissingAnchor entity_id must identify the edge, got: {entity_id}"
+            );
         }
         err => panic!("Expected MissingAnchor, got: {err:?}"),
     }
@@ -4860,4 +4868,42 @@ fn test_competing_valid_times_stored_and_queried_by_bitemporal_interval() {
         Some(v2_id),
         "At tx_time=2500, v2 should be visible at valid_time=2500"
     );
+}
+
+#[test]
+fn test_reconstruct_nonexistent_node_version_returns_version_not_found() {
+    // When version_ids is empty (the very first lookup fails), the code must return
+    // StorageError::VersionNotFound, NOT TemporalError::MissingAnchor.
+    //
+    // A mutant that removes the `!version_ids.is_empty()` guard in the match arm would
+    // cause this call to return MissingAnchor for any missing version — this test
+    // catches that mutation by checking for the exact VersionNotFound error type.
+    let storage = HistoricalStorage::new();
+    let nonexistent = VersionId::new(9999).unwrap();
+    let result = storage.reconstruct_node_properties(nonexistent);
+    assert!(result.is_err(), "Non-existent version must return an error");
+    match result.unwrap_err() {
+        crate::core::error::Error::Storage(StorageError::VersionNotFound(_)) => {}
+        err => panic!("Expected VersionNotFound for a never-added version, got: {err:?}"),
+    }
+}
+
+#[test]
+fn test_reconstruct_nonexistent_edge_version_returns_version_not_found() {
+    // Mirror of test_reconstruct_nonexistent_node_version_returns_version_not_found
+    // for the edge reconstruction path.
+    //
+    // Kills the `!version_ids.is_empty()` guard mutation in
+    // reconstruct_edge_properties_iterative.
+    let storage = HistoricalStorage::new();
+    let nonexistent = VersionId::new(9998).unwrap();
+    let result = storage.reconstruct_edge_properties(nonexistent);
+    assert!(
+        result.is_err(),
+        "Non-existent edge version must return an error"
+    );
+    match result.unwrap_err() {
+        crate::core::error::Error::Storage(StorageError::VersionNotFound(_)) => {}
+        err => panic!("Expected VersionNotFound for a never-added edge version, got: {err:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for temporal error detection and validation, along with edge-specific temporal validation in write operations. It ensures that temporal invariants are properly enforced and that error conditions are correctly reported to callers.

## Key Changes

### Temporal Error Detection Tests (Issue #350)
- **Corrupted version chain detection**: Added `test_corrupted_version_chain_delta_no_prev_version()` to verify that delta versions with missing backward links are detected as `CorruptedVersionChain` errors during property reconstruction
- **Missing anchor detection**: Added `test_missing_anchor_detected_after_anchor_deletion()` to verify that when an anchor version is removed from storage, attempting to reconstruct downstream deltas returns `MissingAnchor` rather than generic `VersionNotFound`
- **Edge anchor detection**: Added `test_edge_missing_anchor_detected_after_anchor_deletion()` to mirror node anchor detection for edge versions
- **Multi-hop delta reconstruction**: Added `test_version_chain_reconstruction_multi_hop_deltas()` to verify correct property reconstruction across four-version chains
- **Bi-temporal competing valid times**: Added `test_competing_valid_times_stored_and_queried_by_bitemporal_interval()` to verify that overlapping valid_time ranges are correctly handled as valid state

### Historical Storage Improvements
- Enhanced `reconstruct_node_properties_iterative()` to distinguish between "version never existed" (`VersionNotFound`) and "chain integrity broken" (`MissingAnchor`) by detecting when a subsequent lookup fails after successfully retrieving the first version
- Applied same logic to `reconstruct_edge_properties_iterative()` for consistency
- Added test-only helpers `__test_remove_edge_version()` and `__test_clear_edge_property_cache()` to support edge-specific corruption testing

### Edge Temporal Validation
- Added `valid_from` validation to `update_edge_with_valid_time()` to reject updates with `valid_from` before the edge's own creation time
- Added `valid_from` validation to `delete_edge_with_valid_time()` to reject deletions with `valid_from` before the edge's own creation time
- Both validations use existing `validate_valid_from_future()` and `validate_valid_from_not_before_creation()` helpers for consistency with node operations

### Transaction Timestamp Tests
- Added `test_rollback_does_not_advance_current_timestamp()` to verify that rolled-back transactions do not advance the shared HLC frontier
- Added `test_concurrent_commits_never_produce_equal_timestamps()` to verify that concurrent commits always produce unique, strictly-increasing timestamps via HLC logical counter

### Temporal Boundary Tests
- Added `test_timestamp_boundary_max_valid_timestamp()` to verify that `MAX_VALID_TIMESTAMP` boundary is correctly enforced
- Added `test_valid_time_one_year_in_future_rejected()` to verify that `MAX_VALID_TIME_FUTURE_OFFSET_US` limit is enforced

## Implementation Details

- **MissingAnchor vs VersionNotFound**: The distinction is made by checking if `version_ids` is non-empty when a `VersionNotFound` occurs during chain traversal. If we've already retrieved at least one version, a subsequent lookup failure indicates chain corruption rather than the version never existing.
- **Entity ID in MissingAnchor**: The error includes the entity ID (node or edge) extracted from the first successfully-retrieved version, providing better diagnostics.
- **Edge validation parity**: Edge update/delete operations now have the same temporal validation as node operations, ensuring consistent temporal semantics across entity types.

https://claude.ai/code/session_012ACk5Fx8GuuxqbvdJsBFsS