### PR TITLE
🎻 Bard: Fix broken and redundant intra-doc links

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -231,7 +231,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: `src/db/ops.rs` and `src/db/temporal.rs`
🔦 Insight: The `StorageError` path in `ops.rs` was incorrect, causing a broken intra-doc link, and `ChangeRecord` in `temporal.rs` had a redundant explicit target.
🧪 Example: Removed the explicit path in `temporal.rs` and fixed the module path in `ops.rs` to satisfy rustdoc.
🖼️ Preview: (Ran `cargo doc --no-deps` successfully).

---
*PR created automatically by Jules for task [4734673367481620558](https://jules.google.com/task/4734673367481620558) started by @madmax983*