### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-20 - [Removing `#[allow(missing_docs)]` from core enums]
+**Confusion:** Several core public enums (`PredicateExpr`, `Expression`, `QueryRequest`, `MigrationError`, `NetworkError`, `CommitLogError`, `ExecutorError`) were using the `#[allow(missing_docs)]` escape hatch. This led to undocumented variants that users would have to dig into the source code to understand, going against the "If it isn't documented, it doesn't exist" philosophy.
+**Clarification:** Removed the `#[allow(missing_docs)]` attributes and added proper `///` documentation to all undocumented variants in these enums to ensure their purpose is clear in the generated `cargo doc` output.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -62,49 +62,76 @@ pub async fn health_check() -> Json<HealthResponse> {
 /// Polymorphic request for the `/query` endpoint, discriminated by `operation`.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case")]
-#[allow(missing_docs)] // fields are self-describing via their names and variant-level docs
 pub enum QueryRequest {
     /// Find nodes matching label/property filters. Paginated.
     FindNode {
+        /// The node label to filter by (optional)
         label: Option<String>,
+        /// Exact match property filters (optional)
         properties: Option<HashMap<String, Value>>,
+        /// Maximum number of results to return
         limit: Option<usize>,
+        /// Number of results to skip for pagination
         offset: Option<usize>,
     },
     /// Get a single node by its 64-bit ID.
-    GetNode { node_id: u64 },
+    GetNode {
+        /// The internal 64-bit ID of the node to retrieve
+        node_id: u64,
+    },
     /// Create a new node with an optional property map.
     CreateNode {
+        /// The label for the new node
         label: String,
+        /// The properties to set on the new node
         properties: Option<HashMap<String, Value>>,
     },
     /// Create many nodes atomically in one transaction.
-    BulkCreateNodes { nodes: Vec<CreateNodeInput> },
+    BulkCreateNodes {
+        /// A list of node creation payloads
+        nodes: Vec<CreateNodeInput>,
+    },
     /// Fetch many nodes by ID.
-    BulkGetNodes { node_ids: Vec<u64> },
+    BulkGetNodes {
+        /// A list of 64-bit node IDs to fetch
+        node_ids: Vec<u64>,
+    },
     /// Update many nodes atomically in one transaction.
-    BulkUpdateNodes { updates: Vec<UpdateNodeInput> },
+    BulkUpdateNodes {
+        /// A list of node update payloads
+        updates: Vec<UpdateNodeInput>,
+    },
     /// Delete many nodes atomically in one transaction.
     BulkDeleteNodes {
+        /// A list of 64-bit node IDs to delete
         node_ids: Vec<u64>,
+        /// Whether to cascade deletes to connected edges
         #[serde(default)]
         cascade: bool,
     },
     /// Find neighbors (either direction) of a node. Paginated, deduped.
     FindNeighbors {
+        /// The ID of the starting node
         node_id: u64,
+        /// Maximum number of neighbors to return
         #[serde(default)]
         limit: Option<usize>,
+        /// Number of neighbors to skip for pagination
         #[serde(default)]
         offset: Option<usize>,
     },
     /// Execute an AQL query string, optionally with bound parameters.
     ExecuteQuery {
+        /// The AQL query string to execute
         query: String,
+        /// Optional parameter bindings to prevent injection attacks
         parameters: Option<HashMap<String, Value>>,
     },
     /// Execute many AQL queries in sequence and return per-query rows.
-    BulkExecuteQuery { queries: Vec<ExecuteQueryInput> },
+    BulkExecuteQuery {
+        /// A list of AQL queries with their parameters
+        queries: Vec<ExecuteQueryInput>,
+    },
 }
 
 /// Payload for node creation inside a bulk request.

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -447,47 +447,69 @@ pub struct WhereClause {
 
 /// A predicate expression.
 #[derive(Debug, Clone, PartialEq)]
-#[allow(missing_docs)]
 pub enum PredicateExpr {
-    /// Comparison: n.prop = value
+    /// Comparison: n.prop = value.
+    /// Used for strict equality and inequality comparisons.
     Comparison {
+        /// The left-hand side of the comparison
         left: Expression,
+        /// The operator used for comparison
         op: ComparisonOp,
+        /// The right-hand side of the comparison
         right: Expression,
     },
-    /// Existence check: EXISTS(n.prop)
+    /// Existence check: EXISTS(n.prop).
+    /// Used to filter out nodes that do not have a certain property.
     Exists(PropertyAccess),
-    /// NULL check: n.prop IS NULL
+    /// NULL check: n.prop IS NULL.
+    /// Used to find nodes where a property is explicitly set to NULL or is missing.
     IsNull(PropertyAccess),
-    /// NOT NULL check: n.prop IS NOT NULL
+    /// NOT NULL check: n.prop IS NOT NULL.
+    /// Used to find nodes where a property is explicitly set to a non-NULL value.
     IsNotNull(PropertyAccess),
-    /// String contains: n.prop CONTAINS 'str'
+    /// String contains: n.prop CONTAINS 'str'.
+    /// Used for basic full-text filtering on string properties.
     Contains {
+        /// The property being searched
         property: PropertyAccess,
+        /// The substring to search for
         substring: String,
     },
     /// String starts with: n.prop STARTS WITH 'str'
+    /// Used for prefix matching on string properties.
     StartsWith {
+        /// The property being searched
         property: PropertyAccess,
+        /// The prefix to search for
         prefix: String,
     },
     /// String ends with: n.prop ENDS WITH 'str'
+    /// Used for suffix matching on string properties.
     EndsWith {
+        /// The property being searched
         property: PropertyAccess,
+        /// The suffix to search for
         suffix: String,
     },
     /// IN list: n.prop IN [1, 2, 3]
+    /// Used to match a property against a set of valid values.
     In {
+        /// The property being checked
         property: PropertyAccess,
+        /// The set of valid values
         values: Vec<PropertyValue>,
     },
-    /// Logical AND
+    /// Logical AND.
+    /// Used to combine multiple predicates that must all be true.
     And(Box<PredicateExpr>, Box<PredicateExpr>),
-    /// Logical OR
+    /// Logical OR.
+    /// Used to combine multiple predicates where at least one must be true.
     Or(Box<PredicateExpr>, Box<PredicateExpr>),
-    /// Logical NOT
+    /// Logical NOT.
+    /// Used to negate the result of a predicate.
     Not(Box<PredicateExpr>),
-    /// Parenthesized expression
+    /// Parenthesized expression.
+    /// Used to group predicates and define order of evaluation.
     Grouped(Box<PredicateExpr>),
 }
 
@@ -553,18 +575,27 @@ pub enum ComparisonOp {
 
 /// An expression (used in comparisons and projections).
 #[derive(Debug, Clone, PartialEq)]
-#[allow(missing_docs)]
 pub enum Expression {
-    /// Property access: n.prop
+    /// Property access: n.prop.
+    /// Represents the extraction of a specific property from a matched element.
     Property(PropertyAccess),
-    /// Bare identifier (variable reference): n
+    /// Bare identifier (variable reference): n.
+    /// Refers to an element matched in a pattern (e.g., node 'n').
     Identifier(String),
-    /// Literal value
+    /// Literal value.
+    /// A raw, constant value used in queries (e.g., 'Alice', 30, true).
     Literal(PropertyValue),
-    /// Parameter: $param
+    /// Parameter: $param.
+    /// Represents a dynamic parameter injected into the query at runtime to prevent SQL injection.
     Parameter(String),
-    /// Function call: func(args)
-    FunctionCall { name: String, args: Vec<Expression> },
+    /// Function call: func(args).
+    /// Used for invoking built-in functions (e.g., date formatting, math operations).
+    FunctionCall {
+        /// The name of the function to call
+        name: String,
+        /// The arguments passed to the function
+        args: Vec<Expression>,
+    },
 }
 
 impl Expression {

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -48,31 +48,45 @@ use std::time::{Duration, Instant};
 
 /// Error types for query execution.
 #[derive(Debug, Clone)]
-#[allow(missing_docs)]
 pub enum ExecutorError {
     /// All target shards failed.
+    /// Used when a scatter query receives no successful responses.
     AllShardsFailed {
+        /// The unique ID of the failed query
         query_id: u64,
+        /// The list of shards and their respective network errors
         failures: Vec<(ShardId, NetworkError)>,
     },
     /// Query timed out.
+    /// Used when the gather phase exceeds the configured timeout before all shards respond.
     Timeout {
+        /// The unique ID of the timed out query
         query_id: u64,
+        /// The timeout threshold that was exceeded
         timeout: Duration,
+        /// The shards that successfully responded in time
         responded: Vec<ShardId>,
+        /// The shards that were still pending when the timeout occurred
         pending: Vec<ShardId>,
     },
     /// Partial failure (some shards succeeded, some failed).
+    /// Used when at least one shard failed, preventing a complete global result.
     PartialFailure {
+        /// The unique ID of the partially failed query
         query_id: u64,
+        /// The shards that successfully responded
         successes: Vec<ShardId>,
+        /// The shards that failed, along with their errors
         failures: Vec<(ShardId, NetworkError)>,
     },
     /// No shards available for query.
+    /// Used when the query router determines there are no healthy shards to send the query to.
     NoShardsAvailable,
     /// Invalid query.
+    /// Used when a query cannot be planned or routed.
     InvalidQuery(String),
     /// Aggregation error.
+    /// Used when the executor fails to merge the responses from multiple shards.
     AggregationError(String),
 }
 

--- a/src/storage/sharding/migration.rs
+++ b/src/storage/sharding/migration.rs
@@ -53,38 +53,65 @@ pub struct RoutingToken {
 
 /// Error types for migration operations.
 #[derive(Debug, Clone)]
-#[allow(missing_docs)]
 pub enum MigrationError {
     /// Network error during migration.
+    /// Indicates an underlying network failure while transferring data or coordinating state.
     NetworkError(NetworkError),
     /// Checksum verification failed.
+    /// Used when the target shard calculates a different checksum than the source, indicating data corruption in transit.
     ChecksumMismatch {
+        /// The sequential batch number that failed checksum verification
         batch_number: u64,
+        /// The checksum calculated by the source
         expected: u64,
+        /// The checksum calculated by the target
         actual: u64,
     },
     /// Batch was rejected by target shard.
-    BatchRejected { batch_number: u64, reason: String },
+    /// Used when the target actively rejects a batch (e.g., due to schema mismatch or internal errors).
+    BatchRejected {
+        /// The sequential batch number that was rejected
+        batch_number: u64,
+        /// The reason provided by the target for rejecting the batch
+        reason: String,
+    },
     /// Migration was cancelled.
+    /// Used when a human operator or the rebalance manager explicitly aborts the migration.
     Cancelled(u64),
     /// Migration timed out.
+    /// Used when a specific phase of the migration takes longer than the configured timeout threshold.
     Timeout {
+        /// The unique ID of the migration
         migration_id: u64,
+        /// The phase during which the timeout occurred
         phase: MigrationState,
+        /// The total time elapsed before timing out
         elapsed: Duration,
     },
     /// Source shard unavailable.
+    /// Used when the shard containing the data to be migrated goes offline.
     SourceUnavailable(ShardId),
     /// Target shard unavailable.
+    /// Used when the shard receiving the data goes offline.
     TargetUnavailable(ShardId),
     /// Invalid migration state.
+    /// Used when a command is issued that is incompatible with the current phase (e.g., cutting over before verifying).
     InvalidState {
+        /// The unique ID of the migration
         migration_id: u64,
+        /// The state required for the operation
         expected: MigrationState,
+        /// The actual current state
         actual: MigrationState,
     },
     /// Verification failed.
-    VerificationFailed { migration_id: u64, reason: String },
+    /// Used when the post-copy consistency checks (row counts, indexes) fail.
+    VerificationFailed {
+        /// The unique ID of the migration
+        migration_id: u64,
+        /// The specific reason verification failed
+        reason: String,
+    },
 }
 
 impl fmt::Display for MigrationError {

--- a/src/storage/sharding/network.rs
+++ b/src/storage/sharding/network.rs
@@ -17,30 +17,48 @@ use std::time::{Duration, Instant};
 
 /// Error types for network operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub enum NetworkError {
     /// Connection failed.
-    ConnectionFailed { shard_id: ShardId, reason: String },
-    /// Request timed out.
-    Timeout {
+    /// Used when the initial TCP handshake or TLS negotiation fails.
+    ConnectionFailed {
+        /// The target shard that refused the connection
         shard_id: ShardId,
+        /// The low-level reason (e.g., "Connection refused")
+        reason: String,
+    },
+    /// Request timed out.
+    /// Used when the connection succeeds but the remote shard takes too long to reply.
+    Timeout {
+        /// The target shard that timed out
+        shard_id: ShardId,
+        /// The logical operation that was being attempted (e.g., "CommitTransaction")
         operation: String,
+        /// The duration waited before giving up
         duration: Duration,
     },
     /// Circuit breaker is open.
+    /// Used to quickly fail requests without hitting the network when a shard is known to be failing.
     CircuitOpen {
+        /// The shard that has tripped its circuit breaker
         shard_id: ShardId,
+        /// The time remaining before the circuit breaker attempts a half-open retry
         remaining: Duration,
     },
     /// Shard is unavailable.
+    /// Used when a shard has explicitly communicated that it is shutting down or in maintenance mode.
     ShardUnavailable(ShardId),
     /// Serialization error.
+    /// Used when the client fails to encode a request or decode a response.
     SerializationError(String),
     /// Protocol error.
+    /// Used when the server responds with a structurally invalid or unexpected message.
     ProtocolError(String),
     /// Connection pool exhausted.
+    /// Used when too many concurrent requests are targeting the same shard and the pool is full.
     PoolExhausted {
+        /// The target shard whose connection pool is exhausted
         shard_id: ShardId,
+        /// The maximum number of allowed connections
         max_connections: usize,
     },
 }

--- a/src/storage/sharding/persistent_commit_log.rs
+++ b/src/storage/sharding/persistent_commit_log.rs
@@ -61,18 +61,27 @@ const ENTRY_TYPE_COMPLETE: u8 = 3;
 
 /// Error types for commit log operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub enum CommitLogError {
     /// I/O error.
+    /// Indicates an underlying filesystem error (e.g., disk full, permission denied).
     IoError(String),
     /// Corrupt log file.
+    /// Indicates structural issues with the log file, such as a missing magic header or truncated entries.
     CorruptedLog(String),
     /// Invalid entry.
+    /// Indicates that an entry was parsed, but contained semantically invalid data (e.g., unknown entry type).
     InvalidEntry(String),
     /// Transaction not found.
+    /// Used when attempting to update or complete a transaction that is not recorded in the log.
     TransactionNotFound(TxId),
     /// Checksum mismatch.
-    ChecksumMismatch { expected: u32, actual: u32 },
+    /// Indicates data corruption within a specific entry.
+    ChecksumMismatch {
+        /// The checksum calculated based on the entry payload
+        expected: u32,
+        /// The checksum actually found in the log file
+        actual: u32,
+    },
 }
 
 impl std::fmt::Display for CommitLogError {


### PR DESCRIPTION
📖 Chapter: Removal of `allow(missing_docs)` and proper enum documentation
🔦 Insight: Banned the use of the `allow(missing_docs)` escape hatch on core public enums across `query`, `http`, and `storage/sharding` modules. Replaced them with proper descriptions explaining *why* these variants exist, following the "If it isn't documented, it doesn't exist" philosophy.
🧪 Example: N/A
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [12397451930388532812](https://jules.google.com/task/12397451930388532812) started by @madmax983*