### PR TITLE
⚔️ Elenchus: src/storage/historical/tests.rs Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+## [Historical Storage Temporal Missing Anchor Reconstruction Mutants]
+**Module:** `src/storage/historical/mod.rs`
+**Severity:** 🔴 Critical
+**Finding:** The tests covering temporal reconstruction errors (`test_missing_anchor_detected_after_anchor_deletion`, `test_edge_missing_anchor_detected_after_anchor_deletion`, `test_reconstruct_nonexistent_node_version_returns_version_not_found`, etc) had blind spots that allowed mutants to survive where the fallback string was used instead of the entity ID, or the exact nonexistent id was not verified. This causes incorrect error payloads or incorrectly identifying `MissingAnchor` instead of `VersionNotFound` on nonexistent nodes/edges.
+**Evidence:** Running `cargo mutants` manually by modifying conditions and returning invalid entity IDs shows that replacing `entity_id` formatting strings survives because the tests do not assert the exact string value of the entity ID inside the `MissingAnchor` error beyond a generic `starts_with("Node(")`.
+**Recommendation:** Add assertions to verify the exact string values in the error messages. For example, verify that `entity_id` is exactly `"Node(99)"` or `"Edge(55)"`. Check that the id returned in `VersionNotFound` matches the nonexistent ID.

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4649,7 +4649,7 @@ fn test_missing_anchor_detected_after_anchor_deletion() {
             // get_node_version_any_tier), not the generic "version V" fallback.
             // This assertion kills the mutation that removes the .and_then() lookup.
             assert!(
-                entity_id.starts_with("Node("),
+                entity_id == "Node(99)",
                 "MissingAnchor entity_id must identify the node, got: {entity_id}"
             );
         }
@@ -4736,7 +4736,7 @@ fn test_edge_missing_anchor_detected_after_anchor_deletion() {
             // entity_id must come from the version's edge_id field (via
             // get_edge_version_any_tier), not the generic "version V" fallback.
             assert!(
-                entity_id.starts_with("Edge("),
+                entity_id == "Edge(55)",
                 "MissingAnchor entity_id must identify the edge, got: {entity_id}"
             );
         }
@@ -4883,8 +4883,8 @@ fn test_reconstruct_nonexistent_node_version_returns_version_not_found() {
     let result = storage.reconstruct_node_properties(nonexistent);
     assert!(result.is_err(), "Non-existent version must return an error");
     match result.unwrap_err() {
-        crate::core::error::Error::Storage(StorageError::VersionNotFound(_)) => {}
-        err => panic!("Expected VersionNotFound for a never-added version, got: {err:?}"),
+        crate::core::error::Error::Storage(StorageError::VersionNotFound(id)) => assert_eq!(id, nonexistent),
+        err => panic!("Expected VersionNotFound for a never-added version, got: {:?}", err),
     }
 }
 
@@ -4903,7 +4903,7 @@ fn test_reconstruct_nonexistent_edge_version_returns_version_not_found() {
         "Non-existent edge version must return an error"
     );
     match result.unwrap_err() {
-        crate::core::error::Error::Storage(StorageError::VersionNotFound(_)) => {}
+        crate::core::error::Error::Storage(StorageError::VersionNotFound(id)) => assert_eq!(id, nonexistent),
         err => panic!("Expected VersionNotFound for a never-added edge version, got: {err:?}"),
     }
 }


### PR DESCRIPTION
**Summary:**
Overall mutation-readiness assessment of the `src/storage/historical/tests.rs` module. The module correctly exercises temporal error detection logic but had weak string assertions, allowing simulated `MissingAnchor` entity ID replacement mutants to survive.

**Verdict table:**
| Test Function | Verdict | Reason |
| :--- | :--- | :--- |
| `test_missing_anchor_detected_after_anchor_deletion` | 🟡 Suspect -> 🟢 Acquitted | Assertion on `entity_id` used `starts_with` instead of an exact match, allowing ID replacement mutants. |
| `test_edge_missing_anchor_detected_after_anchor_deletion` | 🟡 Suspect -> 🟢 Acquitted | Assertion on `entity_id` used `starts_with` instead of an exact match, allowing ID replacement mutants. |
| `test_reconstruct_nonexistent_node_version_returns_version_not_found` | 🔴 Condemned -> 🟢 Acquitted | Assertion blindly accepted any `VersionNotFound` without checking if the enclosed ID matched the missing one. |
| `test_reconstruct_nonexistent_edge_version_returns_version_not_found` | 🔴 Condemned -> 🟢 Acquitted | Assertion blindly accepted any `VersionNotFound` without checking if the enclosed ID matched the missing one. |

**Priority fixes:**
1. **Node MissingAnchor Check:** Update `test_missing_anchor_detected_after_anchor_deletion` to assert that `entity_id` exactly matches `"Node(99)"`.
2. **Edge MissingAnchor Check:** Update `test_edge_missing_anchor_detected_after_anchor_deletion` to assert that `entity_id` exactly matches `"Edge(55)"`.
3. **VersionNotFound ID Check:** Update nonexistent version tests to explicitly assert that the `id` inside `VersionNotFound(id)` exactly matches the expected missing version ID, rather than just asserting the error type using a wildcard `_`.

**Missing coverage:**
No major missing coverage categories found in the targeted review functions, only missing assertion strength.

---
*PR created automatically by Jules for task [16266955359405584626](https://jules.google.com/task/16266955359405584626) started by @madmax983*