### PR TITLE
👺 Havoc: Fix lock inversion deadlock in CircuitBreaker

### DIFF
--- a/src/storage/sharding/network.rs
+++ b/src/storage/sharding/network.rs
@@ -425,16 +425,24 @@ impl CircuitBreaker {
         };
 
         if state == CircuitState::Open {
+            let mut should_transition = false;
             if let Ok(opened) = self.opened_at.read() {
                 if let Some(opened_time) = *opened {
                     if opened_time.elapsed() >= self.config.open_duration {
-                        // Transition to half-open
-                        if let Ok(mut s) = self.state.write() {
-                            *s = CircuitState::HalfOpen;
-                        }
-                        self.success_count.store(0, Ordering::SeqCst);
+                        should_transition = true;
                     }
                 }
+            }
+
+            if should_transition {
+                // Transition to half-open
+                if let Ok(mut s) = self.state.write() {
+                    // Only transition if it's still Open
+                    if *s == CircuitState::Open {
+                        *s = CircuitState::HalfOpen;
+                    }
+                }
+                self.success_count.store(0, Ordering::SeqCst);
             }
         }
     }

--- a/tests/havoc_loom_network_deadlock.rs
+++ b/tests/havoc_loom_network_deadlock.rs
@@ -1,0 +1,91 @@
+#![allow(unexpected_cfgs)]
+#[cfg(loom)]
+mod loom_test {
+    use loom::sync::{Arc, RwLock};
+    use loom::thread;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum CircuitState {
+        Closed,
+        Open,
+        HalfOpen,
+    }
+
+    struct CircuitBreaker {
+        state: RwLock<CircuitState>,
+        opened_at: RwLock<Option<()>>,
+        last_failure: RwLock<Option<()>>,
+    }
+
+    impl CircuitBreaker {
+        fn new() -> Self {
+            Self {
+                state: RwLock::new(CircuitState::Closed),
+                opened_at: RwLock::new(None),
+                last_failure: RwLock::new(None),
+            }
+        }
+
+        fn record_failure(&self) {
+            let state = *self.state.read().unwrap();
+
+            if state == CircuitState::Closed {
+                {
+                    let _last = self.last_failure.read().unwrap();
+                }
+                let mut _last_w = self.last_failure.write().unwrap();
+
+                let mut s = self.state.write().unwrap();
+                *s = CircuitState::Open;
+                let mut opened = self.opened_at.write().unwrap();
+                *opened = Some(());
+            } else if state == CircuitState::HalfOpen {
+                let mut s = self.state.write().unwrap();
+                *s = CircuitState::Open;
+                let mut opened = self.opened_at.write().unwrap();
+                *opened = Some(());
+            } else {
+                let mut opened = self.opened_at.write().unwrap();
+                *opened = Some(());
+            }
+        }
+
+        fn maybe_transition(&self) {
+            let state = *self.state.read().unwrap();
+            if state == CircuitState::Open {
+                let mut should_transition = false;
+                {
+                    let _opened = self.opened_at.read().unwrap();
+                    should_transition = true;
+                }
+
+                if should_transition {
+                    let mut s = self.state.write().unwrap();
+                    if *s == CircuitState::Open {
+                        *s = CircuitState::HalfOpen;
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_circuit_breaker_deadlock() {
+        loom::model(|| {
+            let cb = Arc::new(CircuitBreaker::new());
+
+            let c1 = cb.clone();
+            let t1 = thread::spawn(move || {
+                c1.record_failure();
+            });
+
+            let c2 = cb.clone();
+            let t2 = thread::spawn(move || {
+                c2.maybe_transition();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+        });
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** A thread evaluating `maybe_transition()` holds a read lock on `opened_at` while simultaneously attempting to acquire a write lock on `state`. If another thread concurrently calls `record_failure()` from `CircuitState::Closed`, it acquires the `state` write lock and then attempts to acquire the `opened_at` write lock.
📉 **The Stack Trace:**
```text
thread 'loom_test::test_circuit_breaker_deadlock' (29403) panicked at loom-0.7.2/src/rt/execution.rs:216:13:
deadlock; threads = [(Id(0), Blocked(Location(None))), (Id(1), Blocked(Location(None))), (Id(2), Terminated)]
```
🧪 **Reproduction:** Run `RUSTFLAGS="--cfg loom" cargo test --test havoc_loom_network_deadlock`
😈 **Comment:** You assumed reading a timestamp inside an IF block was harmless. You were wrong. Lock inversion thrives exactly where you think it's just "one quick check". By evaluating the timestamp state *before* requesting the `state` write lock, we guarantee the transition completes cleanly without locking arms with a concurrently failing connection.

---
*PR created automatically by Jules for task [418589406225075510](https://jules.google.com/task/418589406225075510) started by @madmax983*