### PR TITLE
Add read-only `query` tool for declarative Cypher/AQL execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,23 @@ cargo run --bin aletheia-mcp --features mcp-server
 | **Vector** | `find_similar`, `enable_vector_index`, `list_vector_indexes` |
 | **Temporal** | `get_node_at_time`, `get_edge_at_time` |
 | **Hybrid** | `hybrid_query` (combined graph + vector + temporal) |
+| **Query** | `query` (execute a single read-only Cypher/AQL statement; see below) |
+
+**`query` tool (read-only Cypher/AQL):** Lets an LLM answer a multi-hop,
+filtered, temporally-scoped question with **one declarative statement** instead
+of chaining `get_node`/`traverse`/filter calls. Accepts `language`
+(`"cypher"` | `"aql"`), `query` (the statement), optional `params` (`$param`
+bindings, Cypher only — numeric arrays are treated as embeddings), and `limit`
+(default 100, max 10000). Returns `{language, columns, rows, row_count,
+truncated}`. It is **read-only**: mutating clauses
+(CREATE/MERGE/SET/DELETE/REMOVE/DETACH/DROP/CALL/FOREACH/LOAD) are rejected
+before execution and never write. Errors come back as a structured
+`{error:{kind, message, clause?, language}}` payload (kinds: `invalid_request`,
+`read_only_violation`, `language_unavailable`, `parse_error`,
+`unsupported_construct`, `invalid_params`, `runtime_error`) so the caller can
+self-correct. When the `cypher` feature is not compiled in, `language:"cypher"`
+returns `language_unavailable` (AQL is always available). See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md).
 
 **Programmatic Usage:**
 ```rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,9 +4408,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -5518,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -1,0 +1,129 @@
+# MCP `query` Tool — Read-Only Cypher/AQL over MCP
+
+AletheiaDB's primary client is the LLM driving it through the [MCP
+server](../../src/mcp/server.rs). The `query` tool lets that LLM answer a
+multi-hop, filtered, temporally-scoped question with **one declarative
+statement** instead of orchestrating and stitching together several structured
+tool calls (`get_node` → `traverse` → fetch each → filter client-side).
+
+It wraps the engine's existing public APIs — `execute_aql`,
+`execute_cypher`, and `execute_cypher_with_params` (see
+[`src/db/query.rs`](../../src/db/query.rs)) — and is strictly **read-only**.
+
+## When to use it
+
+Reach for `query` when the question is a join/filter/temporal-scope expressible
+as one Cypher/AQL statement. Keep using the structured tools (`create_node`,
+`update_edge`, …) for writes and for simple single-entity lookups.
+
+## Tool contract
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `language` | string | `"cypher"` or `"aql"`. AQL is always available; Cypher requires the `cypher` build feature. |
+| `query` | string | The read-only statement. |
+| `params` | object (optional) | `$param` bindings — **Cypher only**. Numbers, strings, booleans, and null map directly; a numeric array is treated as an **embedding**. |
+| `limit` | number (optional) | Max rows. Default `100`, capped at `10000`. |
+
+### Success response
+
+```json
+{
+  "language": "cypher",
+  "columns": [
+    {"name": "entity", "type": "node|edge", "description": "..."},
+    {"name": "score", "type": "number|null", "description": "..."},
+    {"name": "path", "type": "array<number>|null", "description": "..."},
+    {"name": "timestamp", "type": "string|null", "description": "..."}
+  ],
+  "rows": [
+    {
+      "entity": {"type": "node", "id": 7, "label": "Product",
+                 "properties": {"name": "Widget", "price": 42}},
+      "score": null,
+      "path": null,
+      "timestamp": null
+    }
+  ],
+  "row_count": 1,
+  "truncated": false
+}
+```
+
+`truncated` is `true` when the result hit the `limit` cap (there were more rows).
+
+### Structured errors
+
+Errors are returned as a machine-readable payload so the LLM can self-correct:
+
+```json
+{ "error": { "kind": "read_only_violation", "clause": "CREATE",
+             "language": "cypher",
+             "message": "The `query` tool is read-only; the `CREATE` clause ..." } }
+```
+
+`kind` is one of: `invalid_request`, `read_only_violation`,
+`language_unavailable`, `parse_error`, `unsupported_construct`,
+`invalid_params`, `runtime_error`.
+
+## Supported read-only subset
+
+The tool exposes whatever the shipped grammars already support — it does **not**
+extend them. Advertised, supported constructs:
+
+- `MATCH` patterns with node/edge labels and inline property filters
+- Variable-depth traversal `-[:REL*1..3]->` and directions `->`, `<-`, `-`
+- `WHERE`, `RETURN [DISTINCT]` / `AS` aliases, `ORDER BY`, `SKIP`/`LIMIT`,
+  `WITH` chaining
+- Vector similarity ranking
+- Bi-temporal scoping: `AS OF TIMESTAMP/VALID_TIME/SYSTEM_TIME`,
+  `FOR SYSTEM_TIME AS OF '…'`, `BETWEEN '…' AND '…'`
+
+Mutating clauses (`CREATE`, `MERGE`, `SET`, `DELETE`, `REMOVE`, `DETACH`,
+`DROP`, `CALL`, `FOREACH`, `LOAD`) are rejected **before execution**.
+
+## End-to-end example (LLM-style)
+
+**Question:** *"As of June 2026, which Products does Alice's KNOWS-network view
+that cost under $100?"*
+
+Previously this required ≥4 structured calls (resolve Alice → traverse `KNOWS`
+→ traverse `VIEWED` → fetch each Product → filter by price). With `query` it is
+**one** tool call:
+
+```jsonc
+// tools/call -> "query"
+{
+  "language": "cypher",
+  "query": "MATCH (a:Person {name: $name})-[:KNOWS]->(:Person)-[:VIEWED]->(p:Product) FOR SYSTEM_TIME AS OF '2026-06-01T00:00:00Z' WHERE p.price < 100 RETURN p ORDER BY p.price",
+  "params": { "name": "Alice" },
+  "limit": 20
+}
+```
+
+The response is structured rows of `Product` nodes, already filtered and
+temporally scoped by the engine's planner.
+
+### Passing an embedding as a parameter
+
+```jsonc
+{
+  "language": "cypher",
+  "query": "MATCH (d:Document) RETURN d ORDER BY vector.similarity(d.embedding, $q) DESC LIMIT 5",
+  "params": { "q": [0.12, 0.04, 0.98, 0.33] }
+}
+```
+
+A numeric array parameter is bound as an embedding, so the LLM never has to
+string-concatenate vectors into the query text.
+
+## Notes
+
+- **AQL has no parameter binding.** Sending `params` with `language: "aql"`
+  returns an `invalid_request` error — inline literal values or use Cypher.
+- **Feature gating.** When AletheiaDB is built without the `cypher` feature,
+  `language: "cypher"` returns `language_unavailable` rather than failing; AQL
+  remains available.
+- **Result cap.** Large result sets are capped (default 100, max 10000); use the
+  `truncated` flag to detect a cap hit. A streaming/cursor protocol is future
+  work.

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -33,7 +33,7 @@ as one Cypher/AQL statement. Keep using the structured tools (`create_node`,
   "columns": [
     {"name": "entity", "type": "node|edge", "description": "..."},
     {"name": "score", "type": "number|null", "description": "..."},
-    {"name": "path", "type": "array<number>|null", "description": "..."},
+    {"name": "path", "type": "array<{type:string,id:number}>|null", "description": "..."},
     {"name": "timestamp", "type": "string|null", "description": "..."}
   ],
   "rows": [

--- a/src/bin/mcp_server.rs
+++ b/src/bin/mcp_server.rs
@@ -46,6 +46,12 @@
 //!
 //! ## Hybrid Queries
 //! - `hybrid_query`: Combined graph + vector + temporal query
+//!
+//! ## Declarative Query
+//! - `query`: Execute a single read-only Cypher/AQL statement (with optional
+//!   `$param` bindings) and get structured rows back. Mutating statements are
+//!   rejected before execution. Cypher requires the `cypher` feature; AQL is
+//!   always available.
 
 use std::sync::Arc;
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -36,7 +36,7 @@ pub use tools::{
     DeleteNodeCascadeRequest, DeleteNodeRequest, EnableVectorIndexRequest, FindSimilarRequest,
     GetEdgeAtTimeRequest, GetEdgeRequest, GetIncomingEdgesRequest, GetNodeAtTimeRequest,
     GetNodeRequest, GetOutgoingEdgesRequest, HybridQueryRequest, ListChangesRequest,
-    ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest, TraverseRequest,
+    ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest, QueryRequest, TraverseRequest,
     UpdateEdgeRequest, UpdateNodeRequest,
 };
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2530,34 +2530,40 @@ const MUTATING_KEYWORDS: &[&str] = &[
 ];
 
 /// Scan a query string for a mutating clause, ignoring string-literal contents
-/// (so `{name: 'DELETE'}` does not trip the guard). Returns the offending
+/// (so `{name: 'DELETE'}` does not trip the guard), single-line `//` comments,
+/// node labels (`:CALL`), and property keys (`n.set`). Returns the offending
 /// keyword so the error can name it.
 fn detect_mutating_clause(query: &str) -> Option<&'static str> {
