### PR TITLE
⚡ Bolt: Optimize Vec allocations in vector delta materialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**[Optimize Vec allocations in vector delta materialization]**
+**Learning:** Collecting Hashmap keys into a `Vec` just to iterate and remove them causes unnecessary intermediate heap reallocations.
+**Action:** Use `std::mem::take(&mut map)` to extract the contents for zero-allocation iteration.

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -599,35 +599,33 @@ impl PropertyDelta {
     ) -> std::result::Result<(), String> {
         // Materialize ALL vector deltas (both Sparse and Full) into regular changed properties
         // This is necessary for persistence since the persistence format doesn't support VectorDelta
-        let keys: Vec<_> = self.vector_deltas.keys().copied().collect();
+        let vector_deltas = std::mem::take(&mut self.vector_deltas);
 
-        for key in keys {
-            if let Some(vec_delta) = self.vector_deltas.remove(&key) {
-                match vec_delta {
-                    VectorDelta::Full(vec) => {
-                        // Full delta can be directly converted
-                        self.changed.insert(key, PropertyValue::Vector(vec));
-                    }
-                    VectorDelta::Sparse { .. } => {
-                        // Sparse delta requires base vector to materialize
-                        let base_value = base.get_by_interned_key(&key).ok_or_else(|| {
+        for (key, vec_delta) in vector_deltas {
+            match vec_delta {
+                VectorDelta::Full(vec) => {
+                    // Full delta can be directly converted
+                    self.changed.insert(key, PropertyValue::Vector(vec));
+                }
+                VectorDelta::Sparse { .. } => {
+                    // Sparse delta requires base vector to materialize
+                    let base_value = base.get_by_interned_key(&key).ok_or_else(|| {
                             format!(
                                 "Cannot materialize sparse vector delta: base property not found for key {:?}",
                                 key
                             )
                         })?;
 
-                        let base_vec = base_value.as_vector().ok_or_else(|| {
+                    let base_vec = base_value.as_vector().ok_or_else(|| {
                             format!(
                                 "Cannot materialize sparse vector delta: base property is not a vector for key {:?}",
                                 key
                             )
                         })?;
 
-                        // Apply sparse delta to get full vector
-                        let new_vec = vec_delta.apply(base_vec);
-                        self.changed.insert(key, new_vec.into());
-                    }
+                    // Apply sparse delta to get full vector
+                    let new_vec = vec_delta.apply(base_vec);
+                    self.changed.insert(key, new_vec.into());
                 }
             }
         }

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -702,7 +702,7 @@ impl QueryResults {
                 EntityResult::NodeId(id) => {
                     nodes.push(id);
                     if let Some(ref mut props) = properties {
-                        props.push(Default::default());
+                        props.push(crate::core::property::PropertyMapBuilder::new().build());
                     }
                 }
                 _ => {} // Ignore edges, etc.


### PR DESCRIPTION
💡 **What:** Replaced the intermediate `Vec` allocation during vector delta materialization (`let keys: Vec<_> = self.vector_deltas.keys().copied().collect();`) with `std::mem::take(&mut self.vector_deltas)`. Additionally, refactored a `Default::default()` fallback for `PropertyMap` to explicitly use `PropertyMapBuilder::new().build()`.

🎯 **Why:** Collecting map keys into a vector only to loop through them and perform map removals caused unnecessary intermediate heap allocations and O(1) hashmap lookup overhead per element. The `PropertyMap` does not implement `Default`, so calling `Default::default()` created a `HashMap` rather than using the specialized builder.

📊 **Impact:** 
- Removes 1 intermediate `Vec` heap allocation per transaction commit where vector deltas are materialized.
- Eliminates repeated O(1) `.remove(&key)` overhead by moving to a direct iterator on the taken map.

🔬 **Measurement:** `cargo test --lib -- core::version` and `cargo test --lib -- query::executor::results`.

---
*PR created automatically by Jules for task [16922049379984458060](https://jules.google.com/task/16922049379984458060) started by @madmax983*