### PR TITLE
🛡️ Sentry: [test coverage improvement] Prevent division by zero in RippleConfig

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+**[Handling Invalid Bin Sizes in RippleConfig]**
+**Learning:** Found a division by zero panic risk in `RippleDetector::compute_flux` when `RippleConfig::bin_size_us` is zero or less. I initially attempted to return `StorageError::InvalidInput` but discovered `core::error::StorageError` doesn't have an `InvalidInput` variant.
+**Action:** Use `StorageError::InconsistentState { reason: String }` for custom validation errors like "bin_size_us must be strictly positive" when `InvalidInput` isn't available. Ensure both Red (failing test) and Green (code fix) phases are completed to prevent CI failures.

--- a/src/experimental/diagnostics/ripple.rs
+++ b/src/experimental/diagnostics/ripple.rs
@@ -164,6 +164,12 @@ impl<'a> RippleDetector<'a> {
         let end_time = config.window.end().wallclock();
         let duration = end_time - start_time;
 
+        if config.bin_size_us <= 0 {
+            return Err(Error::Storage(StorageError::InconsistentState {
+                reason: "RippleConfig bin_size_us must be strictly positive".to_string(),
+            }));
+        }
+
         if duration <= 0 {
             return Ok(Vec::new());
         }
@@ -295,6 +301,23 @@ mod tests {
     use crate::api::transaction::WriteOps;
     use crate::core::property::PropertyMapBuilder;
     use crate::core::temporal::time;
+
+    #[test]
+    fn test_zero_bin_size_returns_error() {
+        let db = AletheiaDB::new().unwrap();
+        let detector = RippleDetector::new(&db);
+        let config = RippleConfig {
+            window: TimeRange::new(0.into(), 1000.into()).unwrap(),
+            bin_size_us: 0,
+            max_lag_bins: 5,
+            min_correlation: 0.8,
+        };
+
+        // We don't need real nodes if it errors early, but let's pass a dummy id.
+        let a = crate::core::id::NodeId::new(1).unwrap();
+        let result = detector.detect_causality(a, a, &config, "vec");
+        assert!(result.is_err(), "Expected error for bin_size_us <= 0");
+    }
 
     #[test]
     fn test_ripple_exact_match_zero_lag() {


### PR DESCRIPTION
🎯 **Target:** `RippleDetector::compute_flux` in `src/experimental/diagnostics/ripple.rs`.
💣 **Risk:** Potential division by zero panic when `config.bin_size_us` is 0 or less.
🧪 **Strategy:** Added a failing test `test_zero_bin_size_returns_error` and then implemented the corresponding check to return an `Err` containing `StorageError::InconsistentState` instead of panicking.
🔬 **Verification:** Run `cargo test --features nova test_zero_bin_size_returns_error` to verify the fix.

---
*PR created automatically by Jules for task [3500461659233313544](https://jules.google.com/task/3500461659233313544) started by @madmax983*