-    // Strip single- and double-quoted string literals, respecting backslash
-    // escapes so that `\'` or `\"` inside a string does not prematurely close
-    // the literal and leak its content into the token scan.
+    // First pass: strip string literals (single and double quoted, with backslash
+    // escapes) and single-line comments (//) into a sanitized string.
     let mut sanitized = String::with_capacity(query.len());
     let mut quote: Option<char> = None;
     let mut escaped = false;
-    for c in query.chars() {
+    let mut chars = query.chars().peekable();
+    while let Some(c) = chars.next() {
         if escaped {
-            // Previous character was a backslash inside a string — skip this
-            // character unconditionally regardless of what it is.
             escaped = false;
             continue;
         }
         match quote {
             Some(q) => {
                 if c == '\\' {
-                    escaped = true; // next char is escaped, don't close the string on it
+                    escaped = true;
                 } else if c == q {
                     quote = None;
                 }
-                // Characters inside string literals are not pushed to sanitized.
+                // Inside a string literal — don't emit characters.
             }
             None => {
                 if c == '\'' || c == '"' {
                     quote = Some(c);
+                } else if c == '/' && chars.peek() == Some(&'/') {
+                    // Single-line comment: skip to end of line.
+                    for next in chars.by_ref() {
+                        if next == '\n' {
+                            break;
+                        }
+                    }
                 } else {
                     sanitized.push(c);
                 }
@@ -2565,16 +2571,36 @@ fn detect_mutating_clause(query: &str) -> Option<&'static str> {
         }
     }
 
-    sanitized
-        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
-        .filter(|token| !token.is_empty())
-        .find_map(|token| {
-            // eq_ignore_ascii_case avoids a per-token String allocation.
-            MUTATING_KEYWORDS
-                .iter()
-                .copied()
-                .find(|kw| kw.eq_ignore_ascii_case(token))
-        })
+    // Second pass: tokenise and match, but skip tokens immediately preceded by
+    // ':' or '.' so that node labels (`:CALL`) and property keys (`n.set`) do
+    // not trigger a false positive.
+    let mut last_non_ws: Option<char> = None;
+    let mut current_token = String::new();
+
+    for c in sanitized.chars().chain(std::iter::once(' ')) {
+        if c.is_alphanumeric() || c == '_' {
+            current_token.push(c);
+        } else {
+            if !current_token.is_empty() {
+                let preceded_by_label_or_prop =
+                    last_non_ws == Some(':') || last_non_ws == Some('.');
+                if !preceded_by_label_or_prop
+                    && let Some(kw) = MUTATING_KEYWORDS
+                        .iter()
+                        .copied()
+                        .find(|kw| kw.eq_ignore_ascii_case(&current_token))
+                {
+                    return Some(kw);
+                }
+                current_token.clear();
+            }
+            if !c.is_whitespace() {
+                last_non_ws = Some(c);
+            }
+        }
+    }
+
+    None
 }
 
 /// Column metadata describing the structured shape of each `query` result row.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2900,3 +2900,79 @@ impl ServerHandler for AletheiaMcpServer {
         Ok(result)
     }
 }
