### PR TITLE
🎻 Bard: Fix rustdoc warnings

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-06-27 - [Fixing intra-doc links in db module]
+**Confusion:** The rustdoc build had warnings due to an incorrect path `crate::storage::StorageError::NodeNotFound` in `src/db/ops.rs`, and a redundant explicit link target `[`ChangeRecord`](crate::core::ChangeRecord)` in `src/db/temporal.rs`.
+**Clarification:** I fixed the incorrect path to `crate::core::StorageError::NodeNotFound` (as StorageError is re-exported from `core`) and removed the explicit redundant link target, keeping just `[`ChangeRecord`]`.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -231,7 +231,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: The `db` module.
🔦 Insight: Fixed rustdoc warnings related to `StorageError` and `ChangeRecord` intra-doc links.
🧪 Example: N/A.
🖼️ Preview: N/A.

---
*PR created automatically by Jules for task [951104639054005025](https://jules.google.com/task/951104639054005025) started by @madmax983*