### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
         .as_of(valid_time, tx_time)              // temporal: point-in-time snapshot
         .start(alice)                            // graph: starting node
         .traverse("KNOWS")                       // graph: follow edges
-        .rank_by_similarity(&query_embedding, 10) // vector: re-rank by similarity
+        .rank_by_similarity_builder(&query_embedding, 10).property("embedding").finish() // vector: re-rank by similarity
         .execute(&db)?;
 
     Ok(())


### PR DESCRIPTION
🗣️ Echo: Getting Started example is broken
🤦 **The Confusion:** Tried to run the hybrid query example in README. Compiler complained that `rank_by_similarity` method was not found on `QueryBuilder<HasTraversalResults>`.
🕵️ **The Reality:** The method is indeed missing for `HasTraversalResults`. However, there is a `rank_by_similarity_builder` that can be used on traversal results, and its result has a `finish()` method.
💡 **The Fix:** I modified the `README.md` to use `.rank_by_similarity_builder(&query_embedding, 10).property("embedding").finish()` instead of `.rank_by_similarity(&query_embedding, 10)` after a traversal.

---
*PR created automatically by Jules for task [13593299239047860110](https://jules.google.com/task/13593299239047860110) started by @madmax983*