### PR TITLE
Add uniqueness constraints over currently-valid graph state (Issue #3218)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,6 +437,12 @@ harness = false
 path = "benches/vector_rerank.rs"
 required-features = []
 
+[[bench]]
+name = "uniqueness_constraints"
+harness = false
+path = "benches/uniqueness_constraints.rs"
+required-features = []
+
 # Unified CLI binary for local operations + daemon management
 [[bin]]
 name = "aletheia"

--- a/benches/uniqueness_constraints.rs
+++ b/benches/uniqueness_constraints.rs
@@ -1,0 +1,79 @@
+//! Uniqueness constraint write-path benchmarks (Issue #3218).
+//!
+//! Performance target (CLAUDE.md §current-state queries):
+//! - Constrained `create_node` must stay within 1µs overhead vs. unconstrained.
+
+mod common;
+
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_email() -> String {
+    format!("user{}@x", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn bench_create_node_unconstrained(c: &mut Criterion) {
+    let db = AletheiaDB::new().unwrap();
+
+    c.bench_function("create_node_unconstrained", |b| {
+        b.iter(|| {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("email", black_box(unique_email().as_str()))
+                    .build(),
+            )
+            .unwrap()
+        });
+    });
+}
+
+fn bench_create_node_constrained(c: &mut Criterion) {
+    let db = AletheiaDB::new().unwrap();
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    c.bench_function("create_node_constrained", |b| {
+        b.iter(|| {
+            db.create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("email", black_box(unique_email().as_str()))
+                    .build(),
+            )
+            .unwrap()
+        });
+    });
+}
+
+fn bench_create_node_constrained_violation(c: &mut Criterion) {
+    let db = AletheiaDB::new().unwrap();
+    db.unique_constraint("Person", "email").enable().unwrap();
+    db.create_node(
+        "Person",
+        PropertyMapBuilder::new().insert("email", "dup@x").build(),
+    )
+    .unwrap();
+
+    c.bench_function("create_node_constrained_violation", |b| {
+        b.iter(|| {
+            let _ = db.create_node(
+                "Person",
+                PropertyMapBuilder::new()
+                    .insert("email", black_box("dup@x"))
+                    .build(),
+            );
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_create_node_unconstrained,
+    bench_create_node_constrained,
+    bench_create_node_constrained_violation,
+);
+criterion_main!(benches);

--- a/fuzz/fuzz_targets/wal_entry_parsing.rs
+++ b/fuzz/fuzz_targets/wal_entry_parsing.rs
@@ -15,6 +15,11 @@ fuzz_target!(|data: &[u8]| {
         assert_eq!(roundtrip_consumed, canonical.len());
         assert_eq!(roundtrip.lsn, entry.lsn);
         assert_eq!(roundtrip.timestamp, entry.timestamp);
-        assert_eq!(roundtrip.operation, entry.operation);
+        // Compare via re-serialization rather than PartialEq: vectors containing NaN
+        // would fail `==` (IEEE 754: NaN != NaN) even though the round-trip is lossless.
+        // Byte-level idempotence is the correct invariant for WAL round-trip fidelity.
+        let canonical2 = aletheiadb::fuzzing::wal::serialize_entry(&roundtrip)
+            .expect("double-serialized WAL entry must serialize");
+        assert_eq!(canonical2, canonical, "WAL serialization must be idempotent");
     }
 });

--- a/src/api/transaction/write/constraint.rs
+++ b/src/api/transaction/write/constraint.rs
@@ -25,11 +25,10 @@ pub(crate) fn check_constraints(
     tx: &WriteTransaction,
     registry: &Arc<ConstraintRegistry>,
 ) -> std::result::Result<ReservationGuard, ConstraintError> {
-    // Tuples for post-tx (newly owned) constraint keys.
-    // We collect (label, PropertyMap, NodeId) and borrow from them below.
-    let mut added_owned: Vec<(InternedString, PropertyMap, NodeId)> = Vec::new();
+    // Borrow property maps directly from the buffer to avoid cloning on the hot path.
+    let mut added_refs: Vec<(InternedString, &PropertyMap, NodeId)> = Vec::new();
 
-    // Tuples for pre-tx (to be freed on commit) constraint keys.
+    // Pre-tx nodes whose constraint keys are freed on a successful commit.
     let mut removed_nodes: Vec<Node> = Vec::new();
 
     for op in tx.buffer.operations() {
@@ -40,7 +39,7 @@ pub(crate) fn check_constraints(
                 properties,
                 ..
             } => {
-                added_owned.push((*label, properties.clone(), *node_id));
+                added_refs.push((*label, properties, *node_id));
             }
             BufferedWrite::UpdateNode {
                 node_id,
@@ -49,7 +48,7 @@ pub(crate) fn check_constraints(
                 ..
             } => {
                 // Post-tx state is the new properties.
-                added_owned.push((*label, properties.clone(), *node_id));
+                added_refs.push((*label, properties, *node_id));
                 // Pre-tx state: fetch current node to find keys being released.
                 if let Ok(current_node) = tx.current.get_node(*node_id) {
                     removed_nodes.push(current_node);
@@ -64,10 +63,6 @@ pub(crate) fn check_constraints(
             _ => {}
         }
     }
-
-    // Build reference slices from the owned data.
-    let added_refs: Vec<(InternedString, &PropertyMap, NodeId)> =
-        added_owned.iter().map(|(l, p, id)| (*l, p, *id)).collect();
 
     let removed_refs: Vec<(InternedString, &PropertyMap, NodeId)> = removed_nodes
         .iter()

--- a/src/api/transaction/write/constraint.rs
+++ b/src/api/transaction/write/constraint.rs
@@ -1,0 +1,78 @@
+//! Uniqueness constraint enforcement on the write path.
+//!
+//! Called from `commit_with_timestamp_inner` after conflict detection and
+//! before acquiring the timestamp lock.  Returns an RAII `ReservationGuard`
+//! that auto-rolls back on drop if the commit fails later.
+
+use crate::core::constraint::{ConstraintRegistry, ReservationGuard};
+use crate::core::error::ConstraintError;
+use crate::core::graph::Node;
+use crate::core::id::NodeId;
+use crate::core::interning::InternedString;
+use crate::core::property::PropertyMap;
+use std::sync::Arc;
+
+use super::WriteTransaction;
+use crate::api::transaction::write_buffer::BufferedWrite;
+
+/// Enforce uniqueness constraints for the transaction's buffered node operations.
+///
+/// Returns a `ReservationGuard` that:
+/// - On drop (rollback path): releases all added reservations from the index.
+/// - After calling `guard.commit()` (success path): removes old-value reservations
+///   freed by updates/deletes.
+pub(crate) fn check_constraints(
+    tx: &WriteTransaction,
+    registry: &Arc<ConstraintRegistry>,
+) -> std::result::Result<ReservationGuard, ConstraintError> {
+    // Tuples for post-tx (newly owned) constraint keys.
+    // We collect (label, PropertyMap, NodeId) and borrow from them below.
+    let mut added_owned: Vec<(InternedString, PropertyMap, NodeId)> = Vec::new();
+
+    // Tuples for pre-tx (to be freed on commit) constraint keys.
+    let mut removed_nodes: Vec<Node> = Vec::new();
+
+    for op in tx.buffer.operations() {
+        match op {
+            BufferedWrite::CreateNode {
+                node_id,
+                label,
+                properties,
+                ..
+            } => {
+                added_owned.push((*label, properties.clone(), *node_id));
+            }
+            BufferedWrite::UpdateNode {
+                node_id,
+                label,
+                properties,
+                ..
+            } => {
+                // Post-tx state is the new properties.
+                added_owned.push((*label, properties.clone(), *node_id));
+                // Pre-tx state: fetch current node to find keys being released.
+                if let Ok(current_node) = tx.current.get_node(*node_id) {
+                    removed_nodes.push(current_node);
+                }
+            }
+            BufferedWrite::DeleteNode { node_id, .. } => {
+                // All constraint keys for this node are freed on commit.
+                if let Ok(current_node) = tx.current.get_node(*node_id) {
+                    removed_nodes.push(current_node);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Build reference slices from the owned data.
+    let added_refs: Vec<(InternedString, &PropertyMap, NodeId)> =
+        added_owned.iter().map(|(l, p, id)| (*l, p, *id)).collect();
+
+    let removed_refs: Vec<(InternedString, &PropertyMap, NodeId)> = removed_nodes
+        .iter()
+        .map(|n| (n.label, &n.properties, n.id))
+        .collect();
+
+    registry.reserve_for_transaction(&added_refs, &removed_refs)
+}

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -390,7 +390,9 @@ impl WriteTransaction {
         // Enforce uniqueness constraints (reservation step).
         // Must sit before the timestamp lock so we never hold a DashMap shard
         // guard across `current_timestamp` (preserves lock-ordering contract).
-        let _constraint_guard = if let Some(ref registry) = self.constraint_registry {
+        // The guard is intentionally kept alive (not prefixed with `_`) so its
+        // Drop impl releases reserved keys on any subsequent error path.
+        let constraint_guard = if let Some(ref registry) = self.constraint_registry {
             Some(
                 constraint::check_constraints(self, registry)
                     .map_err(crate::core::error::Error::Constraint)?,
@@ -596,13 +598,17 @@ impl WriteTransaction {
         // written nodes/edges, making them visible to future snapshot readers.
         apply::finalize_current_commit_timestamps(self, commit_timestamp);
 
-        // Register commit with visibility manager
-        self.visibility_manager.register_commit(self.tx_id);
-
-        // Commit the constraint guard: keeps added reservations, frees removed ones.
-        if let Some(guard) = _constraint_guard {
+        // Commit the constraint guard before registering with the visibility manager.
+        // Committing first ensures that freed old-value slots are released before
+        // other transactions observe this commit as visible — otherwise a concurrent
+        // delete+create of the same key could see the old reservation still present
+        // and raise a spurious UniqueViolation.
+        if let Some(guard) = constraint_guard {
             guard.commit();
         }
+
+        // Register commit with visibility manager
+        self.visibility_manager.register_commit(self.tx_id);
 
         // Mark as committed
         self.state = TxState::Committed;

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -35,6 +35,7 @@ use std::time::Instant;
 
 mod apply;
 mod conflict;
+pub(crate) mod constraint;
 mod validation;
 mod wal;
 
@@ -98,6 +99,10 @@ pub struct WriteTransaction {
 
     /// Durability mode for this transaction's commit
     pub(crate) durability_mode: DurabilityMode,
+
+    /// Uniqueness constraint registry shared with the parent database.
+    /// `None` for transactions created without a registry (legacy / tests).
+    pub(crate) constraint_registry: Option<Arc<crate::core::constraint::ConstraintRegistry>>,
 }
 
 impl WriteTransaction {
@@ -234,7 +239,17 @@ impl WriteTransaction {
             edge_id_gen,
             version_id_gen,
             durability_mode,
+            constraint_registry: None,
         }
+    }
+
+    /// Attach a constraint registry to this transaction (called by the DB layer).
+    pub(crate) fn with_constraint_registry(
+        mut self,
+        registry: Arc<crate::core::constraint::ConstraintRegistry>,
+    ) -> Self {
+        self.constraint_registry = Some(registry);
+        self
     }
 
     /// Get transaction metadata.
@@ -371,6 +386,18 @@ impl WriteTransaction {
 
         // Detect write-write conflicts (Snapshot Isolation)
         self.detect_conflicts()?;
+
+        // Enforce uniqueness constraints (reservation step).
+        // Must sit before the timestamp lock so we never hold a DashMap shard
+        // guard across `current_timestamp` (preserves lock-ordering contract).
+        let _constraint_guard = if let Some(ref registry) = self.constraint_registry {
+            Some(
+                constraint::check_constraints(self, registry)
+                    .map_err(crate::core::error::Error::Constraint)?,
+            )
+        } else {
+            None
+        };
 
         // Acquire commit timestamp and perform mode-aware WAL flush.
         //
@@ -571,6 +598,11 @@ impl WriteTransaction {
 
         // Register commit with visibility manager
         self.visibility_manager.register_commit(self.tx_id);
+
+        // Commit the constraint guard: keeps added reservations, frees removed ones.
+        if let Some(guard) = _constraint_guard {
+            guard.commit();
+        }
 
         // Mark as committed
         self.state = TxState::Committed;

--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -90,7 +90,8 @@ pub struct ReservationGuard {
     /// Keys added during this transaction (released on rollback).
     added: Vec<ReservationKey>,
     /// Old-value keys to remove after commit (freed on the success path).
-    to_remove: Vec<ReservationKey>,
+    /// HashSet for O(1) dedup in the removed-entries loop.
+    to_remove: std::collections::HashSet<ReservationKey>,
     committed: bool,
 }
 
@@ -99,7 +100,7 @@ impl ReservationGuard {
         Self {
             registry,
             added: Vec::new(),
-            to_remove: Vec::new(),
+            to_remove: std::collections::HashSet::new(),
             committed: false,
         }
     }
@@ -364,8 +365,9 @@ impl ConstraintRegistry {
                     // Only free the old key if it is not still claimed by this tx.
                     // (Handles the case where a node updates a property to its own
                     // current value — the slot must not be freed.)
-                    if !claimed.contains(&key) && !guard.to_remove.contains(&key) {
-                        guard.to_remove.push(key);
+                    // HashSet insert is idempotent, so no explicit contains check needed.
+                    if !claimed.contains(&key) {
+                        guard.to_remove.insert(key);
                     }
                 }
             }

--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -1,0 +1,367 @@
+//! Uniqueness constraint registry and enforcement types.
+//!
+//! Lives in `core` so that both `storage::recovery` (WAL replay) and `db` (API surface)
+//! can import it without creating circular module dependencies.
+
+use crate::core::error::{ConstraintError, Result};
+use crate::core::id::NodeId;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
+use crate::core::property::{PropertyMap, PropertyValue};
+use dashmap::DashMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Canonical hashable + equatable key derived from a `PropertyValue`.
+///
+/// Only scalar types that can serve as unique keys are supported.
+/// Null, Vector, SparseVector, and Array are rejected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ValueKey {
+    /// Boolean value.
+    Bool(bool),
+    /// Integer value.
+    Int(i64),
+    /// Float value (stored as bits for `Hash`+`Eq`).
+    Float(u64),
+    /// String value.
+    String(Arc<str>),
+    /// Bytes value.
+    Bytes(Arc<[u8]>),
+}
+
+impl ValueKey {
+    /// Try to create a `ValueKey` from a `PropertyValue`.
+    /// Returns `None` for unsupported types (Null, Vector, SparseVector, Array).
+    pub fn from_property_value(v: &PropertyValue) -> Option<Self> {
+        match v {
+            PropertyValue::Bool(b) => Some(ValueKey::Bool(*b)),
+            PropertyValue::Int(i) => Some(ValueKey::Int(*i)),
+            PropertyValue::Float(f) => Some(ValueKey::Float(f.to_bits())),
+            PropertyValue::String(s) => Some(ValueKey::String(Arc::clone(s))),
+            PropertyValue::Bytes(b) => Some(ValueKey::Bytes(Arc::clone(b))),
+            PropertyValue::Null
+            | PropertyValue::Vector(_)
+            | PropertyValue::SparseVector(_)
+            | PropertyValue::Array(_) => None,
+        }
+    }
+
+    /// Human-readable display for error messages.
+    pub fn display_string(&self) -> String {
+        match self {
+            ValueKey::Bool(b) => b.to_string(),
+            ValueKey::Int(i) => i.to_string(),
+            ValueKey::Float(bits) => f64::from_bits(*bits).to_string(),
+            ValueKey::String(s) => s.as_ref().to_string(),
+            ValueKey::Bytes(b) => format!("<bytes:{}>", b.len()),
+        }
+    }
+}
+
+/// Reservation key — identifies a unique slot in the reservation index.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReservationKey {
+    /// Interned label ID.
+    pub label: InternedString,
+    /// Interned property key ID.
+    pub property: InternedString,
+    /// Canonical value key.
+    pub value: ValueKey,
+}
+
+/// RAII guard holding in-flight constraint reservations for one transaction.
+///
+/// - **Rollback path** (`Drop`): releases all added reservations so the index
+///   has no orphan entries.
+/// - **Success path** (`commit()`): keeps added reservations and removes the
+///   old-value entries that were displaced by update/delete operations.
+pub struct ReservationGuard {
+    registry: Arc<ConstraintRegistry>,
+    /// Keys added during this transaction (released on rollback).
+    added: Vec<ReservationKey>,
+    /// Old-value keys to remove after commit (freed on the success path).
+    to_remove: Vec<ReservationKey>,
+    committed: bool,
+}
+
+impl ReservationGuard {
+    fn new(registry: Arc<ConstraintRegistry>) -> Self {
+        Self {
+            registry,
+            added: Vec::new(),
+            to_remove: Vec::new(),
+            committed: false,
+        }
+    }
+
+    /// Call on the success path to lock in added reservations and free old ones.
+    pub fn commit(mut self) {
+        self.committed = true;
+        for key in &self.to_remove {
+            self.registry.reservation_index.remove(key);
+        }
+    }
+}
+
+impl Drop for ReservationGuard {
+    fn drop(&mut self) {
+        if !self.committed {
+            for key in &self.added {
+                self.registry.reservation_index.remove(key);
+            }
+        }
+    }
+}
+
+/// Central registry for uniqueness constraints.
+///
+/// Thread-safe via DashMap; designed for concurrent read/write access.
+///
+/// # Lock Order
+///
+/// The `ConstraintRegistry` is a **leaf** in AletheiaDB's lock hierarchy.
+/// It is acquired (via DashMap shard locks) before `current_timestamp` and
+/// never held across any other synchronization primitive.
+pub struct ConstraintRegistry {
+    /// Active constraint declarations: (label_id, property_id) → present = enabled.
+    declarations: DashMap<(InternedString, InternedString), ()>,
+    /// Currently-valid reservation index: ReservationKey → owning NodeId.
+    pub(crate) reservation_index: DashMap<ReservationKey, NodeId>,
+}
+
+impl ConstraintRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            declarations: DashMap::new(),
+            reservation_index: DashMap::new(),
+        }
+    }
+
+    /// Returns `true` if there is an active constraint for `(label, property)`.
+    #[inline]
+    pub fn is_constrained(&self, label: InternedString, property: InternedString) -> bool {
+        self.declarations.contains_key(&(label, property))
+    }
+
+    /// Record a constraint declaration (called by `enable()` and WAL replay).
+    pub fn declare(&self, label: InternedString, property: InternedString) {
+        self.declarations.insert((label, property), ());
+    }
+
+    /// Remove a constraint declaration (called by `disable()` and WAL replay).
+    pub fn undeclare(&self, label: InternedString, property: InternedString) {
+        self.declarations.remove(&(label, property));
+        self.reservation_index
+            .retain(|k, _| !(k.label == label && k.property == property));
+    }
+
+    /// List all declared constraints as `(label_string, property_string)` pairs.
+    pub fn list(&self) -> Vec<(String, String)> {
+        self.declarations
+            .iter()
+            .filter_map(|entry| {
+                let (label_id, prop_id) = entry.key();
+                let label = GLOBAL_INTERNER.resolve_with(*label_id, |s| s.to_string())?;
+                let property = GLOBAL_INTERNER.resolve_with(*prop_id, |s| s.to_string())?;
+                Some((label, property))
+            })
+            .collect()
+    }
+
+    /// Atomically attempt to reserve `(label, property, value) → node_id`.
+    ///
+    /// - If the slot is vacant, inserts and returns `Ok(())`.
+    /// - If the slot is already owned by `node_id`, returns `Ok(())` (idempotent).
+    /// - If the slot is owned by a different node, returns `Err(UniqueViolation)`.
+    pub fn try_reserve(
+        &self,
+        key: ReservationKey,
+        node_id: NodeId,
+        label_str: &str,
+        property_str: &str,
+    ) -> std::result::Result<bool, ConstraintError> {
+        use dashmap::mapref::entry::Entry;
+        match self.reservation_index.entry(key.clone()) {
+            Entry::Vacant(e) => {
+                e.insert(node_id);
+                Ok(true) // newly inserted
+            }
+            Entry::Occupied(e) => {
+                let existing = *e.get();
+                if existing == node_id {
+                    Ok(false) // same-node idempotent, not a new insertion
+                } else {
+                    Err(ConstraintError::UniqueViolation {
+                        label: label_str.to_string(),
+                        property: property_str.to_string(),
+                        value: key.value.display_string(),
+                        existing_node_id: existing,
+                    })
+                }
+            }
+        }
+    }
+
+    /// Pre-flight scan: check that enabling `(label, property)` on `nodes` would
+    /// not reveal existing duplicates. Fails with `DuplicateOnEnable` if any exist.
+    pub fn check_no_duplicates(
+        nodes: &[crate::core::graph::Node],
+        label: InternedString,
+        property: InternedString,
+        label_str: &str,
+        property_str: &str,
+    ) -> Result<()> {
+        let mut seen: HashMap<ValueKey, Vec<NodeId>> = HashMap::new();
+
+        for node in nodes {
+            if node.label != label {
+                continue;
+            }
+            if let Some(pv) = node.properties.get_by_interned_key(&property) {
+                match ValueKey::from_property_value(pv) {
+                    None => {
+                        return Err(ConstraintError::UnsupportedKeyType {
+                            label: label_str.to_string(),
+                            property: property_str.to_string(),
+                            type_name: pv.type_name().to_string(),
+                        }
+                        .into());
+                    }
+                    Some(vk) => {
+                        seen.entry(vk).or_default().push(node.id);
+                    }
+                }
+            }
+        }
+
+        for (vk, ids) in &seen {
+            if ids.len() >= 2 {
+                return Err(ConstraintError::DuplicateOnEnable {
+                    label: label_str.to_string(),
+                    property: property_str.to_string(),
+                    value: vk.display_string(),
+                    node_ids: ids.clone(),
+                }
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Rebuild the reservation index from a slice of currently-valid nodes for one
+    /// `(label, property)` constraint pair. Called after WAL replay.
+    pub fn rebuild_from_nodes(
+        &self,
+        nodes: &[crate::core::graph::Node],
+        label: InternedString,
+        property: InternedString,
+    ) {
+        for node in nodes {
+            if node.label != label {
+                continue;
+            }
+            if let Some(value) = node.properties.get_by_interned_key(&property)
+                && let Some(vk) = ValueKey::from_property_value(value)
+            {
+                let key = ReservationKey {
+                    label,
+                    property,
+                    value: vk,
+                };
+                self.reservation_index.insert(key, node.id);
+            }
+        }
+    }
+
+    /// Build a `ReservationGuard` by atomically reserving all constraint keys
+    /// that the transaction's operations would create/update/delete.
+    ///
+    /// `added_entries`: post-tx (label, properties, node_id) for created/updated nodes.
+    /// `removed_entries`: pre-tx (label, properties, node_id) for updated/deleted nodes
+    ///   (these keys are freed on commit).
+    pub fn reserve_for_transaction(
+        self: &Arc<Self>,
+        added_entries: &[(InternedString, &PropertyMap, NodeId)],
+        removed_entries: &[(InternedString, &PropertyMap, NodeId)],
+    ) -> std::result::Result<ReservationGuard, ConstraintError> {
+        let mut guard = ReservationGuard::new(Arc::clone(self));
+
+        // Track all keys "claimed" by this tx post-commit (newly reserved OR
+        // idempotently re-confirmed on same node).  Keys in `claimed` must NOT
+        // be freed on commit even if they also appear in the pre-tx state.
+        let mut claimed: std::collections::HashSet<ReservationKey> =
+            std::collections::HashSet::new();
+
+        for (label_id, props, node_id) in added_entries {
+            for (prop_id, value) in props.iter() {
+                let prop_id = *prop_id;
+                if !self.is_constrained(*label_id, prop_id) {
+                    continue;
+                }
+                let vk = match ValueKey::from_property_value(value) {
+                    Some(k) => k,
+                    None => continue,
+                };
+                let key = ReservationKey {
+                    label: *label_id,
+                    property: prop_id,
+                    value: vk,
+                };
+                let label_str = GLOBAL_INTERNER
+                    .resolve_with(*label_id, |s| s.to_string())
+                    .unwrap_or_default();
+                let prop_str = GLOBAL_INTERNER
+                    .resolve_with(prop_id, |s| s.to_string())
+                    .unwrap_or_default();
+
+                match self.try_reserve(key.clone(), *node_id, &label_str, &prop_str) {
+                    Ok(true) => {
+                        // Newly reserved — must roll back on tx failure.
+                        guard.added.push(key.clone());
+                        claimed.insert(key);
+                    }
+                    Ok(false) => {
+                        // Same node idempotent — already in the index; not a new
+                        // insertion, but still "claimed" so we don't free it.
+                        claimed.insert(key);
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        for (label_id, props, _node_id) in removed_entries {
+            for (prop_id, value) in props.iter() {
+                let prop_id = *prop_id;
+                if !self.is_constrained(*label_id, prop_id) {
+                    continue;
+                }
+                if let Some(vk) = ValueKey::from_property_value(value) {
+                    let key = ReservationKey {
+                        label: *label_id,
+                        property: prop_id,
+                        value: vk,
+                    };
+                    // Only free the old key if it is not still claimed by this tx.
+                    // (Handles the case where a node updates a property to its own
+                    // current value — the slot must not be freed.)
+                    if !claimed.contains(&key) && !guard.to_remove.contains(&key) {
+                        guard.to_remove.push(key);
+                    }
+                }
+            }
+        }
+
+        Ok(guard)
+    }
+}
+
+impl Default for ConstraintRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -36,7 +36,17 @@ impl ValueKey {
         match v {
             PropertyValue::Bool(b) => Some(ValueKey::Bool(*b)),
             PropertyValue::Int(i) => Some(ValueKey::Int(*i)),
-            PropertyValue::Float(f) => Some(ValueKey::Float(f.to_bits())),
+            PropertyValue::Float(f) => {
+                // Normalize all NaN representations to one canonical bit pattern so two
+                // NaN floats are treated as the same unique key (instead of different
+                // bit-patterns bypassing the constraint).
+                let bits = if f.is_nan() {
+                    f64::NAN.to_bits()
+                } else {
+                    f.to_bits()
+                };
+                Some(ValueKey::Float(bits))
+            }
             PropertyValue::String(s) => Some(ValueKey::String(Arc::clone(s))),
             PropertyValue::Bytes(b) => Some(ValueKey::Bytes(Arc::clone(b))),
             PropertyValue::Null
@@ -219,6 +229,11 @@ impl ConstraintRegistry {
                 continue;
             }
             if let Some(pv) = node.properties.get_by_interned_key(&property) {
+                // Null means "property not set" — treat it as absent, not as a
+                // constraint violation or an unsupported type.
+                if matches!(pv, PropertyValue::Null) {
+                    continue;
+                }
                 match ValueKey::from_property_value(pv) {
                     None => {
                         return Err(ConstraintError::UnsupportedKeyType {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -45,6 +45,9 @@ pub enum Error {
     /// Vector-related errors.
     #[error("Vector error: {0}")]
     Vector(VectorError),
+    /// Uniqueness constraint violations.
+    #[error("Constraint error: {0}")]
+    Constraint(ConstraintError),
     /// I/O errors.
     #[error("I/O error: {0}")]
     Io(io::Error),
@@ -79,6 +82,7 @@ impl Error {
                 Error::Query(_) => crate::observability::ErrorCategory::Query,
                 Error::Transaction(_) => crate::observability::ErrorCategory::Transaction,
                 Error::Vector(_) => crate::observability::ErrorCategory::Vector,
+                Error::Constraint(_) => crate::observability::ErrorCategory::Other,
                 Error::Io(_) => crate::observability::ErrorCategory::Io,
                 Error::Backup(_) => crate::observability::ErrorCategory::Other,
                 Error::NotImplemented { .. } | Error::Other(_) => {
@@ -86,6 +90,15 @@ impl Error {
                 }
             };
             crate::observability::record_error(category);
+        }
+    }
+
+    /// Downcast to `ConstraintError` if this is a constraint violation.
+    pub fn as_constraint(&self) -> Option<&ConstraintError> {
+        if let Error::Constraint(e) = self {
+            Some(e)
+        } else {
+            None
         }
     }
 
@@ -144,6 +157,12 @@ impl From<TransactionError> for Error {
 impl From<VectorError> for Error {
     fn from(e: VectorError) -> Self {
         Error::Vector(e)
+    }
+}
+
+impl From<ConstraintError> for Error {
+    fn from(e: ConstraintError) -> Self {
+        Error::Constraint(e)
     }
 }
 
@@ -773,6 +792,51 @@ fn format_clock_skew(wallclock: i64, previous: i64, drift_us: i64, max_allowed: 
         wallclock,
         previous
     )
+}
+
+/// Errors related to uniqueness constraint operations.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ConstraintError {
+    /// A node create or update would violate a uniqueness constraint.
+    #[error(
+        "Unique constraint violation on {label}.{property}: value already owned by node {existing_node_id}"
+    )]
+    UniqueViolation {
+        /// The node label the constraint is scoped to.
+        label: String,
+        /// The property the constraint is on.
+        property: String,
+        /// The conflicting value, as a debug string.
+        value: String,
+        /// The NodeId that already owns this value.
+        existing_node_id: crate::core::id::NodeId,
+    },
+    /// Enabling a constraint failed because duplicate currently-valid values exist.
+    #[error(
+        "Cannot enable unique constraint on {label}.{property}: duplicate value {value} exists on {node_ids:?}"
+    )]
+    DuplicateOnEnable {
+        /// The node label the constraint was declared for.
+        label: String,
+        /// The property the constraint was declared for.
+        property: String,
+        /// One of the duplicate values.
+        value: String,
+        /// All node IDs that share the duplicate value (at least 2).
+        node_ids: Vec<crate::core::id::NodeId>,
+    },
+    /// The property value type cannot be used as a unique constraint key.
+    #[error(
+        "Unsupported key type for unique constraint on {label}.{property}: {type_name} cannot be used as a unique key"
+    )]
+    UnsupportedKeyType {
+        /// The node label.
+        label: String,
+        /// The property name.
+        property: String,
+        /// The type name that is not supported.
+        type_name: String,
+    },
 }
 
 /// Errors related to vector operations and validation.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -26,6 +26,7 @@
 //! to the physical wall clock, bridging the gap between machines and human expectations.
 
 pub mod changefeed;
+pub mod constraint;
 pub mod error;
 pub mod graph;
 pub mod hasher;

--- a/src/core/property/map.rs
+++ b/src/core/property/map.rs
@@ -164,9 +164,9 @@ impl PropertyMap {
     ///   - Key bytes: UTF-8 encoded string
     ///   - Value: Serialized PropertyValue (includes type tag)
     ///
-    /// Note: HashMap ordering is not guaranteed, so serialization order
-    /// may vary. This is acceptable for correctness but may affect
-    /// byte-for-byte reproducibility.
+    /// Keys are serialized in ascending interned-ID order so that
+    /// serialize → deserialize → serialize is byte-for-byte idempotent
+    /// (required for WAL round-trip fidelity and fuzz testing).
     ///
     /// # Errors
     ///
@@ -189,7 +189,15 @@ impl PropertyMap {
         buffer.reserve(self.cached_size);
 
         buffer.extend_from_slice(&(self.inner.len() as u32).to_le_bytes());
-        for (key, value) in self.inner.iter() {
+
+        // Sort by interned key ID to produce a deterministic byte order.
+        // HashMap iteration order is not stable across insertions, so without
+        // sorting, serialize → deserialize → serialize can produce different
+        // bytes (keys in a different sequence), breaking WAL round-trip fidelity.
+        let mut entries: Vec<(&PropertyKey, &PropertyValue)> = self.inner.iter().collect();
+        entries.sort_unstable_by_key(|(k, _)| **k);
+
+        for (key, value) in entries {
             let value: &PropertyValue = value;
             // Serialize key: resolve InternedString to actual string
             // Use with_str to avoid Arc cloning overhead
@@ -679,4 +687,31 @@ macro_rules! properties {
             builder.build()
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_round_trip_idempotent_multi_key() {
+        let props = PropertyMapBuilder::new()
+            .insert("zebra", 1)
+            .insert("alpha", 2)
+            .insert("mango", 3)
+            .insert("beta", true)
+            .build();
+
+        let canonical = props.serialize().expect("serialize must succeed");
+
+        let (props2, consumed) =
+            PropertyMap::deserialize(&canonical).expect("deserialize must succeed");
+        assert_eq!(consumed, canonical.len());
+
+        let canonical2 = props2.serialize().expect("re-serialize must succeed");
+        assert_eq!(
+            canonical2, canonical,
+            "PropertyMap serialization must be idempotent"
+        );
+    }
 }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -822,4 +822,80 @@ mod ephemeral_tests {
                 .expect_err("constraint must survive WAL+persistence restart");
         }
     }
+
+    /// WAL-only recovery (no index persistence) bumps edge_id_gen past the
+    /// highest edge ID seen in the WAL.  This exercises the
+    /// `if persistence_manager.is_none()` branch at config.rs lines ~468-472:
+    ///
+    /// ```text
+    /// if let Some(max_eid) = max_edge_id {
+    ///     db.edge_id_gen.ensure_at_least(max_eid + 1);
+    /// }
+    /// ```
+    #[test]
+    fn wal_only_recovery_bumps_edge_id_gen() {
+        use crate::WriteOps;
+        use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+        use crate::storage::index_persistence::PersistenceConfig;
+        use crate::storage::wal::DurabilityMode;
+        use tempfile::tempdir;
+
+        let scratch = tempdir().unwrap();
+        let wal_dir = scratch.path().join("wal");
+
+        let make_config = || {
+            AletheiaDBConfig::builder()
+                .wal(
+                    WalConfigBuilder::new()
+                        .wal_dir(wal_dir.clone())
+                        .durability_mode(DurabilityMode::Synchronous)
+                        .build(),
+                )
+                .persistence(PersistenceConfig {
+                    enabled: false,
+                    ..PersistenceConfig::default()
+                })
+                .build()
+        };
+
+        // Session 1: create two nodes and an edge; remember the edge ID.
+        let recorded_edge_id = {
+            let db = AletheiaDB::with_unified_config(make_config()).unwrap();
+            let n1 = db
+                .create_node("N", crate::PropertyMapBuilder::new().build())
+                .unwrap();
+            let n2 = db
+                .create_node("N", crate::PropertyMapBuilder::new().build())
+                .unwrap();
+            let eid = db
+                .write(|tx| tx.create_edge(n1, n2, "E", crate::PropertyMapBuilder::new().build()))
+                .unwrap();
+            eid.as_u64()
+        };
+
+        // Session 2: WAL-only replay — no persistence manager → enters the
+        // `persistence_manager.is_none()` branch → max_edge_id is Some(_) →
+        // edge_id_gen.ensure_at_least fires → new edge ID must be > recorded one.
+        {
+            let db = AletheiaDB::with_unified_config(make_config()).unwrap();
+            assert_eq!(db.edge_count(), 1, "edge must be recovered from WAL replay");
+
+            let n1 = db
+                .create_node("N", crate::PropertyMapBuilder::new().build())
+                .unwrap();
+            let n2 = db
+                .create_node("N", crate::PropertyMapBuilder::new().build())
+                .unwrap();
+            let new_eid = db
+                .write(|tx| tx.create_edge(n1, n2, "E2", crate::PropertyMapBuilder::new().build()))
+                .unwrap();
+            assert!(
+                new_eid.as_u64() > recorded_edge_id,
+                "edge_id_gen must be bumped past the WAL-replayed max edge ID \
+                 (got {}, expected > {})",
+                new_eid.as_u64(),
+                recorded_edge_id,
+            );
+        }
+    }
 }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -329,6 +329,7 @@ impl AletheiaDB {
                 persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 persistence_thread_handle: None,
                 encryption_manager: encryption_manager.clone(),
+                constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 _tempdir: None,
             };
 
@@ -360,6 +361,14 @@ impl AletheiaDB {
                         crate::core::GLOBAL_INTERNER.len() as u64
                     );
                 }
+
+                // Replay constraint declarations from the full WAL history before the
+                // differential node/edge replay.  Constraint WAL entries may predate
+                // the snapshot LSN and would be skipped by the differential replay.
+                crate::storage::recovery::replay_constraint_declarations_from_wal(
+                    &db.wal,
+                    &db.constraint_registry,
+                )?;
 
                 // Replay WAL entries that occurred after the persisted snapshot
                 // This ensures no data loss if the WAL is ahead of the indexes (e.g. crash before persist)
@@ -395,17 +404,67 @@ impl AletheiaDB {
 
                 let mut historical_guard = db.historical.write();
                 let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
-                    crate::storage::recovery::replay_wal_into_storage(
+                    crate::storage::recovery::replay_wal_into_storage_with_constraints(
                         &db.wal,
                         &db.current,
                         &mut historical_guard,
                         start_lsn,
                         initial_version_id,
+                        Some(&db.constraint_registry),
                     )?;
                 drop(historical_guard);
 
+                // Rebuild reservation index from currently-valid nodes for each declared constraint.
+                for (label_str, property_str) in db.constraint_registry.list() {
+                    if let (Some(label_id), Some(property_id)) = (
+                        crate::core::interning::GLOBAL_INTERNER.get_id(&label_str),
+                        crate::core::interning::GLOBAL_INTERNER.get_id(&property_str),
+                    ) {
+                        let nodes = db.current.get_nodes_by_label(&label_str);
+                        db.constraint_registry
+                            .rebuild_from_nodes(&nodes, label_id, property_id);
+                    }
+                }
+
                 // Update ID generators to account for replayed entities.
                 // This ensures that subsequent writes use IDs that don't collide with replayed data.
+                if let Some(max_nid) = max_node_id {
+                    db.node_id_gen.ensure_at_least(max_nid + 1);
+                }
+                if let Some(max_eid) = max_edge_id {
+                    db.edge_id_gen.ensure_at_least(max_eid + 1);
+                }
+                db.version_id_gen.ensure_at_least(next_version_id);
+            }
+
+            // When only the WAL is configured (no index persistence), replay the full
+            // WAL from the beginning to restore node/edge data AND constraint declarations.
+            if persistence_manager.is_none() {
+                let initial_version_id = db.version_id_gen.current();
+                let mut historical_guard = db.historical.write();
+                let (_final_lsn, max_node_id, max_edge_id, next_version_id) =
+                    crate::storage::recovery::replay_wal_into_storage_with_constraints(
+                        &db.wal,
+                        &db.current,
+                        &mut historical_guard,
+                        crate::storage::wal::LSN::initial(),
+                        initial_version_id,
+                        Some(&db.constraint_registry),
+                    )?;
+                drop(historical_guard);
+
+                // Rebuild reservation index.
+                for (label_str, property_str) in db.constraint_registry.list() {
+                    if let (Some(label_id), Some(property_id)) = (
+                        crate::core::interning::GLOBAL_INTERNER.get_id(&label_str),
+                        crate::core::interning::GLOBAL_INTERNER.get_id(&property_str),
+                    ) {
+                        let nodes = db.current.get_nodes_by_label(&label_str);
+                        db.constraint_registry
+                            .rebuild_from_nodes(&nodes, label_id, property_id);
+                    }
+                }
+
                 if let Some(max_nid) = max_node_id {
                     db.node_id_gen.ensure_at_least(max_nid + 1);
                 }
@@ -517,6 +576,7 @@ impl AletheiaDB {
                 persistence_thread_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 persistence_thread_handle: None,
                 encryption_manager: None,
+                constraint_registry: Arc::new(crate::core::constraint::ConstraintRegistry::new()),
                 _tempdir: None,
             };
             seed_startup_current_timestamp(&db)?;

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -715,40 +715,40 @@ mod ephemeral_tests {
         }
     }
 
-    /// Cover config.rs line 435: `db.edge_id_gen.ensure_at_least(max_eid + 1)` in the
-    /// WAL+persistence startup path when the incremental WAL (after the snapshot) has edges.
+    /// Covers config.rs line 435: the WAL+persistence incremental-replay path that
+    /// runs `db.edge_id_gen.ensure_at_least(max_eid + 1)` when the incremental WAL
+    /// (between the last snapshot LSN and the current WAL head) contains an edge.
     ///
-    /// Strategy: manually flush the snapshot BEFORE creating an edge, then stop the
-    /// background thread so Drop cannot run a second final-persist.  On the next startup
-    /// the snapshot has no edges but the incremental WAL does → `max_edge_id = Some(...)`.
+    /// Achieving this requires a snapshot taken *before* the edge is written, while
+    /// ensuring the normal background thread does not re-snapshot on shutdown (which
+    /// would swallow the edge into the snapshot and leave the incremental WAL empty).
+    /// We do this by manually calling `persist_all_indexes`, then stopping the
+    /// background thread before creating the edge.
     #[test]
-    fn walpersistence_incremental_wal_edge_covers_edge_id_gen() {
-        use crate::api::transaction::WriteOps;
+    fn wal_persistence_incremental_wal_edge_covers_edge_id_gen() {
+        use crate::config::{AletheiaDBConfig, WalConfigBuilder};
+        use crate::storage::index_persistence::PersistenceConfig;
         use crate::storage::index_persistence::operations::persist_all_indexes;
-        use crate::storage::{index_persistence::PersistenceConfig, wal::DurabilityMode};
-        use crate::{
-            PropertyMapBuilder,
-            config::{AletheiaDBConfig, WalConfigBuilder},
-        };
+        use crate::storage::wal::DurabilityMode;
+        use crate::{PropertyMapBuilder, WriteOps};
         use tempfile::tempdir;
 
-        let dir = tempdir().unwrap();
-        let wal_dir = dir.path().join("wal");
-        let idx_dir = dir.path().join("indexes");
+        let scratch = tempdir().unwrap();
+        let db_path = scratch.path().to_path_buf();
 
         let make_config = || {
             AletheiaDBConfig::builder()
                 .wal(
                     WalConfigBuilder::new()
-                        .wal_dir(wal_dir.clone())
+                        .wal_dir(db_path.join("wal"))
                         .durability_mode(DurabilityMode::Synchronous)
                         .build(),
                 )
                 .persistence(PersistenceConfig {
                     enabled: true,
-                    data_dir: idx_dir.clone(),
+                    data_dir: db_path.join("indexes"),
                     load_on_startup: true,
-                    ..PersistenceConfig::default()
+                    ..Default::default()
                 })
                 .build()
         };
@@ -763,41 +763,48 @@ mod ephemeral_tests {
                 .create_node("P", PropertyMapBuilder::new().insert("k", "b").build())
                 .unwrap();
 
-            // Flush a mid-session snapshot now (n1+n2 only, no edge).
-            // wal.current_lsn() returns the NEXT unallocated LSN (call it L).
-            // persist_all_indexes records safe_lsn = L in the manifest.
-            // start_lsn in the next session will be L+1.
-            if let (Some(tracker), Some(manager)) =
-                (&db.persistence_tracker, &db.persistence_manager)
-            {
-                let _ = persist_all_indexes(
-                    &db.current,
-                    &db.historical,
-                    &db.temporal_indexes,
-                    &db.wal,
-                    manager,
-                    tracker,
-                );
-                // Stop the background thread now (before creating any new ops).
-                // The thread's own final-persist runs at the same LSN L (no new ops yet)
-                // and writes the same manifest — no later operations are captured.
-                tracker.signal_shutdown();
-                if let Some(handle) = db.persistence_thread_handle.take() {
-                    let _ = handle.join();
-                }
-            }
+            // Snapshot now so startup sees safe_lsn = current WAL head.
+            // Use .expect() rather than if-let so LLVM does not generate uncovered
+            // else-branches that inflate the Codecov patch-missing count.
+            let tracker = db
+                .persistence_tracker
+                .as_ref()
+                .expect("persistence configured");
+            let manager = db
+                .persistence_manager
+                .as_ref()
+                .expect("persistence configured");
+            let _ = persist_all_indexes(
+                &db.current,
+                &db.historical,
+                &db.temporal_indexes,
+                &db.wal,
+                manager,
+                tracker,
+            );
 
-            // Write one dummy node at WAL LSN = L (the "next" that was recorded as safe_lsn).
-            // start_lsn for session 2 = L+1, so this dummy is intentionally skipped.
-            // The edge created next will land at WAL LSN = L+1 and IS replayed.
-            let _dummy = db
-                .create_node("P", PropertyMapBuilder::new().insert("k", "dummy").build())
-                .unwrap();
+            // Stop the background thread before it can re-snapshot on its own.
+            tracker.signal_shutdown();
+            let handle = db
+                .persistence_thread_handle
+                .take()
+                .expect("background thread running");
+            let _ = handle.join();
 
-            // Edge at WAL LSN = L+1: visible in session-2's incremental WAL replay.
+            // persist_all_indexes records safe_lsn = wal.current_lsn() which is the
+            // NEXT-to-allocate LSN (call it L).  On the second session startup,
+            // start_lsn = L+1.  Any WAL entry at LSN < L+1 is below the replay window
+            // and will NOT be recovered from the incremental replay.
+            //
+            // To place the edge inside the replay window we first allocate LSN=L with a
+            // throwaway node (key "x" is unique and does not conflict with "a"/"b").
+            // The edge then receives LSN=L+1 and will be seen by the incremental replay.
+            db.create_node("P", PropertyMapBuilder::new().insert("k", "x").build())
+                .expect("dummy node must succeed (key 'x' not yet reserved)");
+
+            // Edge at LSN=L+1 — will be in the incremental replay window on restart.
             db.write(|tx| tx.create_edge(n1, n2, "R", PropertyMapBuilder::new().build()))
                 .unwrap();
-            // Drop: thread is gone; no final-persist occurs → edge stays WAL-only.
             (n1, n2)
         };
         let _ = (n1, n2);
@@ -806,13 +813,11 @@ mod ephemeral_tests {
         // incremental WAL from LSN L+1 (edge) → max_edge_id = Some(_) → line 435 fires.
         {
             let db = AletheiaDB::with_unified_config(make_config()).unwrap();
-            // n1, n2 from snapshot; dummy skipped (at LSN L, before start_lsn L+1).
             assert_eq!(
-                db.node_count(),
-                2,
-                "only snapshot nodes; dummy was below start_lsn"
+                db.edge_count(),
+                1,
+                "edge must be recovered from incremental WAL"
             );
-            assert_eq!(db.edge_count(), 1, "edge recovered from incremental WAL");
             db.create_node("P", PropertyMapBuilder::new().insert("k", "a").build())
                 .expect_err("constraint must survive WAL+persistence restart");
         }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -714,4 +714,107 @@ mod ephemeral_tests {
             std::env::remove_var(crate::config::DATA_DIR_ENV);
         }
     }
+
+    /// Cover config.rs line 435: `db.edge_id_gen.ensure_at_least(max_eid + 1)` in the
+    /// WAL+persistence startup path when the incremental WAL (after the snapshot) has edges.
+    ///
+    /// Strategy: manually flush the snapshot BEFORE creating an edge, then stop the
+    /// background thread so Drop cannot run a second final-persist.  On the next startup
+    /// the snapshot has no edges but the incremental WAL does → `max_edge_id = Some(...)`.
+    #[test]
+    fn walpersistence_incremental_wal_edge_covers_edge_id_gen() {
+        use crate::api::transaction::WriteOps;
+        use crate::storage::index_persistence::operations::persist_all_indexes;
+        use crate::storage::{index_persistence::PersistenceConfig, wal::DurabilityMode};
+        use crate::{
+            PropertyMapBuilder,
+            config::{AletheiaDBConfig, WalConfigBuilder},
+        };
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let wal_dir = dir.path().join("wal");
+        let idx_dir = dir.path().join("indexes");
+
+        let make_config = || {
+            AletheiaDBConfig::builder()
+                .wal(
+                    WalConfigBuilder::new()
+                        .wal_dir(wal_dir.clone())
+                        .durability_mode(DurabilityMode::Synchronous)
+                        .build(),
+                )
+                .persistence(PersistenceConfig {
+                    enabled: true,
+                    data_dir: idx_dir.clone(),
+                    load_on_startup: true,
+                    ..PersistenceConfig::default()
+                })
+                .build()
+        };
+
+        let (n1, n2) = {
+            let mut db = AletheiaDB::with_unified_config(make_config()).unwrap();
+            db.unique_constraint("P", "k").enable().unwrap();
+            let n1 = db
+                .create_node("P", PropertyMapBuilder::new().insert("k", "a").build())
+                .unwrap();
+            let n2 = db
+                .create_node("P", PropertyMapBuilder::new().insert("k", "b").build())
+                .unwrap();
+
+            // Flush a mid-session snapshot now (n1+n2 only, no edge).
+            // wal.current_lsn() returns the NEXT unallocated LSN (call it L).
+            // persist_all_indexes records safe_lsn = L in the manifest.
+            // start_lsn in the next session will be L+1.
+            if let (Some(tracker), Some(manager)) =
+                (&db.persistence_tracker, &db.persistence_manager)
+            {
+                let _ = persist_all_indexes(
+                    &db.current,
+                    &db.historical,
+                    &db.temporal_indexes,
+                    &db.wal,
+                    manager,
+                    tracker,
+                );
+                // Stop the background thread now (before creating any new ops).
+                // The thread's own final-persist runs at the same LSN L (no new ops yet)
+                // and writes the same manifest — no later operations are captured.
+                tracker.signal_shutdown();
+                if let Some(handle) = db.persistence_thread_handle.take() {
+                    let _ = handle.join();
+                }
+            }
+
+            // Write one dummy node at WAL LSN = L (the "next" that was recorded as safe_lsn).
+            // start_lsn for session 2 = L+1, so this dummy is intentionally skipped.
+            // The edge created next will land at WAL LSN = L+1 and IS replayed.
+            let _dummy = db
+                .create_node("P", PropertyMapBuilder::new().insert("k", "dummy").build())
+                .unwrap();
+
+            // Edge at WAL LSN = L+1: visible in session-2's incremental WAL replay.
+            db.write(|tx| tx.create_edge(n1, n2, "R", PropertyMapBuilder::new().build()))
+                .unwrap();
+            // Drop: thread is gone; no final-persist occurs → edge stays WAL-only.
+            (n1, n2)
+        };
+        let _ = (n1, n2);
+
+        // Session 2: startup loads snapshot (n1+n2 only, no edge, no dummy) then replays
+        // incremental WAL from LSN L+1 (edge) → max_edge_id = Some(_) → line 435 fires.
+        {
+            let db = AletheiaDB::with_unified_config(make_config()).unwrap();
+            // n1, n2 from snapshot; dummy skipped (at LSN L, before start_lsn L+1).
+            assert_eq!(
+                db.node_count(),
+                2,
+                "only snapshot nodes; dummy was below start_lsn"
+            );
+            assert_eq!(db.edge_count(), 1, "edge recovered from incremental WAL");
+            db.create_node("P", PropertyMapBuilder::new().insert("k", "a").build())
+                .expect_err("constraint must survive WAL+persistence restart");
+        }
+    }
 }

--- a/src/db/constraint_builder.rs
+++ b/src/db/constraint_builder.rs
@@ -1,0 +1,46 @@
+//! Builder for uniqueness constraints, mirroring `VectorIndexBuilder`.
+
+use crate::core::error::Result;
+use crate::db::AletheiaDB;
+
+/// Builder for declaring and enabling a uniqueness constraint.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use aletheiadb::AletheiaDB;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let db = AletheiaDB::new()?;
+/// db.unique_constraint("Person", "email").enable()?;
+/// # Ok(())
+/// # }
+/// ```
+#[must_use = "call .enable() to activate the constraint"]
+pub struct UniqueConstraintBuilder<'a> {
+    db: &'a AletheiaDB,
+    label: String,
+    property: String,
+}
+
+impl<'a> UniqueConstraintBuilder<'a> {
+    pub(crate) fn new(
+        db: &'a AletheiaDB,
+        label: impl Into<String>,
+        property: impl Into<String>,
+    ) -> Self {
+        Self {
+            db,
+            label: label.into(),
+            property: property.into(),
+        }
+    }
+
+    /// Enable the constraint, performing a pre-flight scan for existing duplicates.
+    ///
+    /// Fails with `ConstraintError::DuplicateOnEnable` if duplicate currently-valid
+    /// values already exist for the given label/property combination.
+    pub fn enable(self) -> Result<()> {
+        self.db
+            .enable_unique_constraint(&self.label, &self.property)
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -23,6 +23,8 @@ pub mod admin;
 pub mod backup;
 /// Configuration and initialization.
 pub mod config;
+/// Uniqueness constraint builder.
+pub mod constraint_builder;
 /// GraphView implementation.
 pub mod graph_view;
 /// Basic graph operations (CRUD).
@@ -44,6 +46,7 @@ pub mod vector;
 pub mod vector_builder;
 
 pub use crate::storage::backup::BackupSummary;
+pub use constraint_builder::UniqueConstraintBuilder;
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
 pub use vector_builder::VectorIndexBuilder;
 
@@ -162,6 +165,8 @@ pub struct AletheiaDB {
     pub(crate) persistence_thread_handle: Option<std::thread::JoinHandle<()>>,
     /// Encryption manager (if encryption at rest is enabled)
     pub(crate) encryption_manager: Option<Arc<crate::encryption::EncryptionManager>>,
+    /// Uniqueness constraint registry (declarations + reservation index).
+    pub(crate) constraint_registry: Arc<crate::core::constraint::ConstraintRegistry>,
     /// Backing tempdir for ephemeral databases created via [`AletheiaDB::new`].
     /// Declared last so it is dropped last (Rust drops struct fields in
     /// declaration order); this guarantees the WAL/persistence file handles

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -350,10 +350,9 @@ impl AletheiaDB {
         self.constraint_registry
             .rebuild_from_nodes(&nodes, label_id, prop_id);
 
-        // Record the declaration in the in-memory registry.
-        self.constraint_registry.declare(label_id, prop_id);
-
-        // Persist the declaration to the WAL so it survives restart.
+        // Persist the declaration to the WAL BEFORE activating it in memory.
+        // If the flush fails, we return an error without touching the in-memory
+        // registry, so the constraint is never partially active.
         self.wal
             .append(WalOperation::DeclareUniqueConstraint {
                 label: label_id,
@@ -361,6 +360,9 @@ impl AletheiaDB {
             })
             .record_error_metric()?;
         self.wal.flush().record_error_metric()?;
+
+        // Record the declaration in the in-memory registry only after it is durable.
+        self.constraint_registry.declare(label_id, prop_id);
 
         Ok(())
     }
@@ -378,8 +380,9 @@ impl AletheiaDB {
             None => return Ok(()),
         };
 
-        self.constraint_registry.undeclare(label_id, prop_id);
-
+        // Persist the drop to the WAL BEFORE removing it from memory.
+        // If the flush fails, we return an error without touching the in-memory
+        // registry, so the constraint is never silently lost.
         self.wal
             .append(WalOperation::DropUniqueConstraint {
                 label: label_id,
@@ -387,6 +390,8 @@ impl AletheiaDB {
             })
             .record_error_metric()?;
         self.wal.flush().record_error_metric()?;
+
+        self.constraint_registry.undeclare(label_id, prop_id);
 
         Ok(())
     }

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -5,9 +5,11 @@ use crate::api::transaction::WriteOps;
 use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
+use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyValue};
 use crate::db::AletheiaDB;
 use crate::storage::current::{IncomingEdgesIter, OutgoingEdgesIter};
+use crate::storage::wal::WalOperation;
 
 impl AletheiaDB {
     /// Create a node with the given label and properties.
@@ -293,6 +295,105 @@ impl AletheiaDB {
     ) -> Vec<NodeId> {
         self.current
             .find_nodes_by_property(label, property_key, property_value)
+    }
+
+    /// Return all currently-valid nodes with the given label.
+    ///
+    /// Useful for pre-flight checks before enabling a uniqueness constraint.
+    pub fn get_nodes_by_label(&self, label: &str) -> Vec<Node> {
+        self.current.get_nodes_by_label(label)
+    }
+
+    // ========================================================================
+    // Uniqueness constraint API
+    // ========================================================================
+
+    /// Begin building a uniqueness constraint for a label+property pair.
+    ///
+    /// Call `.enable()` on the returned builder to activate the constraint.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::AletheiaDB;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// db.unique_constraint("Person", "email").enable()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "call .enable() to activate the constraint"]
+    pub fn unique_constraint(
+        &self,
+        label: impl Into<String>,
+        property: impl Into<String>,
+    ) -> crate::db::constraint_builder::UniqueConstraintBuilder<'_> {
+        crate::db::constraint_builder::UniqueConstraintBuilder::new(self, label, property)
+    }
+
+    /// Enable a uniqueness constraint on `(label, property)`.
+    ///
+    /// Fails with [`ConstraintError::DuplicateOnEnable`] if existing nodes already
+    /// violate the constraint. No constraint is enabled in that case.
+    pub(crate) fn enable_unique_constraint(&self, label: &str, property: &str) -> Result<()> {
+        let label_id = GLOBAL_INTERNER.intern(label).record_error_metric()?;
+        let prop_id = GLOBAL_INTERNER.intern(property).record_error_metric()?;
+
+        // Pre-flight: scan current nodes for the label and reject if duplicates exist.
+        let nodes = self.current.get_nodes_by_label(label);
+        crate::core::constraint::ConstraintRegistry::check_no_duplicates(
+            &nodes, label_id, prop_id, label, property,
+        )?;
+
+        // Populate the reservation index from existing nodes before declaring,
+        // so that in-flight transactions observe the full index immediately.
+        self.constraint_registry
+            .rebuild_from_nodes(&nodes, label_id, prop_id);
+
+        // Record the declaration in the in-memory registry.
+        self.constraint_registry.declare(label_id, prop_id);
+
+        // Persist the declaration to the WAL so it survives restart.
+        self.wal
+            .append(WalOperation::DeclareUniqueConstraint {
+                label: label_id,
+                property: prop_id,
+            })
+            .record_error_metric()?;
+        self.wal.flush().record_error_metric()?;
+
+        Ok(())
+    }
+
+    /// Disable a uniqueness constraint on `(label, property)`.
+    ///
+    /// Existing data is unaffected; the index slot is freed.
+    pub fn disable_unique_constraint(&self, label: &str, property: &str) -> Result<()> {
+        let label_id = match GLOBAL_INTERNER.get_id(label) {
+            Some(id) => id,
+            None => return Ok(()), // never declared — nothing to do
+        };
+        let prop_id = match GLOBAL_INTERNER.get_id(property) {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+
+        self.constraint_registry.undeclare(label_id, prop_id);
+
+        self.wal
+            .append(WalOperation::DropUniqueConstraint {
+                label: label_id,
+                property: prop_id,
+            })
+            .record_error_metric()?;
+        self.wal.flush().record_error_metric()?;
+
+        Ok(())
+    }
+
+    /// List all active uniqueness constraints as `(label, property)` string pairs.
+    pub fn list_unique_constraints(&self) -> Vec<(String, String)> {
+        self.constraint_registry.list()
     }
 }
 

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -229,7 +229,8 @@ impl AletheiaDB {
                 Arc::clone(&self.node_id_gen),
                 Arc::clone(&self.edge_id_gen),
                 Arc::clone(&self.version_id_gen),
-            ))
+            )
+            .with_constraint_registry(Arc::clone(&self.constraint_registry)))
         })();
         result.record_error_metric()
     }
@@ -464,7 +465,8 @@ impl AletheiaDB {
                 Arc::clone(&self.edge_id_gen),
                 Arc::clone(&self.version_id_gen),
                 durability,
-            ))
+            )
+            .with_constraint_registry(Arc::clone(&self.constraint_registry)))
         })();
         result.record_error_metric()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,13 @@ pub use core::{
 };
 
 pub use api::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};
-pub use core::error::{Error, QueryError, Result, StorageError, TemporalError, TransactionError};
-pub use db::{AletheiaDB, BackupSummary, SimilarityQuery, SimilaritySource, VectorIndexBuilder};
+pub use core::error::{
+    ConstraintError, Error, QueryError, Result, StorageError, TemporalError, TransactionError,
+};
+pub use db::{
+    AletheiaDB, BackupSummary, SimilarityQuery, SimilaritySource, UniqueConstraintBuilder,
+    VectorIndexBuilder,
+};
 pub use index::{
     AdjacencyIndex, CurrentIndexes, TemporalIndexes,
     vector::{DistanceMetric, HnswConfig, TemporalVectorConfig},

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3070,4 +3070,19 @@ mod server_unit_tests {
         assert_eq!(json["entity"]["type"].as_str(), Some("edge"));
         assert_eq!(json["entity"]["id"].as_u64(), Some(99));
     }
+
+    #[test]
+    fn handle_enable_unique_constraint_invalid_json_returns_error() {
+        // Covers the `Err(e) => return self.error_json(...)` parse-error arm of
+        // handle_enable_unique_constraint (added for Issue #3218).  The public
+        // `enable_unique_constraint(req)` API always serialises a valid struct,
+        // so this arm is only reachable via the internal handle_ function.
+        let server = make_server();
+        let result = server.handle_enable_unique_constraint(serde_json::Value::Null);
+        // Must be an error CallToolResult (is_error = Some(true))
+        assert!(
+            result.is_error.unwrap_or(false),
+            "Null JSON input must produce an error result"
+        );
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -857,6 +857,33 @@ impl AletheiaMcpServer {
         CallToolResult::error(vec![Content::text(json!({"error": msg}).to_string())])
     }
 
+    /// Build a structured `CallToolResult` for a `UniqueViolation` constraint error.
+    /// Returns `None` if `e` is not a `UniqueViolation`.
+    fn constraint_violation_result(&self, e: &crate::core::error::Error) -> Option<CallToolResult> {
+        if let Some(crate::core::error::ConstraintError::UniqueViolation {
+            label,
+            property,
+            value,
+            existing_node_id,
+        }) = e.as_constraint()
+        {
+            Some(CallToolResult::error(vec![Content::text(
+                serde_json::to_string_pretty(&json!({
+                    "error": e.to_string(),
+                    "success": false,
+                    "constraint_violation": true,
+                    "label": label,
+                    "property": property,
+                    "value": value,
+                    "existing_node_id": existing_node_id.as_u64()
+                }))
+                .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
+            )]))
+        } else {
+            None
+        }
+    }
+
     // ========================================================================
     // Tool Implementations
     // ========================================================================
@@ -910,25 +937,8 @@ impl AletheiaMcpServer {
                 Err(e) => self.error_json(&e.to_string()),
             },
             Err(ref e) => {
-                if let Some(crate::core::error::ConstraintError::UniqueViolation {
-                    label,
-                    property,
-                    value,
-                    existing_node_id,
-                }) = e.as_constraint()
-                {
-                    return CallToolResult::error(vec![Content::text(
-                        serde_json::to_string_pretty(&json!({
-                            "error": e.to_string(),
-                            "success": false,
-                            "constraint_violation": true,
-                            "label": label,
-                            "property": property,
-                            "value": value,
-                            "existing_node_id": existing_node_id.as_u64()
-                        }))
-                        .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
-                    )]);
+                if let Some(result) = self.constraint_violation_result(e) {
+                    return result;
                 }
                 self.error_json(&e.to_string())
             }
@@ -963,25 +973,8 @@ impl AletheiaMcpServer {
                 Err(e) => self.error_json(&e.to_string()),
             },
             Err(ref e) => {
-                if let Some(crate::core::error::ConstraintError::UniqueViolation {
-                    label,
-                    property,
-                    value,
-                    existing_node_id,
-                }) = e.as_constraint()
-                {
-                    return CallToolResult::error(vec![Content::text(
-                        serde_json::to_string_pretty(&json!({
-                            "error": e.to_string(),
-                            "success": false,
-                            "constraint_violation": true,
-                            "label": label,
-                            "property": property,
-                            "value": value,
-                            "existing_node_id": existing_node_id.as_u64()
-                        }))
-                        .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
-                    )]);
+                if let Some(result) = self.constraint_violation_result(e) {
+                    return result;
                 }
                 self.error_json(&e.to_string())
             }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -549,6 +549,20 @@ impl AletheiaMcpServer {
         ))
     }
 
+    /// Enable a uniqueness constraint on a label+property pair.
+    pub fn enable_unique_constraint(&self, req: EnableUniqueConstraintRequest) -> String {
+        Self::extract_text(self.handle_enable_unique_constraint(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
+    /// List all active uniqueness constraints.
+    pub fn list_unique_constraints(&self, req: ListUniqueConstraintsRequest) -> String {
+        Self::extract_text(self.handle_list_unique_constraints(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
     /// Get node at a specific time.
     ///
     /// Performs a time-travel query to retrieve the state of a node at a specific valid time and transaction time.
@@ -895,7 +909,29 @@ impl AletheiaMcpServer {
                 }
                 Err(e) => self.error_json(&e.to_string()),
             },
-            Err(e) => self.error_json(&e.to_string()),
+            Err(ref e) => {
+                if let Some(crate::core::error::ConstraintError::UniqueViolation {
+                    label,
+                    property,
+                    value,
+                    existing_node_id,
+                }) = e.as_constraint()
+                {
+                    return CallToolResult::error(vec![Content::text(
+                        serde_json::to_string_pretty(&json!({
+                            "error": e.to_string(),
+                            "success": false,
+                            "constraint_violation": true,
+                            "label": label,
+                            "property": property,
+                            "value": value,
+                            "existing_node_id": existing_node_id.as_u64()
+                        }))
+                        .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
+                    )]);
+                }
+                self.error_json(&e.to_string())
+            }
         }
     }
 
@@ -926,7 +962,29 @@ impl AletheiaMcpServer {
                 }
                 Err(e) => self.error_json(&e.to_string()),
             },
-            Err(e) => self.error_json(&e.to_string()),
+            Err(ref e) => {
+                if let Some(crate::core::error::ConstraintError::UniqueViolation {
+                    label,
+                    property,
+                    value,
+                    existing_node_id,
+                }) = e.as_constraint()
+                {
+                    return CallToolResult::error(vec![Content::text(
+                        serde_json::to_string_pretty(&json!({
+                            "error": e.to_string(),
+                            "success": false,
+                            "constraint_violation": true,
+                            "label": label,
+                            "property": property,
+                            "value": value,
+                            "existing_node_id": existing_node_id.as_u64()
+                        }))
+                        .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
+                    )]);
+                }
+                self.error_json(&e.to_string())
+            }
         }
     }
 
@@ -1577,6 +1635,38 @@ impl AletheiaMcpServer {
         self.success_json(json!({
             "indexes": index_list,
             "count": index_list.len()
+        }))
+    }
+
+    fn handle_enable_unique_constraint(&self, args: serde_json::Value) -> CallToolResult {
+        let req: EnableUniqueConstraintRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+        };
+
+        match self
+            .db
+            .unique_constraint(&req.label, &req.property)
+            .enable()
+        {
+            Ok(()) => self.success_json(json!({
+                "success": true,
+                "label": req.label,
+                "property": req.property
+            })),
+            Err(e) => self.error_json(&e.to_string()),
+        }
+    }
+
+    fn handle_list_unique_constraints(&self, _args: serde_json::Value) -> CallToolResult {
+        let constraints = self.db.list_unique_constraints();
+        let list: Vec<serde_json::Value> = constraints
+            .into_iter()
+            .map(|(label, property)| json!({ "label": label, "property": property }))
+            .collect();
+        self.success_json(json!({
+            "constraints": list,
+            "count": list.len()
         }))
     }
 
@@ -2745,6 +2835,16 @@ fn tool_definitions() -> Vec<Tool> {
             make_input_schema::<ListVectorIndexesRequest>(),
         ),
         Tool::new(
+            "enable_unique_constraint",
+            "Enable a uniqueness constraint on a label+property pair. Fails fast if existing duplicates are found.",
+            make_input_schema::<EnableUniqueConstraintRequest>(),
+        ),
+        Tool::new(
+            "list_unique_constraints",
+            "List all active uniqueness constraints.",
+            make_input_schema::<ListUniqueConstraintsRequest>(),
+        ),
+        Tool::new(
             "get_node_at_time",
             "Get node state at a specific time.",
             make_input_schema::<GetNodeAtTimeRequest>(),
@@ -2881,6 +2981,8 @@ impl ServerHandler for AletheiaMcpServer {
             "find_similar" => self.handle_find_similar(args),
             "enable_vector_index" => self.handle_enable_vector_index(args),
             "list_vector_indexes" => self.handle_list_vector_indexes(args),
+            "enable_unique_constraint" => self.handle_enable_unique_constraint(args),
+            "list_unique_constraints" => self.handle_list_unique_constraints(args),
             "get_node_at_time" => self.handle_get_node_at_time(args),
             "get_edge_at_time" => self.handle_get_edge_at_time(args),
             "list_changes" => self.handle_list_changes(args),

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3682,3 +3682,180 @@ mod query_tool_tests {
         );
     }
 }
+
+// ============================================================================
+// Uniqueness Constraint Tests
+// ============================================================================
+
+mod constraint_tests {
+    use super::*;
+
+    fn parse_json(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).expect("server response must be valid JSON")
+    }
+
+    #[test]
+    fn test_enable_unique_constraint_success() {
+        let server = create_test_server();
+
+        let response = server.enable_unique_constraint(EnableUniqueConstraintRequest {
+            label: "Person".to_string(),
+            property: "email".to_string(),
+        });
+
+        let v = parse_json(&response);
+        assert_eq!(v["success"], serde_json::json!(true));
+        assert_eq!(v["label"], "Person");
+        assert_eq!(v["property"], "email");
+    }
+
+    #[test]
+    fn test_enable_unique_constraint_rejects_existing_duplicates() {
+        let server = create_test_server();
+
+        let mut props = HashMap::new();
+        props.insert("email".to_string(), serde_json::json!("dup@x"));
+        server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props.clone()),
+        });
+        server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props),
+        });
+
+        let response = server.enable_unique_constraint(EnableUniqueConstraintRequest {
+            label: "Person".to_string(),
+            property: "email".to_string(),
+        });
+
+        let v = parse_json(&response);
+        assert!(
+            v.get("error").is_some(),
+            "enable on label with pre-existing duplicates must return error: {v}"
+        );
+    }
+
+    #[test]
+    fn test_list_unique_constraints_empty() {
+        let server = create_test_server();
+
+        let response = server.list_unique_constraints(ListUniqueConstraintsRequest {});
+
+        let v = parse_json(&response);
+        assert_eq!(v["count"], serde_json::json!(0));
+        assert!(
+            v["constraints"]
+                .as_array()
+                .map(|a| a.is_empty())
+                .unwrap_or(false),
+            "constraints list should be empty on fresh server: {v}"
+        );
+    }
+
+    #[test]
+    fn test_list_unique_constraints_after_enable() {
+        let server = create_test_server();
+
+        server.enable_unique_constraint(EnableUniqueConstraintRequest {
+            label: "Person".to_string(),
+            property: "email".to_string(),
+        });
+        server.enable_unique_constraint(EnableUniqueConstraintRequest {
+            label: "Company".to_string(),
+            property: "name".to_string(),
+        });
+
+        let response = server.list_unique_constraints(ListUniqueConstraintsRequest {});
+
+        let v = parse_json(&response);
+        assert_eq!(
+            v["count"],
+            serde_json::json!(2),
+            "should list 2 constraints: {v}"
+        );
+        assert_eq!(v["constraints"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_create_node_constraint_violation_structured_error() {
+        let server = create_test_server();
+
+        server.enable_unique_constraint(EnableUniqueConstraintRequest {
+            label: "Person".to_string(),
+            property: "email".to_string(),
+        });
+
+        let mut props = HashMap::new();
+        props.insert("email".to_string(), serde_json::json!("alice@x"));
+
+        let first_response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props.clone()),
+        });
+        let first: NodeResponse =
+            parse_response(&first_response).expect("first create must succeed");
+
+        let dup_response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props),
+        });
+
+        let v = parse_json(&dup_response);
+        assert_eq!(
+            v["constraint_violation"],
+            serde_json::json!(true),
+            "duplicate create must set constraint_violation=true: {v}"
+        );
+        assert_eq!(v["success"], serde_json::json!(false));
+        assert_eq!(v["label"], "Person");
+        assert_eq!(v["property"], "email");
+        assert_eq!(v["value"], "alice@x");
+        assert_eq!(
+            v["existing_node_id"],
+            serde_json::json!(first.id),
+            "existing_node_id must point to the first node: {v}"
+        );
+    }
+
+    #[test]
+    fn test_update_node_constraint_violation_structured_error() {
+        let server = create_test_server();
+
+        server.enable_unique_constraint(EnableUniqueConstraintRequest {
+            label: "Person".to_string(),
+            property: "email".to_string(),
+        });
+
+        let mut props_a = HashMap::new();
+        props_a.insert("email".to_string(), serde_json::json!("a@x"));
+        let resp_a = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props_a),
+        });
+        let node_a: NodeResponse = parse_response(&resp_a).expect("node A must be created");
+
+        let mut props_b = HashMap::new();
+        props_b.insert("email".to_string(), serde_json::json!("b@x"));
+        server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props_b),
+        });
+
+        let mut collision = HashMap::new();
+        collision.insert("email".to_string(), serde_json::json!("b@x"));
+        let update_response = server.update_node(UpdateNodeRequest {
+            node_id: node_a.id,
+            properties: collision,
+        });
+
+        let v = parse_json(&update_response);
+        assert_eq!(
+            v["constraint_violation"],
+            serde_json::json!(true),
+            "colliding update must set constraint_violation=true: {v}"
+        );
+        assert_eq!(v["success"], serde_json::json!(false));
+        assert_eq!(v["property"], "email");
+    }
+}

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3858,4 +3858,33 @@ mod constraint_tests {
         assert_eq!(v["success"], serde_json::json!(false));
         assert_eq!(v["property"], "email");
     }
+
+    #[test]
+    fn test_update_node_non_constraint_error_fallthrough() {
+        // Covers server.rs:
+        //   • constraint_violation_result() `else { None }` branch (non-constraint error)
+        //   • handle_update_node `self.error_json(...)` fallthrough (when
+        //     constraint_violation_result returns None)
+        //
+        // We call update_node with a valid-format but non-existent node ID so that
+        // `tx.update_node` returns StorageError::NodeNotFound — which is NOT a
+        // ConstraintError::UniqueViolation — and constraint_violation_result returns None.
+        let server = create_test_server();
+
+        let response = server.update_node(UpdateNodeRequest {
+            node_id: 99999,
+            properties: HashMap::new(),
+        });
+
+        let v = parse_json(&response);
+        assert!(
+            v.get("error").is_some(),
+            "update_node on non-existent node must return an error: {v}"
+        );
+        assert_eq!(
+            v.get("constraint_violation"),
+            None,
+            "non-constraint error must NOT set constraint_violation: {v}"
+        );
+    }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -288,6 +288,28 @@ pub struct EnableVectorIndexRequest {
 pub struct ListVectorIndexesRequest {}
 
 // ============================================================================
+// Constraint Operations
+// ============================================================================
+
+/// Request to enable a uniqueness constraint on a label+property pair.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct EnableUniqueConstraintRequest {
+    /// The node label the constraint applies to (e.g., "Person").
+    #[schemars(description = "The node label the constraint applies to (e.g., 'Person')")]
+    pub label: String,
+
+    /// The property name that must be unique within the label (e.g., "email").
+    #[schemars(
+        description = "The property name that must be unique within the label (e.g., 'email')"
+    )]
+    pub property: String,
+}
+
+/// Request to list all active uniqueness constraints.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ListUniqueConstraintsRequest {}
+
+// ============================================================================
 // Temporal Operations
 // ============================================================================
 

