### PR TITLE
⚔️ Elenchus: generic_error_types Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,17 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[Generic Error Types Assertion Weakness]**
+**Module:** `tests/generic_error_types.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The tests in this file exhibited the "Ceremony Test" anti-pattern. Several tests relied on redundant `assert!(result.is_ok())` immediately before an `unwrap()`, or exclusively asserted `is_ok()` (e.g., `test_default_error_type_with_turbofish`) without verifying the underlying success states (like node creation validity or result counts).
+**Evidence:** The test `test_default_error_type_with_turbofish` asserted `is_ok()` without checking if the operations returned the expected valid logic states (`count == 0` or valid `NodeId` presence).
+**Recommendation:** Refactored tests to use direct `assert_eq!(result, Ok(expected))` and `assert_eq!(result, Err(expected))` matching. Strengthened `test_default_error_type_with_turbofish` to explicitly evaluate the created outputs (e.g., `read_result.unwrap()`).
+
+**[HLC Tests Audit]**
+**Module:** `src/core/hlc.rs`, `tests/hlc_tests.rs`
+**Severity:** 🟢 Acquitted
+**Finding:** Previous concerns regarding "HLC Causality Blind Spot" and "HLC Assertion Weakness" have been thoroughly addressed. The tests now use precise boundary definitions (e.g., `test_new_validation` for `MAX_VALID_TIMESTAMP`), exact sentinel value verifications, strong `matches!(result, Err(...))` error checking, and explicit Oracles (e.g., `test_receive_collision_oracle`) instead of tautological mirror logic.
+**Evidence:** Code inspection and mutation tools confirm strong coverage across serialization, bounds checking, and causality propagation constraints.
+**Recommendation:** None. The suite has earned its place.

--- a/tests/generic_error_types.rs
+++ b/tests/generic_error_types.rs
@@ -42,8 +42,7 @@ fn test_read_with_custom_error_type() {
             .ok_or(RepositoryError::NotFound) // Custom error
     });
 
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "Alice");
+    assert_eq!(result, Ok("Alice".to_string()));
 }
 
 #[test]
@@ -67,8 +66,7 @@ fn test_read_with_custom_error_not_found() {
             .ok_or(RepositoryError::NotFound)
     });
 
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), RepositoryError::NotFound);
+    assert_eq!(result, Err(RepositoryError::NotFound));
 }
 
 #[test]
@@ -101,8 +99,7 @@ fn test_write_with_custom_error_type() {
         Ok("Bob".to_string())
     });
 
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "Bob");
+    assert_eq!(result, Ok("Bob".to_string()));
 }
 
 #[test]
@@ -171,8 +168,7 @@ fn test_write_with_timestamp_error() {
         Ok(name)
     });
 
-    assert!(result.is_ok());
-    let (name, _timestamp) = result.unwrap();
+    let (name, _timestamp) = result.expect("Expected Ok");
     assert_eq!(name, "Diana");
 }
 
@@ -196,8 +192,7 @@ fn test_write_with_options_error() {
         Ok(10)
     });
 
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), 10);
+    assert_eq!(result, Ok(10));
 }
 
 #[test]
@@ -213,6 +208,7 @@ fn test_default_error_type_with_turbofish() {
     });
 
     assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 0);
 
     let result = db.write::<_, _, Error>(|tx| {
         let node_id = tx.create_node(
@@ -223,6 +219,12 @@ fn test_default_error_type_with_turbofish() {
     });
 
     assert!(result.is_ok());
+    let node_id = result.unwrap();
+
+    // Verify the node actually exists
+    let read_result = db.read::<_, _, Error>(|tx| Ok(tx.get_node(node_id).is_ok()));
+    assert!(read_result.is_ok());
+    assert!(read_result.unwrap());
 }
 
 #[test]
@@ -279,8 +281,5 @@ fn test_chained_operations_with_custom_errors() {
         Ok((name.to_string(), age))
     });
 
-    assert!(result.is_ok());
-    let (name, age) = result.unwrap();
-    assert_eq!(name, "Frank");
-    assert_eq!(age, 30);
+    assert_eq!(result, Ok(("Frank".to_string(), 30)));
 }


### PR DESCRIPTION
Summary: Overall mutation-readiness assessment of the generic_error_types module and the HLC codebase module tests. Verdict table: `tests/generic_error_types.rs` - 🟡 Suspect (Ceremony tests and redundant `is_ok` assertions); `src/core/hlc.rs` and `tests/hlc_tests.rs` - 🟢 Acquitted (Robust boundaries, Oracles, and coverage). Priority fixes: Refactored `tests/generic_error_types.rs` to use stronger assertions (`assert_eq!(result, Ok(...))` and `assert_eq!(result, Err(...))`) and improved `test_default_error_type_with_turbofish` to verify the actual output logic values instead of just asserting `is_ok()`. Missing coverage: None. All previously highlighted mutation test evasions inside HLC were patched properly by Sentry/Warden in prior PRs.

---
*PR created automatically by Jules for task [13254120564644918183](https://jules.google.com/task/13254120564644918183) started by @madmax983*