### PR TITLE
🔭 Vantage: Spec for Cascade Delete & Referential Integrity / Read-Your-Writes for Edge Traversal

### DIFF
--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -861,15 +861,67 @@ impl ReadOps for WriteTransaction {
     }
 
     fn get_outgoing_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
-        self.current.get_outgoing_edges(node_id)
+        let mut edges = self.current.get_outgoing_edges(node_id);
+
+        for op in self.buffer.operations() {
+            if let crate::api::transaction::BufferedWrite::CreateEdge { edge_id, source, .. } = op {
+                if *source == node_id && !edges.contains(edge_id) {
+                    edges.push(*edge_id);
+                }
+            }
+        }
+
+        edges.retain(|edge_id| {
+            !matches!(self.buffer.get_edge_write(*edge_id), Some(crate::api::transaction::BufferedWrite::DeleteEdge { .. }))
+        });
+
+        edges
     }
 
     fn get_incoming_edges(&self, node_id: NodeId) -> Vec<EdgeId> {
-        self.current.get_incoming_edges(node_id)
+        let mut edges = self.current.get_incoming_edges(node_id);
+
+        for op in self.buffer.operations() {
+            if let crate::api::transaction::BufferedWrite::CreateEdge { edge_id, target, .. } = op {
+                if *target == node_id && !edges.contains(edge_id) {
+                    edges.push(*edge_id);
+                }
+            }
+        }
+
+        edges.retain(|edge_id| {
+            !matches!(self.buffer.get_edge_write(*edge_id), Some(crate::api::transaction::BufferedWrite::DeleteEdge { .. }))
+        });
+
+        edges
     }
 
     fn get_outgoing_edges_with_label(&self, node_id: NodeId, label: &str) -> Vec<EdgeId> {
-        self.current.get_outgoing_edges_with_label(node_id, label)
+        let mut edges = self.current.get_outgoing_edges_with_label(node_id, label);
+
+        for op in self.buffer.operations() {
+            if let crate::api::transaction::BufferedWrite::CreateEdge {
+                edge_id,
+                source,
+                label: op_label,
+                ..
+            } = op {
+                if *source == node_id
+                    && crate::core::interning::GLOBAL_INTERNER
+                        .resolve_with(*op_label, |s| s == label)
+                        .unwrap_or(false)
+                    && !edges.contains(edge_id)
+                {
+                    edges.push(*edge_id);
+                }
+            }
+        }
+
+        edges.retain(|edge_id| {
+            !matches!(self.buffer.get_edge_write(*edge_id), Some(crate::api::transaction::BufferedWrite::DeleteEdge { .. }))
+        });
+
+        edges
     }
 
     fn node_count(&self) -> usize {
@@ -1190,11 +1242,19 @@ impl WriteOps for WriteTransaction {
             }
 
             // Verify node exists and check for vector properties
-            let node = self.current.get_node(node_id)?;
+            let contains_vector = match self.buffer.get_node_write(node_id) {
+                Some(crate::api::transaction::BufferedWrite::CreateNode { properties, .. } | crate::api::transaction::BufferedWrite::UpdateNode { properties, .. }) => {
+                    properties.contains_vector()
+                }
+                _ => {
+                    let node = self.current.get_node(node_id)?;
+                    node.properties.contains_vector()
+                }
+            };
 
             // If the node being deleted contains vector properties, mark the buffer
             // to ensure the temporal vector index is notified on commit
-            if !self.buffer.has_vector_operations() && node.properties.contains_vector() {
+            if !self.buffer.has_vector_operations() && contains_vector {
                 self.buffer.mark_has_vector_operations();
             }
 
@@ -1242,7 +1302,9 @@ impl WriteOps for WriteTransaction {
         }
 
         // Verify node exists before attempting deletion
-        let _node = self.current.get_node(node_id)?;
+        if !matches!(self.buffer.get_node_write(node_id), Some(crate::api::transaction::BufferedWrite::CreateNode { .. } | crate::api::transaction::BufferedWrite::UpdateNode { .. })) {
+            self.current.get_node(node_id)?;
+        }
 
         // Collect all edges connected to this node (both outgoing and incoming)
         // We do this before any deletions to avoid borrowing issues
@@ -1285,11 +1347,19 @@ impl WriteOps for WriteTransaction {
             }
 
             // Verify edge exists and check for vector properties
-            let edge = self.current.get_edge(edge_id)?;
+            let contains_vector = match self.buffer.get_edge_write(edge_id) {
+                Some(crate::api::transaction::BufferedWrite::CreateEdge { properties, .. } | crate::api::transaction::BufferedWrite::UpdateEdge { properties, .. }) => {
+                    properties.contains_vector()
+                }
+                _ => {
+                    let edge = self.current.get_edge(edge_id)?;
+                    edge.properties.contains_vector()
+                }
+            };
 
             // If the edge being deleted contains vector properties, mark the buffer
             // to ensure the temporal vector index is notified on commit
-            if !self.buffer.has_vector_operations() && edge.properties.contains_vector() {
+            if !self.buffer.has_vector_operations() && contains_vector {
                 self.buffer.mark_has_vector_operations();
             }
 

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -1219,6 +1219,51 @@ mod general_tests {
     // ===================================================================
 
     #[test]
+    fn test_read_your_writes_edge_traversal() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let node1 = tx.create_node("Node", PropertyMapBuilder::new().build()).unwrap();
+        let node2 = tx.create_node("Node", PropertyMapBuilder::new().build()).unwrap();
+        let edge_id = tx.create_edge(node1, node2, "KNOWS", PropertyMapBuilder::new().build()).unwrap();
+
+        let out_edges = tx.get_outgoing_edges(node1);
+        assert_eq!(out_edges.len(), 1);
+        assert_eq!(out_edges[0], edge_id);
+
+        let in_edges = tx.get_incoming_edges(node2);
+        assert_eq!(in_edges.len(), 1);
+        assert_eq!(in_edges[0], edge_id);
+
+        let labeled_edges = tx.get_outgoing_edges_with_label(node1, "KNOWS");
+        assert_eq!(labeled_edges.len(), 1);
+        assert_eq!(labeled_edges[0], edge_id);
+
+        tx.delete_edge(edge_id).unwrap();
+        let out_edges_after_delete = tx.get_outgoing_edges(node1);
+        assert_eq!(out_edges_after_delete.len(), 0);
+
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn test_delete_node_cascade_removes_buffered_edges() {
+        let (mut tx, _temp_dir) = create_test_write_tx();
+        let node1 = tx.create_node("Node", PropertyMapBuilder::new().build()).unwrap();
+        let node2 = tx.create_node("Node", PropertyMapBuilder::new().build()).unwrap();
+        let edge_id = tx.create_edge(node1, node2, "KNOWS", PropertyMapBuilder::new().build()).unwrap();
+
+        // Verify edge exists in buffer
+        let out_edges = tx.get_outgoing_edges(node1);
+        assert_eq!(out_edges.len(), 1);
+
+        // Perform cascade delete on node1
+        tx.delete_node_cascade(node1).unwrap();
+
+        // Verify edge is deleted
+        assert!(tx.get_edge(edge_id).is_err());
+        assert!(tx.buffer.get_edge_write(edge_id).map(|w| matches!(w, crate::api::transaction::BufferedWrite::DeleteEdge { .. })).unwrap_or(false));
+    }
+
+    #[test]
     fn test_delete_node_cascade_removes_edges() {
         let (mut tx, _temp_dir) = create_test_write_tx();
         let current = Arc::clone(&tx.current);


### PR DESCRIPTION
This implements SPEC-009 and SPEC-017, introducing read-your-writes functionality for edge traversals and fixing the cascade delete bug where deleting an entity created in the same transaction resulted in a `NotFound` error.

---
*PR created automatically by Jules for task [8062327183574693656](https://jules.google.com/task/8062327183574693656) started by @madmax983*