### PR TITLE
👺 Havoc: Fix ABBA deadlock in ShardCoordinator

### DIFF
--- a/src/storage/sharding/coordinator.rs
+++ b/src/storage/sharding/coordinator.rs
@@ -675,41 +675,52 @@ impl ShardCoordinator {
         };
 
         // CRITICAL: Log the commit decision BEFORE sending commits
-        // This ensures we can recover if the coordinator crashes
-        {
-            let log = match self.commit_log.write() {
-                Ok(log) => log,
+        // This ensures we can recover if the coordinator crashes.
+        // We removed the transaction from `active_transactions` above, dropping the lock.
+        // We now acquire the `commit_log` write lock cleanly to avoid ABBA deadlocks.
+        // We MUST reinsert the transaction AFTER the log lock is dropped if it fails.
+        let log_result = {
+            match self.commit_log.write() {
                 Err(_) => {
-                    self.reinsert_transaction(tx_id, transaction);
-                    return Err(DistributedTxError::Aborted {
+                    Err(DistributedTxError::Aborted {
                         reason: "Lock poisoned".to_string(),
-                    });
+                    })
                 }
-            };
+                Ok(log) => {
+                    let should_log = match log.get_decision(tx_id) {
+                        Some(existing) => {
+                            use super::persistent_commit_log::EntryType;
+                            !transaction.commit_decision_logged
+                                || existing.entry_type != EntryType::Commit
+                                || existing.commit_timestamp != commit_timestamp
+                        }
+                        None => true,
+                    };
 
-            let should_log = match log.get_decision(tx_id) {
-                Some(existing) => {
-                    // Check if existing decision matches what we want to log
-                    // PersistentCommitLog entries are specific types (Commit/Abort)
-                    // If we found an entry, check if it's a Commit and has same timestamp
-                    use super::persistent_commit_log::EntryType;
-                    !transaction.commit_decision_logged
-                        || existing.entry_type != EntryType::Commit
-                        || existing.commit_timestamp != commit_timestamp
-                }
-                None => true,
-            };
-
-            if should_log {
-                match log.log_commit(tx_id, transaction.participant_shards(), commit_timestamp) {
-                    Ok(_) => transaction.commit_decision_logged = true,
-                    Err(e) => {
-                        self.reinsert_transaction(tx_id, transaction);
-                        return Err(DistributedTxError::Aborted {
-                            reason: format!("Failed to log commit decision: {}", e),
-                        });
+                    if should_log {
+                        match log.log_commit(tx_id, transaction.participant_shards(), commit_timestamp)
+                        {
+                            Ok(_) => Ok(true),
+                            Err(e) => Err(DistributedTxError::Aborted {
+                                reason: format!("Failed to log commit decision: {}", e),
+                            }),
+                        }
+                    } else {
+                        Ok(false)
                     }
                 }
+            }
+        };
+
+        match log_result {
+            Ok(logged) => {
+                if logged {
+                    transaction.commit_decision_logged = true;
+                }
+            }
+            Err(e) => {
+                self.reinsert_transaction(tx_id, transaction);
+                return Err(e);
             }
         }
 

--- a/tests/havoc/havoc_loom_sharding_coordinator_deadlock.rs
+++ b/tests/havoc/havoc_loom_sharding_coordinator_deadlock.rs
@@ -20,7 +20,10 @@ mod loom_test {
         }
 
         fn recover_pending_transactions(&self) {
-            let _log_guard = self.commit_log.read().unwrap();
+            let _decisions = {
+                let _log_guard = self.commit_log.read().unwrap();
+                ()
+            }; // explicitly drop the log guard just like in the real implementation
 
             // Reinserting recovered txns
             let _tx_guard = self.active_transactions.write().unwrap();
@@ -50,9 +53,10 @@ mod loom_test {
 
             {
                 let _log_guard = self.commit_log.write().unwrap();
-                // Modeling failure branch: reinsert_transaction
-                // let _tx_guard = self.active_transactions.write().unwrap();
-            }
+            } // FIX: Drop the commit log lock before taking the active transactions lock!
+
+            // Modeling failure branch: reinsert_transaction
+            let _tx_guard = self.active_transactions.write().unwrap();
 
             let connections = self.connections.read().unwrap();
 


### PR DESCRIPTION
This PR addresses an ABBA deadlock vulnerability in `ShardCoordinator`. 

The `commit_distributed_transaction` method acquired a `write` lock on `commit_log` and, inside an error-handling block, invoked `self.reinsert_transaction`. This helper function acquired a `write` lock on `active_transactions`. This violated the lock ordering convention (which must be `active_transactions` -> `commit_log` as established in `recover_pending_transactions`) and caused a deadlock when both methods executed concurrently.

To fix the deadlock, the evaluation of the log decision was refactored into a localized scoped block (`let log_result = { ... }`). This completely drops the `commit_log` lock before the program execution yields down to the error handler, where `reinsert_transaction` is safely invoked without holding two locks. 

The `loom` harness for this scenario was also updated to explicitly drop the lock as required, which successfully models the non-deadlocking correct implementation.

---
*PR created automatically by Jules for task [17724642962675603395](https://jules.google.com/task/17724642962675603395) started by @madmax983*