### PR TITLE
⚡ Bolt: Remove unnecessary Vec allocation during encrypted WAL entry flush

### DIFF
--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -30,7 +30,6 @@
 //! The coordinator is designed to be run from a single thread. Multiple
 //! threads should not call `flush()` concurrently.
 
-use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -671,8 +670,7 @@ impl FlushCoordinator {
                     // 4-byte LE length prefix so the reader knows how many bytes
                     // each encrypted entry occupies. Without a cipher, write the
                     // raw entry data directly (no allocation, zero overhead).
-                    let write_data: Cow<'_, [u8]> = if let Some(ref cipher) = self.config.wal_cipher
-                    {
+                    if let Some(ref cipher) = self.config.wal_cipher {
                         let encrypted = crate::encryption::wal_encryption::encrypt_wal_payload(
                             &entry.data,
                             cipher,
@@ -680,21 +678,32 @@ impl FlushCoordinator {
                         .map_err(|e| Error::Storage(StorageError::Encryption(e.to_string())))?;
                         // Prepend 4-byte LE length of the encrypted block
                         let len_bytes = (encrypted.len() as u32).to_le_bytes();
-                        let mut framed = Vec::with_capacity(4 + encrypted.len());
-                        framed.extend_from_slice(&len_bytes);
-                        framed.extend_from_slice(&encrypted);
-                        Cow::Owned(framed)
-                    } else {
-                        Cow::Borrowed(&entry.data)
-                    };
 
-                    writer.write_all(&write_data).map_err(|e| {
-                        Error::Storage(StorageError::IoError(format!(
-                            "Failed to write WAL entry: {}",
-                            e
-                        )))
-                    })?;
-                    bytes_written += write_data.len();
+                        writer.write_all(&len_bytes).map_err(|e| {
+                            Error::Storage(StorageError::IoError(format!(
+                                "Failed to write WAL entry length: {}",
+                                e
+                            )))
+                        })?;
+
+                        writer.write_all(&encrypted).map_err(|e| {
+                            Error::Storage(StorageError::IoError(format!(
+                                "Failed to write WAL entry: {}",
+                                e
+                            )))
+                        })?;
+
+                        bytes_written += 4 + encrypted.len();
+                    } else {
+                        writer.write_all(&entry.data).map_err(|e| {
+                            Error::Storage(StorageError::IoError(format!(
+                                "Failed to write WAL entry: {}",
+                                e
+                            )))
+                        })?;
+
+                        bytes_written += entry.data.len();
+                    }
                 }
 
                 // Flush buffer to OS


### PR DESCRIPTION
💡 **What:** Eliminated an intermediate `Vec<u8>` heap allocation and `Cow` wrapper in `flush_coordinator.rs` when WAL encryption is enabled.
🎯 **Why:** To write an encrypted WAL entry, the system previously allocated a new `Vec`, copied a 4-byte length prefix into it, and then copied the encrypted payload into it. By writing these two components sequentially into the existing `BufWriter`, we avoid this entirely unnecessary per-entry heap allocation.
📊 **Impact:** Saves one `Vec::with_capacity` heap allocation per WAL entry when encryption is active, reducing memory overhead and CPU time on the WAL flush hot path.
🔬 **Measurement:** Run standard storage/WAL unit tests and benchmarks: `cargo test --lib -- storage::wal`.

---
*PR created automatically by Jules for task [9717712398120055302](https://jules.google.com/task/9717712398120055302) started by @madmax983*