### PR TITLE
🛡️ Sentry: [test coverage improvement] Lock Poisoning Crash Risks

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+## Lock Poisoning Crash Risks in Mocks and Observers
+**Learning:** `unwrap()` is often used inside mock client trait implementations (`MockShardClient`) and test observers (`CollectingObserver`) on `RwLock` and `Mutex`. While these are test/mock utilities, they can cause an entire test process or coordinator thread to crash when a lock is intentionally poisoned during simulated chaos testing, masking the actual behavior being tested.
+**Action:** Always gracefully handle `PoisonError` by mapping it to a domain-specific error (`NetworkError::ProtocolError` or `StorageError::LockPoisoned`), returning default values for getters, or ignoring void setter failures, and write tests specifically verifying that poisoning a lock doesn't crash the system.

--- a/src/core/observer.rs
+++ b/src/core/observer.rs
@@ -448,9 +448,45 @@ mod tests {
 
     impl StorageObserver for CollectingObserver {
         fn on_event(&self, event: &StorageEvent) -> Result<()> {
-            self.events.lock().unwrap().push(event.clone());
+            if let Ok(mut events) = self.events.lock() {
+                events.push(event.clone());
+            } else {
+                return Err(crate::core::error::Error::Storage(
+                    crate::core::error::StorageError::LockPoisoned {
+                        resource: "CollectingObserver events lock".to_string(),
+                    },
+                ));
+            }
             Ok(())
         }
+    }
+
+    #[test]
+    fn test_collecting_observer_lock_poisoning() {
+        let collector = std::sync::Arc::new(CollectingObserver {
+            events: std::sync::Mutex::new(Vec::new()),
+        });
+
+        let collector_clone = std::sync::Arc::clone(&collector);
+        let _ = std::thread::spawn(move || {
+            let _lock = collector_clone.events.lock().unwrap();
+            panic!("Poisoning the lock!");
+        })
+        .join();
+
+        let event = StorageEvent::NodeAnchorCreated {
+            version_id: VersionId::new(1).unwrap(),
+            node_id: NodeId::new(1).unwrap(),
+            timestamp: 1000.into(),
+        };
+
+        let result = collector.on_event(&event);
+        assert!(matches!(
+            result,
+            Err(crate::core::error::Error::Storage(
+                crate::core::error::StorageError::LockPoisoned { .. }
+            ))
+        ));
     }
 
     #[test]

--- a/src/storage/sharding/network.rs
+++ b/src/storage/sharding/network.rs
@@ -683,61 +683,82 @@ impl MockShardClient {
 
     /// Set whether the client is healthy.
     pub fn set_healthy(&self, healthy: bool) {
-        *self.healthy.write().unwrap() = healthy;
+        if let Ok(mut lock) = self.healthy.write() {
+            *lock = healthy;
+        }
     }
 
     /// Set the prepare response.
     pub fn set_prepare_response(&self, response: PrepareResponse) {
-        *self.prepare_response.write().unwrap() = Some(response);
+        if let Ok(mut lock) = self.prepare_response.write() {
+            *lock = Some(response);
+        }
     }
 
     /// Set the commit response.
     pub fn set_commit_response(&self, response: CommitResponse) {
-        *self.commit_response.write().unwrap() = Some(response);
+        if let Ok(mut lock) = self.commit_response.write() {
+            *lock = Some(response);
+        }
     }
 
     /// Set the abort response.
     pub fn set_abort_response(&self, response: AbortResponse) {
-        *self.abort_response.write().unwrap() = Some(response);
+        if let Ok(mut lock) = self.abort_response.write() {
+            *lock = Some(response);
+        }
     }
 
     /// Set the query response.
     pub fn set_query_response(&self, response: Vec<u8>) {
-        *self.query_response.write().unwrap() = response;
+        if let Ok(mut lock) = self.query_response.write() {
+            *lock = response;
+        }
     }
 
     /// Set the shard state.
     pub fn set_state(&self, state: ShardState) {
-        *self.state.write().unwrap() = state;
+        if let Ok(mut lock) = self.state.write() {
+            *lock = state;
+        }
     }
 
     /// Set simulated latency.
     pub fn set_latency(&self, latency: Duration) {
-        *self.latency.write().unwrap() = latency;
+        if let Ok(mut lock) = self.latency.write() {
+            *lock = latency;
+        }
     }
 
     /// Make the next call fail with the given error.
     pub fn fail_next(&self, error: NetworkError) {
-        *self.fail_next.write().unwrap() = Some(error);
+        if let Ok(mut lock) = self.fail_next.write() {
+            *lock = Some(error);
+        }
     }
 
     /// Get call count for a method.
     pub fn call_count(&self, method: &str) -> usize {
-        self.call_counts
-            .read()
-            .unwrap()
-            .get(method)
-            .copied()
-            .unwrap_or(0)
+        if let Ok(counts) = self.call_counts.read() {
+            counts.get(method).copied().unwrap_or(0)
+        } else {
+            0
+        }
     }
 
     fn increment_call(&self, method: &str) {
-        let mut counts = self.call_counts.write().unwrap();
+        let mut counts = match self.call_counts.write() {
+            Ok(lock) => lock,
+            Err(_) => return,
+        };
         *counts.entry(method.to_string()).or_insert(0) += 1;
     }
 
     fn check_fail(&self) -> NetworkResult<()> {
-        let mut fail = self.fail_next.write().unwrap();
+        let mut fail = self
+            .fail_next
+            .write()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?;
         if let Some(err) = fail.take() {
             return Err(err);
         }
@@ -745,7 +766,7 @@ impl MockShardClient {
     }
 
     fn simulate_latency(&self) {
-        let latency = *self.latency.read().unwrap();
+        let latency = *self.latency.read().unwrap_or_else(|e| e.into_inner());
         if latency > Duration::ZERO {
             std::thread::sleep(latency);
         }
@@ -758,7 +779,7 @@ impl ShardClient for MockShardClient {
     }
 
     fn is_healthy(&self) -> bool {
-        *self.healthy.read().unwrap()
+        self.healthy.read().map(|h| *h).unwrap_or(false)
     }
 
     fn prepare(
@@ -778,7 +799,7 @@ impl ShardClient for MockShardClient {
 
         self.prepare_response
             .read()
-            .unwrap()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
             .clone()
             .ok_or(NetworkError::ProtocolError("No response configured".into()))
     }
@@ -799,7 +820,7 @@ impl ShardClient for MockShardClient {
 
         self.commit_response
             .read()
-            .unwrap()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
             .clone()
             .ok_or(NetworkError::ProtocolError("No response configured".into()))
     }
@@ -816,7 +837,7 @@ impl ShardClient for MockShardClient {
 
         self.abort_response
             .read()
-            .unwrap()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
             .clone()
             .ok_or(NetworkError::ProtocolError("No response configured".into()))
     }
@@ -830,7 +851,11 @@ impl ShardClient for MockShardClient {
         }
 
         self.simulate_latency();
-        Ok(self.query_response.read().unwrap().clone())
+        Ok(self
+            .query_response
+            .read()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
+            .clone())
     }
 
     fn get_state(&self) -> NetworkResult<ShardState> {
@@ -842,7 +867,11 @@ impl ShardClient for MockShardClient {
         }
 
         self.simulate_latency();
-        Ok(self.state.read().unwrap().clone())
+        Ok(self
+            .state
+            .read()
+            .map_err(|_| NetworkError::ProtocolError("Lock poisoned".into()))?
+            .clone())
     }
 
     fn receive_migration_batch(&self, batch: MigrationBatch) -> NetworkResult<MigrationResponse> {
@@ -1162,6 +1191,21 @@ mod tests {
     }
 
     // ============ MockShardClient Tests ============
+
+    #[test]
+    fn test_mock_client_lock_poisoning() {
+        let client = std::sync::Arc::new(MockShardClient::new(make_shard_id(0)));
+        let client_clone = std::sync::Arc::clone(&client);
+
+        let _ = std::thread::spawn(move || {
+            let _lock = client_clone.prepare_response.write().unwrap();
+            panic!("Poisoning the lock!");
+        })
+        .join();
+
+        let result = client.prepare(TxId::new(1), &[], None);
+        assert!(matches!(result, Err(NetworkError::ProtocolError(_))));
+    }
 
     #[test]
     fn test_mock_client_creation() {


### PR DESCRIPTION
🎯 **Target:** `src/storage/sharding/network.rs` (`MockShardClient`) and `src/core/observer.rs` (`CollectingObserver`)
💣 **Risk:** The use of `.unwrap()` on `RwLock` and `Mutex` guards inside mock clients and test observers can cause an entire test process or coordinator thread to crash when a lock is intentionally poisoned during simulated chaos testing, masking the actual behavior being tested.
🧪 **Strategy:** Replaced `.unwrap()` calls with graceful `PoisonError` handling. Mapped errors to domain-specific types (`NetworkError::ProtocolError` or `StorageError::LockPoisoned`), returned default values for getters, or ignored void setter failures. Added explicit tests simulating lock poisoning to verify graceful error propagation.
🔭 **Verification:** `cargo check --all-targets --all-features` followed by scoped tests `cargo test storage::sharding::network` and `cargo test core::observer`.

---
*PR created automatically by Jules for task [2639165027060947882](https://jules.google.com/task/2639165027060947882) started by @madmax983*