### PR TITLE
🛡️ Sentry: [test coverage improvement for index persistence error]

### DIFF
--- a/src/storage/index_persistence/error.rs
+++ b/src/storage/index_persistence/error.rs
@@ -86,3 +86,50 @@ impl IndexPersistenceError {
 
 /// Result type for index persistence operations.
 pub type Result<T> = std::result::Result<T, IndexPersistenceError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn should_return_true_for_not_found_io_error() {
+        let err =
+            IndexPersistenceError::Io(io::Error::new(io::ErrorKind::NotFound, "file not found"));
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn should_return_false_for_other_io_errors() {
+        let err = IndexPersistenceError::Io(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "permission denied",
+        ));
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn should_return_false_for_non_io_errors() {
+        let err = IndexPersistenceError::MissingIndex {
+            name: "test".to_string(),
+        };
+        assert!(!err.is_not_found());
+    }
+
+    #[test]
+    fn should_convert_from_bitcode_error() {
+        // Generate a bitcode error by trying to decode empty bytes into a u32
+        let bitcode_err = bitcode::decode::<u32>(&[]).unwrap_err();
+        let err: IndexPersistenceError = bitcode_err.into();
+
+        match err {
+            IndexPersistenceError::Serialization(msg) => {
+                assert!(
+                    !msg.is_empty(),
+                    "Serialization error message should not be empty"
+                );
+            }
+            _ => panic!("Expected Serialization error"),
+        }
+    }
+}


### PR DESCRIPTION
🎯 Target: `src/storage/index_persistence/error.rs`
💣 Risk: Missing test coverage for error conversions and helper methods, which could lead to incorrect error handling.
🧪 Strategy: Added unit tests for `IndexPersistenceError::is_not_found()` and `From<bitcode::Error>` trait implementation.
🔬 Verification: `cargo test --lib storage::index_persistence::error`

---
*PR created automatically by Jules for task [8565142220940799938](https://jules.google.com/task/8565142220940799938) started by @madmax983*