### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -159,29 +159,21 @@ impl<'a> NarrativeGenerator<'a> {
 #[allow(deprecated)]
 impl<'a> NarrativeGenerator<'a> {
     /// Create a new narrative generator.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
-    #[track_caller]
     pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
+        Self {
+            _marker: std::marker::PhantomData,
+        }
     }
 
     /// Generate a narrative for a specific node.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
     #[allow(unused_variables)]
-    #[track_caller]
     pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
+        Err(crate::core::error::Error::Query(
+            crate::core::error::QueryError::UnsupportedFeature {
+                feature: "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml.".to_string(),
+            },
+        ))
     }
 }
 
@@ -309,27 +301,21 @@ mod stub_tests {
     use super::*;
 
     #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
+    fn test_stub_no_panic_on_new() {
         let db = AletheiaDB::new().unwrap();
-        // This should panic
         let _ = NarrativeGenerator::new(&db);
     }
 
     #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
+    fn test_stub_error_on_generate() {
         // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
         // We just need it to call the method.
         let generator: NarrativeGenerator<'_> = NarrativeGenerator {
             _marker: std::marker::PhantomData,
         };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
+        let result = generator.generate_node_narrative(NodeId::new(0).unwrap());
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("requires the 'nova' feature"));
     }
 }


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the examples from the README.md and ran into several confusing issues: The `story_demo` code throws a deprecated warning but then crashes if the `nova` feature is not enabled. The `NarrativeGenerator` fails with a hard panic rather than gracefully handling feature omissions.

🕵️ **The Reality:** In `src/experimental/temporal_narrative.rs`, the stub implementations for `NarrativeGenerator` used `panic!` macros instead of returning proper `Result` errors when the feature was disabled.

💡 **The Fix:** Modified `NarrativeGenerator`'s fallback implementation to gracefully return an `UnsupportedFeature` error instead of panicking, and updated the `stub_tests` to expect `Err` instead of `#[should_panic]`.

---
*PR created automatically by Jules for task [11779679754457188582](https://jules.google.com/task/11779679754457188582) started by @madmax983*