### PR TITLE
⚡ Bolt: Zero-allocation HashSet replacement in Tx ID generation

### DIFF
--- a/src/api/transaction/types.rs
+++ b/src/api/transaction/types.rs
@@ -159,12 +159,9 @@ mod tests {
         }
 
         // All IDs should be unique
-        all_ids.sort();
-        let unique_count = all_ids
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len();
-        assert_eq!(unique_count, 1000);
+        all_ids.sort_unstable();
+        all_ids.dedup();
+        assert_eq!(all_ids.len(), 1000);
 
         // Final current should be 1000
         assert_eq!(generator.current().as_u64(), 1000u64);


### PR DESCRIPTION
💡 What: Replaced a `std::collections::HashSet` collection step with in-place vector `.sort_unstable()` and `.dedup()` in `src/api/transaction/types.rs` test `test_tx_id_generator_concurrent`.
🎯 Why: Creating a `HashSet` from a vector requires unnecessary heap allocation and hashing overhead, especially on small/medium collections, when a sorted vector can simply be deduplicated in-place.
📊 Impact: Removes one large heap allocation and O(N) hash operations per test run. 
🔬 Measurement: Run `cargo test --test '*' types` to ensure unique deduplication logic remains functionally exact.

---
*PR created automatically by Jules for task [7139990693073811243](https://jules.google.com/task/7139990693073811243) started by @madmax983*