+
+#[cfg(test)]
+mod server_unit_tests {
+    use std::sync::Arc;
+
+    use super::AletheiaMcpServer;
+    use crate::core::error::{Error, QueryError};
+    use crate::core::id::{EdgeId, NodeId};
+    use crate::db::AletheiaDB;
+    use crate::query::executor::{EntityResult, QueryRow};
+
+    fn make_server() -> AletheiaMcpServer {
+        AletheiaMcpServer::new(Arc::new(AletheiaDB::new().expect("db init")))
+    }
+
+    fn error_kind(server: &AletheiaMcpServer, err: Error) -> String {
+        let result = server.map_query_error(err, "aql");
+        let text = AletheiaMcpServer::extract_text(result);
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        val["error"]["kind"].as_str().unwrap_or("").to_string()
+    }
+
+    #[test]
+    fn map_query_error_unsupported_feature_yields_unsupported_construct() {
+        let server = make_server();
+        let err = Error::Query(QueryError::UnsupportedFeature {
+            feature: "DISTINCT".to_string(),
+        });
+        assert_eq!(error_kind(&server, err), "unsupported_construct");
+    }
+
+    #[test]
+    fn map_query_error_invalid_parameter_yields_invalid_params() {
+        let server = make_server();
+        let err = Error::Query(QueryError::InvalidParameter {
+            parameter: "p".to_string(),
+            reason: "out of range".to_string(),
+        });
+        assert_eq!(error_kind(&server, err), "invalid_params");
+    }
+
+    #[test]
+    fn map_query_error_execution_error_yields_runtime_error() {
+        let server = make_server();
+        let err = Error::Query(QueryError::ExecutionError {
+            message: "boom".to_string(),
+        });
+        assert_eq!(error_kind(&server, err), "runtime_error");
+    }
+
+    #[test]
+    fn map_query_error_other_variant_yields_runtime_error() {
+        let server = make_server();
+        // Error::Other is a variant not matched by any specific arm — falls through to `other`.
+        let err = Error::Other("unexpected situation".to_string());
+        assert_eq!(error_kind(&server, err), "runtime_error");
+    }
+
+    #[test]
+    fn query_row_to_json_node_id_variant() {
+        let server = make_server();
+        let row = QueryRow::from_entity(EntityResult::NodeId(NodeId::new(42).unwrap()));
+        let json = server.query_row_to_json(row);
+        assert_eq!(json["entity"]["type"].as_str(), Some("node"));
+        assert_eq!(json["entity"]["id"].as_u64(), Some(42));
+    }
+
+    #[test]
+    fn query_row_to_json_edge_id_variant() {
+        let server = make_server();
+        let row = QueryRow::from_entity(EntityResult::EdgeId(EdgeId::new(99).unwrap()));
+        let json = server.query_row_to_json(row);
+        assert_eq!(json["entity"]["type"].as_str(), Some("edge"));
+        assert_eq!(json["entity"]["id"].as_u64(), Some(99));
+    }
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2259,13 +2259,13 @@ impl AletheiaMcpServer {
             Error::Query(QueryError::UnsupportedFeature { feature }) => self.query_error(
                 "unsupported_construct",
                 &format!("Unsupported query construct: {feature}"),
-                Some(&feature),
+                None,
                 Some(language),
             ),
             Error::Query(QueryError::InvalidParameter { parameter, reason }) => self.query_error(
                 "invalid_params",
                 &format!("Invalid parameter '{parameter}': {reason}"),
-                Some(&parameter),
+                None,
                 Some(language),
             ),
             Error::Query(QueryError::ExecutionError { message }) => {
@@ -2302,8 +2302,8 @@ impl AletheiaMcpServer {
             "path": row.path.map(|p| {
                 p.iter()
                     .map(|e| match e {
-                        ResultEntityId::Node(id) => id.as_u64(),
-                        ResultEntityId::Edge(id) => id.as_u64(),
+                        ResultEntityId::Node(id) => json!({"type": "node", "id": id.as_u64()}),
+                        ResultEntityId::Edge(id) => json!({"type": "edge", "id": id.as_u64()}),
                     })
                     .collect::<Vec<_>>()
             }),
@@ -2328,7 +2328,12 @@ impl AletheiaMcpServer {
                 serde_json::Value::Null => CypherParameterValue::Null,
                 serde_json::Value::Bool(b) => CypherParameterValue::Bool(*b),
                 serde_json::Value::Number(n) => {
-                    if let Some(i) = n.as_i64() {
+                    // Check is_f64() first so that JSON floats (e.g. 1.0) are not
+                    // silently coerced to Int by as_i64(), which would succeed for
+                    // whole-number floats in some representations.
+                    if n.is_f64() {
+                        CypherParameterValue::Float(n.as_f64().unwrap())
+                    } else if let Some(i) = n.as_i64() {
                         CypherParameterValue::Int(i)
                     } else if let Some(f) = n.as_f64() {
                         CypherParameterValue::Float(f)
@@ -2338,6 +2343,14 @@ impl AletheiaMcpServer {
                 }
                 serde_json::Value::String(s) => CypherParameterValue::String(s.clone()),
                 serde_json::Value::Array(arr) => {
+                    if arr.is_empty() {
+                        return Err((
+                            key.clone(),
+                            "array parameters must not be empty; embeddings require at least \
+                             one dimension"
+                                .to_string(),
+                        ));
+                    }
                     let mut floats = Vec::with_capacity(arr.len());
                     for element in arr {
                         match element.as_f64() {
@@ -2367,6 +2380,13 @@ impl AletheiaMcpServer {
     }
 
     fn handle_query(&self, args: serde_json::Value) -> CallToolResult {
+        // Extract language early so it can appear in error payloads even when
+        // full deserialization fails (language is not yet known at that point).
+        let raw_language = args
+            .get("language")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_ascii_lowercase());
+
         let req: QueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
             Err(e) => {
@@ -2374,7 +2394,7 @@ impl AletheiaMcpServer {
                     "invalid_request",
                     &format!("Invalid arguments: {e}"),
                     None,
-                    None,
+                    raw_language.as_deref(),
                 );
             }
         };
@@ -2436,7 +2456,7 @@ impl AletheiaMcpServer {
                             return self.query_error(
                                 "invalid_params",
                                 &format!("Invalid parameter '{parameter}': {reason}"),
-                                Some(&parameter),
+                                None,
                                 Some("cypher"),
                             );
                         }
@@ -2513,15 +2533,27 @@ const MUTATING_KEYWORDS: &[&str] = &[
 /// (so `{name: 'DELETE'}` does not trip the guard). Returns the offending
 /// keyword so the error can name it.
 fn detect_mutating_clause(query: &str) -> Option<&'static str> {
-    // Strip single- and double-quoted string literals.
+    // Strip single- and double-quoted string literals, respecting backslash
+    // escapes so that `\'` or `\"` inside a string does not prematurely close
+    // the literal and leak its content into the token scan.
     let mut sanitized = String::with_capacity(query.len());
     let mut quote: Option<char> = None;
+    let mut escaped = false;
     for c in query.chars() {
+        if escaped {
+            // Previous character was a backslash inside a string — skip this
+            // character unconditionally regardless of what it is.
+            escaped = false;
+            continue;
+        }
         match quote {
             Some(q) => {
-                if c == q {
+                if c == '\\' {
+                    escaped = true; // next char is escaped, don't close the string on it
+                } else if c == q {
                     quote = None;
                 }
+                // Characters inside string literals are not pushed to sanitized.
             }
             None => {
                 if c == '\'' || c == '"' {
@@ -2537,38 +2569,48 @@ fn detect_mutating_clause(query: &str) -> Option<&'static str> {
         .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
         .filter(|token| !token.is_empty())
         .find_map(|token| {
-            let upper = token.to_ascii_uppercase();
-            MUTATING_KEYWORDS.iter().copied().find(|kw| *kw == upper)
+            // eq_ignore_ascii_case avoids a per-token String allocation.
+            MUTATING_KEYWORDS
+                .iter()
+                .copied()
+                .find(|kw| kw.eq_ignore_ascii_case(token))
         })
 }
 
 /// Column metadata describing the structured shape of each `query` result row.
 ///
 /// `QueryRow` does not carry the `RETURN` aliases, so the contract is the fixed
-/// row schema rather than per-query projection names.
+/// row schema rather than per-query projection names. Constructed once and
+/// cloned cheaply on each call via `OnceLock`.
 fn query_columns() -> serde_json::Value {
-    json!([
-        {
-            "name": "entity",
-            "type": "node|edge",
-            "description": "The node or edge bound by the RETURN clause (with label and properties)."
-        },
-        {
-            "name": "score",
-            "type": "number|null",
-            "description": "Vector similarity score, present for ranked queries."
-        },
-        {
-            "name": "path",
-            "type": "array<number>|null",
-            "description": "Entity IDs along the traversal path, when applicable."
-        },
-        {
-            "name": "timestamp",
-            "type": "string|null",
-            "description": "Bi-temporal point this row represents, when applicable."
-        }
-    ])
+    use std::sync::OnceLock;
+    static COLUMNS: OnceLock<serde_json::Value> = OnceLock::new();
+    COLUMNS
+        .get_or_init(|| {
+            json!([
+                {
+                    "name": "entity",
+                    "type": "node|edge",
+                    "description": "The node or edge bound by the RETURN clause (with label and properties)."
+                },
+                {
+                    "name": "score",
+                    "type": "number|null",
+                    "description": "Vector similarity score, present for ranked queries."
+                },
+                {
+                    "name": "path",
+                    "type": "array<{type:string,id:number}>|null",
+                    "description": "Typed entity references along the traversal path (each element has `type` and `id`), when applicable."
+                },
+                {
+                    "name": "timestamp",
+                    "type": "string|null",
+                    "description": "Bi-temporal point this row represents, when applicable."
+                }
+            ])
+        })
+        .clone()
 }
 
 /// Build the list of tool definitions advertised by this MCP server.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -625,6 +625,17 @@ impl AletheiaMcpServer {
         ))
     }
 
+    /// Execute a read-only declarative query (Cypher or AQL).
+    ///
+    /// Returns the engine's structured rows plus column metadata as JSON, or a
+    /// structured `{error:{kind,message,clause?,language}}` payload. Mutating
+    /// statements are rejected before execution and never write.
+    pub fn query(&self, req: QueryRequest) -> String {
+        Self::extract_text(self.handle_query(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
     // ========================================================================
     // Helper methods for converting between AletheiaDB and MCP types
     // ========================================================================
@@ -2208,6 +2219,270 @@ impl AletheiaMcpServer {
         }
     }
 
+    // ========================================================================
+    // Declarative query tool (read-only Cypher / AQL) -- Issue #3213
+    // ========================================================================
+
+    /// Build a structured query-tool error payload.
+    ///
+    /// Distinct `kind`s let an LLM self-correct on retry: `invalid_request`,
+    /// `read_only_violation`, `language_unavailable`, `parse_error`,
+    /// `unsupported_construct`, `invalid_params`, `runtime_error`.
+    fn query_error(
+        &self,
+        kind: &str,
+        message: &str,
+        clause: Option<&str>,
+        language: Option<&str>,
+    ) -> CallToolResult {
+        let mut obj = serde_json::Map::new();
+        obj.insert("kind".to_string(), json!(kind));
+        obj.insert("message".to_string(), json!(message));
+        if let Some(clause) = clause {
+            obj.insert("clause".to_string(), json!(clause));
+        }
+        if let Some(language) = language {
+            obj.insert("language".to_string(), json!(language));
+        }
+        CallToolResult::error(vec![Content::text(
+            json!({ "error": serde_json::Value::Object(obj) }).to_string(),
+        )])
+    }
+
+    /// Map an engine error from query execution into a structured query-tool error.
+    fn map_query_error(&self, error: crate::core::error::Error, language: &str) -> CallToolResult {
+        use crate::core::error::{Error, QueryError};
+        match error {
+            Error::Query(QueryError::SyntaxError { message }) => {
+                self.query_error("parse_error", &message, None, Some(language))
+            }
+            Error::Query(QueryError::UnsupportedFeature { feature }) => self.query_error(
+                "unsupported_construct",
+                &format!("Unsupported query construct: {feature}"),
+                Some(&feature),
+                Some(language),
+            ),
+            Error::Query(QueryError::InvalidParameter { parameter, reason }) => self.query_error(
+                "invalid_params",
+                &format!("Invalid parameter '{parameter}': {reason}"),
+                Some(&parameter),
+                Some(language),
+            ),
+            Error::Query(QueryError::ExecutionError { message }) => {
+                self.query_error("runtime_error", &message, None, Some(language))
+            }
+            other => self.query_error("runtime_error", &other.to_string(), None, Some(language)),
+        }
+    }
+
+    /// Serialize a single query row (entity + score/path/timestamp) to JSON.
+    fn query_row_to_json(&self, row: crate::query::executor::QueryRow) -> serde_json::Value {
+        let entity = match row.entity {
+            EntityResult::Node(node) => {
+                let r = self.node_to_response(&node);
+                json!({"type": "node", "id": r.id, "label": r.label, "properties": r.properties})
+            }
+            EntityResult::Edge(edge) => {
+                let r = self.edge_to_response(&edge);
+                json!({
+                    "type": "edge",
+                    "id": r.id,
+                    "source_id": r.source_id,
+                    "target_id": r.target_id,
+                    "label": r.label,
+                    "properties": r.properties,
+                })
+            }
+            EntityResult::NodeId(id) => json!({"type": "node", "id": id.as_u64()}),
+            EntityResult::EdgeId(id) => json!({"type": "edge", "id": id.as_u64()}),
+        };
+        json!({
+            "entity": entity,
+            "score": row.score,
+            "path": row.path.map(|p| {
+                p.iter()
+                    .map(|e| match e {
+                        ResultEntityId::Node(id) => id.as_u64(),
+                        ResultEntityId::Edge(id) => id.as_u64(),
+                    })
+                    .collect::<Vec<_>>()
+            }),
+            "timestamp": row.timestamp.map(|t| t.wallclock().to_string()),
+        })
+    }
+
+    /// Convert JSON parameter bindings into Cypher parameter values.
+    #[cfg(feature = "cypher")]
+    fn json_to_cypher_params(
+        &self,
+        params: Option<&HashMap<String, serde_json::Value>>,
+    ) -> std::result::Result<HashMap<String, crate::cypher::CypherParameterValue>, (String, String)>
+    {
+        use crate::cypher::CypherParameterValue;
+        let mut out = HashMap::new();
+        let Some(map) = params else {
+            return Ok(out);
+        };
+        for (key, value) in map {
+            let pv = match value {
+                serde_json::Value::Null => CypherParameterValue::Null,
+                serde_json::Value::Bool(b) => CypherParameterValue::Bool(*b),
+                serde_json::Value::Number(n) => {
+                    if let Some(i) = n.as_i64() {
+                        CypherParameterValue::Int(i)
+                    } else if let Some(f) = n.as_f64() {
+                        CypherParameterValue::Float(f)
+                    } else {
+                        return Err((key.clone(), "unsupported numeric value".to_string()));
+                    }
+                }
+                serde_json::Value::String(s) => CypherParameterValue::String(s.clone()),
+                serde_json::Value::Array(arr) => {
+                    let mut floats = Vec::with_capacity(arr.len());
+                    for element in arr {
+                        match element.as_f64() {
+                            Some(f) => floats.push(f as f32),
+                            None => {
+                                return Err((
+                                    key.clone(),
+                                    "array parameters must contain only numbers (numeric arrays \
+                                     are treated as embeddings)"
+                                        .to_string(),
+                                ));
+                            }
+                        }
+                    }
+                    CypherParameterValue::Embedding(Arc::from(floats))
+                }
+                serde_json::Value::Object(_) => {
+                    return Err((
+                        key.clone(),
+                        "object parameters are not supported".to_string(),
+                    ));
+                }
+            };
+            out.insert(key.clone(), pv);
+        }
+        Ok(out)
+    }
+
+    fn handle_query(&self, args: serde_json::Value) -> CallToolResult {
+        let req: QueryRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => {
+                return self.query_error(
+                    "invalid_request",
+                    &format!("Invalid arguments: {e}"),
+                    None,
+                    None,
+                );
+            }
+        };
+
+        let language = req.language.to_ascii_lowercase();
+        if language != "cypher" && language != "aql" {
+            return self.query_error(
+                "invalid_request",
+                &format!(
+                    "Unsupported query language '{}'. Use \"cypher\" or \"aql\".",
+                    req.language
+                ),
+                None,
+                Some(&language),
+            );
+        }
+
+        // Read-only guard: reject mutating statements BEFORE any execution.
+        // Runs for every language so the tool can never write, even if the
+        // grammars later gain write support.
+        if let Some(clause) = detect_mutating_clause(&req.query) {
+            return self.query_error(
+                "read_only_violation",
+                &format!(
+                    "The `query` tool is read-only; the `{clause}` clause would mutate state and \
+                     is rejected before execution."
+                ),
+                Some(clause),
+                Some(&language),
+            );
+        }
+
+        let limit = req
+            .limit
+            .unwrap_or(DEFAULT_RESULT_LIMIT)
+            .min(MAX_RESULT_LIMIT);
+        let has_params = req.params.as_ref().is_some_and(|p| !p.is_empty());
+
+        let execution = match language.as_str() {
+            "aql" => {
+                if has_params {
+                    return self.query_error(
+                        "invalid_request",
+                        "AQL does not support parameter bindings; inline literal values or use \
+                         language \"cypher\" with $params.",
+                        None,
+                        Some("aql"),
+                    );
+                }
+                self.db.execute_aql(&req.query)
+            }
+            "cypher" => {
+                #[cfg(feature = "cypher")]
+                {
+                    match self.json_to_cypher_params(req.params.as_ref()) {
+                        Ok(params) if params.is_empty() => self.db.execute_cypher(&req.query),
+                        Ok(params) => self.db.execute_cypher_with_params(&req.query, params),
+                        Err((parameter, reason)) => {
+                            return self.query_error(
+                                "invalid_params",
+                                &format!("Invalid parameter '{parameter}': {reason}"),
+                                Some(&parameter),
+                                Some("cypher"),
+                            );
+                        }
+                    }
+                }
+                #[cfg(not(feature = "cypher"))]
+                {
+                    return self.query_error(
+                        "language_unavailable",
+                        "Cypher support is not compiled in (enable the `cypher` feature). Use \
+                         language \"aql\" instead.",
+                        None,
+                        Some("cypher"),
+                    );
+                }
+            }
+            _ => unreachable!("language already validated above"),
+        };
+
+        let results = match execution {
+            Ok(results) => results,
+            Err(e) => return self.map_query_error(e, &language),
+        };
+
+        // Collect one extra row to detect (and report) truncation at the cap.
+        let collected = match results.take_n(limit.saturating_add(1)) {
+            Ok(rows) => rows,
+            Err(e) => return self.map_query_error(e, &language),
+        };
+        let truncated = collected.len() > limit;
+        let rows: Vec<serde_json::Value> = collected
+            .into_iter()
+            .take(limit)
+            .map(|row| self.query_row_to_json(row))
+            .collect();
+        let row_count = rows.len();
+
+        self.success_json(json!({
+            "language": language,
+            "columns": query_columns(),
+            "rows": rows,
+            "row_count": row_count,
+            "truncated": truncated,
+        }))
+    }
+
     /// Test-only accessor returning the names of all advertised tools.
     #[cfg(test)]
     pub(crate) fn list_tools_for_test(&self) -> Vec<String> {
@@ -2226,6 +2501,74 @@ fn make_input_schema<T: rmcp::schemars::JsonSchema>()
         serde_json::Value::Object(map) => Arc::new(map),
         _ => Arc::new(serde_json::Map::new()),
     }
+}
+
+/// Clauses that would mutate state. The read-only `query` tool rejects any
+/// statement containing one of these (as a whole token) before execution.
+const MUTATING_KEYWORDS: &[&str] = &[
+    "CREATE", "MERGE", "SET", "DELETE", "REMOVE", "DETACH", "DROP", "CALL", "FOREACH", "LOAD",
+];
+
+/// Scan a query string for a mutating clause, ignoring string-literal contents
+/// (so `{name: 'DELETE'}` does not trip the guard). Returns the offending
+/// keyword so the error can name it.
+fn detect_mutating_clause(query: &str) -> Option<&'static str> {
+    // Strip single- and double-quoted string literals.
+    let mut sanitized = String::with_capacity(query.len());
+    let mut quote: Option<char> = None;
+    for c in query.chars() {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                }
+            }
+            None => {
+                if c == '\'' || c == '"' {
+                    quote = Some(c);
+                } else {
+                    sanitized.push(c);
+                }
+            }
+        }
+    }
+
+    sanitized
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .filter(|token| !token.is_empty())
+        .find_map(|token| {
+            let upper = token.to_ascii_uppercase();
+            MUTATING_KEYWORDS.iter().copied().find(|kw| *kw == upper)
+        })
+}
+
+/// Column metadata describing the structured shape of each `query` result row.
+///
+/// `QueryRow` does not carry the `RETURN` aliases, so the contract is the fixed
+/// row schema rather than per-query projection names.
+fn query_columns() -> serde_json::Value {
+    json!([
+        {
+            "name": "entity",
+            "type": "node|edge",
+            "description": "The node or edge bound by the RETURN clause (with label and properties)."
+        },
+        {
+            "name": "score",
+            "type": "number|null",
+            "description": "Vector similarity score, present for ranked queries."
+        },
+        {
+            "name": "path",
+            "type": "array<number>|null",
+            "description": "Entity IDs along the traversal path, when applicable."
+        },
+        {
+            "name": "timestamp",
+            "type": "string|null",
+            "description": "Bi-temporal point this row represents, when applicable."
+        }
+    ])
 }
 
 /// Build the list of tool definitions advertised by this MCP server.
@@ -2393,6 +2736,26 @@ fn tool_definitions() -> Vec<Tool> {
             "Execute a hybrid query combining graph traversal, vector similarity, and temporal filtering.",
             make_input_schema::<HybridQueryRequest>(),
         ),
+        Tool::new(
+            "query",
+            "Execute a single READ-ONLY declarative query and get structured rows back, \
+             replacing a chain of get_node/traverse/filter calls. \
+             `language` is \"cypher\" or \"aql\"; pass the statement in `query` and optional \
+             `$param` bindings in `params` (Cypher only; numeric arrays are treated as \
+             embeddings). \
+             Supported read-only subset: MATCH patterns with node/edge labels and inline \
+             property filters, variable-depth traversal (-[:REL*1..3]->), directions \
+             (->, <-, -), WHERE, RETURN [DISTINCT] / AS aliases, ORDER BY, SKIP/LIMIT, WITH \
+             chaining, vector similarity ranking, and bi-temporal scoping \
+             (AS OF TIMESTAMP/VALID_TIME/SYSTEM_TIME, FOR SYSTEM_TIME AS OF, BETWEEN ... AND ...). \
+             Mutating statements (CREATE/MERGE/SET/DELETE/REMOVE/DETACH/DROP/CALL/FOREACH/LOAD) \
+             are rejected before execution and never write. Results are capped (default 100, \
+             max 10000 rows; `truncated` indicates a cap hit). Errors are returned as a \
+             structured {error:{kind,message,clause?,language}} payload \
+             (kinds: invalid_request, read_only_violation, language_unavailable, parse_error, \
+             unsupported_construct, invalid_params, runtime_error) so callers can self-correct.",
+            make_input_schema::<QueryRequest>(),
+        ),
     ]
 }
 
@@ -2462,6 +2825,7 @@ impl ServerHandler for AletheiaMcpServer {
             "get_edge_history" => self.handle_get_edge_history(args),
             "diff_edge_versions" => self.handle_diff_edge_versions(args),
             "hybrid_query" => self.handle_hybrid_query(args),
+            "query" => self.handle_query(args),
             _ => self.error_json(&format!("Unknown tool: {}", request.name)),
         };
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3354,4 +3354,121 @@ mod query_tool_tests {
             "an invalid temporal timestamp must yield a structured error: {value}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Tests for fixes applied after the initial code review
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_query_backslash_escape_in_string_does_not_block_valid_query() {
+        // A query whose string literal contains a backslash-escaped quote must
+        // NOT be rejected as a read_only_violation. The old sanitizer would
+        // close the quote at the `\'` and then scan `s fine'}) RETURN n` as
+        // bare tokens, finding no mutating keyword and passing — but the correct
+        // behavior is that the whole content stays inside the string.
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                // String literal `it\'s fine` — backslash-escaped quote inside single quotes.
+                query: "MATCH (n:Person {note: 'it\\'s fine'}) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        // The guard must not fire (no read_only_violation for a read-only query).
+        let err = value.get("error");
+        if let Some(err) = err {
+            assert_ne!(
+                err["kind"].as_str(),
+                Some("read_only_violation"),
+                "backslash-escaped quote inside a string literal must not trip the read-only guard: {value}"
+            );
+        }
+        // Whether the engine can parse this specific AQL variant is a grammar
+        // question; what matters is that the guard itself does not reject it.
+    }
+
+    #[test]
+    fn test_query_clause_field_absent_for_non_write_errors() {
+        // `clause` is reserved exclusively for read_only_violation (it names the
+        // mutating keyword). For other error kinds (parse_error,
+        // unsupported_construct, invalid_params, runtime_error) the field must
+        // NOT appear, since it would be semantically wrong.
+        let server = create_test_server();
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                query: "this is not valid".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        let err = error_obj(&value);
+        assert_eq!(err["kind"].as_str(), Some("parse_error"));
+        assert!(
+            err.get("clause").is_none(),
+            "parse_error must not include a `clause` field: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_empty_array_param_is_invalid() {
+        // An empty JSON array [] must be rejected with invalid_params rather
+        // than silently accepted as a zero-dimension embedding.
+        let server = create_test_server();
+        let mut params = HashMap::new();
+        params.insert("vec".to_string(), serde_json::json!([]));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n) RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("invalid_params"),
+            "empty array parameter must yield invalid_params: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_float_param_preserved_as_float() {
+        // A JSON number with a decimal point (1.0) must be bound as Float, not Int.
+        // We verify indirectly: the query must not fail with a type error, and
+        // the params round-trip must work (parse_error or correct rows, not a
+        // crash or wrong type coercion error).
+        let server = create_test_server();
+        seed_named(&server, "Product", "Gadget");
+        let mut params = HashMap::new();
+        // 1.0 is an explicit float in JSON — must not be coerced to Int.
+        params.insert("threshold".to_string(), serde_json::json!(1.0_f64));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Product) WHERE n.price < $threshold RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        // The key assertion: the error must NOT be invalid_params (the float
+        // was accepted as a float). Whether the engine returns rows or a
+        // parse/runtime error for the WHERE predicate is a grammar question.
+        if let Some(err) = value.get("error") {
+            assert_ne!(
+                err["kind"].as_str(),
+                Some("invalid_params"),
+                "a float-valued JSON param must be accepted as Float, not rejected: {value}"
+            );
+        }
+    }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3471,4 +3471,214 @@ mod query_tool_tests {
             );
         }
     }
+
+    #[test]
+    fn test_query_single_line_comment_before_mutation_is_not_rejected() {
+        // A `//`-style comment that contains a mutating keyword must NOT trip the
+        // read-only guard — only bare (outside-comment, outside-string) tokens count.
+        let server = create_test_server();
+        seed_named(&server, "Widget", "alpha");
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                query: "// CREATE would mutate\nMATCH (n:Widget) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        if let Some(err) = value.get("error") {
+            assert_ne!(
+                err["kind"].as_str(),
+                Some("read_only_violation"),
+                "mutating keyword inside a // comment must not trigger the guard: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_query_node_label_matching_mutating_keyword_is_allowed() {
+        // A node label that happens to spell a mutating keyword (e.g. :Call, :Set)
+        // must NOT be rejected — the token is preceded by ':' and is a label, not
+        // a clause.
+        for stmt in [
+            "MATCH (c:Call) RETURN c",
+            "MATCH (s:Set) RETURN s",
+            "MATCH (d:Drop) RETURN d",
+        ] {
+            let server = create_test_server();
+            let value = run_query(
+                &server,
+                QueryRequest {
+                    language: "aql".to_string(),
+                    query: stmt.to_string(),
+                    params: None,
+                    limit: None,
+                },
+            );
+            if let Some(err) = value.get("error") {
+                assert_ne!(
+                    err["kind"].as_str(),
+                    Some("read_only_violation"),
+                    "node label `{stmt}` must not trip the read-only guard: {value}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_query_property_key_matching_mutating_keyword_is_allowed() {
+        // A property key that happens to spell a mutating keyword (e.g. n.set,
+        // n.merge) must NOT be rejected — the token is preceded by '.' and is a
+        // property access, not a clause.
+        for stmt in [
+            "MATCH (n) RETURN n.set",
+            "MATCH (n) RETURN n.merge",
+            "MATCH (n) RETURN n.delete",
+        ] {
+            let server = create_test_server();
+            let value = run_query(
+                &server,
+                QueryRequest {
+                    language: "aql".to_string(),
+                    query: stmt.to_string(),
+                    params: None,
+                    limit: None,
+                },
+            );
+            if let Some(err) = value.get("error") {
+                assert_ne!(
+                    err["kind"].as_str(),
+                    Some("read_only_violation"),
+                    "property key in `{stmt}` must not trip the read-only guard: {value}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_query_remaining_mutating_keywords_are_rejected() {
+        // DETACH, DROP, FOREACH, and LOAD are listed as mutating keywords but are
+        // not exercised by the existing CREATE/SET/DELETE/MERGE/REMOVE tests.
+        for (stmt, kw) in [
+            ("DETACH DELETE (n)", "DETACH"),
+            ("DROP INDEX ON :Person(name)", "DROP"),
+            ("FOREACH (x IN $list | SET x.flag = 1)", "FOREACH"),
+            ("LOAD CSV FROM 'file' AS row", "LOAD"),
+        ] {
+            let server = create_test_server();
+            let value = run_query(
+                &server,
+                QueryRequest {
+                    language: "aql".to_string(),
+                    query: stmt.to_string(),
+                    params: None,
+                    limit: None,
+                },
+            );
+            assert_eq!(
+                error_obj(&value)["kind"].as_str(),
+                Some("read_only_violation"),
+                "statement with `{kw}` must be rejected: {value}"
+            );
+        }
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_null_param_is_accepted() {
+        // JSON null must be bound as CypherParameterValue::Null without error.
+        let server = create_test_server();
+        let mut params = HashMap::new();
+        params.insert("x".to_string(), serde_json::json!(null));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n) WHERE n.x = $x RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        if let Some(err) = value.get("error") {
+            assert_ne!(
+                err["kind"].as_str(),
+                Some("invalid_params"),
+                "null param must be accepted: {value}"
+            );
+        }
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_bool_and_int_params_are_accepted() {
+        // JSON booleans and integers must bind without error.
+        let server = create_test_server();
+        let mut params = HashMap::new();
+        params.insert("flag".to_string(), serde_json::json!(true));
+        params.insert("count".to_string(), serde_json::json!(42_i64));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n) WHERE n.flag = $flag AND n.count = $count RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        if let Some(err) = value.get("error") {
+            assert_ne!(
+                err["kind"].as_str(),
+                Some("invalid_params"),
+                "bool/int params must be accepted: {value}"
+            );
+        }
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_object_param_is_invalid() {
+        // A JSON object parameter is not supported; must yield invalid_params.
+        let server = create_test_server();
+        let mut params = HashMap::new();
+        params.insert("obj".to_string(), serde_json::json!({"key": "value"}));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n) RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("invalid_params"),
+            "object parameter must yield invalid_params: {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_non_numeric_array_param_is_invalid() {
+        // An array containing non-numeric elements is not a valid embedding;
+        // must yield invalid_params.
+        let server = create_test_server();
+        let mut params = HashMap::new();
+        params.insert("vec".to_string(), serde_json::json!(["not", "numbers"]));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n) RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("invalid_params"),
+            "non-numeric array parameter must yield invalid_params: {value}"
+        );
+    }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3025,3 +3025,333 @@ mod list_nodes_extended_tests {
         assert_eq!(nodes.len(), 1, "Page 3 should have 1 node");
     }
 }
+
+// ============================================================================
+// Declarative Query Tool Tests (Issue #3213)
+// ============================================================================
+
+mod query_tool_tests {
+    use super::*;
+
+    /// Seed a node with the given label and `name` property, returning its id.
+    fn seed_named(server: &AletheiaMcpServer, label: &str, name: &str) -> u64 {
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!(name));
+        let resp = server.create_node(CreateNodeRequest {
+            label: label.to_string(),
+            properties: Some(props),
+        });
+        let node: NodeResponse = parse_response(&resp).expect("seed node should succeed");
+        node.id
+    }
+
+    /// Run a query and return the parsed JSON value (success or error).
+    fn run_query(server: &AletheiaMcpServer, req: QueryRequest) -> serde_json::Value {
+        serde_json::from_str(&server.query(req)).expect("query response should be JSON")
+    }
+
+    /// Extract the structured error object from a query response.
+    fn error_obj(value: &serde_json::Value) -> &serde_json::Value {
+        value
+            .get("error")
+            .expect("expected an `error` payload in the response")
+    }
+
+    #[test]
+    fn test_query_tool_is_advertised() {
+        let server = create_test_server();
+        assert!(
+            server.list_tools_for_test().contains(&"query".to_string()),
+            "the `query` tool must be advertised in list_tools"
+        );
+    }
+
+    #[test]
+    fn test_query_aql_returns_structured_rows() {
+        let server = create_test_server();
+        seed_named(&server, "Widget", "alpha");
+
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                query: "MATCH (n:Widget) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+
+        // Column metadata is present.
+        assert!(
+            value.get("columns").and_then(|c| c.as_array()).is_some(),
+            "response must include column metadata: {value}"
+        );
+        assert_eq!(
+            value["row_count"].as_u64(),
+            Some(1),
+            "exactly one row: {value}"
+        );
+        let rows = value["rows"].as_array().expect("rows array");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["entity"]["label"].as_str(), Some("Widget"));
+        assert_eq!(
+            rows[0]["entity"]["properties"]["name"].as_str(),
+            Some("alpha")
+        );
+    }
+
+    #[test]
+    fn test_query_rejects_mutations_before_execution() {
+        for stmt in [
+            "CREATE (n:Hacker {name: 'x'})",
+            "MATCH (n:Widget) SET n.name = 'x'",
+            "MATCH (n:Widget) DELETE n",
+            "MERGE (n:Widget {name: 'x'})",
+            "MATCH (n:Widget) REMOVE n.name",
+        ] {
+            let server = create_test_server();
+            seed_named(&server, "Widget", "alpha");
+            let before = server.db().node_count();
+
+            let value = run_query(
+                &server,
+                QueryRequest {
+                    language: "cypher".to_string(),
+                    query: stmt.to_string(),
+                    params: None,
+                    limit: None,
+                },
+            );
+
+            let err = error_obj(&value);
+            assert_eq!(
+                err["kind"].as_str(),
+                Some("read_only_violation"),
+                "statement `{stmt}` must be rejected as read-only: {value}"
+            );
+            assert!(
+                err.get("clause").and_then(|c| c.as_str()).is_some(),
+                "the error must name the offending clause: {value}"
+            );
+            // It must never write.
+            assert_eq!(
+                server.db().node_count(),
+                before,
+                "statement `{stmt}` must not have mutated state"
+            );
+        }
+    }
+
+    #[test]
+    fn test_query_parse_error_is_structured() {
+        let server = create_test_server();
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                query: "this is not a valid query".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("parse_error"),
+            "malformed query must yield a parse_error: {value}"
+        );
+    }
+
+    #[test]
+    fn test_query_unknown_language_is_invalid_request() {
+        let server = create_test_server();
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "sql".to_string(),
+                query: "MATCH (n) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("invalid_request"),
+            "unknown language must yield invalid_request: {value}"
+        );
+    }
+
+    #[test]
+    fn test_query_aql_rejects_params() {
+        let server = create_test_server();
+        let mut params = HashMap::new();
+        params.insert("name".to_string(), serde_json::json!("alpha"));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                query: "MATCH (n:Widget) RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("invalid_request"),
+            "AQL does not support params and must reject them: {value}"
+        );
+    }
+
+    #[test]
+    fn test_query_row_cap_truncates() {
+        let server = create_test_server();
+        for i in 0..5 {
+            seed_named(&server, "Widget", &format!("w{i}"));
+        }
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "aql".to_string(),
+                query: "MATCH (n:Widget) RETURN n".to_string(),
+                params: None,
+                limit: Some(2),
+            },
+        );
+        assert_eq!(
+            value["row_count"].as_u64(),
+            Some(2),
+            "row cap honored: {value}"
+        );
+        assert_eq!(
+            value["truncated"].as_bool(),
+            Some(true),
+            "truncated flag must be set when results exceed the cap: {value}"
+        );
+    }
+
+    #[cfg(not(feature = "cypher"))]
+    #[test]
+    fn test_query_cypher_reports_unavailable_when_feature_disabled() {
+        let server = create_test_server();
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(
+            error_obj(&value)["kind"].as_str(),
+            Some("language_unavailable"),
+            "with the cypher feature off, cypher must report as unavailable (not fail to compile): {value}"
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_returns_rows() {
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person {name: 'Alice'}) RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        assert_eq!(value["row_count"].as_u64(), Some(1), "{value}");
+        assert_eq!(
+            value["rows"][0]["entity"]["properties"]["name"].as_str(),
+            Some("Alice")
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_with_params() {
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+        seed_named(&server, "Person", "Bob");
+        let mut params = HashMap::new();
+        params.insert("name".to_string(), serde_json::json!("Alice"));
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person {name: $name}) RETURN n".to_string(),
+                params: Some(params),
+                limit: None,
+            },
+        );
+        assert_eq!(value["row_count"].as_u64(), Some(1), "{value}");
+        assert_eq!(
+            value["rows"][0]["entity"]["properties"]["name"].as_str(),
+            Some("Alice")
+        );
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_temporal_clauses_are_honored() {
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+
+        // Each temporal form must parse, flow through to the engine, and return
+        // the correct row (the clause is honored, not dropped or rejected).
+        for clause in [
+            "AS OF VALID_TIME '2099-01-01'",
+            "AS OF SYSTEM_TIME '2099-01-01'",
+            "AS OF TIMESTAMP '2099-01-01T00:00:00Z'",
+            "BETWEEN '2000-01-01' AND '2099-01-01'",
+        ] {
+            let q = format!("MATCH (n:Person) {clause} RETURN n");
+            let value = run_query(
+                &server,
+                QueryRequest {
+                    language: "cypher".to_string(),
+                    query: q.clone(),
+                    params: None,
+                    limit: None,
+                },
+            );
+            assert!(
+                value.get("error").is_none(),
+                "temporal query `{q}` must not error: {value}"
+            );
+            assert_eq!(
+                value["row_count"].as_u64(),
+                Some(1),
+                "temporal query `{q}` must return the node: {value}"
+            );
+            assert_eq!(
+                value["rows"][0]["entity"]["properties"]["name"].as_str(),
+                Some("Alice"),
+                "temporal query `{q}` must return correct data: {value}"
+            );
+        }
+    }
+
+    #[cfg(feature = "cypher")]
+    #[test]
+    fn test_query_cypher_invalid_temporal_timestamp_is_structured() {
+        let server = create_test_server();
+        seed_named(&server, "Person", "Alice");
+        let value = run_query(
+            &server,
+            QueryRequest {
+                language: "cypher".to_string(),
+                query: "MATCH (n:Person) AS OF TIMESTAMP 'not-a-timestamp' RETURN n".to_string(),
+                params: None,
+                limit: None,
+            },
+        );
+        let kind = error_obj(&value)["kind"].as_str();
+        assert!(
+            matches!(kind, Some("invalid_params") | Some("parse_error")),
+            "an invalid temporal timestamp must yield a structured error: {value}"
+        );
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -529,6 +529,40 @@ pub struct HybridQueryRequest {
 }
 
 // ============================================================================
+// Declarative Query Operations (read-only Cypher / AQL)
+// ============================================================================
+
+/// Request to execute a read-only declarative query (Cypher or AQL).
+///
+/// This is the single-call counterpart to chaining several structured tools:
+/// the LLM emits one Cypher/AQL statement and receives structured rows back.
+/// Mutating statements (CREATE/SET/DELETE/MERGE/REMOVE/…) are rejected before
+/// execution — the tool never writes.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct QueryRequest {
+    /// Query language: "cypher" or "aql".
+    #[schemars(description = "Query language to use: \"cypher\" or \"aql\"")]
+    pub language: String,
+
+    /// The read-only query string to execute.
+    #[schemars(
+        description = "The read-only query string (e.g. MATCH (n:Person {name:$name}) RETURN n)"
+    )]
+    pub query: String,
+
+    /// Optional `$param` bindings (Cypher only). Numbers, strings, booleans,
+    /// null, and numeric arrays (treated as embeddings) are supported.
+    #[schemars(
+        description = "Optional $param bindings for Cypher. Numeric arrays are treated as embeddings."
+    )]
+    pub params: Option<HashMap<String, serde_json::Value>>,
+
+    /// Maximum number of rows to return (default: 100, capped at 10000).
+    #[schemars(description = "Maximum number of rows to return (default: 100, capped at 10000)")]
+    pub limit: Option<usize>,
+}
+
+// ============================================================================
 // Response Types (for serialization)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Adds a new MCP `query` tool that lets LLMs execute single read-only Cypher or AQL statements and receive structured rows back, replacing the need to chain multiple structured tool calls (`get_node` → `traverse` → filter). The tool is strictly read-only: mutating statements are rejected before execution and never write to the database.

