### PR TITLE
🎻 Bard: [documentation update] Fix broken intra-doc links

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -231,7 +231,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: `src/db/ops.rs` and `src/db/temporal.rs`
🔦 Insight: Fixed a broken link to `StorageError` by updating the module path, and removed a redundant explicit link target for `ChangeRecord`.
🧪 Example: N/A - formatting only.
🖼️ Preview: N/A - links are now functional.

---
*PR created automatically by Jules for task [15592224360208718335](https://jules.google.com/task/15592224360208718335) started by @madmax983*