### PR TITLE
🗣️ Echo: Fix prelude Result shadowing and experimental feature gating

### DIFF
--- a/src/experimental/reasoning/mod.rs
+++ b/src/experimental/reasoning/mod.rs
@@ -11,7 +11,9 @@ pub mod chimera;
 pub mod dreamer;
 pub mod hindsight;
 pub mod luna;
+#[cfg(feature = "semantic-reasoning")]
 pub mod metaphor;
+#[cfg(feature = "semantic-reasoning")]
 pub mod muse;
 pub mod omen;
 pub mod oracle;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@
 
 pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};
-pub use crate::core::error::{Error, Result};
+pub use crate::core::error::Error;
 pub use crate::core::id::{EdgeId, NodeId, VersionId};
 pub use crate::core::interning::InternedString;
 pub use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};


### PR DESCRIPTION
🤦 **The Confusion:** The `Result` type in the prelude shadows `std::result::Result`, causing confusing errors for users writing `fn main() -> Result<(), Box<dyn std::error::Error>> { ... }`. Also, `muse` and `metaphor` were accessible without the `nova` or `semantic-reasoning` feature enabled, leading to an inconsistent API surface.
🕵️ **The Reality:** `aletheiadb::core::error::Result` was exported in `src/prelude.rs`. `muse` and `metaphor` were missing the `#[cfg(feature = "semantic-reasoning")]` feature gates in `src/experimental/reasoning/mod.rs`.
💡 **The Fix:** Removed `Result` from the prelude export to prevent shadowing `std::result::Result`. Added `#[cfg(feature = "semantic-reasoning")]` to the `muse` and `metaphor` module declarations.

---
*PR created automatically by Jules for task [17514344012740489329](https://jules.google.com/task/17514344012740489329) started by @madmax983*