### PR TITLE
🗺️ Atlas: Decouple query module from db module to break circular dependency

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -90,3 +90,6 @@
 ## 2026-06-21 - Splitting Redb Cold Storage Blob
 **Tangle:** `src/storage/redb_cold_storage.rs` was over 4100 lines long, a "Blob" module holding both core cold storage logic and over 2000 lines of tests. It made navigation and understanding the core operations difficult.
 **Blueprint:** Refactored into a `src/storage/redb_cold_storage/` module. Kept the core data definitions and implementation in `mod.rs` (reduced to ~2000 lines) and moved all tests to `tests.rs` (~2000 lines), maintaining the `#[cfg(test)]` block functionality but with better physical separation.
+**Decouple query module from db module**
+**Tangle:** The `db` module imported `query` for `QueryBuilder`, `QueryResults`, etc., while `query` imported `db::AletheiaDB` so `QueryBuilder::execute` could run queries against it, causing a circular dependency (`db <-> query`).
+**Blueprint:** Extracted a `QueryEngine` trait into `query::traits` and made `QueryBuilder::execute` accept `&impl QueryEngine`. Implemented `QueryEngine` for `AletheiaDB` and `Arc<AletheiaDB>` in the `db` module. This enforces unidirectional dependencies where `db` depends on `query`, but `query` knows nothing about `db` implementation details.

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -9,6 +9,18 @@ use crate::query::builder::state::Initial;
 use crate::query::{Query, QueryBuilder, QueryExecutor, QueryPlanner, QueryResults};
 use std::sync::Arc;
 
+impl crate::query::traits::QueryEngine for AletheiaDB {
+    fn execute_query(&self, query: Query) -> Result<QueryResults> {
+        self.execute_query(query)
+    }
+}
+
+impl crate::query::traits::QueryEngine for std::sync::Arc<AletheiaDB> {
+    fn execute_query(&self, query: Query) -> Result<QueryResults> {
+        (**self).execute_query(query)
+    }
+}
+
 impl AletheiaDB {
     /// Execute a Cypher-like AletheiaDB Query Language (AQL) string.
     ///

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -802,9 +802,9 @@ impl<S: QueryState> QueryBuilder<S> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn execute(
+    pub fn execute<E: crate::query::traits::QueryEngine>(
         self,
-        db: &crate::AletheiaDB,
+        db: &E,
     ) -> crate::core::error::Result<super::executor::QueryResults> {
         let query = self.build();
         db.execute_query(query)

--- a/src/query/planner/stats.rs
+++ b/src/query/planner/stats.rs
@@ -21,7 +21,6 @@
 //! 4. **Invalidation**: Schema changes (e.g., adding an index) invalidate the cache,
 //!    forcing a refresh on the next query.
 //!
-//! [`AletheiaDB::refresh_statistics`]: crate::db::AletheiaDB::refresh_statistics
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -335,7 +334,7 @@ impl Statistics {
 
     /// Update statistics from storage.
     ///
-    /// This is called by [`AletheiaDB::refresh_statistics`](crate::db::AletheiaDB::refresh_statistics)
+    /// This is called by `AletheiaDB::refresh_statistics`
     /// to populate the cache with fresh values from the storage engine.
     ///
     /// ## Examples

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -76,3 +76,12 @@ pub trait GraphView {
         timestamp: Timestamp,
     ) -> Result<Vec<(NodeId, f32)>>;
 }
+
+/// A trait for executing generic queries.
+///
+/// This abstracts the execution engine so the query builder does not
+/// need to depend directly on the concrete database implementation.
+pub trait QueryEngine {
+    /// Execute a generic hybrid query and return the results.
+    fn execute_query(&self, query: crate::query::Query) -> Result<crate::query::QueryResults>;
+}


### PR DESCRIPTION
🕸️ Tangle: The `db` module imported `query` for execution models (`QueryBuilder`, `QueryResults`), while `query` imported `db::AletheiaDB` back so `QueryBuilder::execute` could run queries against it, causing a circular dependency (`db <-> query`).

📐 Blueprint: Extracted a `QueryEngine` trait into `query::traits` and made `QueryBuilder::execute` accept an abstracted `&impl QueryEngine`. Implemented `QueryEngine` for `AletheiaDB` and `Arc<AletheiaDB>` in the `db` module.

🧱 Stability: This enforces clean unidirectional dependencies where `db` relies on `query`, but `query` knows nothing about `db` implementation details, improving compilation boundaries and lowering technical debt.

🔬 Verification: Ran `cargo check`, `cargo test`, and `cargo clippy`. No functionality was lost since methods cleanly delegate.

---
*PR created automatically by Jules for task [6075110284662312102](https://jules.google.com/task/6075110284662312102) started by @madmax983*