### PR TITLE
⚡ Bolt: [performance improvement] Optimize edge deduplication in temporal adjacency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize Deduplication with `Vec` instead of `HashSet`**
+**Learning:** In AletheiaDB, retrieving incident edges at a specific time (e.g., `get_outgoing_at_time`) involves deduplicating a short list of edges. Using `let mut seen = std::collections::HashSet::new();` to filter items inside `.filter_map(|e| if seen.insert(e) { Some(e) } else { None }).collect()` causes unnecessary heap allocations and expensive hashing overhead for small collections.
+**Action:** When deduplicating small collections in performance-critical hot paths, prefer collecting into a `Vec` and calling `.sort_unstable()` followed by `.dedup()` rather than using a `HashSet`, to avoid expensive hashing and allocation overhead.

--- a/src/index/temporal_adjacency.rs
+++ b/src/index/temporal_adjacency.rs
@@ -355,27 +355,22 @@ impl TemporalAdjacencyIndex {
         self.outgoing
             .get(&node_id)
             .map(|entries| {
-                let mut seen = std::collections::HashSet::new();
-
                 // Binary search to find first entry where valid_from <= valid_time
                 // Entries are sorted by valid_from, so we scan from this point forward
                 let start_idx = entries.partition_point(|e| e.valid_from <= valid_time);
 
                 // Scan backward from start_idx to find all entries that could be valid at valid_time
                 // An entry at index i could be valid if valid_from <= valid_time < valid_to
-                entries[..start_idx]
+                let mut edges: Vec<_> = entries[..start_idx]
                     .iter()
                     .rev()
                     .take_while(|e| e.valid_to > valid_time) // Stop when valid_to <= valid_time
                     .filter(|e| e.is_valid_at(valid_time, tx_time))
-                    .filter_map(|e| {
-                        if seen.insert(e.edge_id) {
-                            Some(e.edge_id)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+                    .map(|e| e.edge_id)
+                    .collect();
+                edges.sort_unstable();
+                edges.dedup();
+                edges
             })
             .unwrap_or_default()
     }
@@ -397,25 +392,20 @@ impl TemporalAdjacencyIndex {
         self.incoming
             .get(&node_id)
             .map(|entries| {
-                let mut seen = std::collections::HashSet::new();
-
                 // Binary search to find first entry where valid_from <= valid_time
                 let start_idx = entries.partition_point(|e| e.valid_from <= valid_time);
 
                 // Scan backward from start_idx to find all entries that could be valid at valid_time
-                entries[..start_idx]
+                let mut edges: Vec<_> = entries[..start_idx]
                     .iter()
                     .rev()
                     .take_while(|e| e.valid_to > valid_time)
                     .filter(|e| e.is_valid_at(valid_time, tx_time))
-                    .filter_map(|e| {
-                        if seen.insert(e.edge_id) {
-                            Some(e.edge_id)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+                    .map(|e| e.edge_id)
+                    .collect();
+                edges.sort_unstable();
+                edges.dedup();
+                edges
             })
             .unwrap_or_default()
     }
@@ -438,25 +428,20 @@ impl TemporalAdjacencyIndex {
         self.outgoing
             .get(&node_id)
             .map(|entries| {
-                let mut seen = std::collections::HashSet::new();
-
                 // Binary search to find first entry where valid_from <= valid_time
                 let start_idx = entries.partition_point(|e| e.valid_from <= valid_time);
 
                 // Scan backward from start_idx to find all entries that could be valid at valid_time
-                entries[..start_idx]
+                let mut edges: Vec<_> = entries[..start_idx]
                     .iter()
                     .rev()
                     .take_while(|e| e.valid_to > valid_time)
                     .filter(|e| e.label == label && e.is_valid_at(valid_time, tx_time))
-                    .filter_map(|e| {
-                        if seen.insert(e.edge_id) {
-                            Some(e.edge_id)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+                    .map(|e| e.edge_id)
+                    .collect();
+                edges.sort_unstable();
+                edges.dedup();
+                edges
             })
             .unwrap_or_default()
     }


### PR DESCRIPTION
💡 **What:** Replaced `HashSet` deduplication with `Vec` sorting (`sort_unstable` and `dedup`) in `get_outgoing_at_time`, `get_incoming_at_time`, and `get_outgoing_with_label_at_time` within `src/index/temporal_adjacency.rs`.
🎯 **Why:** Allocating a new `HashSet` and calculating hashes for a typically small set of elements is an unnecessary overhead in a hot path.
📊 **Impact:** Reduces heap allocations and eliminates expensive hashing logic during graph traversals.
🔬 **Measurement:** `cargo test --lib --features nova index::temporal_adjacency` has verified that correctness remains intact.

---
*PR created automatically by Jules for task [8074983169118760497](https://jules.google.com/task/8074983169118760497) started by @madmax983*