### PR TITLE
⚡ Bolt: Optimize vector allocations in Sybil algorithm

### DIFF
--- a/src/experimental/characterization/sybil.rs
+++ b/src/experimental/characterization/sybil.rs
@@ -111,7 +111,11 @@ impl PropagationModel for LinearPropagation {
             return current_self.map(|v| v.to_vec());
         }
 
-        let avg: Vec<f32> = sum.iter().map(|x| x / count as f32).collect();
+        let count_f32 = count as f32;
+        for val in sum.iter_mut() {
+            *val /= count_f32;
+        }
+        let mut avg = sum; // Re-use the allocation
 
         match current_self {
             Some(self_vec) => {
@@ -122,12 +126,11 @@ impl PropagationModel for LinearPropagation {
                 }
 
                 // Blend: (1 - alpha) * self + alpha * avg
-                let new_vec: Vec<f32> = self_vec
-                    .iter()
-                    .zip(avg.iter())
-                    .map(|(s, a)| (1.0 - self.alpha) * s + self.alpha * a)
-                    .collect();
-                Some(new_vec)
+                // Optimization: Compute in-place using the existing `avg` vector to avoid allocations.
+                for (a, &s) in avg.iter_mut().zip(self_vec.iter()) {
+                    *a = (1.0 - self.alpha) * s + self.alpha * *a;
+                }
+                Some(avg)
             }
             None => {
                 // If we didn't have a state, we "adopt" the average (if alpha allows adoption)


### PR DESCRIPTION
💡 What: Modified the `calculate_next_state` function in `src/experimental/characterization/sybil.rs` to compute the average in-place using the existing `sum` vector, and then compute the blended state in-place.
🎯 Why: The original code used `.map().collect()` to create an `avg` vector and a `new_vec` vector, causing two unnecessary heap allocations per node per iteration in the Sybil algorithm simulation loop.
📊 Impact: Eliminates two `Vec<f32>` heap allocations per node iteration.
🔬 Measurement: Verified with `cargo test sybil` and `cargo clippy`.

---
*PR created automatically by Jules for task [2841844216304383152](https://jules.google.com/task/2841844216304383152) started by @madmax983*