### PR TITLE
Add include_vectors parameter to elide vector properties by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,19 @@ self-correct. When the `cypher` feature is not compiled in, `language:"cypher"`
 returns `language_unavailable` (AQL is always available). See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md).
 
+**Vector properties are elided by default (Issue #3220)**: `get_node`,
+`list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,
+`get_incoming_edges`, `traverse`, `find_similar`, and `hybrid_query` replace
+vector/embedding properties with a `{type, dim, elided: true}` descriptor
+(or `{type: "sparse_vector", dim, nnz, elided: true}` for sparse vectors)
+instead of the raw float array -- a single embedding can otherwise cost
+thousands of tokens of context an LLM can't reason over. Pass
+`include_vectors: true` on the request to receive the full array. This does
+not affect `find_similar`'s `score` or `hybrid_query`'s `similarity_score`,
+which are always returned in full, nor the write path (`create_node`,
+`update_node`, `create_edge`, `update_edge`) or temporal/history tools,
+which are unaffected by this flag and always return full vectors.
+
 **Programmatic Usage:**
 ```rust
 use aletheiadb::mcp::AletheiaMcpServer;

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ Exposes AletheiaDB as a set of MCP tools over stdio: node/edge CRUD,
 multi-hop traversal, vector search, temporal queries, and hybrid queries.
 Compatible with Claude, Claude Code, and any MCP-capable host.
 
+**Vector elision by default**: read tools (`get_node`, `list_nodes`,
+`get_edge`, `list_edges`, `get_outgoing_edges`, `get_incoming_edges`,
+`traverse`, `find_similar`, `hybrid_query`) replace vector/embedding
+properties with a small `{type, dim, elided: true}` descriptor instead of
+the raw float array, since a single embedding can cost thousands of tokens
+of context an LLM can't reason over. Pass `include_vectors: true` on the
+request to get the full array back. Similarity scores (`score` /
+`similarity_score`) are always returned in full regardless of this flag.
+
 ---
 
 ## Contributing

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -671,34 +671,42 @@ impl AletheiaMcpServer {
         GLOBAL_INTERNER.resolve_or_else(interned, || format!("<unknown:{}>", interned.as_u32()))
     }
 
-    fn node_to_response(&self, node: &crate::core::Node) -> NodeResponse {
+    fn node_to_response(&self, node: &crate::core::Node, include_vectors: bool) -> NodeResponse {
         NodeResponse {
             id: node.id.as_u64(),
             label: self.interned_to_string(node.label),
-            properties: self.property_map_to_json(&node.properties),
+            properties: self.property_map_to_json(&node.properties, include_vectors),
         }
     }
 
-    fn edge_to_response(&self, edge: &crate::core::Edge) -> EdgeResponse {
+    fn edge_to_response(&self, edge: &crate::core::Edge, include_vectors: bool) -> EdgeResponse {
         EdgeResponse {
             id: edge.id.as_u64(),
             source_id: edge.source.as_u64(),
             target_id: edge.target.as_u64(),
             label: self.interned_to_string(edge.label),
-            properties: self.property_map_to_json(&edge.properties),
+            properties: self.property_map_to_json(&edge.properties, include_vectors),
         }
     }
 
-    fn property_map_to_json(&self, props: &PropertyMap) -> HashMap<String, serde_json::Value> {
+    fn property_map_to_json(
+        &self,
+        props: &PropertyMap,
+        include_vectors: bool,
+    ) -> HashMap<String, serde_json::Value> {
         let mut result = HashMap::new();
         for (key, value) in props.iter() {
             let key_str = self.interned_to_string(*key);
-            result.insert(key_str, self.property_value_to_json(value));
+            result.insert(key_str, self.property_value_to_json(value, include_vectors));
         }
         result
     }
 
-    fn property_value_to_json(&self, value: &PropertyValue) -> serde_json::Value {
+    fn property_value_to_json(
+        &self,
+        value: &PropertyValue,
+        include_vectors: bool,
+    ) -> serde_json::Value {
         match value {
             PropertyValue::Null => serde_json::Value::Null,
             PropertyValue::Bool(b) => serde_json::Value::Bool(*b),
@@ -709,16 +717,31 @@ impl AletheiaMcpServer {
                 serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(b))
             }
             PropertyValue::Array(arr) => serde_json::Value::Array(
-                arr.iter().map(|v| self.property_value_to_json(v)).collect(),
+                arr.iter()
+                    .map(|v| self.property_value_to_json(v, include_vectors))
+                    .collect(),
             ),
             PropertyValue::Vector(v) => {
-                serde_json::Value::Array(v.iter().map(|f| json!(*f)).collect())
+                if include_vectors {
+                    serde_json::Value::Array(v.iter().map(|f| json!(*f)).collect())
+                } else {
+                    json!({"type": "vector", "dim": v.len(), "elided": true})
+                }
             }
             PropertyValue::SparseVector(sv) => {
-                json!({
-                    "indices": sv.indices(),
-                    "values": sv.values()
-                })
+                if include_vectors {
+                    json!({
+                        "indices": sv.indices(),
+                        "values": sv.values()
+                    })
+                } else {
+                    json!({
+                        "type": "sparse_vector",
+                        "dim": sv.dimension(),
+                        "nnz": sv.nnz(),
+                        "elided": true
+                    })
+                }
             }
         }
     }
@@ -912,7 +935,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_node(node_id) {
             Ok(node) => {
-                let response = self.node_to_response(&node);
+                let response = self.node_to_response(&node, req.include_vectors.unwrap_or(false));
                 self.success_json(
                     serde_json::to_value(&response)
                         .expect("response serialization should not fail"),
@@ -939,7 +962,7 @@ impl AletheiaMcpServer {
         match self.db.create_node(&req.label, properties) {
             Ok(node_id) => match self.db.get_node(node_id) {
                 Ok(node) => {
-                    let response = self.node_to_response(&node);
+                    let response = self.node_to_response(&node, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -975,7 +998,7 @@ impl AletheiaMcpServer {
         match self.db.write(|tx| tx.update_node(node_id, properties)) {
             Ok(()) => match self.db.get_node(node_id) {
                 Ok(node) => {
-                    let response = self.node_to_response(&node);
+                    let response = self.node_to_response(&node, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1131,10 +1154,11 @@ impl AletheiaMcpServer {
                 .db
                 .find_nodes_by_property(label, prop_key, &property_value);
 
+            let include_vectors = req.include_vectors.unwrap_or(false);
             let mut nodes = Vec::with_capacity(limit);
             for node_id in node_ids.into_iter().skip(offset).take(limit) {
                 if let Ok(node) = self.db.get_node(node_id) {
-                    nodes.push(self.node_to_response(&node));
+                    nodes.push(self.node_to_response(&node, include_vectors));
                 }
             }
 
@@ -1155,6 +1179,7 @@ impl AletheiaMcpServer {
             match builder.limit(limit + offset).execute(&self.db) {
                 Ok(results) => {
                     // Use iterator-based approach to avoid allocating full Vec
+                    let include_vectors = req.include_vectors.unwrap_or(false);
                     let mut nodes = Vec::with_capacity(limit);
                     let mut skipped = 0;
 
@@ -1166,7 +1191,7 @@ impl AletheiaMcpServer {
                                     continue;
                                 }
                                 if let EntityResult::Node(node) = row.entity {
-                                    nodes.push(self.node_to_response(&node));
+                                    nodes.push(self.node_to_response(&node, include_vectors));
                                     if nodes.len() >= limit {
                                         break;
                                     }
@@ -1242,7 +1267,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_edge(edge_id) {
             Ok(edge) => {
-                let response = self.edge_to_response(&edge);
+                let response = self.edge_to_response(&edge, req.include_vectors.unwrap_or(false));
                 self.success_json(
                     serde_json::to_value(&response)
                         .expect("response serialization should not fail"),
@@ -1282,7 +1307,7 @@ impl AletheiaMcpServer {
         {
             Ok(edge_id) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
-                    let response = self.edge_to_response(&edge);
+                    let response = self.edge_to_response(&edge, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1313,7 +1338,7 @@ impl AletheiaMcpServer {
         match self.db.write(|tx| tx.update_edge(edge_id, properties)) {
             Ok(()) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
-                    let response = self.edge_to_response(&edge);
+                    let response = self.edge_to_response(&edge, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1407,10 +1432,11 @@ impl AletheiaMcpServer {
             self.db.get_outgoing_edges(node_id)
         };
 
+        let include_vectors = req.include_vectors.unwrap_or(false);
         let edges: Vec<EdgeResponse> = edge_ids
             .into_iter()
             .filter_map(|eid| self.db.get_edge(eid).ok())
-            .map(|e| self.edge_to_response(&e))
+            .map(|e| self.edge_to_response(&e, include_vectors))
             .collect();
 
         self.success_json(json!({
@@ -1433,6 +1459,7 @@ impl AletheiaMcpServer {
         let edge_ids = self.db.get_incoming_edges(node_id);
 
         // Filter by label if provided
+        let include_vectors = req.include_vectors.unwrap_or(false);
         let edges: Vec<EdgeResponse> = edge_ids
             .into_iter()
             .filter_map(|eid| self.db.get_edge(eid).ok())
@@ -1442,7 +1469,7 @@ impl AletheiaMcpServer {
                     .map(|l| self.matches_label(e.label, l))
                     .unwrap_or(true)
             })
-            .map(|e| self.edge_to_response(&e))
+            .map(|e| self.edge_to_response(&e, include_vectors))
             .collect();
 
         self.success_json(json!({
@@ -1484,7 +1511,7 @@ impl AletheiaMcpServer {
                 visited.insert(current_id.as_u64());
                 if let Ok(node) = self.db.get_node(current_id) {
                     results.push(TraversalResult {
-                        node: self.node_to_response(&node),
+                        node: self.node_to_response(&node, req.include_vectors.unwrap_or(false)),
                         path: path.clone(),
                         depth: current_depth,
                     });
@@ -1580,11 +1607,12 @@ impl AletheiaMcpServer {
             .similarity_search(crate::SimilarityQuery::from_embedding(req.embedding).k(k))
         {
             Ok(results) => {
+                let include_vectors = req.include_vectors.unwrap_or(false);
                 let similarity_results: Vec<SimilarityResult> = results
                     .into_iter()
                     .filter_map(|(node_id, score)| {
                         self.db.get_node(node_id).ok().map(|node| SimilarityResult {
-                            node: self.node_to_response(&node),
+                            node: self.node_to_response(&node, include_vectors),
                             score,
                         })
                     })
@@ -1697,7 +1725,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_node_at_time(node_id, valid_time, tx_time) {
             Ok(node) => {
-                let response = self.node_to_response(&node);
+                let response = self.node_to_response(&node, true);
                 self.success_json(json!({
                     "node": response,
                     "valid_time": req.valid_time,
@@ -1731,7 +1759,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_edge_at_time(edge_id, valid_time, tx_time) {
             Ok(edge) => {
-                let response = self.edge_to_response(&edge);
+                let response = self.edge_to_response(&edge, true);
                 self.success_json(json!({
                     "edge": response,
                     "valid_time": req.valid_time,
@@ -1839,7 +1867,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_node_at_valid_time(node_id, valid_time) {
             Ok(node) => {
-                let response = self.node_to_response(&node);
+                let response = self.node_to_response(&node, true);
                 self.success_json(json!({
                     "node": response,
                     "valid_time": req.valid_time
@@ -1867,7 +1895,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_node_at_transaction_time(node_id, tx_time) {
             Ok(node) => {
-                let response = self.node_to_response(&node);
+                let response = self.node_to_response(&node, true);
                 self.success_json(json!({
                     "node": response,
                     "transaction_time": req.transaction_time
@@ -1957,7 +1985,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_edge_at_valid_time(edge_id, valid_time) {
             Ok(edge) => {
-                let response = self.edge_to_response(&edge);
+                let response = self.edge_to_response(&edge, true);
                 self.success_json(json!({
                     "edge": response,
                     "valid_time": req.valid_time
@@ -1985,7 +2013,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_edge_at_transaction_time(edge_id, tx_time) {
             Ok(edge) => {
-                let response = self.edge_to_response(&edge);
+                let response = self.edge_to_response(&edge, true);
                 self.success_json(json!({
                     "edge": response,
                     "transaction_time": req.transaction_time
@@ -2062,7 +2090,7 @@ impl AletheiaMcpServer {
     fn version_info_to_response(&self, info: &crate::query::VersionInfo) -> serde_json::Value {
         use crate::core::temporal::TIMESTAMP_MAX;
 
-        let properties = self.property_map_to_json(&info.properties);
+        let properties = self.property_map_to_json(&info.properties, true);
 
         let valid_to = {
             let end = info.temporal.valid_time().end();
@@ -2095,8 +2123,8 @@ impl AletheiaMcpServer {
     }
 
     fn version_diff_to_response(&self, diff: &crate::query::VersionDiff) -> serde_json::Value {
-        let added = self.property_map_to_json(&diff.added);
-        let removed = self.property_map_to_json(&diff.removed);
+        let added = self.property_map_to_json(&diff.added, true);
+        let removed = self.property_map_to_json(&diff.removed, true);
 
         let modified: Vec<_> = diff
             .modified
@@ -2108,8 +2136,8 @@ impl AletheiaMcpServer {
 
                 json!({
                     "key": key_str,
-                    "old_value": self.property_value_to_json(old_val),
-                    "new_value": self.property_value_to_json(new_val)
+                    "old_value": self.property_value_to_json(old_val, true),
+                    "new_value": self.property_value_to_json(new_val, true)
                 })
             })
             .collect();
@@ -2233,6 +2261,8 @@ impl AletheiaMcpServer {
             None
         };
 
+        let include_vectors = req.include_vectors.unwrap_or(false);
+
         // Helper to convert rows to hybrid results with temporal info
         let rows_to_results =
             |rows: Vec<crate::query::executor::QueryRow>| -> Vec<HybridQueryResult> {
@@ -2240,7 +2270,7 @@ impl AletheiaMcpServer {
                     .filter_map(|row| {
                         if let EntityResult::Node(node) = row.entity {
                             Some(HybridQueryResult {
-                                node: self.node_to_response(&node),
+                                node: self.node_to_response(&node, include_vectors),
                                 similarity_score: row.score,
                                 traversal_path: row.path.map(|p| {
                                     p.iter()
@@ -2271,7 +2301,7 @@ impl AletheiaMcpServer {
                 // Temporal query for a single node
                 return match self.db.get_node_at_time(node_id, vt, tt) {
                     Ok(node) => {
-                        let response = self.node_to_response(&node);
+                        let response = self.node_to_response(&node, include_vectors);
                         self.success_json(json!({
                             "results": [HybridQueryResult {
                                 node: response,
@@ -2303,7 +2333,7 @@ impl AletheiaMcpServer {
                 // Just return the start node
                 return match self.db.get_node(node_id) {
                     Ok(node) => {
-                        let response = self.node_to_response(&node);
+                        let response = self.node_to_response(&node, include_vectors);
                         self.success_json(json!({
                             "results": [HybridQueryResult {
                                 node: response,
@@ -2448,11 +2478,11 @@ impl AletheiaMcpServer {
     fn query_row_to_json(&self, row: crate::query::executor::QueryRow) -> serde_json::Value {
         let entity = match row.entity {
             EntityResult::Node(node) => {
-                let r = self.node_to_response(&node);
+                let r = self.node_to_response(&node, true);
                 json!({"type": "node", "id": r.id, "label": r.label, "properties": r.properties})
             }
             EntityResult::Edge(edge) => {
-                let r = self.edge_to_response(&edge);
+                let r = self.edge_to_response(&edge, true);
                 json!({
                     "type": "edge",
                     "id": r.id,
@@ -2816,7 +2846,10 @@ fn tool_definitions() -> Vec<Tool> {
     vec![
         Tool::new(
             "get_node",
-            "Get a node by its ID. Returns the node's label and properties.",
+            "Get a node by its ID. Returns the node's label and properties. \
+                     Vector/embedding properties are elided by default (replaced with a \
+                     `{type, dim, elided:true}` descriptor) to protect LLM context; pass \
+                     `include_vectors: true` to receive the full float array.",
             make_input_schema::<GetNodeRequest>(),
         ),
         Tool::new(
@@ -2845,7 +2878,10 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "list_nodes",
-            "List nodes with optional label filter and pagination.",
+            "List nodes with optional label filter and pagination. Vector/embedding \
+                     properties are elided by default (replaced with a `{type, dim, elided:true}` \
+                     descriptor) to protect LLM context; pass `include_vectors: true` to receive \
+                     the full float arrays.",
             make_input_schema::<ListNodesRequest>(),
         ),
         Tool::new(
@@ -2855,7 +2891,9 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "get_edge",
-            "Get an edge by its ID.",
+            "Get an edge by its ID. Vector/embedding properties are elided by default \
+                     (replaced with a `{type, dim, elided:true}` descriptor) to protect LLM \
+                     context; pass `include_vectors: true` to receive the full float array.",
             make_input_schema::<GetEdgeRequest>(),
         ),
         Tool::new(
@@ -2875,7 +2913,10 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "list_edges",
-            "List edges with optional label filter and pagination.",
+            "List edges with optional label filter and pagination. Vector/embedding \
+                     properties are elided by default (replaced with a `{type, dim, elided:true}` \
+                     descriptor) to protect LLM context; pass `include_vectors: true` to receive \
+                     the full float arrays.",
             make_input_schema::<ListEdgesRequest>(),
         ),
         Tool::new(
@@ -2885,22 +2926,34 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "get_outgoing_edges",
-            "Get all outgoing edges from a node.",
+            "Get all outgoing edges from a node. Vector/embedding properties are elided \
+                     by default (replaced with a `{type, dim, elided:true}` descriptor) to \
+                     protect LLM context; pass `include_vectors: true` to receive the full float \
+                     arrays.",
             make_input_schema::<GetOutgoingEdgesRequest>(),
         ),
         Tool::new(
             "get_incoming_edges",
-            "Get all incoming edges to a node.",
+            "Get all incoming edges to a node. Vector/embedding properties are elided by \
+                     default (replaced with a `{type, dim, elided:true}` descriptor) to protect \
+                     LLM context; pass `include_vectors: true` to receive the full float arrays.",
             make_input_schema::<GetIncomingEdgesRequest>(),
         ),
         Tool::new(
             "traverse",
-            "Traverse the graph starting from a node.",
+            "Traverse the graph starting from a node. Vector/embedding properties are \
+                     elided by default (replaced with a `{type, dim, elided:true}` descriptor) to \
+                     protect LLM context; pass `include_vectors: true` to receive the full float \
+                     arrays.",
             make_input_schema::<TraverseRequest>(),
         ),
         Tool::new(
             "find_similar",
-            "Find nodes similar to a query embedding.",
+            "Find nodes similar to a query embedding. The similarity `score` is always \
+                     returned in full. Vector/embedding properties on the returned nodes are \
+                     elided by default (replaced with a `{type, dim, elided:true}` descriptor) to \
+                     protect LLM context; pass `include_vectors: true` to receive the full float \
+                     arrays.",
             make_input_schema::<FindSimilarRequest>(),
         ),
         Tool::new(
@@ -2980,7 +3033,11 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "hybrid_query",
-            "Execute a hybrid query combining graph traversal, vector similarity, and temporal filtering.",
+            "Execute a hybrid query combining graph traversal, vector similarity, and \
+                     temporal filtering. The `similarity_score` is always returned in full. \
+                     Vector/embedding properties on returned nodes are elided by default \
+                     (replaced with a `{type, dim, elided:true}` descriptor) to protect LLM \
+                     context; pass `include_vectors: true` to receive the full float arrays.",
             make_input_schema::<HybridQueryRequest>(),
         ),
         Tool::new(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -723,7 +723,11 @@ impl AletheiaMcpServer {
             ),
             PropertyValue::Vector(v) => {
                 if include_vectors {
-                    serde_json::Value::Array(v.iter().map(|f| json!(*f)).collect())
+                    serde_json::Value::Array(
+                        v.iter()
+                            .map(|&f| serde_json::Value::from(f as f64))
+                            .collect(),
+                    )
                 } else {
                     json!({"type": "vector", "dim": v.len(), "elided": true})
                 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -4737,10 +4737,13 @@ mod vector_elision_tests {
             value["properties"]["embedding"]["indices"],
             serde_json::json!([1, 4])
         );
-        assert_eq!(
-            value["properties"]["embedding"]["values"],
-            serde_json::json!([1.5, 2.3])
-        );
+        let values: Vec<f32> = value["properties"]["embedding"]["values"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_f64().unwrap() as f32)
+            .collect();
+        assert_eq!(values, vec![1.5_f32, 2.3_f32]);
     }
 
     #[test]

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -154,6 +154,7 @@ mod node_tests {
         // Now get it
         let get_req = GetNodeRequest {
             node_id: created.id,
+            include_vectors: None,
         };
 
         let get_response = server.get_node(get_req);
@@ -171,7 +172,10 @@ mod node_tests {
     fn test_get_nonexistent_node() {
         let server = create_test_server();
 
-        let req = GetNodeRequest { node_id: 999999 };
+        let req = GetNodeRequest {
+            node_id: 999999,
+            include_vectors: None,
+        };
 
         let response = server.get_node(req);
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -242,7 +246,10 @@ mod node_tests {
         assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
 
         // Verify it's gone
-        let get_req = GetNodeRequest { node_id };
+        let get_req = GetNodeRequest {
+            node_id,
+            include_vectors: None,
+        };
         let get_response = server.get_node(get_req);
         let get_value: serde_json::Value = serde_json::from_str(&get_response).unwrap();
 
@@ -276,8 +283,11 @@ mod node_tests {
         assert_eq!(value.get("connected_edges"), Some(&serde_json::json!(1)));
 
         // The node must still exist (refused, not destroyed).
-        let get_value: serde_json::Value =
-            serde_json::from_str(&server.get_node(GetNodeRequest { node_id: source_id })).unwrap();
+        let get_value: serde_json::Value = serde_json::from_str(&server.get_node(GetNodeRequest {
+            node_id: source_id,
+            include_vectors: None,
+        }))
+        .unwrap();
         assert!(get_value.get("error").is_none());
     }
 
@@ -320,8 +330,11 @@ mod node_tests {
         assert_eq!(value.get("detached"), Some(&serde_json::json!(true)));
 
         // Node is gone.
-        let get_value: serde_json::Value =
-            serde_json::from_str(&server.get_node(GetNodeRequest { node_id: source_id })).unwrap();
+        let get_value: serde_json::Value = serde_json::from_str(&server.get_node(GetNodeRequest {
+            node_id: source_id,
+            include_vectors: None,
+        }))
+        .unwrap();
         assert!(get_value.get("error").is_some());
 
         // Traversal from the surviving neighbors yields no dangling endpoint to
@@ -330,6 +343,7 @@ mod node_tests {
             serde_json::from_str(&server.get_outgoing_edges(GetOutgoingEdgesRequest {
                 node_id: third_id,
                 label: None,
+                include_vectors: None,
             }))
             .unwrap();
         let edges = outgoing.get("edges").and_then(|e| e.as_array());
@@ -342,6 +356,7 @@ mod node_tests {
             serde_json::from_str(&server.get_incoming_edges(GetIncomingEdgesRequest {
                 node_id: target_id,
                 label: None,
+                include_vectors: None,
             }))
             .unwrap();
         let in_edges = incoming.get("edges").and_then(|e| e.as_array());
@@ -394,6 +409,7 @@ mod node_tests {
             property_value: None,
             limit: None,
             offset: None,
+            include_vectors: None,
         };
 
         let response = server.list_nodes(list_req);
@@ -428,6 +444,7 @@ mod node_tests {
             property_value: None,
             limit: None,
             offset: None,
+            include_vectors: None,
         };
 
         let response = server.list_nodes(list_req);
@@ -458,6 +475,7 @@ mod node_tests {
             property_value: None,
             limit: Some(5),
             offset: Some(0),
+            include_vectors: None,
         };
 
         let page1_response = server.list_nodes(page1_req);
@@ -472,6 +490,7 @@ mod node_tests {
             property_value: None,
             limit: Some(5),
             offset: Some(5),
+            include_vectors: None,
         };
 
         let page2_response = server.list_nodes(page2_req);
@@ -632,6 +651,7 @@ mod edge_tests {
 
         let get_response = server.get_edge(GetEdgeRequest {
             edge_id: created.id,
+            include_vectors: None,
         });
         let retrieved: EdgeResponse = parse_response(&get_response).unwrap();
 
@@ -690,6 +710,7 @@ mod edge_tests {
         // Verify it's gone
         let get_response = server.get_edge(GetEdgeRequest {
             edge_id: created.id,
+            include_vectors: None,
         });
         let get_value: serde_json::Value = serde_json::from_str(&get_response).unwrap();
         assert!(get_value.get("error").is_some());
@@ -727,6 +748,7 @@ mod edge_tests {
             label: None,
             limit: None,
             offset: None,
+            include_vectors: None,
         });
         let value: serde_json::Value = serde_json::from_str(&list_response).unwrap();
         // Verify total_count is 2 (edges exist, even if not returned)
@@ -786,6 +808,7 @@ mod edge_tests {
         let response = server.get_outgoing_edges(GetOutgoingEdgesRequest {
             node_id: n1,
             label: None,
+            include_vectors: None,
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert_eq!(value.get("count"), Some(&serde_json::json!(2)));
@@ -794,6 +817,7 @@ mod edge_tests {
         let response = server.get_outgoing_edges(GetOutgoingEdgesRequest {
             node_id: n1,
             label: Some("KNOWS".to_string()),
+            include_vectors: None,
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert_eq!(value.get("count"), Some(&serde_json::json!(1)));
@@ -828,6 +852,7 @@ mod edge_tests {
         let response = server.get_incoming_edges(GetIncomingEdgesRequest {
             node_id: n2,
             label: None,
+            include_vectors: None,
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert_eq!(value.get("count"), Some(&serde_json::json!(2)));
@@ -882,6 +907,7 @@ mod traversal_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -901,6 +927,7 @@ mod traversal_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(3),
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -921,6 +948,7 @@ mod traversal_tests {
             direction: Some("incoming".to_string()),
             depth: Some(1),
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -939,6 +967,7 @@ mod traversal_tests {
             direction: None,
             depth: Some(3),
             limit: Some(2),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1000,6 +1029,7 @@ mod vector_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(5),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1042,6 +1072,7 @@ mod vector_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1296,6 +1327,7 @@ mod hybrid_tests {
             transaction_time: None,
             filter_label: None,
             limit: Some(10),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1333,6 +1365,7 @@ mod hybrid_tests {
             transaction_time: None,
             filter_label: Some("Person".to_string()),
             limit: Some(100),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1363,6 +1396,7 @@ mod hybrid_tests {
             transaction_time: None,
             filter_label: None,
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1405,6 +1439,7 @@ mod hybrid_tests {
             transaction_time: None,
             filter_label: None,
             limit: Some(10),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1504,6 +1539,7 @@ mod coverage_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3], // Wrong: 3 dimensions instead of 4
             k: Some(5),
+            include_vectors: None,
         });
 
         // Should get dimension mismatch error
@@ -1543,6 +1579,7 @@ mod coverage_tests {
             limit: None,
             valid_time: None,
             transaction_time: None,
+            include_vectors: None,
         });
 
         // Should get dimension mismatch error
@@ -1690,7 +1727,8 @@ mod coverage_tests {
             property_key: None,
             property_value: None,
             limit: Some(10),
-            offset: Some(100_000), // Very large offset, should be capped to MAX_PAGINATION_OFFSET
+            offset: Some(100_000), // Very large offset, should be capped to MAX_PAGINATION_OFFSET,
+            include_vectors: None,
         });
 
         // Should not error, just return empty results due to offset being beyond data
@@ -1737,6 +1775,7 @@ mod coverage_tests {
             depth: Some(100), // Very large depth, should be capped
             direction: Some("outgoing".to_string()),
             limit: Some(50),
+            include_vectors: None,
         });
 
         // Should not error
@@ -1823,7 +1862,10 @@ mod error_handling_tests {
     fn test_get_edge_nonexistent() {
         let server = create_test_server();
 
-        let req = GetEdgeRequest { edge_id: 999999 };
+        let req = GetEdgeRequest {
+            edge_id: 999999,
+            include_vectors: None,
+        };
 
         let response = server.get_edge(req);
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -1996,7 +2038,8 @@ mod vector_distance_tests {
         let response = server.find_similar(FindSimilarRequest {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
-            k: Some(10000), // Much larger than MAX_VECTOR_K
+            k: Some(10000), // Much larger than MAX_VECTOR_K,
+            include_vectors: None,
         });
 
         // Should not error (k gets capped internally)
@@ -2250,6 +2293,7 @@ mod traversal_extended_tests {
             direction: Some("both".to_string()),
             depth: Some(1),
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2279,6 +2323,7 @@ mod traversal_extended_tests {
             direction: None,
             depth: Some(3),
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2318,6 +2363,7 @@ mod traversal_extended_tests {
             direction: None, // Default to outgoing
             depth: Some(1),
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2362,6 +2408,7 @@ mod traversal_extended_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: Some(5),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2409,6 +2456,7 @@ mod hybrid_extended_tests {
             transaction_time: Some(now_micros.to_string()),
             filter_label: None,
             limit: Some(10),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2462,6 +2510,7 @@ mod hybrid_extended_tests {
             transaction_time: None,
             filter_label: None,
             limit: Some(10),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2493,6 +2542,7 @@ mod hybrid_extended_tests {
             transaction_time: None,
             filter_label: None,
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2526,6 +2576,7 @@ mod hybrid_extended_tests {
             transaction_time: Some("bad-tx-time".to_string()),
             filter_label: None,
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2564,7 +2615,8 @@ mod hybrid_extended_tests {
             valid_time: None,
             transaction_time: None,
             filter_label: Some("LimitTest".to_string()),
-            limit: Some(100000), // Much larger than MAX_RESULT_LIMIT
+            limit: Some(100000), // Much larger than MAX_RESULT_LIMIT,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2591,6 +2643,7 @@ mod hybrid_extended_tests {
             transaction_time: None,
             filter_label: None,
             limit: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2646,6 +2699,7 @@ mod edge_extended_tests {
             label: Some("KNOWS".to_string()),
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2736,6 +2790,7 @@ mod edge_extended_tests {
         let response = server.get_incoming_edges(GetIncomingEdgesRequest {
             node_id: n2.id,
             label: Some("KNOWS".to_string()),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2773,6 +2828,7 @@ mod list_nodes_extended_tests {
             property_value: None,
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2807,6 +2863,7 @@ mod list_nodes_extended_tests {
             property_value: None,
             limit: Some(100000), // Much larger than MAX_RESULT_LIMIT
             offset: Some(0),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2858,6 +2915,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!("Alice")),
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2892,6 +2950,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!(42)),
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2922,6 +2981,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!("blue")),
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2940,6 +3000,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!("Alice")),
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2960,6 +3021,7 @@ mod list_nodes_extended_tests {
             property_value: None,
             limit: None,
             offset: None,
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -2992,6 +3054,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!("active")),
             limit: Some(2),
             offset: Some(0),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -3005,6 +3068,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!("active")),
             limit: Some(2),
             offset: Some(2),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -3018,6 +3082,7 @@ mod list_nodes_extended_tests {
             property_value: Some(serde_json::json!("active")),
             limit: Some(2),
             offset: Some(4),
+            include_vectors: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -4177,5 +4242,581 @@ mod schema_tests {
         let total_edges: serde_json::Value =
             serde_json::from_str(&server.count_edges(CountEdgesRequest { label: None })).unwrap();
         assert_eq!(schema_value["total_edges"], total_edges["count"]);
+    }
+}
+
+// ============================================================================
+// Vector Elision Tests (Issue #3220)
+// ============================================================================
+//
+// MCP read responses elide vector/embedding properties by default (replacing
+// them with a `{type, dim, elided:true}` descriptor) to protect LLM context.
+// `include_vectors: true` is the escape hatch that restores the full float
+// array. These tests pin that contract across every affected tool.
+
+mod vector_elision_tests {
+    use super::*;
+    use crate::core::vector::SparseVec;
+
+    fn embedding_of(dim: usize) -> Vec<f32> {
+        (0..dim).map(|i| (i as f32) * 0.001 + 0.1).collect()
+    }
+
+    fn create_node_with_embedding(server: &AletheiaMcpServer, dim: usize) -> (u64, Vec<f32>) {
+        let embedding = embedding_of(dim);
+        let mut props = HashMap::new();
+        props.insert(
+            "embedding".to_string(),
+            serde_json::json!(embedding.clone()),
+        );
+        let response = server.create_node(CreateNodeRequest {
+            label: "Document".to_string(),
+            properties: Some(props),
+        });
+        let node: NodeResponse = parse_response(&response).expect("Failed to create node");
+        (node.id, embedding)
+    }
+
+    #[test]
+    fn test_get_node_elides_vector_by_default() {
+        let server = create_test_server();
+        let (node_id, _embedding) = create_node_with_embedding(&server, 1536);
+
+        let response = server.get_node(GetNodeRequest {
+            node_id,
+            include_vectors: None,
+        });
+
+        assert!(
+            response.len() < 500,
+            "elided response should be small, was {} bytes: {response}",
+            response.len()
+        );
+
+        let node: NodeResponse = parse_response(&response).expect("Failed to get node");
+        assert_eq!(
+            node.properties.get("embedding"),
+            Some(&serde_json::json!({"type": "vector", "dim": 1536, "elided": true}))
+        );
+    }
+
+    #[test]
+    fn test_get_node_include_vectors_true_is_lossless() {
+        let server = create_test_server();
+        let (node_id, embedding) = create_node_with_embedding(&server, 1536);
+
+        let response = server.get_node(GetNodeRequest {
+            node_id,
+            include_vectors: Some(true),
+        });
+
+        let node: NodeResponse = parse_response(&response).expect("Failed to get node");
+        let returned = node.properties.get("embedding").unwrap();
+        let returned_array = returned.as_array().expect("embedding should be an array");
+        assert_eq!(returned_array.len(), 1536);
+
+        let returned_floats: Vec<f32> = returned_array
+            .iter()
+            .map(|v| v.as_f64().unwrap() as f32)
+            .collect();
+        assert_eq!(returned_floats, embedding);
+    }
+
+    #[test]
+    fn test_list_nodes_elides_vectors_by_default() {
+        let server = create_test_server();
+        for _ in 0..3 {
+            create_node_with_embedding(&server, 8);
+        }
+
+        let response = server.list_nodes(ListNodesRequest {
+            label: Some("Document".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+        });
+
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let nodes = value["nodes"].as_array().expect("nodes array");
+        assert_eq!(nodes.len(), 3);
+        for node in nodes {
+            assert_eq!(
+                node["properties"]["embedding"],
+                serde_json::json!({"type": "vector", "dim": 8, "elided": true})
+            );
+        }
+
+        // include_vectors: true restores the full arrays.
+        let response = server.list_nodes(ListNodesRequest {
+            label: Some("Document".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: None,
+            offset: None,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        for node in value["nodes"].as_array().unwrap() {
+            let arr = node["properties"]["embedding"]
+                .as_array()
+                .expect("embedding should be a full array");
+            assert_eq!(arr.len(), 8);
+        }
+    }
+
+    #[test]
+    fn test_get_edge_and_outgoing_incoming_edges_elide_vectors_by_default() {
+        let server = create_test_server();
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+        }))
+        .unwrap();
+
+        let embedding = embedding_of(6);
+        let mut props = HashMap::new();
+        props.insert("embedding".to_string(), serde_json::json!(embedding));
+        let edge_response = server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "SIMILAR_TO".to_string(),
+            properties: Some(props),
+        });
+        let edge: EdgeResponse = parse_response(&edge_response).unwrap();
+
+        // get_edge
+        let response = server.get_edge(GetEdgeRequest {
+            edge_id: edge.id,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["properties"]["embedding"],
+            serde_json::json!({"type": "vector", "dim": 6, "elided": true})
+        );
+
+        let response = server.get_edge(GetEdgeRequest {
+            edge_id: edge.id,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["properties"]["embedding"].as_array().unwrap().len(),
+            6
+        );
+
+        // get_outgoing_edges
+        let response = server.get_outgoing_edges(GetOutgoingEdgesRequest {
+            node_id: n1.id,
+            label: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["edges"][0]["properties"]["embedding"],
+            serde_json::json!({"type": "vector", "dim": 6, "elided": true})
+        );
+
+        let response = server.get_outgoing_edges(GetOutgoingEdgesRequest {
+            node_id: n1.id,
+            label: None,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["edges"][0]["properties"]["embedding"]
+                .as_array()
+                .unwrap()
+                .len(),
+            6
+        );
+
+        // get_incoming_edges
+        let response = server.get_incoming_edges(GetIncomingEdgesRequest {
+            node_id: n2.id,
+            label: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["edges"][0]["properties"]["embedding"],
+            serde_json::json!({"type": "vector", "dim": 6, "elided": true})
+        );
+
+        let response = server.get_incoming_edges(GetIncomingEdgesRequest {
+            node_id: n2.id,
+            label: None,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["edges"][0]["properties"]["embedding"]
+                .as_array()
+                .unwrap()
+                .len(),
+            6
+        );
+    }
+
+    #[test]
+    fn test_traverse_elides_vectors_by_default() {
+        let server = create_test_server();
+        let (n1_id, _) = create_node_with_embedding(&server, 5);
+        let (n2_id, _) = create_node_with_embedding(&server, 5);
+        server.create_edge(CreateEdgeRequest {
+            source_id: n1_id,
+            target_id: n2_id,
+            label: "NEXT".to_string(),
+            properties: None,
+        });
+
+        let response = server.traverse(TraverseRequest {
+            start_node_id: n1_id,
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(1),
+            limit: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let results = value["results"].as_array().expect("results array");
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0]["node"]["properties"]["embedding"],
+            serde_json::json!({"type": "vector", "dim": 5, "elided": true})
+        );
+
+        let response = server.traverse(TraverseRequest {
+            start_node_id: n1_id,
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(1),
+            limit: None,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let results = value["results"].as_array().unwrap();
+        assert_eq!(
+            results[0]["node"]["properties"]["embedding"]
+                .as_array()
+                .unwrap()
+                .len(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_find_similar_elides_vectors_but_keeps_score() {
+        let server = create_test_server();
+        server.enable_vector_index(EnableVectorIndexRequest {
+            property_name: "embedding".to_string(),
+            dimensions: 4,
+            distance_metric: Some("cosine".to_string()),
+        });
+
+        for i in 0..3 {
+            let mut props = HashMap::new();
+            props.insert(
+                "embedding".to_string(),
+                serde_json::json!([
+                    (i as f32) * 0.1,
+                    (i as f32) * 0.2,
+                    (i as f32) * 0.3,
+                    (i as f32) * 0.4,
+                ]),
+            );
+            server.create_node(CreateNodeRequest {
+                label: "Document".to_string(),
+                properties: Some(props),
+            });
+        }
+
+        let response = server.find_similar(FindSimilarRequest {
+            property_name: "embedding".to_string(),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            k: Some(3),
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let results = value["results"].as_array().expect("results array");
+        assert!(!results.is_empty());
+        for result in results {
+            assert!(result.get("score").and_then(|s| s.as_f64()).is_some());
+            assert_eq!(
+                result["node"]["properties"]["embedding"],
+                serde_json::json!({"type": "vector", "dim": 4, "elided": true})
+            );
+        }
+
+        let response = server.find_similar(FindSimilarRequest {
+            property_name: "embedding".to_string(),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            k: Some(3),
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        for result in value["results"].as_array().unwrap() {
+            assert!(result.get("score").and_then(|s| s.as_f64()).is_some());
+            assert_eq!(
+                result["node"]["properties"]["embedding"]
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                4
+            );
+        }
+    }
+
+    #[test]
+    fn test_hybrid_query_vector_first_elides_vectors_but_keeps_similarity_score() {
+        let server = create_test_server();
+        server.enable_vector_index(EnableVectorIndexRequest {
+            property_name: "embedding".to_string(),
+            dimensions: 4,
+            distance_metric: Some("cosine".to_string()),
+        });
+        for i in 0..3 {
+            let mut props = HashMap::new();
+            props.insert(
+                "embedding".to_string(),
+                serde_json::json!([
+                    (i as f32) * 0.1,
+                    (i as f32) * 0.2,
+                    (i as f32) * 0.3,
+                    (i as f32) * 0.4,
+                ]),
+            );
+            server.create_node(CreateNodeRequest {
+                label: "Document".to_string(),
+                properties: Some(props),
+            });
+        }
+
+        let response = server.hybrid_query(HybridQueryRequest {
+            start_node_id: None,
+            traverse_edge: None,
+            traverse_depth: None,
+            vector_property: Some("embedding".to_string()),
+            query_embedding: Some(vec![0.1, 0.2, 0.3, 0.4]),
+            top_k: Some(3),
+            valid_time: None,
+            transaction_time: None,
+            filter_label: None,
+            limit: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let results = value["results"].as_array().expect("results array");
+        assert!(!results.is_empty());
+        for result in results {
+            assert!(result.get("similarity_score").is_some());
+            assert_eq!(
+                result["node"]["properties"]["embedding"],
+                serde_json::json!({"type": "vector", "dim": 4, "elided": true})
+            );
+        }
+
+        let response = server.hybrid_query(HybridQueryRequest {
+            start_node_id: None,
+            traverse_edge: None,
+            traverse_depth: None,
+            vector_property: Some("embedding".to_string()),
+            query_embedding: Some(vec![0.1, 0.2, 0.3, 0.4]),
+            top_k: Some(3),
+            valid_time: None,
+            transaction_time: None,
+            filter_label: None,
+            limit: None,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        for result in value["results"].as_array().unwrap() {
+            assert_eq!(
+                result["node"]["properties"]["embedding"]
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                4
+            );
+        }
+    }
+
+    #[test]
+    fn test_hybrid_query_graph_first_elides_vectors_but_keeps_similarity_score() {
+        let server = create_test_server();
+        let (n1_id, _) = create_node_with_embedding(&server, 4);
+        let (n2_id, _) = create_node_with_embedding(&server, 4);
+        server.create_edge(CreateEdgeRequest {
+            source_id: n1_id,
+            target_id: n2_id,
+            label: "NEXT".to_string(),
+            properties: None,
+        });
+
+        let response = server.hybrid_query(HybridQueryRequest {
+            start_node_id: Some(n1_id),
+            traverse_edge: Some("NEXT".to_string()),
+            traverse_depth: Some(1),
+            vector_property: None,
+            query_embedding: None,
+            top_k: None,
+            valid_time: None,
+            transaction_time: None,
+            filter_label: None,
+            limit: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let results = value["results"].as_array().expect("results array");
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0]["node"]["properties"]["embedding"],
+            serde_json::json!({"type": "vector", "dim": 4, "elided": true})
+        );
+
+        let response = server.hybrid_query(HybridQueryRequest {
+            start_node_id: Some(n1_id),
+            traverse_edge: Some("NEXT".to_string()),
+            traverse_depth: Some(1),
+            vector_property: None,
+            query_embedding: None,
+            top_k: None,
+            valid_time: None,
+            transaction_time: None,
+            filter_label: None,
+            limit: None,
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["results"][0]["node"]["properties"]["embedding"]
+                .as_array()
+                .unwrap()
+                .len(),
+            4
+        );
+    }
+
+    #[test]
+    fn test_sparse_vector_elided_by_default_with_dim_and_nnz() {
+        let server = create_test_server();
+
+        let sparse = SparseVec::new(vec![1, 4], vec![1.5, 2.3], 10).expect("valid sparse vector");
+        let props = PropertyMapBuilder::new()
+            .try_insert("embedding", sparse)
+            .expect("insert sparse vector")
+            .build();
+        let node_id = server
+            .db()
+            .create_node("Document", props)
+            .expect("create node with sparse vector");
+
+        let response = server.get_node(GetNodeRequest {
+            node_id: node_id.as_u64(),
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["properties"]["embedding"],
+            serde_json::json!({"type": "sparse_vector", "dim": 10, "nnz": 2, "elided": true})
+        );
+
+        let response = server.get_node(GetNodeRequest {
+            node_id: node_id.as_u64(),
+            include_vectors: Some(true),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["properties"]["embedding"]["indices"],
+            serde_json::json!([1, 4])
+        );
+        assert_eq!(
+            value["properties"]["embedding"]["values"],
+            serde_json::json!([1.5, 2.3])
+        );
+    }
+
+    #[test]
+    fn test_create_node_and_update_node_always_return_full_vectors() {
+        let server = create_test_server();
+
+        let mut props = HashMap::new();
+        props.insert(
+            "embedding".to_string(),
+            serde_json::json!([0.1, 0.2, 0.3, 0.4]),
+        );
+        let response = server.create_node(CreateNodeRequest {
+            label: "Document".to_string(),
+            properties: Some(props),
+        });
+        let node: NodeResponse = parse_response(&response).expect("Failed to create node");
+        assert_eq!(
+            node.properties
+                .get("embedding")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .len(),
+            4
+        );
+
+        let mut new_props = HashMap::new();
+        new_props.insert(
+            "embedding".to_string(),
+            serde_json::json!([0.5, 0.6, 0.7, 0.8]),
+        );
+        let update_response = server.update_node(UpdateNodeRequest {
+            node_id: node.id,
+            properties: new_props,
+        });
+        let updated: NodeResponse =
+            parse_response(&update_response).expect("Failed to update node");
+        let updated_embedding = updated
+            .properties
+            .get("embedding")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(updated_embedding.len(), 4);
+        assert_eq!(updated_embedding[0].as_f64().unwrap() as f32, 0.5);
+    }
+
+    #[test]
+    fn test_non_vector_properties_unaffected_by_include_vectors_flag() {
+        let server = create_test_server();
+
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!("Alice"));
+        props.insert("age".to_string(), serde_json::json!(30));
+        props.insert("active".to_string(), serde_json::json!(true));
+        props.insert("nickname".to_string(), serde_json::Value::Null);
+        props.insert("tags".to_string(), serde_json::json!(["a", "b", "c"]));
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props),
+        });
+        let node: NodeResponse = parse_response(&response).expect("Failed to create node");
+
+        let variants = [None, Some(false), Some(true)];
+        let mut previous: Option<HashMap<String, serde_json::Value>> = None;
+        for include_vectors in variants {
+            let response = server.get_node(GetNodeRequest {
+                node_id: node.id,
+                include_vectors,
+            });
+            let fetched: NodeResponse = parse_response(&response).expect("Failed to get node");
+            if let Some(prev) = &previous {
+                assert_eq!(prev, &fetched.properties);
+            }
+            previous = Some(fetched.properties);
+        }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -17,6 +17,14 @@ pub struct GetNodeRequest {
     /// The unique identifier of the node (u64).
     #[schemars(description = "The unique identifier of the node")]
     pub node_id: u64,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 /// Request to create a new node.
@@ -103,6 +111,14 @@ pub struct ListNodesRequest {
     /// Number of nodes to skip (for pagination).
     #[schemars(description = "Number of nodes to skip (for pagination)")]
     pub offset: Option<usize>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 /// Request to count nodes.
@@ -123,6 +139,14 @@ pub struct GetEdgeRequest {
     /// The unique identifier of the edge (u64).
     #[schemars(description = "The unique identifier of the edge")]
     pub edge_id: u64,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 /// Request to create a new edge between nodes.
@@ -179,6 +203,14 @@ pub struct ListEdgesRequest {
     /// Number of edges to skip (for pagination).
     #[schemars(description = "Number of edges to skip (for pagination)")]
     pub offset: Option<usize>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 /// Request to count edges.
@@ -199,6 +231,14 @@ pub struct GetOutgoingEdgesRequest {
     /// Filter by edge label (optional).
     #[schemars(description = "Filter by edge label (optional)")]
     pub label: Option<String>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 /// Request to get incoming edges to a node.
@@ -211,6 +251,14 @@ pub struct GetIncomingEdgesRequest {
     /// Filter by edge label (optional).
     #[schemars(description = "Filter by edge label (optional)")]
     pub label: Option<String>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 // ============================================================================
@@ -241,6 +289,14 @@ pub struct TraverseRequest {
     /// Maximum number of results to return.
     #[schemars(description = "Maximum number of results to return (default: 100)")]
     pub limit: Option<usize>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 // ============================================================================
@@ -263,6 +319,16 @@ pub struct FindSimilarRequest {
     /// Number of similar results to return.
     #[schemars(description = "Number of similar results to return (default: 10)")]
     pub k: Option<usize>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false). Does not affect the similarity
+    /// `score`, which is always returned in full.
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false). The similarity score \
+                       is always returned in full regardless of this flag."
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 /// Request to enable vector indexing on a property.
@@ -548,6 +614,16 @@ pub struct HybridQueryRequest {
     /// Maximum number of results.
     #[schemars(description = "Maximum number of results (default: 100)")]
     pub limit: Option<usize>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false). Does not affect the
+    /// `similarity_score`, which is always returned in full.
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false). The similarity_score \
+                       is always returned in full regardless of this flag."
+    )]
+    pub include_vectors: Option<bool>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements vector elision by default across all MCP read tools (Issue #3220). Vector and sparse vector properties are now replaced with lightweight descriptors (`{type, dim, elided: true}` or `{type: "sparse_vector", dim, nnz, elided: true}`) to protect LLM context window. The `include_vectors: Option<bool>` parameter provides an escape hatch to restore full float arrays when needed.

## Key Changes

- **Request structs** (`tools.rs`): Added `include_vectors: Option<bool>` field to all read request types:
  - Node operations: `GetNodeRequest`, `ListNodesRequest`
  - Edge operations: `GetEdgeRequest`, `ListEdgesRequest`, `GetOutgoingEdgesRequest`, `GetIncomingEdgesRequest`
  - Graph traversal: `TraverseRequest`
  - Vector search: `FindSimilarRequest`
  - Hybrid queries: `HybridQueryRequest`

- **Server implementation** (`server.rs`): Modified property serialization pipeline:
  - `property_value_to_json()` now accepts `include_vectors: bool` parameter
  - Dense vectors: elided as `{type: "vector", dim, elided: true}` by default; full array when `include_vectors=true`
  - Sparse vectors: elided as `{type: "sparse_vector", dim, nnz, elided: true}` by default; full `{indices, values}` when `include_vectors=true`
  - Updated all call sites: `node_to_response()`, `edge_to_response()`, `property_map_to_json()`
  - Write operations (create/update) always include vectors (no elision on mutations)

- **Comprehensive test coverage** (`tests.rs`): Added 576 lines of new tests in `vector_elision_tests` module:
  - `test_get_node_elides_vector_by_default()`: Verifies elision and response size reduction
  - `test_get_node_include_vectors_true_is_lossless()`: Confirms full restoration with `include_vectors=true`
  - `test_list_nodes_elides_vectors_by_default()`: Batch elision behavior
  - `test_get_edge_and_outgoing_incoming_edges_elide_vectors_by_default()`: Edge property elision
  - `test_traverse_elides_vectors_by_default()`: Traversal result elision
  - `test_find_similar_elides_vectors_but_keeps_score()`: Vector search with elision (scores preserved)
  - `test_hybrid_query_vector_first_elides_vectors_but_keeps_similarity_score()`: Hybrid vector-first queries
  - `test_hybrid_query_graph_first_elides_vectors_but_keeps_similarity_score()`: Hybrid graph-first queries
  - `test_sparse_vector_elided_by_default_with_dim_and_nnz()`: Sparse vector elision with metadata
  - Updated all existing tests to pass `include_vectors: None` to request constructors

- **Documentation** (`CLAUDE.md`, `README.md`): Added notes on vector elision behavior and the `include_vectors` parameter

## Implementation Details

- **Default behavior**: `include_vectors.unwrap_or(false)` ensures backward compatibility while protecting context by default
- **Elision descriptors**: Lightweight JSON objects replace large float arrays, reducing response size by orders of magnitude for high-dimensional embeddings
- **Sparse vector metadata**: Elided form includes `dim` (total dimensions) and `nnz` (non-zero count) for schema introspection without data transfer
- **Mutation operations**: `create_node`, `update_node`, `create_edge`, `update_edge` always return full vectors (no elision) to confirm write success
- **Search scores preserved**: `find_similar` and `hybrid_query` always include similarity/relevance scores even when vectors are elided

https://claude.ai/code/session_01Pfxzg28wV8zGt6xsSxEf1e