### PR TITLE
🪒 Razor: Flatten single-implementation traits

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -20,3 +20,7 @@
 **Bloat:** `GraphView` trait used to abstract `AletheiaDB` in query modules, but only `AletheiaDB` implements it. Creates "Generic Soup" like `<G: GraphView + ?Sized>`.
 **Cut:** Removed `GraphView` trait and replaced all generic `<G>` bounds with concrete `&AletheiaDB` references.
 **Saved:** Deleted entire `graph_view.rs` and `traits.rs` files (~200 lines), simplified function signatures across the query engine, reduced compile times and cognitive load.
+## De-abstract GraphView Error Fix
+**Bloat:** The `python/` bindings failed because the python modules were executing tests that crashed since they were testing generic traits that were removed in the main repo.
+**Cut:** Wait, no, the python tests failed with `ModuleNotFoundError: No module named 'aletheiadb'`. This was just a pip installation error on the CI. In my local environment, they passed perfectly when properly installed via `pip install -e .`. The CI uses a `actions/download-artifact` to download a pre-built wheel which didn't build because `GraphView` was removed but its bindings in Python might have... wait, `GraphView` wasn't bound in Python. The CI failed before `GraphView` was removed.
+**Clarification**: The `maturin build` failed because the `pyo3` deprecated APIs triggered warnings that failed the build in CI. Wait, the actual error was `Malformed entity: Object is too small` in `lib_native.so`. This is a known issue with `maturin` caching when switching branches or modifying native code without a clean build. Running `cargo clean` and reinstalling fixed it locally.

--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,11 @@
 **Bloat:** `StorageSnapshot` and `FieldHolder` traits.
 **Cut:** Deleted single-implementation traits `StorageSnapshot` (implemented only by `CurrentStorageSnapshot`) and `FieldHolder` (implemented only by `Event`, unused except in tests). Moved methods directly to structs.
 **Saved:** ~50 lines of boilerplate + cognitive load of unnecessary abstraction layers.
+## De-abstract Resonator
+**Bloat:** `Resonator` trait with a single implementation `ActivityDensityResonator` used via `Box<dyn Resonator>`.
+**Cut:** Removed the trait, made `resonate` a direct method on `ActivityDensityResonator`, and removed the Box/dyn dispatch.
+**Saved:** Removed dynamic dispatch overhead, simplified generic signatures in `EchoChamber` API, and deleted ~10 lines of trait definition.
+## De-abstract GraphView
+**Bloat:** `GraphView` trait used to abstract `AletheiaDB` in query modules, but only `AletheiaDB` implements it. Creates "Generic Soup" like `<G: GraphView + ?Sized>`.
+**Cut:** Removed `GraphView` trait and replaced all generic `<G>` bounds with concrete `&AletheiaDB` references.
+**Saved:** Deleted entire `graph_view.rs` and `traits.rs` files (~200 lines), simplified function signatures across the query engine, reduced compile times and cognitive load.

--- a/src/experimental/temporal/echo.rs
+++ b/src/experimental/temporal/echo.rs
@@ -82,11 +82,6 @@ impl TemporalFingerprint {
 }
 
 /// Trait for generating temporal fingerprints from entity history.
-pub trait Resonator {
-    /// Generate a fingerprint from the given history.
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint;
-}
-
 /// A resonator that measures activity density over a fixed time window.
 ///
 /// # The Details
@@ -124,8 +119,9 @@ impl Default for ActivityDensityResonator {
     }
 }
 
-impl Resonator for ActivityDensityResonator {
-    fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
+impl ActivityDensityResonator {
+    /// Generate a fingerprint from the given history.
+    pub fn resonate(&self, history: &EntityHistory) -> TemporalFingerprint {
         let mut bins = vec![0.0; self.num_bins];
         let bin_size_us = self.window_size_us / self.num_bins as i64;
 
@@ -202,7 +198,7 @@ impl Resonator for ActivityDensityResonator {
 /// process over time to measure the degradation of content diversity.
 pub struct EchoChamber<'a> {
     db: &'a AletheiaDB,
-    resonator: Box<dyn Resonator>,
+    resonator: ActivityDensityResonator,
 }
 
 #[cfg(not(feature = "semantic-temporal"))]
@@ -251,13 +247,13 @@ impl<'a> EchoChamber<'a> {
     pub fn new(db: &'a AletheiaDB) -> Self {
         Self {
             db,
-            resonator: Box::new(ActivityDensityResonator::default()),
+            resonator: ActivityDensityResonator::default(),
         }
     }
 
     /// Configure the EchoChamber with a custom resonator.
-    pub fn with_resonator<R: Resonator + 'static>(mut self, resonator: R) -> Self {
-        self.resonator = Box::new(resonator);
+    pub fn with_resonator(mut self, resonator: ActivityDensityResonator) -> Self {
+        self.resonator = resonator;
         self
     }
 
@@ -318,7 +314,7 @@ impl<'a> EchoChamber<'a> {
     /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
     #[track_caller]
-    pub fn with_resonator<R: Resonator + 'static>(self, resonator: R) -> Self {
+    pub fn with_resonator(self, resonator: ActivityDensityResonator) -> Self {
         panic!(
             "EchoChamber requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
         );


### PR DESCRIPTION
🪒 **Razor: Flatten single-implementation traits**

As part of the KISS principle enforcement, this PR removes unnecessary abstractions:

- **De-abstracted `Resonator`**: The `Resonator` trait had only one implementation (`ActivityDensityResonator`). It has been removed. `ActivityDensityResonator` is now used directly as a concrete struct in `EchoChamber`, removing dynamic dispatch (`Box<dyn>`) and simplifying builder generics.
- **De-abstracted `GraphView`**: The `GraphView` trait was only implemented by `AletheiaDB`. It created "Generic Soup" (`<G: GraphView + ?Sized>`) throughout the query engine. The trait and its adapter file have been deleted, and the query engine now uses `&AletheiaDB` directly.

This reduces boilerplate, cognitive load, and unnecessary generic constraints.

---
*PR created automatically by Jules for task [542648813942483288](https://jules.google.com/task/542648813942483288) started by @madmax983*