### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -1,3 +1,6 @@
+## 2026-06-21 - [Doctests for Embeddings module]
+**Confusion:** The `src/embeddings/mod.rs` module lacked executable doctests for its primary functions `to_dense_iter` and `embed_data_to_dense_iter`, as well as the struct `DenseEmbedData`.
+**Clarification:** Added `## Examples` sections with executable Rust code in the `///` docs to ensure developers understand how to use these interfaces.
 ## 2024-04-07 - [The Missing Documentation of the WAL internals]
 **Confusion:** Many core public functions and structures within the `src/storage/wal` submodules were completely undocumented. Since the internals of the Write-Ahead Log are deeply nuanced (stripe concurrency, lock-free allocations, background flush threads), a developer trying to extend or debug this sub-system would be met with an opaque wall of uncommented signatures.
 **Clarification:** I added structured `///` documentation for all un-commented public structs and functions across `stripe.rs`, `lsn_allocator.rs`, `ring_buffer.rs`, `flush_coordinator.rs`, `concurrent.rs`, `durability.rs`, and `group_commit.rs`. Specifically, I utilized the `# Why?` convention to articulate exactly why a particular structural unit or function is publicly exposed.

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -21,6 +21,21 @@ pub use embed_anything::embeddings::embed::{
 };
 
 /// Dense embedding data with chunk text and metadata preserved.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::embeddings::{DenseEmbedData, DenseEmbeddingError};
+/// use std::collections::HashMap;
+///
+/// let data = DenseEmbedData {
+///     text: Some("Example text".to_string()),
+///     metadata: Some(HashMap::new()),
+///     embedding: vec![0.1, 0.2, 0.3],
+/// };
+///
+/// assert_eq!(data.embedding.len(), 3);
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct DenseEmbedData {
     /// Text associated with the embedding chunk, when provided upstream.
@@ -51,6 +66,22 @@ impl Error for DenseEmbeddingError {}
 /// Converts upstream embedding results into dense vectors lazily.
 ///
 /// When `limit` is provided, at most that many results are converted.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::embeddings::{EmbeddingResult, to_dense_iter};
+///
+/// let results = vec![
+///     EmbeddingResult::DenseVector(vec![0.1, 0.2]),
+///     EmbeddingResult::DenseVector(vec![0.3, 0.4]),
+/// ];
+///
+/// let mut iter = to_dense_iter(results, None);
+/// assert_eq!(iter.next().unwrap().unwrap(), vec![0.1, 0.2]);
+/// assert_eq!(iter.next().unwrap().unwrap(), vec![0.3, 0.4]);
+/// assert!(iter.next().is_none());
+/// ```
 pub fn to_dense_iter<I>(
     results: I,
     limit: Option<usize>,
@@ -68,6 +99,26 @@ where
 /// chunk text and metadata.
 ///
 /// When `limit` is provided, at most that many chunks are converted.
+///
+/// ## Examples
+///
+/// ```rust
+/// use aletheiadb::embeddings::{EmbedData, EmbeddingResult, embed_data_to_dense_iter};
+/// use std::collections::HashMap;
+///
+/// let data = vec![
+///     EmbedData {
+///         text: Some("hello".to_string()),
+///         metadata: None,
+///         embedding: EmbeddingResult::DenseVector(vec![0.1, 0.2]),
+///     }
+/// ];
+///
+/// let mut iter = embed_data_to_dense_iter(data, None);
+/// let dense_data = iter.next().unwrap().unwrap();
+/// assert_eq!(dense_data.text.as_deref(), Some("hello"));
+/// assert_eq!(dense_data.embedding, vec![0.1, 0.2]);
+/// ```
 pub fn embed_data_to_dense_iter<I>(
     data: I,
     limit: Option<usize>,


### PR DESCRIPTION
Added executable doctests for `DenseEmbedData`, `to_dense_iter`, and `embed_data_to_dense_iter` in the `embeddings` module and documented the changes in `.jules/bard.md`.

---
*PR created automatically by Jules for task [12118816736407287673](https://jules.google.com/task/12118816736407287673) started by @madmax983*