### PR TITLE
🎻 Bard: Fix broken and redundant intra-doc links in src/db

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,7 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+
+## 2024-05-18 - [Fixing broken intra-doc links in src/db]
+**Confusion:** Using `crate::storage::StorageError::NodeNotFound` is incorrect since `StorageError` is exported in `crate::core`, and explicitly targeting a label that resolves to the same place like ``[`ChangeRecord`](crate::core::ChangeRecord)`` triggers `redundant explicit link target` warnings in rustdoc.
+**Clarification:** Replaced `crate::storage::StorageError::NodeNotFound` with `crate::core::StorageError::NodeNotFound` in `src/db/ops.rs` and removed the explicit target in `src/db/temporal.rs` for `[`ChangeRecord`]`, resolving both the `broken_intra_doc_links` and `redundant_explicit_links` warnings.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -231,7 +231,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: The `db` module.
🔦 Insight: Fixed a broken intra-doc link in `src/db/ops.rs` and removed a redundant explicit link target in `src/db/temporal.rs`.
🧪 Example: Clean `cargo doc` compilation with 0 warnings.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [2040245569509139164](https://jules.google.com/task/2040245569509139164) started by @madmax983*