### PR TITLE
🗣️ Echo: Fix broken examples and outdated types in Hybrid Query Guide

### DIFF
--- a/docs/guides/hybrid-query-guide.md
+++ b/docs/guides/hybrid-query-guide.md
@@ -234,10 +234,12 @@ let results = db.query()
 "Who does Alice know that's most similar to Bob?"
 
 ```rust
-let bob_embedding = db.get_node(bob_id)?
+let bob_node = db.get_node(bob_id)?;
+let bob_embedding = bob_node
     .get_property("embedding")
     .and_then(|p| p.as_vector())
-    .ok_or(Error::PropertyNotFound)?;
+    .ok_or(Error::other("Property not found"))?
+    .to_vec();
 
 let results = db.query()
     .start(alice_id)
@@ -485,7 +487,7 @@ Predicate::gt("score", 0.5f64)        // f64
 ### Common Errors
 
 ```rust
-use aletheiadb::utils::error::{Error, StorageError, VectorError};
+use aletheiadb::core::error::{Error, StorageError, VectorError};
 
 match results.next() {
     Some(Ok(row)) => { /* process row */ }
@@ -535,7 +537,7 @@ use aletheiadb::query::plan::IndexHint;
 db.query()
     .start(node_id)
     .with_hint(IndexHint::UseVectorIndex)  // Force vector index use
-    .with_hint(IndexHint::ForceScan)       // Skip indexes
+    .with_hint(IndexHint::UseBruteForce)   // Skip indexes
     // ...
 ```
 


### PR DESCRIPTION
🤦 **The Confusion:** The "Find Similar Neighbors" example in the Hybrid Query Guide fails to compile due to a temporary value dropped error (`E0716`) and an unresolved `Error::PropertyNotFound`. The `utils::error` import path is also outdated, and `IndexHint::ForceScan` doesn't exist.

🕵️ **The Reality:** We need to store `db.get_node()` in a variable (`bob_node`) and copy the embedding (`.to_vec()`). The error path is actually `core::error`, `Error::other()` should be used instead of the non-existent enum variant, and the correct hint is `IndexHint::UseBruteForce`.

💡 **The Fix:** Updated the guide with correct code snippets that compile out of the box and removed non-existent code paths/variants.

---
*PR created automatically by Jules for task [7052368640140825370](https://jules.google.com/task/7052368640140825370) started by @madmax983*