### PR TITLE
🗺️ Atlas: Decouple Query module from AletheiaDB

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -90,3 +90,7 @@
 ## 2026-06-21 - Splitting Redb Cold Storage Blob
 **Tangle:** `src/storage/redb_cold_storage.rs` was over 4100 lines long, a "Blob" module holding both core cold storage logic and over 2000 lines of tests. It made navigation and understanding the core operations difficult.
 **Blueprint:** Refactored into a `src/storage/redb_cold_storage/` module. Kept the core data definitions and implementation in `mod.rs` (reduced to ~2000 lines) and moved all tests to `tests.rs` (~2000 lines), maintaining the `#[cfg(test)]` block functionality but with better physical separation.
+
+## 2026-06-21 - Decouple Query module from AletheiaDB
+**Tangle:** `src/query/builder.rs` took `&crate::AletheiaDB` directly in its `execute` method, creating a structural dependency cycle where `query` depends on `db`, and `db` depends on `query`.
+**Blueprint:** Defined `QueryEngine` trait in `query::traits` and updated `QueryBuilder::execute` to accept `&impl QueryEngine`. Implemented `QueryEngine` for `AletheiaDB` and `Arc<AletheiaDB>` in `db::query.rs`, enforcing unidirectional dependency from `db` -> `query` and eliminating structural coupling.

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -9,6 +9,18 @@ use crate::query::builder::state::Initial;
 use crate::query::{Query, QueryBuilder, QueryExecutor, QueryPlanner, QueryResults};
 use std::sync::Arc;
 
+impl crate::query::traits::QueryEngine for AletheiaDB {
+    fn execute_query(&self, query: Query) -> crate::core::error::Result<QueryResults> {
+        AletheiaDB::execute_query(self, query)
+    }
+}
+
+impl<T: crate::query::traits::QueryEngine> crate::query::traits::QueryEngine for std::sync::Arc<T> {
+    fn execute_query(&self, query: Query) -> crate::core::error::Result<QueryResults> {
+        (**self).execute_query(query)
+    }
+}
+
 impl AletheiaDB {
     /// Execute a Cypher-like AletheiaDB Query Language (AQL) string.
     ///

--- a/src/query/builder.rs
+++ b/src/query/builder.rs
@@ -804,7 +804,7 @@ impl<S: QueryState> QueryBuilder<S> {
     /// ```
     pub fn execute(
         self,
-        db: &crate::AletheiaDB,
+        db: &impl crate::query::traits::QueryEngine,
     ) -> crate::core::error::Result<super::executor::QueryResults> {
         let query = self.build();
         db.execute_query(query)

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -4,6 +4,16 @@ use crate::core::error::Result;
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::temporal::Timestamp;
+use crate::query::{Query, QueryResults};
+
+/// A trait representing an engine capable of executing a hybrid query.
+///
+/// This trait abstracts the query execution capabilities of the database,
+/// preventing circular dependencies between the query module and the db module.
+pub trait QueryEngine {
+    /// Execute a constructed query and return the results.
+    fn execute_query(&self, query: Query) -> Result<QueryResults>;
+}
 
 /// A trait representing a read-only view of the graph.
 ///


### PR DESCRIPTION
🕸️ Tangle: `src/query/builder.rs` took `&crate::AletheiaDB` directly in its `execute` method, creating a structural dependency cycle where `query` depends on `db`, and `db` depends on `query`.
📐 Blueprint: Defined `QueryEngine` trait in `query::traits` and updated `QueryBuilder::execute` to accept `&impl QueryEngine`. Implemented `QueryEngine` for `AletheiaDB` in `db::query.rs`.
🧱 Stability: Enforces unidirectional dependency from `db` -> `query` and eliminates structural coupling.
🔬 Verification: Ran `cargo test` and `cargo check` to ensure correctness.

---
*PR created automatically by Jules for task [4163988840414163845](https://jules.google.com/task/4163988840414163845) started by @madmax983*