### PR TITLE
⚖️ Elenchus: Planner Rules Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+## [Planner Rules Binary/Logical Partial Optimization Test Gap]
+**Module:** `src/query/planner/rules/`
+**Verdict:** 🟡 Suspect
+**Finding:** The logical query planner rules (`FilterScanFusion`, `OperationReordering`, `LimitPushdown`) propagated `changed` state across `BinaryOp` and nested limits using logical OR (`||`) operators. These logic paths lacked specific tests that verified partial modification (e.g. only the left branch of a Union, or only the child of a Limit), meaning mutations that transformed `||` into `&&` survived.
+**Evidence:** Mutation tests (e.g., `replace || with && in OperationReordering::reorder`) survived in CI because existing tests only covered scenarios where both branches changed or neither changed, missing the XOR case.
+**Recommendation:** Added missing boundary tests (`test_binary_op_partial_optimization` and equivalent variant logic tests) across `limit_pushdown`, `operation_reordering`, and `filter_scan_fusion` to prevent any logical short-circuits from regressing.

--- a/src/query/planner/rules/filter_scan_fusion.rs
+++ b/src/query/planner/rules/filter_scan_fusion.rs
@@ -243,3 +243,53 @@ mod tests {
         assert!(result.unwrap().temporal_context.is_some());
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::query::ir::Predicate;
+    use crate::query::plan::{BinaryOp, ScanOp};
+    use crate::query::planner::stats::Statistics;
+
+    fn test_stats() -> Statistics {
+        Statistics::default()
+    }
+
+    #[test]
+    fn test_binary_op_partial_optimization() {
+        let rule = FilterScanFusion;
+        let stats = test_stats();
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("name", "Alice")),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Person".to_string()),
+                estimated_rows: None,
+            }),
+        );
+
+        let right = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Other".to_string()),
+            estimated_rows: None,
+        });
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left, right));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::Scan(ScanOp::PropertyScan {
+                label: "Person".to_string(),
+                key: "name".to_string(),
+                value: crate::query::ir::PredicateValue::String("Alice".to_string()),
+            }),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Other".to_string()),
+                estimated_rows: None,
+            }),
+        ));
+
+        assert_eq!(result, Some(expected_plan));
+    }
+}

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -542,4 +542,89 @@ mod sentry_tests {
             panic!("Expected VectorRank");
         }
     }
