### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-20 - [Adding Examples to WAL configurations and structures]
+**Confusion:** Many WAL configuration options, metrics structures, and handles lacked basic usage examples in their `///` rustdoc, forcing developers to look at tests to see how they should be instantiated or handled.
+**Clarification:** I added `## Examples` blocks to structures such as `GroupCommitConfig`, `LsnAllocator`, `BackpressureConfig`, `PendingEntry`, `CompletionNotifier`, `CompletionHandle`, `WalRingBuffer`, `StripeMetrics`, `SegmentMetadata`, `FlushCoordinatorConfig`, `FlushStats`, `ConcurrentWalConfig`, `ConcurrentWalMetrics`, `ConcurrentWalSystemConfig`, and `WriteOptions`. This directly answers the 'how' for developers attempting to tweak WAL configurations.

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -84,6 +84,15 @@ pub const DEFAULT_NUM_STRIPES: usize = 16;
 pub const DEFAULT_STRIPE_CAPACITY: usize = 1024;
 
 /// Configuration for the concurrent WAL.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::concurrent::ConcurrentWalConfig;
+///
+/// let config = ConcurrentWalConfig::default();
+/// assert_eq!(config.num_stripes, 16);
+/// ```
 #[derive(Debug, Clone)]
 pub struct ConcurrentWalConfig {
     /// WAL directory path.
@@ -615,6 +624,21 @@ impl ConcurrentWal {
 }
 
 /// Aggregate metrics for the concurrent WAL.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::concurrent::ConcurrentWalMetrics;
+/// use aletheiadb::storage::wal::entry::LSN;
+///
+/// let metrics = ConcurrentWalMetrics {
+///     total_appends: 100,
+///     current_lsn: LSN(101),
+///     stripes: vec![],
+///     total_pending: 0,
+/// };
+/// assert_eq!(metrics.total_appends, 100);
+/// ```
 #[derive(Debug, Clone)]
 pub struct ConcurrentWalMetrics {
     /// Total entries appended across all stripes.

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -57,6 +57,15 @@ use crate::core::error::{Error, Result, StorageError};
 use crate::storage::wal::DurabilityMode;
 
 /// Configuration for the concurrent WAL system.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
+///
+/// let config = ConcurrentWalSystemConfig::new("data/wal");
+/// assert_eq!(config.wal_dir.to_str().unwrap(), "data/wal");
+/// ```
 #[derive(Clone)]
 pub struct ConcurrentWalSystemConfig {
     /// WAL directory path.

--- a/src/storage/wal/durability.rs
+++ b/src/storage/wal/durability.rs
@@ -473,6 +473,15 @@ impl DurabilityMode {
 ///     Ok(())
 /// })?;
 /// ```
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::durability::{WriteOptions, DurabilityMode};
+///
+/// let options = WriteOptions::new().with_durability(DurabilityMode::Synchronous);
+/// assert_eq!(options.durability_mode, Some(DurabilityMode::Synchronous));
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct WriteOptions {
     /// Override the default durability mode for this transaction.

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -50,6 +50,16 @@ use super::segment_reader::{WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION, WAL_VERSION
 ///
 /// This is stored in a companion `.meta` file for each segment to enable
 /// efficient LSN-based truncation without reading the entire segment.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::entry::LSN;
+/// use aletheiadb::storage::wal::flush_coordinator::SegmentMetadata;
+///
+/// let meta = SegmentMetadata::new(LSN(1), LSN(100), 100);
+/// assert_eq!(meta.entry_count, 100);
+/// ```
 #[derive(Debug, Clone)]
 pub struct SegmentMetadata {
     /// Minimum LSN in this segment.
@@ -105,6 +115,17 @@ impl SegmentMetadata {
 }
 
 /// Configuration for the flush coordinator.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::flush_coordinator::FlushCoordinatorConfig;
+/// use std::path::PathBuf;
+///
+/// let mut config = FlushCoordinatorConfig::default();
+/// config.wal_dir = PathBuf::from("data/wal");
+/// assert_eq!(config.wal_dir.to_str().unwrap(), "data/wal");
+/// ```
 #[derive(Clone)]
 pub struct FlushCoordinatorConfig {
     /// WAL directory path.
@@ -169,6 +190,21 @@ impl FlushCoordinatorConfig {
 }
 
 /// Statistics from a single flush operation.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::flush_coordinator::FlushStats;
+/// use std::time::Duration;
+///
+/// let stats = FlushStats {
+///     entries_flushed: 10,
+///     bytes_written: 1024,
+///     flush_duration: Duration::from_millis(1),
+///     segment_rotated: false,
+/// };
+/// assert_eq!(stats.entries_flushed, 10);
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct FlushStats {
     /// Number of entries flushed.

--- a/src/storage/wal/group_commit.rs
+++ b/src/storage/wal/group_commit.rs
@@ -102,6 +102,18 @@ pub struct GroupCommitCoordinator {
 }
 
 /// Configuration for group commit behavior.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::group_commit::GroupCommitConfig;
+///
+/// let config = GroupCommitConfig {
+///     max_delay_ms: 10,
+///     max_batch_size: 100,
+///     ..GroupCommitConfig::default()
+/// };
+/// ```
 #[derive(Debug, Clone)]
 pub struct GroupCommitConfig {
     /// Maximum time to wait for more transactions before flushing.

--- a/src/storage/wal/lsn_allocator.rs
+++ b/src/storage/wal/lsn_allocator.rs
@@ -42,6 +42,17 @@ use super::LSN;
 /// This is the single synchronization point for the concurrent WAL.
 /// All writers allocate LSNs from this shared allocator, ensuring
 /// global ordering of WAL entries.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::lsn_allocator::LsnAllocator;
+///
+/// let allocator = LsnAllocator::new();
+/// let lsn1 = allocator.allocate();
+/// let lsn2 = allocator.allocate();
+/// assert!(lsn2 > lsn1);
+/// ```
 pub struct LsnAllocator {
     /// Next LSN to allocate.
     next_lsn: AtomicU64,

--- a/src/storage/wal/ring_buffer.rs
+++ b/src/storage/wal/ring_buffer.rs
@@ -80,6 +80,15 @@ pub const DEFAULT_RING_BUFFER_CAPACITY: usize = 1024;
 /// - **Low-latency workloads**: Higher `initial_spins` (100-1000), lower sleep times
 /// - **High-throughput batch**: Lower `initial_spins` (10-50), higher sleep times
 /// - **Mixed workloads**: Use defaults, which balance both
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::ring_buffer::BackpressureConfig;
+///
+/// let config = BackpressureConfig::low_latency();
+/// assert!(config.validate().is_ok());
+/// ```
 #[derive(Debug, Clone)]
 pub struct BackpressureConfig {
     /// Initial spin loop iterations on first contention (default: 10).
@@ -147,6 +156,18 @@ impl BackpressureConfig {
 }
 
 /// A pending WAL entry waiting to be flushed to disk.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::entry::LSN;
+/// use aletheiadb::storage::wal::ring_buffer::PendingEntry;
+///
+/// let lsn = LSN(1);
+/// let data = vec![1, 2, 3];
+/// let entry = PendingEntry::new_async(lsn, data);
+/// assert_eq!(entry.lsn, LSN(1));
+/// ```
 #[derive(Debug)]
 pub struct PendingEntry {
     /// Pre-allocated LSN from the global allocator.
@@ -250,6 +271,18 @@ enum CompletionState {
 ///
 /// 4. **Fail-safe default**: If we can't determine the error, we return
 ///    "Unknown error" rather than propagating the panic.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::ring_buffer::CompletionNotifier;
+/// use std::sync::Arc;
+///
+/// let notifier = Arc::new(CompletionNotifier::new());
+/// assert!(!notifier.is_complete());
+/// notifier.notify_success();
+/// assert!(notifier.is_complete());
+/// ```
 #[derive(Debug)]
 pub struct CompletionNotifier {
     /// Current state (Pending, Complete, or Error).
@@ -354,6 +387,23 @@ impl Default for CompletionNotifier {
 /// This is returned to callers who need to wait for their entry to be
 /// durably flushed. The handle can be used to block until completion
 /// or to poll for completion status.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::ring_buffer::{PendingEntry, CompletionHandle, CompletionNotifier};
+/// use aletheiadb::storage::wal::entry::LSN;
+/// use std::sync::Arc;
+///
+/// let lsn = LSN(1);
+/// let data = vec![1, 2, 3];
+/// let (entry, handle) = PendingEntry::new_sync(lsn, data);
+///
+/// if let Some(notifier) = &entry.completion {
+///     notifier.notify_success();
+/// }
+/// assert!(handle.is_complete());
+/// ```
 #[derive(Debug, Clone)]
 pub struct CompletionHandle(pub(crate) Arc<CompletionNotifier>);
 
@@ -441,6 +491,15 @@ impl<T> std::ops::Deref for CacheLinePadded<T> {
 /// 2. Yield/sleep with doubling duration (1µs → 2µs → ... → max)
 ///
 /// Configure via [`BackpressureConfig`] for your workload.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::ring_buffer::WalRingBuffer;
+///
+/// let buffer = WalRingBuffer::with_default_capacity();
+/// assert_eq!(buffer.capacity(), 1024);
+/// ```
 pub struct WalRingBuffer {
     /// Pre-allocated slots.
     slots: Box<[Slot]>,

--- a/src/storage/wal/stripe.rs
+++ b/src/storage/wal/stripe.rs
@@ -239,6 +239,20 @@ impl WalStripe {
 }
 
 /// Metrics for a WAL stripe.
+///
+/// # Examples
+///
+/// ```
+/// use aletheiadb::storage::wal::stripe::StripeMetrics;
+///
+/// let metrics = StripeMetrics {
+///     id: 0,
+///     total_appends: 100,
+///     total_bytes: 1024,
+///     pending_count: 5,
+/// };
+/// assert_eq!(metrics.pending_count, 5);
+/// ```
 #[derive(Debug, Clone)]
 pub struct StripeMetrics {
     /// Stripe ID.


### PR DESCRIPTION
📖 Chapter: `src/storage/wal` submodules
🔦 Insight: Many WAL configuration options, metrics structures, and handles lacked basic usage examples in their `///` rustdoc, forcing developers to look at tests to see how they should be instantiated or handled. Added `## Examples` blocks to structures across multiple files (`group_commit.rs`, `lsn_allocator.rs`, `ring_buffer.rs`, `stripe.rs`, `flush_coordinator.rs`, `concurrent.rs`, `concurrent_system.rs`, and `durability.rs`) to clarify usage directly in the API documentation.
🧪 Example: Added multiple executable doctests.
🖼️ Preview: Evaluated by `cargo doc --open` showing newly enriched `## Examples` blocks.

---
*PR created automatically by Jules for task [7260593542305001329](https://jules.google.com/task/7260593542305001329) started by @madmax983*