### PR TITLE
🗣️ Echo: Fix broken examples, add prelude warnings, and remove panicking stub

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -166,7 +166,7 @@ AletheiaDB stores dense vector embeddings as node properties and indexes them
 with HNSW for fast k-NN search. Enable the index before inserting nodes.
 
 ```rust
-use aletheiadb::{AletheiaDB, HnswConfig, DistanceMetric};
+use aletheiadb::{AletheiaDB, HnswConfig, DistanceMetric, SimilarityQuery};
 
 let db = AletheiaDB::new()?;
 
@@ -190,7 +190,7 @@ let _doc2 = db.create_node("Document", properties! {
 
 // Find the 10 nodes most similar to doc1
 // (doc1 itself is excluded from results)
-let similar = db.find_similar(doc1, 10)?;
+let similar = db.similarity_search(SimilarityQuery::from_node(doc1).k(10))?;
 for (node_id, score) in similar {
     println!("Node {:?} similarity: {:.3}", node_id, score);
 }

--- a/docs/guides/tiered-storage-guide.md
+++ b/docs/guides/tiered-storage-guide.md
@@ -80,6 +80,8 @@ use aletheiadb::storage::{
 };
 use std::sync::Arc;
 
+let mut historical = HistoricalStorage::new();
+
 // 1. Create Redb cold storage
 let cold = Arc::new(RedbColdStorage::new("data/cold.redb", RedbConfig::new())?);
 

--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -155,36 +155,6 @@ impl<'a> NarrativeGenerator<'a> {
     }
 }
 
-#[cfg(not(feature = "semantic-temporal"))]
-#[allow(deprecated)]
-impl<'a> NarrativeGenerator<'a> {
-    /// Create a new narrative generator.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-
-    /// Generate a narrative for a specific node.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-}
-
 #[cfg(all(test, feature = "semantic-temporal"))]
 mod tests {
     use super::*;
@@ -300,36 +270,5 @@ mod tests {
                 .any(|s| s.contains("was '\"delete_me\"'")),
             "Expected original value in removal message"
         );
-    }
-}
-
-#[cfg(all(test, not(feature = "semantic-temporal")))]
-#[allow(deprecated)]
-mod stub_tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
-        let db = AletheiaDB::new().unwrap();
-        // This should panic
-        let _ = NarrativeGenerator::new(&db);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
-        // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
-            _marker: std::marker::PhantomData,
-        };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,6 +8,11 @@
 //! ```rust
 //! use aletheiadb::prelude::*;
 //! ```
+//!
+//! > **Note:** This module exports a custom `Result` type (`aletheiadb::Result<T>`)
+//! > which shadows `std::result::Result`. If your code specifies `Result` with two
+//! > generic parameters (e.g., `Result<(), Box<dyn std::error::Error>>`), you must
+//! > fully qualify it as `std::result::Result` to avoid compiler errors.
 
 pub use crate::AletheiaDB;
 pub use crate::api::{ReadOps, ReadTransaction, WriteOps, WriteTransaction};


### PR DESCRIPTION
### 🗣️ Echo: Getting Started examples and DX fixes

🤦 **The Confusion:** 
- The `README.md` and `getting-started.md` examples used a deprecated `db.find_similar` method which threw compiler warnings.
- The `tiered-storage-guide.md` legacy example was missing a `let mut historical = HistoricalStorage::new();` declaration, causing it to fail to compile.
- The `NarrativeGenerator` exposed a panicking stub when the `semantic-temporal` (or `nova`) feature was omitted, causing runtime crashes instead of standard compiler errors.
- Users copy-pasting `fn main() -> Result<(), Box<dyn std::error::Error>>` with `use aletheiadb::prelude::*;` encountered confusing compiler errors because `prelude::Result` shadows `std::result::Result` and only accepts a single generic parameter.

🕵️ **The Reality:** 
- The fluent API `db.similarity_search` is the correct replacement for `find_similar`.
- `HistoricalStorage::new()` needs to be explicitly created in the legacy tiered storage setup.
- Panicking stubs for feature-gated items provide a poor developer experience compared to standard `unresolved import` compiler errors.

💡 **The Fix:**
1. Updated `getting-started.md` to use `db.similarity_search(SimilarityQuery::from_node(doc1).k(10))?` and imported `SimilarityQuery`.
2. Added `let mut historical = HistoricalStorage::new();` to the `tiered-storage-guide.md` example.
3. Completely removed the `#[cfg(not(feature = "semantic-temporal"))]` panicking stub and its associated tests for `NarrativeGenerator` in `src/experimental/temporal/temporal_narrative.rs`.
4. Added a blockquote doc comment in `src/prelude.rs` clarifying that `Result` shadows `std::result::Result` and requires a single generic parameter.

Verified locally with `cargo check --lib --all-features` and `cargo test --doc`.

---
*PR created automatically by Jules for task [17837550818346518211](https://jules.google.com/task/17837550818346518211) started by @madmax983*