### PR TITLE
⚡ Bolt: Remove intermediate vector allocation during temporal deduplication

### DIFF
--- a/src/index/temporal/mod.rs
+++ b/src/index/temporal/mod.rs
@@ -360,16 +360,13 @@ impl EntityTimeline {
             }
             DeduplicationPolicy::LastOccurrence => {
                 // Keep the latest occurrence for each metadata_idx by scanning in reverse.
-                // Reverse scan avoids O(n^2) lookups and preserves sorted order after reverse().
+                // ⚡ Bolt Optimization: Operates in-place via reverse + retain + reverse to avoid
+                // allocating an intermediate Vec of potentially equal size.
                 let mut seen = std::collections::HashSet::with_capacity(self.versions.len());
-                let mut deduped = Vec::with_capacity(self.versions.len());
-                for entry in self.versions.iter().rev() {
-                    if seen.insert(entry.metadata_idx) {
-                        deduped.push(*entry);
-                    }
-                }
-                deduped.reverse();
-                self.versions = deduped;
+                self.versions.reverse();
+                self.versions
+                    .retain(|entry| seen.insert(entry.metadata_idx));
+                self.versions.reverse();
             }
             DeduplicationPolicy::Reject => {
                 // Already checked above, no further deduplication needed.


### PR DESCRIPTION
💡 What: Replaced an out-of-place vector deduplication (`DeduplicationPolicy::LastOccurrence`) in temporal index consolidation with an in-place one using `reverse()` + `retain()` + `reverse()`.

🎯 Why: The original code allocated a brand-new intermediate `Vec` (`deduped`) with the exact same capacity as the original, populated it, and then reassigned. This caused completely unnecessary heap allocations when deduplicating large version histories.

📊 Impact: Removes 1 intermediate `Vec` heap allocation per batch consolidation for every entity timeline that undergoes deduplication.

🔬 Measurement: Verified correctness via `cargo test --lib -- index::temporal`.

---
*PR created automatically by Jules for task [17594443277485109231](https://jules.google.com/task/17594443277485109231) started by @madmax983*