### PR TITLE
⚡ Bolt: Remove intermediate Vec<QueryRow> allocation in collect_structured

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**[Optimize Result Structurization]**
+**Learning:** Lazily allocating parallel vectors during iteration eliminates intermediate O(N) tuple collection allocations while maintaining strict parallel alignment via padding.
+**Action:** Use single-pass lazy columnar allocation with aligned padding for transforming iterators of structs into structs of arrays.

--- a/src/query/executor/results.rs
+++ b/src/query/executor/results.rs
@@ -636,94 +636,81 @@ impl QueryResults {
     /// ⚡ Bolt Optimization: Pre-allocates vector based on iterator's lower size bound
     /// to reduce heap allocations during collection of structured results.
     pub fn collect_structured(mut self) -> Result<QueryResult> {
-        // First pass: collect all rows
         let (lower, _) = self.iterator.size_hint();
-        let mut rows = Vec::with_capacity(lower);
+        let mut nodes = Vec::with_capacity(lower);
+        let mut properties: Option<Vec<PropertyMap>> = None;
+        let mut scores: Option<Vec<f32>> = None;
+        let mut paths: Option<Vec<Path>> = None;
+        let mut versions: Option<Vec<VersionId>> = None;
+
+        let mut row_count = 0usize;
+
         while let Some(row) = self.iterator.next() {
-            rows.push(row?);
-        }
-
-        // Determine which fields we have (single pass)
-        let (mut has_any_scores, mut has_any_paths, mut has_any_versions, mut has_any_nodes) =
-            (false, false, false, false);
-        let mut node_count = 0usize;
-        for row in &rows {
-            has_any_scores = has_any_scores || row.score.is_some();
-            has_any_paths = has_any_paths || row.path.is_some();
-            has_any_versions = has_any_versions || row.timestamp.is_some();
-            if row.entity.as_node().is_some() {
-                has_any_nodes = true;
-                node_count += 1;
-            }
-        }
-
-        // Second pass: extract data with padding
-        let capacity = rows.len();
-        let mut nodes = Vec::with_capacity(node_count);
-        let mut properties = if has_any_nodes {
-            Some(Vec::with_capacity(node_count))
-        } else {
-            None
-        };
-        let mut scores = if has_any_scores {
-            Some(Vec::with_capacity(capacity))
-        } else {
-            None
-        };
-        let mut paths = if has_any_paths {
-            Some(Vec::with_capacity(capacity))
-        } else {
-            None
-        };
-        let mut versions = if has_any_versions {
-            Some(Vec::with_capacity(capacity))
-        } else {
-            None
-        };
-
-        for row in rows {
             let QueryRow {
                 entity,
                 score,
                 path,
                 timestamp,
-            } = row;
+            } = row?;
 
-            // ⚡ Bolt Optimization: Consumes the entity directly by value instead of cloning
-            // properties map via `as_node().map(|n| n.properties.clone())`. This eliminates
-            // one large heap allocation per row during result structurization.
+            row_count += 1;
+
             match entity {
                 EntityResult::Node(n) => {
+                    if properties.is_none() {
+                        let mut props = Vec::with_capacity(lower);
+                        props.resize_with(nodes.len(), Default::default);
+                        properties = Some(props);
+                    }
                     nodes.push(n.id);
                     if let Some(ref mut props) = properties {
                         props.push(n.properties);
                     }
                 }
                 EntityResult::NodeId(id) => {
+                    if properties.is_none() {
+                        let mut props = Vec::with_capacity(lower);
+                        props.resize_with(nodes.len(), Default::default);
+                        properties = Some(props);
+                    }
                     nodes.push(id);
                     if let Some(ref mut props) = properties {
                         props.push(Default::default());
                     }
                 }
                 _ => {} // Ignore edges, etc.
-            }
+            };
 
             // Extract or pad scores
+            if score.is_some() && scores.is_none() {
+                let mut s = Vec::with_capacity(lower);
+                s.resize(row_count.saturating_sub(1), 0.0);
+                scores = Some(s);
+            }
             if let Some(ref mut s) = scores {
                 s.push(score.unwrap_or(0.0));
             }
 
             // Extract or pad paths
+            if path.is_some() && paths.is_none() {
+                let mut p = Vec::with_capacity(lower);
+                p.resize_with(row_count.saturating_sub(1), Default::default);
+                paths = Some(p);
+            }
             if let Some(ref mut p) = paths {
                 p.push(path.unwrap_or_default());
             }
 
             // Extract or pad versions
+            if timestamp.is_some() && versions.is_none() {
+                let mut v = Vec::with_capacity(lower);
+                v.resize(row_count.saturating_sub(1), VersionId::new(0).unwrap());
+                versions = Some(v);
+            }
             if let Some(ref mut v) = versions {
                 if let Some(timestamp) = timestamp {
                     // Safely convert timestamp (i64) to VersionId (u64)
                     // Negative timestamps are clamped to 0
-                    // Phase 2: Use wallclock component for version ID
                     let wallclock = timestamp.wallclock();
                     let ts_u64 = if wallclock < 0 {
                         0_u64


### PR DESCRIPTION
💡 What: Replaced two-pass result collection in `collect_structured` with single-pass lazy columnar allocation.
🎯 Why: Two-pass collection allocated an intermediate `Vec<QueryRow>` for all results, which unnecessarily consumed memory for large datasets.
📊 Impact: Removes one intermediate O(N) heap allocation per query that returns structured results.
🔬 Measurement: Run `cargo test` to verify logic.

---
*PR created automatically by Jules for task [14427252004481802816](https://jules.google.com/task/14427252004481802816) started by @madmax983*