### PR TITLE
⚡ Bolt: Replace intermediate vector collection on hot paths with pre-allocated vectors

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize Vector Collection using Iterators**
+**Learning:** In Rust, when mapping and filtering an iterator using `.filter_map(...).collect()`, the iterator's exact size hint is lost, causing multiple dynamic heap allocations as the target `Vec` grows. This is especially impactful in hot paths traversing graph edges.
+**Action:** Manually pre-allocate using `Vec::with_capacity(iter.size_hint().0)` and populate it with a `for` loop to guarantee exactly one allocation and eliminate intermediate heap reallocations.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -824,65 +824,69 @@ impl TraversalIterator {
             Direction::Outgoing => {
                 // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
                 if let Some(ref label) = self.label {
-                    self.current
-                        .get_outgoing_edges_with_label_iter(node_id, label)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get target NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_target(edge_id)
-                                .ok()
-                                .map(|target| (target, edge_id))
-                        })
-                        .collect()
+                    // ⚡ Bolt Optimization: Calculate required capacity and pre-allocate to prevent heap reallocations.
+                    let iter = self
+                        .current
+                        .get_outgoing_edges_with_label_iter(node_id, label);
+                    let mut neighbors = Vec::with_capacity(iter.size_hint().0);
+                    for edge_id in iter {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        // Zero-copy: only get target NodeId, not full Edge (Issue #190)
+                        if let Ok(target) = self.current.get_edge_target(edge_id) {
+                            neighbors.push((target, edge_id));
+                        }
+                    }
+                    neighbors
                 } else {
-                    self.current
-                        .get_outgoing_edges_iter(node_id)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get target NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_target(edge_id)
-                                .ok()
-                                .map(|target| (target, edge_id))
-                        })
-                        .collect()
+                    // ⚡ Bolt Optimization: Calculate required capacity and pre-allocate to prevent heap reallocations.
+                    let iter = self.current.get_outgoing_edges_iter(node_id);
+                    let mut neighbors = Vec::with_capacity(iter.size_hint().0);
+                    for edge_id in iter {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        // Zero-copy: only get target NodeId, not full Edge (Issue #190)
+                        if let Ok(target) = self.current.get_edge_target(edge_id) {
+                            neighbors.push((target, edge_id));
+                        }
+                    }
+                    neighbors
                 }
             }
             Direction::Incoming => {
                 // Use iterator methods to avoid intermediate Vec allocation (Issue #187)
                 if let Some(ref label) = self.label {
-                    self.current
-                        .get_incoming_edges_with_label_iter(node_id, label)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get source NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_source(edge_id)
-                                .ok()
-                                .map(|source| (source, edge_id))
-                        })
-                        .collect()
+                    // ⚡ Bolt Optimization: Calculate required capacity and pre-allocate to prevent heap reallocations.
+                    let iter = self
+                        .current
+                        .get_incoming_edges_with_label_iter(node_id, label);
+                    let mut neighbors = Vec::with_capacity(iter.size_hint().0);
+                    for edge_id in iter {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        // Zero-copy: only get source NodeId, not full Edge (Issue #190)
+                        if let Ok(source) = self.current.get_edge_source(edge_id) {
+                            neighbors.push((source, edge_id));
+                        }
+                    }
+                    neighbors
                 } else {
-                    self.current
-                        .get_incoming_edges_iter(node_id)
-                        .filter_map(|edge_id| {
-                            if !self.edge_visible_at_time(edge_id, &historical_guard) {
-                                return None;
-                            }
-                            // Zero-copy: only get source NodeId, not full Edge (Issue #190)
-                            self.current
-                                .get_edge_source(edge_id)
-                                .ok()
-                                .map(|source| (source, edge_id))
-                        })
-                        .collect()
+                    // ⚡ Bolt Optimization: Calculate required capacity and pre-allocate to prevent heap reallocations.
+                    let iter = self.current.get_incoming_edges_iter(node_id);
+                    let mut neighbors = Vec::with_capacity(iter.size_hint().0);
+                    for edge_id in iter {
+                        if !self.edge_visible_at_time(edge_id, &historical_guard) {
+                            continue;
+                        }
+                        // Zero-copy: only get source NodeId, not full Edge (Issue #190)
+                        if let Ok(source) = self.current.get_edge_source(edge_id) {
+                            neighbors.push((source, edge_id));
+                        }
+                    }
+                    neighbors
                 }
             }
             Direction::Both => {


### PR DESCRIPTION
💡 What: Switched intermediate `.filter_map(|...| ...).collect()` chains in the graph traversal iterators `get_neighbors` method to use explicit `Vec::with_capacity(iter.size_hint().0)` and a `for` loop.
🎯 Why: `.filter_map` obscures the lower bounds of the iterator size hint, forcing `.collect()` to start with a minimum allocation and dynamically grow on the heap. Graph traversals are extremely hot paths, so multiple heap allocations are heavily penalized.
📊 Impact: Guarantees a single heap allocation when assembling neighbor vectors during traversal (eliminates all intermediate allocations).
🔬 Measurement: Run `cargo bench` on query/traversal modules.

---
*PR created automatically by Jules for task [5484584006803084664](https://jules.google.com/task/5484584006803084664) started by @madmax983*