## Key Changes

- **New `query` tool in MCP server** (`src/mcp/server.rs`):
  - `handle_query()` method orchestrates language selection, read-only validation, parameter binding, and result formatting
  - `query_error()` builds structured error payloads with distinct `kind`s (invalid_request, read_only_violation, language_unavailable, parse_error, unsupported_construct, invalid_params, runtime_error) so LLMs can self-correct
  - `map_query_error()` translates engine errors into tool-level error kinds
  - `query_row_to_json()` serializes QueryRow entities (nodes/edges) with score, path, and timestamp metadata
  - `json_to_cypher_params()` converts JSON parameter bindings to Cypher values, with special handling for numeric arrays as embeddings and validation of empty arrays

- **Read-only guard** (`src/mcp/server.rs`):
  - `detect_mutating_clause()` scans query strings for mutating keywords (CREATE, MERGE, SET, DELETE, REMOVE, DETACH, DROP, CALL, FOREACH, LOAD) while correctly handling string literals with backslash escapes
  - Rejects mutations before any execution, ensuring the tool never writes regardless of grammar changes

- **Tool definition and routing**:
  - Registered in `tool_definitions()` with comprehensive description of supported read-only constructs
  - Routed in `ServerHandler::call_tool()` dispatch

- **Request/response types** (`src/mcp/tools.rs`):
  - `QueryRequest` struct with language, query, optional params (Cypher only), and optional limit
  - Success response includes language, column metadata, structured rows, row_count, and truncated flag
  - Error response is `{error: {kind, message, clause?, language}}`

