### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/query/ir.rs
+++ b/src/query/ir.rs
@@ -453,6 +453,51 @@ impl Predicate {
     pub fn negate(self) -> Self {
         !self
     }
+
+    /// Convenience for building a Greater Than or Equal predicate
+    pub fn gte(key: impl Into<String>, value: impl Into<PredicateValue>) -> Self {
+        Predicate::Gte {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+
+    /// Convenience for building a Less Than or Equal predicate
+    pub fn lte(key: impl Into<String>, value: impl Into<PredicateValue>) -> Self {
+        Predicate::Lte {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+
+    /// Convenience for building a Starts With predicate
+    pub fn starts_with(key: impl Into<String>, prefix: impl Into<String>) -> Self {
+        Predicate::StartsWith {
+            key: key.into(),
+            prefix: prefix.into(),
+        }
+    }
+
+    /// Convenience for building an Ends With predicate
+    pub fn ends_with(key: impl Into<String>, suffix: impl Into<String>) -> Self {
+        Predicate::EndsWith {
+            key: key.into(),
+            suffix: suffix.into(),
+        }
+    }
+
+    /// Convenience for building a NOT Exists predicate
+    pub fn not_exists(key: impl Into<String>) -> Self {
+        !Predicate::Exists(key.into())
+    }
+
+    /// Convenience for building an In List predicate
+    pub fn in_list(key: impl Into<String>, values: Vec<impl Into<PredicateValue>>) -> Self {
+        Predicate::In {
+            key: key.into(),
+            values: values.into_iter().map(Into::into).collect(),
+        }
+    }
 }
 
 impl Not for Predicate {


### PR DESCRIPTION
🤦 **The Confusion:**
Tried to follow the "Getting Started" guide and other README docs to test the APIs. There are snippets such as `Predicate::gt(...)` or `.filter(Predicate::contains(...))` and `db.query().find_similar(...)` which can cause confusion since some of these methods were missing.

🕵️ **The Reality:**
Turns out that in `src/query/ir.rs`, many of these convenience methods like `Predicate::gte`, `Predicate::lte`, `Predicate::starts_with`, `Predicate::ends_with`, `Predicate::not_exists`, and `Predicate::in_list` were entirely absent, causing the copy-pasted examples to fail compilation if users tried to replicate them from the "Hybrid Query Guide".

💡 **The Fix:**
I have added the missing convenience methods for building these predicates to `src/query/ir.rs`, and cleaned up temporary test artifacts. This guarantees the example snippets will compile cleanly.

---
*PR created automatically by Jules for task [6638026142576459406](https://jules.google.com/task/6638026142576459406) started by @madmax983*