### PR TITLE
Add bulk graph importer for CSV/JSONL with per-row valid-time backfill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crossterm",
+ "csv",
  "dashmap",
  "embed_anything",
  "hkdf",
@@ -1924,6 +1925,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,9 @@ redb = "4.1"
 # SQL parser for SQL:2011 temporal syntax support (optional)
 sqlparser = { version = "0.40", optional = true }
 
+# CSV parsing for the bulk graph importer (optional, Issue #3211)
+csv = { version = "1.3", optional = true }
+
 # Parallel iteration for sharded vector index
 rayon = "1.12"
 comfy-table = "7.2.2"
@@ -202,6 +205,11 @@ sql = ["dep:sqlparser"]
 
 # Cypher query language support
 cypher = []
+
+# Bulk graph importer for CSV/JSONL with per-row valid-time backfill (Issue #3211).
+# serde_json (JSONL) and chrono (timestamp parsing) are already non-optional deps,
+# so the only extra dependency is the `csv` reader.
+import = ["dep:csv"]
 
 # HTTP server support (Issue #465) — built on autumn-web.
 http-server = [
@@ -460,3 +468,14 @@ required-features = ["semantic-temporal"]
 [[example]]
 name = "russian_writers"
 required-features = ["semantic-search", "semantic-reasoning"]
+
+# Bulk graph import with valid-time backfill (Issue #3211)
+[[example]]
+name = "bulk_import"
+required-features = ["import"]
+
+[[bench]]
+name = "import_throughput"
+harness = false
+path = "benches/import_throughput.rs"
+required-features = ["import"]

--- a/benches/import_throughput.rs
+++ b/benches/import_throughput.rs
@@ -1,0 +1,91 @@
+//! Bulk import throughput benchmark (Issue #3211).
+//!
+//! Compares the batched bulk importer against a naive per-row `create_node` loop.
+//!
+//! Success metric (from the issue): loading a 1M-node / 5M-edge CSV pair completes in
+//! < 60s in GroupCommit mode on commodity hardware, with >= 20% higher throughput than a
+//! naive per-row loop. This bench measures that relative win on a smaller, CI-friendly
+//! row count; scale `ROWS` (or `BENCH_IMPORT_ROWS`) up to reproduce the production target.
+
+mod common;
+
+use std::io::Write;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::api::import::{ColumnType, LabelSource, NodeMapping};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+
+/// Default row count for the benchmark (override with `BENCH_IMPORT_ROWS`).
+const ROWS: usize = 10_000;
+
+fn rows() -> usize {
+    std::env::var("BENCH_IMPORT_ROWS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ROWS)
+}
+
+/// Build a node CSV with `n` rows in a temp dir and return (dir, path).
+fn make_node_csv(n: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nodes.csv");
+    let mut file = std::fs::File::create(&path).expect("create csv");
+    writeln!(file, "id,name,age").unwrap();
+    for i in 0..n {
+        writeln!(file, "n{i},Name{i},{}", i % 100).unwrap();
+    }
+    file.flush().unwrap();
+    (dir, path)
+}
+
+fn node_mapping() -> NodeMapping {
+    NodeMapping::new(LabelSource::fixed("Person"), "id")
+        .property("name", "name", ColumnType::String)
+        .property("age", "age", ColumnType::Int)
+}
+
+fn bench_import(c: &mut Criterion) {
+    let n = rows();
+    let (_dir, csv_path) = make_node_csv(n);
+
+    let mut group = c.benchmark_group("bulk_import_nodes");
+    group.throughput(Throughput::Elements(n as u64));
+
+    // Batched importer: one commit per batch through the WAL append_batch path.
+    group.bench_function("importer_batched", |b| {
+        b.iter(|| {
+            let db = AletheiaDB::new().expect("db");
+            let mut importer = db.import();
+            let report = importer
+                .nodes_from_csv(&csv_path, node_mapping())
+                .expect("import");
+            black_box(report.nodes_imported);
+        });
+    });
+
+    // Naive baseline: one write transaction (one commit) per row.
+    group.bench_function("naive_per_row", |b| {
+        use aletheiadb::PropertyMapBuilder;
+        b.iter(|| {
+            let db = AletheiaDB::new().expect("db");
+            for i in 0..n {
+                let props = PropertyMapBuilder::new()
+                    .insert("name", format!("Name{i}"))
+                    .insert("age", (i % 100) as i64)
+                    .build();
+                db.create_node("Person", props).expect("create_node");
+            }
+            black_box(db.node_count());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_import
+);
+criterion_main!(benches);

--- a/examples/bulk_import.rs
+++ b/examples/bulk_import.rs
@@ -1,0 +1,89 @@
+//! Bulk graph import with valid-time backfill (Issue #3211).
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --features import --example bulk_import
+//! ```
+//!
+//! This example writes a small sample dataset (a node CSV carrying a per-row
+//! `valid_time` column, plus an edge CSV that references nodes by business key),
+//! bulk-loads both with **fewer than 15 lines of importer code**, and then issues an
+//! `AS OF VALID_TIME` query proving the historical backfill round-trips.
+
+use std::io::Write;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::api::import::{ColumnType, EdgeMapping, LabelSource, NodeMapping};
+use aletheiadb::core::temporal::time;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // --- Sample dataset -----------------------------------------------------
+    // Two people, each with the valid time at which the fact became true, and one
+    // KNOWS edge that references them by business key ("id").
+    let dir = tempfile::tempdir()?;
+    let nodes_csv = dir.path().join("people.csv");
+    let edges_csv = dir.path().join("knows.csv");
+
+    write(
+        &nodes_csv,
+        "id,name,role,known_since\n\
+         alice,Alice,Engineer,2021-01-01\n\
+         bob,Bob,Designer,2023-06-15\n",
+    )?;
+    write(&edges_csv, "src,dst,since\nalice,bob,2023-06-15\n")?;
+
+    // --- Bulk import (the < 15 lines of caller code) ------------------------
+    let db = AletheiaDB::new()?;
+    let mut importer = db.import();
+    importer.nodes_from_csv(
+        &nodes_csv,
+        NodeMapping::new(LabelSource::fixed("Person"), "id")
+            .property("name", "name", ColumnType::String)
+            .property("role", "role", ColumnType::String)
+            .valid_time_column("known_since"),
+    )?;
+    importer.edges_from_csv(
+        &edges_csv,
+        EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst").valid_time_column("since"),
+    )?;
+
+    println!(
+        "Imported {} nodes and {} edges.",
+        db.node_count(),
+        db.edge_count()
+    );
+
+    // --- Prove the valid-time backfill with AS OF VALID_TIME ----------------
+    let alice = importer.resolve_key("alice").expect("alice imported");
+    let now = time::now();
+
+    // 2022-01-01: Alice's fact (valid since 2021-01-01) is already true.
+    let in_2022 = time::from_secs(1_640_995_200);
+    let alice_2022 = db.get_node_at_time(alice, in_2022, now);
+
+    // 2020-01-01: before Alice's valid_from — she is not yet a known fact.
+    let in_2020 = time::from_secs(1_577_836_800);
+    let alice_2020 = db.get_node_at_time(alice, in_2020, now);
+
+    println!("\nAS OF VALID_TIME round-trip:");
+    println!(
+        "  2022-01-01 -> Alice present: {} (expected true)",
+        alice_2022.is_ok()
+    );
+    println!(
+        "  2020-01-01 -> Alice present: {} (expected false)",
+        alice_2020.is_ok()
+    );
+
+    assert!(alice_2022.is_ok(), "Alice should exist in 2022");
+    assert!(alice_2020.is_err(), "Alice should not exist in 2020");
+    println!("\nBackfill verified: the imported history is time-travelable.");
+
+    Ok(())
+}
+
+fn write(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(contents.as_bytes())
+}

--- a/src/api/import/mapping.rs
+++ b/src/api/import/mapping.rs
@@ -1,0 +1,198 @@
+//! Column mappings that tell the [`Importer`](super::Importer) how to interpret
+//! the rows of a CSV/JSONL file when building graph nodes and edges.
+//!
+//! Mappings are explicit: the caller declares which column supplies the label, the
+//! business key, each property (with a coercion [`ColumnType`]), and — optionally —
+//! the per-row `valid_time`. There is no schema inference (out of scope for #3211).
+
+/// The type a source column's raw value is coerced into before being stored as a
+/// property value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnType {
+    /// Store the value as a UTF-8 string.
+    String,
+    /// Parse the value as a 64-bit signed integer.
+    Int,
+    /// Parse the value as a 64-bit float.
+    Float,
+    /// Parse the value as a boolean (`true`/`false`, case-insensitive, or `1`/`0`).
+    Bool,
+}
+
+/// Where a node's or edge's label comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabelSource {
+    /// A constant label applied to every imported row.
+    Fixed(String),
+    /// The label is read from the named column on each row.
+    Column(String),
+}
+
+impl LabelSource {
+    /// A constant label applied to every row.
+    pub fn fixed(label: impl Into<String>) -> Self {
+        LabelSource::Fixed(label.into())
+    }
+
+    /// Read the label from the named column.
+    pub fn column(column: impl Into<String>) -> Self {
+        LabelSource::Column(column.into())
+    }
+}
+
+/// Maps one source column to a stored property with an explicit coercion type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropertyMapping {
+    /// The source column name (CSV header or JSONL object key).
+    pub column: String,
+    /// The property name to store on the node/edge.
+    pub name: String,
+    /// How to coerce the raw value.
+    pub ty: ColumnType,
+}
+
+impl PropertyMapping {
+    /// Map `column` to a property named `name` with coercion `ty`.
+    pub fn new(column: impl Into<String>, name: impl Into<String>, ty: ColumnType) -> Self {
+        PropertyMapping {
+            column: column.into(),
+            name: name.into(),
+            ty,
+        }
+    }
+
+    /// Map a column to a property of the same name.
+    pub fn same(column: impl Into<String>, ty: ColumnType) -> Self {
+        let column = column.into();
+        PropertyMapping {
+            name: column.clone(),
+            column,
+            ty,
+        }
+    }
+}
+
+/// Describes how to turn the rows of a node file into graph nodes.
+///
+/// Built fluently:
+///
+/// ```rust,no_run
+/// use aletheiadb::api::import::{ColumnType, LabelSource, NodeMapping};
+///
+/// let mapping = NodeMapping::new(LabelSource::fixed("Person"), "id")
+///     .property("name", "name", ColumnType::String)
+///     .property("age", "age", ColumnType::Int)
+///     .valid_time_column("known_since");
+/// ```
+#[derive(Debug, Clone)]
+pub struct NodeMapping {
+    /// Where the node label comes from.
+    pub label: LabelSource,
+    /// The column holding the business key used to resolve edges to this node.
+    pub key_column: String,
+    /// Columns to store as properties.
+    pub properties: Vec<PropertyMapping>,
+    /// Optional column carrying the per-row valid time. When `None` (or empty for a
+    /// given row) the row defaults to import (transaction) time.
+    pub valid_time_column: Option<String>,
+}
+
+impl NodeMapping {
+    /// Create a node mapping with the given label source and business-key column.
+    pub fn new(label: LabelSource, key_column: impl Into<String>) -> Self {
+        NodeMapping {
+            label,
+            key_column: key_column.into(),
+            properties: Vec::new(),
+            valid_time_column: None,
+        }
+    }
+
+    /// Add a property mapping (`column` -> property `name` with coercion `ty`).
+    #[must_use]
+    pub fn property(
+        mut self,
+        column: impl Into<String>,
+        name: impl Into<String>,
+        ty: ColumnType,
+    ) -> Self {
+        self.properties.push(PropertyMapping::new(column, name, ty));
+        self
+    }
+
+    /// Add a property mapping where the property name equals the column name.
+    #[must_use]
+    pub fn property_same(mut self, column: impl Into<String>, ty: ColumnType) -> Self {
+        self.properties.push(PropertyMapping::same(column, ty));
+        self
+    }
+
+    /// Designate the per-row valid-time column.
+    #[must_use]
+    pub fn valid_time_column(mut self, column: impl Into<String>) -> Self {
+        self.valid_time_column = Some(column.into());
+        self
+    }
+}
+
+/// Describes how to turn the rows of an edge file into graph edges.
+///
+/// Edges reference nodes by a user-supplied **business key** (not internal `NodeId`);
+/// the [`Importer`](super::Importer) resolves keys to ids using the nodes imported in
+/// the same session.
+#[derive(Debug, Clone)]
+pub struct EdgeMapping {
+    /// Where the edge label comes from.
+    pub label: LabelSource,
+    /// The column holding the source node's business key.
+    pub source_key_column: String,
+    /// The column holding the target node's business key.
+    pub target_key_column: String,
+    /// Columns to store as properties.
+    pub properties: Vec<PropertyMapping>,
+    /// Optional column carrying the per-row valid time.
+    pub valid_time_column: Option<String>,
+}
+
+impl EdgeMapping {
+    /// Create an edge mapping with the given label source and source/target key columns.
+    pub fn new(
+        label: LabelSource,
+        source_key_column: impl Into<String>,
+        target_key_column: impl Into<String>,
+    ) -> Self {
+        EdgeMapping {
+            label,
+            source_key_column: source_key_column.into(),
+            target_key_column: target_key_column.into(),
+            properties: Vec::new(),
+            valid_time_column: None,
+        }
+    }
+
+    /// Add a property mapping (`column` -> property `name` with coercion `ty`).
+    #[must_use]
+    pub fn property(
+        mut self,
+        column: impl Into<String>,
+        name: impl Into<String>,
+        ty: ColumnType,
+    ) -> Self {
+        self.properties.push(PropertyMapping::new(column, name, ty));
+        self
+    }
+
+    /// Add a property mapping where the property name equals the column name.
+    #[must_use]
+    pub fn property_same(mut self, column: impl Into<String>, ty: ColumnType) -> Self {
+        self.properties.push(PropertyMapping::same(column, ty));
+        self
+    }
+
+    /// Designate the per-row valid-time column.
+    #[must_use]
+    pub fn valid_time_column(mut self, column: impl Into<String>) -> Self {
+        self.valid_time_column = Some(column.into());
+        self
+    }
+}

--- a/src/api/import/mod.rs
+++ b/src/api/import/mod.rs
@@ -1,0 +1,600 @@
+//! Bulk graph importer for CSV/JSONL with per-row valid-time backfill (Issue #3211).
+//!
+//! The importer loads a file of nodes and a file of edges into the graph in one pass.
+//! Compared to a hand-written per-record `create_node` / `create_edge` loop it:
+//!
+//! - commits **chunks** of rows in a single ACID transaction (never one commit per row),
+//!   routing the writes through the WAL `append_batch` path for higher throughput;
+//! - supports an **optional per-row `valid_time` column**, so historical facts are
+//!   backfilled and immediately queryable with `AS OF VALID_TIME`. When the column is
+//!   absent (or blank for a row) the row defaults to import (transaction) time;
+//! - resolves edges by a user-supplied **business key** (not internal `NodeId`) in one
+//!   pass; unresolved endpoints are **reported, not silently dropped**;
+//! - reports malformed rows with a precise `row N:` message, with a caller-selectable
+//!   [`FailureMode`] (abort on the first bad row, or skip-and-report).
+//!
+//! # Atomicity
+//!
+//! Each chunk of [`ImportConfig::batch_size`] rows commits as one ACID transaction. A
+//! multi-file import (nodes then edges) is therefore **not** a single global transaction:
+//! in [`FailureMode::Abort`] the first bad row returns an `Err` and no further chunks are
+//! committed, but any *already-committed* chunks persist. Callers needing all-or-nothing
+//! semantics should validate input first or run against a disposable database.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use aletheiadb::AletheiaDB;
+//! use aletheiadb::api::import::{ColumnType, EdgeMapping, LabelSource, NodeMapping};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = AletheiaDB::new()?;
+//! let mut importer = db.import();
+//!
+//! let nodes = NodeMapping::new(LabelSource::fixed("Person"), "id")
+//!     .property("name", "name", ColumnType::String)
+//!     .valid_time_column("known_since");
+//! importer.nodes_from_csv("people.csv", nodes)?;
+//!
+//! let edges = EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst");
+//! importer.edges_from_csv("knows.csv", edges)?;
+//! # Ok(())
+//! # }
+//! ```
+
+mod mapping;
+mod parse;
+
+#[cfg(test)]
+mod tests;
+
+pub use mapping::{ColumnType, EdgeMapping, LabelSource, NodeMapping, PropertyMapping};
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+
+use parse::{Row, RowIter};
+
+use crate::core::error::{Error, Result};
+use crate::core::id::NodeId;
+use crate::core::property::{PropertyMap, PropertyMapBuilder, PropertyValue};
+use crate::core::temporal::Timestamp;
+use crate::db::AletheiaDB;
+
+/// How the importer reacts to a malformed row or an edge whose endpoint key cannot
+/// be resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FailureMode {
+    /// Abort the entire import on the first bad row, returning an `Err`.
+    #[default]
+    Abort,
+    /// Skip bad rows, collect them in the [`ImportReport`], and keep importing.
+    SkipAndReport,
+}
+
+/// Tunables for an import run.
+#[derive(Debug, Clone)]
+pub struct ImportConfig {
+    /// Number of rows committed per WAL batch transaction (default `1000`).
+    pub batch_size: usize,
+    /// How to react to malformed rows / unresolved endpoints (default [`FailureMode::Abort`]).
+    pub failure_mode: FailureMode,
+}
+
+impl Default for ImportConfig {
+    fn default() -> Self {
+        ImportConfig {
+            batch_size: 1000,
+            failure_mode: FailureMode::Abort,
+        }
+    }
+}
+
+/// Which end of an edge failed to resolve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endpoint {
+    /// The edge's source endpoint.
+    Source,
+    /// The edge's target endpoint.
+    Target,
+}
+
+impl fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Endpoint::Source => f.write_str("source"),
+            Endpoint::Target => f.write_str("target"),
+        }
+    }
+}
+
+/// A row that could not be imported, with its 1-based row/line number.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RowError {
+    /// The 1-based row (CSV) or line (JSONL) number.
+    pub row: usize,
+    /// A precise, human-readable reason.
+    pub message: String,
+}
+
+impl fmt::Display for RowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "row {}: {}", self.row, self.message)
+    }
+}
+
+/// An edge whose source or target business key did not resolve to an imported node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedEndpoint {
+    /// The 1-based row number of the offending edge.
+    pub row: usize,
+    /// The unresolved business key.
+    pub key: String,
+    /// Which endpoint failed to resolve.
+    pub side: Endpoint,
+}
+
+impl fmt::Display for UnresolvedEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "row {}: unresolved {} key '{}'",
+            self.row, self.side, self.key
+        )
+    }
+}
+
+/// Summary of a single `nodes_from_*` / `edges_from_*` call.
+#[derive(Debug, Clone, Default)]
+pub struct ImportReport {
+    /// Number of input rows read (including skipped ones).
+    pub rows_read: usize,
+    /// Number of nodes successfully imported.
+    pub nodes_imported: usize,
+    /// Number of edges successfully imported.
+    pub edges_imported: usize,
+    /// Malformed rows that were skipped (only populated in [`FailureMode::SkipAndReport`]).
+    pub skipped: Vec<RowError>,
+    /// Edges whose endpoints could not be resolved (only populated in
+    /// [`FailureMode::SkipAndReport`]).
+    pub unresolved_endpoints: Vec<UnresolvedEndpoint>,
+}
+
+/// Errors raised by the bulk importer.
+#[derive(Debug)]
+pub enum ImportError {
+    /// A malformed row.
+    Row(RowError),
+    /// An edge endpoint that did not resolve to a node.
+    UnresolvedEndpoint(UnresolvedEndpoint),
+    /// An I/O error opening or reading the source file.
+    Io(String),
+}
+
+impl fmt::Display for ImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImportError::Row(e) => write!(f, "{e}"),
+            ImportError::UnresolvedEndpoint(e) => write!(f, "{e}"),
+            ImportError::Io(msg) => write!(f, "import I/O error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {}
+
+impl From<ImportError> for Error {
+    fn from(e: ImportError) -> Self {
+        Error::other(e.to_string())
+    }
+}
+
+/// Internal error from preparing a single edge: either a malformed row or an
+/// unresolved endpoint.
+enum EdgePrepError {
+    Row(RowError),
+    Unresolved(UnresolvedEndpoint),
+}
+
+/// A node prepared (parsed + coerced) and ready to be written.
+struct PreparedNode {
+    key: String,
+    label: String,
+    properties: PropertyMap,
+    valid_from: Option<Timestamp>,
+}
+
+/// An edge prepared (parsed + coerced + endpoints resolved) and ready to be written.
+struct PreparedEdge {
+    source: NodeId,
+    target: NodeId,
+    label: String,
+    properties: PropertyMap,
+    valid_from: Option<Timestamp>,
+}
+
+/// A stateful bulk importer obtained via [`AletheiaDB::import`].
+///
+/// The importer remembers the business-key → [`NodeId`] mapping built while importing
+/// nodes, so a subsequent `edges_from_*` call can resolve edge endpoints by key.
+pub struct Importer<'a> {
+    db: &'a AletheiaDB,
+    config: ImportConfig,
+    key_to_id: HashMap<String, NodeId>,
+}
+
+impl AletheiaDB {
+    /// Begin a bulk import session.
+    ///
+    /// Returns a stateful [`Importer`] that resolves edge endpoints against nodes
+    /// imported earlier in the same session. See the [module docs](self) for details.
+    pub fn import(&self) -> Importer<'_> {
+        Importer {
+            db: self,
+            config: ImportConfig::default(),
+            key_to_id: HashMap::new(),
+        }
+    }
+}
+
+impl<'a> Importer<'a> {
+    /// Override the full import configuration.
+    #[must_use]
+    pub fn with_config(mut self, config: ImportConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the failure mode (abort vs. skip-and-report).
+    #[must_use]
+    pub fn failure_mode(mut self, mode: FailureMode) -> Self {
+        self.config.failure_mode = mode;
+        self
+    }
+
+    /// Set the per-transaction batch size.
+    #[must_use]
+    pub fn batch_size(mut self, batch_size: usize) -> Self {
+        self.config.batch_size = batch_size.max(1);
+        self
+    }
+
+    /// Look up the [`NodeId`] imported for a business key (handy for assertions/examples).
+    pub fn resolve_key(&self, key: &str) -> Option<NodeId> {
+        self.key_to_id.get(key).copied()
+    }
+
+    // ---- Nodes -----------------------------------------------------------------
+
+    /// Import nodes from a CSV file.
+    pub fn nodes_from_csv(
+        &mut self,
+        path: impl AsRef<Path>,
+        mapping: NodeMapping,
+    ) -> Result<ImportReport> {
+        let rows = parse::csv_rows(path.as_ref())?;
+        self.import_nodes(rows, &mapping)
+    }
+
+    /// Import nodes from a JSONL file (one JSON object per line).
+    pub fn nodes_from_jsonl(
+        &mut self,
+        path: impl AsRef<Path>,
+        mapping: NodeMapping,
+    ) -> Result<ImportReport> {
+        let rows = parse::jsonl_rows(path.as_ref())?;
+        self.import_nodes(rows, &mapping)
+    }
+
+    fn import_nodes(&mut self, rows: RowIter, mapping: &NodeMapping) -> Result<ImportReport> {
+        let mut report = ImportReport::default();
+        let mut chunk: Vec<PreparedNode> = Vec::with_capacity(self.config.batch_size);
+
+        for row_result in rows {
+            report.rows_read += 1;
+            let row = match row_result {
+                Ok(row) => row,
+                Err(err) => {
+                    self.handle_row_failure(err, &mut report)?;
+                    continue;
+                }
+            };
+
+            match prepare_node(&row, mapping) {
+                Ok(prepared) => chunk.push(prepared),
+                Err(row_err) => match self.config.failure_mode {
+                    FailureMode::Abort => return Err(ImportError::Row(row_err).into()),
+                    FailureMode::SkipAndReport => report.skipped.push(row_err),
+                },
+            }
+
+            if chunk.len() >= self.config.batch_size {
+                self.commit_node_chunk(&mut chunk, &mut report)?;
+            }
+        }
+
+        self.commit_node_chunk(&mut chunk, &mut report)?;
+        Ok(report)
+    }
+
+    fn commit_node_chunk(
+        &mut self,
+        chunk: &mut Vec<PreparedNode>,
+        report: &mut ImportReport,
+    ) -> Result<()> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+        let prepared = std::mem::take(chunk);
+        let keys: Vec<String> = prepared.iter().map(|p| p.key.clone()).collect();
+
+        // One ACID transaction for the whole chunk: writes flow through the WAL
+        // `append_batch` path (see `api::transaction::write::wal`).
+        let ids = self.db.write(move |tx| {
+            use crate::api::transaction::WriteOps;
+            let mut ids = Vec::with_capacity(prepared.len());
+            for node in prepared {
+                let id =
+                    tx.create_node_with_valid_time(&node.label, node.properties, node.valid_from)?;
+                ids.push(id);
+            }
+            Ok::<Vec<NodeId>, Error>(ids)
+        })?;
+
+        for (key, id) in keys.into_iter().zip(ids) {
+            self.key_to_id.insert(key, id);
+            report.nodes_imported += 1;
+        }
+        Ok(())
+    }
+
+    // ---- Edges -----------------------------------------------------------------
+
+    /// Import edges from a CSV file, resolving endpoints by business key.
+    pub fn edges_from_csv(
+        &mut self,
+        path: impl AsRef<Path>,
+        mapping: EdgeMapping,
+    ) -> Result<ImportReport> {
+        let rows = parse::csv_rows(path.as_ref())?;
+        self.import_edges(rows, &mapping)
+    }
+
+    /// Import edges from a JSONL file, resolving endpoints by business key.
+    pub fn edges_from_jsonl(
+        &mut self,
+        path: impl AsRef<Path>,
+        mapping: EdgeMapping,
+    ) -> Result<ImportReport> {
+        let rows = parse::jsonl_rows(path.as_ref())?;
+        self.import_edges(rows, &mapping)
+    }
+
+    fn import_edges(&mut self, rows: RowIter, mapping: &EdgeMapping) -> Result<ImportReport> {
+        let mut report = ImportReport::default();
+        let mut chunk: Vec<PreparedEdge> = Vec::with_capacity(self.config.batch_size);
+
+        for row_result in rows {
+            report.rows_read += 1;
+            let row = match row_result {
+                Ok(row) => row,
+                Err(err) => {
+                    self.handle_row_failure(err, &mut report)?;
+                    continue;
+                }
+            };
+
+            match prepare_edge(&self.key_to_id, &row, mapping) {
+                Ok(prepared) => chunk.push(prepared),
+                Err(EdgePrepError::Row(row_err)) => match self.config.failure_mode {
+                    FailureMode::Abort => return Err(ImportError::Row(row_err).into()),
+                    FailureMode::SkipAndReport => report.skipped.push(row_err),
+                },
+                Err(EdgePrepError::Unresolved(endpoint)) => match self.config.failure_mode {
+                    FailureMode::Abort => {
+                        return Err(ImportError::UnresolvedEndpoint(endpoint).into());
+                    }
+                    FailureMode::SkipAndReport => report.unresolved_endpoints.push(endpoint),
+                },
+            }
+
+            if chunk.len() >= self.config.batch_size {
+                self.commit_edge_chunk(&mut chunk, &mut report)?;
+            }
+        }
+
+        self.commit_edge_chunk(&mut chunk, &mut report)?;
+        Ok(report)
+    }
+
+    fn commit_edge_chunk(
+        &mut self,
+        chunk: &mut Vec<PreparedEdge>,
+        report: &mut ImportReport,
+    ) -> Result<()> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+        let prepared = std::mem::take(chunk);
+        let count = prepared.len();
+
+        self.db.write(move |tx| {
+            use crate::api::transaction::WriteOps;
+            for edge in prepared {
+                tx.create_edge_with_valid_time(
+                    edge.source,
+                    edge.target,
+                    &edge.label,
+                    edge.properties,
+                    edge.valid_from,
+                )?;
+            }
+            Ok::<(), Error>(())
+        })?;
+
+        report.edges_imported += count;
+        Ok(())
+    }
+
+    /// Apply the failure mode to a row-level reader/parse error.
+    fn handle_row_failure(&self, err: ImportError, report: &mut ImportReport) -> Result<()> {
+        match self.config.failure_mode {
+            FailureMode::Abort => Err(err.into()),
+            FailureMode::SkipAndReport => {
+                match err {
+                    ImportError::Row(row_err) => report.skipped.push(row_err),
+                    ImportError::UnresolvedEndpoint(endpoint) => {
+                        report.unresolved_endpoints.push(endpoint)
+                    }
+                    // An I/O error mid-stream is fatal even in skip mode.
+                    ImportError::Io(_) => return Err(err.into()),
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Resolve a label from a row per the [`LabelSource`].
+fn resolve_label(row: &Row, source: &LabelSource) -> std::result::Result<String, RowError> {
+    match source {
+        LabelSource::Fixed(label) => Ok(label.clone()),
+        LabelSource::Column(column) => {
+            let value = row.get_str(column).map_err(|message| RowError {
+                row: row.index,
+                message,
+            })?;
+            if value.trim().is_empty() {
+                return Err(RowError {
+                    row: row.index,
+                    message: format!("label column '{column}' is empty"),
+                });
+            }
+            Ok(value)
+        }
+    }
+}
+
+/// Build a [`PropertyMap`] from the mapping's property columns.
+fn build_properties(
+    row: &Row,
+    properties: &[PropertyMapping],
+) -> std::result::Result<PropertyMap, RowError> {
+    let mut builder = PropertyMapBuilder::new();
+    for mapping in properties {
+        let cell = row.cells.get(&mapping.column).ok_or_else(|| RowError {
+            row: row.index,
+            message: format!("missing column '{}'", mapping.column),
+        })?;
+        let value = parse::coerce(cell, mapping.ty).map_err(|message| RowError {
+            row: row.index,
+            message: format!("column '{}': {message}", mapping.column),
+        })?;
+        // Skip nulls so blank cells become absent properties rather than stored nulls.
+        if matches!(value, PropertyValue::Null) {
+            continue;
+        }
+        builder = builder
+            .try_insert(&mapping.name, value)
+            .map_err(|e| RowError {
+                row: row.index,
+                message: e.to_string(),
+            })?;
+    }
+    Ok(builder.build())
+}
+
+/// Extract an optional valid time from the named column.
+fn extract_valid_time(
+    row: &Row,
+    column: &Option<String>,
+) -> std::result::Result<Option<Timestamp>, RowError> {
+    let Some(column) = column else {
+        return Ok(None);
+    };
+    let raw = row.get_str(column).map_err(|message| RowError {
+        row: row.index,
+        message,
+    })?;
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let ts = parse::parse_valid_time(&raw).map_err(|message| RowError {
+        row: row.index,
+        message,
+    })?;
+    Ok(Some(ts))
+}
+
+fn prepare_node(row: &Row, mapping: &NodeMapping) -> std::result::Result<PreparedNode, RowError> {
+    let label = resolve_label(row, &mapping.label)?;
+    let key = row
+        .get_str(&mapping.key_column)
+        .map_err(|message| RowError {
+            row: row.index,
+            message,
+        })?;
+    if key.trim().is_empty() {
+        return Err(RowError {
+            row: row.index,
+            message: format!("key column '{}' is empty", mapping.key_column),
+        });
+    }
+    let properties = build_properties(row, &mapping.properties)?;
+    let valid_from = extract_valid_time(row, &mapping.valid_time_column)?;
+    Ok(PreparedNode {
+        key,
+        label,
+        properties,
+        valid_from,
+    })
+}
+
+fn prepare_edge(
+    key_to_id: &HashMap<String, NodeId>,
+    row: &Row,
+    mapping: &EdgeMapping,
+) -> std::result::Result<PreparedEdge, EdgePrepError> {
+    let label = resolve_label(row, &mapping.label).map_err(EdgePrepError::Row)?;
+
+    let source_key = row.get_str(&mapping.source_key_column).map_err(|message| {
+        EdgePrepError::Row(RowError {
+            row: row.index,
+            message,
+        })
+    })?;
+    let target_key = row.get_str(&mapping.target_key_column).map_err(|message| {
+        EdgePrepError::Row(RowError {
+            row: row.index,
+            message,
+        })
+    })?;
+
+    let source = key_to_id.get(&source_key).copied().ok_or_else(|| {
+        EdgePrepError::Unresolved(UnresolvedEndpoint {
+            row: row.index,
+            key: source_key.clone(),
+            side: Endpoint::Source,
+        })
+    })?;
+    let target = key_to_id.get(&target_key).copied().ok_or_else(|| {
+        EdgePrepError::Unresolved(UnresolvedEndpoint {
+            row: row.index,
+            key: target_key.clone(),
+            side: Endpoint::Target,
+        })
+    })?;
+
+    let properties = build_properties(row, &mapping.properties).map_err(EdgePrepError::Row)?;
+    let valid_from =
+        extract_valid_time(row, &mapping.valid_time_column).map_err(EdgePrepError::Row)?;
+
+    Ok(PreparedEdge {
+        source,
+        target,
+        label,
+        properties,
+        valid_from,
+    })
+}

--- a/src/api/import/parse.rs
+++ b/src/api/import/parse.rs
@@ -1,0 +1,249 @@
+//! Row readers (CSV / JSONL) and value coercion for the bulk importer.
+//!
+//! Both readers yield a uniform stream of `Result<Row, ImportError>` so the import
+//! loop in [`super`] is format-agnostic. A [`Row`] holds raw [`Cell`]s keyed by
+//! column name; coercion to [`PropertyValue`] happens lazily, driven by the caller's
+//! [`ColumnType`](super::mapping::ColumnType) mapping.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
+
+use super::mapping::ColumnType;
+use super::{ImportError, RowError};
+use crate::core::property::PropertyValue;
+use crate::core::temporal::Timestamp;
+
+/// A raw cell value, before coercion. CSV cells are always strings; JSONL cells
+/// preserve their parsed JSON type.
+#[derive(Debug, Clone)]
+pub(crate) enum Cell {
+    Str(String),
+    Json(serde_json::Value),
+}
+
+/// One parsed input row: the 1-based row/line number plus its named cells.
+#[derive(Debug, Clone)]
+pub(crate) struct Row {
+    pub(crate) index: usize,
+    pub(crate) cells: HashMap<String, Cell>,
+}
+
+/// A boxed, streaming iterator of parsed rows.
+pub(crate) type RowIter = Box<dyn Iterator<Item = Result<Row, ImportError>>>;
+
+impl Row {
+    /// Fetch a cell as a string, erroring if the column is absent.
+    pub(crate) fn get_str(&self, column: &str) -> Result<String, String> {
+        match self.cells.get(column) {
+            Some(cell) => Ok(cell_to_string(cell)),
+            None => Err(format!("missing column '{column}'")),
+        }
+    }
+}
+
+/// Render a cell as a plain string (used for labels, keys, and valid-time parsing).
+fn cell_to_string(cell: &Cell) -> String {
+    match cell {
+        Cell::Str(s) => s.clone(),
+        Cell::Json(serde_json::Value::String(s)) => s.clone(),
+        Cell::Json(serde_json::Value::Null) => String::new(),
+        Cell::Json(other) => other.to_string(),
+    }
+}
+
+/// Coerce a raw cell to a [`PropertyValue`] per the requested [`ColumnType`].
+///
+/// An empty value coerces to [`PropertyValue::Null`] for the non-string types so that
+/// blank cells become "absent" rather than a hard error.
+pub(crate) fn coerce(cell: &Cell, ty: ColumnType) -> Result<PropertyValue, String> {
+    match cell {
+        Cell::Str(s) => coerce_str(s, ty),
+        Cell::Json(value) => coerce_json(value, ty),
+    }
+}
+
+fn coerce_str(raw: &str, ty: ColumnType) -> Result<PropertyValue, String> {
+    let trimmed = raw.trim();
+    match ty {
+        ColumnType::String => Ok(PropertyValue::string(raw)),
+        ColumnType::Int => {
+            if trimmed.is_empty() {
+                return Ok(PropertyValue::Null);
+            }
+            trimmed
+                .parse::<i64>()
+                .map(PropertyValue::Int)
+                .map_err(|_| format!("cannot coerce '{raw}' to Int"))
+        }
+        ColumnType::Float => {
+            if trimmed.is_empty() {
+                return Ok(PropertyValue::Null);
+            }
+            trimmed
+                .parse::<f64>()
+                .map(PropertyValue::Float)
+                .map_err(|_| format!("cannot coerce '{raw}' to Float"))
+        }
+        ColumnType::Bool => {
+            if trimmed.is_empty() {
+                return Ok(PropertyValue::Null);
+            }
+            parse_bool(trimmed)
+                .map(PropertyValue::Bool)
+                .ok_or_else(|| format!("cannot coerce '{raw}' to Bool"))
+        }
+    }
+}
+
+fn coerce_json(value: &serde_json::Value, ty: ColumnType) -> Result<PropertyValue, String> {
+    use serde_json::Value;
+    match (ty, value) {
+        (_, Value::Null) => Ok(PropertyValue::Null),
+        (ColumnType::String, Value::String(s)) => Ok(PropertyValue::string(s)),
+        (ColumnType::String, other) => Ok(PropertyValue::string(other.to_string())),
+        (ColumnType::Int, Value::Number(n)) => n
+            .as_i64()
+            .map(PropertyValue::Int)
+            .ok_or_else(|| format!("cannot coerce '{n}' to Int")),
+        (ColumnType::Int, Value::String(s)) => coerce_str(s, ColumnType::Int),
+        (ColumnType::Float, Value::Number(n)) => n
+            .as_f64()
+            .map(PropertyValue::Float)
+            .ok_or_else(|| format!("cannot coerce '{n}' to Float")),
+        (ColumnType::Float, Value::String(s)) => coerce_str(s, ColumnType::Float),
+        (ColumnType::Bool, Value::Bool(b)) => Ok(PropertyValue::Bool(*b)),
+        (ColumnType::Bool, Value::String(s)) => coerce_str(s, ColumnType::Bool),
+        (ty, other) => Err(format!("cannot coerce JSON {other} to {ty:?}")),
+    }
+}
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "t" => Some(true),
+        "false" | "0" | "no" | "f" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse a per-row valid-time string into a [`Timestamp`].
+///
+/// Accepts (in priority order): bare integer microseconds since the Unix epoch,
+/// RFC 3339 / ISO 8601 with `Z` or a numeric offset, a naive datetime (assumed UTC),
+/// and a bare date (`YYYY-MM-DD`, midnight UTC). Mirrors the SQL temporal parser so
+/// imported timestamps round-trip with `AS OF` queries.
+pub(crate) fn parse_valid_time(s: &str) -> Result<Timestamp, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err("empty valid_time value".to_string());
+    }
+
+    // Bare integer => microseconds since epoch (matches SQL temporal parser).
+    if let Ok(micros) = trimmed.parse::<i64>() {
+        return Ok(Timestamp::from(micros));
+    }
+    if let Ok(dt) = trimmed.parse::<DateTime<Utc>>() {
+        return Ok(Timestamp::from(dt.timestamp_micros()));
+    }
+    if let Ok(dt) = trimmed.parse::<DateTime<FixedOffset>>() {
+        return Ok(Timestamp::from(dt.with_timezone(&Utc).timestamp_micros()));
+    }
+    if let Ok(dt) = trimmed.parse::<NaiveDateTime>() {
+        return Ok(Timestamp::from(dt.and_utc().timestamp_micros()));
+    }
+    if let Ok(date) = trimmed.parse::<NaiveDate>() {
+        let dt = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| format!("invalid date '{s}'"))?;
+        return Ok(Timestamp::from(dt.and_utc().timestamp_micros()));
+    }
+
+    Err(format!("could not parse valid_time '{s}'"))
+}
+
+/// Build a streaming row reader over a CSV file (first record is the header).
+pub(crate) fn csv_rows(path: &Path) -> Result<RowIter, ImportError> {
+    let file = File::open(path)
+        .map_err(|e| ImportError::Io(format!("opening {}: {e}", path.display())))?;
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_reader(file);
+
+    let headers = reader
+        .headers()
+        .map_err(|e| ImportError::Io(format!("reading header of {}: {e}", path.display())))?
+        .clone();
+
+    let iter = reader.into_records().enumerate().map(move |(i, record)| {
+        let row_num = i + 1;
+        match record {
+            Ok(record) => {
+                let mut cells = HashMap::with_capacity(headers.len());
+                for (header, value) in headers.iter().zip(record.iter()) {
+                    cells.insert(header.to_string(), Cell::Str(value.to_string()));
+                }
+                Ok(Row {
+                    index: row_num,
+                    cells,
+                })
+            }
+            Err(e) => Err(ImportError::Row(RowError {
+                row: row_num,
+                message: format!("CSV parse error: {e}"),
+            })),
+        }
+    });
+
+    Ok(Box::new(iter))
+}
+
+/// Build a streaming row reader over a JSONL file (one JSON object per line).
+///
+/// Blank lines are skipped and do not count as rows; the 1-based line number is used
+/// as the row index for error reporting.
+pub(crate) fn jsonl_rows(path: &Path) -> Result<RowIter, ImportError> {
+    let file = File::open(path)
+        .map_err(|e| ImportError::Io(format!("opening {}: {e}", path.display())))?;
+    let reader = BufReader::new(file);
+
+    let iter = reader.lines().enumerate().filter_map(move |(i, line)| {
+        let line_num = i + 1;
+        match line {
+            Ok(line) => {
+                if line.trim().is_empty() {
+                    return None;
+                }
+                match serde_json::from_str::<serde_json::Value>(&line) {
+                    Ok(serde_json::Value::Object(map)) => {
+                        let cells = map
+                            .into_iter()
+                            .map(|(k, v)| (k, Cell::Json(v)))
+                            .collect::<HashMap<_, _>>();
+                        Some(Ok(Row {
+                            index: line_num,
+                            cells,
+                        }))
+                    }
+                    Ok(_) => Some(Err(ImportError::Row(RowError {
+                        row: line_num,
+                        message: "JSONL line is not a JSON object".to_string(),
+                    }))),
+                    Err(e) => Some(Err(ImportError::Row(RowError {
+                        row: line_num,
+                        message: format!("invalid JSON: {e}"),
+                    }))),
+                }
+            }
+            Err(e) => Some(Err(ImportError::Row(RowError {
+                row: line_num,
+                message: format!("IO error reading line: {e}"),
+            }))),
+        }
+    });
+
+    Ok(Box::new(iter))
+}

--- a/src/api/import/tests.rs
+++ b/src/api/import/tests.rs
@@ -1,0 +1,301 @@
+//! Tests for the bulk graph importer (Issue #3211).
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::core::property::PropertyValue;
+use crate::core::temporal::time;
+use crate::test_utils::create_test_db;
+
+/// Write `contents` to a file named `name` inside `dir`, returning its path.
+fn write_file(dir: &TempDir, name: &str, contents: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    let mut file = std::fs::File::create(&path).expect("create temp file");
+    file.write_all(contents.as_bytes())
+        .expect("write temp file");
+    path
+}
+
+fn person_nodes(key_col: &str) -> NodeMapping {
+    NodeMapping::new(LabelSource::fixed("Person"), key_col)
+        .property("name", "name", ColumnType::String)
+        .property("age", "age", ColumnType::Int)
+}
+
+// AC: happy path — nodes + edges CSV load with type coercion.
+#[test]
+fn happy_path_nodes_and_edges_csv() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        "id,name,age\nalice,Alice,30\nbob,Bob,25\n",
+    );
+    let edges = write_file(&files, "edges.csv", "src,dst,since\nalice,bob,2020\n");
+
+    let mut importer = db.import();
+    let node_report = importer
+        .nodes_from_csv(&nodes, person_nodes("id"))
+        .expect("nodes import");
+    assert_eq!(node_report.rows_read, 2);
+    assert_eq!(node_report.nodes_imported, 2);
+    assert!(node_report.skipped.is_empty());
+
+    let edge_mapping = EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst").property(
+        "since",
+        "since",
+        ColumnType::Int,
+    );
+    let edge_report = importer
+        .edges_from_csv(&edges, edge_mapping)
+        .expect("edges import");
+    assert_eq!(edge_report.edges_imported, 1);
+    assert!(edge_report.unresolved_endpoints.is_empty());
+
+    assert_eq!(db.node_count(), 2);
+    assert_eq!(db.edge_count(), 1);
+
+    // Type coercion: name is a String, age is an Int.
+    let alice = importer.resolve_key("alice").expect("alice resolved");
+    let node = db.get_node(alice).unwrap();
+    assert_eq!(
+        node.properties.get("name"),
+        Some(&PropertyValue::string("Alice"))
+    );
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(30)));
+
+    // Edge endpoints resolved by business key.
+    let bob = importer.resolve_key("bob").expect("bob resolved");
+    let out = db.get_outgoing_edges(alice);
+    assert_eq!(out.len(), 1);
+    assert_eq!(db.get_edge_target(out[0]).unwrap(), bob);
+}
+
+// AC: malformed row, Abort mode -> precise `row N:` error, nothing past it committed.
+#[test]
+fn malformed_row_abort_reports_row_number() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // Row 2 ("bob") has a non-integer age.
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        "id,name,age\nalice,Alice,30\nbob,Bob,notanumber\ncarol,Carol,40\n",
+    );
+
+    let mut importer = db.import().batch_size(1);
+    let err = importer
+        .nodes_from_csv(&nodes, person_nodes("id"))
+        .expect_err("should abort on malformed row");
+    let msg = err.to_string();
+    assert!(msg.contains("row 2"), "message was: {msg}");
+    assert!(msg.contains("Int"), "message was: {msg}");
+
+    // Abort: alice (row 1) committed before the bad row, carol (row 3) never reached.
+    assert_eq!(db.node_count(), 1);
+}
+
+// AC: malformed row, SkipAndReport mode -> good rows committed, precise errors reported.
+#[test]
+fn malformed_row_skip_and_report() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        "id,name,age\nalice,Alice,30\nbob,Bob,notanumber\ncarol,Carol,40\n",
+    );
+
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    let report = importer
+        .nodes_from_csv(&nodes, person_nodes("id"))
+        .expect("skip mode should not error");
+
+    assert_eq!(report.rows_read, 3);
+    assert_eq!(report.nodes_imported, 2);
+    assert_eq!(report.skipped.len(), 1);
+    assert_eq!(report.skipped[0].row, 2);
+    assert!(report.skipped[0].message.contains("Int"));
+    assert_eq!(db.node_count(), 2);
+}
+
+// AC: edges referencing missing endpoints are reported, not silently dropped.
+#[test]
+fn missing_endpoint_edges_reported() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let nodes = write_file(&files, "nodes.csv", "id,name,age\nalice,Alice,30\n");
+    // bob does not exist as a node.
+    let edges = write_file(&files, "edges.csv", "src,dst\nalice,bob\n");
+
+    let mut importer = db.import().failure_mode(FailureMode::SkipAndReport);
+    importer
+        .nodes_from_csv(&nodes, person_nodes("id"))
+        .expect("nodes");
+    let report = importer
+        .edges_from_csv(
+            &edges,
+            EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst"),
+        )
+        .expect("edges");
+
+    assert_eq!(report.edges_imported, 0);
+    assert_eq!(report.unresolved_endpoints.len(), 1);
+    let unresolved = &report.unresolved_endpoints[0];
+    assert_eq!(unresolved.row, 1);
+    assert_eq!(unresolved.key, "bob");
+    assert_eq!(unresolved.side, Endpoint::Target);
+    assert_eq!(db.edge_count(), 0);
+
+    // Same situation aborts in Abort mode.
+    let (_tmp2, db2) = create_test_db().unwrap();
+    let mut importer2 = db2.import();
+    importer2
+        .nodes_from_csv(&nodes, person_nodes("id"))
+        .unwrap();
+    let err = importer2
+        .edges_from_csv(
+            &edges,
+            EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst"),
+        )
+        .expect_err("abort on unresolved endpoint");
+    assert!(err.to_string().contains("unresolved"));
+}
+
+// AC: optional valid_time column -> data is queryable with AS OF VALID_TIME.
+#[test]
+fn valid_time_backfill_round_trips_with_as_of() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    // Alice's fact is valid from 2021-01-01.
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        "id,name,age,known_since\nalice,Alice,30,2021-01-01\n",
+    );
+
+    let mapping = person_nodes("id").valid_time_column("known_since");
+    let mut importer = db.import();
+    importer.nodes_from_csv(&nodes, mapping).unwrap();
+    let alice = importer.resolve_key("alice").unwrap();
+
+    let now = time::now();
+    // 2021-06-01 (after valid_from): node is visible.
+    let after = time::from_secs(1_622_505_600);
+    assert!(
+        db.get_node_at_time(alice, after, now).is_ok(),
+        "node should be valid after its valid_from"
+    );
+
+    // 2020-06-01 (before valid_from): node is NOT yet valid.
+    let before = time::from_secs(1_590_969_600);
+    assert!(
+        db.get_node_at_time(alice, before, now).is_err(),
+        "node should not be valid before its valid_from"
+    );
+}
+
+// AC: when valid_time is absent, rows default to import (transaction) time.
+#[test]
+fn without_valid_time_defaults_to_now() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(&files, "nodes.csv", "id,name,age\nalice,Alice,30\n");
+
+    let mut importer = db.import();
+    importer.nodes_from_csv(&nodes, person_nodes("id")).unwrap();
+    let alice = importer.resolve_key("alice").unwrap();
+
+    // Visible now in current state.
+    assert!(db.get_node(alice).is_ok());
+    let now = time::now();
+    assert!(db.get_node_at_time(alice, now, now).is_ok());
+}
+
+// AC: JSONL variant parses + imports equivalently.
+#[test]
+fn jsonl_nodes_and_edges() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let nodes = write_file(
+        &files,
+        "nodes.jsonl",
+        "{\"id\":\"alice\",\"name\":\"Alice\",\"age\":30}\n\n{\"id\":\"bob\",\"name\":\"Bob\",\"age\":25}\n",
+    );
+    let edges = write_file(
+        &files,
+        "edges.jsonl",
+        "{\"src\":\"alice\",\"dst\":\"bob\"}\n",
+    );
+
+    let mut importer = db.import();
+    let node_report = importer
+        .nodes_from_jsonl(&nodes, person_nodes("id"))
+        .unwrap();
+    // Blank line is skipped, not counted.
+    assert_eq!(node_report.rows_read, 2);
+    assert_eq!(node_report.nodes_imported, 2);
+
+    let edge_report = importer
+        .edges_from_jsonl(
+            &edges,
+            EdgeMapping::new(LabelSource::fixed("KNOWS"), "src", "dst"),
+        )
+        .unwrap();
+    assert_eq!(edge_report.edges_imported, 1);
+
+    let alice = importer.resolve_key("alice").unwrap();
+    let node = db.get_node(alice).unwrap();
+    assert_eq!(node.properties.get("age"), Some(&PropertyValue::Int(30)));
+}
+
+// AC: label-from-column works (in addition to fixed labels).
+#[test]
+fn label_from_column() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+    let nodes = write_file(
+        &files,
+        "nodes.csv",
+        "id,kind,name\nn1,Person,Alice\nn2,Company,Acme\n",
+    );
+
+    let mapping = NodeMapping::new(LabelSource::column("kind"), "id").property(
+        "name",
+        "name",
+        ColumnType::String,
+    );
+    let mut importer = db.import();
+    importer.nodes_from_csv(&nodes, mapping).unwrap();
+
+    assert_eq!(db.scan_nodes_by_label("Person").count(), 1);
+    assert_eq!(db.scan_nodes_by_label("Company").count(), 1);
+}
+
+// Batching: a chunk larger than one batch still imports every row.
+#[test]
+fn batching_across_multiple_chunks() {
+    let files = TempDir::new().unwrap();
+    let (_tmp, db) = create_test_db().unwrap();
+
+    let mut csv = String::from("id,name,age\n");
+    for i in 0..25 {
+        csv.push_str(&format!("n{i},Name{i},{i}\n"));
+    }
+    let nodes = write_file(&files, "nodes.csv", &csv);
+
+    let mut importer = db.import().batch_size(10);
+    let report = importer.nodes_from_csv(&nodes, person_nodes("id")).unwrap();
+    assert_eq!(report.nodes_imported, 25);
+    assert_eq!(db.node_count(), 25);
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -91,5 +91,15 @@
 
 pub mod transaction;
 
+/// Bulk graph importer for CSV/JSONL with per-row valid-time backfill (Issue #3211).
+#[cfg(feature = "import")]
+pub mod import;
+
 // Re-export commonly used types
 pub use transaction::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};