- **Comprehensive test suite** (`src/mcp/tests.rs`):
  - Tool advertisement verification
  - AQL and Cypher query execution with structured row output
  - Mutation rejection for all mutating clauses (CREATE, MERGE, SET, DELETE, REMOVE)
  - Parse error and invalid language handling
  - AQL parameter rejection (AQL has no param binding)
  - Row cap truncation detection
  - Feature-gated Cypher tests (unavailable when feature disabled, execution when enabled)
  - Cypher parameter binding and temporal clause support
  - Edge cases: backslash-escaped quotes in strings, clause field exclusion for non-write errors, empty array parameter validation, float parameter preservation

- **Documentation** (`docs/guides/mcp-query-tool.md`):
  - Tool contract and field descriptions
  - Success/error response formats
  - Supported read-only subset (MATCH, WHERE, RETURN, ORDER BY, SKIP/LIMIT, WITH, vector ranking, bi-temporal scoping)
  - End-to-end examples including embedding parameters
  - Feature gating and result cap notes

- **Updated project documentation** (`CLAUDE.md`, `src/bin/mcp_server.rs`):
  - Added `query` tool to tool inventory
  - Brief description of read-only Cypher/AQL execution

## Notable Implementation Details

- **String literal handling**: The read-only guard correctly respects backslash escapes (`\'` and `\"`) so that string contents like `{name: 'DELETE'}` do not trip the mutation detector
- **Parameter type preservation**: JSON floats (e.g., `1.0`) are bound as Float, not Int, by checking `is_f64()` before `as_i64()`
- **Empty array validation**: Numeric array parameters must have at least one element (embeddings require dimensions); empty arrays are rejected with `invalid_params`
- **Structured errors**: Each error kind is distinct so

https://claude.ai/code/session_01TAMdYXVTmxzKZsgHN4veyH