### PR TITLE
🎻 Bard: [documentation update] Fix broken and redundant intra-doc links

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -233,7 +233,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
@@ -333,7 +333,7 @@ impl AletheiaDB {
 
     /// Enable a uniqueness constraint on `(label, property)`.
     ///
-    /// Fails with [`ConstraintError::DuplicateOnEnable`] if existing nodes already
+    /// Fails with [`ConstraintError::DuplicateOnEnable`](crate::core::error::ConstraintError::DuplicateOnEnable) if existing nodes already
     /// violate the constraint. No constraint is enabled in that case.
     pub(crate) fn enable_unique_constraint(&self, label: &str, property: &str) -> Result<()> {
         let label_id = GLOBAL_INTERNER.intern(label).record_error_metric()?;

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: `src/db/ops.rs` and `src/db/temporal.rs`
🔦 Insight: Fixed `cargo doc` warnings. Replaced unresolved paths to `StorageError::NodeNotFound` with its proper `crate::core::StorageError` path. Added explicit `crate::core::error::ConstraintError` path to `ConstraintError::DuplicateOnEnable` to fix scoping issues. Replaced redundant explicit link `[`ChangeRecord`](crate::core::ChangeRecord)` with standard `[`ChangeRecord`]`.
🧪 Example: N/A - Documentation link fix only.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [6436042130194170058](https://jules.google.com/task/6436042130194170058) started by @madmax983*