### PR TITLE
⚡ Bolt: Remove heap allocation in materialize_vector_deltas

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Removed heap allocation in `materialize_vector_deltas`**
+**Learning:** Collecting elements from an iterator into a `Vec` just to iterate over them safely while modifying the source collection can be a hidden performance bottleneck, especially on hot paths like graph version snapshotting/persistence.
+**Action:** Use `std::mem::take(&mut self.map)` to efficiently extract all entries from a map into a local variable. This allows zero-allocation iteration over the entries. If an error occurs midway and the collection needs to be preserved or left in a consistent state, you can either re-insert the current item and `extend()` the rest back into the map, or simply fail closed if partial modification is acceptable.

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -599,35 +599,47 @@ impl PropertyDelta {
     ) -> std::result::Result<(), String> {
         // Materialize ALL vector deltas (both Sparse and Full) into regular changed properties
         // This is necessary for persistence since the persistence format doesn't support VectorDelta
-        let keys: Vec<_> = self.vector_deltas.keys().copied().collect();
+        // ⚡ Bolt Optimization: Avoid heap allocation by taking ownership of the map directly.
+        let old_deltas = std::mem::take(&mut self.vector_deltas);
+        let mut old_deltas_iter = old_deltas.into_iter();
 
-        for key in keys {
-            if let Some(vec_delta) = self.vector_deltas.remove(&key) {
-                match vec_delta {
-                    VectorDelta::Full(vec) => {
-                        // Full delta can be directly converted
-                        self.changed.insert(key, PropertyValue::Vector(vec));
-                    }
-                    VectorDelta::Sparse { .. } => {
-                        // Sparse delta requires base vector to materialize
-                        let base_value = base.get_by_interned_key(&key).ok_or_else(|| {
-                            format!(
+        while let Some((key, vec_delta)) = old_deltas_iter.next() {
+            match vec_delta {
+                VectorDelta::Full(vec) => {
+                    // Full delta can be directly converted
+                    self.changed.insert(key, PropertyValue::Vector(vec));
+                }
+                VectorDelta::Sparse { .. } => {
+                    // Sparse delta requires base vector to materialize
+                    let base_value = match base.get_by_interned_key(&key) {
+                        Some(val) => val,
+                        None => {
+                            // Restore state on error to maintain consistency
+                            self.vector_deltas.insert(key, vec_delta);
+                            self.vector_deltas.extend(old_deltas_iter);
+                            return Err(format!(
                                 "Cannot materialize sparse vector delta: base property not found for key {:?}",
                                 key
-                            )
-                        })?;
+                            ));
+                        }
+                    };
 
-                        let base_vec = base_value.as_vector().ok_or_else(|| {
-                            format!(
+                    let base_vec = match base_value.as_vector() {
+                        Some(val) => val,
+                        None => {
+                            // Restore state on error to maintain consistency
+                            self.vector_deltas.insert(key, vec_delta);
+                            self.vector_deltas.extend(old_deltas_iter);
+                            return Err(format!(
                                 "Cannot materialize sparse vector delta: base property is not a vector for key {:?}",
                                 key
-                            )
-                        })?;
+                            ));
+                        }
+                    };
 
-                        // Apply sparse delta to get full vector
-                        let new_vec = vec_delta.apply(base_vec);
-                        self.changed.insert(key, new_vec.into());
-                    }
+                    // Apply sparse delta to get full vector
+                    let new_vec = vec_delta.apply(base_vec);
+                    self.changed.insert(key, new_vec.into());
                 }
             }
         }


### PR DESCRIPTION
💡 **What:** Replaced the intermediate `Vec` collection (`let keys: Vec<_> = self.vector_deltas.keys().copied().collect();`) in `PropertyDelta::materialize_vector_deltas` with a zero-allocation map extraction using `std::mem::take(&mut self.vector_deltas)`. Un-processed items are re-inserted if an error occurs to maintain data consistency.

🎯 **Why:** `materialize_vector_deltas` is called during the persistence process to convert sparse vector updates into full vectors. Collecting the keys into an intermediate vector causes an unnecessary heap allocation on this hot path. Taking ownership of the map directly allows for in-place iteration and avoids this allocation.

📊 **Impact:** Removes one heap allocation per node/edge version delta that contains vector updates during checkpointing/persistence, reducing memory pressure and improving performance on large graphs with vectors.

🔬 **Measurement:** `cargo test --lib core::version` and general `cargo clippy` and `cargo test` pass successfully, ensuring no regressions in behavior.

---
*PR created automatically by Jules for task [18077102944124139348](https://jules.google.com/task/18077102944124139348) started by @madmax983*