### PR TITLE
🛡️ Sentry: Add LimitPushdown boolean propagation structural tests

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+## LimitPushdown Mutants Propagation Coverage
+**Learning:** In optimization rule tests (like `LimitPushdown`), checking for `true/false` return values across `||` combinations in `BinaryOp` nodes (like Union) is essential to eliminate `cargo mutants` escapees. Specifically, if a boolean short-circuits or requires both sides to be evaluated, test suites must explicitly hit the `left_changed = false, right_changed = true` combination to prove the right branch actually propagates limits.
+**Action:** Wrote comprehensive structural test cases verifying limits propagating into right-hand branches correctly when the left hand does not change, and explicitly verified that identical `top_k` matches do not spuriously trigger boolean changes.

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -543,3 +543,68 @@ mod sentry_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod more_sentry_tests {
+    use super::*;
+    use crate::core::NodeId;
+    use crate::query::plan::{BinaryOp, ScanOp};
+
+    #[test]
+    fn test_pushdown_binary_partial_change_right() {
+        let rule = LimitPushdown;
+        let stats = Statistics::default();
+
+        // Left: Scan -> Scan [changed = false]
+        let left = LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()]));
+
+        // Right: Limit(10, Limit(20, Scan)) -> Limit(10, Scan) [changed = true]
+        let right = LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::unary(
+                UnaryOp::Limit(20),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        );
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left, right));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            LogicalOp::unary(
+                UnaryOp::Limit(10),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+            ),
+        ));
+
+        assert_eq!(
+            result,
+            Some(expected_plan),
+            "Partial optimization in right branch should propagate"
+        );
+    }
+
+    #[test]
+    fn test_pushdown_vector_rank_equal_top_k() {
+        let rule = LimitPushdown;
+
+        let op = LogicalOp::unary(
+            UnaryOp::VectorRank {
+                embedding: vec![0.1f32].into(),
+                top_k: Some(5),
+                property_key: None,
+            },
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        );
+        let (_new_op, changed) = rule.push_down(&op, Some(5)).unwrap();
+
+        // When top_k equals limit, it should NOT mark as changed,
+        // UNLESS the input itself changed.
+        assert!(
+            !changed,
+            "Vector rank should not apply new top_k if it's equal and input didn't change"
+        );
+    }
+}


### PR DESCRIPTION
🎯 Target: `src/query/planner/rules/limit_pushdown.rs`
💣 Risk: Missed structural and propagation tests. Specifically around the `||` propagation paths such as binary children bounds (left false, right true) and vector limits matching top_k (missing bounds check for unchanged equality)
🧪 Strategy: Authored two comprehensive tests explicitly verifying the `||` mutation combinations across branch paths as highlighted by mutation tools.
🔬 Verification: Run `cargo test --lib query::planner::rules::limit_pushdown`.

---
*PR created automatically by Jules for task [5879191673046004560](https://jules.google.com/task/5879191673046004560) started by @madmax983*