### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ See the [Hybrid Query guide](docs/guides/hybrid-query-guide.md).
 
 ---
 
+## Narrative Generation (Experimental)
+
+> ⚠️ **REQUIRES FEATURE NOVA**: You must enable the `nova` feature in your `Cargo.toml` to use Narrative Generation.
+
+```rust
+// Requires "nova" feature in Cargo.toml
+use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
+use aletheiadb::prelude::*;
+
+fn main() -> Result<()> {
+    let db = AletheiaDB::new()?;
+
+    // Create and update nodes to generate history...
+    // let node_id = ...
+
+    let generator = NarrativeGenerator::new(&db);
+    // let narrative = generator.generate_node_narrative(node_id)?;
+    Ok(())
+}
+```
+
+---
+
 ## Performance
 
 Benchmarks run on every push to trunk.


### PR DESCRIPTION
This PR addresses the friction points reported by the "Echo" DX persona regarding the Narrative Generation example.

Previously, users attempting to use the experimental Narrative Generation feature could encounter confusing compiler warnings or runtime panics if they did not explicitly enable the `nova` feature in their `Cargo.toml`. 

This PR adds a new section to `README.md` that:
1. Provides a clear, copy-pasteable example of using `NarrativeGenerator`.
2. Includes a highly visible Markdown warning banner (`> ⚠️ **REQUIRES FEATURE NOVA**`) *before* the code block, ensuring users are explicitly informed of the feature requirement before attempting to run the code.

All relevant tests and documentation checks have been run and passed.

---
*PR created automatically by Jules for task [17684527823387986484](https://jules.google.com/task/17684527823387986484) started by @madmax983*