### PR TITLE
🎻 Bard: [documentation update] Add examples to core AletheiaDB ops

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-18 - [Missing Executeable Examples for DB Ops]
+**Confusion:** The core database operations exposed directly on `AletheiaDB` in `src/db/config.rs` and `src/db/ops.rs` lacked executable `## Examples` doc-tests, forcing users to read the test suites to figure out how to create an ephemeral DB, scan nodes, or get edges.
+**Clarification:** I added robust, executable `## Examples` using `aletheiadb::PropertyMapBuilder` to `AletheiaDB::new()`, `scan_nodes_by_label()`, and `get_outgoing_edges()`.

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -110,6 +110,17 @@ impl AletheiaDB {
     /// [`Self::open_from_env`] to honor the `ALETHEIADB_DATA_DIR` environment
     /// variable.
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// // The database is ephemeral and will be removed when dropped.
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns an error if the temporary directory cannot be created or WAL

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -31,6 +31,21 @@ impl AletheiaDB {
     /// # }
     /// ```
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// db.create_node("Person", PropertyMapBuilder::new().build())?;
+    /// db.create_node("Person", PropertyMapBuilder::new().build())?;
+    ///
+    /// let count = db.scan_nodes_by_label("Person").count();
+    /// assert_eq!(count, 2);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # See Also
     ///
     /// * [`write`](Self::write) - For batched write operations.
@@ -191,6 +206,22 @@ impl AletheiaDB {
     }
 
     /// Get outgoing edges from a node (current state).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let src = db.create_node("Person", PropertyMapBuilder::new().build())?;
+    /// let target = db.create_node("Company", PropertyMapBuilder::new().build())?;
+    /// db.create_edge(src, target, "WORKS_AT", PropertyMapBuilder::new().build())?;
+    ///
+    /// let edges = db.get_outgoing_edges(src);
+    /// assert_eq!(edges.len(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
         self.current.get_outgoing_edges(node_id)
     }


### PR DESCRIPTION
📖 Chapter: Database Initialization & Basic Operations (`src/db/config.rs` and `src/db/ops.rs`)
🔦 Insight: Users lacked immediate, copy-pasteable examples for the most critical paths (bootstrapping an ephemeral database and basic graph traversals) directly on the `AletheiaDB` struct.
🧪 Example: Added 3 executable doc-tests utilizing `PropertyMapBuilder` and standard `Result` propagation.
🖼️ Preview: (Verified via `cargo doc --no-deps`)

---
*PR created automatically by Jules for task [9853928438166346581](https://jules.google.com/task/9853928438166346581) started by @madmax983*