### PR TITLE
🛡️ Sentry: SparseVec unsorted fallback path test coverage

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,7 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+
+## SparseVec Fallback Path Testing Coverage
+**Learning:** Rust's sparse vector instantiation path has an optimized `O(N)` fast-path to validate structurally correct inputs, falling back to an `O(N log N)` path if indices are unsorted. While the fast-path was implicitly tested, explicit coverage confirming that edge cases—such as unsorted duplicate indices and zero/invalid float values (NaN, Inf)—are correctly captured by the fallback validation block was missing.
+**Action:** When implementing algorithms with "fast" and "slow" paths, use table-driven tests explicitly exercising the slow path to ensure that constraints applied during fallback mapping or sorting don't silently accept malformed states. Added table-driven unsorted constraint checks.

--- a/src/core/vector/tests.rs
+++ b/src/core/vector/tests.rs
@@ -2489,6 +2489,70 @@ fn test_cosine_similarity_zero_magnitude_handling() {
     }
 }
 
+#[test]
+fn test_sparse_vec_new_unsorted_invalid_inputs() {
+    struct TestCase {
+        name: &'static str,
+        indices: Vec<u32>,
+        values: Vec<f32>,
+        dimension: u32,
+        expected_error_contains: &'static str,
+    }
+
+    let cases = vec![
+        TestCase {
+            name: "Unsorted duplicate index",
+            indices: vec![1, 0, 1],
+            values: vec![1.0, 2.0, 3.0],
+            dimension: 10,
+            expected_error_contains: "Duplicate index 1 found",
+        },
+        TestCase {
+            name: "Unsorted zero value",
+            indices: vec![1, 0],
+            values: vec![1.0, 0.0],
+            dimension: 10,
+            expected_error_contains: "zero value",
+        },
+        TestCase {
+            name: "Unsorted NaN value",
+            indices: vec![1, 0],
+            values: vec![1.0, f32::NAN],
+            dimension: 10,
+            expected_error_contains: "NaN",
+        },
+        TestCase {
+            name: "Unsorted Infinity value",
+            indices: vec![1, 0],
+            values: vec![1.0, f32::INFINITY],
+            dimension: 10,
+            expected_error_contains: "infinity",
+        },
+        TestCase {
+            name: "Unsorted Negative Infinity value",
+            indices: vec![1, 0],
+            values: vec![1.0, f32::NEG_INFINITY],
+            dimension: 10,
+            expected_error_contains: "infinity",
+        },
+    ];
+
+    for case in cases {
+        let result = SparseVec::new(case.indices.clone(), case.values.clone(), case.dimension);
+        assert!(result.is_err(), "Test '{}' should have failed", case.name);
+
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains(case.expected_error_contains),
+            "Test '{}' failed with wrong message: '{}', expected to contain '{}'",
+            case.name,
+            err_msg,
+            case.expected_error_contains
+        );
+    }
+}
+
 // ========================================================================
 // SparseVec Tests
 // ========================================================================


### PR DESCRIPTION
🎯 Target: `src/core/vector/sparse.rs`
💣 Risk: Unsorted input indices fallback path in `SparseVec::new` may not correctly catch duplicate indices, bounds checking, or invalid values due to missing explicit tests.
🧪 Strategy: Added table-driven tests explicitly exercising the fallback path by providing unsorted indices combined with invalid conditions.
🔬 Verification: Run `cargo test --lib core::vector::tests`

---
*PR created automatically by Jules for task [15131253230474247660](https://jules.google.com/task/15131253230474247660) started by @madmax983*