### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ pr_description.md
 
 # Re-include Python SDK sources (overrides "*.py" above)
 !python/**/*.py
+echo_test/

--- a/.jules/echo.md
+++ b/.jules/echo.md
@@ -19,3 +19,6 @@ Turns out, `NarrativeGenerator` is hidden behind an experimental `nova` feature 
 
 💡 **The Fix:**
 Add a huge, unmistakable banner or note in the README section *before* the code block that explicitly warns users to update their `Cargo.toml` with `features = ["nova"]` before they even try to copy the code. The warning needs to be in the Markdown text, not just hidden in the code comments. Also, maybe don't make the stub compile just to panic at runtime—if it's missing the feature, make it a hard compile error so I don't get false hope!
+**Docs Fix**
+**Context:** When users try to run experimental examples (like `story_demo`) from the README, they hit unresolved import errors (`NarrativeGenerator`) because experimental modules require specific feature flags (like `nova`).
+**Action:** Added a `> ⚠️ **Note:**` callout to `README.md` explicitly warning that experimental features require modifying `Cargo.toml` dependencies to include `features = ["nova"]`.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ fn main() -> Result<()> {
 
 See the [Getting Started guide](docs/guides/getting-started.md) for a full walkthrough.
 
+> ⚠️ **Note:** Some experimental examples like `story_demo` require the `nova` feature flag to run. Add `features = ["nova"]` to your dependencies if you are using them.
+
 ---
 
 ## Hybrid Queries


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the `story_demo`. Compiler said `NarrativeGenerator` not found.
🕵️ **The Reality:** Turns out I needed to enable feature `nova`.
💡 **The Fix:** Add a huge banner in README saying 'REQUIRES FEATURE NOVA' (or similar wording) near the quick start.

---
*PR created automatically by Jules for task [11142340213957979921](https://jules.google.com/task/11142340213957979921) started by @madmax983*