### PR TITLE
🗣️ Echo: Prelude shadows standard Result type

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@
 
 pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};
-pub use crate::core::error::{Error, Result};
+pub use crate::core::error::Error;
 pub use crate::core::id::{EdgeId, NodeId, VersionId};
 pub use crate::core::interning::InternedString;
 pub use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};


### PR DESCRIPTION
🤦 **The Confusion:** Tried to use standard `Result<(), std::io::Error>` with `use aletheiadb::prelude::*;` but it failed to compile saying 'type alias takes 1 generic argument but 2 generic arguments were supplied'.
🕵️ **The Reality:** The prelude exports AletheiaDB's custom `Result` type, which shadows `std::result::Result`.
💡 **The Fix:** Remove `Result` from the `src/prelude.rs` export.

---
*PR created automatically by Jules for task [3767192250735713481](https://jules.google.com/task/3767192250735713481) started by @madmax983*