### PR TITLE
⚖️ Elenchus: [temporal] Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[Temporal Error Assertion Weakness]**
+**Module:** `tests/sentry_temporal_invariants.rs`, `src/storage/historical/tests.rs`
+**Severity:** 🟡 Suspect
+**Finding:** Tests validating temporal invariants (e.g., `close_at` boundaries and `MissingAnchor` detection) relied on ceremonial `assert!(result.is_err())` followed by separated value extractions or matches (`result.unwrap_err()`). This creates a minor false confidence gap where a panic in `unwrap_err` obscures the actual failure, and the initial assertion is redundant if the match is exhaustive.
+**Evidence:** In `tests/sentry_temporal_invariants.rs`, `assert!(result.is_err());` preceded `assert!(matches!(result.unwrap_err(), ...))`. In `src/storage/historical/tests.rs`, `assert!(result.is_err()); match result.unwrap_err() { ... }` was used for `MissingAnchor` validations.
+**Recommendation:** Refactored tests to use direct structural matching: either a single `assert!(matches!(result, Err(...)))` or a direct `match result { Err(...) => ..., _ => panic!(...) }`. This provides a single, robust point of failure that asserts both existence of error and its correctness simultaneously.

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4640,11 +4640,10 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
     );
 
     let result = storage.reconstruct_node_properties(v1_id);
-    assert!(result.is_err(), "Expected error when anchor is missing");
-    match result.unwrap_err() {
-        crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
-            entity_id,
-        }) => {
+    match result {
+        Err(crate::core::error::Error::Temporal(
+            crate::core::error::TemporalError::MissingAnchor { entity_id },
+        )) => {
             // entity_id must come from the version's node_id field (via
             // get_node_version_any_tier), not the generic "version V" fallback.
             // This assertion kills the mutation that removes the .and_then() lookup.
@@ -4653,7 +4652,7 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
                 "MissingAnchor entity_id must identify the node, got: {entity_id}"
             );
         }
-        err => panic!("Expected MissingAnchor, got: {err:?}"),
+        res => panic!("Expected MissingAnchor error, got: {res:?}"),
     }
 }
 
@@ -4725,14 +4724,10 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
     );
 
     let result = storage.reconstruct_edge_properties(e1_id);
-    assert!(
-        result.is_err(),
-        "Expected error when edge anchor is missing"
-    );
-    match result.unwrap_err() {
-        crate::core::error::Error::Temporal(crate::core::error::TemporalError::MissingAnchor {
-            entity_id,
-        }) => {
+    match result {
+        Err(crate::core::error::Error::Temporal(
+            crate::core::error::TemporalError::MissingAnchor { entity_id },
+        )) => {
             // entity_id must come from the version's edge_id field (via
             // get_edge_version_any_tier), not the generic "version V" fallback.
             assert!(
@@ -4740,7 +4735,7 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
                 "MissingAnchor entity_id must identify the edge, got: {entity_id}"
             );
         }
-        err => panic!("Expected MissingAnchor, got: {err:?}"),
+        res => panic!("Expected MissingAnchor error, got: {res:?}"),
     }
 }
 

--- a/tests/sentry_temporal_invariants.rs
+++ b/tests/sentry_temporal_invariants.rs
@@ -13,10 +13,9 @@ mod tests {
         let result = range.close_at(invalid_end);
 
         // This MUST fail now
-        assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err(),
-            TemporalError::InvalidTimeRange { .. }
+            result,
+            Err(TemporalError::InvalidTimeRange { .. })
         ));
     }
 
@@ -29,10 +28,9 @@ mod tests {
         let result = interval.close_valid_time(invalid_end);
 
         // This MUST fail now
-        assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err(),
-            TemporalError::InvalidTimeRange { .. }
+            result,
+            Err(TemporalError::InvalidTimeRange { .. })
         ));
     }
 }


### PR DESCRIPTION
Summary: Conducted an Elenchus test quality audit on `tests/sentry_temporal_invariants.rs` and `src/storage/historical/tests.rs` to address ceremonial assertion weaknesses that provided false confidence.

Verdict table:
- `test_timerange_close_at_enforces_invariant` | 🟡 Suspect | Redundant `assert!(result.is_err())` before unwrapping
- `test_bitemporal_close_enforces_invariant` | 🟡 Suspect | Redundant `assert!(result.is_err())` before unwrapping
- `test_missing_anchor_detected_after_anchor_deletion` | 🟡 Suspect | Redundant `assert!(result.is_err())` before matching unwrap
- `test_edge_missing_anchor_detected_after_anchor_deletion` | 🟡 Suspect | Redundant `assert!(result.is_err())` before matching unwrap

Priority fixes:
1. Replaced redundant assertions in `tests/sentry_temporal_invariants.rs` with `assert!(matches!(...))` for direct structural matching.
2. Refactored `test_missing_anchor_detected_after_anchor_deletion` and `test_edge_missing_anchor_detected_after_anchor_deletion` in `src/storage/historical/tests.rs` to use a direct `match result { ... }` block, ensuring atomic verification of the error type and its payload without risking obscure unwrapping panics.

Missing coverage:
- No new coverage gaps identified in these functions; test strength was improved.

---
*PR created automatically by Jules for task [5672279490352121078](https://jules.google.com/task/5672279490352121078) started by @madmax983*