### PR TITLE
🛡️ Sentry: [PhysicalOp PropertyScan] Test Coverage Improvement

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+## Missing Test Coverage for `PhysicalOp::PropertyScan`
+**Learning:** The `is_leaf` and `depth` functions for `PhysicalOp` did not have explicit test coverage for the `PropertyScan` variant, leading to potential regressions if these implementations were altered.
+**Action:** Always verify all variants in a large enum are explicitly tested in properties like `is_leaf` and `depth`, and do not assume `all_leaf_operators` tests are actually exhaustive without explicit validation. Added `test_is_leaf_property_scan` and `test_depth_property_scan` to `physical.rs`.

--- a/src/query/planner/physical.rs
+++ b/src/query/planner/physical.rs
@@ -2042,4 +2042,33 @@ mod tests {
         };
         assert!(op.get_input().is_none());
     }
+
+    #[test]
+    fn test_is_leaf_property_scan() {
+        use crate::query::ir::PredicateValue;
+        assert!(
+            PhysicalOp::PropertyScan {
+                label: "Person".to_string(),
+                key: "age".to_string(),
+                value: PredicateValue::Int(10),
+                estimated_rows: 100,
+            }
+            .is_leaf()
+        );
+    }
+
+    #[test]
+    fn test_depth_property_scan() {
+        use crate::query::ir::PredicateValue;
+        assert_eq!(
+            PhysicalOp::PropertyScan {
+                label: "Person".to_string(),
+                key: "age".to_string(),
+                value: PredicateValue::Int(10),
+                estimated_rows: 100,
+            }
+            .depth(),
+            1
+        );
+    }
 }


### PR DESCRIPTION
🎯 **Target:** `src/query/planner/physical.rs` (`is_leaf` and `depth` functions for `PhysicalOp` enum).
💣 **Risk:** The `PhysicalOp::PropertyScan` variant was completely missing from `is_leaf` and `depth` unit tests. This created a test gap where adding fields to `PropertyScan` or refactoring how leaves are determined might break quietly without test failures alerting developers.
🧪 **Strategy:** Added targeted tests `test_is_leaf_property_scan` and `test_depth_property_scan` to explicitly verify that a configured `PropertyScan` correctly identifies as a leaf node and has a depth of 1.
🔬 **Verification:** `cargo test -p aletheiadb --lib query::planner::physical`

---
*PR created automatically by Jules for task [3589122939376783727](https://jules.google.com/task/3589122939376783727) started by @madmax983*