### PR TITLE
🎻 Bard: Fix intra-doc link warnings

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2026-07-02 - Broken Intra-Doc Links
+**Confusion:** Documentation contained broken intra-doc links for `StorageError`, `ConstraintError`, and `ChangeRecord`, causing `cargo doc` warnings.
+**Clarification:** Updated the links to point to their correct, fully qualified paths (e.g., `crate::core::error::StorageError`) or removed redundant explicit link targets when the label itself correctly resolves the path.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -233,7 +233,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
@@ -333,7 +333,7 @@ impl AletheiaDB {
 
     /// Enable a uniqueness constraint on `(label, property)`.
     ///
-    /// Fails with [`ConstraintError::DuplicateOnEnable`] if existing nodes already
+    /// Fails with [`ConstraintError::DuplicateOnEnable`](crate::core::error::ConstraintError::DuplicateOnEnable) if existing nodes already
     /// violate the constraint. No constraint is enabled in that case.
     pub(crate) fn enable_unique_constraint(&self, label: &str, property: &str) -> Result<()> {
         let label_id = GLOBAL_INTERNER.intern(label).record_error_metric()?;

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///


### PR DESCRIPTION
📖 Chapter: The `ops` and `temporal` modules.
🔦 Insight: Fixed broken intra-doc links for `StorageError`, `ConstraintError`, and a redundant explicit link for `ChangeRecord`. This ensures accurate and warning-free `cargo doc` output.
🧪 Example: N/A (Documentation link fix)
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [13435031723601612813](https://jules.google.com/task/13435031723601612813) started by @madmax983*