### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -38,21 +38,6 @@ pub struct NarrativeGenerator<'a> {
     db: &'a AletheiaDB,
 }
 
-#[cfg(not(feature = "semantic-temporal"))]
-/// Generator for creating natural language narratives from temporal history.
-#[deprecated(
-    note = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-)]
-/// Generates human-readable summaries of temporal graph mutations.
-///
-/// # Why?
-/// When analyzing a `BiTemporalInterval`, users often need to understand
-/// the sequence of events (e.g., "Alice liked the post, then Bob deleted it").
-/// This struct translates raw `VersionMetadata` into a chronological narrative.
-pub struct NarrativeGenerator<'a> {
-    _marker: std::marker::PhantomData<&'a AletheiaDB>,
-}
-
 #[cfg(feature = "semantic-temporal")]
 impl<'a> NarrativeGenerator<'a> {
     /// Create a new narrative generator.
@@ -152,36 +137,6 @@ impl<'a> NarrativeGenerator<'a> {
         }
 
         Ok(events)
-    }
-}
-
-#[cfg(not(feature = "semantic-temporal"))]
-#[allow(deprecated)]
-impl<'a> NarrativeGenerator<'a> {
-    /// Create a new narrative generator.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-
-    /// Generate a narrative for a specific node.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
     }
 }
 
@@ -300,36 +255,5 @@ mod tests {
                 .any(|s| s.contains("was '\"delete_me\"'")),
             "Expected original value in removal message"
         );
-    }
-}
-
-#[cfg(all(test, not(feature = "semantic-temporal")))]
-#[allow(deprecated)]
-mod stub_tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
-        let db = AletheiaDB::new().unwrap();
-        // This should panic
-        let _ = NarrativeGenerator::new(&db);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
-        // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
-            _marker: std::marker::PhantomData,
-        };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
     }
 }


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the `story_demo`. Compiler said `NarrativeGenerator` not found. Then when I removed the `nova` feature, it just panic crashed at runtime instead of giving a normal compiler error.
🕵️ **The Reality:** The feature is behind the `nova` flag, but there were panicking stubs compiled when the flag was off, leading to a horrible DX of runtime panics instead of compilation errors.
💡 **The Fix:** Removed the panicking stub for `NarrativeGenerator`. Now if users try to use it without the `nova` feature, they get a standard Rust `unresolved import` error at compile time, which is exactly how cargo features should work.

---
*PR created automatically by Jules for task [9329712301171430716](https://jules.google.com/task/9329712301171430716) started by @madmax983*