### PR TITLE
⚡ Bolt: Remove unnecessary heap allocation in semantic search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Optimize HashMap lookups with iter_mut]**
+**Learning:** Extracting `keys()` into an intermediate `Vec` (like `candidate_scores.keys().cloned().collect()`) just to loop over them and mutate their associated values in the same map using `.entry().and_modify()` introduces an unnecessary heap allocation and causes an O(1) double-lookup inside the loop.
+**Action:** Iterate directly over the map using `iter_mut()` whenever mutating its values. This completely avoids the intermediate `Vec` allocation and grants direct mutable references to the values, eliding the need for redundant dictionary lookups.

--- a/src/semantic_search/fishing.rs
+++ b/src/semantic_search/fishing.rs
@@ -186,10 +186,8 @@ impl<'a> FishingRod<'a> {
             let now_micros = time::now().wallclock();
 
             // We need to fetch nodes to check timestamps.
-            // Collect all candidate IDs
-            let all_candidates: Vec<NodeId> = candidate_scores.keys().cloned().collect();
-
-            for node_id in all_candidates {
+            // ⚡ Bolt Optimization: Use `iter_mut()` instead of allocating a temporary `Vec` and performing double-lookups.
+            for (node_id, score) in candidate_scores.iter_mut() {
                 // Not collapsing if to keep it simple and compatible with potentially older rust versions
                 // or just to be explicit. But clippy complained, so let's try to satisfy it without let_chains
                 // if they are experimental (as per memory), but `if let && let` is stable?
@@ -197,7 +195,7 @@ impl<'a> FishingRod<'a> {
                 // So I CANNOT collapse it using `if let ... && let ...`.
                 // I will suppress the lint.
                 #[allow(clippy::collapsible_if)]
-                if let Ok(node) = self.db.get_node(node_id) {
+                if let Ok(node) = self.db.get_node(*node_id) {
                     if let Some(ts) = node.metadata.commit_timestamp {
                         let age_micros = now_micros.saturating_sub(ts.wallclock());
                         let age_seconds = age_micros as f32 / 1_000_000.0;
@@ -205,9 +203,7 @@ impl<'a> FishingRod<'a> {
                         let age_hours = age_seconds / 3600.0;
                         let freshness_score = 1.0 / (1.0 + age_hours);
 
-                        candidate_scores.entry(node_id).and_modify(|s| {
-                            *s += freshness_score * config.freshness_weight;
-                        });
+                        *score += freshness_score * config.freshness_weight;
                     }
                 }
             }


### PR DESCRIPTION
💡 What: Replaced intermediate Vec collection of HashMap keys with direct iteration over iter_mut()
🎯 Why: Extracting keys into a Vec to loop over and mutate their associated values causes an unnecessary heap allocation and redundant O(1) lookups inside the loop
📊 Impact: Removes one heap allocation and multiple hash lookups per freshness check
🔬 Measurement: Run cargo check and clippy. `cargo test` is skipping the specific tests for the module, but the type system guarantees memory safety and we aren't changing logic. (Assuming tests pass per the earlier user instruction).

---
*PR created automatically by Jules for task [14863902228099429604](https://jules.google.com/task/14863902228099429604) started by @madmax983*