### PR TITLE
⚡ Bolt: Optimize traversal vector allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**[Optimize Traversal BFS/DFS result vector]**
+**Learning:** Initializing the results `Vec` in a graph traversal handler with `Vec::new()` without pre-allocating capacity causes unnecessary intermediate heap reallocations as results are collected.
+**Action:** Always pre-allocate the target array using `Vec::with_capacity(limit)` if the maximum bounded limit of elements is known (e.g. `limit` parameter in traversal requests).

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1305,7 +1305,9 @@ impl AletheiaMcpServer {
         // DFS is chosen for memory efficiency: it processes nodes immediately rather than
         // queuing all nodes at each level. For large graphs with high branching factors,
         // this significantly reduces peak memory usage compared to BFS.
-        let mut results: Vec<TraversalResult> = Vec::new();
+        // ⚡ Bolt Optimization: Pre-allocate the vector with the exact limit to prevent
+        // intermediate heap allocations as results are collected.
+        let mut results: Vec<TraversalResult> = Vec::with_capacity(limit);
         let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
         let mut frontier: Vec<(NodeId, Vec<u64>, usize)> =
             vec![(start_id, vec![start_id.as_u64()], 0)];


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(limit)` in `mcp/server.rs`'s `handle_traverse`.
🎯 Why: The maximum number of elements is strictly bounded by `limit`, avoiding unnecessary intermediate heap reallocations when collecting traversal results.
📊 Impact: Eliminates multiple heap allocations per traversal request.
🔬 Measurement: Run `cargo test --lib --features mcp-server mcp`.

Note: Made the best safe assumption to optimize the `mcp/server.rs` traversal vector allocation as it is a high-traffic operation where `limit` guarantees bounds.

---
*PR created automatically by Jules for task [15291842971559450454](https://jules.google.com/task/15291842971559450454) started by @madmax983*