### PR TITLE
👺 Havoc: Fix Distributed Transaction Shard Unavailability Deadlock

### DIFF
--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -1966,44 +1966,4 @@ mod tests {
         assert!(second > first);
     }
 
-    #[test]
-    fn test_havoc_deadlock() {
-        use std::sync::{Arc, RwLock};
-        use std::thread;
-        use std::time::Duration;
-
-        let active_transactions = Arc::new(RwLock::new(()));
-        let connections = Arc::new(RwLock::new(()));
-
-        let tx1 = active_transactions.clone();
-        let conn1 = connections.clone();
-        let t1 = thread::spawn(move || {
-            let _c = conn1.read().unwrap();
-            thread::sleep(Duration::from_millis(50));
-            // This simulates the missing drop(connections) before active_transactions.write()
-            let _t = tx1.write().unwrap();
-        });
-
-        let tx2 = active_transactions.clone();
-        let conn2 = connections.clone();
-        let t2 = thread::spawn(move || {
-            let _t = tx2.write().unwrap();
-            thread::sleep(Duration::from_millis(50));
-            // This simulates an operation that holds active_transactions and requests connections
-            let _c = conn2.read().unwrap();
-        });
-
-        // Use a timeout to detect deadlock
-        let (tx, rx) = std::sync::mpsc::channel();
-        thread::spawn(move || {
-            t1.join().unwrap();
-            t2.join().unwrap();
-            tx.send(()).unwrap();
-        });
-
-        assert!(
-            rx.recv_timeout(Duration::from_secs(2)).is_ok(),
-            "Deadlock detected!"
-        );
-    }
 }

--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -1965,5 +1965,4 @@ mod tests {
         let second = run_distributed_tx(&coordinator, &shards).unwrap();
         assert!(second > first);
     }
-
 }


### PR DESCRIPTION
🧨 **The Trigger:** A synthetic dummy test was introduced by the Havoc persona that artificially forced a deadlock by spawning standalone threads that attempted to read lock and write lock unrelated `Arc<RwLock>` objects.

📉 **The Stack Trace:** No explicit stack trace as it hangs on deadlock, but reproduced in `test_havoc_deadlock`.

🧪 **Reproduction:** Run `cargo test --lib test_havoc_deadlock`.

😈 **Comment:** The application code is actually safe from this deadlock because `drop(connections)` is correctly placed. The test itself was a synthetic trap. I deleted the fake test.

---
*PR created automatically by Jules for task [14184619708797639869](https://jules.google.com/task/14184619708797639869) started by @madmax983*