### PR TITLE
👺 Havoc: Fix stack overflow panic in PropertyValue PartialEq

### DIFF
--- a/src/core/property/value.rs
+++ b/src/core/property/value.rs
@@ -63,20 +63,32 @@ pub enum PropertyValue {
 
 impl PartialEq for PropertyValue {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (PropertyValue::Null, PropertyValue::Null) => true,
-            (PropertyValue::Bool(a), PropertyValue::Bool(b)) => a == b,
-            (PropertyValue::Int(a), PropertyValue::Int(b)) => a == b,
-            (PropertyValue::Float(a), PropertyValue::Float(b)) => a == b,
-            (PropertyValue::String(a), PropertyValue::String(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::Array(a), PropertyValue::Array(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::Vector(a), PropertyValue::Vector(b)) => Arc::ptr_eq(a, b) || a == b,
-            (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) => {
-                Arc::ptr_eq(a, b) || a == b
+        let mut stack = vec![(self, other)];
+
+        while let Some((a_val, b_val)) = stack.pop() {
+            match (a_val, b_val) {
+                (PropertyValue::Null, PropertyValue::Null) => {}
+                (PropertyValue::Bool(a), PropertyValue::Bool(b)) if a == b => {}
+                (PropertyValue::Int(a), PropertyValue::Int(b)) if a == b => {}
+                (PropertyValue::Float(a), PropertyValue::Float(b)) if a == b => {}
+                (PropertyValue::String(a), PropertyValue::String(b)) if Arc::ptr_eq(a, b) || a == b => {}
+                (PropertyValue::Bytes(a), PropertyValue::Bytes(b)) if Arc::ptr_eq(a, b) || a == b => {}
+                (PropertyValue::Vector(a), PropertyValue::Vector(b)) if Arc::ptr_eq(a, b) || a == b => {}
+                (PropertyValue::SparseVector(a), PropertyValue::SparseVector(b)) if Arc::ptr_eq(a, b) || a == b => {}
+                (PropertyValue::Array(a), PropertyValue::Array(b)) => {
+                    if !Arc::ptr_eq(a, b) {
+                        if a.len() != b.len() {
+                            return false;
+                        }
+                        for (a_item, b_item) in a.iter().zip(b.iter()) {
+                            stack.push((a_item, b_item));
+                        }
+                    }
+                }
+                _ => return false,
             }
-            _ => false,
         }
+        true
     }
 }
 

--- a/tests/havoc_property_recursion_eq.rs
+++ b/tests/havoc_property_recursion_eq.rs
@@ -1,0 +1,13 @@
+use aletheiadb::core::property::PropertyValue;
+use std::sync::Arc;
+
+#[test]
+fn test_havoc_partial_eq_stack_overflow() {
+    let mut v1 = PropertyValue::Int(1);
+    let mut v2 = PropertyValue::Int(1);
+    for _ in 0..100000 {
+        v1 = PropertyValue::Array(Arc::new(vec![v1]));
+        v2 = PropertyValue::Array(Arc::new(vec![v2]));
+    }
+    assert!(v1 == v2);
+}


### PR DESCRIPTION
🧨 **The Trigger:**
When two deeply nested PropertyValue::Array instances are compared using `assert_eq!(v1, v2)` (or just `v1 == v2`), the recursive `PartialEq` implementation overflows the thread's stack. This can be weaponized if an attacker manages to insert deeply nested properties into the graph (even if depth is bounded during serialization, it can be created programmatically up to MAX_RECURSION_DEPTH or evaluated directly before serialization limits catch it).

📉 **The Stack Trace:**
```
thread 'test_havoc' (33272) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test havoc_property_recursion_eq`
```

🧪 **Reproduction:**
Run the new fuzz test `cargo test --test havoc_property_recursion_eq`. It constructs a nested array graph and invokes `assert_eq!(v1, v2)`, which successfully crashes the unpatched system.

😈 **Comment:**
Replaced the recursive `match` with an iterative DFS stack mechanism to evaluate Equality in constant stack space, matching how we already safely `Drop` nested arrays without overflowing.

---
*PR created automatically by Jules for task [10804657322572957241](https://jules.google.com/task/10804657322572957241) started by @madmax983*