+
+#[cfg(feature = "import")]
+pub use import::{
+    ColumnType, EdgeMapping, Endpoint, FailureMode, ImportConfig, ImportError, ImportReport,
+    Importer, LabelSource, NodeMapping, PropertyMapping, RowError, UnresolvedEndpoint,
+};

--- a/src/api/transaction/write/wal.rs
+++ b/src/api/transaction/write/wal.rs
@@ -56,10 +56,24 @@ pub(crate) fn log_operations_to_wal(
     tx: &WriteTransaction,
     _commit_timestamp: Timestamp,
 ) -> Result<()> {
-    for write in tx.buffer.operations() {
-        // Append to WAL (lock-free!)
-        tx.wal.append_async(WalOperation::from(write))?;
+    // Collect all buffered writes into a single batch and append them under one atomic
+    // LSN allocation via the WAL `append_batch` path (Issue #219). This is strictly more
+    // efficient than the previous per-operation `append_async` loop for multi-operation
+    // transactions — e.g. each chunk committed by the bulk importer (Issue #3211) — and is
+    // behavior-preserving: `append_batch_async` only buffers, leaving the subsequent
+    // `wal.commit()` to perform the `DurabilityMode`-appropriate flush.
+    let operations: Vec<WalOperation> = tx
+        .buffer
+        .operations()
+        .iter()
+        .map(WalOperation::from)
+        .collect();
+
+    if operations.is_empty() {
+        return Ok(());
     }
+
+    tx.wal.append_batch_async(operations)?;
 
     Ok(())
 }

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -460,6 +460,19 @@ impl ConcurrentWalSystem {
         self.wal.append_async(operation)
     }
 
+    /// Append a batch of operations to the buffer without flushing (returns immediately).
+    ///
+    /// This is the batch counterpart of [`append_async`](Self::append_async): it buffers
+    /// every operation under a single atomic LSN allocation (the Issue #219 win) and lets
+    /// the configured durability path flush them later. Like `append_async`, it performs
+    /// **no** durability-mode branching — callers that need a flush still call
+    /// [`commit`](Self::commit) afterwards, which honors the active `DurabilityMode`. This
+    /// keeps the transaction commit path's behavior identical across Sync/Async/GroupCommit
+    /// while routing multi-operation transactions through the efficient batch append.
+    pub fn append_batch_async(&self, operations: Vec<WalOperation>) -> Result<Vec<LSN>> {
+        self.wal.append_batch(operations)
+    }
+
     /// Append an operation synchronously (waits for durability).
     ///
     /// This flushes immediately and waits for fsync.


### PR DESCRIPTION
## Summary

Implements a high-performance bulk graph importer for CSV and JSONL files with support for per-row valid-time backfill (Issue #3211). The importer commits chunks of rows in single ACID transactions through the WAL `append_batch` path, resolves edges by business key in one pass, and provides precise error reporting with configurable failure modes.

## Key Changes

- **New `api::import` module** with four submodules:
  - `mapping.rs`: Column type definitions and fluent mapping builders for nodes and edges
  - `parse.rs`: CSV/JSONL row readers and value coercion with temporal parsing
  - `mod.rs`: Core importer logic with batching, endpoint resolution, and error handling
  - `tests.rs`: Comprehensive test coverage for happy paths, error modes, and temporal queries

- **Importer features**:
  - Batched commits (configurable batch size, default 1000 rows) through WAL `append_batch` for higher throughput
  - Optional per-row `valid_time` column for historical fact backfill, queryable with `AS OF VALID_TIME`
  - Business-key-based edge resolution with unresolved endpoint reporting (not silent drops)
  - Precise row-level error messages with 1-based row numbers
  - Configurable failure modes: `Abort` (fail on first error) or `SkipAndReport` (collect errors, continue)
  - Stateful session that remembers node key→id mappings for edge resolution

- **Type coercion** for property values:
  - String, Int, Float, Bool with empty-cell-to-null semantics
  - Supports both CSV (string) and JSONL (native JSON types) sources
  - Temporal parsing accepts bare microseconds, RFC 3339, ISO 8601, naive datetime, and bare dates

- **WAL integration**:
  - Modified `src/api/transaction/write/wal.rs` to use `append_batch` for multi-operation transactions
  - Single atomic LSN allocation for entire chunk, improving CPU cache locality

- **Feature flag**: New optional `import` feature in `Cargo.toml` (depends on `csv`, `serde_json`, `chrono`)

- **Benchmark & example**:
  - `benches/import_throughput.rs`: Compares batched importer vs. naive per-row loop
  - `examples/bulk_import.rs`: Demonstrates CSV import with valid-time backfill and `AS OF` query

## Notable Implementation Details

- **Atomicity contract**: Each chunk commits as one ACID transaction; multi-file imports (nodes then edges) are not globally atomic. Callers needing all-or-nothing semantics should validate input first or use a disposable database.
- **Error handling**: Row-level parse errors and unresolved endpoints are distinguished; I/O errors are fatal even in `SkipAndReport` mode.
- **Streaming**: Both CSV and JSONL readers are streaming iterators to handle large files without loading into memory.
- **Valid-time defaults**: When the `valid_time_column` is absent or blank for a row, the row defaults to import (transaction) time.
- **Business keys**: Nodes are indexed by caller-supplied business keys (not internal `NodeId`); edges reference nodes by these keys, resolved in one pass after all nodes are imported.

https://claude.ai/code/session_01CN63KnujUAs48Ez27AC8Qf