+
+    #[test]
+    fn test_pushdown_limit_input_changed_but_same_limit() {
+        let rule = LimitPushdown;
+        // The limit doesn't change (10 -> 10), but the child changes because
+        // the child has a limit that gets pushed down.
+        let op = LogicalOp::unary(
+            UnaryOp::Limit(10),
+            LogicalOp::unary(
+                UnaryOp::Limit(20),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        );
+        let (new_op, changed) = rule.push_down(&op, Some(10)).unwrap();
+        assert!(changed, "Limit should propagate changed=true if input changed, even if its own limit didn't change");
+
+        if let LogicalOp::Unary {
+            op: UnaryOp::Limit(n),
+            ..
+        } = new_op
+        {
+            assert_eq!(n, 10);
+        } else {
+            panic!("Expected limit");
+        }
+    }
+
+    #[test]
+    fn test_pushdown_vector_rank_input_changed_but_same_limit() {
+        let rule = LimitPushdown;
+        // top_k = Some(10), pass down limit = None. The limit doesn't change,
+        // but the child changes (e.g. limit is pushed to the scan).
+        // Let's pass limit=None. The child is Limit(20, Limit(30, Scan)) -> Limit(20, Scan) which is a change.
+        let op = LogicalOp::unary(
+            UnaryOp::VectorRank {
+                embedding: vec![0.1f32].into(),
+                top_k: Some(10),
+                property_key: None,
+            },
+            LogicalOp::unary(
+                UnaryOp::Limit(20),
+                LogicalOp::unary(
+                    UnaryOp::Limit(30),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        );
+        let (new_op, changed) = rule.push_down(&op, None).unwrap();
+        assert!(changed, "Vector rank should apply changed=true if input changed");
+
+        if let LogicalOp::Unary {
+            op: UnaryOp::VectorRank { top_k, .. },
+            ..
+        } = new_op
+        {
+            assert_eq!(top_k, Some(10));
+        } else {
+            panic!("Expected VectorRank");
+        }
+    }
+
+    #[test]
+    fn test_pushdown_vector_rank_same_input_but_changed_limit() {
+        let rule = LimitPushdown;
+        let op = LogicalOp::unary(
+            UnaryOp::VectorRank {
+                embedding: vec![0.1f32].into(),
+                top_k: Some(10),
+                property_key: None,
+            },
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        );
+        let (new_op, changed) = rule.push_down(&op, Some(5)).unwrap();
+        assert!(changed, "Vector rank should apply changed=true if limit changed");
+
+        if let LogicalOp::Unary {
+            op: UnaryOp::VectorRank { top_k, .. },
+            ..
+        } = new_op
+        {
+            assert_eq!(top_k, Some(5));
+        } else {
+            panic!("Expected VectorRank");
+        }
+    }
 }

--- a/src/query/planner/rules/operation_reordering.rs
+++ b/src/query/planner/rules/operation_reordering.rs
@@ -159,6 +159,112 @@ impl OptimizationRule for OperationReordering {
     }
 }
 
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+    use crate::query::ir::Predicate;
+    use crate::query::plan::{BinaryOp, ScanOp};
+    use crate::query::planner::stats::Statistics;
+
+    fn test_stats() -> Statistics {
+        let stats = Statistics::default();
+        stats.update_property_stats("rare_property", 10);
+        stats.update_property_stats("common_property", 500);
+        stats
+    }
+
+    #[test]
+    fn test_binary_op_partial_optimization() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        let left = LogicalOp::unary(
+            UnaryOp::Filter(Predicate::eq("common_property", "value")),
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("rare_property", "value")),
+                LogicalOp::Scan(ScanOp::NodeScan {
+                    label: None,
+                    estimated_rows: Some(1000),
+                }),
+            ),
+        );
+
+        let right = LogicalOp::Scan(ScanOp::NodeScan {
+            label: None,
+            estimated_rows: Some(100),
+        });
+
+        let plan = LogicalPlan::new(LogicalOp::binary(BinaryOp::Union, left, right));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Union,
+            LogicalOp::unary(
+                UnaryOp::Filter(Predicate::eq("rare_property", "value")),
+                LogicalOp::unary(
+                    UnaryOp::Filter(Predicate::eq("common_property", "value")),
+                    LogicalOp::Scan(ScanOp::NodeScan {
+                        label: None,
+                        estimated_rows: Some(1000),
+                    }),
+                ),
+            ),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: None,
+                estimated_rows: Some(100),
+            }),
+        ));
+
+        assert_eq!(result, Some(expected_plan));
+    }
+
+    #[test]
+    fn test_join_op_partial_optimization() {
+        let rule = OperationReordering;
+        let stats = test_stats();
+
+        // Right side is smaller (10 rows vs 100 rows), so they should be swapped.
+        let left = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Large".to_string()),
+            estimated_rows: Some(100),
+        });
+
+        let right = LogicalOp::Scan(ScanOp::NodeScan {
+            label: Some("Small".to_string()),
+            estimated_rows: Some(10),
+        });
+
+        let plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "id".to_string(),
+                right_key: "ref_id".to_string(),
+            },
+            left,
+            right,
+        ));
+
+        let result = rule.apply(&plan, &stats).unwrap();
+
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            BinaryOp::Join {
+                left_key: "ref_id".to_string(),
+                right_key: "id".to_string(),
+            },
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Small".to_string()),
+                estimated_rows: Some(10),
+            }),
+            LogicalOp::Scan(ScanOp::NodeScan {
+                label: Some("Large".to_string()),
+                estimated_rows: Some(100),
+            }),
+        ));
+
+        assert_eq!(result, Some(expected_plan));
+    }
+}
+
 impl OperationReordering {
     /// Recursively reorder operations in the plan tree.
     fn reorder(&self, op: &LogicalOp, stats: &Statistics) -> Result<(LogicalOp, bool)> {


### PR DESCRIPTION
This PR directly handles missing boundary edge-case coverage highlighted by Elenchus across `LimitPushdown`, `FilterScanFusion`, and `OperationReordering` logic paths concerning short-circuits.

- Adds binary boundary cases across rules.
- Explicit `changed=true` evaluation for limits.
- Included corresponding `.jules/elenchus.md` evaluation matrix updates.

---
*PR created automatically by Jules for task [7859712044067261953](https://jules.google.com/task/7859712044067261953) started by @madmax983*