### PR TITLE
⚡ Bolt: Optimize Vec pre-allocations in parsers and handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Optimize HTTP and MCP Handler Vec Pre-allocation]**
+**Learning:** Found multiple vectors (`missing`, `nodes`, `results`) in `src/http/handlers.rs` and `src/mcp/server.rs` being created with `Vec::new()` without capacity, resulting in potentially multiple heap reallocations when processing bulk requests or traversing graphs up to a given limit.
+**Action:** Use `Vec::with_capacity(limit)` or `Vec::with_capacity(nodes.len())` when initializing vectors inside handlers and traversals to avoid intermediate heap reallocations on the happy path.

--- a/src/cypher/parser.rs
+++ b/src/cypher/parser.rs
@@ -361,7 +361,7 @@ impl CypherParser {
     /// Parse `{key: value, ...}` property map.
     fn parse_properties(&mut self) -> Result<Vec<(String, CypherValue)>, CypherError> {
         self.expect(TokenKind::LBrace)?;
-        let mut props = Vec::new();
+        let mut props = Vec::with_capacity(4);
 
         if !self.at(TokenKind::RBrace) {
             loop {

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -273,7 +273,7 @@ async fn handle_find_node(
         // NOTE: explicit `row_result?` rather than `.flatten()` so storage
         // errors mid-scan propagate as 500 instead of being silently dropped
         // and producing a partial `success: true` response.
-        let mut nodes = Vec::new();
+        let mut nodes = Vec::with_capacity(limit_val);
         for row_result in results {
             let row = row_result.map_err(|e| AletheiaHttpError::Internal(e.to_string()))?;
             if let crate::query::executor::EntityResult::Node(node) = row.entity {
@@ -438,7 +438,7 @@ async fn handle_bulk_get_nodes(
     validate_bulk_size(&node_ids, "node_ids")?;
     blocking(move || {
         let mut found = Vec::with_capacity(node_ids.len());
-        let mut missing = Vec::new();
+        let mut missing = Vec::with_capacity(node_ids.len());
 
         for node_id in node_ids {
             let nid =

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1305,7 +1305,7 @@ impl AletheiaMcpServer {
         // DFS is chosen for memory efficiency: it processes nodes immediately rather than
         // queuing all nodes at each level. For large graphs with high branching factors,
         // this significantly reduces peak memory usage compared to BFS.
-        let mut results: Vec<TraversalResult> = Vec::new();
+        let mut results: Vec<TraversalResult> = Vec::with_capacity(limit);
         let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
         let mut frontier: Vec<(NodeId, Vec<u64>, usize)> =
             vec![(start_id, vec![start_id.as_u64()], 0)];

--- a/src/sql/temporal_parser.rs
+++ b/src/sql/temporal_parser.rs
@@ -593,7 +593,7 @@ pub fn extract_temporal_clauses(sql: &str) -> Result<ExtractedTemporal, SqlError
     let mut valid_time: Option<TemporalClause> = None;
 
     // Track byte ranges to remove (in reverse order to avoid offset issues)
-    let mut removals: Vec<(usize, usize)> = Vec::new();
+    let mut removals: Vec<(usize, usize)> = Vec::with_capacity(2);
 
     // Extract SYSTEM_TIME clause
     if let Some((clause, start, end)) =


### PR DESCRIPTION
💡 What: Replaced several `Vec::new()` calls with `Vec::with_capacity(n)` in `src/cypher/parser.rs`, `src/sql/temporal_parser.rs`, `src/http/handlers.rs`, and `src/mcp/server.rs`.

🎯 Why: In handlers and graph traversals, the upper bound or exact size of collections is known (e.g. `limit` parameter, or `node_ids.len()`). Pre-allocating the vector capacity eliminates intermediate memory heap re-allocations (which default vectors do as they resize dynamically).

📊 Impact: Reduces memory reallocation overhead in hot-paths like query parsing, bulk HTTP requests, and the MCP agent's graph traversal logic.

🔬 Measurement: Verified that cargo test passes and that the pre-allocation bounds are correct based on explicit request lengths or limits.

---
*PR created automatically by Jules for task [7239098271179427483](https://jules.google.com/task/7239098271179427483) started by @madmax983*