### PR TITLE
⚡ Bolt: Optimize temporal metadata deduplication in-place

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**Optimize Vector Deduplication with In-Place Retain**
+**Learning:** When needing to deduplicate a `Vec` while keeping the *last* occurrence of each item (scanning in reverse), the previous approach involved allocating a new `Vec`, iterating backwards to populate it, and then reversing the new `Vec`. This causes an unnecessary O(N) heap allocation.
+**Action:** Use `.reverse()`, `.retain()`, and `.reverse()` again on the original `Vec` to perform the deduplication entirely in-place, eliminating the heap allocation completely.

--- a/src/index/temporal/mod.rs
+++ b/src/index/temporal/mod.rs
@@ -361,15 +361,12 @@ impl EntityTimeline {
             DeduplicationPolicy::LastOccurrence => {
                 // Keep the latest occurrence for each metadata_idx by scanning in reverse.
                 // Reverse scan avoids O(n^2) lookups and preserves sorted order after reverse().
+                // ⚡ Bolt Optimization: Use in-place `.retain()` with `reverse()` instead of allocating a new `Vec`.
+                // Eliminates a O(N) heap allocation during temporal index updates.
                 let mut seen = std::collections::HashSet::with_capacity(self.versions.len());
-                let mut deduped = Vec::with_capacity(self.versions.len());
-                for entry in self.versions.iter().rev() {
-                    if seen.insert(entry.metadata_idx) {
-                        deduped.push(*entry);
-                    }
-                }
-                deduped.reverse();
-                self.versions = deduped;
+                self.versions.reverse();
+                self.versions.retain(|entry| seen.insert(entry.metadata_idx));
+                self.versions.reverse();
             }
             DeduplicationPolicy::Reject => {
                 // Already checked above, no further deduplication needed.


### PR DESCRIPTION
💡 What: Replaced a `Vec` allocation with an in-place `reverse()`, `retain()`, and `reverse()` chain during temporal deduplication.
🎯 Why: The original logic in `LastOccurrence` deduplication allocated an intermediate `deduped` `Vec` and copied items over to avoid O(n^2) lookups, causing an unnecessary O(N) heap allocation on the hot path for indexing updates.
📊 Impact: Eliminates a O(N) heap allocation and memory copy for temporal storage transactions.
🔬 Measurement: Run `cargo test --lib index::temporal`.

---
*PR created automatically by Jules for task [14841031028074645351](https://jules.google.com/task/14841031028074645351) started by @madmax983*