### PR TITLE
⚖️ Elenchus: [query::planner::rules::filter_scan_fusion] Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[FilterScanFusion Optimization Rule Weakness]**
+**Module:** `src/query/planner/rules/filter_scan_fusion.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The tests for `FilterScanFusion` missed key logic branches. Specifically, they did not verify that pseudo-keys (e.g., `_label`) bypass the fusion logic, they didn't assert that `Unary` operations correctly apply recursion, and they failed to correctly verify boolean change propagation across `Binary` operations (e.g. `left_changed || right_changed`). They also missed tests for the rule's `name()` and `apply()` fallback.
+**Evidence:** `cargo mutants` identified 10 surviving mutants, including match arm mutations on `!key.starts_with('_')`, mutating `||` to `&&` in the `Binary` match arm, and fully replacing `apply` or `name` methods.
+**Recommendation:** Added 7 new sentry tests (`test_fuse_changed_boolean_logic`, `test_fuse_changed_boolean_logic_changed_right`, `test_fuse_recursively_handles_binary_ops`, `test_fuses_unary_op_recursively`, `test_pseudo_key_not_fused`, `test_apply_returns_none_if_no_change`, `test_filter_scan_fusion_name`) to explicitly cover these edge cases, ensuring robust mutation resistance.

--- a/.jules/filter_scan_fusion_tests.rs
+++ b/.jules/filter_scan_fusion_tests.rs
@@ -1,0 +1,167 @@
+    #[test]
+    fn test_filter_scan_fusion_name() {
+        let rule = FilterScanFusion;
+        assert_eq!(rule.name(), "filter-scan-fusion");
+    }
+
+    #[test]
+    fn test_apply_returns_none_if_no_change() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+        let plan = LogicalPlan::new(LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Person".to_string()),
+            estimated_rows: None,
+        }));
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fuse_changed_boolean_logic() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 30i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 40i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none(), "Should not fuse either side and return none");
+    }
+
+    #[test]
+    fn test_fuse_changed_boolean_logic_changed_right() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 30i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should fuse right side and return some");
+    }
+
+    #[test]
+    fn test_fuse_recursively_handles_binary_ops() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        // Left: can be fused
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        // Right: cannot be fused
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 30i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        // Binary op combining them
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should fuse left side and return some");
+
+        let new_plan = result.unwrap();
+        if let LogicalOp::Binary { op: _, left, right } = new_plan.root {
+            // Left should be PropertyScan
+            assert!(matches!(*left, LogicalOp::Scan(ScanOp::PropertyScan { .. })));
+
+            // Right should be Filter over NodeScan
+            assert!(matches!(*right, LogicalOp::Unary { op: UnaryOp::Filter(_), .. }));
+        } else {
+            panic!("Expected BinaryOp at root");
+        }
+    }
+
+    #[test]
+    fn test_pseudo_key_not_fused() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        // NodeScan with label but key starts with _
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("_label", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none(), "Should not fuse pseudo keys");
+    }
+
+    #[test]
+    fn test_fuses_unary_op_recursively() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let inner = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(10),
+            inner
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should fuse nested");
+
+        let new_plan = result.unwrap();
+        if let LogicalOp::Unary { op: UnaryOp::Limit(10), input } = new_plan.root {
+            assert!(matches!(*input, LogicalOp::Scan(ScanOp::PropertyScan { .. })));
+        } else {
+            panic!("Expected Limit at root");
+        }
+    }

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -242,4 +242,187 @@ mod tests {
         assert!(result.is_some());
         assert!(result.unwrap().temporal_context.is_some());
     }
+    #[test]
+    fn test_filter_scan_fusion_name() {
+        let rule = FilterScanFusion;
+        assert_eq!(rule.name(), "filter-scan-fusion");
+    }
+
+    #[test]
+    fn test_apply_returns_none_if_no_change() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+        let plan = LogicalPlan::new(LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Person".to_string()),
+            estimated_rows: None,
+        }));
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fuse_changed_boolean_logic() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 30i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 40i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(
+            result.is_none(),
+            "Should not fuse either side and return none"
+        );
+    }
+
+    #[test]
+    fn test_fuse_changed_boolean_logic_changed_right() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 30i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should fuse right side and return some");
+    }
+
+    #[test]
+    fn test_fuse_recursively_handles_binary_ops() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        // Left: can be fused
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        // Right: cannot be fused
+        let right = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::gt("age", 30i64)),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        // Binary op combining them
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should fuse left side and return some");
+
+        let new_plan = result.unwrap();
+        if let LogicalOp::Binary { op: _, left, right } = new_plan.root {
+            // Left should be PropertyScan
+            assert!(matches!(
+                *left,
+                LogicalOp::Scan(ScanOp::PropertyScan { .. })
+            ));
+
+            // Right should be Filter over NodeScan
+            assert!(matches!(
+                *right,
+                LogicalOp::Unary {
+                    op: UnaryOp::Filter(_),
+                    ..
+                }
+            ));
+        } else {
+            panic!("Expected BinaryOp at root");
+        }
+    }
+
+    #[test]
+    fn test_pseudo_key_not_fused() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        // NodeScan with label but key starts with _
+        let plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("_label", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_none(), "Should not fuse pseudo keys");
+    }
+
+    #[test]
+    fn test_fuses_unary_op_recursively() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let inner = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        let plan = LogicalPlan::new(LogicalOp::unary(UnaryOp::Limit(10), inner));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+        assert!(result.is_some(), "Should fuse nested");
+
+        let new_plan = result.unwrap();
+        if let LogicalOp::Unary {
+            op: UnaryOp::Limit(10),
+            input,
+        } = new_plan.root
+        {
+            assert!(matches!(
+                *input,
+                LogicalOp::Scan(ScanOp::PropertyScan { .. })
+            ));
+        } else {
+            panic!("Expected Limit at root");
+        }
+    }
 }


### PR DESCRIPTION
Added robust tests to `src/query/planner/rules/filter_scan_fusion.rs` to address logic gaps identified by `cargo mutants`.

- Added `test_pseudo_key_not_fused` to verify `_label` filter bypassing.
- Added `test_fuse_changed_boolean_logic` and `test_fuse_changed_boolean_logic_changed_right` to verify correct boolean propagation across `BinaryOp` branches.
- Added `test_fuses_unary_op_recursively` to check proper deep recursive logic application.
- Added explicit tests for `apply()` fallback and `name()`.

---
*PR created automatically by Jules for task [1058405781789838743](https://jules.google.com/task/1058405781789838743) started by @madmax983*