### PR TITLE
🎸 Bard: fix broken intra-doc links

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -26,7 +26,7 @@
 //! - `ALETHEIADB_CORS_PERMISSIVE`: Set to "true" to allow any origin (default: false)
 //! - `ALETHEIADB_CORS_ORIGINS`: Comma-separated list of allowed origins
 //! - `ALETHEIADB_CONFIG`: Path to a TOML config file consumed by
-//!   [`AletheiaDBConfig::from_toml_file`]. Takes precedence over
+//!   [`aletheiadb::AletheiaDBConfig::from_toml_file`]. Takes precedence over
 //!   `ALETHEIADB_DATA_DIR`.
 //! - `ALETHEIADB_DATA_DIR`: Directory for WAL + index persistence. When set,
 //!   the server persists state across restarts. When unset (and `ALETHEIADB_CONFIG`

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -210,7 +210,7 @@ impl ServerConfig {
         self.data_dir.as_deref()
     }
 
-    /// Materialize the [`AletheiaDBConfig`] this server config implies.
+    /// Materialize the [`crate::AletheiaDBConfig`] this server config implies.
     ///
     /// Returns `None` when no [`data_dir`](Self::data_dir) is set — that
     /// signals in-memory mode, and the caller should construct the DB via

--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`SimulatedClock::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: Fixing the Broken Lore

🔦 Insight: Found several broken intra-doc links causing `rustdoc::broken_intra_doc_links` warnings. Fixed them by using the correct, fully-qualified item paths (`crate::AletheiaDBConfig`, `SimulatedClock::jump_to`, and `aletheiadb::AletheiaDBConfig::from_toml_file`).

🧪 Example: N/A - Links are now resolvable by `cargo doc`.

🖼️ Preview: The `cargo doc --all-features --no-deps` command now runs perfectly clean with no warnings.

---
*PR created automatically by Jules for task [360274798677800342](https://jules.google.com/task/360274798677800342) started by @madmax983*