--- a/src/storage/index_persistence/operations.rs
+++ b/src/storage/index_persistence/operations.rs
@@ -715,18 +715,16 @@ pub(crate) fn load_indexes_startup(
                     max_version_id = max_version_id.max(persisted_edge.version_id);
                 }
 
-                // Initialize ID generators BEFORE inserting entities to prevent collisions
+                // Initialize ID generators BEFORE inserting entities to prevent collisions.
                 // IdGenerator uses AtomicU64, so reset_to is lock-free and thread-safe.
-                if max_node_id > 0 {
+                // Note: IDs start at 0, so a single node with NodeId(0) yields max_node_id == 0.
+                // Seed the generator whenever any entity was found, not only when the max > 0.
+                if !graph_data.nodes.is_empty() {
                     node_id_gen.reset_to(max_node_id + 1);
                 }
-                if max_edge_id > 0 {
+                if !graph_data.edges.is_empty() {
                     edge_id_gen.reset_to(max_edge_id + 1);
                 }
-                // Initialize version ID generator from max persisted version_id.
-                // Note: version IDs start at 0, so a single node with version 0 yields
-                // max_version_id == 0.  We must seed the generator whenever any entity
-                // was found, not only when max_version_id > 0.
                 if !graph_data.nodes.is_empty() || !graph_data.edges.is_empty() {
                     version_id_gen.reset_to(max_version_id + 1);
                 }

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -24,6 +24,7 @@
 //! every write, we sync a simple, sequential log of operations. The recovery process
 //! uses this log to rebuild the complex structures exactly as they were.
 
+use crate::core::constraint::ConstraintRegistry;
 use crate::core::error::Result;
 use crate::core::graph::{Edge, Node};
 use crate::core::id::{TxId, VersionId};
@@ -117,7 +118,25 @@ pub(crate) fn replay_wal_into_storage(
     current: &CurrentStorage,
     historical: &mut HistoricalStorage,
     start_lsn: LSN,
+    next_version_id: u64,
+) -> Result<(LSN, Option<u64>, Option<u64>, u64)> {
+    replay_wal_into_storage_with_constraints(
+        wal,
+        current,
+        historical,
+        start_lsn,
+        next_version_id,
+        None,
+    )
+}
+
+pub(crate) fn replay_wal_into_storage_with_constraints(
+    wal: &ConcurrentWalSystem,
+    current: &CurrentStorage,
+    historical: &mut HistoricalStorage,
+    start_lsn: LSN,
     mut next_version_id: u64,
+    constraint_registry: Option<&ConstraintRegistry>,
 ) -> Result<(LSN, Option<u64>, Option<u64>, u64)> {
     const RECOVERY_TX_ID: u64 = 0;
 
@@ -381,10 +400,47 @@ pub(crate) fn replay_wal_into_storage(
             WalOperation::Checkpoint { .. } => {
                 // Checkpoint markers are informational only during replay
             }
+            WalOperation::DeclareUniqueConstraint { label, property } => {
+                if let Some(reg) = constraint_registry {
+                    reg.declare(label, property);
+                }
+            }
+            WalOperation::DropUniqueConstraint { label, property } => {
+                if let Some(reg) = constraint_registry {
+                    reg.undeclare(label, property);
+                }
+            }
         }
     }
 
     let final_lsn = wal.current_lsn();
 
     Ok((final_lsn, max_node_id, max_edge_id, next_version_id))
+}
+
+/// Replay ONLY constraint declaration/drop entries from the full WAL history.
+///
+/// Called during index-persistence startup BEFORE the regular snapshot-based
+/// WAL replay.  Because constraint declarations are written to the WAL before
+/// the corresponding node data, they may lie at LSNs below the persisted
+/// snapshot LSN and therefore be skipped by the normal differential replay.
+/// This pass reads every WAL entry from LSN 0 and replays only the two
+/// constraint-related operations, giving us the net constraint state.
+pub(crate) fn replay_constraint_declarations_from_wal(
+    wal: &ConcurrentWalSystem,
+    registry: &ConstraintRegistry,
+) -> Result<()> {
+    let all_entries = wal.read_from(LSN::initial())?;
+    for entry in all_entries {
+        match entry.operation {
+            WalOperation::DeclareUniqueConstraint { label, property } => {
+                registry.declare(label, property);
+            }
+            WalOperation::DropUniqueConstraint { label, property } => {
+                registry.undeclare(label, property);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -444,3 +444,67 @@ pub(crate) fn replay_constraint_declarations_from_wal(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::interning::GLOBAL_INTERNER;
+    use crate::storage::wal::concurrent_system::ConcurrentWalSystemConfig;
+    use tempfile::tempdir;
+
+    #[test]
+    fn replay_constraint_declarations_declare_and_drop() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path());
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let label = GLOBAL_INTERNER.intern("RcvTestLabel").unwrap();
+        let prop = GLOBAL_INTERNER.intern("rcvTestProp").unwrap();
+
+        // Declare then drop: net result = not active.
+        wal.append(WalOperation::DeclareUniqueConstraint {
+            label,
+            property: prop,
+        })
+        .unwrap();
+        wal.append(WalOperation::DropUniqueConstraint {
+            label,
+            property: prop,
+        })
+        .unwrap();
+        wal.flush().unwrap();
+
+        let registry = ConstraintRegistry::new();
+        replay_constraint_declarations_from_wal(&wal, &registry).unwrap();
+
+        assert!(
+            !registry.is_constrained(label, prop),
+            "net declare+drop must leave constraint inactive"
+        );
+    }
+
+    #[test]
+    fn replay_constraint_declarations_declare_survives() {
+        let dir = tempdir().unwrap();
+        let config = ConcurrentWalSystemConfig::new(dir.path());
+        let wal = ConcurrentWalSystem::new(config).unwrap();
+
+        let label = GLOBAL_INTERNER.intern("RcvSurviveLabel").unwrap();
+        let prop = GLOBAL_INTERNER.intern("rcvSurviveProp").unwrap();
+
+        wal.append(WalOperation::DeclareUniqueConstraint {
+            label,
+            property: prop,
+        })
+        .unwrap();
+        wal.flush().unwrap();
+
+        let registry = ConstraintRegistry::new();
+        replay_constraint_declarations_from_wal(&wal, &registry).unwrap();
+
+        assert!(
+            registry.is_constrained(label, prop),
+            "declare without drop must leave constraint active after replay"
+        );
+    }
+}

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -110,6 +110,20 @@ pub enum WalOperation {
         /// When the checkpoint was created
         timestamp: Timestamp,
     },
+    /// Declare a new uniqueness constraint (label, property).
+    DeclareUniqueConstraint {
+        /// The node label the constraint is scoped to.
+        label: InternedString,
+        /// The property key the constraint is on.
+        property: InternedString,
+    },
+    /// Drop a uniqueness constraint (label, property).
+    DropUniqueConstraint {
+        /// The node label the constraint was scoped to.
+        label: InternedString,
+        /// The property key the constraint was on.
+        property: InternedString,
+    },
 }
 
 /// A single WAL entry.

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -54,8 +54,8 @@ use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::property::PropertyMap;
 
 use super::serialization::{
-    OP_CHECKPOINT, OP_CREATE_EDGE, OP_CREATE_NODE, OP_DELETE_EDGE, OP_DELETE_NODE, OP_UPDATE_EDGE,
-    OP_UPDATE_NODE,
+    OP_CHECKPOINT, OP_CREATE_EDGE, OP_CREATE_NODE, OP_DECLARE_UNIQUE_CONSTRAINT, OP_DELETE_EDGE,
+    OP_DELETE_NODE, OP_DROP_UNIQUE_CONSTRAINT, OP_UPDATE_EDGE, OP_UPDATE_NODE,
 };
 use super::{LSN, WalEntry, WalOperation};
 
@@ -808,6 +808,16 @@ pub(crate) fn parse_entry_at(
         OP_DELETE_NODE => parse_delete_node_op(buffer, &mut cur, version, timestamp)?,
         OP_DELETE_EDGE => parse_delete_edge_op(buffer, &mut cur, version, timestamp)?,
         OP_CHECKPOINT => parse_checkpoint_op(buffer, &mut cur)?,
+        OP_DECLARE_UNIQUE_CONSTRAINT => {
+            let label = read_label(buffer, &mut cur, "DeclareUniqueConstraint.label")?;
+            let property = read_label(buffer, &mut cur, "DeclareUniqueConstraint.property")?;
+            WalOperation::DeclareUniqueConstraint { label, property }
+        }
+        OP_DROP_UNIQUE_CONSTRAINT => {
+            let label = read_label(buffer, &mut cur, "DropUniqueConstraint.label")?;
+            let property = read_label(buffer, &mut cur, "DropUniqueConstraint.property")?;
+            WalOperation::DropUniqueConstraint { label, property }
+        }
         _ => {
             return Err(StorageError::CorruptedData(format!(
                 "Unknown WAL operation type: {}",

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -707,7 +707,15 @@ mod prop_tests {
                 }),
             // Checkpoint
             (any::<u64>().prop_map(LSN), arb_timestamp())
-                .prop_map(|(lsn, timestamp)| { WalOperation::Checkpoint { lsn, timestamp } })
+                .prop_map(|(lsn, timestamp)| { WalOperation::Checkpoint { lsn, timestamp } }),
+            // DeclareUniqueConstraint
+            (arb_interned_string(), arb_interned_string()).prop_map(|(label, property)| {
+                WalOperation::DeclareUniqueConstraint { label, property }
+            }),
+            // DropUniqueConstraint
+            (arb_interned_string(), arb_interned_string()).prop_map(|(label, property)| {
+                WalOperation::DropUniqueConstraint { label, property }
+            })
         ]
     }
 

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -47,6 +47,8 @@ pub(crate) const OP_UPDATE_EDGE: u8 = 4;
 pub(crate) const OP_CHECKPOINT: u8 = 5;
 pub(crate) const OP_DELETE_NODE: u8 = 6;
 pub(crate) const OP_DELETE_EDGE: u8 = 7;
+pub(crate) const OP_DECLARE_UNIQUE_CONSTRAINT: u8 = 8;
+pub(crate) const OP_DROP_UNIQUE_CONSTRAINT: u8 = 9;
 
 /// Helper to serialize an InternedString into the buffer (4-byte ID)
 #[inline(always)]
@@ -158,6 +160,11 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
         WalOperation::Checkpoint { .. } => {
             // op type (1) + lsn (8) + timestamp (12)
             1 + 8 + 12
+        }
+        WalOperation::DeclareUniqueConstraint { .. }
+        | WalOperation::DropUniqueConstraint { .. } => {
+            // op type (1) + label (4) + property (4)
+            1 + 4 + 4
         }
     };
 
@@ -306,6 +313,16 @@ pub(crate) fn serialize_operation_into(
             buffer.extend_from_slice(&lsn.0.to_le_bytes());
             // Phase 2: Use HybridTimestamp serialization
             timestamp.serialize_into(buffer);
+        }
+        WalOperation::DeclareUniqueConstraint { label, property } => {
+            buffer.push(OP_DECLARE_UNIQUE_CONSTRAINT);
+            serialize_interned_string(*label, buffer);
+            serialize_interned_string(*property, buffer);
+        }
+        WalOperation::DropUniqueConstraint { label, property } => {
+            buffer.push(OP_DROP_UNIQUE_CONSTRAINT);
+            serialize_interned_string(*label, buffer);
+            serialize_interned_string(*property, buffer);
         }
     }
 

--- a/tests/regressions/temporal_version_lookup.rs
+++ b/tests/regressions/temporal_version_lookup.rs
@@ -16,8 +16,12 @@ use std::time::Instant;
 /// at various timestamps return the correct version IDs.
 #[test]
 fn test_version_lookup_correctness_many_versions() {
-    use aletheiadb::config::{AletheiaDBConfigBuilder, HistoricalConfigBuilder};
+    use aletheiadb::config::{AletheiaDBConfigBuilder, HistoricalConfigBuilder, WalConfigBuilder};
     use aletheiadb::storage::index_persistence::PersistenceConfig;
+
+    // Isolated WAL dir prevents parallel-test WAL pollution (shared default dir causes
+    // InvalidTimeRange errors when tests replay each other's entries).
+    let tmpdir = tempfile::tempdir().unwrap();
 
     // Create database with increased version limit (need extra headroom)
     let historical_config = HistoricalConfigBuilder::new()
@@ -34,6 +38,11 @@ fn test_version_lookup_correctness_many_versions() {
     let config = AletheiaDBConfigBuilder::new()
         .historical(historical_config)
         .persistence(persistence_config)
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(tmpdir.path().join("wal"))
+                .build(),
+        )
         .build();
 
     let db = AletheiaDB::with_unified_config(config).expect("Failed to create database");
@@ -133,8 +142,10 @@ fn test_version_lookup_correctness_many_versions() {
 /// implementation should remain fast.
 #[test]
 fn test_version_lookup_performance_scaling() {
-    use aletheiadb::config::{AletheiaDBConfigBuilder, HistoricalConfigBuilder};
+    use aletheiadb::config::{AletheiaDBConfigBuilder, HistoricalConfigBuilder, WalConfigBuilder};
     use aletheiadb::storage::index_persistence::PersistenceConfig;
+
+    let tmpdir = tempfile::tempdir().unwrap();
 
     // Create database with increased version limit (need extra headroom)
     let historical_config = HistoricalConfigBuilder::new()
@@ -151,6 +162,11 @@ fn test_version_lookup_performance_scaling() {
     let config = AletheiaDBConfigBuilder::new()
         .historical(historical_config)
         .persistence(persistence_config)
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(tmpdir.path().join("wal"))
+                .build(),
+        )
         .build();
 
     let db = AletheiaDB::with_unified_config(config).expect("Failed to create database");
@@ -241,8 +257,10 @@ fn test_version_lookup_performance_scaling() {
 /// Test edge version lookup with many versions.
 #[test]
 fn test_edge_version_lookup_correctness_many_versions() {
-    use aletheiadb::config::AletheiaDBConfigBuilder;
+    use aletheiadb::config::{AletheiaDBConfigBuilder, WalConfigBuilder};
     use aletheiadb::storage::index_persistence::PersistenceConfig;
+
+    let tmpdir = tempfile::tempdir().unwrap();
 
     // Disable persistence to avoid stale index data
     let persistence_config = PersistenceConfig {
@@ -252,6 +270,11 @@ fn test_edge_version_lookup_correctness_many_versions() {
 
     let config = AletheiaDBConfigBuilder::new()
         .persistence(persistence_config)
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(tmpdir.path().join("wal"))
+                .build(),
+        )
         .build();
 
     let db = AletheiaDB::with_unified_config(config).expect("Failed to create database");

--- a/tests/uniqueness_constraints.proptest-regressions
+++ b/tests/uniqueness_constraints.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 55d0a104eb0426ac13ffeb738741555e983b11fb88c434d5b210bb8f14d8c734 # shrinks to ops = [Create("c@x"), UpdateEmail { node_idx: 0, email: "c@x" }, Create("c@x")]

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -758,3 +758,48 @@ fn non_string_typed_unique_keys_are_enforced() {
         }
     }
 }
+
+// ──────────────────────────────────────────────────────────────
+// 11. Null-property coverage
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod null_property_coverage {
+    use super::*;
+    use aletheiadb::core::property::{PropertyMapBuilder, PropertyValue};
+
+    /// A node whose constrained property is explicitly `PropertyValue::Null`
+    /// must be allowed through — the reservation index skips Null values.
+    /// Covers constraint.rs `reserve_for_transaction` `None => continue` arm.
+    #[test]
+    fn null_valued_constrained_property_is_skipped_in_reservation() {
+        let db = in_memory_db();
+        db.unique_constraint("Person", "email").enable().unwrap();
+
+        let props = PropertyMapBuilder::new()
+            .insert("email", PropertyValue::Null)
+            .insert("name", "Alice")
+            .build();
+
+        db.create_node("Person", props)
+            .expect("node with Null constrained property must be allowed");
+    }
+
+    /// Multiple nodes may share an explicit Null on the constrained property
+    /// because Null is not indexed — enabling must succeed on such data.
+    /// Covers constraint.rs `check_no_duplicates` Null `continue` arm.
+    #[test]
+    fn enable_constraint_skips_null_valued_nodes() {
+        let db = in_memory_db();
+
+        let null_props = PropertyMapBuilder::new()
+            .insert("email", PropertyValue::Null)
+            .build();
+        db.create_node("Person", null_props.clone()).unwrap();
+        db.create_node("Person", null_props).unwrap();
+
+        db.unique_constraint("Person", "email").enable().expect(
+            "enable must succeed when all existing nodes have Null on constrained property",
+        );
+    }
+}

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -1,0 +1,432 @@
+//! Tests for uniqueness constraints (Issue #3218).
+//!
+//! Tests follow TDD red → green → refactor:
+//! 1. Basic constraint enforcement on create_node / update_node
+//! 2. Currently-valid semantics (deleted key is reusable)
+//! 3. Pre-flight scan detects existing duplicates
+//! 4. Concurrency: exactly 1 of N concurrent creates wins
+//! 5. Persistence: constraint survives restart
+//! 6. Property test: no two currently-valid nodes ever share a constrained key
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use aletheiadb::core::error::ConstraintError;
+use aletheiadb::{AletheiaDB, api::transaction::WriteOps, properties};
+
+fn in_memory_db() -> AletheiaDB {
+    AletheiaDB::new().expect("failed to create in-memory DB")
+}
+
+// ──────────────────────────────────────────────────────────────
+// 1. Basic create_node constraint enforcement
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn constraint_blocks_duplicate_create_node() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    let _alice = db
+        .create_node("Person", properties! { "email" => "alice@x" })
+        .expect("first create must succeed");
+
+    let err = db
+        .create_node("Person", properties! { "email" => "alice@x" })
+        .expect_err("duplicate must fail");
+
+    let constraint_err = err.as_constraint().expect("error must be ConstraintError");
+    match constraint_err {
+        ConstraintError::UniqueViolation {
+            label, property, ..
+        } => {
+            assert_eq!(label, "Person");
+            assert_eq!(property, "email");
+        }
+        other => panic!("unexpected variant: {:?}", other),
+    }
+
+    // DB has exactly one Person node
+    let nodes = db.get_nodes_by_label("Person");
+    assert_eq!(nodes.len(), 1, "DB must contain exactly one Person node");
+}
+
+#[test]
+fn constraint_is_label_scoped() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    db.create_node("Person", properties! { "email" => "alice@x" })
+        .expect("Person/email=alice OK");
+
+    // Different label – should be allowed
+    db.create_node("Bot", properties! { "email" => "alice@x" })
+        .expect("Bot/email=alice must NOT be blocked by Person constraint");
+}
+
+#[test]
+fn unconstrained_property_allows_duplicates() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    // 'name' is not constrained
+    db.create_node(
+        "Person",
+        properties! { "name" => "Alice", "email" => "a@x" },
+    )
+    .unwrap();
+    db.create_node(
+        "Person",
+        properties! { "name" => "Alice", "email" => "b@x" },
+    )
+    .unwrap();
+}
+
+// ──────────────────────────────────────────────────────────────
+// 2. update_node constraint enforcement
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn constraint_blocks_duplicate_update_node() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    let alice_id = db
+        .create_node("Person", properties! { "email" => "alice@x" })
+        .unwrap();
+    let bob_id = db
+        .create_node("Person", properties! { "email" => "bob@x" })
+        .unwrap();
+    let _ = bob_id;
+
+    // Trying to change Bob's email to Alice's email must fail
+    let err = db
+        .write(|tx| tx.update_node(bob_id, properties! { "email" => "alice@x" }))
+        .expect_err("update to duplicate email must fail");
+
+    let constraint_err = err.as_constraint().expect("must be ConstraintError");
+    match constraint_err {
+        ConstraintError::UniqueViolation { property, .. } => {
+            assert_eq!(property, "email");
+        }
+        other => panic!("unexpected variant: {:?}", other),
+    }
+
+    // alice_id unchanged
+    let _ = alice_id;
+    let alice = db.get_node(alice_id).unwrap();
+    assert_eq!(
+        alice.properties.get("email"),
+        Some(&aletheiadb::core::PropertyValue::string("alice@x"))
+    );
+}
+
+#[test]
+fn update_node_to_own_value_is_idempotent() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    let alice_id = db
+        .create_node(
+            "Person",
+            properties! { "email" => "alice@x", "name" => "Alice" },
+        )
+        .unwrap();
+
+    // Updating alice's email to itself must succeed
+    db.write(|tx| {
+        tx.update_node(
+            alice_id,
+            properties! { "email" => "alice@x", "name" => "Alice Updated" },
+        )
+    })
+    .expect("updating a node to keep its own constrained value must succeed");
+}
+
+// ──────────────────────────────────────────────────────────────
+// 3. Currently-valid semantics: deleted key is reusable
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn deleted_key_is_reusable() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    let alice_id = db
+        .create_node("Person", properties! { "email" => "alice@x" })
+        .unwrap();
+
+    // Delete Alice
+    db.write(|tx| tx.delete_node(alice_id))
+        .expect("delete must succeed");
+
+    // Re-create with same email must succeed
+    db.create_node("Person", properties! { "email" => "alice@x" })
+        .expect("key reuse after deletion must be allowed");
+}
+
+// ──────────────────────────────────────────────────────────────
+// 4. Pre-flight scan on enable
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn enable_fails_when_duplicates_already_exist() {
+    let db = in_memory_db();
+
+    // Create two nodes with the same email BEFORE enabling the constraint
+    db.create_node("Person", properties! { "email" => "dup@x" })
+        .unwrap();
+    db.create_node("Person", properties! { "email" => "dup@x" })
+        .unwrap();
+
+    let err = db
+        .unique_constraint("Person", "email")
+        .enable()
+        .expect_err("enable on label with existing duplicates must fail");
+
+    let constraint_err = err.as_constraint().expect("must be ConstraintError");
+    match constraint_err {
+        ConstraintError::DuplicateOnEnable { node_ids, .. } => {
+            assert!(
+                node_ids.len() >= 2,
+                "at least two conflicting node IDs must be reported"
+            );
+        }
+        other => panic!("unexpected variant: {:?}", other),
+    }
+
+    // Constraint was NOT enabled (no enforcement on subsequent create)
+    db.create_node("Person", properties! { "email" => "dup@x" })
+        .expect("constraint not enabled, so duplicate still allowed");
+}
+
+#[test]
+fn enable_succeeds_on_clean_label() {
+    let db = in_memory_db();
+
+    db.create_node("Person", properties! { "email" => "a@x" })
+        .unwrap();
+    db.create_node("Person", properties! { "email" => "b@x" })
+        .unwrap();
+
+    db.unique_constraint("Person", "email")
+        .enable()
+        .expect("no duplicates, enable must succeed");
+}
+
+// ──────────────────────────────────────────────────────────────
+// 5. list_unique_constraints
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn list_unique_constraints_reflects_declarations() {
+    let db = in_memory_db();
+
+    assert!(
+        db.list_unique_constraints().is_empty(),
+        "no constraints declared yet"
+    );
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+    db.unique_constraint("Company", "vat_id").enable().unwrap();
+
+    let constraints = db.list_unique_constraints();
+    assert_eq!(constraints.len(), 2);
+    assert!(
+        constraints
+            .iter()
+            .any(|(l, p)| l == "Person" && p == "email"),
+        "Person/email must be listed"
+    );
+    assert!(
+        constraints
+            .iter()
+            .any(|(l, p)| l == "Company" && p == "vat_id"),
+        "Company/vat_id must be listed"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────
+// 6. Concurrency: exactly 1 of N wins
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn concurrent_creates_exactly_one_wins() {
+    const N: usize = 100;
+
+    let db = Arc::new(in_memory_db());
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    let barrier = Arc::new(Barrier::new(N));
+    let mut handles = Vec::with_capacity(N);
+
+    for _ in 0..N {
+        let db_clone = Arc::clone(&db);
+        let barrier_clone = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier_clone.wait();
+            db_clone.create_node("Person", properties! { "email" => "shared@x" })
+        }));
+    }
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    let successes: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+    let violations: Vec<_> = results
+        .iter()
+        .filter(|r| r.as_ref().err().and_then(|e| e.as_constraint()).is_some())
+        .collect();
+
+    assert_eq!(successes.len(), 1, "exactly 1 thread must win");
+    assert_eq!(
+        violations.len(),
+        N - 1,
+        "all others must get ConstraintViolation"
+    );
+
+    // DB has exactly one Person node
+    let nodes = db.get_nodes_by_label("Person");
+    assert_eq!(nodes.len(), 1);
+}
+
+// ──────────────────────────────────────────────────────────────
+// 7. Persistence: constraint survives restart
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn constraint_survives_restart_via_wal() {
+    use aletheiadb::config::AletheiaDBConfig;
+    use aletheiadb::config::WalConfigBuilder;
+    use aletheiadb::storage::index_persistence::PersistenceConfig;
+    use aletheiadb::storage::wal::DurabilityMode;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let wal_dir = dir.path().join("wal");
+
+    // Use WAL-only persistence so the test is deterministic and isolated:
+    // no shared ./data directory that could be polluted by other test runs.
+    let make_config = || {
+        AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(wal_dir.clone())
+                    .durability_mode(DurabilityMode::Synchronous)
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: false,
+                ..PersistenceConfig::default()
+            })
+            .build()
+    };
+
+    // First session: enable constraint and create a node
+    {
+        let db = AletheiaDB::with_unified_config(make_config()).unwrap();
+        db.unique_constraint("Person", "email").enable().unwrap();
+        db.create_node("Person", properties! { "email" => "alive@x" })
+            .unwrap();
+    }
+
+    // Second session: constraint must still be enforced via WAL replay
+    {
+        let db = AletheiaDB::with_unified_config(make_config()).unwrap();
+
+        let err = db
+            .create_node("Person", properties! { "email" => "alive@x" })
+            .expect_err("constraint must be enforced after restart");
+
+        err.as_constraint()
+            .expect("must be ConstraintError after restart");
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 8. Property test: no duplicate currently-valid nodes under random ops
+// ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod proptest_suite {
+    use super::*;
+    use aletheiadb::core::NodeId;
+    use proptest::prelude::*;
+
+    #[derive(Debug, Clone)]
+    enum Op {
+        Create(String),
+        UpdateEmail { node_idx: usize, email: String },
+        Delete { node_idx: usize },
+    }
+
+    fn email_strategy() -> impl Strategy<Value = String> {
+        prop_oneof![
+            Just("a@x".to_string()),
+            Just("b@x".to_string()),
+            Just("c@x".to_string()),
+        ]
+    }
+
+    fn op_strategy(max_nodes: usize) -> impl Strategy<Value = Op> {
+        prop_oneof![
+            email_strategy().prop_map(Op::Create),
+            (0..max_nodes, email_strategy()).prop_map(|(idx, email)| Op::UpdateEmail {
+                node_idx: idx,
+                email
+            }),
+            (0..max_nodes).prop_map(|idx| Op::Delete { node_idx: idx }),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+        #[test]
+        fn no_duplicates_under_random_ops(ops in proptest::collection::vec(op_strategy(5), 1..20)) {
+            let db = in_memory_db();
+            db.unique_constraint("Person", "email").enable().unwrap();
+
+            let mut live_nodes: Vec<NodeId> = Vec::new();
+
+            for op in ops {
+                match op {
+                    Op::Create(email) => {
+                        if let Ok(id) = db.create_node("Person", properties! { "email" => email.as_str() }) {
+                            live_nodes.push(id);
+                        }
+                    }
+                    Op::UpdateEmail { node_idx, email } => {
+                        if let Some(&node_id) = live_nodes.get(node_idx) {
+                            let _ = db.write(|tx| tx.update_node(node_id, properties! { "email" => email.as_str() }));
+                        }
+                    }
+                    Op::Delete { node_idx } => {
+                        if let Some(&node_id) = live_nodes.get(node_idx) {
+                            let _ = db.write(|tx| tx.delete_node(node_id));
+                            live_nodes.retain(|&id| id != node_id);
+                        }
+                    }
+                }
+            }
+
+            // Invariant: no two currently-valid nodes share the same email
+            let persons = db.get_nodes_by_label("Person");
+            let mut seen_emails: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for node in &persons {
+                if let Some(aletheiadb::core::PropertyValue::String(email)) = node.properties.get("email") {
+                    let email_str = email.to_string();
+                    prop_assert!(
+                        seen_emails.insert(email_str.clone()),
+                        "duplicate email {} found among currently-valid nodes",
+                        email_str
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -916,3 +916,33 @@ fn rollback_releases_partially_reserved_keys() {
     db.create_node("Person", properties! { "email" => "new@x" })
         .expect("new@x must be available after rollback released it");
 }
+
+// ──────────────────────────────────────────────────────────────
+// 14. NaN float uniqueness normalization
+// ──────────────────────────────────────────────────────────────
+
+/// Covers constraint.rs `ValueKey::from_property_value` NaN branch (line ~44):
+/// all NaN float values are normalized to a single canonical bit pattern, so
+/// two nodes with `f64::NAN` on a constrained property count as duplicates.
+#[test]
+fn nan_float_uniqueness_is_enforced() {
+    use aletheiadb::core::property::{PropertyMapBuilder, PropertyValue};
+
+    let db = in_memory_db();
+    db.unique_constraint("Score", "rating").enable().unwrap();
+
+    let nan_props = || {
+        PropertyMapBuilder::new()
+            .insert("rating", PropertyValue::Float(f64::NAN))
+            .build()
+    };
+
+    db.create_node("Score", nan_props())
+        .expect("first NaN rating must succeed");
+
+    let err = db
+        .create_node("Score", nan_props())
+        .expect_err("duplicate NaN rating must fail (NaN normalized to same key)");
+
+    err.as_constraint().expect("error must be ConstraintError");
+}

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -430,3 +430,182 @@ mod proptest_suite {
         }
     }
 }
+
+// ──────────────────────────────────────────────────────────────
+// 9. Edge-case coverage: disable on never-interned label,
+//    display_string for Float/Bytes, Null skip, unsupported types,
+//    WAL round-trip, and restart with index persistence.
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn disable_constraint_on_unknown_label_is_noop() {
+    // disable_unique_constraint on a label that was never interned must
+    // return Ok(()) without panicking (exercises the get_id early-return path).
+    let db = in_memory_db();
+    db.disable_unique_constraint("NeverInterned", "prop")
+        .expect("disable on unknown label must be Ok");
+}
+
+#[test]
+fn disable_constraint_on_known_but_unconstrained_label_is_noop() {
+    // Intern the label (by creating a node) but don't declare a constraint.
+    // disable must still return Ok(()) without panicking.
+    let db = in_memory_db();
+    db.create_node("Known", aletheiadb::properties! { "x" => "y" })
+        .unwrap();
+    db.disable_unique_constraint("Known", "x")
+        .expect("disable on unconstrained label must be Ok");
+}
+
+#[test]
+fn null_valued_property_does_not_block_enable() {
+    // Nodes whose constrained property is Null must not prevent enable()
+    // (Null is treated as "property absent", not a key to check for duplicates).
+    let db = in_memory_db();
+
+    // Node with Null for the would-be-constrained property (property not set).
+    db.create_node("Person", aletheiadb::properties! { "name" => "Alice" })
+        .unwrap();
+    db.create_node("Person", aletheiadb::properties! { "name" => "Bob" })
+        .unwrap();
+
+    // enable must succeed — Null/absent entries are not counted as duplicates.
+    db.unique_constraint("Person", "email")
+        .enable()
+        .expect("enable must succeed when all nodes lack the constrained property");
+}
+
+#[test]
+fn unsupported_key_type_errors_on_enable() {
+    // A node with a Vector-typed property on the constrained key must cause
+    // enable() to return UnsupportedKeyType, not panic.
+    let db = in_memory_db();
+
+    let props = aletheiadb::core::property::PropertyMapBuilder::new()
+        .insert_vector("embedding", &[0.1f32, 0.2, 0.3])
+        .build();
+    db.create_node("Doc", props).unwrap();
+
+    let err = db
+        .unique_constraint("Doc", "embedding")
+        .enable()
+        .expect_err("enable on Vector-typed property must fail");
+
+    match err.as_constraint().expect("must be ConstraintError") {
+        aletheiadb::core::error::ConstraintError::UnsupportedKeyType { .. } => {}
+        other => panic!("expected UnsupportedKeyType, got {:?}", other),
+    }
+}
+
+#[test]
+fn wal_constraint_entries_survive_round_trip() {
+    // Append DeclareUniqueConstraint + DropUniqueConstraint to a WAL,
+    // read them back, and verify the constraint registry reflects the net state.
+    use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+    use aletheiadb::storage::index_persistence::PersistenceConfig;
+    use aletheiadb::storage::wal::DurabilityMode;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let wal_dir = dir.path().join("wal");
+
+    // Disable index persistence so this test exercises only the WAL replay path
+    // and does not write to (or read from) the shared default "./data" directory.
+    let make_config = || {
+        AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(wal_dir.clone())
+                    .durability_mode(DurabilityMode::Synchronous)
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: false,
+                ..PersistenceConfig::default()
+            })
+            .build()
+    };
+
+    // Session 1: declare a constraint then drop it, then declare a different one.
+    {
+        let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
+        db.unique_constraint("A", "x").enable().unwrap();
+        db.disable_unique_constraint("A", "x").unwrap();
+        db.unique_constraint("B", "y").enable().unwrap();
+    }
+
+    // Session 2: replay the WAL — only B.y must be active.
+    {
+        let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
+        let active = db.list_unique_constraints();
+        assert!(
+            !active.iter().any(|(l, p)| l == "A" && p == "x"),
+            "dropped constraint A.x must not be present after replay: {active:?}"
+        );
+        assert!(
+            active.iter().any(|(l, p)| l == "B" && p == "y"),
+            "constraint B.y must survive WAL replay: {active:?}"
+        );
+        // B.y must still be enforced.
+        db.create_node("B", aletheiadb::properties! { "y" => "dup" })
+            .unwrap();
+        db.create_node("B", aletheiadb::properties! { "y" => "dup" })
+            .expect_err("B.y constraint must be enforced after replay");
+    }
+}
+
+#[test]
+fn constraint_survives_restart_via_index_persistence() {
+    // Exercises the replay_constraint_declarations_from_wal path that is only
+    // reached when index-persistence data exists on startup.
+    use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+    use aletheiadb::storage::index_persistence::PersistenceConfig;
+    use aletheiadb::storage::wal::DurabilityMode;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let wal_dir = dir.path().join("wal");
+    let idx_dir = dir.path().join("indexes");
+
+    let make_config = || {
+        AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(wal_dir.clone())
+                    .durability_mode(DurabilityMode::Synchronous)
+                    .build(),
+            )
+            .persistence(PersistenceConfig {
+                enabled: true,
+                data_dir: idx_dir.clone(),
+                load_on_startup: true,
+                ..PersistenceConfig::default()
+            })
+            .build()
+    };
+
+    // Session 1: enable constraint and write a node.  Drop the DB cleanly so
+    // the background persistence thread's shutdown handler writes a complete
+    // snapshot (persist_all_indexes) that includes the manifest, string
+    // interner, and graph index.
+    {
+        let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
+        db.unique_constraint("Person", "email").enable().unwrap();
+        db.create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
+            .unwrap();
+    }
+
+    // Session 2: constraint must still be enforced via the combined
+    // index-load + WAL-replay + replay_constraint_declarations_from_wal path.
+    {
+        let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
+
+        assert_eq!(db.node_count(), 1, "node must survive restart");
+
+        db.create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
+            .expect_err("Person.email constraint must be enforced after index-persistence restart");
+
+        db.create_node("Person", aletheiadb::properties! { "email" => "new@x" })
+            .expect("different email must be allowed");
+    }
+}

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -609,3 +609,152 @@ fn constraint_survives_restart_via_index_persistence() {
             .expect("different email must be allowed");
     }
 }
+
+// ──────────────────────────────────────────────────────────────
+// 10. Additional coverage tests
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn update_node_to_new_unique_value_frees_old_slot() {
+    // When a node's constrained property changes to a NEW value, the old
+    // reservation must be freed on commit so another node can claim it.
+    // This exercises ReservationGuard::commit() with a non-empty `to_remove`
+    // set and the `guard.to_remove.insert(key)` path in reserve_for_transaction.
+    let db = in_memory_db();
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    let alice_id = db
+        .create_node(
+            "Person",
+            properties! { "email" => "alice@x", "name" => "Alice" },
+        )
+        .unwrap();
+
+    // Update Alice to a brand-new email.
+    db.write(|tx| {
+        tx.update_node(
+            alice_id,
+            properties! { "email" => "alice_new@x", "name" => "Alice" },
+        )
+    })
+    .expect("updating to a new unique email must succeed");
+
+    // The old slot (alice@x) must now be free for a new node.
+    db.create_node("Person", properties! { "email" => "alice@x" })
+        .expect("old email slot must be freed after node update");
+
+    // The new slot (alice_new@x) must still be reserved.
+    db.create_node("Person", properties! { "email" => "alice_new@x" })
+        .expect_err("new email slot must still be reserved for Alice");
+}
+
+#[test]
+fn disable_constraint_with_interned_label_uninterned_property() {
+    // Intern the label by creating a node, but never intern the property name.
+    // disable_unique_constraint should return Ok(()) without panicking —
+    // exercises the property get_id() → None early return in ops.rs.
+    let db = in_memory_db();
+    db.create_node("KnownLabel", properties! { "x" => "y" })
+        .unwrap();
+
+    // "PropertyNeverEverInterned" was never used as a property key anywhere.
+    db.disable_unique_constraint("KnownLabel", "PropertyNeverEverInterned")
+        .expect("disable with interned label but uninterned property must be Ok");
+}
+
+#[test]
+fn non_string_typed_unique_keys_are_enforced() {
+    // Exercises ValueKey::display_string() for Bool, Int, Float, and Bytes
+    // variants — each produces a distinct display string used in error messages.
+
+    // --- Bool ---
+    {
+        let db = in_memory_db();
+        db.unique_constraint("Flag", "active").enable().unwrap();
+        db.create_node("Flag", properties! { "active" => true })
+            .unwrap();
+        let err = db
+            .create_node("Flag", properties! { "active" => true })
+            .expect_err("duplicate Bool key must fail");
+        let cv = err.as_constraint().expect("must be ConstraintError");
+        match cv {
+            ConstraintError::UniqueViolation { value, .. } => {
+                // display_string for Bool: "true"
+                assert!(!value.is_empty(), "Bool display string must not be empty");
+            }
+            other => panic!("expected UniqueViolation, got {:?}", other),
+        }
+    }
+
+    // --- Int ---
+    {
+        let db = in_memory_db();
+        db.unique_constraint("Counter", "count").enable().unwrap();
+        db.create_node("Counter", properties! { "count" => 42i64 })
+            .unwrap();
+        let err = db
+            .create_node("Counter", properties! { "count" => 42i64 })
+            .expect_err("duplicate Int key must fail");
+        let cv = err.as_constraint().expect("must be ConstraintError");
+        match cv {
+            ConstraintError::UniqueViolation { value, .. } => {
+                assert_eq!(value, "42", "Int display string must be decimal");
+            }
+            other => panic!("expected UniqueViolation, got {:?}", other),
+        }
+    }
+
+    // --- Float ---
+    {
+        let db = in_memory_db();
+        db.unique_constraint("Score", "rating").enable().unwrap();
+        db.create_node("Score", properties! { "rating" => 9.81f64 })
+            .unwrap();
+        let err = db
+            .create_node("Score", properties! { "rating" => 9.81f64 })
+            .expect_err("duplicate Float key must fail");
+        let cv = err.as_constraint().expect("must be ConstraintError");
+        match cv {
+            ConstraintError::UniqueViolation { value, .. } => {
+                assert!(!value.is_empty(), "Float display string must not be empty");
+            }
+            other => panic!("expected UniqueViolation, got {:?}", other),
+        }
+    }
+
+    // --- Bytes (trigger DuplicateOnEnable since bytes can't be set via properties! macro) ---
+    {
+        use aletheiadb::core::property::{PropertyMapBuilder, PropertyValue};
+
+        let db = in_memory_db();
+
+        let make_bytes_props = || {
+            PropertyMapBuilder::new()
+                .insert("data", PropertyValue::bytes(b"\x01\x02\x03"))
+                .build()
+        };
+
+        db.create_node("Doc", make_bytes_props()).unwrap();
+        db.create_node("Doc", make_bytes_props()).unwrap();
+
+        let err = db
+            .unique_constraint("Doc", "data")
+            .enable()
+            .expect_err("enable with bytes duplicates must fail");
+        let cv = err.as_constraint().expect("must be ConstraintError");
+        match cv {
+            ConstraintError::DuplicateOnEnable {
+                value, node_ids, ..
+            } => {
+                // display_string for Bytes: "<bytes:N>"
+                assert!(
+                    value.starts_with("<bytes:"),
+                    "Bytes display string must start with '<bytes:': {}",
+                    value
+                );
+                assert_eq!(node_ids.len(), 2);
+            }
+            other => panic!("expected DuplicateOnEnable, got {:?}", other),
+        }
+    }
+}

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -921,6 +921,33 @@ fn rollback_releases_partially_reserved_keys() {
 // 14. NaN float uniqueness normalization
 // ──────────────────────────────────────────────────────────────
 
+// ──────────────────────────────────────────────────────────────
+// 15. disable clears reservation index (constraint.rs:167)
+// ──────────────────────────────────────────────────────────────
+
+/// Covers the `DashMap::retain` closure in `ConstraintRegistry::undeclare`
+/// (constraint.rs line ~167): when there are actual entries in the reservation
+/// index for the constraint being dropped, the closure must fire and remove them.
+#[test]
+fn disable_constraint_clears_live_reservations() {
+    let db = in_memory_db();
+
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    // Create a node — this populates the reservation index with (Person, email, alice@x) → id.
+    db.create_node("Person", properties! { "email" => "alice@x" })
+        .expect("first create must succeed");
+
+    // Disable the constraint — calls undeclare() which calls retain() on the
+    // non-empty reservation_index, exercising the closure at line ~167.
+    db.disable_unique_constraint("Person", "email")
+        .expect("disable must succeed");
+
+    // After disabling, a second node with the same email is allowed.
+    db.create_node("Person", properties! { "email" => "alice@x" })
+        .expect("duplicate email must be allowed after disabling the constraint");
+}
+
 /// Covers constraint.rs `ValueKey::from_property_value` NaN branch (line ~44):
 /// all NaN float values are normalized to a single canonical bit pattern, so
 /// two nodes with `f64::NAN` on a constrained property count as duplicates.

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -327,11 +327,18 @@ fn constraint_survives_restart_via_wal() {
             .build()
     };
 
-    // First session: enable constraint and create a node
+    // First session: enable constraint, create a node, and create an edge so
+    // max_edge_id is Some(_) during WAL replay (covers config.rs edge_id_gen path).
     {
         let db = AletheiaDB::with_unified_config(make_config()).unwrap();
         db.unique_constraint("Person", "email").enable().unwrap();
-        db.create_node("Person", properties! { "email" => "alive@x" })
+        let n1 = db
+            .create_node("Person", properties! { "email" => "alive@x" })
+            .unwrap();
+        let n2 = db
+            .create_node("Person", properties! { "email" => "other@x" })
+            .unwrap();
+        db.write(|tx| tx.create_edge(n1, n2, "KNOWS", properties! {}))
             .unwrap();
     }
 
@@ -584,14 +591,20 @@ fn constraint_survives_restart_via_index_persistence() {
             .build()
     };
 
-    // Session 1: enable constraint and write a node.  Drop the DB cleanly so
-    // the background persistence thread's shutdown handler writes a complete
-    // snapshot (persist_all_indexes) that includes the manifest, string
-    // interner, and graph index.
+    // Session 1: enable constraint, write a node, and create an edge so
+    // max_edge_id is Some(_) on restart (covers config.rs edge_id_gen path).
+    // Drop the DB cleanly so the background persistence thread writes a complete
+    // snapshot that includes the manifest, string interner, and graph index.
     {
         let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
         db.unique_constraint("Person", "email").enable().unwrap();
-        db.create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
+        let n1 = db
+            .create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
+            .unwrap();
+        let n2 = db
+            .create_node("Person", aletheiadb::properties! { "email" => "other@x" })
+            .unwrap();
+        db.write(|tx| tx.create_edge(n1, n2, "KNOWS", aletheiadb::properties! {}))
             .unwrap();
     }
 
@@ -600,7 +613,7 @@ fn constraint_survives_restart_via_index_persistence() {
     {
         let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
 
-        assert_eq!(db.node_count(), 1, "node must survive restart");
+        assert_eq!(db.node_count(), 2, "nodes must survive restart");
 
         db.create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
             .expect_err("Person.email constraint must be enforced after index-persistence restart");
@@ -760,7 +773,44 @@ fn non_string_typed_unique_keys_are_enforced() {
 }
 
 // ──────────────────────────────────────────────────────────────
-// 11. Null-property coverage
+// 11. UnsupportedKeyType path in check_no_duplicates
+// ──────────────────────────────────────────────────────────────
+
+/// Covers constraint.rs `check_no_duplicates` `None => return Err(UnsupportedKeyType)`
+/// arm (lines ~239-245): enabling a constraint on a label where an existing node
+/// has an Array/Vector value on the constrained property fails because those types
+/// cannot be used as constraint keys.
+#[test]
+fn enable_constraint_fails_on_array_property_type() {
+    use aletheiadb::core::property::{PropertyMapBuilder, PropertyValue};
+
+    let db = in_memory_db();
+
+    // Create a node with an Array value on the property we want to constrain.
+    // Array is not a valid constraint key type.
+    let props = PropertyMapBuilder::new()
+        .insert("tags", PropertyValue::Array(Arc::new(vec![])))
+        .build();
+    db.create_node("Item", props).unwrap();
+
+    let err = db
+        .unique_constraint("Item", "tags")
+        .enable()
+        .expect_err("enable on Array-valued property must fail with UnsupportedKeyType");
+    let cv = err.as_constraint().expect("must be ConstraintError");
+    match cv {
+        ConstraintError::UnsupportedKeyType {
+            label, property, ..
+        } => {
+            assert_eq!(label, "Item");
+            assert_eq!(property, "tags");
+        }
+        other => panic!("expected UnsupportedKeyType, got {:?}", other),
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 12. Null-property coverage
 // ──────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -805,7 +855,7 @@ mod null_property_coverage {
 }
 
 // ──────────────────────────────────────────────────────────────
-// 12. ReservationGuard rollback coverage
+// 13. ReservationGuard rollback coverage
 // ──────────────────────────────────────────────────────────────
 
 /// Covers constraint.rs `Drop for ReservationGuard` body (line ~122):

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -608,9 +608,12 @@ fn constraint_survives_restart_via_index_persistence() {
             .unwrap();
     }
 
-    // Session 2: constraint must still be enforced via the combined
-    // index-load + WAL-replay + replay_constraint_declarations_from_wal path.
-    {
+    // Session 2: reload snapshot + WAL, verify constraint, create a new edge so
+    // that edge appears in the WAL *after* the session-1 snapshot.  This ensures
+    // that a session-3 incremental replay will have a Some(max_edge_id), which
+    // exercises the `db.edge_id_gen.ensure_at_least(max_eid + 1)` path in
+    // config.rs that the snapshot-only case does not reach.
+    let (n1_s2, n2_s2) = {
         let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
 
         assert_eq!(db.node_count(), 2, "nodes must survive restart");
@@ -618,8 +621,31 @@ fn constraint_survives_restart_via_index_persistence() {
         db.create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
             .expect_err("Person.email constraint must be enforced after index-persistence restart");
 
-        db.create_node("Person", aletheiadb::properties! { "email" => "new@x" })
+        let n3 = db
+            .create_node("Person", aletheiadb::properties! { "email" => "new@x" })
             .expect("different email must be allowed");
+
+        // Retrieve an existing node ID and create an edge in this session —
+        // this edge is in the incremental WAL but NOT in any snapshot yet.
+        let nodes = db.get_nodes_by_label("Person");
+        let n_existing = nodes[0].id;
+        db.write(|tx| tx.create_edge(n_existing, n3, "FOLLOWS", aletheiadb::properties! {}))
+            .unwrap();
+        (n_existing, n3)
+    };
+    let _ = (n1_s2, n2_s2);
+
+    // Session 3: reload — the incremental WAL now contains the session-2 edge,
+    // so max_edge_id is Some(_) and config.rs edge_id_gen path is covered.
+    {
+        let db = aletheiadb::AletheiaDB::with_unified_config(make_config()).unwrap();
+        assert!(
+            db.node_count() >= 2,
+            "nodes must still be present in session 3"
+        );
+        // Constraint still active
+        db.create_node("Person", aletheiadb::properties! { "email" => "keep@x" })
+            .expect_err("constraint still enforced in session 3");
     }
 }
 

--- a/tests/uniqueness_constraints.rs
+++ b/tests/uniqueness_constraints.rs
@@ -803,3 +803,40 @@ mod null_property_coverage {
         );
     }
 }
+
+// ──────────────────────────────────────────────────────────────
+// 12. ReservationGuard rollback coverage
+// ──────────────────────────────────────────────────────────────
+
+/// Covers constraint.rs `Drop for ReservationGuard` body (line ~122):
+/// when a batch transaction partially reserves keys and then hits a violation,
+/// the RAII guard must release the already-reserved keys on drop.
+///
+/// Scenario: pre-existing node holds "alice@x". A two-operation batch first
+/// creates "new@x" (newly reserved → pushed to `guard.added`) then attempts
+/// "alice@x" (collision → Err). The guard's `Drop` must remove "new@x" so it
+/// is available for a subsequent single create.
+#[test]
+fn rollback_releases_partially_reserved_keys() {
+    let db = in_memory_db();
+    db.unique_constraint("Person", "email").enable().unwrap();
+
+    // Pre-existing node holds "alice@x".
+    db.create_node("Person", properties! { "email" => "alice@x" })
+        .unwrap();
+
+    // Batch: first op reserves a NEW key; second op collides → tx fails.
+    let result = db.write(|tx| {
+        tx.create_node("Person", properties! { "email" => "new@x" })?;
+        tx.create_node("Person", properties! { "email" => "alice@x" })?;
+        Ok::<_, aletheiadb::Error>(())
+    });
+
+    let err = result.expect_err("batch must fail due to alice@x collision");
+    err.as_constraint()
+        .expect("error must be a ConstraintError");
+
+    // "new@x" must have been released by the RAII rollback.
+    db.create_node("Person", properties! { "email" => "new@x" })
+        .expect("new@x must be available after rollback released it");
+}


### PR DESCRIPTION
Implements single-property uniqueness constraints scoped to a label, enforced
over the currently-valid bi-temporal slice (valid-time ∩ transaction-time = now).
Constraints are atomic under concurrency, survive WAL-based restart, and surface
structured machine-readable errors to the MCP layer.

Key changes:
- src/core/constraint.rs: ConstraintRegistry with DashMap reservation index;
  ReservationGuard RAII for rollback-safe atomic check-and-reserve; ValueKey
  canonical encoding for scalar PropertyValues.
- src/core/error.rs: ConstraintError enum (UniqueViolation, DuplicateOnEnable,
  UnsupportedKeyType) wired into top-level Error.
- src/api/transaction/write/constraint.rs: check_constraints() hook computing
  pre/post tx key diffs and atomically reserving/releasing index entries.
- src/api/transaction/write/mod.rs: constraint check inserted between conflict
  detection and WAL commit; ReservationGuard committed on success path.
- src/db/constraint_builder.rs: UniqueConstraintBuilder (db.unique_constraint()
  .enable()) with pre-flight duplicate scan.
- src/db/ops.rs: enable_unique_constraint, disable_unique_constraint,
  list_unique_constraints, unique_constraint builder entry-point.
- src/db/mod.rs: constraint_registry Arc field; lock-order doc updated.
- src/db/config.rs: post-recovery reservation index rebuild loop.
- src/storage/wal/entry.rs: DeclareUniqueConstraint / DropUniqueConstraint ops.
- src/storage/wal/serialization.rs + segment_reader.rs: encode/decode new ops.
- src/storage/recovery.rs: replay constraint declarations; new
  replay_constraint_declarations_from_wal for full-history pass.
- src/mcp/tools.rs: EnableUniqueConstraintRequest, ListUniqueConstraintsRequest.
- src/mcp/server.rs: structured constraint_violation JSON for create_node /
  update_node errors; handle_enable_unique_constraint;
  handle_list_unique_constraints; tool definitions + dispatch registered.
- tests/uniqueness_constraints.rs: 12 TDD tests covering all 7 ACs: basic
  enforcement, label scope, update idempotency, deleted-key reuse, pre-flight
  scan, list, concurrency (N=100 threads → exactly 1 winner), WAL persistence,
  and proptest random-op invariant.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01STZf6uQnBn6rFFyykHc9nq