### PR TITLE
Add graph schema discovery API (Issue #3214)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,7 @@ cargo run --bin aletheia-mcp --features mcp-server
 | **Temporal** | `get_node_at_time`, `get_edge_at_time` |
 | **Hybrid** | `hybrid_query` (combined graph + vector + temporal) |
 | **Query** | `query` (execute a single read-only Cypher/AQL statement; see below) |
+| **Schema** | `get_schema` (node labels, edge types, and property keys, each with counts; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
 
 **`query` tool (read-only Cypher/AQL):** Lets an LLM answer a multi-hop,
 filtered, temporally-scoped question with **one declarative statement** instead

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -195,6 +195,7 @@ max_batch_size = 1000
 | `max_versions_per_entity` | usize | 1000 | Maximum versions to keep per entity |
 | `max_reconstruction_depth` | usize | 100 | Maximum anchor chain depth (max: 1000) |
 | `reconstruction_cache_size` | usize | 10000 | LFU cache size for reconstructed versions |
+| `max_schema_as_of_entities` | usize | 50000 | Per-kind (nodes/edges) cap on entities `AletheiaDB::schema_as_of` reconstructs in one call; truncation is disclosed via `GraphSchema::sampled` |
 
 **Validation:**
 - `max_versions_per_entity` must be > 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,6 +372,15 @@ pub struct HistoricalConfig {
     /// Maximum number of hot versions to keep per entity before triggering migration.
     /// Default: 1000 (same as max_versions_per_entity)
     pub max_hot_versions: usize,
+
+    /// Safety cap (per entity kind: nodes, edges) on the number of
+    /// ever-versioned entities `AletheiaDB::schema_as_of` will reconstruct
+    /// in a single call. Without a cap, a bi-temporal schema query would be
+    /// an unbounded scan over every entity ever versioned. When the actual
+    /// population exceeds this cap, the scan is truncated to this many
+    /// entities and `GraphSchema::sampled` is set to `true` to disclose it.
+    /// Default: 50000
+    pub max_schema_as_of_entities: usize,
 }
 
 impl Default for HistoricalConfig {
@@ -387,6 +396,8 @@ impl Default for HistoricalConfig {
             cold_storage_path: None,
             migration_age_threshold: std::time::Duration::from_secs(3600), // 1 hour
             max_hot_versions: 1000,
+            max_schema_as_of_entities:
+                crate::storage::historical::DEFAULT_MAX_SCHEMA_AS_OF_ENTITIES,
         }
     }
 }
@@ -579,6 +590,35 @@ impl HistoricalConfigBuilder {
     /// ```
     pub fn max_hot_versions(mut self, max: usize) -> Self {
         self.config.max_hot_versions = max;
+        self
+    }
+
+    /// Set the safety cap (per entity kind) on the number of ever-versioned
+    /// entities `AletheiaDB::schema_as_of` will reconstruct in a single
+    /// call.
+    ///
+    /// Without a cap, a bi-temporal schema query would be an unbounded scan
+    /// over every node/edge ever versioned. When the actual population
+    /// exceeds this cap, the scan is truncated and `GraphSchema::sampled` is
+    /// set to `true` to disclose it -- raise this if you need exhaustive
+    /// bi-temporal schema results on a large history and can afford the
+    /// extra scan cost; lower it to bound worst-case latency more tightly.
+    ///
+    /// # Default
+    ///
+    /// 50000
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use aletheiadb::config::HistoricalConfigBuilder;
+    ///
+    /// let config = HistoricalConfigBuilder::new()
+    ///     .max_schema_as_of_entities(200_000) // allow a larger bi-temporal scan
+    ///     .build();
+    /// ```
+    pub fn max_schema_as_of_entities(mut self, max: usize) -> Self {
+        self.config.max_schema_as_of_entities = max;
         self
     }
 
@@ -1053,6 +1093,7 @@ mod tests {
         assert_eq!(config.reconstruction_cache_size, 10000);
         assert_eq!(config.anchor_interval, 10);
         assert_eq!(config.max_delta_chain, 20);
+        assert_eq!(config.max_schema_as_of_entities, 50_000);
     }
 
     #[test]
@@ -1068,6 +1109,7 @@ mod tests {
             .unwrap()
             .max_delta_chain(10)
             .unwrap()
+            .max_schema_as_of_entities(100_000)
             .build();
 
         assert_eq!(config.max_versions_per_entity, 5000);
@@ -1075,6 +1117,7 @@ mod tests {
         assert_eq!(config.reconstruction_cache_size, 20000);
         assert_eq!(config.anchor_interval, 5);
         assert_eq!(config.max_delta_chain, 10);
+        assert_eq!(config.max_schema_as_of_entities, 100_000);
     }
 
     #[test]

--- a/src/core/interning.rs
+++ b/src/core/interning.rs
@@ -312,6 +312,23 @@ impl StringInterner {
         self.resolve_with(id, f)
     }
 
+    /// Resolve an interned string to an owned `String`, or compute a fallback
+    /// if the ID is somehow not (or no longer) present.
+    ///
+    /// A resolve miss should not happen for an ID obtained from a live
+    /// `Node`/`Edge`/property key, but callers across the codebase each need
+    /// their own fallback text (an empty string, a diagnostic placeholder,
+    /// etc.) for the case where it does. This centralizes the resolve step
+    /// so each call site only has to supply its fallback.
+    pub fn resolve_or_else<F: FnOnce() -> String>(
+        &self,
+        id: InternedString,
+        fallback: F,
+    ) -> String {
+        self.resolve_with(id, |s| s.to_string())
+            .unwrap_or_else(fallback)
+    }
+
     /// Check if a string has been interned.
     pub fn contains<S: AsRef<str>>(&self, string: S) -> bool {
         self.string_to_id.contains_key(string.as_ref())

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -31,6 +31,8 @@ pub mod graph_view;
 pub mod ops;
 /// Query builder and executor hooks.
 pub mod query;
+/// Graph schema discovery (labels, edge types, property keys).
+pub mod schema;
 /// Unified vector similarity query builder.
 pub mod similarity_query;
 /// Temporal query operations.
@@ -47,6 +49,7 @@ pub mod vector_builder;
 
 pub use crate::storage::backup::BackupSummary;
 pub use constraint_builder::UniqueConstraintBuilder;
+pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
 pub use vector_builder::VectorIndexBuilder;
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -14,13 +14,25 @@ use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Resolve an interned label to an owned `String`, falling back to empty if
-/// the interner entry is somehow missing (cannot happen in practice, since
-/// labels are interned before being stored on a node/edge).
+/// Safety cap on the number of ever-versioned entities [`AletheiaDB::schema_as_of`]
+/// will reconstruct in a single call, applied independently to nodes and edges.
+///
+/// Without a cap, `schema_as_of` would be an unbounded
+/// O(all-ever-versioned entities x average delta-chain length) scan on any
+/// database with substantial bi-temporal history -- directly at odds with
+/// this tool being advertised (in the MCP tool manifest) as a cheap,
+/// call-it-first discovery primitive. When the actual population exceeds
+/// this cap, the scan is truncated to a deterministic (ID-sorted) prefix and
+/// [`GraphSchema::sampled`] is set to `true`; per this feature's disclosure
+/// requirement, sampling must never happen silently.
+const MAX_SCHEMA_AS_OF_ENTITIES: usize = 50_000;
+
+/// Resolve an interned label/key to an owned `String`, falling back to empty
+/// if the interner entry is somehow missing (cannot happen in practice,
+/// since labels and property keys are interned before being stored on a
+/// node/edge).
 fn resolve_label(label: InternedString) -> String {
-    GLOBAL_INTERNER
-        .resolve_with(label, |s| s.to_string())
-        .unwrap_or_default()
+    GLOBAL_INTERNER.resolve_or_else(label, String::new)
 }
 
 /// A point in bi-temporal space that a [`GraphSchema`] was computed as of.
@@ -59,11 +71,11 @@ pub struct EdgeTypeSchema {
 /// each.
 ///
 /// Returned by [`AletheiaDB::schema`] (current state) and
-/// [`AletheiaDB::schema_as_of`] (bi-temporal). Property-key enumeration is
-/// always exhaustive in this version (`sampled` is always `false`); the flag
-/// is present for forward compatibility should a sampling strategy be
-/// introduced later -- any future sampling must set it to `true` rather than
-/// silently truncating.
+/// [`AletheiaDB::schema_as_of`] (bi-temporal). Property-key enumeration
+/// within a summarized label/type is always exhaustive; `sampled` instead
+/// reports whether the *set of entities summarized* was truncated (see
+/// [`AletheiaDB::schema_as_of`]'s entity cap) -- any such truncation is
+/// always disclosed via this flag, never silent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraphSchema {
     /// Distinct node labels present, sorted by label.
@@ -74,18 +86,21 @@ pub struct GraphSchema {
     pub total_nodes: usize,
     /// Total number of edges summarized.
     pub total_edges: usize,
-    /// Whether property-key enumeration was sampled rather than exhaustive.
+    /// Whether the summarized entity set was truncated (see
+    /// [`AletheiaDB::schema_as_of`]'s entity cap). Always `false` for
+    /// [`AletheiaDB::schema`], which is always exhaustive.
     pub sampled: bool,
     /// The bi-temporal instant this schema reflects, or `None` for current state.
     pub as_of: Option<SchemaInstant>,
 }
 
-/// Accumulates per-label/per-type counts and the union of property keys seen.
-///
-/// Keyed by a `BTreeMap` so the final summary is naturally sorted by label
-/// without a separate sort pass.
+/// Accumulates per-label/per-type counts and the union of property keys
+/// seen, keyed by `InternedString` rather than resolving to `String` per
+/// entity -- resolution happens once per *distinct* label/key in
+/// [`build_schema`] instead of once per node/edge, avoiding an interner
+/// lookup + allocation for every property of every entity.
 struct Accumulator {
-    entries: BTreeMap<String, (usize, BTreeSet<String>)>,
+    entries: BTreeMap<InternedString, (usize, BTreeSet<InternedString>)>,
 }
 
 impl Accumulator {
@@ -95,17 +110,13 @@ impl Accumulator {
         }
     }
 
-    fn record(&mut self, label: &str, properties: &PropertyMap) {
+    fn record(&mut self, label: InternedString, properties: &PropertyMap) {
         let entry = self
             .entries
-            .entry(label.to_string())
+            .entry(label)
             .or_insert_with(|| (0, BTreeSet::new()));
         entry.0 += 1;
-        entry.1.extend(
-            properties
-                .keys()
-                .filter_map(|key| GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())),
-        );
+        entry.1.extend(properties.keys().copied());
     }
 }
 
@@ -114,9 +125,12 @@ impl AletheiaDB {
     /// types, their counts, and the property keys observed on each.
     ///
     /// Returns an empty-but-well-formed [`GraphSchema`] on an empty database,
-    /// never an error. Counts are exact and match
-    /// [`AletheiaDB::node_count`]/[`AletheiaDB::edge_count`] (summed across
-    /// labels/types) by construction.
+    /// never an error, and is always exhaustive (`sampled` is always
+    /// `false`). Counts reflect a best-effort read over live storage: as
+    /// with every other full-scan method on this storage layer (e.g.
+    /// `label_counts`), there is no cross-call snapshot isolation, so under
+    /// concurrent writes the totals may not exactly match a `node_count`/
+    /// `edge_count` call made at a slightly different instant.
     ///
     /// # Example
     ///
@@ -134,16 +148,14 @@ impl AletheiaDB {
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn schema(&self) -> Result<GraphSchema> {
         let mut node_acc = Accumulator::new();
-        for node in self.current.get_all_nodes() {
-            node_acc.record(&resolve_label(node.label), &node.properties);
-        }
+        self.current
+            .visit_nodes(|node| node_acc.record(node.label, &node.properties));
 
         let mut edge_acc = Accumulator::new();
-        for edge in self.current.get_all_edges() {
-            edge_acc.record(&resolve_label(edge.label), &edge.properties);
-        }
+        self.current
+            .visit_edges(|edge| edge_acc.record(edge.label, &edge.properties));
 
-        Ok(build_schema(node_acc, edge_acc, None))
+        Ok(build_schema(node_acc, edge_acc, false, None))
     }
 
     /// Discover the graph's schema as it existed at a specific bi-temporal
@@ -154,6 +166,12 @@ impl AletheiaDB {
     /// A label/type that had not yet been written as of the given instant
     /// (in either temporal dimension) is simply absent from the result --
     /// there is no error case for "nothing existed yet".
+    ///
+    /// The set of candidate entities (every node/edge that has ever had a
+    /// version recorded) is capped at [`MAX_SCHEMA_AS_OF_ENTITIES`] per
+    /// entity kind to keep this call bounded on databases with substantial
+    /// bi-temporal history; when the cap is hit, [`GraphSchema::sampled`] is
+    /// set to `true` to disclose the truncation.
     ///
     /// # Example
     ///
@@ -173,31 +191,35 @@ impl AletheiaDB {
         valid_time: Timestamp,
         transaction_time: Timestamp,
     ) -> Result<GraphSchema> {
-        let (node_ids, edge_ids) = {
+        let (node_ids, edge_ids, sampled) = {
             let historical = self.historical.read();
-            (
-                historical.versioned_node_ids(),
-                historical.versioned_edge_ids(),
-            )
+            let mut node_ids = historical.versioned_node_ids();
+            let mut edge_ids = historical.versioned_edge_ids();
+            drop(historical);
+
+            let node_sampled = cap_ids(&mut node_ids, MAX_SCHEMA_AS_OF_ENTITIES);
+            let edge_sampled = cap_ids(&mut edge_ids, MAX_SCHEMA_AS_OF_ENTITIES);
+            (node_ids, edge_ids, node_sampled || edge_sampled)
         };
 
         let mut node_acc = Accumulator::new();
         for (_, node) in self.get_nodes_at_time(&node_ids, valid_time, transaction_time)? {
             if let Some(node) = node {
-                node_acc.record(&resolve_label(node.label), &node.properties);
+                node_acc.record(node.label, &node.properties);
             }
         }
 
         let mut edge_acc = Accumulator::new();
         for (_, edge) in self.get_edges_at_time(&edge_ids, valid_time, transaction_time)? {
             if let Some(edge) = edge {
-                edge_acc.record(&resolve_label(edge.label), &edge.properties);
+                edge_acc.record(edge.label, &edge.properties);
             }
         }
 
         Ok(build_schema(
             node_acc,
             edge_acc,
+            sampled,
             Some(SchemaInstant {
                 valid_time,
                 transaction_time,
@@ -206,45 +228,102 @@ impl AletheiaDB {
     }
 }
 
+/// Truncate `ids` to a deterministic (sorted) prefix of at most `cap`
+/// elements. Returns `true` if truncation actually happened, so the caller
+/// can disclose it via [`GraphSchema::sampled`].
+fn cap_ids<T: Ord>(ids: &mut Vec<T>, cap: usize) -> bool {
+    if ids.len() > cap {
+        ids.sort_unstable();
+        ids.truncate(cap);
+        true
+    } else {
+        false
+    }
+}
+
 fn build_schema(
     node_acc: Accumulator,
     edge_acc: Accumulator,
+    sampled: bool,
     as_of: Option<SchemaInstant>,
 ) -> GraphSchema {
     let mut total_nodes = 0;
-    let node_labels: Vec<LabelSchema> = node_acc
+    let mut node_labels: Vec<LabelSchema> = node_acc
         .entries
         .into_iter()
         .map(|(label, (count, keys))| {
             total_nodes += count;
+            let mut property_keys: Vec<String> = keys.into_iter().map(resolve_label).collect();
+            property_keys.sort_unstable();
             LabelSchema {
-                label,
+                label: resolve_label(label),
                 count,
-                property_keys: keys.into_iter().collect(),
+                property_keys,
             }
         })
         .collect();
+    node_labels.sort_unstable_by(|a, b| a.label.cmp(&b.label));
 
     let mut total_edges = 0;
-    let edge_types: Vec<EdgeTypeSchema> = edge_acc
+    let mut edge_types: Vec<EdgeTypeSchema> = edge_acc
         .entries
         .into_iter()
         .map(|(edge_type, (count, keys))| {
             total_edges += count;
+            let mut property_keys: Vec<String> = keys.into_iter().map(resolve_label).collect();
+            property_keys.sort_unstable();
             EdgeTypeSchema {
-                edge_type,
+                edge_type: resolve_label(edge_type),
                 count,
-                property_keys: keys.into_iter().collect(),
+                property_keys,
             }
         })
         .collect();
+    edge_types.sort_unstable_by(|a, b| a.edge_type.cmp(&b.edge_type));
 
     GraphSchema {
         node_labels,
         edge_types,
         total_nodes,
         total_edges,
-        sampled: false,
+        sampled,
         as_of,
+    }
+}
+
+#[cfg(test)]
+mod cap_ids_tests {
+    use super::cap_ids;
+
+    #[test]
+    fn under_cap_is_untouched_and_not_sampled() {
+        let mut ids = vec![5, 1, 3];
+        let sampled = cap_ids(&mut ids, 10);
+        assert!(!sampled);
+        assert_eq!(ids, vec![5, 1, 3], "no truncation, order preserved");
+    }
+
+    #[test]
+    fn exactly_at_cap_is_untouched_and_not_sampled() {
+        let mut ids = vec![5, 1, 3];
+        let sampled = cap_ids(&mut ids, 3);
+        assert!(!sampled);
+        assert_eq!(ids, vec![5, 1, 3]);
+    }
+
+    #[test]
+    fn over_cap_truncates_to_sorted_prefix_and_is_sampled() {
+        let mut ids = vec![9, 1, 5, 3, 7, 2];
+        let sampled = cap_ids(&mut ids, 3);
+        assert!(sampled);
+        assert_eq!(ids, vec![1, 2, 3], "deterministic sorted prefix");
+    }
+
+    #[test]
+    fn cap_of_zero_truncates_everything() {
+        let mut ids = vec![1, 2, 3];
+        let sampled = cap_ids(&mut ids, 0);
+        assert!(sampled);
+        assert!(ids.is_empty());
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,0 +1,250 @@
+//! Graph schema discovery: node labels, edge types, and property keys.
+//!
+//! Provides a read-only summary of the graph's shape -- the labels and edge
+//! types present, how many entities have each, and which property keys are
+//! observed -- so callers (notably LLM/MCP integrators) can discover what is
+//! queryable without already knowing label/property names. See
+//! [`AletheiaDB::schema`] for the current-state summary and
+//! [`AletheiaDB::schema_as_of`] for the bi-temporal variant.
+
+use crate::core::error::Result;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
+use crate::core::property::PropertyMap;
+use crate::core::temporal::Timestamp;
+use crate::db::AletheiaDB;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Resolve an interned label to an owned `String`, falling back to empty if
+/// the interner entry is somehow missing (cannot happen in practice, since
+/// labels are interned before being stored on a node/edge).
+fn resolve_label(label: InternedString) -> String {
+    GLOBAL_INTERNER
+        .resolve_with(label, |s| s.to_string())
+        .unwrap_or_default()
+}
+
+/// A point in bi-temporal space that a [`GraphSchema`] was computed as of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaInstant {
+    /// The valid-time instant the schema reflects.
+    pub valid_time: Timestamp,
+    /// The transaction-time instant the schema reflects.
+    pub transaction_time: Timestamp,
+}
+
+/// Schema summary for a single node label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelSchema {
+    /// The node label.
+    pub label: String,
+    /// Number of nodes with this label.
+    pub count: usize,
+    /// Union of property keys observed on nodes with this label, sorted.
+    pub property_keys: Vec<String>,
+}
+
+/// Schema summary for a single edge/relationship type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EdgeTypeSchema {
+    /// The edge/relationship type.
+    pub edge_type: String,
+    /// Number of edges with this type.
+    pub count: usize,
+    /// Union of property keys observed on edges of this type, sorted.
+    pub property_keys: Vec<String>,
+}
+
+/// A structured summary of the graph's shape: distinct node labels and
+/// edge/relationship types, their counts, and the property keys observed on
+/// each.
+///
+/// Returned by [`AletheiaDB::schema`] (current state) and
+/// [`AletheiaDB::schema_as_of`] (bi-temporal). Property-key enumeration is
+/// always exhaustive in this version (`sampled` is always `false`); the flag
+/// is present for forward compatibility should a sampling strategy be
+/// introduced later -- any future sampling must set it to `true` rather than
+/// silently truncating.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphSchema {
+    /// Distinct node labels present, sorted by label.
+    pub node_labels: Vec<LabelSchema>,
+    /// Distinct edge/relationship types present, sorted by type.
+    pub edge_types: Vec<EdgeTypeSchema>,
+    /// Total number of nodes summarized.
+    pub total_nodes: usize,
+    /// Total number of edges summarized.
+    pub total_edges: usize,
+    /// Whether property-key enumeration was sampled rather than exhaustive.
+    pub sampled: bool,
+    /// The bi-temporal instant this schema reflects, or `None` for current state.
+    pub as_of: Option<SchemaInstant>,
+}
+
+/// Accumulates per-label/per-type counts and the union of property keys seen.
+///
+/// Keyed by a `BTreeMap` so the final summary is naturally sorted by label
+/// without a separate sort pass.
+struct Accumulator {
+    entries: BTreeMap<String, (usize, BTreeSet<String>)>,
+}
+
+impl Accumulator {
+    fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+        }
+    }
+
+    fn record(&mut self, label: &str, properties: &PropertyMap) {
+        let entry = self
+            .entries
+            .entry(label.to_string())
+            .or_insert_with(|| (0, BTreeSet::new()));
+        entry.0 += 1;
+        entry.1.extend(
+            properties
+                .keys()
+                .filter_map(|key| GLOBAL_INTERNER.resolve_with(*key, |s| s.to_string())),
+        );
+    }
+}
+
+impl AletheiaDB {
+    /// Discover the graph's current schema: distinct node labels and edge
+    /// types, their counts, and the property keys observed on each.
+    ///
+    /// Returns an empty-but-well-formed [`GraphSchema`] on an empty database,
+    /// never an error. Counts are exact and match
+    /// [`AletheiaDB::node_count`]/[`AletheiaDB::edge_count`] (summed across
+    /// labels/types) by construction.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::AletheiaDB;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let schema = db.schema()?;
+    /// for label in &schema.node_labels {
+    ///     println!("{}: {} nodes", label.label, label.count);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn schema(&self) -> Result<GraphSchema> {
+        let mut node_acc = Accumulator::new();
+        for node in self.current.get_all_nodes() {
+            node_acc.record(&resolve_label(node.label), &node.properties);
+        }
+
+        let mut edge_acc = Accumulator::new();
+        for edge in self.current.get_all_edges() {
+            edge_acc.record(&resolve_label(edge.label), &edge.properties);
+        }
+
+        Ok(build_schema(node_acc, edge_acc, None))
+    }
+
+    /// Discover the graph's schema as it existed at a specific bi-temporal
+    /// instant: the node labels and edge types visible at
+    /// `(valid_time, transaction_time)`, with counts and property keys
+    /// reflecting only the entities visible at that instant.
+    ///
+    /// A label/type that had not yet been written as of the given instant
+    /// (in either temporal dimension) is simply absent from the result --
+    /// there is no error case for "nothing existed yet".
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::AletheiaDB;
+    /// # use aletheiadb::core::temporal::time;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let now = time::now();
+    /// let schema = db.schema_as_of(now, now)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn schema_as_of(
+        &self,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+    ) -> Result<GraphSchema> {
+        let (node_ids, edge_ids) = {
+            let historical = self.historical.read();
+            (
+                historical.versioned_node_ids(),
+                historical.versioned_edge_ids(),
+            )
+        };
+
+        let mut node_acc = Accumulator::new();
+        for (_, node) in self.get_nodes_at_time(&node_ids, valid_time, transaction_time)? {
+            if let Some(node) = node {
+                node_acc.record(&resolve_label(node.label), &node.properties);
+            }
+        }
+
+        let mut edge_acc = Accumulator::new();
+        for (_, edge) in self.get_edges_at_time(&edge_ids, valid_time, transaction_time)? {
+            if let Some(edge) = edge {
+                edge_acc.record(&resolve_label(edge.label), &edge.properties);
+            }
+        }
+
+        Ok(build_schema(
+            node_acc,
+            edge_acc,
+            Some(SchemaInstant {
+                valid_time,
+                transaction_time,
+            }),
+        ))
+    }
+}
+
+fn build_schema(
+    node_acc: Accumulator,
+    edge_acc: Accumulator,
+    as_of: Option<SchemaInstant>,
+) -> GraphSchema {
+    let mut total_nodes = 0;
+    let node_labels: Vec<LabelSchema> = node_acc
+        .entries
+        .into_iter()
+        .map(|(label, (count, keys))| {
+            total_nodes += count;
+            LabelSchema {
+                label,
+                count,
+                property_keys: keys.into_iter().collect(),
+            }
+        })
+        .collect();
+
+    let mut total_edges = 0;
+    let edge_types: Vec<EdgeTypeSchema> = edge_acc
+        .entries
+        .into_iter()
+        .map(|(edge_type, (count, keys))| {
+            total_edges += count;
+            EdgeTypeSchema {
+                edge_type,
+                count,
+                property_keys: keys.into_iter().collect(),
+            }
+        })
+        .collect();
+
+    GraphSchema {
+        node_labels,
+        edge_types,
+        total_nodes,
+        total_edges,
+        sampled: false,
+        as_of,
+    }
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -22,9 +22,9 @@ use std::collections::{BTreeMap, BTreeSet};
 /// database with substantial bi-temporal history -- directly at odds with
 /// this tool being advertised (in the MCP tool manifest) as a cheap,
 /// call-it-first discovery primitive. When the actual population exceeds
-/// this cap, the scan is truncated to a deterministic (ID-sorted) prefix and
-/// [`GraphSchema::sampled`] is set to `true`; per this feature's disclosure
-/// requirement, sampling must never happen silently.
+/// this cap, the scan is truncated to a deterministic set (the `cap`
+/// smallest IDs) and [`GraphSchema::sampled`] is set to `true`; per this
+/// feature's disclosure requirement, sampling must never happen silently.
 const MAX_SCHEMA_AS_OF_ENTITIES: usize = 50_000;
 
 /// Resolve an interned label/key to an owned `String`, falling back to empty
@@ -228,12 +228,18 @@ impl AletheiaDB {
     }
 }
 
-/// Truncate `ids` to a deterministic (sorted) prefix of at most `cap`
-/// elements. Returns `true` if truncation actually happened, so the caller
-/// can disclose it via [`GraphSchema::sampled`].
+/// Truncate `ids` down to the `cap` smallest elements (a deterministic set,
+/// though not necessarily in sorted order -- the order among the kept
+/// elements doesn't matter, since they're only used as a scan input, not
+/// exposed to callers). Returns `true` if truncation actually happened, so
+/// the caller can disclose it via [`GraphSchema::sampled`].
+///
+/// Uses a partial selection (`select_nth_unstable`, O(n) average) rather
+/// than a full sort (O(n log n)), since only membership in the smallest-`cap`
+/// set matters here, not a total order.
 fn cap_ids<T: Ord>(ids: &mut Vec<T>, cap: usize) -> bool {
     if ids.len() > cap {
-        ids.sort_unstable();
+        ids.select_nth_unstable(cap);
         ids.truncate(cap);
         true
     } else {
@@ -312,11 +318,16 @@ mod cap_ids_tests {
     }
 
     #[test]
-    fn over_cap_truncates_to_sorted_prefix_and_is_sampled() {
+    fn over_cap_truncates_to_the_cap_smallest_elements_and_is_sampled() {
         let mut ids = vec![9, 1, 5, 3, 7, 2];
         let sampled = cap_ids(&mut ids, 3);
         assert!(sampled);
-        assert_eq!(ids, vec![1, 2, 3], "deterministic sorted prefix");
+        assert_eq!(ids.len(), 3);
+        // select_nth_unstable only guarantees a correct partition, not a
+        // sorted order among the kept elements -- compare as a set.
+        let mut kept = ids.clone();
+        kept.sort_unstable();
+        assert_eq!(kept, vec![1, 2, 3], "kept elements are the 3 smallest");
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -14,19 +14,6 @@ use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Safety cap on the number of ever-versioned entities [`AletheiaDB::schema_as_of`]
-/// will reconstruct in a single call, applied independently to nodes and edges.
-///
-/// Without a cap, `schema_as_of` would be an unbounded
-/// O(all-ever-versioned entities x average delta-chain length) scan on any
-/// database with substantial bi-temporal history -- directly at odds with
-/// this tool being advertised (in the MCP tool manifest) as a cheap,
-/// call-it-first discovery primitive. When the actual population exceeds
-/// this cap, the scan is truncated to a deterministic set (the `cap`
-/// smallest IDs) and [`GraphSchema::sampled`] is set to `true`; per this
-/// feature's disclosure requirement, sampling must never happen silently.
-const MAX_SCHEMA_AS_OF_ENTITIES: usize = 50_000;
-
 /// Resolve an interned label/key to an owned `String`, falling back to empty
 /// if the interner entry is somehow missing (cannot happen in practice,
 /// since labels and property keys are interned before being stored on a
@@ -168,10 +155,11 @@ impl AletheiaDB {
     /// there is no error case for "nothing existed yet".
     ///
     /// The set of candidate entities (every node/edge that has ever had a
-    /// version recorded) is capped at [`MAX_SCHEMA_AS_OF_ENTITIES`] per
-    /// entity kind to keep this call bounded on databases with substantial
-    /// bi-temporal history; when the cap is hit, [`GraphSchema::sampled`] is
-    /// set to `true` to disclose the truncation.
+    /// version recorded) is capped per entity kind (see
+    /// [`crate::config::HistoricalConfigBuilder::max_schema_as_of_entities`],
+    /// default 50,000) to keep this call bounded on databases with
+    /// substantial bi-temporal history; when the cap is hit,
+    /// [`GraphSchema::sampled`] is set to `true` to disclose the truncation.
     ///
     /// # Example
     ///
@@ -195,10 +183,11 @@ impl AletheiaDB {
             let historical = self.historical.read();
             let mut node_ids = historical.versioned_node_ids();
             let mut edge_ids = historical.versioned_edge_ids();
+            let cap = historical.max_schema_as_of_entities();
             drop(historical);
 
-            let node_sampled = cap_ids(&mut node_ids, MAX_SCHEMA_AS_OF_ENTITIES);
-            let edge_sampled = cap_ids(&mut edge_ids, MAX_SCHEMA_AS_OF_ENTITIES);
+            let node_sampled = cap_ids(&mut node_ids, cap);
+            let edge_sampled = cap_ids(&mut edge_ids, cap);
             (node_ids, edge_ids, node_sampled || edge_sampled)
         };
 

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2494,3 +2494,38 @@ fn test_schema_as_of_label_absent_before_first_write() {
         })
     );
 }
+
+#[test]
+fn test_schema_as_of_entity_cap_is_configurable_and_discloses_sampling() {
+    use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder};
+    use crate::test_utils::create_test_db_with_config;
+
+    // A tiny cap makes the truncation path cheap to exercise directly,
+    // instead of needing 50,000+ real entities to hit the default cap.
+    let config = AletheiaDBConfig::builder()
+        .historical(
+            HistoricalConfigBuilder::new()
+                .max_schema_as_of_entities(2)
+                .build(),
+        )
+        .build();
+    let (_temp_dir, db) = create_test_db_with_config(config).unwrap();
+
+    for _ in 0..3 {
+        db.create_node("Widget", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+
+    let now = crate::core::temporal::time::now();
+    let schema = db.schema_as_of(now, now).unwrap();
+    assert!(
+        schema.sampled,
+        "a cap of 2 with 3 versioned nodes must disclose truncation"
+    );
+
+    // schema() (current state) is always exhaustive, regardless of the
+    // schema_as_of() cap.
+    let current = db.schema().unwrap();
+    assert!(!current.sampled);
+    assert_eq!(current.total_nodes, 3);
+}

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2323,3 +2323,174 @@ fn test_write_commit_error_counts_once() {
     let snapshot = crate::observability::METRICS.snapshot();
     assert_eq!(snapshot.error_transaction_total, 1);
 }
+
+// ==================== Schema Discovery Tests (Issue #3214) ====================
+
+#[test]
+fn test_schema_empty_database() {
+    let db = AletheiaDB::new().unwrap();
+
+    let schema = db.schema().unwrap();
+
+    assert!(schema.node_labels.is_empty());
+    assert!(schema.edge_types.is_empty());
+    assert_eq!(schema.total_nodes, 0);
+    assert_eq!(schema.total_edges, 0);
+    assert!(!schema.sampled);
+    assert!(schema.as_of.is_none());
+}
+
+#[test]
+fn test_schema_populated_graph_labels_and_edge_types() {
+    let db = AletheiaDB::new().unwrap();
+
+    let alice = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Alice")
+                .insert("age", 30i64)
+                .build(),
+        )
+        .unwrap();
+    let bob = db
+        .create_node(
+            "Person",
+            PropertyMapBuilder::new()
+                .insert("name", "Bob")
+                .insert("email", "bob@example.com")
+                .build(),
+        )
+        .unwrap();
+    let acme = db
+        .create_node(
+            "Company",
+            PropertyMapBuilder::new().insert("name", "Acme").build(),
+        )
+        .unwrap();
+
+    db.create_edge(
+        alice,
+        bob,
+        "KNOWS",
+        PropertyMapBuilder::new().insert("since", 2020i64).build(),
+    )
+    .unwrap();
+    db.create_edge(
+        alice,
+        acme,
+        "WORKS_AT",
+        PropertyMapBuilder::new().insert("role", "Engineer").build(),
+    )
+    .unwrap();
+
+    let schema = db.schema().unwrap();
+
+    // Sorted by label.
+    assert_eq!(schema.node_labels.len(), 2);
+    assert_eq!(schema.node_labels[0].label, "Company");
+    assert_eq!(schema.node_labels[0].count, 1);
+    assert_eq!(schema.node_labels[1].label, "Person");
+    assert_eq!(schema.node_labels[1].count, 2);
+
+    // Property keys are the union across all nodes of that label, sorted.
+    assert_eq!(
+        schema.node_labels[1].property_keys,
+        vec!["age".to_string(), "email".to_string(), "name".to_string()]
+    );
+
+    assert_eq!(schema.edge_types.len(), 2);
+    assert_eq!(schema.edge_types[0].edge_type, "KNOWS");
+    assert_eq!(schema.edge_types[0].count, 1);
+    assert_eq!(
+        schema.edge_types[0].property_keys,
+        vec!["since".to_string()]
+    );
+    assert_eq!(schema.edge_types[1].edge_type, "WORKS_AT");
+    assert_eq!(schema.edge_types[1].count, 1);
+    assert_eq!(schema.edge_types[1].property_keys, vec!["role".to_string()]);
+
+    assert_eq!(schema.total_nodes, 3);
+    assert_eq!(schema.total_edges, 2);
+    assert!(!schema.sampled);
+}
+
+#[test]
+fn test_schema_counts_are_consistent_with_scan_and_count_nodes() {
+    let db = AletheiaDB::new().unwrap();
+
+    for _ in 0..3 {
+        db.create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+    for _ in 0..2 {
+        db.create_node("Company", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+
+    let schema = db.schema().unwrap();
+
+    let mut total_from_labels = 0;
+    for label_schema in &schema.node_labels {
+        let scanned = db.scan_nodes_by_label(&label_schema.label).count();
+        assert_eq!(
+            label_schema.count, scanned,
+            "count for label '{}' must match scan_nodes_by_label",
+            label_schema.label
+        );
+        total_from_labels += label_schema.count;
+    }
+    assert_eq!(total_from_labels, db.node_count());
+    assert_eq!(schema.total_nodes, db.node_count());
+}
+
+#[test]
+fn test_schema_as_of_label_absent_before_first_write() {
+    use crate::core::hlc::HybridTimestamp;
+
+    let db = AletheiaDB::new().unwrap();
+
+    let jan_1 = HybridTimestamp::new(1_704_067_200_000_000, 0).unwrap(); // 2024-01-01
+    let jan_15 = HybridTimestamp::new(1_705_276_800_000_000, 0).unwrap(); // 2024-01-15
+
+    // Before any writes have happened, the schema is empty.
+    let before_any_writes = db.schema_as_of(jan_1, jan_1).unwrap();
+    assert!(before_any_writes.node_labels.is_empty());
+
+    // Create a "Widget" node with valid_time = Jan 1, but the write is recorded
+    // (transaction time) at the real current time, which is after jan_15.
+    db.write(|tx| {
+        tx.create_node_with_valid_time(
+            "Widget",
+            PropertyMapBuilder::new().insert("name", "Thing").build(),
+            Some(jan_1),
+        )
+    })
+    .unwrap();
+
+    // As of Jan 15 transaction time (before the write was actually recorded),
+    // the "Widget" label must still be absent.
+    let still_absent = db.schema_as_of(jan_15, jan_1).unwrap();
+    assert!(
+        still_absent.node_labels.iter().all(|l| l.label != "Widget"),
+        "label should be absent before its first write was committed"
+    );
+
+    // As of the current bi-temporal instant, the label is present.
+    let now = crate::core::temporal::time::now();
+    let present = db.schema_as_of(now, now).unwrap();
+    let widget = present
+        .node_labels
+        .iter()
+        .find(|l| l.label == "Widget")
+        .expect("Widget label should be present as of now");
+    assert_eq!(widget.count, 1);
+
+    assert_eq!(
+        present.as_of,
+        Some(crate::db::schema::SchemaInstant {
+            valid_time: now,
+            transaction_time: now,
+        })
+    );
+}

--- a/src/experimental/characterization/graph_context.rs
+++ b/src/experimental/characterization/graph_context.rs
@@ -130,9 +130,7 @@ impl<'a> GraphContextBuilder<'a> {
     }
 
     fn resolve(s: InternedString) -> String {
-        GLOBAL_INTERNER
-            .resolve_with(s, |s| s.to_string())
-            .unwrap_or_else(|| format!("<interned:{}>", s.as_u32()))
+        GLOBAL_INTERNER.resolve_or_else(s, || format!("<interned:{}>", s.as_u32()))
     }
 
     /// Build the context string (Markdown).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,8 +122,8 @@ pub use core::error::{
     ConstraintError, Error, QueryError, Result, StorageError, TemporalError, TransactionError,
 };
 pub use db::{
-    AletheiaDB, BackupSummary, SimilarityQuery, SimilaritySource, UniqueConstraintBuilder,
-    VectorIndexBuilder,
+    AletheiaDB, BackupSummary, EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant,
+    SimilarityQuery, SimilaritySource, UniqueConstraintBuilder, VectorIndexBuilder,
 };
 pub use index::{
     AdjacencyIndex, CurrentIndexes, TemporalIndexes,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -668,9 +668,7 @@ impl AletheiaMcpServer {
     // ========================================================================
 
     fn interned_to_string(&self, interned: crate::core::InternedString) -> String {
-        GLOBAL_INTERNER
-            .resolve_with(interned, |s| s.to_string())
-            .unwrap_or_else(|| format!("<unknown:{}>", interned.as_u32()))
+        GLOBAL_INTERNER.resolve_or_else(interned, || format!("<unknown:{}>", interned.as_u32()))
     }
 
     fn node_to_response(&self, node: &crate::core::Node) -> NodeResponse {
@@ -2187,6 +2185,10 @@ impl AletheiaMcpServer {
 
         let result = match (valid_time, transaction_time) {
             (None, None) => self.db.schema(),
+            // Only one axis supplied: default the other to "now", matching
+            // db.get_node_at_valid_time()/get_node_at_transaction_time()'s
+            // independent-dimension convention (see GetSchemaRequest's doc
+            // comment for the exact semantics this produces).
             (vt, tt) => self
                 .db
                 .schema_as_of(vt.unwrap_or_else(time::now), tt.unwrap_or_else(time::now)),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -24,6 +24,7 @@
 //! | **Vector** | `find_similar`, `enable_vector_index` | Semantic similarity search |
 //! | **Temporal** | `get_node_at_time`, `get_node_history` | Time-travel queries and history |
 //! | **Hybrid** | `hybrid_query` | Combined graph + vector + temporal queries |
+//! | **Schema** | `get_schema` | Discover node labels, edge types, and property keys (optionally bi-temporal) |
 //!
 //! # Examples
 //!
@@ -577,6 +578,18 @@ impl AletheiaMcpServer {
     /// Performs a time-travel query to retrieve the state of an edge at a specific valid time and transaction time.
     pub fn get_edge_at_time(&self, req: GetEdgeAtTimeRequest) -> String {
         Self::extract_text(self.handle_get_edge_at_time(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
+    /// Discover the graph's schema: distinct node labels and edge types,
+    /// their counts, and the property keys observed on each.
+    ///
+    /// With no `as_of_*` fields, returns the current-state schema. With
+    /// either field set, returns the schema as it existed at that bi-temporal
+    /// instant. Never errors on an empty database.
+    pub fn get_schema(&self, req: GetSchemaRequest) -> String {
+        Self::extract_text(self.handle_get_schema(
             serde_json::to_value(req).expect("request serialization should not fail"),
         ))
     }
@@ -2114,6 +2127,77 @@ impl AletheiaMcpServer {
         })
     }
 
+    /// Convert a [`crate::db::GraphSchema`] into its JSON wire representation.
+    fn schema_to_json(&self, schema: &crate::db::GraphSchema) -> serde_json::Value {
+        let node_labels: Vec<serde_json::Value> = schema
+            .node_labels
+            .iter()
+            .map(|l| {
+                json!({
+                    "label": l.label,
+                    "count": l.count,
+                    "property_keys": l.property_keys,
+                })
+            })
+            .collect();
+
+        let edge_types: Vec<serde_json::Value> = schema
+            .edge_types
+            .iter()
+            .map(|e| {
+                json!({
+                    "edge_type": e.edge_type,
+                    "count": e.count,
+                    "property_keys": e.property_keys,
+                })
+            })
+            .collect();
+
+        json!({
+            "node_labels": node_labels,
+            "edge_types": edge_types,
+            "total_nodes": schema.total_nodes,
+            "total_edges": schema.total_edges,
+            "sampled": schema.sampled,
+            "as_of": schema.as_of.map(|instant| json!({
+                "valid_time": time::to_iso8601(instant.valid_time),
+                "transaction_time": time::to_iso8601(instant.transaction_time),
+            })),
+        })
+    }
+
+    /// Discover the graph's schema (labels, edge types, property keys),
+    /// optionally as of a bi-temporal instant. Never errors on an empty
+    /// database — returns a well-formed, empty summary instead.
+    fn handle_get_schema(&self, args: serde_json::Value) -> CallToolResult {
+        let req: GetSchemaRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+        };
+
+        let valid_time = match self.parse_opt_timestamp("as_of_valid_time", &req.as_of_valid_time) {
+            Ok(t) => t,
+            Err(result) => return result,
+        };
+        let transaction_time =
+            match self.parse_opt_timestamp("as_of_transaction_time", &req.as_of_transaction_time) {
+                Ok(t) => t,
+                Err(result) => return result,
+            };
+
+        let result = match (valid_time, transaction_time) {
+            (None, None) => self.db.schema(),
+            (vt, tt) => self
+                .db
+                .schema_as_of(vt.unwrap_or_else(time::now), tt.unwrap_or_else(time::now)),
+        };
+
+        match result {
+            Ok(schema) => self.success_json(self.schema_to_json(&schema)),
+            Err(e) => self.error_json(&e.to_string()),
+        }
+    }
+
     fn handle_hybrid_query(&self, args: serde_json::Value) -> CallToolResult {
         let req: HybridQueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -2917,6 +3001,17 @@ fn tool_definitions() -> Vec<Tool> {
              unsupported_construct, invalid_params, runtime_error) so callers can self-correct.",
             make_input_schema::<QueryRequest>(),
         ),
+        Tool::new(
+            "get_schema",
+            "Discover the graph's schema: distinct node labels and edge/relationship types, \
+             each with an entity count and the union of property keys observed. Call this \
+             first to learn what labels/edge-types/properties exist before guessing names in \
+             list_nodes, traverse, or query. Accepts optional as_of_valid_time / \
+             as_of_transaction_time (ISO 8601 or microseconds since epoch) to return the \
+             schema as it existed at that bi-temporal instant instead of the current state. \
+             Returns a well-formed empty summary on an empty database, never an error.",
+            make_input_schema::<GetSchemaRequest>(),
+        ),
     ]
 }
 
@@ -2989,6 +3084,7 @@ impl ServerHandler for AletheiaMcpServer {
             "diff_edge_versions" => self.handle_diff_edge_versions(args),
             "hybrid_query" => self.handle_hybrid_query(args),
             "query" => self.handle_query(args),
+            "get_schema" => self.handle_get_schema(args),
             _ => self.error_json(&format!("Unknown tool: {}", request.name)),
         };
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3996,6 +3996,75 @@ mod schema_tests {
         assert!(value.get("error").is_some());
     }
 
+    /// AC: with only `as_of_valid_time` set, `as_of_transaction_time`
+    /// defaults to "now" -- so a node created (and thus recorded) right now
+    /// is visible, since "now" covers both "the fact is valid as of
+    /// as_of_valid_time" (explicit) and "it was recorded by now" (default).
+    #[test]
+    fn test_get_schema_only_valid_time_set_defaults_transaction_time_to_now() {
+        let server = create_test_server();
+
+        server.create_node(CreateNodeRequest {
+            label: "Report".to_string(),
+            properties: None,
+        });
+
+        let now_micros = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as i64;
+
+        let response = server.get_schema(schema_req(Some(&now_micros.to_string()), None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        assert!(!value["as_of"].is_null(), "temporal branch must be taken");
+        let labels: Vec<String> = value["node_labels"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["label"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            labels.contains(&"Report".to_string()),
+            "Report should be visible: valid_time=now (explicit), transaction_time defaults to now: {labels:?}"
+        );
+    }
+
+    /// AC: with only `as_of_transaction_time` set, `as_of_valid_time`
+    /// defaults to "now" -- so a node created (and thus recorded) right now
+    /// is visible.
+    #[test]
+    fn test_get_schema_only_transaction_time_set_defaults_valid_time_to_now() {
+        let server = create_test_server();
+
+        server.create_node(CreateNodeRequest {
+            label: "Invoice".to_string(),
+            properties: None,
+        });
+
+        let now_micros = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as i64;
+
+        let response = server.get_schema(schema_req(None, Some(&now_micros.to_string())));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        assert!(!value["as_of"].is_null(), "temporal branch must be taken");
+        let labels: Vec<String> = value["node_labels"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["label"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            labels.contains(&"Invoice".to_string()),
+            "Invoice should be visible: transaction_time=now (explicit), valid_time defaults to now: {labels:?}"
+        );
+    }
+
     #[test]
     fn test_get_schema_as_of_label_absent_before_first_write() {
         let server = create_test_server();

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3888,3 +3888,225 @@ mod constraint_tests {
         );
     }
 }
+
+// ============================================================================
+// Schema Discovery Tests (get_schema, Issue #3214)
+// ============================================================================
+
+mod schema_tests {
+    use super::*;
+
+    fn schema_req(
+        as_of_valid_time: Option<&str>,
+        as_of_transaction_time: Option<&str>,
+    ) -> GetSchemaRequest {
+        GetSchemaRequest {
+            as_of_valid_time: as_of_valid_time.map(str::to_string),
+            as_of_transaction_time: as_of_transaction_time.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn test_get_schema_empty_database() {
+        let server = create_test_server();
+
+        let response = server.get_schema(schema_req(None, None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        assert_eq!(value["node_labels"].as_array().unwrap().len(), 0);
+        assert_eq!(value["edge_types"].as_array().unwrap().len(), 0);
+        assert_eq!(value["total_nodes"], serde_json::json!(0));
+        assert_eq!(value["total_edges"], serde_json::json!(0));
+        assert_eq!(value["sampled"], serde_json::json!(false));
+        assert!(value["as_of"].is_null());
+    }
+
+    #[test]
+    fn test_get_schema_populated_graph() {
+        let server = create_test_server();
+
+        let alice_response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some({
+                let mut m = HashMap::new();
+                m.insert("name".to_string(), serde_json::json!("Alice"));
+                m
+            }),
+        });
+        let alice: NodeResponse = parse_response(&alice_response).unwrap();
+
+        let bob_response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some({
+                let mut m = HashMap::new();
+                m.insert("email".to_string(), serde_json::json!("bob@example.com"));
+                m
+            }),
+        });
+        let bob: NodeResponse = parse_response(&bob_response).unwrap();
+
+        server.create_edge(CreateEdgeRequest {
+            source_id: alice.id,
+            target_id: bob.id,
+            label: "KNOWS".to_string(),
+            properties: Some({
+                let mut m = HashMap::new();
+                m.insert("since".to_string(), serde_json::json!(2020));
+                m
+            }),
+        });
+
+        let response = server.get_schema(schema_req(None, None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+
+        let node_labels = value["node_labels"].as_array().unwrap();
+        assert_eq!(node_labels.len(), 1);
+        assert_eq!(node_labels[0]["label"], serde_json::json!("Person"));
+        assert_eq!(node_labels[0]["count"], serde_json::json!(2));
+        let person_keys: Vec<String> = node_labels[0]["property_keys"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(person_keys, vec!["email".to_string(), "name".to_string()]);
+
+        let edge_types = value["edge_types"].as_array().unwrap();
+        assert_eq!(edge_types.len(), 1);
+        assert_eq!(edge_types[0]["edge_type"], serde_json::json!("KNOWS"));
+        assert_eq!(edge_types[0]["count"], serde_json::json!(1));
+        assert_eq!(edge_types[0]["property_keys"], serde_json::json!(["since"]));
+
+        assert_eq!(value["total_nodes"], serde_json::json!(2));
+        assert_eq!(value["total_edges"], serde_json::json!(1));
+        assert_eq!(value["sampled"], serde_json::json!(false));
+        assert!(value["as_of"].is_null());
+    }
+
+    #[test]
+    fn test_get_schema_invalid_timestamp() {
+        let server = create_test_server();
+
+        let response = server.get_schema(schema_req(Some("not-a-timestamp"), None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_some());
+    }
+
+    #[test]
+    fn test_get_schema_as_of_label_absent_before_first_write() {
+        let server = create_test_server();
+
+        // Schema as of the Unix epoch — well before any writes — must be empty.
+        let before = server.get_schema(schema_req(Some("0"), Some("0")));
+        let before_value: serde_json::Value = serde_json::from_str(&before).unwrap();
+        assert!(before_value.get("error").is_none());
+        assert_eq!(before_value["node_labels"].as_array().unwrap().len(), 0);
+
+        // Create a node now.
+        server.create_node(CreateNodeRequest {
+            label: "Gadget".to_string(),
+            properties: None,
+        });
+
+        // Still as of the epoch: "Gadget" must remain absent (recorded later).
+        let still_before = server.get_schema(schema_req(Some("0"), Some("0")));
+        let still_before_value: serde_json::Value = serde_json::from_str(&still_before).unwrap();
+        assert!(still_before_value.get("error").is_none());
+        let labels: Vec<String> = still_before_value["node_labels"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["label"].as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            !labels.contains(&"Gadget".to_string()),
+            "Gadget should be absent as of the epoch: {labels:?}"
+        );
+
+        // Current-state schema (no as_of) must include it.
+        let now = server.get_schema(schema_req(None, None));
+        let now_value: serde_json::Value = serde_json::from_str(&now).unwrap();
+        let now_labels: Vec<String> = now_value["node_labels"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["label"].as_str().unwrap().to_string())
+            .collect();
+        assert!(now_labels.contains(&"Gadget".to_string()));
+    }
+
+    #[test]
+    fn test_get_schema_registered_in_tool_list() {
+        let server = create_test_server();
+        let tools = server.list_tools_for_test();
+        assert!(
+            tools.iter().any(|name| name == "get_schema"),
+            "get_schema must be registered in the tools manifest: {tools:?}"
+        );
+    }
+
+    /// AC: "Counts in the summary match the results of the corresponding
+    /// count_nodes / count_edges calls for each label/type."
+    #[test]
+    fn test_get_schema_counts_match_count_nodes_and_count_edges_tools() {
+        let server = create_test_server();
+
+        for _ in 0..3 {
+            server.create_node(CreateNodeRequest {
+                label: "Person".to_string(),
+                properties: None,
+            });
+        }
+        for _ in 0..2 {
+            server.create_node(CreateNodeRequest {
+                label: "Company".to_string(),
+                properties: None,
+            });
+        }
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Company".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+        server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "WORKS_AT".to_string(),
+            properties: None,
+        });
+
+        let schema_value: serde_json::Value =
+            serde_json::from_str(&server.get_schema(schema_req(None, None))).unwrap();
+
+        // Per-label node counts must match the count_nodes tool filtered by that label.
+        for label_entry in schema_value["node_labels"].as_array().unwrap() {
+            let label = label_entry["label"].as_str().unwrap();
+            let count_response = server.count_nodes(CountNodesRequest {
+                label: Some(label.to_string()),
+            });
+            let count_value: serde_json::Value = serde_json::from_str(&count_response).unwrap();
+            assert_eq!(
+                label_entry["count"], count_value["count"],
+                "schema count for label '{label}' must match count_nodes(label='{label}')"
+            );
+        }
+
+        // Total node/edge counts must match the unfiltered count_nodes/count_edges tools.
+        let total_nodes: serde_json::Value =
+            serde_json::from_str(&server.count_nodes(CountNodesRequest { label: None })).unwrap();
+        assert_eq!(schema_value["total_nodes"], total_nodes["count"]);
+
+        let total_edges: serde_json::Value =
+            serde_json::from_str(&server.count_edges(CountEdgesRequest { label: None })).unwrap();
+        assert_eq!(schema_value["total_edges"], total_edges["count"]);
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -591,26 +591,36 @@ pub struct QueryRequest {
 /// Request to discover the graph's schema: distinct node labels and edge
 /// types, their counts, and the property keys observed on each.
 ///
-/// With no `as_of_*` fields, returns the current-state schema. If either
-/// `as_of_valid_time` or `as_of_transaction_time` is supplied, returns the
-/// schema as it existed at that bi-temporal instant (the other dimension
-/// defaults to the current time, matching the independent-dimension query
-/// tools).
+/// With no `as_of_*` fields, returns the current-state schema.
+///
+/// With either field supplied, returns the schema as it existed at that
+/// bi-temporal instant. Each dimension defaults independently to the
+/// current time when the *other* one is supplied but it isn't -- e.g.
+/// `as_of_transaction_time` alone answers "what does the schema look like,
+/// using only facts recorded by transaction-time T, for whatever is valid
+/// right now" (valid_time defaults to now). This mirrors the Rust API's
+/// `get_node_at_valid_time`/`get_node_at_transaction_time` convenience
+/// methods, which default the unspecified dimension the same way. If you
+/// want a specific instant on *both* axes, supply both fields explicitly.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct GetSchemaRequest {
     /// Optional valid time as ISO 8601 timestamp or microseconds since epoch.
     /// If supplied (alone or with `as_of_transaction_time`), the schema is
     /// computed as of this bi-temporal instant instead of the current state.
+    /// If omitted while `as_of_transaction_time` is set, defaults to the
+    /// current time (i.e. "whatever is valid right now").
     #[schemars(
-        description = "Optional valid time (ISO 8601 or microseconds since epoch). Supplying this or as_of_transaction_time switches to a bi-temporal schema snapshot."
+        description = "Optional valid time (ISO 8601 or microseconds since epoch). Supplying this or as_of_transaction_time switches to a bi-temporal schema snapshot. If omitted while as_of_transaction_time is set, defaults to the current time."
     )]
     pub as_of_valid_time: Option<String>,
 
     /// Optional transaction time as ISO 8601 timestamp or microseconds since epoch.
     /// If supplied (alone or with `as_of_valid_time`), the schema is computed
-    /// as of this bi-temporal instant instead of the current state.
+    /// as of this bi-temporal instant instead of the current state. If
+    /// omitted while `as_of_valid_time` is set, defaults to the current time
+    /// (i.e. "everything recorded so far").
     #[schemars(
-        description = "Optional transaction time (ISO 8601 or microseconds since epoch). Supplying this or as_of_valid_time switches to a bi-temporal schema snapshot."
+        description = "Optional transaction time (ISO 8601 or microseconds since epoch). Supplying this or as_of_valid_time switches to a bi-temporal schema snapshot. If omitted while as_of_valid_time is set, defaults to the current time."
     )]
     pub as_of_transaction_time: Option<String>,
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -585,6 +585,37 @@ pub struct QueryRequest {
 }
 
 // ============================================================================
+// Schema Discovery (Issue #3214)
+// ============================================================================
+
+/// Request to discover the graph's schema: distinct node labels and edge
+/// types, their counts, and the property keys observed on each.
+///
+/// With no `as_of_*` fields, returns the current-state schema. If either
+/// `as_of_valid_time` or `as_of_transaction_time` is supplied, returns the
+/// schema as it existed at that bi-temporal instant (the other dimension
+/// defaults to the current time, matching the independent-dimension query
+/// tools).
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct GetSchemaRequest {
+    /// Optional valid time as ISO 8601 timestamp or microseconds since epoch.
+    /// If supplied (alone or with `as_of_transaction_time`), the schema is
+    /// computed as of this bi-temporal instant instead of the current state.
+    #[schemars(
+        description = "Optional valid time (ISO 8601 or microseconds since epoch). Supplying this or as_of_transaction_time switches to a bi-temporal schema snapshot."
+    )]
+    pub as_of_valid_time: Option<String>,
+
+    /// Optional transaction time as ISO 8601 timestamp or microseconds since epoch.
+    /// If supplied (alone or with `as_of_valid_time`), the schema is computed
+    /// as of this bi-temporal instant instead of the current state.
+    #[schemars(
+        description = "Optional transaction time (ISO 8601 or microseconds since epoch). Supplying this or as_of_valid_time switches to a bi-temporal schema snapshot."
+    )]
+    pub as_of_transaction_time: Option<String>,
+}
+
+// ============================================================================
 // Response Types (for serialization)
 // ============================================================================
 

--- a/src/storage/current/mod.rs
+++ b/src/storage/current/mod.rs
@@ -1830,6 +1830,27 @@ impl CurrentStorage {
         edges
     }
 
+    /// Visit every node in the current storage by reference, without cloning.
+    ///
+    /// Prefer this over `get_all_nodes()` when only a read-only pass over each
+    /// node is needed (e.g. aggregation), since it avoids allocating an owned
+    /// `Vec<Node>` and cloning each node.
+    pub fn visit_nodes<F: FnMut(&crate::Node)>(&self, mut f: F) {
+        for node in self.indexes.iter_nodes() {
+            f(&node);
+        }
+    }
+
+    /// Visit every edge in the current storage by reference, without cloning.
+    ///
+    /// See [`Self::visit_nodes`] for why this is preferable to `get_all_edges()`
+    /// for read-only aggregation passes.
+    pub fn visit_edges<F: FnMut(&crate::Edge)>(&self, mut f: F) {
+        for edge in self.indexes.iter_edges() {
+            f(&edge);
+        }
+    }
+
     /// Get node IDs by label.
     ///
     /// Returns the IDs of all nodes with the given label.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1322,6 +1322,24 @@ impl HistoricalStorage {
         self.edge_version_heads.get(&edge_id).copied()
     }
 
+    /// Get the IDs of every node that has ever had at least one version recorded.
+    ///
+    /// Used for bi-temporal schema discovery (Issue #3214): the caller reconstructs
+    /// each ID at a given instant via [`AletheiaDB::get_nodes_at_time`](crate::db::AletheiaDB::get_nodes_at_time)
+    /// to determine which were visible.
+    pub fn versioned_node_ids(&self) -> Vec<NodeId> {
+        self.node_version_heads.keys().copied().collect()
+    }
+
+    /// Get the IDs of every edge that has ever had at least one version recorded.
+    ///
+    /// Used for bi-temporal schema discovery (Issue #3214): the caller reconstructs
+    /// each ID at a given instant via [`AletheiaDB::get_edges_at_time`](crate::db::AletheiaDB::get_edges_at_time)
+    /// to determine which were visible.
+    pub fn versioned_edge_ids(&self) -> Vec<EdgeId> {
+        self.edge_version_heads.keys().copied().collect()
+    }
+
     /// Get all node versions for all nodes.
     ///
     /// Returns a map of NodeId -> `Vec<NodeVersion>` for recovery property tests.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -47,6 +47,12 @@ pub const DEFAULT_MAX_VERSION_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
 ///   Still provides infinite loop protection while enabling practical use cases.
 pub const MAX_RECONSTRUCTION_DEPTH: usize = 1_000;
 
+/// Default safety cap on the number of ever-versioned entities
+/// `AletheiaDB::schema_as_of` will reconstruct in a single call, per entity
+/// kind (nodes/edges). See [`crate::config::HistoricalConfigBuilder::max_schema_as_of_entities`]
+/// to override this.
+pub const DEFAULT_MAX_SCHEMA_AS_OF_ENTITIES: usize = 50_000;
+
 /// Retention policy for version history (DoS protection).
 ///
 /// Controls how many versions are kept and for how long to prevent
@@ -171,6 +177,9 @@ pub struct HistoricalStorage {
     retention_policy: RetentionPolicy,
     /// Maximum depth for version reconstruction (DoS protection)
     max_reconstruction_depth: usize,
+    /// Safety cap (per entity kind) on the number of ever-versioned entities
+    /// `AletheiaDB::schema_as_of` will reconstruct in a single call.
+    max_schema_as_of_entities: usize,
     // All FastHashMap fields below use IdentityHasher to avoid SipHash overhead
     // on integer keys (NodeId, EdgeId, VersionId are all newtypes over u64).
     /// All node versions, indexed by version ID.
@@ -329,6 +338,7 @@ impl HistoricalStorage {
 
         // Override max_reconstruction_depth from config
         storage.max_reconstruction_depth = config.max_reconstruction_depth;
+        storage.max_schema_as_of_entities = config.max_schema_as_of_entities;
 
         storage
     }
@@ -358,6 +368,7 @@ impl HistoricalStorage {
             config,
             retention_policy,
             max_reconstruction_depth: MAX_RECONSTRUCTION_DEPTH,
+            max_schema_as_of_entities: DEFAULT_MAX_SCHEMA_AS_OF_ENTITIES,
             node_versions: FastHashMap::default(),
             edge_versions: FastHashMap::default(),
             node_version_heads: FastHashMap::default(),
@@ -1338,6 +1349,14 @@ impl HistoricalStorage {
     /// to determine which were visible.
     pub fn versioned_edge_ids(&self) -> Vec<EdgeId> {
         self.edge_version_heads.keys().copied().collect()
+    }
+
+    /// Get the configured safety cap (per entity kind) on the number of
+    /// ever-versioned entities `AletheiaDB::schema_as_of` will reconstruct
+    /// in a single call. See
+    /// [`crate::config::HistoricalConfigBuilder::max_schema_as_of_entities`].
+    pub fn max_schema_as_of_entities(&self) -> usize {
+        self.max_schema_as_of_entities
     }
 
     /// Get all node versions for all nodes.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2052,15 +2052,20 @@ impl HistoricalStorage {
                             version.id,
                         ))
                     }
-                    Err(_e) => {
+                    Err(e) => {
+                        // Per this method's documented contract, a reconstruction failure
+                        // is a systemic failure (corruption, not "didn't exist") and must
+                        // propagate as `Err`, not be silently downgraded to `None` --
+                        // otherwise callers can't distinguish "not visible at this instant"
+                        // from "we couldn't tell".
                         #[cfg(feature = "observability")]
                         tracing::error!(
                             version_id = %version_id,
                             node_id = %node_id,
-                            error = %_e,
+                            error = %e,
                             "Property reconstruction failed in batch query"
                         );
-                        None
+                        return Err(e);
                     }
                 }
             } else {
@@ -2108,15 +2113,17 @@ impl HistoricalStorage {
                             version.id,
                         ))
                     }
-                    Err(_e) => {
+                    Err(e) => {
+                        // See the matching comment in get_nodes_at_time: reconstruction
+                        // failures are systemic and must propagate, not become `None`.
                         #[cfg(feature = "observability")]
                         tracing::error!(
                             version_id = %version_id,
                             edge_id = %edge_id,
-                            error = %_e,
+                            error = %e,
                             "Property reconstruction failed in batch query"
                         );
-                        None
+                        return Err(e);
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary

Implements a new schema discovery feature that allows callers (notably LLM/MCP integrators) to discover the graph's shape without prior knowledge of label or property names. Provides both current-state and bi-temporal schema snapshots with entity counts and property key enumeration.

## Key Changes

- **New `schema` module** (`src/db/schema.rs`): Core schema discovery implementation
  - `GraphSchema` struct: Summarizes distinct node labels, edge types, their counts, and observed property keys
  - `AletheiaDB::schema()`: Returns current-state schema (always exhaustive)
  - `AletheiaDB::schema_as_of(valid_time, transaction_time)`: Returns schema at a specific bi-temporal instant
  - `SchemaInstant`, `LabelSchema`, `EdgeTypeSchema`: Supporting types for structured schema representation
  - Safety cap (`MAX_SCHEMA_AS_OF_ENTITIES = 50,000`) on entity reconstruction to keep bi-temporal queries bounded; `sampled` flag discloses any truncation

- **MCP tool integration** (`src/mcp/tools.rs`, `src/mcp/server.rs`):
  - New `GetSchemaRequest` type with optional `as_of_valid_time` and `as_of_transaction_time` fields
  - Independent dimension defaulting: each temporal axis defaults to "now" when the other is supplied but it isn't
  - `handle_get_schema()` handler with proper timestamp parsing and error handling
  - `schema_to_json()` converter for wire representation

- **Storage layer support** (`src/storage/historical/mod.rs`, `src/storage/current/mod.rs`):
  - `HistoricalStorage::versioned_node_ids()` and `versioned_edge_ids()`: Enumerate all entities that have ever had versions
  - `CurrentStorage::visit_nodes()` and `visit_edges()`: Zero-copy iteration for aggregation passes (avoids cloning)

- **Core utilities** (`src/core/interning.rs`):
  - `StringInterner::resolve_or_else()`: Centralized fallback resolution for interned strings

- **Comprehensive test coverage**:
  - Unit tests in `src/db/tests.rs`: Empty database, populated graph, label/edge type discovery, bi-temporal visibility, count consistency
  - MCP integration tests in `src/mcp/tests.rs`: Empty database, populated graph, timestamp parsing, temporal defaults, tool registration, count validation

## Notable Implementation Details

- **Performance optimization**: Uses `Accumulator` with `InternedString` keys to defer string resolution until final output, avoiding per-entity interner lookups
- **Deterministic sampling**: When entity cap is exceeded, truncates to a sorted prefix for reproducible results
- **Bi-temporal semantics**: Properly handles entities that didn't exist at earlier instants (absent from result, not an error)
- **No snapshot isolation**: Counts reflect best-effort reads over live storage, consistent with other full-scan methods
- **Property key union**: Aggregates all property keys observed across entities of a label/type, sorted for stable output

https://claude.ai/code/session_014M4jrt2iWhWH1ZHowU552a