### PR TITLE
⚡ Bolt: Replace HashSet with FastHashSet for node traversal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,9 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**⚡ Bolt Optimization: Replace HashSet with FastHashSet**
+**Learning:**  uses SipHash by default, which is slow and overkill for simple integer keys like . We can speed up graph traversals by using a custom hasher.
+**Action:** Replaced  with  (which is aliased to ) in  to eliminate hashing overhead for visited nodes.
+**⚡ Bolt Optimization: Replace HashSet with FastHashSet**
+**Learning:** `std::collections::HashSet` uses SipHash by default, which is slow and overkill for simple integer keys like `NodeId`. We can speed up graph traversals by using a custom hasher.
+**Action:** Replaced `HashSet<NodeId>` with `FastHashSet<NodeId>` (which is aliased to `HashSet<T, BuildHasherDefault<IdentityHasher>>`) in `src/query/executor/iterators.rs` to eliminate hashing overhead for visited nodes.

--- a/src/query/executor/iterators.rs
+++ b/src/query/executor/iterators.rs
@@ -5,7 +5,7 @@
 
 use parking_lot::RwLock;
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashSet, VecDeque};
+use std::collections::{BinaryHeap, VecDeque};
 use std::sync::Arc;
 
 #[cfg(feature = "observability")]
@@ -16,6 +16,7 @@ use crate::core::graph::Node;
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::PropertyValue;
 use crate::core::vector::cosine_similarity;
+use crate::core::version::FastHashSet;
 use crate::core::{NodeId, Timestamp};
 use crate::query::ir::{Direction, Predicate, PredicateValue};
 use crate::storage::current::CurrentStorage;
@@ -760,7 +761,10 @@ pub struct TraversalIterator {
     temporal_context: Option<(Timestamp, Timestamp)>,
     // BFS state - reset for each input node (see doc comment above)
     frontier: VecDeque<(NodeId, Vec<EntityId>, usize)>,
-    visited: HashSet<NodeId>,
+
+    /// ⚡ Bolt Optimization: Replace `std::collections::HashSet` with `FastHashSet`
+    /// `NodeId` is a small u64 identifier. Default SipHash is overkill and slows down traversal.
+    visited: FastHashSet<NodeId>,
     input_exhausted: bool,
 }
 
@@ -789,7 +793,7 @@ impl TraversalIterator {
             historical,
             temporal_context,
             frontier: VecDeque::new(),
-            visited: HashSet::new(),
+            visited: FastHashSet::default(),
             input_exhausted: false,
         }
     }


### PR DESCRIPTION
💡 What: Changed the visited set in `TraversalIterator` from `std::collections::HashSet` to `FastHashSet`.
🎯 Why: `NodeId` is a small u64 wrapper. The default SipHash algorithm is overkill and wastes CPU cycles.
📊 Impact: Speeds up BFS graph traversal algorithms significantly by removing hashing overhead for visited nodes.
🔬 Measurement: Run graph traversal queries (`MATCH (a)-[*]->(b)`).

---
*PR created automatically by Jules for task [3492460718891767652](https://jules.google.com/task/3492460718891767652) started by @madmax983*