### PR TITLE
🗣️ Echo: Fix Getting Started examples and NarrativeGenerator feature flag DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ pr_description.md
 
 # Re-include Python SDK sources (overrides "*.py" above)
 !python/**/*.py
+target/

--- a/README.md
+++ b/README.md
@@ -23,12 +23,21 @@ Requires Rust 1.92+.
 
 ---
 
+
+> **⚠️ REQUIRES FEATURE NOVA:**
+> The `NarrativeGenerator` and other experimental modules are gated behind the `nova` feature.
+> You must enable this feature in your `Cargo.toml` or you will get compile errors!
+> ```toml
+> [dependencies]
+> aletheiadb = { version = "0.1", features = ["nova"] }
+> ```
+
 ## Quick Start
 
 ```rust
 use aletheiadb::prelude::*;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
 
     // Create nodes and a relationship
@@ -63,7 +72,7 @@ query with a consistent view of the data:
 use aletheiadb::prelude::*;
 use aletheiadb::HnswConfig;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
     db.vector_index("embedding").hnsw(HnswConfig { dimensions: 2, ..Default::default() }).enable()?;
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -13,7 +13,7 @@ By the end you'll have a working mental model of how AletheiaDB works day-to-day
 ```rust
 use aletheiadb::prelude::*;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let db = AletheiaDB::new()?;
     // db is ready to use
     Ok(())
@@ -190,7 +190,8 @@ let _doc2 = db.create_node("Document", properties! {
 
 // Find the 10 nodes most similar to doc1
 // (doc1 itself is excluded from results)
-let similar = db.find_similar(doc1, 10)?;
+use aletheiadb::SimilarityQuery;
+let similar = db.similarity_search(SimilarityQuery::from_node(doc1).k(10))?;
 for (node_id, score) in similar {
     println!("Node {:?} similarity: {:.3}", node_id, score);
 }

--- a/docs/guides/tiered-storage-guide.md
+++ b/docs/guides/tiered-storage-guide.md
@@ -69,26 +69,7 @@ let config = AletheiaDBConfig::builder()
 let db = AletheiaDB::with_unified_config(config)?;
 ```
 
-**Legacy: Manual Setup**
 
-For advanced use cases requiring custom backends:
-
-```rust
-use aletheiadb::storage::{
-    HistoricalStorage, TieredStorage, TieredStorageConfig,
-    RedbColdStorage, RedbConfig,
-};
-use std::sync::Arc;
-
-// 1. Create Redb cold storage
-let cold = Arc::new(RedbColdStorage::new("data/cold.redb", RedbConfig::new())?);
-
-// 2. Create tiered storage
-let tiered = TieredStorage::new(TieredStorageConfig::default(), cold);
-
-// 3. Wire to historical storage
-historical.set_tiered_storage(Arc::new(tiered));
-```
 
 ## Configuration
 

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -39,6 +39,14 @@
 //! > graduated semantic-search cohort. Add `"semantic-search"` alongside `"nova"`
 //! > if you want every former-nova module compiled.
 //!
+//! # ⚠️ Important Note on Stubs
+//!
+//! Certain structs in this module (like `NarrativeGenerator`) may be visible in documentation
+//! even when their respective feature flags are disabled. However, attempting to instantiate
+//! or use these stubs without the proper feature flag (e.g., `nova` or `semantic-temporal`)
+//! will result in a hard **compile error**. Always ensure the appropriate features are
+//! enabled in your `Cargo.toml`.
+//!
 //! # Categories
 //!
 //! | Flag | What it gates | Modules |

--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -38,20 +38,6 @@ pub struct NarrativeGenerator<'a> {
     db: &'a AletheiaDB,
 }
 
-#[cfg(not(feature = "semantic-temporal"))]
-/// Generator for creating natural language narratives from temporal history.
-#[deprecated(
-    note = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-)]
-/// Generates human-readable summaries of temporal graph mutations.
-///
-/// # Why?
-/// When analyzing a `BiTemporalInterval`, users often need to understand
-/// the sequence of events (e.g., "Alice liked the post, then Bob deleted it").
-/// This struct translates raw `VersionMetadata` into a chronological narrative.
-pub struct NarrativeGenerator<'a> {
-    _marker: std::marker::PhantomData<&'a AletheiaDB>,
-}
 
 #[cfg(feature = "semantic-temporal")]
 impl<'a> NarrativeGenerator<'a> {


### PR DESCRIPTION
Audited Developer Experience and fixed documentation friction points:
- Added `nova` feature warning banner to `README.md`.
- Fully qualified `Result` types in docs to allow copy-paste standalone examples.
- Replaced deprecated `find_similar` with `similarity_search` in `getting-started.md`.
- Removed `NarrativeGenerator` dummy stub to generate standard compile errors when `nova` is disabled.
- Removed legacy tiered storage manual setup.

---
*PR created automatically by Jules for task [13337892108038202895](https://jules.google.com/task/13337892108038202895) started by @madmax983*