### PR TITLE
⚡ Bolt: optimize migration queue sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+## ⚡ Bolt: Optimize migration queue sorting
+**Learning:** `VecDeque::make_contiguous()` can be used to sort a deque in-place, eliminating the need to `.drain(..).collect::<Vec<_>>()` into an intermediate `Vec`, sort the `Vec`, and then `.into_iter().collect()` back into the deque.
+**Action:** Always prefer `make_contiguous().sort()` or `make_contiguous().sort_by_key()` when sorting a `VecDeque` to avoid unnecessary heap allocations.

--- a/src/storage/sharding/rebalance.rs
+++ b/src/storage/sharding/rebalance.rs
@@ -556,9 +556,12 @@ impl RebalanceManager {
     pub fn queue_migration(&mut self, plan: MigrationPlan) {
         self.migration_queue.push_back(plan);
         // Sort by priority (higher priority first)
-        let mut vec: Vec<_> = self.migration_queue.drain(..).collect();
-        vec.sort_by_key(|p| std::cmp::Reverse(p.priority));
-        self.migration_queue = vec.into_iter().collect();
+        // ⚡ Bolt Optimization: Using `make_contiguous` allows us to sort the queue in-place,
+        // eliminating the heap allocation of an intermediate `Vec` and avoiding redundant
+        // iteration over the elements during drain and collect.
+        self.migration_queue
+            .make_contiguous()
+            .sort_by_key(|p| std::cmp::Reverse(p.priority));
     }
 
     /// Start the next migration from the queue.


### PR DESCRIPTION
💡 What: Replaced draining the migration queue into a Vec for sorting with an in-place sort using make_contiguous().
🎯 Why: To eliminate an unnecessary heap allocation and prevent iterating over the elements twice (during drain/collect).
📊 Impact: Removes 1 heap allocation per queued migration.
🔬 Measurement: Run cargo test --lib

---
*PR created automatically by Jules for task [17420679013472369191](https://jules.google.com/task/17420679013472369191) started by @madmax983*