### PR TITLE
🎻 Bard: Fix rustdoc warnings in db module

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,9 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-15 - [Redundant Explicit Links in Documentation]
+**Confusion:** Sometimes users specify explicit link targets in their documentation like `[\`ChangeRecord\`](crate::core::ChangeRecord)`. The `rustdoc` tool warns about these as redundant explicit links.
+**Clarification:** Removed the explicit link targets. Instead of `[\`ChangeRecord\`](crate::core::ChangeRecord)`, use `[\`ChangeRecord\`]`.
+## 2024-05-15 - [Broken Intra-Doc Links for StorageError]
+**Confusion:** The documentation for `count_connected_edges` in `src/db/ops.rs` linked to `crate::storage::StorageError::NodeNotFound`, but `StorageError` is actually exported from `crate::core::StorageError` (and defined in `crate::core::error::StorageError`).
+**Clarification:** Corrected the intra-doc link to point to `crate::core::StorageError::NodeNotFound` in `src/db/ops.rs`.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -231,7 +231,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
- Fixed a broken intra-doc link to `StorageError` in `src/db/ops.rs`.
- Fixed a redundant explicit link target for `ChangeRecord` in `src/db/temporal.rs`.
- Documented these findings in `.jules/bard.md`.

---
*PR created automatically by Jules for task [2986043511939347273](https://jules.google.com/task/2986043511939347273) started by @madmax983*