### PR TITLE
🛡️ Sentry: [test coverage improvement] HLC Logical Counter Overflow

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,11 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+
+**AletheiaDB Serialization Panic Guards**
+**Learning:** During extensive auditing of `try_into().unwrap()` in AletheiaDB's vector, mapping, and HLC parsers, no unguarded panics were found. Every occurrence of `from_le_bytes(bytes[A..B].try_into().unwrap())` is explicitly guarded by preceding `if bytes.len() < X` checks.
+**Action:** Use these modules as an example of correct defensive serialization programming in Rust, returning `StorageError::CorruptedData` instead of panicking on malformed user input.
+
+**AletheiaDB Serialization Panic Guards**
+**Learning:** During extensive auditing of `try_into().unwrap()` in AletheiaDB's vector, mapping, and HLC parsers, no unguarded panics were found. Every occurrence of `from_le_bytes(bytes[A..B].try_into().unwrap())` is explicitly guarded by preceding `if bytes.len() < X` checks.
+**Action:** Use these modules as an example of correct defensive serialization programming in Rust, returning `StorageError::CorruptedData` instead of panicking on malformed user input.

--- a/src/core/hlc.rs
+++ b/src/core/hlc.rs
@@ -1241,4 +1241,23 @@ mod sentinel_evaluate_clock_skew_tests {
         let err_f = result_forward_strict.unwrap_err();
         assert_eq!(err_f.direction, ClockSkewDirection::Forward);
     }
+
+    #[test]
+    fn should_return_error_when_increment_logical_overflows() {
+        // Create an HLC timestamp with logical max value
+        let wallclock = 12345;
+        let result = HybridTimestamp::increment_logical(u32::MAX, wallclock);
+
+        assert!(result.is_err());
+        match result {
+            Err(TemporalError::LogicalCounterOverflow {
+                wallclock: w,
+                current_logical: l,
+            }) => {
+                assert_eq!(w, wallclock);
+                assert_eq!(l, u32::MAX);
+            }
+            _ => panic!("Expected LogicalCounterOverflow error"),
+        }
+    }
 }


### PR DESCRIPTION
🎯 Target: `src/core/hlc.rs` (Hybrid Logical Clock)
💣 Risk: `increment_logical` has a `checked_add` bounds check to prevent `u32::MAX` overflow that lacked explicit test coverage, leaving a potential regression risk if the code was modified.
🧪 Strategy: Added a targeted unit test to ensure `increment_logical(u32::MAX)` triggers the `TemporalError::LogicalCounterOverflow` gracefully.
🔬 Verification: `cargo test should_return_error_when_increment_logical_overflows -- core::hlc`

*(Note: Extensive workspace-wide auditing of `try_into().unwrap()`, `.expect()`, and buffer indexing arrays revealed that AletheiaDB's serialization, WAL parsing, and index layers are heavily guarded with strict length verifications and return `StorageError::CorruptedData` safely).*

---
*PR created automatically by Jules for task [13885640357372005620](https://jules.google.com/task/13885640357372005620) started by @madmax983*