### PR TITLE
🎻 Bard: Add executable ## Examples doc-tests to experimental characterization modules

### DIFF
--- a/src/experimental/characterization/gravity.rs
+++ b/src/experimental/characterization/gravity.rs
@@ -209,6 +209,30 @@ impl<'a> GravitySimulator<'a> {
     /// # Returns
     ///
     /// A list of `(NodeId, Vec<f32>)` pairs representing the proposed new vector positions for neighbors.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::experimental::characterization::gravity::GravitySimulator;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    ///
+    /// let center_props = PropertyMapBuilder::new().insert_vector("vec", &[1.0, 0.0]).build();
+    /// let center = db.create_node("Sun", center_props)?;
+    ///
+    /// let neighbor_props = PropertyMapBuilder::new().insert_vector("vec", &[0.0, 1.0]).build();
+    /// let neighbor = db.create_node("Planet", neighbor_props)?;
+    ///
+    /// db.create_edge(center, neighbor, "ORBITS", Default::default())?;
+    ///
+    /// let sim = GravitySimulator::new(&db);
+    /// let updates = sim.simulate_pull(center, "vec", 10.0, 0.1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn simulate_pull(
         &self,
         center_id: NodeId,

--- a/src/experimental/characterization/kaleidoscope.rs
+++ b/src/experimental/characterization/kaleidoscope.rs
@@ -191,6 +191,20 @@ impl LayoutEngine {
     }
 
     /// Add a semantic link (Vector constraint).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::core::id::NodeId;
+    /// use aletheiadb::experimental::characterization::kaleidoscope::{LayoutConfig, LayoutEngine};
+    ///
+    /// let mut engine = LayoutEngine::new(LayoutConfig::default());
+    /// let n1 = NodeId::new(1).unwrap();
+    /// let n2 = NodeId::new(2).unwrap();
+    ///
+    /// // Add a semantic link with a similarity score of 0.8
+    /// engine.add_semantic_link(n1, n2, 0.8);
+    /// ```
     pub fn add_semantic_link(&mut self, a: NodeId, b: NodeId, similarity: f32) {
         if similarity > 0.0 {
             self.add_node(a);
@@ -213,6 +227,21 @@ impl LayoutEngine {
     }
 
     /// Execute one step of physics.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::core::id::NodeId;
+    /// use aletheiadb::experimental::characterization::kaleidoscope::{LayoutConfig, LayoutEngine};
+    ///
+    /// let mut engine = LayoutEngine::new(LayoutConfig::default());
+    /// let n1 = NodeId::new(1).unwrap();
+    /// let n2 = NodeId::new(2).unwrap();
+    /// engine.add_edge(n1, n2);
+    ///
+    /// // Run one step of the physics simulation manually
+    /// engine.step();
+    /// ```
     pub fn step(&mut self) {
         let k = self.config.optimal_distance;
         let mut forces: HashMap<NodeId, Point> = self

--- a/src/experimental/characterization/papyrus.rs
+++ b/src/experimental/characterization/papyrus.rs
@@ -48,6 +48,31 @@ impl<'a> Papyrus<'a> {
     /// `Some(n)` is provided the BFS stops once `n` nodes have been visited,
     /// preventing excessive memory use on dense or deeply-connected graphs.
     /// Pass `None` to visit all reachable nodes within `max_depth`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::experimental::characterization::papyrus::Papyrus;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    ///
+    /// let props_a = PropertyMapBuilder::new().insert("name", "Alice").build();
+    /// let node_a = db.create_node("Person", props_a)?;
+    ///
+    /// let props_b = PropertyMapBuilder::new().insert("name", "Bob").build();
+    /// let node_b = db.create_node("Person", props_b)?;
+    ///
+    /// db.create_edge(node_a, node_b, "KNOWS", Default::default())?;
+    ///
+    /// let papyrus = Papyrus::new(&db);
+    /// let mermaid_chart = papyrus.export_ego_graph(node_a, 2, Some(500))?;
+    /// println!("{}", mermaid_chart);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn export_ego_graph(
         &self,
         start_node: NodeId,

--- a/src/experimental/characterization/prism.rs
+++ b/src/experimental/characterization/prism.rs
@@ -271,6 +271,26 @@ impl<'a> Prism<'a> {
     }
 
     /// Analyze a node using a specific vector property.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::experimental::characterization::prism::Prism;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let mut prism = Prism::new(&db);
+    /// prism.add_axis("Logic", vec![1.0, 0.0]);
+    ///
+    /// let props = PropertyMapBuilder::new().insert_vector("custom_vec", &[1.0, 0.5]).build();
+    /// let node = db.create_node("Concept", props)?;
+    ///
+    /// let spectrum = prism.analyze_node_with_property(node, "custom_vec")?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn analyze_node_with_property(
         &self,
         node_id: NodeId,
@@ -286,6 +306,30 @@ impl<'a> Prism<'a> {
     ///
     /// This method retrieves the node's history and projects the vector at each version
     /// onto the defined axes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::core::temporal::{TimeRange, time};
+    /// use aletheiadb::api::transaction::WriteOps;
+    /// use aletheiadb::experimental::characterization::prism::Prism;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let mut prism = Prism::new(&db).with_vector_property("vec");
+    /// prism.add_axis("Logic", vec![1.0, 0.0]);
+    ///
+    /// let t1 = time::from_millis(1000);
+    /// let props1 = PropertyMapBuilder::new().insert_vector("vec", &[1.0, 0.0]).build();
+    /// let node_id = db.write(|tx| tx.create_node_with_valid_time("Concept", props1, Some(t1)))?;
+    ///
+    /// let range = TimeRange::new(time::from_millis(0), time::from_millis(2000)).unwrap();
+    /// let evolution = prism.analyze_evolution(node_id, range)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn analyze_evolution(
         &self,
         node_id: NodeId,

--- a/src/experimental/characterization/starlight.rs
+++ b/src/experimental/characterization/starlight.rs
@@ -41,6 +41,31 @@ impl<'a> Starlight<'a> {
     }
 
     /// Exports an ego-graph centered around `start_node` up to `max_depth` hops in JSON.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::experimental::characterization::starlight::Starlight;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    ///
+    /// let props_a = PropertyMapBuilder::new().insert("name", "Alice").build();
+    /// let node_a = db.create_node("Person", props_a)?;
+    ///
+    /// let props_b = PropertyMapBuilder::new().insert("name", "Bob").build();
+    /// let node_b = db.create_node("Person", props_b)?;
+    ///
+    /// db.create_edge(node_a, node_b, "KNOWS", Default::default())?;
+    ///
+    /// let starlight = Starlight::new(&db);
+    /// let json = starlight.export_ego_graph(node_a, 2, Some(500))?;
+    /// println!("{}", json);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn export_ego_graph(
         &self,
         start_node: NodeId,

--- a/src/experimental/characterization/sybil.rs
+++ b/src/experimental/characterization/sybil.rs
@@ -156,6 +156,34 @@ impl<'a> Sybil<'a> {
     /// * `property_name` - The vector property to use as the "meme".
     /// * `model` - The propagation logic.
     /// * `steps` - Number of iterations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::experimental::characterization::sybil::{Sybil, LinearPropagation};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    ///
+    /// // Create nodes and edges
+    /// let props_a = PropertyMapBuilder::new().insert_vector("opinion", &[1.0, 0.0]).build();
+    /// let node_a = db.create_node("Person", props_a)?;
+    ///
+    /// let props_b = PropertyMapBuilder::new().insert_vector("opinion", &[0.0, 1.0]).build();
+    /// let node_b = db.create_node("Person", props_b)?;
+    ///
+    /// db.create_edge(node_a, node_b, "INFLUENCES", Default::default())?;
+    ///
+    /// let sybil = Sybil::new(&db);
+    /// let model = LinearPropagation::new(0.5); // Average between self and neighbors
+    ///
+    /// // Run 1 step of simulation
+    /// let state = sybil.simulate("opinion", &model, 1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn simulate<M: PropagationModel>(
         &self,
         property_name: &str,

--- a/src/experimental/characterization/synapse.rs
+++ b/src/experimental/characterization/synapse.rs
@@ -168,6 +168,35 @@ impl<'a> Synapse<'a> {
     ///
     /// This encourages the algorithm to choose paths that are semantically "good enough"
     /// but highly popular, over paths that are semantically perfect but unknown.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use aletheiadb::AletheiaDB;
+    /// use aletheiadb::core::property::PropertyMapBuilder;
+    /// use aletheiadb::experimental::characterization::synapse::{Synapse, SynapseContext};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let context = SynapseContext::new();
+    /// let synapse = Synapse::new(&db, &context);
+    ///
+    /// let props_a = PropertyMapBuilder::new().insert_vector("vec", &[1.0, 0.0]).build();
+    /// let a = db.create_node("Node", props_a)?;
+    ///
+    /// let props_b = PropertyMapBuilder::new().insert_vector("vec", &[0.8, 0.6]).build();
+    /// let b = db.create_node("Node", props_b)?;
+    ///
+    /// let edge_id = db.create_edge(a, b, "NEXT", Default::default())?;
+    ///
+    /// // Simulate traversing the edge
+    /// synapse.observe(edge_id);
+    ///
+    /// // Find path
+    /// let path = synapse.adaptive_semantic_path(a, b, "vec")?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn adaptive_semantic_path(
         &self,
         start: NodeId,


### PR DESCRIPTION
📖 Chapter: The experimental characterization modules (sybil, papyrus, starlight, gravity, synapse, kaleidoscope, and prism) public functions lacked execution examples.

🔦 Insight: The `## Examples` doc-tests have been systematically added to critical public functions to ensure the codebase acts as the documentation source of truth and meets Bard's directives.

🧪 Example: Added multiple executable doctests such as `Sybil::simulate`, `Papyrus::export_ego_graph`, `Starlight::export_ego_graph`, `GravitySimulator::simulate_pull`, `Synapse::adaptive_semantic_path`, `LayoutEngine::add_semantic_link`/`step`, and `Prism::analyze_node_with_property`/`analyze_evolution`.

🖼️ Preview: Documentation is automatically validated and passes `cargo doc`.

---
*PR created automatically by Jules for task [5243165659315792958](https://jules.google.com/task/5243165659315792958) started by @madmax983*