### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,3 @@ pr_description.md
 
 # Re-include Python SDK sources (overrides "*.py" above)
 !python/**/*.py
-target/

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ pr_description.md
 
 # Re-include Python SDK sources (overrides "*.py" above)
 !python/**/*.py
+target/

--- a/docs/guides/hybrid-query-guide.md
+++ b/docs/guides/hybrid-query-guide.md
@@ -535,7 +535,7 @@ use aletheiadb::query::plan::IndexHint;
 db.query()
     .start(node_id)
     .with_hint(IndexHint::UseVectorIndex)  // Force vector index use
-    .with_hint(IndexHint::ForceScan)       // Skip indexes
+    .with_hint(IndexHint::UseBruteForce)   // Skip indexes
     // ...
 ```
 


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the code example in the Hybrid Query Guide for using an optimizer hint. It uses `IndexHint::ForceScan`, which causes a compiler error `variant or associated item not found in IndexHint`.

🕵️ **The Reality:** There is no `ForceScan` variant in `IndexHint` (defined in `src/query/plan.rs`). The actual intended hint to force a brute-force vector search and skip the HNSW index is `IndexHint::UseBruteForce`.

💡 **The Fix:** Updated `docs/guides/hybrid-query-guide.md` to replace the invalid `IndexHint::ForceScan` with `IndexHint::UseBruteForce`.

---
*PR created automatically by Jules for task [10553659087364172037](https://jules.google.com/task/10553659087364172037) started by @madmax983*