### PR TITLE
🎸 Bard: Fix broken and redundant intra-doc links

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -231,7 +231,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: The `db::ops` and `db::temporal` modules
🔦 Insight: Fixed broken intra-doc link to `StorageError::NodeNotFound` in `src/db/ops.rs` by fully qualifying the path to `crate::core::error::StorageError`. Fixed a redundant explicit link target warning in `src/db/temporal.rs` by simplifying `[`ChangeRecord`](crate::core::ChangeRecord)` to `[`ChangeRecord`]`.
🧪 Example: N/A, fixes rustdoc generation warnings.
🖼️ Preview: `cargo doc` now runs with zero warnings.

---
*PR created automatically by Jules for task [4380616555326168893](https://jules.google.com/task/4380616555326168893) started by @madmax983*