### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+**[MockVectorNodeClient Lock Unwrapping]**
+**Learning:** In tests and mock components (like `MockVectorNodeClient`), using `.unwrap()` on lock acquisitions (`.read()` or `.write()`) can cause the testing thread or query process to panic unexpectedly if the lock gets poisoned. This masks actual logic failures with lock poisoning panics and poses a stability risk if these components are ever utilized in scenarios outside strict isolation.
+**Action:** Always gracefully handle lock acquisition by mapping the `PoisonError` to a domain-specific error using `.map_err` when the signature returns a `Result`, or by using an `if let Ok(...)` block when the signature returns `()`, avoiding panics entirely.

--- a/src/index/vector/distributed.rs
+++ b/src/index/vector/distributed.rs
@@ -1315,11 +1315,16 @@ impl MockVectorNodeClient {
 
     /// Make the next operation fail.
     pub fn fail_next(&self, error: impl Into<String>) {
-        *self.fail_next.write().unwrap() = Some(error.into());
+        if let Ok(mut lock) = self.fail_next.write() {
+            *lock = Some(error.into());
+        }
     }
 
     fn check_fail(&self) -> Result<()> {
-        if let Some(err) = self.fail_next.write().unwrap().take() {
+        let mut lock = self.fail_next.write().map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!("Lock poisoned: {}", e)))
+        })?;
+        if let Some(err) = lock.take() {
             return Err(Error::Vector(VectorError::IndexError(err)));
         }
         Ok(())
@@ -1381,7 +1386,10 @@ impl VectorNodeClient for MockVectorNodeClient {
             }));
         }
 
-        self.vectors.write().unwrap().insert(id, vector.to_vec());
+        let mut vectors = self.vectors.write().map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!("Lock poisoned: {}", e)))
+        })?;
+        vectors.insert(id, vector.to_vec());
         Ok(())
     }
 
@@ -1395,7 +1403,10 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))));
         }
 
-        self.vectors.write().unwrap().remove(&id);
+        let mut vectors = self.vectors.write().map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!("Lock poisoned: {}", e)))
+        })?;
+        vectors.remove(&id);
         Ok(())
     }
 
@@ -1409,7 +1420,9 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))));
         }
 
-        let vectors = self.vectors.read().unwrap();
+        let vectors = self.vectors.read().map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!("Lock poisoned: {}", e)))
+        })?;
         let mut results: Vec<(NodeId, f32)> = vectors
             .iter()
             .map(|(id, vec)| (*id, self.compute_similarity(query, vec)))
@@ -1431,7 +1444,10 @@ impl VectorNodeClient for MockVectorNodeClient {
             ))));
         }
 
-        Ok(self.vectors.read().unwrap().len())
+        let vectors = self.vectors.read().map_err(|e| {
+            Error::Vector(VectorError::IndexError(format!("Lock poisoned: {}", e)))
+        })?;
+        Ok(vectors.len())
     }
 
     fn health_check(&self) -> Result<()> {


### PR DESCRIPTION
🎯 Target: `MockVectorNodeClient` lock acquisitions in `src/index/vector/distributed.rs`.
💣 Risk: `write().unwrap()` and `read().unwrap()` could panic and crash the thread or query process if the lock gets poisoned, leading to unhandled failures in simulated tests or environments instead of graceful error degradation.
🧪 Strategy: Mapped the `PoisonError` to `VectorError::IndexError` when returning a `Result`, and safely handled failures using `if let Ok` when returning `()`, ensuring tests continue to function accurately without introducing `unwrap` panics.
🔬 Verification: `cargo test --lib index::vector::distributed`

---
*PR created automatically by Jules for task [5125209455022632746](https://jules.google.com/task/5125209455022632746) started by @madmax983*