### PR TITLE
⚔️ Elenchus: query::planner::rules::limit_pushdown Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,10 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[LimitPushdown Weak Assertions]**
+**Module:** `src/query/planner/rules/limit_pushdown.rs`
+**Severity:** 🟢 Acquitted (Strengthened)
+**Finding:** Several tests in the LimitPushdown planner rule (`test_combine_consecutive_limits`, `test_propagate_limit_to_vector_rank`, `test_propagate_limit_through_project`, and `test_binary_op_limit_pushdown_children`) contained weak assertions that only checked `assert!(result.is_some())` or performed incomplete AST destructuring.
+**Evidence:** Tests lacked rigorous structural comparison against the fully formed, expected `LogicalPlan` output.
+**Recommendation:** Refactored tests to use a single, strong `assert_eq!(result, Some(expected_plan))` which verifies the complete structure of the output AST.

--- a/src/query/planner/rules/limit_pushdown.rs
+++ b/src/query/planner/rules/limit_pushdown.rs
@@ -255,20 +255,11 @@ mod tests {
         ));
 
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
-
-        let new_plan = result.unwrap();
-        // Should be Limit(5, Scan) - no nested limit
-        match &new_plan.root {
-            LogicalOp::Unary {
-                op: UnaryOp::Limit(n),
-                input,
-            } => {
-                assert_eq!(*n, 5);
-                assert!(matches!(input.as_ref(), LogicalOp::Scan(_)));
-            }
-            _ => panic!("Expected Limit"),
-        }
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+        ));
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]
@@ -290,25 +281,18 @@ mod tests {
         ));
 
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
-
-        let new_plan = result.unwrap();
-        // VectorRank should have top_k=5 now
-        match &new_plan.root {
-            LogicalOp::Unary {
-                op: UnaryOp::Limit(_),
-                input,
-            } => match input.as_ref() {
-                LogicalOp::Unary {
-                    op: UnaryOp::VectorRank { top_k, .. },
-                    ..
-                } => {
-                    assert_eq!(*top_k, Some(5));
-                }
-                _ => panic!("Expected VectorRank"),
-            },
-            _ => panic!("Expected Limit"),
-        }
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::unary(
+                UnaryOp::VectorRank {
+                    embedding: Arc::from([0.1f32; 4].as_slice()),
+                    top_k: Some(5),
+                    property_key: None,
+                },
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+        ));
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]
@@ -364,7 +348,17 @@ mod tests {
         ));
 
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
+        let expected_plan = LogicalPlan::new(LogicalOp::unary(
+            UnaryOp::Limit(5),
+            LogicalOp::unary(
+                UnaryOp::Project(vec!["name".to_string()]),
+                LogicalOp::unary(
+                    UnaryOp::Limit(5),
+                    LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+                ),
+            ),
+        ));
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]
@@ -405,7 +399,15 @@ mod tests {
             LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
         ));
         let result = rule.apply(&plan, &stats).unwrap();
-        assert!(result.is_some());
+        let expected_plan = LogicalPlan::new(LogicalOp::binary(
+            crate::query::plan::BinaryOp::Union,
+            LogicalOp::unary(
+                UnaryOp::Limit(10),
+                LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(1).unwrap()])),
+            ),
+            LogicalOp::Scan(ScanOp::NodeLookup(vec![NodeId::new(2).unwrap()])),
+        ));
+        assert_eq!(result, Some(expected_plan));
     }
 
     #[test]


### PR DESCRIPTION
### Summary:
Overall mutation-readiness assessment of the module: Strengthened several weak existence checks (`assert!(result.is_some())`) in the `limit_pushdown.rs` tests into full structural AST matches.

### Verdict table:
- `test_combine_consecutive_limits`: 🟡 Suspect -> 🟢 Acquitted (Weak `is_some()` and partial property check replaced by full AST assert).
- `test_propagate_limit_to_vector_rank`: 🟡 Suspect -> 🟢 Acquitted (Weak `is_some()` and manual inner destructuring replaced by full AST assert).
- `test_propagate_limit_through_project`: 🟡 Suspect -> 🟢 Acquitted (Only verified `is_some()`; now fully structural).
- `test_binary_op_limit_pushdown_children`: 🟡 Suspect -> 🟢 Acquitted (Only verified `is_some()`; now fully structural).
- `test_pushdown_binary_partial_change`: 🟢 Acquitted (Already structurally rigorous).

### Priority fixes:
Replaced existential assertions (`is_some()`) and fragmented `unwrap()` checks with comprehensive `assert_eq!(result, Some(expected_plan))` assertions across four tests.

### Missing coverage:
None at this time. 

(Included update to Elenchus journal).

---
*PR created automatically by Jules for task [5190035198613584237](https://jules.google.com/task/5190035198613584237) started by @madmax983*