### PR TITLE
⚡ Bolt: Remove double Arc allocation in historical storage caches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Option 1: Optimize Cache Insertions in HistoricalStorage]**
+**Learning:** `PropertyMap` uses `#[derive(Clone)]` and wraps an `Arc<HashMap>`, so cloning it is just an O(1) atomic refcount increment. However, `HistoricalStorage`'s caches used `Arc<Cache<VersionId, Arc<PropertyMap>>>`, which wrapped the `PropertyMap` in *another* `Arc`, causing an unnecessary heap allocation on every cache miss and insertion.
+**Action:** Changed the cache type to `Arc<Cache<VersionId, PropertyMap>>` to avoid the double-boxing and eliminate the heap allocation on cache insertions.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -197,21 +197,21 @@ pub struct HistoricalStorage {
     cached_edge_anchor_count: usize,
     cached_edge_delta_count: usize,
     /// TinyLFU cache for reconstructed node properties (reduces lock contention)
-    node_property_cache: Arc<Cache<VersionId, Arc<PropertyMap>>>,
+    node_property_cache: Arc<Cache<VersionId, PropertyMap>>,
     /// TinyLFU cache for reconstructed edge properties
-    edge_property_cache: Arc<Cache<VersionId, Arc<PropertyMap>>>,
+    edge_property_cache: Arc<Cache<VersionId, PropertyMap>>,
     /// Improvement #1: Dedicated cache for node anchor properties.
     ///
     /// This separate cache ensures anchors are never evicted by delta cache pressure,
     /// providing guaranteed O(1) access to anchors even under heavy load. Anchors are
     /// frequently reused as base points for delta reconstruction, so keeping them cached
     /// reduces average reconstruction cost from O(N) to O(M) where M << N.
-    node_anchor_cache: Arc<Cache<VersionId, Arc<PropertyMap>>>,
+    node_anchor_cache: Arc<Cache<VersionId, PropertyMap>>,
     /// Improvement #1: Dedicated cache for edge anchor properties.
     ///
     /// This separate cache ensures anchors are never evicted by delta cache pressure,
     /// providing guaranteed O(1) access to anchors even under heavy load.
-    edge_anchor_cache: Arc<Cache<VersionId, Arc<PropertyMap>>>,
+    edge_anchor_cache: Arc<Cache<VersionId, PropertyMap>>,
     /// Improvement #3: Primary cache hit counter for adaptive sizing.
     ///
     /// Tracks successful lookups in the primary property cache (fast path).
@@ -661,13 +661,12 @@ impl HistoricalStorage {
         //         the previous delta's properties even though we just added them.
         // AFTER:  All versions are cached in the main property cache, eliminating
         //         unnecessary reconstructions during consecutive writes.
-        let props_arc = Arc::new(properties);
         self.node_property_cache
-            .insert(version_id, props_arc.clone());
+            .insert(version_id, properties.clone());
 
         // Anchors are also cached in the dedicated anchor cache for fallback
         if is_anchor {
-            self.node_anchor_cache.insert(version_id, props_arc);
+            self.node_anchor_cache.insert(version_id, properties);
         }
 
         // Notify observers
@@ -875,13 +874,12 @@ impl HistoricalStorage {
 
         // Issue #210: Cache properties for ALL versions (anchors and deltas) to avoid
         // reconstructing properties we just added when creating the next delta.
-        let props_arc = Arc::new(properties);
         self.edge_property_cache
-            .insert(version_id, props_arc.clone());
+            .insert(version_id, properties.clone());
 
         // Anchors are also cached in the dedicated anchor cache for fallback
         if is_anchor {
-            self.edge_anchor_cache.insert(version_id, props_arc);
+            self.edge_anchor_cache.insert(version_id, properties);
         }
 
         // Notify observers
@@ -1240,14 +1238,14 @@ impl HistoricalStorage {
     fn reconstruct_node_properties_with_depth(&self, version_id: VersionId) -> Result<PropertyMap> {
         if let Some(cached) = self.node_property_cache.get(&version_id) {
             self.primary_cache_hits.fetch_add(1, Ordering::Relaxed);
-            return Ok(cached.as_ref().clone());
+            return Ok(cached);
         }
 
         // Anchor cache fallback: survives primary cache eviction under delta pressure
         if let Some(cached) = self.node_anchor_cache.get(&version_id) {
             self.anchor_cache_hits.fetch_add(1, Ordering::Relaxed);
             self.node_property_cache.insert(version_id, cached.clone());
-            return Ok(cached.as_ref().clone());
+            return Ok(cached);
         }
 
         self.full_reconstructions.fetch_add(1, Ordering::Relaxed);
@@ -1256,7 +1254,7 @@ impl HistoricalStorage {
 
         // Populate cache for future reads
         self.node_property_cache
-            .insert(version_id, Arc::new(properties.clone()));
+            .insert(version_id, properties.clone());
 
         Ok(properties)
     }
@@ -1280,14 +1278,14 @@ impl HistoricalStorage {
     fn reconstruct_edge_properties_with_depth(&self, version_id: VersionId) -> Result<PropertyMap> {
         if let Some(cached) = self.edge_property_cache.get(&version_id) {
             self.primary_cache_hits.fetch_add(1, Ordering::Relaxed);
-            return Ok(cached.as_ref().clone());
+            return Ok(cached);
         }
 
         // Anchor cache fallback: survives primary cache eviction under delta pressure
         if let Some(cached) = self.edge_anchor_cache.get(&version_id) {
             self.anchor_cache_hits.fetch_add(1, Ordering::Relaxed);
             self.edge_property_cache.insert(version_id, cached.clone());
-            return Ok(cached.as_ref().clone());
+            return Ok(cached);
         }
 
         self.full_reconstructions.fetch_add(1, Ordering::Relaxed);
@@ -1296,7 +1294,7 @@ impl HistoricalStorage {
 
         // Populate cache for future reads
         self.edge_property_cache
-            .insert(version_id, Arc::new(properties.clone()));
+            .insert(version_id, properties.clone());
 
         Ok(properties)
     }


### PR DESCRIPTION
💡 What: Modified cache definitions in `HistoricalStorage` to store `PropertyMap` values directly instead of wrapping them in an outer `Arc` (`Arc<Cache<VersionId, PropertyMap>>` instead of `Arc<Cache<VersionId, Arc<PropertyMap>>>`).
🎯 Why: `PropertyMap` internally implements copy-on-write semantics by wrapping an `Arc<HashMap>`, making its `.clone()` an O(1) atomic refcount increment. The previous implementation needlessly boxed this already cheap-to-clone map inside another `Arc`, causing an unnecessary heap allocation on every cache miss and cache insertion.
📊 Impact: Removes one heap allocation per node and edge property cache miss (reconstruction) and insertion, improving read and write path performance for temporal point-in-time and as-of queries.
🔬 Measurement: Run a heavy historical workload with temporal index queries that miss cache and verify the reduced allocations via tracing/profiling.

Followed the Bolt persona guidelines for removing unnecessary heap allocations and prioritizing zero-cost abstractions, documented in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [13684721646929374745](https://jules.google.com/task/13684721646929374745) started by @madmax983*