### PR TITLE
🗣️ Echo: Fix DX friction points in examples and docs

### DIFF
--- a/docs/analysis/DX_REPORT_ECHO_STORY_FEATURE.md
+++ b/docs/analysis/DX_REPORT_ECHO_STORY_FEATURE.md
@@ -1,0 +1,45 @@
+# 🗣️ Echo DX Report: The Walkthrough Audit
+
+**Auditor:** Echo (Voice of the User)
+**Date:** 2026-02-02
+**Subject:** `story_demo` Developer Experience
+
+## 🔍 The Walkthrough
+
+I attempted to explore the `story_demo` example to add the "Narrative Generation" feature as a new user.
+
+### 🚧 The Friction Points
+
+#### 1. The Result Shadowing Trap
+
+**Scenario:** I copied the "Narrative Generation" snippet into my project where I already had `use aletheiadb::prelude::*;` for my basic setup.
+**Code:** `fn main() -> Result<(), Box<dyn std::error::Error>> { ... }`
+**Result:** `error[E0107]: enum takes 1 generic argument but 2 generic arguments were supplied`
+**Why it hurts:** `aletheiadb::prelude::Result` maps to `Result<T, aletheiadb::Error>` (one argument), shadowing `std::result::Result` (two arguments). If I try to use the standard main signature with `Box<dyn Error>`, it blows up confusingly.
+**Fix applied:** Refactored `examples/story_demo.rs` to just use `use aletheiadb::prelude::*;` and `fn main() -> Result<()> {`. This matches the expected usage in real projects.
+
+#### 2. The Unused Imports / Trait Tax
+
+**Scenario:** The example used `db.write(|tx| ...)` but explicitly imported `WriteOps`.
+**Why it hurts:** The prelude exists for a reason! Forcing me to understand which traits I need to manually import to write data is annoying.
+**Fix applied:** Changed `examples/story_demo.rs` to rely entirely on the prelude, removing the explicit `WriteOps` import.
+
+#### 3. The `nova` vs `semantic-temporal` Feature Mixup
+
+**Scenario:** I read the comment in the code: `cargo run --features nova --example story_demo`. But if I run `cargo run --example story_demo` (because I'm lazy), Cargo tells me `target story_demo requires the features: semantic-temporal`.
+**Why it hurts:** Mismatch between the documentation and the compiler's helpful hint.
+**Fix applied:** Updated the comment in `examples/story_demo.rs` to match the Cargo hint (`--features semantic-temporal`), while keeping the note that `nova` works too.
+
+#### 4. The Unused Variables in the README
+
+**Scenario:** I copied the "Multi-Operation Transactions" code from `docs/guides/getting-started.md`.
+**Result:** Warnings for `unused variable: carol_id` and `dave_id`.
+**Why it hurts:** Yellow text scares new users. We don't like it.
+**Fix applied:** Rewrote the block to just return `Ok(())` instead of binding unused node IDs.
+
+## 🏁 Conclusion
+
+A smoother copy-paste experience is a happier user experience. The fixes above ensure the examples "just work" without yelling about traits, generic arguments, or unused variables.
+
+Signed,
+**Echo** 🗣️

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -116,11 +116,11 @@ succeed or all roll back.
 For operations that must succeed together:
 
 ```rust
-let (carol_id, dave_id) = db.write(|tx| -> Result<(NodeId, NodeId)> {
+db.write(|tx| -> Result<()> {
     let carol = tx.create_node("Person", properties! { "name" => "Carol" })?;
     let dave  = tx.create_node("Person", properties! { "name" => "Dave"  })?;
     tx.create_edge(carol, dave, "WORKS_WITH", properties! {})?;
-    Ok((carol, dave))
+    Ok(())
 })?;
 ```
 

--- a/examples/story_demo.rs
+++ b/examples/story_demo.rs
@@ -10,7 +10,7 @@
 //! ## Running this example
 //!
 //! ```bash
-//! cargo run --features nova --example story_demo
+//! cargo run --features semantic-temporal --example story_demo
 //! ```
 //!
 //! ## Using in your project
@@ -22,15 +22,13 @@
 //! aletheiadb = { version = "0.1", features = ["nova"] }
 //! ```
 
-use aletheiadb::AletheiaDB;
-use aletheiadb::WriteOps;
-// ⚠️ REQUIRES FEATURE 'NOVA' IN CARGO.TOML
+use aletheiadb::prelude::*;
+// ⚠️ REQUIRES FEATURE 'NOVA' OR 'SEMANTIC-TEMPORAL' IN CARGO.TOML
 // [dependencies]
 // aletheiadb = { version = "0.1", features = ["nova"] }
 use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
-use aletheiadb::properties;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<()> {
     let db = AletheiaDB::new()?;
 
     // 1. Create Node


### PR DESCRIPTION
This submission applies several fixes discovered during a Developer Experience (DX) "Echo" audit:

1. **`examples/story_demo.rs` Refactoring:**
    - Modified the `story_demo` example to use `aletheiadb::prelude::*` instead of forcing users to explicitly import deep traits like `WriteOps`.
    - Using the prelude shadows `std::result::Result` with `aletheiadb::core::error::Result`. Modified the `main` signature from `fn main() -> Result<(), Box<dyn std::error::Error>>` to `fn main() -> Result<()>` to prevent the dreaded `E0107: expected 1 generic argument` error when a user copy-pastes this example.
    - Updated the inline documentation to use `cargo run --features semantic-temporal` (aligning with Cargo's error hint) instead of just `nova`, while maintaining the comment regarding `nova`.

2. **Getting Started Guide Refactoring:**
    - Removed unused variables (`carol_id` and `dave_id`) in `docs/guides/getting-started.md` under the "Multi-Operation Transactions" section to prevent "unused variable" warnings.

3. **DX Report:**
    - Recorded the friction points and their fixes inside the new file `docs/analysis/DX_REPORT_ECHO_STORY_FEATURE.md`.

---
*PR created automatically by Jules for task [7804842015193725267](https://jules.google.com/task/7804842015193725267) started by @madmax983*