### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/simulation/clock.rs
+++ b/src/simulation/clock.rs
@@ -71,7 +71,7 @@ impl SimulatedClock {
     /// Advance the clock by `delta_micros` (must be ≥ 0).
     ///
     /// # Panics
-    /// Panics if `delta_micros` is negative (use [`jump_to`] for backwards moves).
+    /// Panics if `delta_micros` is negative (use [`SimulatedClock::jump_to`] for backwards moves).
     pub fn advance_by(&mut self, delta_micros: i64) {
         assert!(
             delta_micros >= 0,


### PR DESCRIPTION
📖 Chapter: `src/simulation/clock.rs`
🔦 Insight: Fixed a broken intra-doc link in `SimulatedClock::advance_by` that was pointing to `jump_to` instead of `SimulatedClock::jump_to`.
🧪 Example: Verified via `cargo rustdoc --lib --features simulation -- -D missing_docs`
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [365242708248664495](https://jules.google.com/task/365242708248664495) started by @madmax983*