### PR TITLE
⚡ Bolt: Optimize Arc reference counting in PropertyMap and StringInterner

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,11 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize Arc Cloning in StringInterner**
+**Learning:** `DashMap::entry()` takes ownership of its key. If a function takes an `Arc` by reference and needs to pass it into `entry()`, the naive approach is to clone the `Arc` before passing it. However, if the `Arc` is not used in the outer scope after the `entry()` call, it can be passed directly, preventing an unnecessary atomic reference count increment and decrement.
+**Action:** Avoid redundant `Arc::clone()` calls when passing an `Arc` into a `DashMap::entry()` closure if the `Arc` is not used again in the outer scope.
+
+**Refactor to Arc::unwrap_or_clone**
+**Learning:** Rust 1.76+ introduced the stabilized `Arc::unwrap_or_clone` method, which is a cleaner and more efficient alternative to the manual pattern `Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone())` used for copy-on-write semantics.
+**Action:** Always prefer `Arc::unwrap_or_clone(arc)` when implementing copy-on-write patterns in Rust 1.76+.

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -177,7 +177,7 @@ impl StringInterner {
                 let id = InternedString(id_value);
 
                 // Store the reverse mapping
-                self.id_to_string.insert(id, arc_str.clone());
+                self.id_to_string.insert(id, arc_str);
 
                 Ok(id)
             })
@@ -208,7 +208,7 @@ impl StringInterner {
         *self.string_to_id.entry(arc_str.clone()).or_insert_with(|| {
             let id_value = self.next_id.fetch_add(1, Ordering::Relaxed);
             let id = InternedString(id_value);
-            self.id_to_string.insert(id, arc_str.clone());
+            self.id_to_string.insert(id, arc_str);
             id
         })
     }

--- a/src/core/property/map.rs
+++ b/src/core/property/map.rs
@@ -488,7 +488,7 @@ impl PropertyMapBuilder {
     /// implementing copy-on-write semantics.
     pub fn from_map(prop_map: PropertyMap) -> Self {
         let current_size = prop_map.cached_size;
-        let map = Arc::try_unwrap(prop_map.inner).unwrap_or_else(|arc| (*arc).clone());
+        let map = Arc::unwrap_or_clone(prop_map.inner);
         PropertyMapBuilder { map, current_size }
     }
 


### PR DESCRIPTION
💡 What:
- Replaced the manual copy-on-write `Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone())` pattern with `Arc::unwrap_or_clone(arc)` in `src/core/property/map.rs`.
- Removed redundant `Arc::clone()` calls when moving the `arc_str` into the `id_to_string` insertion block in `src/core/interning.rs`.

🎯 Why:
- The manual unwrap pattern creates closure overhead, and the stabilized `Arc::unwrap_or_clone` provides an idiomatic zero-cost alternative.
- In `StringInterner`, the `Arc<str>` was being cloned prior to `DashMap::entry()`, but the outer reference was not used afterward. Moving the outer reference directly into the closure avoids an unnecessary atomic reference count increment and decrement on the slow path (insertion).

📊 Impact:
- Reduces atomic operations and minor heap/closure overheads during `PropertyMap` updates and new string interning.

🔬 Measurement:
- Run `cargo test -p aletheiadb --lib core::property::map`
- Run `cargo test -p aletheiadb --lib core::interning`

---
*PR created automatically by Jules for task [1331055556013493312](https://jules.google.com/task/1331055556013493312) started by @madmax983*