### PR TITLE
Issue #3209: Safe-by-default delete_node with DETACH DELETE contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -693,14 +693,29 @@ db.between("2024-01-01", "2024-12-31").track_changes(node_id)
 
 ### Orphaned Edges on Node Deletion
 
-Calling `delete_node` removes only the node itself -- any edges where the deleted node
-is the source or target will remain in storage as **orphaned edges**. Traversals that
-follow these edges may encounter missing endpoints.
+The **low-level Rust** `delete_node` (`src/storage/current/mod.rs`) removes only the
+node itself -- any edges where the deleted node is the source or target remain in
+storage as **orphaned edges**. This edge-preserving behavior is intentional and is
+retained for audit/history use cases where callers manage edge cleanup themselves or
+need to preserve edge records. Traversals that follow these orphaned edges may
+encounter missing endpoints.
 
-**Recommended**: Use `delete_node_cascade` instead, which atomically deletes the node
-and all connected edges, preventing orphans. The non-cascade `delete_node` is retained
-for cases where callers manage edge cleanup themselves or where performance requires
-avoiding the edge scan.
+**Recommended (Rust API)**: Use `delete_node_cascade` instead, which atomically
+deletes the node and all connected edges, preventing orphans. To decide before acting,
+call `db.count_connected_edges(node_id)` to learn how many edges reference a node.
+
+**MCP surface is safe-by-default (Issue #3209)**: The MCP `delete_node` tool mirrors
+Cypher's `DETACH DELETE` contract -- it never silently orphans edges:
+
+- If the node has connected edges and `detach` is not `true`, the deletion is
+  **refused** and the JSON response reports `connected_edges` (the number of edges
+  that would be orphaned), so an LLM/caller can decide.
+- Passing `detach: true` performs a cascade-equivalent delete and reports
+  `edges_removed`.
+- A node with no connected edges deletes cleanly (`edges_removed: 0`).
+
+This guarantees zero silent orphan-creating successes through the MCP surface: an LLM
+never receives a `success` response that breaks referential integrity.
 
 ## Future Considerations
 

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -239,8 +239,10 @@ impl AletheiaDB {
         // Verify the node exists first; an absent node should error rather than
         // silently report zero connected edges.
         let _ = self.current.get_node_label(node_id)?;
-        let outgoing = self.current.get_outgoing_edges(node_id).len();
-        let incoming = self.current.get_incoming_edges(node_id).len();
+        // Use degree counters rather than materializing edge-id vectors: this
+        // avoids allocations for high-degree nodes.
+        let outgoing = self.current.out_degree(node_id);
+        let incoming = self.current.in_degree(node_id);
         Ok(outgoing + incoming)
     }
 

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -224,6 +224,26 @@ impl AletheiaDB {
         self.current.get_outgoing_edges_with_label(node_id, label)
     }
 
+    /// Count the edges connected to a node (both outgoing and incoming).
+    ///
+    /// This is an additive, non-breaking helper (Issue #3209) that lets callers
+    /// learn how many edges reference a node *before* deleting it, so they can
+    /// decide whether a detach/cascade delete is required to avoid orphaning
+    /// edges.
+    ///
+    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// if the node does not exist in the current state, so callers never receive
+    /// a misleading zero count for a missing node.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn count_connected_edges(&self, node_id: NodeId) -> Result<usize> {
+        // Verify the node exists first; an absent node should error rather than
+        // silently report zero connected edges.
+        let _ = self.current.get_node_label(node_id)?;
+        let outgoing = self.current.get_outgoing_edges(node_id).len();
+        let incoming = self.current.get_incoming_edges(node_id).len();
+        Ok(outgoing + incoming)
+    }
+
     /// Get the number of nodes in the current state.
     #[inline]
     pub fn node_count(&self) -> usize {

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1176,6 +1176,42 @@ fn test_delete_node_cascade() {
 }
 
 #[test]
+fn test_count_connected_edges() {
+    // Issue #3209: additive, non-breaking helper to learn how many edges connect
+    // a node prior to deletion, so callers can decide before acting.
+    let db = AletheiaDB::new().unwrap();
+
+    let alice = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let bob = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let charlie = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // No edges yet
+    assert_eq!(db.count_connected_edges(alice).unwrap(), 0);
+
+    // One outgoing edge
+    db.create_edge(alice, bob, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(db.count_connected_edges(alice).unwrap(), 1);
+
+    // One incoming edge (counts both directions)
+    db.create_edge(charlie, alice, "FOLLOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+    assert_eq!(db.count_connected_edges(alice).unwrap(), 2);
+    assert_eq!(db.count_connected_edges(bob).unwrap(), 1);
+    assert_eq!(db.count_connected_edges(charlie).unwrap(), 1);
+
+    // Missing node returns an error rather than a bogus count
+    let missing = NodeId::new(999_999).unwrap();
+    assert!(db.count_connected_edges(missing).is_err());
+}
+
+#[test]
 fn test_delete_edge_via_transaction() {
     let db = AletheiaDB::new().unwrap();
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -333,10 +333,17 @@ impl AletheiaMcpServer {
         ))
     }
 
-    /// Delete a node.
+    /// Delete a node (safe-by-default).
     ///
-    /// Permanently removes the node from the current state. Historical versions remain accessible via time-travel queries.
-    /// Fails if the node has connected edges (unless `delete_node_cascade` is used).
+    /// Permanently removes the node from the current state. Historical versions
+    /// remain accessible via time-travel queries.
+    ///
+    /// Mirrors Cypher's `DETACH DELETE` contract (Issue #3209): if the node has
+    /// connected edges and `detach` is not `true`, the deletion is **refused**
+    /// and the JSON response reports `connected_edges` (the number of edges that
+    /// would be orphaned) so the caller can decide. Pass `detach: true` to delete
+    /// the node together with all connected edges; the response then reports
+    /// `edges_removed`. A node with no connected edges always deletes cleanly.
     pub fn delete_node(&self, req: DeleteNodeRequest) -> String {
         Self::extract_text(self.handle_delete_node(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -894,12 +901,59 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&e.to_string()),
         };
 
-        match self.db.write(|tx| tx.delete_node(node_id)) {
-            Ok(()) => self.success_json(json!({
-                "success": true,
-                "deleted_node_id": req.node_id
-            })),
-            Err(e) => self.error_json(&e.to_string()),
+        // Determine how many edges are connected before we touch anything. This
+        // both verifies the node exists and lets us honor the safe-by-default
+        // DETACH-DELETE contract (Issue #3209).
+        let connected_edges = match self.db.count_connected_edges(node_id) {
+            Ok(count) => count,
+            Err(e) => return self.error_json(&e.to_string()),
+        };
+
+        let detach = req.detach.unwrap_or(false);
+
+        // Refuse-by-default: never report a bare success while silently orphaning
+        // edges. The caller must opt into destruction via `detach: true`.
+        if connected_edges > 0 && !detach {
+            return CallToolResult::error(vec![Content::text(
+                serde_json::to_string_pretty(&json!({
+                    "error": format!(
+                        "Node {} has {} connected edge(s); refusing to delete. \
+                         Pass `detach: true` to delete the node and its connected edges, \
+                         or remove the edges first.",
+                        req.node_id, connected_edges
+                    ),
+                    "success": false,
+                    "node_id": req.node_id,
+                    "connected_edges": connected_edges,
+                    "detach_required": true
+                }))
+                .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
+            )]);
+        }
+
+        if detach {
+            // Cascade-equivalent delete: remove the node and all connected edges,
+            // reporting exactly how many edges were removed.
+            match self.db.write(|tx| tx.delete_node_cascade(node_id)) {
+                Ok(()) => self.success_json(json!({
+                    "success": true,
+                    "deleted_node_id": req.node_id,
+                    "detached": true,
+                    "edges_removed": connected_edges
+                })),
+                Err(e) => self.error_json(&e.to_string()),
+            }
+        } else {
+            // No connected edges: a plain delete cannot orphan anything.
+            match self.db.write(|tx| tx.delete_node(node_id)) {
+                Ok(()) => self.success_json(json!({
+                    "success": true,
+                    "deleted_node_id": req.node_id,
+                    "detached": false,
+                    "edges_removed": 0
+                })),
+                Err(e) => self.error_json(&e.to_string()),
+            }
         }
     }
 
@@ -2085,7 +2139,10 @@ impl ServerHandler for AletheiaMcpServer {
                 ),
                 Tool::new(
                     "delete_node",
-                    "Delete a node by its ID.",
+                    "Delete a node by its ID (safe-by-default). If the node has connected \
+                     edges and `detach` is not true, the deletion is refused and the response \
+                     reports `connected_edges`. Pass `detach: true` to delete the node together \
+                     with all connected edges; the response then reports `edges_removed`.",
                     make_input_schema::<DeleteNodeRequest>(),
                 ),
                 Tool::new(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -901,20 +901,52 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&e.to_string()),
         };
 
-        // Determine how many edges are connected before we touch anything. This
-        // both verifies the node exists and lets us honor the safe-by-default
-        // DETACH-DELETE contract (Issue #3209).
-        let connected_edges = match self.db.count_connected_edges(node_id) {
-            Ok(count) => count,
+        let detach = req.detach.unwrap_or(false);
+
+        // Perform the connected-edge check and the deletion inside a single write
+        // transaction so they observe the same storage state. Splitting the count
+        // into a separate transaction (or doing it before opening one) leaves a
+        // check-then-act gap in which a concurrent writer could add an edge after
+        // the count but before the delete, silently orphaning it. Keeping both in
+        // one closure removes that cross-transaction gap (Issue #3209).
+        enum Outcome {
+            Refused { connected_edges: usize },
+            Deleted { edges_removed: usize },
+        }
+
+        let outcome = self.db.write(|tx| -> crate::core::error::Result<Outcome> {
+            // `count_connected_edges` reads the same `current` storage the
+            // transaction's edge traversal uses, and also verifies the node
+            // exists (errors propagate via `?`).
+            let connected_edges = self.db.count_connected_edges(node_id)?;
+
+            // Refuse-by-default: never report a bare success while silently
+            // orphaning edges. The caller must opt into destruction via `detach`.
+            if connected_edges > 0 && !detach {
+                return Ok(Outcome::Refused { connected_edges });
+            }
+
+            if detach {
+                // Cascade-equivalent delete: remove the node and all connected
+                // edges, reporting exactly how many edges were removed.
+                tx.delete_node_cascade(node_id)?;
+                Ok(Outcome::Deleted {
+                    edges_removed: connected_edges,
+                })
+            } else {
+                // No connected edges: a plain delete cannot orphan anything.
+                tx.delete_node(node_id)?;
+                Ok(Outcome::Deleted { edges_removed: 0 })
+            }
+        });
+
+        let outcome = match outcome {
+            Ok(o) => o,
             Err(e) => return self.error_json(&e.to_string()),
         };
 
-        let detach = req.detach.unwrap_or(false);
-
-        // Refuse-by-default: never report a bare success while silently orphaning
-        // edges. The caller must opt into destruction via `detach: true`.
-        if connected_edges > 0 && !detach {
-            return CallToolResult::error(vec![Content::text(
+        match outcome {
+            Outcome::Refused { connected_edges } => CallToolResult::error(vec![Content::text(
                 serde_json::to_string_pretty(&json!({
                     "error": format!(
                         "Node {} has {} connected edge(s); refusing to delete. \
@@ -928,32 +960,13 @@ impl AletheiaMcpServer {
                     "detach_required": true
                 }))
                 .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
-            )]);
-        }
-
-        if detach {
-            // Cascade-equivalent delete: remove the node and all connected edges,
-            // reporting exactly how many edges were removed.
-            match self.db.write(|tx| tx.delete_node_cascade(node_id)) {
-                Ok(()) => self.success_json(json!({
-                    "success": true,
-                    "deleted_node_id": req.node_id,
-                    "detached": true,
-                    "edges_removed": connected_edges
-                })),
-                Err(e) => self.error_json(&e.to_string()),
-            }
-        } else {
-            // No connected edges: a plain delete cannot orphan anything.
-            match self.db.write(|tx| tx.delete_node(node_id)) {
-                Ok(()) => self.success_json(json!({
-                    "success": true,
-                    "deleted_node_id": req.node_id,
-                    "detached": false,
-                    "edges_removed": 0
-                })),
-                Err(e) => self.error_json(&e.to_string()),
-            }
+            )]),
+            Outcome::Deleted { edges_removed } => self.success_json(json!({
+                "success": true,
+                "deleted_node_id": req.node_id,
+                "detached": detach,
+                "edges_removed": edges_removed
+            })),
         }
     }
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -80,6 +80,21 @@ fn test_server_with_existing_db() {
 mod node_tests {
     use super::*;
 
+    /// Helper to create two `Person` nodes and return their IDs.
+    fn create_two_nodes(server: &AletheiaMcpServer) -> (u64, u64) {
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+        (n1.id, n2.id)
+    }
+
     #[test]
     fn test_create_node_basic() {
         let server = create_test_server();
@@ -216,7 +231,10 @@ mod node_tests {
         let node_id = created.id;
 
         // Delete it
-        let delete_req = DeleteNodeRequest { node_id };
+        let delete_req = DeleteNodeRequest {
+            node_id,
+            detach: None,
+        };
 
         let delete_response = server.delete_node(delete_req);
         let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
@@ -229,6 +247,128 @@ mod node_tests {
         let get_value: serde_json::Value = serde_json::from_str(&get_response).unwrap();
 
         assert!(get_value.get("error").is_some());
+    }
+
+    #[test]
+    fn test_delete_node_with_edges_refused_without_detach() {
+        // Issue #3209: the MCP delete_node must NOT return a bare success when the
+        // target node has connected edges. Without `detach`, it refuses and reports
+        // the machine-readable count of connected edges.
+        let server = create_test_server();
+        let (source_id, target_id) = create_two_nodes(&server);
+
+        server.create_edge(CreateEdgeRequest {
+            source_id,
+            target_id,
+            label: "KNOWS".to_string(),
+            properties: None,
+        });
+
+        let delete_response = server.delete_node(DeleteNodeRequest {
+            node_id: source_id,
+            detach: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
+
+        // It must not claim success...
+        assert_ne!(value.get("success"), Some(&serde_json::json!(true)));
+        // ...and it must surface exactly the number of connected edges.
+        assert_eq!(value.get("connected_edges"), Some(&serde_json::json!(1)));
+
+        // The node must still exist (refused, not destroyed).
+        let get_value: serde_json::Value =
+            serde_json::from_str(&server.get_node(GetNodeRequest { node_id: source_id })).unwrap();
+        assert!(get_value.get("error").is_none());
+    }
+
+    #[test]
+    fn test_delete_node_with_detach_removes_edges_no_dangling() {
+        // Issue #3209: with detach: true, the MCP path performs a cascade-equivalent
+        // delete and reports the number of edges removed, leaving no dangling endpoints.
+        let server = create_test_server();
+        let (source_id, target_id) = create_two_nodes(&server);
+
+        // A third node so we have both an outgoing and an incoming edge.
+        let third = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+        });
+        let third_id: NodeResponse = parse_response(&third).unwrap();
+        let third_id = third_id.id;
+
+        server.create_edge(CreateEdgeRequest {
+            source_id,
+            target_id,
+            label: "KNOWS".to_string(),
+            properties: None,
+        });
+        server.create_edge(CreateEdgeRequest {
+            source_id: third_id,
+            target_id: source_id,
+            label: "FOLLOWS".to_string(),
+            properties: None,
+        });
+
+        let delete_response = server.delete_node(DeleteNodeRequest {
+            node_id: source_id,
+            detach: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
+
+        assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
+        assert_eq!(value.get("edges_removed"), Some(&serde_json::json!(2)));
+        assert_eq!(value.get("detached"), Some(&serde_json::json!(true)));
+
+        // Node is gone.
+        let get_value: serde_json::Value =
+            serde_json::from_str(&server.get_node(GetNodeRequest { node_id: source_id })).unwrap();
+        assert!(get_value.get("error").is_some());
+
+        // Traversal from the surviving neighbors yields no dangling endpoint to
+        // the deleted node: the connected edges were removed with it.
+        let outgoing: serde_json::Value =
+            serde_json::from_str(&server.get_outgoing_edges(GetOutgoingEdgesRequest {
+                node_id: third_id,
+                label: None,
+            }))
+            .unwrap();
+        let edges = outgoing.get("edges").and_then(|e| e.as_array());
+        assert!(
+            edges.map(|e| e.is_empty()).unwrap_or(true),
+            "third node should have no outgoing edges after detach delete"
+        );
+
+        let incoming: serde_json::Value =
+            serde_json::from_str(&server.get_incoming_edges(GetIncomingEdgesRequest {
+                node_id: target_id,
+                label: None,
+            }))
+            .unwrap();
+        let in_edges = incoming.get("edges").and_then(|e| e.as_array());
+        assert!(
+            in_edges.map(|e| e.is_empty()).unwrap_or(true),
+            "target node should have no incoming edges after detach delete"
+        );
+    }
+
+    #[test]
+    fn test_delete_node_without_edges_succeeds_with_detach_false() {
+        // A node with no edges deletes cleanly and reports zero edges removed.
+        let server = create_test_server();
+        let created: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Lonely".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+
+        let delete_response = server.delete_node(DeleteNodeRequest {
+            node_id: created.id,
+            detach: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
+
+        assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
+        assert_eq!(value.get("edges_removed"), Some(&serde_json::json!(0)));
     }
 
     #[test]
@@ -1568,7 +1708,10 @@ mod error_handling_tests {
     fn test_delete_node_nonexistent() {
         let server = create_test_server();
 
-        let req = DeleteNodeRequest { node_id: 999999 };
+        let req = DeleteNodeRequest {
+            node_id: 999999,
+            detach: None,
+        };
 
         let response = server.delete_node(req);
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -44,11 +44,26 @@ pub struct UpdateNodeRequest {
 }
 
 /// Request to delete a node.
+///
+/// Safe-by-default (Issue #3209): if the node has connected edges and `detach`
+/// is not `true`, the deletion is refused and the response reports the number of
+/// connected edges (mirrors Cypher's `DETACH DELETE` contract). Set `detach:
+/// true` to delete the node together with all of its connected edges.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct DeleteNodeRequest {
     /// The unique identifier of the node to delete.
     #[schemars(description = "The unique identifier of the node to delete")]
     pub node_id: u64,
+
+    /// When `true`, also delete every edge connected to the node (cascade /
+    /// detach delete). When omitted or `false`, deleting a node that has
+    /// connected edges is refused and the response reports `connected_edges`.
+    #[schemars(
+        description = "When true, also delete all edges connected to the node (detach delete). \
+                       When false/omitted, deletion is refused if the node has connected edges, \
+                       and the response reports the connected edge count so the caller can decide."
+    )]
+    pub detach: Option<bool>,
 }
 
 /// Request to delete a node and all its connected edges (cascade delete).

--- a/src/storage/current/tests.rs
+++ b/src/storage/current/tests.rs
@@ -164,6 +164,36 @@ fn test_delete_node() {
 }
 
 #[test]
+fn test_delete_node_preserves_edges_for_audit() {
+    // Issue #3209: the low-level `delete_node` must retain its edge-preserving
+    // semantics for the documented audit/history use case. Its behavior is NOT
+    // changed by the safe-by-default MCP work, so the published crate surface
+    // stays backward-compatible.
+    let storage = CurrentStorage::new();
+
+    let alice = storage
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let bob = storage
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    let edge_id = storage
+        .create_edge(alice, bob, "KNOWS", PropertyMapBuilder::new().build())
+        .unwrap();
+
+    // Direct low-level delete removes only the node...
+    let deleted = storage.delete_node(alice).unwrap();
+    assert_eq!(deleted.id, alice);
+    assert!(storage.get_node(alice).is_err());
+
+    // ...and intentionally preserves the connected edge (audit path intact).
+    let edge = storage.get_edge(edge_id).unwrap();
+    assert_eq!(edge.source, alice);
+    assert_eq!(edge.target, bob);
+}
+
+#[test]
 fn test_delete_edge() {
     let storage = CurrentStorage::new();
 


### PR DESCRIPTION
## Summary

Implements safe-by-default node deletion in the MCP surface (Issue #3209) by mirroring Cypher's `DETACH DELETE` contract. The MCP `delete_node` tool now refuses to silently orphan edges—it either deletes cleanly or reports the number of connected edges and requires explicit opt-in via `detach: true` for cascade deletion.

## Key Changes

- **MCP `delete_node` is now safe-by-default**: 
  - If a node has connected edges and `detach` is not `true`, deletion is **refused** and the response reports `connected_edges` (the count of edges that would be orphaned)
  - Passing `detach: true` performs a cascade-equivalent delete and reports `edges_removed`
  - A node with no connected edges deletes cleanly with `edges_removed: 0`
  - This guarantees zero silent orphan-creating successes through the MCP surface

- **New `DeleteNodeRequest.detach` field**: Optional boolean flag to opt into cascade deletion. When omitted or `false`, deletion is refused if the node has connected edges.

- **New `count_connected_edges()` helper** (`src/db/ops.rs`): Additive, non-breaking method that counts both outgoing and incoming edges for a node. Returns an error if the node doesn't exist, preventing misleading zero counts for missing nodes.

- **Low-level Rust API unchanged**: The `delete_node()` method in `src/storage/current/mod.rs` retains its edge-preserving semantics for audit/history use cases. Only the MCP surface enforces the safe-by-default contract.

- **Comprehensive test coverage**:
  - `test_delete_node_with_edges_refused_without_detach`: Verifies refusal and `connected_edges` reporting
  - `test_delete_node_with_detach_removes_edges_no_dangling`: Verifies cascade delete removes all edges and leaves no dangling endpoints
  - `test_delete_node_without_edges_succeeds_with_detach_false`: Verifies clean deletion of isolated nodes
  - `test_count_connected_edges`: Verifies the new helper counts both directions and errors on missing nodes
  - `test_delete_node_preserves_edges_for_audit`: Confirms low-level API backward compatibility

- **Updated documentation** (`CLAUDE.md`): Clarifies the distinction between low-level edge-preserving semantics and MCP safe-by-default behavior, with examples of the new contract.

- **Helper function** (`create_two_nodes`): Added to test utilities to reduce boilerplate in edge-related tests.

## Implementation Details

The MCP handler now:
1. Calls `count_connected_edges()` to determine if the node has any connected edges
2. If edges exist and `detach` is not `true`, returns an error response with `connected_edges` count and `detach_required: true`
3. If `detach: true`, calls `delete_node_cascade()` and reports `edges_removed`
4. If no edges exist, calls the standard `delete_node()` and reports `edges_removed: 0`

This ensures LLMs and callers never receive a `success` response that breaks referential integrity.

https://claude.ai/code/session_01DG5MresLGWrwumdE4CrbRy