### PR TITLE
Add valid-time write support to convenience API and MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `update_node_with_valid_time`, `update_edge_with_valid_time`,
   `delete_node_with_valid_time`, and `delete_edge_with_valid_time` expose the
   existing `WriteOps::*_with_valid_time` trait methods on the top-level type.
-  The MCP `create_node`, `create_edge`, `update_node`, and `update_edge`
-  tools gain an optional `valid_time` field (ISO 8601 / RFC 3339 or
-  microseconds since epoch) so an LLM can record a fact's real-world
-  effective date in a single tool call. Purely additive; omitting
-  `valid_time` reproduces prior behavior exactly.
+  The MCP `create_node`, `create_edge`, `update_node`, `update_edge`,
+  `delete_node`, and `delete_edge` tools gain an optional `valid_time` field
+  (ISO 8601 / RFC 3339 or microseconds since epoch) so an LLM can record a
+  fact's real-world effective date — including when it stopped being true —
+  in a single tool call. Purely additive; omitting `valid_time` reproduces
+  prior behavior exactly. On `delete_node`, `valid_time` is not supported
+  together with `detach: true` (cascade delete does not support backdating).
+
+### Fixed
+
+- `create_edge_with_valid_time` now enforces the same "not more than one
+  year in the future" cap as every other `*_with_valid_time` operation; it
+  previously accepted an arbitrarily-far-future `valid_time` on edges.
+- The "valid_time must not precede entity creation" check on
+  `update_node_with_valid_time`, `update_edge_with_valid_time`,
+  `delete_node_with_valid_time`, and `delete_edge_with_valid_time` now
+  compares against the entity's true original creation time instead of its
+  most recent version, so backfilling a correction between two existing
+  (already backdated) versions no longer fails with a spurious
+  `ValidTimeBeforeEntityCreation` error.
 
 ## [0.1.1] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Valid-time writes on the convenience API and MCP tools (Issue #3221):
+  `AletheiaDB::create_node_with_valid_time`, `create_edge_with_valid_time`,
+  `update_node_with_valid_time`, `update_edge_with_valid_time`,
+  `delete_node_with_valid_time`, and `delete_edge_with_valid_time` expose the
+  existing `WriteOps::*_with_valid_time` trait methods on the top-level type.
+  The MCP `create_node`, `create_edge`, `update_node`, and `update_edge`
+  tools gain an optional `valid_time` field (ISO 8601 / RFC 3339 or
+  microseconds since epoch) so an LLM can record a fact's real-world
+  effective date in a single tool call. Purely additive; omitting
+  `valid_time` reproduces prior behavior exactly.
+
 ## [0.1.1] - 2026-05-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,11 +332,14 @@ returns `language_unavailable` (AQL is always available). See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md).
 
 **Valid-time writes (Issue #3221)**: `create_node`, `create_edge`,
-`update_node`, and `update_edge` accept an optional `valid_time` (ISO 8601 /
-RFC 3339 or microseconds since epoch) so a caller/LLM can record when a fact
-became true in the real world, independent of when it was recorded. Omitting
-it reproduces prior behavior exactly (valid time defaults to the transaction
-time). Transaction time is always system-assigned and cannot be set. See
+`update_node`, `update_edge`, `delete_node`, and `delete_edge` accept an
+optional `valid_time` (ISO 8601 / RFC 3339 or microseconds since epoch) so a
+caller/LLM can record when a fact became (or stopped being) true in the real
+world, independent of when it was recorded. Omitting it reproduces prior
+behavior exactly (valid time defaults to the transaction time). On
+`delete_node`, `valid_time` is not supported together with `detach: true`
+(cascade delete does not support backdating). Transaction time is always
+system-assigned and cannot be set. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#recording-facts-at-a-specific-valid-time).
 
 **Vector properties are elided by default (Issue #3220)**: `get_node`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,14 @@ self-correct. When the `cypher` feature is not compiled in, `language:"cypher"`
 returns `language_unavailable` (AQL is always available). See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md).
 
+**Valid-time writes (Issue #3221)**: `create_node`, `create_edge`,
+`update_node`, and `update_edge` accept an optional `valid_time` (ISO 8601 /
+RFC 3339 or microseconds since epoch) so a caller/LLM can record when a fact
+became true in the real world, independent of when it was recorded. Omitting
+it reproduces prior behavior exactly (valid time defaults to the transaction
+time). Transaction time is always system-assigned and cannot be set. See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#recording-facts-at-a-specific-valid-time).
+
 **Vector properties are elided by default (Issue #3220)**: `get_node`,
 `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,
 `get_incoming_edges`, `traverse`, `find_similar`, and `hybrid_query` replace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aletheiadb"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aletheiadb"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["AletheiaDB Contributors"]

--- a/docs/guides/core-concepts.md
+++ b/docs/guides/core-concepts.md
@@ -89,6 +89,54 @@ let historical = db.get_node_at_time(
 
 Both times default to "now" if you want the current view.
 
+### Recording Facts at a Specific Valid Time
+
+By default, `create_node`/`create_edge`/`update_node`/`update_edge` set valid
+time to "now" — the moment the transaction runs. But an LLM extracting facts
+from a document is usually recording something that became true **in the
+past** (or, less commonly, that won't become true until a **future** date).
+Use the `_with_valid_time` variants to assert the real-world effective date
+directly, without hand-writing a transaction:
+
+```rust
+use aletheiadb::{AletheiaDB, properties};
+use aletheiadb::core::temporal::time;
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let db = AletheiaDB::new()?;
+// An LLM reads a document today and extracts: "Alice became CEO on 2021-03-01".
+let march_2021 = time::from_secs(1614556800);
+
+let alice = db.create_node_with_valid_time(
+    "Person",
+    properties! { "name" => "Alice", "title" => "CEO" },
+    Some(march_2021),
+)?;
+
+// The fact is retrievable as of its stated valid time...
+let as_of_2021 = db.get_node_at_valid_time(alice, march_2021)?;
+assert_eq!(as_of_2021.properties.get("title").unwrap().as_str(), Some("CEO"));
+
+// ...and invisible before it, even though we recorded it just now.
+let before = time::from_secs(1609459200); // 2021-01-01
+assert!(db.get_node_at_valid_time(alice, before).is_err());
+# Ok(())
+# }
+```
+
+Passing `None` (or calling the plain `create_node`/`create_edge`) behaves
+exactly as before — this is purely additive. **Transaction time is always
+system-assigned** to the commit time; there is no way for a caller to forge
+when a fact was actually recorded, which preserves provenance integrity. A
+`valid_from` that is malformed, more than a year in the future, or precedes
+an entity's own creation time is rejected with a typed `TemporalError`,
+never silently coerced.
+
+The same `_with_valid_time` methods are available on `update_node`/`update_edge`
+(to backdate a correction) and `delete_node`/`delete_edge` (to backdate when a
+fact stopped being true). See the [MCP query tool guide](mcp-query-tool.md#recording-facts-at-a-specific-valid-time)
+for the equivalent MCP tool usage.
+
 ---
 
 ## Storage Architecture

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -120,12 +120,17 @@ string-concatenate vectors into the query text.
 ## Recording facts at a specific valid time
 
 `query` is read-only, but the structured write tools it complements
-(`create_node`, `create_edge`, `update_node`, `update_edge`) accept an
-optional `valid_time` field so an LLM ingesting a document can record the
-fact's real-world effective date in the **same** tool call, instead of
-defaulting to "now". This closes the loop with the bi-temporal `AS OF`
-queries above: without it, every LLM-ingested fact would collapse to "valid
-as of now" and `AS OF VALID_TIME` reads over that data would be wrong.
+(`create_node`, `create_edge`, `update_node`, `update_edge`, `delete_node`,
+`delete_edge`) accept an optional `valid_time` field so an LLM ingesting a
+document can record the fact's real-world effective date — including when it
+stopped being true — in the **same** tool call, instead of defaulting to
+"now". This closes the loop with the bi-temporal `AS OF` queries above:
+without it, every LLM-ingested fact would collapse to "valid as of now" and
+`AS OF VALID_TIME` reads over that data would be wrong.
+
+On `delete_node`, `valid_time` is not supported together with `detach: true`
+(cascade delete does not support backdating): pass one or the other, or
+delete the connected edges individually with `valid_time` first.
 
 **Example:** an LLM reads a filing and extracts "Alice became CEO on
 2021-03-01," today.

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -117,6 +117,56 @@ temporally scoped by the engine's planner.
 A numeric array parameter is bound as an embedding, so the LLM never has to
 string-concatenate vectors into the query text.
 
+## Recording facts at a specific valid time
+
+`query` is read-only, but the structured write tools it complements
+(`create_node`, `create_edge`, `update_node`, `update_edge`) accept an
+optional `valid_time` field so an LLM ingesting a document can record the
+fact's real-world effective date in the **same** tool call, instead of
+defaulting to "now". This closes the loop with the bi-temporal `AS OF`
+queries above: without it, every LLM-ingested fact would collapse to "valid
+as of now" and `AS OF VALID_TIME` reads over that data would be wrong.
+
+**Example:** an LLM reads a filing and extracts "Alice became CEO on
+2021-03-01," today.
+
+```jsonc
+// tools/call -> "create_node"
+{
+  "label": "Person",
+  "properties": { "name": "Alice", "title": "CEO" },
+  "valid_time": "2021-03-01T00:00:00Z"
+}
+```
+
+Verifying the backdated fact is retrievable at its stated valid time, and
+absent before it:
+
+```jsonc
+// tools/call -> "get_node_at_time"
+{ "node_id": 7, "valid_time": "2021-03-01T00:00:00Z" }
+// -> { "node": { "id": 7, "label": "Person", "properties": {...} }, ... }
+
+// tools/call -> "get_node_at_time"
+{ "node_id": 7, "valid_time": "2021-01-01T00:00:00Z" }
+// -> { "error": "..." }  (not yet true at this valid time)
+```
+
+`valid_time` accepts the same formats as every other MCP temporal field
+(ISO 8601 / RFC 3339, or integer microseconds since epoch). Omitting it
+reproduces today's behavior exactly (valid time defaults to the transaction
+time). **Transaction time is always system-assigned** — there is no
+`transaction_time` field on the write tools, so provenance (when the DB
+actually learned the fact) can never be forged. A malformed, more-than-a-year-
+in-the-future, or before-entity-creation `valid_time` is rejected with a
+structured error, e.g.:
+
+```jsonc
+{ "error": "Invalid valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." }
+{ "error": "valid_from ... is too far in future (current: ..., max offset: ...)" }
+{ "error": "valid_from ... is before entity creation time ... for node:7" }
+```
+
 ## Notes
 
 - **AQL has no parameter binding.** Sending `params` with `language: "aql"`

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -1017,6 +1017,9 @@ impl WriteOps for WriteTransaction {
             let timestamp = self.start_timestamp;
             let valid_from = valid_from.unwrap_or(timestamp);
 
+            // Validate valid_from is not too far in future
+            validation::validate_valid_from_future(valid_from)?;
+
             // Buffer the write
             self.buffer.add(super::BufferedWrite::CreateEdge {
                 edge_id,
@@ -1074,12 +1077,11 @@ impl WriteOps for WriteTransaction {
             validation::validate_valid_from_future(valid_from)?;
 
             // Validate valid_from is not before entity creation
-            let historical = self.historical.read();
-            if let Some(current_version_id) = historical.get_current_node_version(node_id)
-                && let Some(current_version) = historical.get_node_version(current_version_id)
-            {
-                let creation_time = current_version.temporal.valid_time().start();
-                drop(historical); // Release lock before calling validation
+            let creation_time = {
+                let historical = self.historical.read();
+                historical.node_creation_time(node_id)
+            };
+            if let Some(creation_time) = creation_time {
                 validation::validate_valid_from_not_before_creation(
                     &format!("node:{}", node_id.as_u64()),
                     creation_time,
@@ -1144,10 +1146,7 @@ impl WriteOps for WriteTransaction {
             // Validate valid_from is not before the edge's own creation time
             let creation_time = {
                 let historical = self.historical.read();
-                historical
-                    .get_current_edge_version(edge_id)
-                    .and_then(|vid| historical.get_edge_version(vid))
-                    .map(|v| v.temporal.valid_time().start())
+                historical.edge_creation_time(edge_id)
             };
             if let Some(creation_time) = creation_time {
                 validation::validate_valid_from_not_before_creation(
@@ -1206,12 +1205,11 @@ impl WriteOps for WriteTransaction {
             validation::validate_valid_from_future(valid_from)?;
 
             // Validate valid_from is not before entity creation
-            let historical = self.historical.read();
-            if let Some(current_version_id) = historical.get_current_node_version(node_id)
-                && let Some(current_version) = historical.get_node_version(current_version_id)
-            {
-                let creation_time = current_version.temporal.valid_time().start();
-                drop(historical); // Release lock before calling validation
+            let creation_time = {
+                let historical = self.historical.read();
+                historical.node_creation_time(node_id)
+            };
+            if let Some(creation_time) = creation_time {
                 validation::validate_valid_from_not_before_creation(
                     &format!("node:{}", node_id.as_u64()),
                     creation_time,
@@ -1303,10 +1301,7 @@ impl WriteOps for WriteTransaction {
             // Validate valid_from is not before the edge's own creation time
             let creation_time = {
                 let historical = self.historical.read();
-                historical
-                    .get_current_edge_version(edge_id)
-                    .and_then(|vid| historical.get_edge_version(vid))
-                    .map(|v| v.temporal.valid_time().start())
+                historical.edge_creation_time(edge_id)
             };
             if let Some(creation_time) = creation_time {
                 validation::validate_valid_from_not_before_creation(

--- a/src/api/transaction/write/tests.rs
+++ b/src/api/transaction/write/tests.rs
@@ -3361,6 +3361,211 @@ mod bitemporal_validation_tests {
         );
     }
 
+    /// Test: `create_edge_with_valid_time` rejects a far-future `valid_time`, mirroring
+    /// `test_create_node_rejects_far_future_valid_time`. Regression test for a gap where
+    /// `create_edge_with_valid_time` was the only one of the six `*_with_valid_time`
+    /// methods that never called `validate_valid_from_future`, silently accepting an
+    /// arbitrarily-far-future `valid_time` on edges.
+    #[test]
+    fn test_create_edge_rejects_far_future_valid_time() {
+        use crate::core::error::TemporalError;
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let two_years_future_wallclock = time::now().wallclock() + 2 * 365 * 24 * 3_600_000_000;
+        let two_years_future = HybridTimestamp::new(two_years_future_wallclock, 0).unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let result = tx2.create_edge_with_valid_time(
+            src,
+            tgt,
+            "KNOWS",
+            PropertyMap::new(),
+            Some(two_years_future),
+        );
+
+        assert!(
+            result.is_err(),
+            "Should reject far-future valid_time on edge creation"
+        );
+        match result.unwrap_err() {
+            crate::core::error::Error::Temporal(TemporalError::ValidTimeTooFarInFuture {
+                ..
+            }) => {}
+            other => panic!("Expected ValidTimeTooFarInFuture, got: {:?}", other),
+        }
+    }
+
+    /// Test: backfilling a node update between two existing (already backdated) versions
+    /// succeeds. Regression test for a bug where the "not before creation" floor was
+    /// computed from the *latest* version's `valid_from` instead of the entity's true
+    /// original creation time, spuriously rejecting legitimate backfills.
+    #[test]
+    fn test_update_node_valid_time_backfill_between_existing_versions_succeeds() {
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+        let now = time::now().wallclock();
+        let t0 = HybridTimestamp::new(now - 3 * 3_600_000_000, 0).unwrap(); // 3h ago: true creation
+        let t2 = HybridTimestamp::new(now - 2 * 3_600_000_000, 0).unwrap(); // 2h ago: latest version
+        let t1 = HybridTimestamp::new(now - 2 * 3_600_000_000 - 1_800_000_000, 0).unwrap(); // 2h30m ago: t0 < t1 < t2
+
+        let mut tx = harness.begin_write();
+        let node_id = tx
+            .create_node_with_valid_time("Person", PropertyMap::new(), Some(t0))
+            .unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        tx2.update_node_with_valid_time(
+            node_id,
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+            Some(t2),
+        )
+        .unwrap();
+        tx2.commit().unwrap();
+
+        // Backfill a correction between t0 and t2: must succeed, not spuriously reject
+        // against t2 (the latest version) instead of t0 (the true creation time).
+        let mut tx3 = harness.begin_write();
+        let result = tx3.update_node_with_valid_time(
+            node_id,
+            PropertyMapBuilder::new().insert("name", "Carol").build(),
+            Some(t1),
+        );
+        assert!(
+            result.is_ok(),
+            "Backfill between existing versions should succeed, got: {:?}",
+            result
+        );
+    }
+
+    /// Edge mirror of `test_update_node_valid_time_backfill_between_existing_versions_succeeds`.
+    #[test]
+    fn test_update_edge_valid_time_backfill_between_existing_versions_succeeds() {
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+        let now = time::now().wallclock();
+        let t0 = HybridTimestamp::new(now - 3 * 3_600_000_000, 0).unwrap();
+        let t2 = HybridTimestamp::new(now - 2 * 3_600_000_000, 0).unwrap();
+        let t1 = HybridTimestamp::new(now - 2 * 3_600_000_000 - 1_800_000_000, 0).unwrap();
+
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let edge_id = tx2
+            .create_edge_with_valid_time(src, tgt, "KNOWS", PropertyMap::new(), Some(t0))
+            .unwrap();
+        tx2.commit().unwrap();
+
+        let mut tx3 = harness.begin_write();
+        tx3.update_edge_with_valid_time(
+            edge_id,
+            PropertyMapBuilder::new().insert("strength", 5i64).build(),
+            Some(t2),
+        )
+        .unwrap();
+        tx3.commit().unwrap();
+
+        let mut tx4 = harness.begin_write();
+        let result = tx4.update_edge_with_valid_time(
+            edge_id,
+            PropertyMapBuilder::new().insert("strength", 3i64).build(),
+            Some(t1),
+        );
+        assert!(
+            result.is_ok(),
+            "Backfill between existing edge versions should succeed, got: {:?}",
+            result
+        );
+    }
+
+    /// Node-delete mirror of the update backfill regression test: deleting with a
+    /// `valid_time` between an entity's true creation and a later update must succeed.
+    #[test]
+    fn test_delete_node_valid_time_backfill_between_existing_versions_succeeds() {
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+        let now = time::now().wallclock();
+        let t0 = HybridTimestamp::new(now - 3 * 3_600_000_000, 0).unwrap();
+        let t2 = HybridTimestamp::new(now - 2 * 3_600_000_000, 0).unwrap();
+        let t1 = HybridTimestamp::new(now - 2 * 3_600_000_000 - 1_800_000_000, 0).unwrap();
+
+        let mut tx = harness.begin_write();
+        let node_id = tx
+            .create_node_with_valid_time("Person", PropertyMap::new(), Some(t0))
+            .unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        tx2.update_node_with_valid_time(
+            node_id,
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+            Some(t2),
+        )
+        .unwrap();
+        tx2.commit().unwrap();
+
+        let mut tx3 = harness.begin_write();
+        let result = tx3.delete_node_with_valid_time(node_id, Some(t1));
+        assert!(
+            result.is_ok(),
+            "Delete backfill between existing versions should succeed, got: {:?}",
+            result
+        );
+    }
+
+    /// Edge-delete mirror of the node-delete backfill regression test.
+    #[test]
+    fn test_delete_edge_valid_time_backfill_between_existing_versions_succeeds() {
+        use crate::core::hlc::HybridTimestamp;
+
+        let harness = TestHarness::new();
+        let now = time::now().wallclock();
+        let t0 = HybridTimestamp::new(now - 3 * 3_600_000_000, 0).unwrap();
+        let t2 = HybridTimestamp::new(now - 2 * 3_600_000_000, 0).unwrap();
+        let t1 = HybridTimestamp::new(now - 2 * 3_600_000_000 - 1_800_000_000, 0).unwrap();
+
+        let mut tx = harness.begin_write();
+        let src = tx.create_node("Person", PropertyMap::new()).unwrap();
+        let tgt = tx.create_node("Person", PropertyMap::new()).unwrap();
+        tx.commit().unwrap();
+
+        let mut tx2 = harness.begin_write();
+        let edge_id = tx2
+            .create_edge_with_valid_time(src, tgt, "KNOWS", PropertyMap::new(), Some(t0))
+            .unwrap();
+        tx2.commit().unwrap();
+
+        let mut tx3 = harness.begin_write();
+        tx3.update_edge_with_valid_time(
+            edge_id,
+            PropertyMapBuilder::new().insert("strength", 5i64).build(),
+            Some(t2),
+        )
+        .unwrap();
+        tx3.commit().unwrap();
+
+        let mut tx4 = harness.begin_write();
+        let result = tx4.delete_edge_with_valid_time(edge_id, Some(t1));
+        assert!(
+            result.is_ok(),
+            "Edge delete backfill between existing versions should succeed, got: {:?}",
+            result
+        );
+    }
+
     /// Test: The maximum valid timestamp boundary is accepted and just above is rejected.
     ///
     /// `HybridTimestamp::new` rejects wallclock values exceeding `MAX_VALID_TIMESTAMP`

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -7,6 +7,7 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyValue};
+use crate::core::temporal::Timestamp;
 use crate::db::AletheiaDB;
 use crate::storage::current::{IncomingEdgesIter, OutgoingEdgesIter};
 use crate::storage::wal::WalOperation;
@@ -16,6 +17,9 @@ impl AletheiaDB {
     ///
     /// This is a convenience method that internally uses a write transaction.
     /// For multiple operations, prefer using `write()` or `write_transaction()`.
+    /// `valid_time` defaults to the transaction start time; use
+    /// [`create_node_with_valid_time`](Self::create_node_with_valid_time) to
+    /// backdate or future-date the fact.
     ///
     /// # Example
     ///
@@ -36,15 +40,69 @@ impl AletheiaDB {
     /// # See Also
     ///
     /// * [`write`](Self::write) - For batched write operations.
+    /// * [`create_node_with_valid_time`](Self::create_node_with_valid_time) - To set a specific valid time.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_node(&self, label: &str, properties: PropertyMap) -> Result<NodeId> {
-        self.write(|tx| tx.create_node(label, properties))
+        self.create_node_with_valid_time(label, properties, None)
+    }
+
+    /// Create a node with the given label, properties, and an optional valid time.
+    ///
+    /// Use this to record a fact whose real-world effective date differs from
+    /// "now" -- for example, an LLM extracting "Alice became CEO on 2021-03-01"
+    /// from a document ingested today. When `valid_from` is `None`, this behaves
+    /// exactly like [`create_node`](Self::create_node) (valid time defaults to
+    /// the transaction start time). Transaction time is always system-assigned
+    /// to the commit time and cannot be set by the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed [`TemporalError`](crate::core::error::TemporalError) if
+    /// `valid_from` is more than one year in the future; it is never silently
+    /// coerced.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+    /// # use aletheiadb::core::temporal::time;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// // Record that Alice became CEO on 2021-03-01, even though we're
+    /// // recording it today.
+    /// let march_2021 = time::from_secs(1614556800);
+    /// let node_id = db.create_node_with_valid_time(
+    ///     "Person",
+    ///     PropertyMapBuilder::new()
+    ///         .insert("name", "Alice")
+    ///         .insert("title", "CEO")
+    ///         .build(),
+    ///     Some(march_2021),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// * [`write`](Self::write) - For batched write operations.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_node_with_valid_time(
+        &self,
+        label: &str,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<NodeId> {
+        self.write(|tx| tx.create_node_with_valid_time(label, properties, valid_from))
     }
 
     /// Create an edge between two nodes.
     ///
     /// This is a convenience method that internally uses a write transaction.
     /// For multiple operations, prefer using `write()` or `write_transaction()`.
+    /// `valid_time` defaults to the transaction start time; use
+    /// [`create_edge_with_valid_time`](Self::create_edge_with_valid_time) to
+    /// backdate or future-date the fact.
     ///
     /// # Example
     ///
@@ -67,6 +125,7 @@ impl AletheiaDB {
     /// # See Also
     ///
     /// * [`write`](Self::write) - For batched write operations.
+    /// * [`create_edge_with_valid_time`](Self::create_edge_with_valid_time) - To set a specific valid time.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_edge(
         &self,
@@ -75,7 +134,155 @@ impl AletheiaDB {
         label: &str,
         properties: PropertyMap,
     ) -> Result<EdgeId> {
-        self.write(|tx| tx.create_edge(source, target, label, properties))
+        self.create_edge_with_valid_time(source, target, label, properties, None)
+    }
+
+    /// Create an edge between two nodes with an optional valid time.
+    ///
+    /// See [`create_node_with_valid_time`](Self::create_node_with_valid_time)
+    /// for the bi-temporal semantics: `valid_from` sets when the relationship
+    /// became true in the real world, while transaction time always remains
+    /// system-assigned to the commit time.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed [`TemporalError`](crate::core::error::TemporalError) if
+    /// `valid_from` is more than one year in the future.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, PropertyMapBuilder, core::NodeId};
+    /// # use aletheiadb::core::temporal::time;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// # let source_id = NodeId::new(1)?;
+    /// # let target_id = NodeId::new(2)?;
+    /// let since_2021 = time::from_secs(1609459200);
+    /// let edge_id = db.create_edge_with_valid_time(
+    ///     source_id,
+    ///     target_id,
+    ///     "KNOWS",
+    ///     PropertyMapBuilder::new().build(),
+    ///     Some(since_2021),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// * [`write`](Self::write) - For batched write operations.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_edge_with_valid_time(
+        &self,
+        source: NodeId,
+        target: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<EdgeId> {
+        self.write(|tx| {
+            tx.create_edge_with_valid_time(source, target, label, properties, valid_from)
+        })
+    }
+
+    /// Update a node's properties with an optional valid time (PATCH semantics).
+    ///
+    /// When `valid_from` is `None`, valid time defaults to the transaction
+    /// start time. Pass `Some(ts)` to retroactively correct or future-date a
+    /// fact. Transaction time is always system-assigned.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed [`TemporalError`](crate::core::error::TemporalError) if
+    /// `valid_from` is more than one year in the future, or precedes the
+    /// node's own creation time.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, PropertyMapBuilder, core::NodeId};
+    /// # use aletheiadb::core::temporal::time;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// # let node_id = NodeId::new(1)?;
+    /// let yesterday = time::from_secs(time::now().wallclock() / 1_000_000 - 86_400);
+    /// db.update_node_with_valid_time(
+    ///     node_id,
+    ///     PropertyMapBuilder::new().insert("city", "London").build(),
+    ///     Some(yesterday),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn update_node_with_valid_time(
+        &self,
+        node_id: NodeId,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.write(|tx| tx.update_node_with_valid_time(node_id, properties, valid_from))
+    }
+
+    /// Update an edge's properties with an optional valid time (PATCH semantics).
+    ///
+    /// See [`update_node_with_valid_time`](Self::update_node_with_valid_time)
+    /// for the bi-temporal semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed [`TemporalError`](crate::core::error::TemporalError) if
+    /// `valid_from` is more than one year in the future, or precedes the
+    /// edge's own creation time.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn update_edge_with_valid_time(
+        &self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.write(|tx| tx.update_edge_with_valid_time(edge_id, properties, valid_from))
+    }
+
+    /// Delete a node with an optional valid time (without deleting connected edges).
+    ///
+    /// # Warning
+    ///
+    /// This does NOT delete edges connected to the node, which may leave
+    /// orphaned edges in the graph. For most use cases, prefer a cascade
+    /// delete that also removes connected edges. Only use this method if you
+    /// explicitly need to preserve edges for a specialized use case.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed [`TemporalError`](crate::core::error::TemporalError) if
+    /// `valid_from` is more than one year in the future, or precedes the
+    /// node's own creation time.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_node_with_valid_time(
+        &self,
+        node_id: NodeId,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.write(|tx| tx.delete_node_with_valid_time(node_id, valid_from))
+    }
+
+    /// Delete an edge with an optional valid time.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed [`TemporalError`](crate::core::error::TemporalError) if
+    /// `valid_from` is more than one year in the future, or precedes the
+    /// edge's own creation time.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn delete_edge_with_valid_time(
+        &self,
+        edge_id: EdgeId,
+        valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        self.write(|tx| tx.delete_edge_with_valid_time(edge_id, valid_from))
     }
 
     /// Get the current state of a node.
@@ -426,5 +633,318 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&a));
         assert!(ids.contains(&b));
+    }
+
+    mod valid_time_tests {
+        use super::*;
+        use crate::core::error::{Error, TemporalError};
+        use crate::core::hlc::HybridTimestamp;
+        use crate::core::property::PropertyValue;
+        use crate::core::temporal::time;
+
+        fn hours_ago(hours: i64) -> HybridTimestamp {
+            HybridTimestamp::new(time::now().wallclock() - hours * 3_600_000_000, 0).unwrap()
+        }
+
+        fn hours_from_now(hours: i64) -> HybridTimestamp {
+            HybridTimestamp::new(time::now().wallclock() + hours * 3_600_000_000, 0).unwrap()
+        }
+
+        #[test]
+        fn create_node_with_valid_time_backdated_round_trip() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let t_past = hours_ago(1);
+
+            let id = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().insert("name", "Alice").build(),
+                    Some(t_past),
+                )
+                .unwrap();
+
+            // Visible at t_past.
+            let node = db.get_node_at_valid_time(id, t_past).unwrap();
+            assert_eq!(
+                node.properties.get("name"),
+                Some(&PropertyValue::from("Alice"))
+            );
+
+            // Invisible strictly before t_past.
+            let before = hours_ago(2);
+            assert!(db.get_node_at_valid_time(id, before).is_err());
+        }
+
+        #[test]
+        fn create_node_with_valid_time_future_dated_invisible_now_visible_at_future() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let t_future = hours_from_now(1);
+
+            let id = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().build(),
+                    Some(t_future),
+                )
+                .unwrap();
+
+            assert!(db.get_node_at_valid_time(id, time::now()).is_err());
+            assert!(db.get_node_at_valid_time(id, t_future).is_ok());
+        }
+
+        #[test]
+        fn create_edge_with_valid_time_backdated_round_trip() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let source = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let target = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+
+            let t_past = hours_ago(1);
+            let edge_id = db
+                .create_edge_with_valid_time(
+                    source,
+                    target,
+                    "KNOWS",
+                    PropertyMapBuilder::new().build(),
+                    Some(t_past),
+                )
+                .unwrap();
+
+            assert!(db.get_edge_at_valid_time(edge_id, t_past).is_ok());
+            assert!(db.get_edge_at_valid_time(edge_id, hours_ago(2)).is_err());
+        }
+
+        // NOTE: Updating/deleting closes the *transaction time* of the previous
+        // version at commit (standard MVCC on the transaction-time axis), so a
+        // valid-time probe strictly between the old and new `valid_from` is not
+        // reachable via `get_node_at_valid_time(id, probe)` (which always queries
+        // as of the *current* transaction time). This is pre-existing, unmodified
+        // `WriteOps` behavior -- verified the same way the transaction-level tests
+        // in `api::transaction::write::tests` do: by reading the recorded
+        // `valid_from` back from historical storage directly.
+        #[test]
+        fn update_node_with_valid_time_backdated_round_trip() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let id = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().insert("city", "Paris").build(),
+                    Some(hours_ago(2)),
+                )
+                .unwrap();
+
+            let t_update = hours_ago(1);
+            db.update_node_with_valid_time(
+                id,
+                PropertyMapBuilder::new().insert("city", "London").build(),
+                Some(t_update),
+            )
+            .unwrap();
+
+            // The caller-specified valid_from was correctly threaded through.
+            let historical = db.historical.read();
+            let version_id = historical.get_current_node_version(id).unwrap();
+            let version = historical.get_node_version(version_id).unwrap();
+            assert_eq!(version.temporal.valid_time().start(), t_update);
+            drop(historical);
+
+            // Updated properties are visible from their own valid_from onward.
+            let new_state = db.get_node_at_valid_time(id, t_update).unwrap();
+            assert_eq!(
+                new_state.properties.get("city"),
+                Some(&PropertyValue::from("London"))
+            );
+            let now_state = db.get_node_at_valid_time(id, time::now()).unwrap();
+            assert_eq!(
+                now_state.properties.get("city"),
+                Some(&PropertyValue::from("London"))
+            );
+        }
+
+        #[test]
+        fn update_edge_with_valid_time_backdated_round_trip() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let source = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let target = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let edge_id = db
+                .create_edge_with_valid_time(
+                    source,
+                    target,
+                    "KNOWS",
+                    PropertyMapBuilder::new().insert("strength", 1i64).build(),
+                    Some(hours_ago(2)),
+                )
+                .unwrap();
+
+            let t_update = hours_ago(1);
+            db.update_edge_with_valid_time(
+                edge_id,
+                PropertyMapBuilder::new().insert("strength", 9i64).build(),
+                Some(t_update),
+            )
+            .unwrap();
+
+            let historical = db.historical.read();
+            let version_id = historical.get_current_edge_version(edge_id).unwrap();
+            let version = historical.get_edge_version(version_id).unwrap();
+            assert_eq!(version.temporal.valid_time().start(), t_update);
+            drop(historical);
+
+            let new_state = db.get_edge_at_valid_time(edge_id, t_update).unwrap();
+            assert_eq!(
+                new_state.properties.get("strength"),
+                Some(&PropertyValue::from(9i64))
+            );
+            let now_state = db.get_edge_at_valid_time(edge_id, time::now()).unwrap();
+            assert_eq!(
+                now_state.properties.get("strength"),
+                Some(&PropertyValue::from(9i64))
+            );
+        }
+
+        #[test]
+        fn delete_node_with_valid_time_round_trip() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let id = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().build(),
+                    Some(hours_ago(2)),
+                )
+                .unwrap();
+
+            let t_delete = hours_ago(1);
+            db.delete_node_with_valid_time(id, Some(t_delete)).unwrap();
+
+            // Tombstone recorded with the caller-specified valid_from.
+            let historical = db.historical.read();
+            let version_id = historical.get_current_node_version(id).unwrap();
+            let version = historical.get_node_version(version_id).unwrap();
+            assert_eq!(version.temporal.valid_time().start(), t_delete);
+            drop(historical);
+
+            // No longer visible as of now.
+            assert!(db.get_node_at_valid_time(id, time::now()).is_err());
+        }
+
+        #[test]
+        fn delete_edge_with_valid_time_round_trip() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let source = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let target = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let edge_id = db
+                .create_edge_with_valid_time(
+                    source,
+                    target,
+                    "KNOWS",
+                    PropertyMapBuilder::new().build(),
+                    Some(hours_ago(2)),
+                )
+                .unwrap();
+
+            let t_delete = hours_ago(1);
+            db.delete_edge_with_valid_time(edge_id, Some(t_delete))
+                .unwrap();
+
+            let historical = db.historical.read();
+            let version_id = historical.get_current_edge_version(edge_id).unwrap();
+            let version = historical.get_edge_version(version_id).unwrap();
+            assert_eq!(version.temporal.valid_time().start(), t_delete);
+            drop(historical);
+
+            assert!(db.get_edge_at_valid_time(edge_id, time::now()).is_err());
+        }
+
+        #[test]
+        fn create_node_with_valid_time_rejects_far_future_typed_error() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let err = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().build(),
+                    Some(hours_from_now(24 * 400)), // > 1 year
+                )
+                .unwrap_err();
+
+            match err {
+                Error::Temporal(TemporalError::ValidTimeTooFarInFuture { .. }) => {}
+                other => panic!("Expected ValidTimeTooFarInFuture, got: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn update_node_with_valid_time_rejects_before_creation_typed_error() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let id = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+
+            let way_in_past = HybridTimestamp::new(1000, 0).unwrap();
+            let err = db
+                .update_node_with_valid_time(
+                    id,
+                    PropertyMapBuilder::new().insert("name", "Bob").build(),
+                    Some(way_in_past),
+                )
+                .unwrap_err();
+
+            match err {
+                Error::Temporal(TemporalError::ValidTimeBeforeEntityCreation { .. }) => {}
+                other => panic!("Expected ValidTimeBeforeEntityCreation, got: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn transaction_time_is_system_assigned_for_backdated_create() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let t_past = hours_ago(1);
+            let id = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().build(),
+                    Some(t_past),
+                )
+                .unwrap();
+
+            // At t_past, the write had not happened yet transactionally.
+            assert!(db.get_node_at_transaction_time(id, t_past).is_err());
+            // At now, the write is visible (transaction time == commit time, near now).
+            assert!(db.get_node_at_transaction_time(id, time::now()).is_ok());
+        }
+
+        #[test]
+        fn create_node_plain_delegates_with_none_and_is_valid_now() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let id = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            assert!(db.get_node_at_valid_time(id, time::now()).is_ok());
+        }
+
+        #[test]
+        fn create_edge_plain_delegates_with_none_and_is_valid_now() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let source = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let target = db
+                .create_node("Person", PropertyMapBuilder::new().build())
+                .unwrap();
+            let edge_id = db
+                .create_edge(source, target, "KNOWS", PropertyMapBuilder::new().build())
+                .unwrap();
+            assert!(db.get_edge_at_valid_time(edge_id, time::now()).is_ok());
+        }
     }
 }

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -642,18 +642,24 @@ mod tests {
         use crate::core::property::PropertyValue;
         use crate::core::temporal::time;
 
-        fn hours_ago(hours: i64) -> HybridTimestamp {
-            HybridTimestamp::new(time::now().wallclock() - hours * 3_600_000_000, 0).unwrap()
+        /// `now` is the caller's own `time::now().wallclock()`, captured once at the
+        /// start of the test and reused for every offset it computes. Calling
+        /// `time::now()` freshly inside the helper would let each call observe a
+        /// slightly different instant under load, making relative orderings between
+        /// offsets (e.g. `t0 < t1 < t2`) non-deterministic.
+        fn hours_ago(now: i64, hours: i64) -> HybridTimestamp {
+            HybridTimestamp::new(now - hours * 3_600_000_000, 0).unwrap()
         }
 
-        fn hours_from_now(hours: i64) -> HybridTimestamp {
-            HybridTimestamp::new(time::now().wallclock() + hours * 3_600_000_000, 0).unwrap()
+        fn hours_from_now(now: i64, hours: i64) -> HybridTimestamp {
+            HybridTimestamp::new(now + hours * 3_600_000_000, 0).unwrap()
         }
 
         #[test]
         fn create_node_with_valid_time_backdated_round_trip() {
             let (_tmp, db) = create_test_db().unwrap();
-            let t_past = hours_ago(1);
+            let now = time::now().wallclock();
+            let t_past = hours_ago(now, 1);
 
             let id = db
                 .create_node_with_valid_time(
@@ -671,14 +677,15 @@ mod tests {
             );
 
             // Invisible strictly before t_past.
-            let before = hours_ago(2);
+            let before = hours_ago(now, 2);
             assert!(db.get_node_at_valid_time(id, before).is_err());
         }
 
         #[test]
         fn create_node_with_valid_time_future_dated_invisible_now_visible_at_future() {
             let (_tmp, db) = create_test_db().unwrap();
-            let t_future = hours_from_now(1);
+            let now = time::now().wallclock();
+            let t_future = hours_from_now(now, 1);
 
             let id = db
                 .create_node_with_valid_time(
@@ -695,6 +702,7 @@ mod tests {
         #[test]
         fn create_edge_with_valid_time_backdated_round_trip() {
             let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
             let source = db
                 .create_node("Person", PropertyMapBuilder::new().build())
                 .unwrap();
@@ -702,7 +710,7 @@ mod tests {
                 .create_node("Person", PropertyMapBuilder::new().build())
                 .unwrap();
 
-            let t_past = hours_ago(1);
+            let t_past = hours_ago(now, 1);
             let edge_id = db
                 .create_edge_with_valid_time(
                     source,
@@ -714,7 +722,10 @@ mod tests {
                 .unwrap();
 
             assert!(db.get_edge_at_valid_time(edge_id, t_past).is_ok());
-            assert!(db.get_edge_at_valid_time(edge_id, hours_ago(2)).is_err());
+            assert!(
+                db.get_edge_at_valid_time(edge_id, hours_ago(now, 2))
+                    .is_err()
+            );
         }
 
         // NOTE: Updating/deleting closes the *transaction time* of the previous
@@ -728,15 +739,16 @@ mod tests {
         #[test]
         fn update_node_with_valid_time_backdated_round_trip() {
             let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
             let id = db
                 .create_node_with_valid_time(
                     "Person",
                     PropertyMapBuilder::new().insert("city", "Paris").build(),
-                    Some(hours_ago(2)),
+                    Some(hours_ago(now, 2)),
                 )
                 .unwrap();
 
-            let t_update = hours_ago(1);
+            let t_update = hours_ago(now, 1);
             db.update_node_with_valid_time(
                 id,
                 PropertyMapBuilder::new().insert("city", "London").build(),
@@ -767,6 +779,7 @@ mod tests {
         #[test]
         fn update_edge_with_valid_time_backdated_round_trip() {
             let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
             let source = db
                 .create_node("Person", PropertyMapBuilder::new().build())
                 .unwrap();
@@ -779,11 +792,11 @@ mod tests {
                     target,
                     "KNOWS",
                     PropertyMapBuilder::new().insert("strength", 1i64).build(),
-                    Some(hours_ago(2)),
+                    Some(hours_ago(now, 2)),
                 )
                 .unwrap();
 
-            let t_update = hours_ago(1);
+            let t_update = hours_ago(now, 1);
             db.update_edge_with_valid_time(
                 edge_id,
                 PropertyMapBuilder::new().insert("strength", 9i64).build(),
@@ -812,15 +825,16 @@ mod tests {
         #[test]
         fn delete_node_with_valid_time_round_trip() {
             let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
             let id = db
                 .create_node_with_valid_time(
                     "Person",
                     PropertyMapBuilder::new().build(),
-                    Some(hours_ago(2)),
+                    Some(hours_ago(now, 2)),
                 )
                 .unwrap();
 
-            let t_delete = hours_ago(1);
+            let t_delete = hours_ago(now, 1);
             db.delete_node_with_valid_time(id, Some(t_delete)).unwrap();
 
             // Tombstone recorded with the caller-specified valid_from.
@@ -837,6 +851,7 @@ mod tests {
         #[test]
         fn delete_edge_with_valid_time_round_trip() {
             let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
             let source = db
                 .create_node("Person", PropertyMapBuilder::new().build())
                 .unwrap();
@@ -849,11 +864,11 @@ mod tests {
                     target,
                     "KNOWS",
                     PropertyMapBuilder::new().build(),
-                    Some(hours_ago(2)),
+                    Some(hours_ago(now, 2)),
                 )
                 .unwrap();
 
-            let t_delete = hours_ago(1);
+            let t_delete = hours_ago(now, 1);
             db.delete_edge_with_valid_time(edge_id, Some(t_delete))
                 .unwrap();
 
@@ -869,11 +884,12 @@ mod tests {
         #[test]
         fn create_node_with_valid_time_rejects_far_future_typed_error() {
             let (_tmp, db) = create_test_db().unwrap();
+            let now = time::now().wallclock();
             let err = db
                 .create_node_with_valid_time(
                     "Person",
                     PropertyMapBuilder::new().build(),
-                    Some(hours_from_now(24 * 400)), // > 1 year
+                    Some(hours_from_now(now, 24 * 400)), // > 1 year
                 )
                 .unwrap_err();
 
@@ -913,13 +929,10 @@ mod tests {
         #[test]
         fn update_node_with_valid_time_backfill_between_existing_versions_succeeds() {
             let (_tmp, db) = create_test_db().unwrap();
-            let t0 = hours_ago(3); // true creation time
-            let t2 = hours_ago(2); // later backdated update (becomes latest version)
-            let t1 = HybridTimestamp::new(
-                time::now().wallclock() - 2 * 3_600_000_000 - 1_800_000_000,
-                0,
-            )
-            .unwrap(); // 2h30m ago: t0 < t1 < t2
+            let now = time::now().wallclock();
+            let t0 = hours_ago(now, 3); // true creation time
+            let t2 = hours_ago(now, 2); // later backdated update (becomes latest version)
+            let t1 = HybridTimestamp::new(now - 2 * 3_600_000_000 - 1_800_000_000, 0).unwrap(); // 2h30m ago: t0 < t1 < t2
 
             let id = db
                 .create_node_with_valid_time(
@@ -951,7 +964,8 @@ mod tests {
         #[test]
         fn transaction_time_is_system_assigned_for_backdated_create() {
             let (_tmp, db) = create_test_db().unwrap();
-            let t_past = hours_ago(1);
+            let now = time::now().wallclock();
+            let t_past = hours_ago(now, 1);
             let id = db
                 .create_node_with_valid_time(
                     "Person",

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -905,6 +905,49 @@ mod tests {
             }
         }
 
+        /// Regression test: backfilling a correction between an entity's true creation
+        /// time and a later (already backdated) update must succeed through the public
+        /// `AletheiaDB` API, not just at the `WriteTransaction` layer. Previously the
+        /// "not before creation" floor was computed from the *latest* version instead of
+        /// the entity's true original creation time, spuriously rejecting this.
+        #[test]
+        fn update_node_with_valid_time_backfill_between_existing_versions_succeeds() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let t0 = hours_ago(3); // true creation time
+            let t2 = hours_ago(2); // later backdated update (becomes latest version)
+            let t1 = HybridTimestamp::new(
+                time::now().wallclock() - 2 * 3_600_000_000 - 1_800_000_000,
+                0,
+            )
+            .unwrap(); // 2h30m ago: t0 < t1 < t2
+
+            let id = db
+                .create_node_with_valid_time(
+                    "Person",
+                    PropertyMapBuilder::new().insert("city", "Paris").build(),
+                    Some(t0),
+                )
+                .unwrap();
+            db.update_node_with_valid_time(
+                id,
+                PropertyMapBuilder::new().insert("city", "London").build(),
+                Some(t2),
+            )
+            .unwrap();
+
+            // Backfilling between t0 and t2 must succeed, not be spuriously rejected
+            // against t2 (the latest version) instead of t0 (the true creation time).
+            let result = db.update_node_with_valid_time(
+                id,
+                PropertyMapBuilder::new().insert("city", "Berlin").build(),
+                Some(t1),
+            );
+            assert!(
+                result.is_ok(),
+                "Backfill between existing versions should succeed, got: {result:?}"
+            );
+        }
+
         #[test]
         fn transaction_time_is_system_assigned_for_backdated_create() {
             let (_tmp, db) = create_test_db().unwrap();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -299,6 +299,7 @@ impl AletheiaMcpServer {
     /// let req = CreateNodeRequest {
     ///     label: "Person".to_string(),
     ///     properties: Some(props),
+    ///     valid_time: None,
     /// };
     /// ```
     ///
@@ -963,7 +964,15 @@ impl AletheiaMcpServer {
             None => PropertyMap::default(),
         };
 
-        match self.db.create_node(&req.label, properties) {
+        let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
+            Ok(v) => v,
+            Err(result) => return result,
+        };
+
+        match self
+            .db
+            .create_node_with_valid_time(&req.label, properties, valid_from)
+        {
             Ok(node_id) => match self.db.get_node(node_id) {
                 Ok(node) => {
                     let response = self.node_to_response(&node, true);
@@ -999,7 +1008,15 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
         };
 
-        match self.db.write(|tx| tx.update_node(node_id, properties)) {
+        let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
+            Ok(v) => v,
+            Err(result) => return result,
+        };
+
+        match self
+            .db
+            .update_node_with_valid_time(node_id, properties, valid_from)
+        {
             Ok(()) => match self.db.get_node(node_id) {
                 Ok(node) => {
                     let response = self.node_to_response(&node, true);
@@ -1305,9 +1322,14 @@ impl AletheiaMcpServer {
             None => PropertyMap::default(),
         };
 
+        let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
+            Ok(v) => v,
+            Err(result) => return result,
+        };
+
         match self
             .db
-            .create_edge(source_id, target_id, &req.label, properties)
+            .create_edge_with_valid_time(source_id, target_id, &req.label, properties, valid_from)
         {
             Ok(edge_id) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
@@ -1339,7 +1361,15 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
         };
 
-        match self.db.write(|tx| tx.update_edge(edge_id, properties)) {
+        let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
+            Ok(v) => v,
+            Err(result) => return result,
+        };
+
+        match self
+            .db
+            .update_edge_with_valid_time(edge_id, properties, valid_from)
+        {
             Ok(()) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
                     let response = self.edge_to_response(&edge, true);
@@ -2858,12 +2888,18 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "create_node",
-            "Create a new node with a label and optional properties.",
+            "Create a new node with a label and optional properties. Optionally pass \
+                     `valid_time` (ISO 8601 or microseconds since epoch) to record when this fact \
+                     became true in the real world (backdating/future-dating); omit it to default \
+                     to the transaction time. Transaction time is always system-assigned.",
             make_input_schema::<CreateNodeRequest>(),
         ),
         Tool::new(
             "update_node",
-            "Update an existing node's properties.",
+            "Update an existing node's properties. Optionally pass `valid_time` (ISO 8601 or \
+                     microseconds since epoch) to record when this update became true in the real \
+                     world; omit it to default to the transaction time. Transaction time is always \
+                     system-assigned.",
             make_input_schema::<UpdateNodeRequest>(),
         ),
         Tool::new(
@@ -2902,12 +2938,18 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "create_edge",
-            "Create a new edge between two nodes.",
+            "Create a new edge between two nodes. Optionally pass `valid_time` (ISO 8601 or \
+                     microseconds since epoch) to record when this relationship became true in the \
+                     real world (backdating/future-dating); omit it to default to the transaction \
+                     time. Transaction time is always system-assigned.",
             make_input_schema::<CreateEdgeRequest>(),
         ),
         Tool::new(
             "update_edge",
-            "Update an existing edge's properties.",
+            "Update an existing edge's properties. Optionally pass `valid_time` (ISO 8601 or \
+                     microseconds since epoch) to record when this update became true in the real \
+                     world; omit it to default to the transaction time. Transaction time is always \
+                     system-assigned.",
             make_input_schema::<UpdateEdgeRequest>(),
         ),
         Tool::new(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1049,6 +1049,19 @@ impl AletheiaMcpServer {
 
         let detach = req.detach.unwrap_or(false);
 
+        let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
+            Ok(v) => v,
+            Err(result) => return result,
+        };
+
+        if detach && valid_from.is_some() {
+            return self.error_json(
+                "valid_time is not supported together with detach:true; cascade delete does \
+                 not support backdating. Delete the connected edges individually with \
+                 valid_time, or omit valid_time to cascade-delete at now.",
+            );
+        }
+
         // Perform the connected-edge check and the deletion inside a single write
         // transaction so they observe the same storage state. Splitting the count
         // into a separate transaction (or doing it before opening one) leaves a
@@ -1081,7 +1094,7 @@ impl AletheiaMcpServer {
                 })
             } else {
                 // No connected edges: a plain delete cannot orphan anything.
-                tx.delete_node(node_id)?;
+                tx.delete_node_with_valid_time(node_id, valid_from)?;
                 Ok(Outcome::Deleted { edges_removed: 0 })
             }
         });
@@ -1395,7 +1408,15 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&e.to_string()),
         };
 
-        match self.db.write(|tx| tx.delete_edge(edge_id)) {
+        let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
+            Ok(v) => v,
+            Err(result) => return result,
+        };
+
+        match self
+            .db
+            .write(|tx| tx.delete_edge_with_valid_time(edge_id, valid_from))
+        {
             Ok(()) => self.success_json(json!({
                 "success": true,
                 "deleted_edge_id": req.edge_id
@@ -2907,7 +2928,10 @@ fn tool_definitions() -> Vec<Tool> {
             "Delete a node by its ID (safe-by-default). If the node has connected \
                      edges and `detach` is not true, the deletion is refused and the response \
                      reports `connected_edges`. Pass `detach: true` to delete the node together \
-                     with all connected edges; the response then reports `edges_removed`.",
+                     with all connected edges; the response then reports `edges_removed`. \
+                     Optionally pass `valid_time` to record when this fact stopped being true in \
+                     the real world; omit it to default to the transaction time. Not supported \
+                     together with `detach: true` (cascade delete does not support backdating).",
             make_input_schema::<DeleteNodeRequest>(),
         ),
         Tool::new(
@@ -2954,7 +2978,9 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "delete_edge",
-            "Delete an edge by its ID.",
+            "Delete an edge by its ID. Optionally pass `valid_time` to record when this \
+                     relationship stopped being true in the real world; omit it to default to the \
+                     transaction time.",
             make_input_schema::<DeleteEdgeRequest>(),
         ),
         Tool::new(

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -4985,31 +4985,36 @@ mod vector_elision_tests {
 
 mod valid_time_write_tests {
     use super::*;
-    use chrono::{Duration, Utc};
+    use chrono::{DateTime, Duration, Utc};
 
-    fn rfc3339_hours_ago(hours: i64) -> String {
-        (Utc::now() - Duration::hours(hours)).to_rfc3339()
+    /// `now` is the caller's own `Utc::now()`, captured once at the start of the test
+    /// and reused for every offset it computes. Calling `Utc::now()` freshly inside the
+    /// helper would let each call observe a slightly different instant under load,
+    /// making relative orderings between offsets non-deterministic.
+    fn rfc3339_hours_ago(now: DateTime<Utc>, hours: i64) -> String {
+        (now - Duration::hours(hours)).to_rfc3339()
     }
 
-    fn rfc3339_hours_from_now(hours: i64) -> String {
-        (Utc::now() + Duration::hours(hours)).to_rfc3339()
+    fn rfc3339_hours_from_now(now: DateTime<Utc>, hours: i64) -> String {
+        (now + Duration::hours(hours)).to_rfc3339()
     }
 
     #[test]
     fn test_create_node_with_valid_time_backdated_round_trip() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let response = server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_ago(1)),
+            valid_time: Some(rfc3339_hours_ago(now, 1)),
         });
         let node: NodeResponse = parse_response(&response).expect("create should succeed");
 
         // Visible shortly after its valid_from.
         let visible = server.get_node_at_time(GetNodeAtTimeRequest {
             node_id: node.id,
-            valid_time: rfc3339_hours_ago(0),
+            valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&visible).unwrap();
@@ -5018,7 +5023,7 @@ mod valid_time_write_tests {
         // Invisible strictly before its valid_from.
         let invisible = server.get_node_at_time(GetNodeAtTimeRequest {
             node_id: node.id,
-            valid_time: rfc3339_hours_ago(2),
+            valid_time: rfc3339_hours_ago(now, 2),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&invisible).unwrap();
@@ -5070,11 +5075,12 @@ mod valid_time_write_tests {
     #[test]
     fn test_create_node_far_future_valid_time_typed_error_surfaced() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let response = server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_from_now(24 * 400)), // > 1 year
+            valid_time: Some(rfc3339_hours_from_now(now, 24 * 400)), // > 1 year
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5086,6 +5092,7 @@ mod valid_time_write_tests {
     #[test]
     fn test_create_edge_with_valid_time_backdated_round_trip() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
@@ -5105,13 +5112,13 @@ mod valid_time_write_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_ago(1)),
+            valid_time: Some(rfc3339_hours_ago(now, 1)),
         });
         let edge: EdgeResponse = parse_response(&response).expect("create_edge should succeed");
 
         let visible = server.get_edge_at_time(GetEdgeAtTimeRequest {
             edge_id: edge.id,
-            valid_time: rfc3339_hours_ago(0),
+            valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&visible).unwrap();
@@ -5119,7 +5126,7 @@ mod valid_time_write_tests {
 
         let invisible = server.get_edge_at_time(GetEdgeAtTimeRequest {
             edge_id: edge.id,
-            valid_time: rfc3339_hours_ago(2),
+            valid_time: rfc3339_hours_ago(now, 2),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&invisible).unwrap();
@@ -5129,19 +5136,20 @@ mod valid_time_write_tests {
     #[test]
     fn test_update_node_with_valid_time_backdated() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let mut props = HashMap::new();
         props.insert("city".to_string(), serde_json::json!("Paris"));
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: Some(props),
-            valid_time: Some(rfc3339_hours_ago(2)),
+            valid_time: Some(rfc3339_hours_ago(now, 2)),
         }))
         .unwrap();
 
         let mut update_props = HashMap::new();
         update_props.insert("city".to_string(), serde_json::json!("London"));
-        let update_valid_time = rfc3339_hours_ago(1);
+        let update_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.update_node(UpdateNodeRequest {
             node_id: node.id,
             properties: update_props,
@@ -5195,20 +5203,21 @@ mod valid_time_write_tests {
     #[test]
     fn test_transaction_time_not_client_settable() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_ago(1)),
+            valid_time: Some(rfc3339_hours_ago(now, 1)),
         }))
         .unwrap();
 
         // As of a transaction_time 30 minutes ago, the write (committed just now)
         // had not happened yet -- the fact must not be retroactively knowable.
-        let too_early_tx = (Utc::now() - Duration::minutes(30)).to_rfc3339();
+        let too_early_tx = (now - Duration::minutes(30)).to_rfc3339();
         let too_early = server.get_node_at_time(GetNodeAtTimeRequest {
             node_id: node.id,
-            valid_time: rfc3339_hours_ago(0),
+            valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: Some(too_early_tx),
         });
         let value: serde_json::Value = serde_json::from_str(&too_early).unwrap();
@@ -5217,7 +5226,7 @@ mod valid_time_write_tests {
         // Omitting transaction_time defaults to now, where the write is visible.
         let now_response = server.get_node_at_time(GetNodeAtTimeRequest {
             node_id: node.id,
-            valid_time: rfc3339_hours_ago(0),
+            valid_time: rfc3339_hours_ago(now, 0),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&now_response).unwrap();
@@ -5227,6 +5236,7 @@ mod valid_time_write_tests {
     #[test]
     fn test_update_edge_with_valid_time_backdated() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
@@ -5248,13 +5258,13 @@ mod valid_time_write_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: Some(props),
-            valid_time: Some(rfc3339_hours_ago(2)),
+            valid_time: Some(rfc3339_hours_ago(now, 2)),
         }))
         .unwrap();
 
         let mut update_props = HashMap::new();
         update_props.insert("strength".to_string(), serde_json::json!(9));
-        let update_valid_time = rfc3339_hours_ago(1);
+        let update_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.update_edge(UpdateEdgeRequest {
             edge_id: edge.id,
             properties: update_props,
@@ -5286,6 +5296,7 @@ mod valid_time_write_tests {
     #[test]
     fn test_create_edge_far_future_valid_time_typed_error_surfaced() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
@@ -5305,7 +5316,7 @@ mod valid_time_write_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_from_now(24 * 400)), // > 1 year
+            valid_time: Some(rfc3339_hours_from_now(now, 24 * 400)), // > 1 year
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5323,15 +5334,16 @@ mod valid_time_write_tests {
     #[test]
     fn test_delete_node_with_valid_time_backdated_round_trip() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_ago(2)),
+            valid_time: Some(rfc3339_hours_ago(now, 2)),
         }))
         .unwrap();
 
-        let delete_valid_time = rfc3339_hours_ago(1);
+        let delete_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.delete_node(DeleteNodeRequest {
             node_id: node.id,
             detach: None,
@@ -5358,7 +5370,7 @@ mod valid_time_write_tests {
         // No longer visible as of now.
         let gone = server.get_node_at_time(GetNodeAtTimeRequest {
             node_id: node.id,
-            valid_time: Utc::now().to_rfc3339(),
+            valid_time: now.to_rfc3339(),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&gone).unwrap();
@@ -5370,6 +5382,7 @@ mod valid_time_write_tests {
     #[test]
     fn test_delete_edge_with_valid_time_backdated_round_trip() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
@@ -5388,11 +5401,11 @@ mod valid_time_write_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
-            valid_time: Some(rfc3339_hours_ago(2)),
+            valid_time: Some(rfc3339_hours_ago(now, 2)),
         }))
         .unwrap();
 
-        let delete_valid_time = rfc3339_hours_ago(1);
+        let delete_valid_time = rfc3339_hours_ago(now, 1);
         let response = server.delete_edge(DeleteEdgeRequest {
             edge_id: edge.id,
             valid_time: Some(delete_valid_time.clone()),
@@ -5418,7 +5431,7 @@ mod valid_time_write_tests {
         // No longer visible as of now.
         let gone = server.get_edge_at_time(GetEdgeAtTimeRequest {
             edge_id: edge.id,
-            valid_time: Utc::now().to_rfc3339(),
+            valid_time: now.to_rfc3339(),
             transaction_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&gone).unwrap();
@@ -5431,6 +5444,7 @@ mod valid_time_write_tests {
     #[test]
     fn test_delete_node_detach_with_valid_time_rejected() {
         let server = create_test_server();
+        let now = Utc::now();
 
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
@@ -5456,7 +5470,7 @@ mod valid_time_write_tests {
         let response = server.delete_node(DeleteNodeRequest {
             node_id: n1.id,
             detach: Some(true),
-            valid_time: Some(rfc3339_hours_ago(1)),
+            valid_time: Some(rfc3339_hours_ago(now, 1)),
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert!(value.get("error").is_some(), "expected error, got {value}");

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -83,11 +83,13 @@ mod node_tests {
     /// Helper to create two `Person` nodes and return their IDs.
     fn create_two_nodes(server: &AletheiaMcpServer) -> (u64, u64) {
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         }))
@@ -100,6 +102,7 @@ mod node_tests {
         let server = create_test_server();
 
         let req = CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         };
@@ -120,6 +123,7 @@ mod node_tests {
         props.insert("age".to_string(), serde_json::json!(30));
 
         let req = CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
         };
@@ -144,6 +148,7 @@ mod node_tests {
         props.insert("name".to_string(), serde_json::json!("Bob"));
 
         let create_req = CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
         };
@@ -193,6 +198,7 @@ mod node_tests {
         props.insert("age".to_string(), serde_json::json!(25));
 
         let create_req = CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
         };
@@ -206,6 +212,7 @@ mod node_tests {
         new_props.insert("city".to_string(), serde_json::json!("London"));
 
         let update_req = UpdateNodeRequest {
+            valid_time: None,
             node_id: created.id,
             properties: new_props,
         };
@@ -226,6 +233,7 @@ mod node_tests {
 
         // Create a node
         let create_req = CreateNodeRequest {
+            valid_time: None,
             label: "ToDelete".to_string(),
             properties: None,
         };
@@ -265,6 +273,7 @@ mod node_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
@@ -300,6 +309,7 @@ mod node_tests {
 
         // A third node so we have both an outgoing and an incoming edge.
         let third = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -307,12 +317,14 @@ mod node_tests {
         let third_id = third_id.id;
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
         });
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: third_id,
             target_id: source_id,
             label: "FOLLOWS".to_string(),
@@ -371,6 +383,7 @@ mod node_tests {
         // A node with no edges deletes cleanly and reports zero edges removed.
         let server = create_test_server();
         let created: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Lonely".to_string(),
             properties: None,
         }))
@@ -396,6 +409,7 @@ mod node_tests {
             props.insert("index".to_string(), serde_json::json!(i));
 
             let req = CreateNodeRequest {
+                valid_time: None,
                 label: "ListTest".to_string(),
                 properties: Some(props),
             };
@@ -425,6 +439,7 @@ mod node_tests {
         // Create nodes with different labels
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "TypeA".to_string(),
                 properties: None,
             });
@@ -432,6 +447,7 @@ mod node_tests {
 
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "TypeB".to_string(),
                 properties: None,
             });
@@ -463,6 +479,7 @@ mod node_tests {
             props.insert("index".to_string(), serde_json::json!(i));
 
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Paginated".to_string(),
                 properties: Some(props),
             });
@@ -512,6 +529,7 @@ mod node_tests {
         // Create some nodes
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Counted".to_string(),
                 properties: None,
             });
@@ -530,6 +548,7 @@ mod node_tests {
         // Create nodes with different labels
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "CountA".to_string(),
                 properties: None,
             });
@@ -537,6 +556,7 @@ mod node_tests {
 
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "CountB".to_string(),
                 properties: None,
             });
@@ -565,6 +585,7 @@ mod edge_tests {
 
     fn create_two_nodes(server: &AletheiaMcpServer) -> (u64, u64) {
         let node1 = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -575,6 +596,7 @@ mod edge_tests {
         let n1: NodeResponse = parse_response(&node1).unwrap();
 
         let node2 = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -593,6 +615,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let req = CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
@@ -617,6 +640,7 @@ mod edge_tests {
         props.insert("strength".to_string(), serde_json::json!(0.9));
 
         let req = CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
@@ -642,6 +666,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let create_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
@@ -666,6 +691,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let create_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
@@ -677,6 +703,7 @@ mod edge_tests {
         new_props.insert("weight".to_string(), serde_json::json!(0.5));
 
         let update_response = server.update_edge(UpdateEdgeRequest {
+            valid_time: None,
             edge_id: created.id,
             properties: new_props,
         });
@@ -694,6 +721,7 @@ mod edge_tests {
         let (source_id, target_id) = create_two_nodes(&server);
 
         let create_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id,
             target_id,
             label: "KNOWS".to_string(),
@@ -723,6 +751,7 @@ mod edge_tests {
 
         // Create node3
         let node3 = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -730,12 +759,14 @@ mod edge_tests {
 
         // Create edges
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1,
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
         });
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n2,
             target_id: n3.id,
             label: "KNOWS".to_string(),
@@ -767,6 +798,7 @@ mod edge_tests {
         assert_eq!(value.get("count"), Some(&serde_json::json!(0)));
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1,
             target_id: n2,
             label: "KNOWS".to_string(),
@@ -785,6 +817,7 @@ mod edge_tests {
 
         // Create node3
         let node3 = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -792,12 +825,14 @@ mod edge_tests {
 
         // Create edges from n1
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1,
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
         });
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1,
             target_id: n3.id,
             label: "WORKS_WITH".to_string(),
@@ -830,6 +865,7 @@ mod edge_tests {
 
         // Create node3
         let node3 = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -837,12 +873,14 @@ mod edge_tests {
 
         // Create edges to n2
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1,
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
         });
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n3.id,
             target_id: n2,
             label: "KNOWS".to_string(),
@@ -871,6 +909,7 @@ mod traversal_tests {
         let nodes: Vec<u64> = (0..4)
             .map(|i| {
                 let response = server.create_node(CreateNodeRequest {
+                    valid_time: None,
                     label: "Node".to_string(),
                     properties: Some({
                         let mut m = HashMap::new();
@@ -886,6 +925,7 @@ mod traversal_tests {
         // Create edges
         for i in 0..3 {
             server.create_edge(CreateEdgeRequest {
+                valid_time: None,
                 source_id: nodes[i],
                 target_id: nodes[i + 1],
                 label: "NEXT".to_string(),
@@ -1062,6 +1102,7 @@ mod vector_tests {
             );
 
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Document".to_string(),
                 properties: Some(props),
             });
@@ -1094,6 +1135,7 @@ mod temporal_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -1116,6 +1158,7 @@ mod temporal_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -1148,18 +1191,21 @@ mod temporal_tests {
 
         // Create nodes and edge
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let edge_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
@@ -1202,6 +1248,7 @@ mod temporal_tests {
     fn test_list_changes_success_shape() {
         let server = create_test_server();
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -1239,6 +1286,7 @@ mod temporal_tests {
     fn test_list_changes_empty_window_is_success() {
         let server = create_test_server();
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -1296,6 +1344,7 @@ mod hybrid_tests {
 
         // Create nodes
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -1306,6 +1355,7 @@ mod hybrid_tests {
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -1341,6 +1391,7 @@ mod hybrid_tests {
         // Create nodes with different labels
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Person".to_string(),
                 properties: None,
             });
@@ -1348,6 +1399,7 @@ mod hybrid_tests {
 
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Document".to_string(),
                 properties: None,
             });
@@ -1409,18 +1461,21 @@ mod hybrid_tests {
 
         // Create a simple graph
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
@@ -1467,6 +1522,7 @@ mod conversion_tests {
         props.insert("array_val".to_string(), serde_json::json!([1, 2, 3]));
 
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Test".to_string(),
             properties: Some(props),
         });
@@ -1499,6 +1555,7 @@ mod conversion_tests {
         );
 
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Document".to_string(),
             properties: Some(props),
         });
@@ -1597,6 +1654,7 @@ mod coverage_tests {
 
         // Create a node first
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Event".to_string(),
             properties: None,
         });
@@ -1629,6 +1687,7 @@ mod coverage_tests {
 
         // Create a node first
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Event".to_string(),
             properties: None,
         });
@@ -1659,6 +1718,7 @@ mod coverage_tests {
 
         // Create a node first
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Event".to_string(),
             properties: None,
         });
@@ -1712,6 +1772,7 @@ mod coverage_tests {
         // Create a few nodes
         for i in 0..5 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "OffsetTest".to_string(),
                 properties: Some({
                     let mut props = HashMap::new();
@@ -1748,6 +1809,7 @@ mod coverage_tests {
         let mut prev_id: Option<u64> = None;
         for i in 0..5 {
             let response = server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "ChainNode".to_string(),
                 properties: Some({
                     let mut props = HashMap::new();
@@ -1759,6 +1821,7 @@ mod coverage_tests {
 
             if let Some(source_id) = prev_id {
                 server.create_edge(CreateEdgeRequest {
+                    valid_time: None,
                     source_id,
                     target_id: node.id,
                     label: "NEXT".to_string(),
@@ -1833,6 +1896,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = UpdateNodeRequest {
+            valid_time: None,
             node_id: 999999,
             properties: HashMap::new(),
         };
@@ -1878,6 +1942,7 @@ mod error_handling_tests {
         let server = create_test_server();
 
         let req = UpdateEdgeRequest {
+            valid_time: None,
             edge_id: 999999,
             properties: HashMap::new(),
         };
@@ -1906,6 +1971,7 @@ mod error_handling_tests {
 
         // Create only target node
         let target_resp = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Target".to_string(),
             properties: None,
         });
@@ -1913,6 +1979,7 @@ mod error_handling_tests {
 
         // Try to create edge with non-existent source
         let req = CreateEdgeRequest {
+            valid_time: None,
             source_id: 999999,
             target_id: target.id,
             label: "KNOWS".to_string(),
@@ -1931,6 +1998,7 @@ mod error_handling_tests {
 
         // Create only source node
         let source_resp = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Source".to_string(),
             properties: None,
         });
@@ -1938,6 +2006,7 @@ mod error_handling_tests {
 
         // Try to create edge with non-existent target
         let req = CreateEdgeRequest {
+            valid_time: None,
             source_id: source.id,
             target_id: 999999,
             label: "KNOWS".to_string(),
@@ -2066,6 +2135,7 @@ mod temporal_extended_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Event".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2108,18 +2178,21 @@ mod temporal_extended_tests {
 
         // Create nodes and edge
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let edge_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
@@ -2151,6 +2224,7 @@ mod temporal_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Test".to_string(),
             properties: None,
         });
@@ -2179,18 +2253,21 @@ mod temporal_extended_tests {
 
         // Create nodes and edge
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let edge_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
@@ -2214,6 +2291,7 @@ mod temporal_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Event".to_string(),
             properties: None,
         });
@@ -2250,6 +2328,7 @@ mod traversal_extended_tests {
         let nodes: Vec<u64> = (0..3)
             .map(|i| {
                 let response = server.create_node(CreateNodeRequest {
+                    valid_time: None,
                     label: "BiNode".to_string(),
                     properties: Some({
                         let mut m = HashMap::new();
@@ -2265,12 +2344,14 @@ mod traversal_extended_tests {
         // Create bidirectional edges
         for i in 0..2 {
             server.create_edge(CreateEdgeRequest {
+                valid_time: None,
                 source_id: nodes[i],
                 target_id: nodes[i + 1],
                 label: "CONNECTED".to_string(),
                 properties: None,
             });
             server.create_edge(CreateEdgeRequest {
+                valid_time: None,
                 source_id: nodes[i + 1],
                 target_id: nodes[i],
                 label: "CONNECTED".to_string(),
@@ -2311,6 +2392,7 @@ mod traversal_extended_tests {
 
         // Create a single node
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Lonely".to_string(),
             properties: None,
         });
@@ -2338,18 +2420,21 @@ mod traversal_extended_tests {
 
         // Create A -> B
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Node".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Node".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "NEXT".to_string(),
@@ -2377,6 +2462,7 @@ mod traversal_extended_tests {
 
         // Create a star graph: center -> 10 spokes
         let center_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Center".to_string(),
             properties: None,
         });
@@ -2384,6 +2470,7 @@ mod traversal_extended_tests {
 
         for i in 0..10 {
             let spoke_response = server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Spoke".to_string(),
                 properties: Some({
                     let mut m = HashMap::new();
@@ -2394,6 +2481,7 @@ mod traversal_extended_tests {
             let spoke: NodeResponse = parse_response(&spoke_response).unwrap();
 
             server.create_edge(CreateEdgeRequest {
+                valid_time: None,
                 source_id: center.id,
                 target_id: spoke.id,
                 label: "SPOKE".to_string(),
@@ -2430,6 +2518,7 @@ mod hybrid_extended_tests {
 
         // Create a node
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2477,6 +2566,7 @@ mod hybrid_extended_tests {
         let nodes: Vec<u64> = (0..4)
             .map(|i| {
                 let response = server.create_node(CreateNodeRequest {
+                    valid_time: None,
                     label: "ChainNode".to_string(),
                     properties: Some({
                         let mut m = HashMap::new();
@@ -2491,6 +2581,7 @@ mod hybrid_extended_tests {
 
         for i in 0..3 {
             server.create_edge(CreateEdgeRequest {
+                valid_time: None,
                 source_id: nodes[i],
                 target_id: nodes[i + 1],
                 label: "CHAIN".to_string(),
@@ -2525,6 +2616,7 @@ mod hybrid_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Test".to_string(),
             properties: None,
         });
@@ -2559,6 +2651,7 @@ mod hybrid_extended_tests {
         let server = create_test_server();
 
         let node_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Test".to_string(),
             properties: None,
         });
@@ -2595,6 +2688,7 @@ mod hybrid_extended_tests {
         // Create some nodes
         for i in 0..5 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "LimitTest".to_string(),
                 properties: Some({
                     let mut m = HashMap::new();
@@ -2669,12 +2763,14 @@ mod edge_extended_tests {
 
         // Create nodes
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -2682,12 +2778,14 @@ mod edge_extended_tests {
 
         // Create edges with different labels
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
         });
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "WORKS_WITH".to_string(),
@@ -2714,18 +2812,21 @@ mod edge_extended_tests {
 
         // Create nodes and edges
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
@@ -2755,18 +2856,21 @@ mod edge_extended_tests {
 
         // Create nodes
         let n1_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
         let n2_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
         let n3_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         });
@@ -2774,12 +2878,14 @@ mod edge_extended_tests {
 
         // Create edges with different labels pointing to n2
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
         });
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n3.id,
             target_id: n2.id,
             label: "WORKS_WITH".to_string(),
@@ -2816,6 +2922,7 @@ mod list_nodes_extended_tests {
         // Create some nodes
         for i in 0..3 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: format!("Type{}", i),
                 properties: None,
             });
@@ -2847,6 +2954,7 @@ mod list_nodes_extended_tests {
         // Create a few nodes
         for i in 0..5 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "LimitCap".to_string(),
                 properties: Some({
                     let mut m = HashMap::new();
@@ -2884,6 +2992,7 @@ mod list_nodes_extended_tests {
 
         // Create nodes with different names
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2892,6 +3001,7 @@ mod list_nodes_extended_tests {
             }),
         });
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2900,6 +3010,7 @@ mod list_nodes_extended_tests {
             }),
         });
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2928,6 +3039,7 @@ mod list_nodes_extended_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Sensor".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2936,6 +3048,7 @@ mod list_nodes_extended_tests {
             }),
         });
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Sensor".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -2967,6 +3080,7 @@ mod list_nodes_extended_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Item".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -3038,6 +3152,7 @@ mod list_nodes_extended_tests {
         // Create 5 nodes with same property
         for _ in 0..5 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Widget".to_string(),
                 properties: Some({
                     let mut m = HashMap::new();
@@ -3103,6 +3218,7 @@ mod query_tool_tests {
         let mut props = HashMap::new();
         props.insert("name".to_string(), serde_json::json!(name));
         let resp = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: label.to_string(),
             properties: Some(props),
         });
@@ -3781,10 +3897,12 @@ mod constraint_tests {
         let mut props = HashMap::new();
         props.insert("email".to_string(), serde_json::json!("dup@x"));
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props.clone()),
         });
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
         });
@@ -3855,6 +3973,7 @@ mod constraint_tests {
         props.insert("email".to_string(), serde_json::json!("alice@x"));
 
         let first_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props.clone()),
         });
@@ -3862,6 +3981,7 @@ mod constraint_tests {
             parse_response(&first_response).expect("first create must succeed");
 
         let dup_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
         });
@@ -3895,6 +4015,7 @@ mod constraint_tests {
         let mut props_a = HashMap::new();
         props_a.insert("email".to_string(), serde_json::json!("a@x"));
         let resp_a = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props_a),
         });
@@ -3903,6 +4024,7 @@ mod constraint_tests {
         let mut props_b = HashMap::new();
         props_b.insert("email".to_string(), serde_json::json!("b@x"));
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props_b),
         });
@@ -3910,6 +4032,7 @@ mod constraint_tests {
         let mut collision = HashMap::new();
         collision.insert("email".to_string(), serde_json::json!("b@x"));
         let update_response = server.update_node(UpdateNodeRequest {
+            valid_time: None,
             node_id: node_a.id,
             properties: collision,
         });
@@ -3937,6 +4060,7 @@ mod constraint_tests {
         let server = create_test_server();
 
         let response = server.update_node(UpdateNodeRequest {
+            valid_time: None,
             node_id: 99999,
             properties: HashMap::new(),
         });
@@ -3992,6 +4116,7 @@ mod schema_tests {
         let server = create_test_server();
 
         let alice_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -4002,6 +4127,7 @@ mod schema_tests {
         let alice: NodeResponse = parse_response(&alice_response).unwrap();
 
         let bob_response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some({
                 let mut m = HashMap::new();
@@ -4012,6 +4138,7 @@ mod schema_tests {
         let bob: NodeResponse = parse_response(&bob_response).unwrap();
 
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: alice.id,
             target_id: bob.id,
             label: "KNOWS".to_string(),
@@ -4070,6 +4197,7 @@ mod schema_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Report".to_string(),
             properties: None,
         });
@@ -4104,6 +4232,7 @@ mod schema_tests {
         let server = create_test_server();
 
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Invoice".to_string(),
             properties: None,
         });
@@ -4142,6 +4271,7 @@ mod schema_tests {
 
         // Create a node now.
         server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Gadget".to_string(),
             properties: None,
         });
@@ -4191,27 +4321,32 @@ mod schema_tests {
 
         for _ in 0..3 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Person".to_string(),
                 properties: None,
             });
         }
         for _ in 0..2 {
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Company".to_string(),
                 properties: None,
             });
         }
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Company".to_string(),
             properties: None,
         }))
         .unwrap();
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "WORKS_AT".to_string(),
@@ -4270,6 +4405,7 @@ mod vector_elision_tests {
             serde_json::json!(embedding.clone()),
         );
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Document".to_string(),
             properties: Some(props),
         });
@@ -4370,11 +4506,13 @@ mod vector_elision_tests {
     fn test_get_edge_and_outgoing_incoming_edges_elide_vectors_by_default() {
         let server = create_test_server();
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: None,
         }))
@@ -4384,6 +4522,7 @@ mod vector_elision_tests {
         let mut props = HashMap::new();
         props.insert("embedding".to_string(), serde_json::json!(embedding));
         let edge_response = server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1.id,
             target_id: n2.id,
             label: "SIMILAR_TO".to_string(),
@@ -4471,6 +4610,7 @@ mod vector_elision_tests {
         let (n1_id, _) = create_node_with_embedding(&server, 5);
         let (n2_id, _) = create_node_with_embedding(&server, 5);
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1_id,
             target_id: n2_id,
             label: "NEXT".to_string(),
@@ -4533,6 +4673,7 @@ mod vector_elision_tests {
                 ]),
             );
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Document".to_string(),
                 properties: Some(props),
             });
@@ -4594,6 +4735,7 @@ mod vector_elision_tests {
                 ]),
             );
             server.create_node(CreateNodeRequest {
+                valid_time: None,
                 label: "Document".to_string(),
                 properties: Some(props),
             });
@@ -4654,6 +4796,7 @@ mod vector_elision_tests {
         let (n1_id, _) = create_node_with_embedding(&server, 4);
         let (n2_id, _) = create_node_with_embedding(&server, 4);
         server.create_edge(CreateEdgeRequest {
+            valid_time: None,
             source_id: n1_id,
             target_id: n2_id,
             label: "NEXT".to_string(),
@@ -4756,6 +4899,7 @@ mod vector_elision_tests {
             serde_json::json!([0.1, 0.2, 0.3, 0.4]),
         );
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Document".to_string(),
             properties: Some(props),
         });
@@ -4776,6 +4920,7 @@ mod vector_elision_tests {
             serde_json::json!([0.5, 0.6, 0.7, 0.8]),
         );
         let update_response = server.update_node(UpdateNodeRequest {
+            valid_time: None,
             node_id: node.id,
             properties: new_props,
         });
@@ -4803,6 +4948,7 @@ mod vector_elision_tests {
         props.insert("tags".to_string(), serde_json::json!(["a", "b", "c"]));
 
         let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
         });
@@ -4821,5 +4967,306 @@ mod vector_elision_tests {
             }
             previous = Some(fetched.properties);
         }
+    }
+}
+
+// ============================================================================
+// Valid-Time Write Tests (Issue #3221)
+// ============================================================================
+
+mod valid_time_write_tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    fn rfc3339_hours_ago(hours: i64) -> String {
+        (Utc::now() - Duration::hours(hours)).to_rfc3339()
+    }
+
+    fn rfc3339_hours_from_now(hours: i64) -> String {
+        (Utc::now() + Duration::hours(hours)).to_rfc3339()
+    }
+
+    #[test]
+    fn test_create_node_with_valid_time_backdated_round_trip() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_ago(1)),
+        });
+        let node: NodeResponse = parse_response(&response).expect("create should succeed");
+
+        // Visible shortly after its valid_from.
+        let visible = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: rfc3339_hours_ago(0),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&visible).unwrap();
+        assert!(value.get("error").is_none(), "expected node, got {value}");
+
+        // Invisible strictly before its valid_from.
+        let invisible = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: rfc3339_hours_ago(2),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&invisible).unwrap();
+        assert!(value.get("error").is_some());
+    }
+
+    #[test]
+    fn test_create_node_omitted_valid_time_matches_today() {
+        // Omitting the field entirely (raw JSON) still deserializes.
+        let parsed: CreateNodeRequest =
+            serde_json::from_value(serde_json::json!({ "label": "Person" }))
+                .expect("valid_time should be optional");
+        assert_eq!(parsed.valid_time, None);
+
+        let server = create_test_server();
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        });
+        let node: NodeResponse = parse_response(&response).expect("create should succeed");
+        assert_eq!(node.label, "Person");
+
+        let now_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: Utc::now().to_rfc3339(),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&now_response).unwrap();
+        assert!(value.get("error").is_none());
+    }
+
+    #[test]
+    fn test_create_node_malformed_valid_time_error_json() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: Some("not-a-timestamp".to_string()),
+        });
+
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        assert!(error.contains("Invalid valid_time"), "got: {error}");
+        assert_eq!(server.db().node_count(), 0, "no node should be created");
+    }
+
+    #[test]
+    fn test_create_node_far_future_valid_time_typed_error_surfaced() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_from_now(24 * 400)), // > 1 year
+        });
+
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        assert!(error.contains("too far in future"), "got: {error}");
+        assert_eq!(server.db().node_count(), 0);
+    }
+
+    #[test]
+    fn test_create_edge_with_valid_time_backdated_round_trip() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+
+        let response = server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_ago(1)),
+        });
+        let edge: EdgeResponse = parse_response(&response).expect("create_edge should succeed");
+
+        let visible = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            edge_id: edge.id,
+            valid_time: rfc3339_hours_ago(0),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&visible).unwrap();
+        assert!(value.get("error").is_none(), "expected edge, got {value}");
+
+        let invisible = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            edge_id: edge.id,
+            valid_time: rfc3339_hours_ago(2),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&invisible).unwrap();
+        assert!(value.get("error").is_some());
+    }
+
+    #[test]
+    fn test_update_node_with_valid_time_backdated() {
+        let server = create_test_server();
+
+        let mut props = HashMap::new();
+        props.insert("city".to_string(), serde_json::json!("Paris"));
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: Some(props),
+            valid_time: Some(rfc3339_hours_ago(2)),
+        }))
+        .unwrap();
+
+        let mut update_props = HashMap::new();
+        update_props.insert("city".to_string(), serde_json::json!("London"));
+        let update_valid_time = rfc3339_hours_ago(1);
+        let response = server.update_node(UpdateNodeRequest {
+            node_id: node.id,
+            properties: update_props,
+            valid_time: Some(update_valid_time.clone()),
+        });
+        let updated: NodeResponse = parse_response(&response).expect("update should succeed");
+        assert_eq!(
+            updated.properties.get("city"),
+            Some(&serde_json::json!("London"))
+        );
+
+        // Visible from its own valid_from onward.
+        let at_update = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: update_valid_time,
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&at_update).unwrap();
+        let fetched: NodeResponse = serde_json::from_value(value["node"].clone()).unwrap();
+        assert_eq!(
+            fetched.properties.get("city"),
+            Some(&serde_json::json!("London"))
+        );
+    }
+
+    #[test]
+    fn test_update_node_valid_time_before_creation_rejected() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+
+        let mut update_props = HashMap::new();
+        update_props.insert("name".to_string(), serde_json::json!("Bob"));
+        let response = server.update_node(UpdateNodeRequest {
+            node_id: node.id,
+            properties: update_props,
+            // Far enough in the past to precede the node's creation time.
+            valid_time: Some("1970-01-01T00:00:01Z".to_string()),
+        });
+
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        assert!(error.contains("before entity creation"), "got: {error}");
+    }
+
+    #[test]
+    fn test_transaction_time_not_client_settable() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_ago(1)),
+        }))
+        .unwrap();
+
+        // As of a transaction_time 30 minutes ago, the write (committed just now)
+        // had not happened yet -- the fact must not be retroactively knowable.
+        let too_early_tx = (Utc::now() - Duration::minutes(30)).to_rfc3339();
+        let too_early = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: rfc3339_hours_ago(0),
+            transaction_time: Some(too_early_tx),
+        });
+        let value: serde_json::Value = serde_json::from_str(&too_early).unwrap();
+        assert!(value.get("error").is_some());
+
+        // Omitting transaction_time defaults to now, where the write is visible.
+        let now_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: rfc3339_hours_ago(0),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&now_response).unwrap();
+        assert!(value.get("error").is_none());
+    }
+
+    #[test]
+    fn test_update_edge_with_valid_time_backdated() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+
+        let mut props = HashMap::new();
+        props.insert("strength".to_string(), serde_json::json!(1));
+        let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: Some(props),
+            valid_time: Some(rfc3339_hours_ago(2)),
+        }))
+        .unwrap();
+
+        let mut update_props = HashMap::new();
+        update_props.insert("strength".to_string(), serde_json::json!(9));
+        let update_valid_time = rfc3339_hours_ago(1);
+        let response = server.update_edge(UpdateEdgeRequest {
+            edge_id: edge.id,
+            properties: update_props,
+            valid_time: Some(update_valid_time.clone()),
+        });
+        let updated: EdgeResponse = parse_response(&response).expect("update should succeed");
+        assert_eq!(
+            updated.properties.get("strength"),
+            Some(&serde_json::json!(9))
+        );
+
+        let at_update = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            edge_id: edge.id,
+            valid_time: update_valid_time,
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&at_update).unwrap();
+        let fetched: EdgeResponse = serde_json::from_value(value["edge"].clone()).unwrap();
+        assert_eq!(
+            fetched.properties.get("strength"),
+            Some(&serde_json::json!(9))
+        );
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -246,6 +246,7 @@ mod node_tests {
         let delete_req = DeleteNodeRequest {
             node_id,
             detach: None,
+            valid_time: None,
         };
 
         let delete_response = server.delete_node(delete_req);
@@ -283,6 +284,7 @@ mod node_tests {
         let delete_response = server.delete_node(DeleteNodeRequest {
             node_id: source_id,
             detach: None,
+            valid_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
 
@@ -334,6 +336,7 @@ mod node_tests {
         let delete_response = server.delete_node(DeleteNodeRequest {
             node_id: source_id,
             detach: Some(true),
+            valid_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
 
@@ -392,6 +395,7 @@ mod node_tests {
         let delete_response = server.delete_node(DeleteNodeRequest {
             node_id: created.id,
             detach: None,
+            valid_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
 
@@ -731,6 +735,7 @@ mod edge_tests {
 
         let delete_response = server.delete_edge(DeleteEdgeRequest {
             edge_id: created.id,
+            valid_time: None,
         });
         let value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
         assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
@@ -1914,6 +1919,7 @@ mod error_handling_tests {
         let req = DeleteNodeRequest {
             node_id: 999999,
             detach: None,
+            valid_time: None,
         };
 
         let response = server.delete_node(req);
@@ -1957,7 +1963,10 @@ mod error_handling_tests {
     fn test_delete_edge_nonexistent() {
         let server = create_test_server();
 
-        let req = DeleteEdgeRequest { edge_id: 999999 };
+        let req = DeleteEdgeRequest {
+            edge_id: 999999,
+            valid_time: None,
+        };
 
         let response = server.delete_edge(req);
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5268,5 +5277,235 @@ mod valid_time_write_tests {
             fetched.properties.get("strength"),
             Some(&serde_json::json!(9))
         );
+    }
+
+    /// Regression test: `create_edge_with_valid_time` used to be the only one of the six
+    /// `*_with_valid_time` operations that never enforced the 1-year future cap, so an
+    /// edge could silently be created with an arbitrarily-far-future `valid_time`. Mirrors
+    /// `test_create_node_far_future_valid_time_typed_error_surfaced`.
+    #[test]
+    fn test_create_edge_far_future_valid_time_typed_error_surfaced() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+
+        let response = server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_from_now(24 * 400)), // > 1 year
+        });
+
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        assert!(error.contains("too far in future"), "got: {error}");
+        assert_eq!(server.db().edge_count(), 0);
+    }
+
+    /// `delete_node`'s `valid_time` field: the caller-specified `valid_from` is
+    /// correctly threaded through to the tombstone version, and the node is no longer
+    /// visible as of now. (A probe strictly between create's and delete's `valid_from`
+    /// is not reachable via `get_node_at_time` -- deleting closes the previous version's
+    /// *transaction* time at commit, same documented caveat as
+    /// `update_node_with_valid_time_backdated_round_trip` in `db::ops::tests`.)
+    #[test]
+    fn test_delete_node_with_valid_time_backdated_round_trip() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_ago(2)),
+        }))
+        .unwrap();
+
+        let delete_valid_time = rfc3339_hours_ago(1);
+        let response = server.delete_node(DeleteNodeRequest {
+            node_id: node.id,
+            detach: None,
+            valid_time: Some(delete_valid_time.clone()),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
+
+        // The caller-specified valid_from was correctly threaded through to the
+        // tombstone version.
+        let node_id = crate::core::id::NodeId::new(node.id).unwrap();
+        let historical = server.db().historical.read();
+        let version_id = historical.get_current_node_version(node_id).unwrap();
+        let version = historical.get_node_version(version_id).unwrap();
+        let recorded_valid_from = version.temporal.valid_time().start();
+        drop(historical);
+        let expected: chrono::DateTime<Utc> = delete_valid_time.parse().unwrap();
+        assert_eq!(
+            recorded_valid_from.wallclock(),
+            expected.timestamp_micros(),
+            "tombstone valid_from should match the requested delete_valid_time"
+        );
+
+        // No longer visible as of now.
+        let gone = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: Utc::now().to_rfc3339(),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&gone).unwrap();
+        assert!(value.get("error").is_some());
+    }
+
+    /// `delete_edge`'s `valid_time` field: edge mirror of the node round trip above --
+    /// same caveat about the probe-strictly-between-versions gap applies.
+    #[test]
+    fn test_delete_edge_with_valid_time_backdated_round_trip() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: Some(rfc3339_hours_ago(2)),
+        }))
+        .unwrap();
+
+        let delete_valid_time = rfc3339_hours_ago(1);
+        let response = server.delete_edge(DeleteEdgeRequest {
+            edge_id: edge.id,
+            valid_time: Some(delete_valid_time.clone()),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
+
+        // The caller-specified valid_from was correctly threaded through to the
+        // tombstone version.
+        let edge_id = crate::core::id::EdgeId::new(edge.id).unwrap();
+        let historical = server.db().historical.read();
+        let version_id = historical.get_current_edge_version(edge_id).unwrap();
+        let version = historical.get_edge_version(version_id).unwrap();
+        let recorded_valid_from = version.temporal.valid_time().start();
+        drop(historical);
+        let expected: chrono::DateTime<Utc> = delete_valid_time.parse().unwrap();
+        assert_eq!(
+            recorded_valid_from.wallclock(),
+            expected.timestamp_micros(),
+            "tombstone valid_from should match the requested delete_valid_time"
+        );
+
+        // No longer visible as of now.
+        let gone = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            edge_id: edge.id,
+            valid_time: Utc::now().to_rfc3339(),
+            transaction_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&gone).unwrap();
+        assert!(value.get("error").is_some());
+    }
+
+    /// `detach: true` (cascade delete) does not support backdating -- passing
+    /// `valid_time` alongside it must be a clear, structured rejection rather than
+    /// silently ignoring `valid_time` or cascading at the wrong time.
+    #[test]
+    fn test_delete_node_detach_with_valid_time_rejected() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+
+        let response = server.delete_node(DeleteNodeRequest {
+            node_id: n1.id,
+            detach: Some(true),
+            valid_time: Some(rfc3339_hours_ago(1)),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("error").is_some(), "expected error, got {value}");
+        assert_ne!(value.get("success"), Some(&serde_json::json!(true)));
+
+        // Node and edge must be untouched by the rejected request.
+        let get_value: serde_json::Value = serde_json::from_str(&server.get_node(GetNodeRequest {
+            node_id: n1.id,
+            include_vectors: None,
+        }))
+        .unwrap();
+        assert!(get_value.get("error").is_none(), "node should still exist");
+    }
+
+    /// Plain cascade delete (`detach: true`, no `valid_time`) must behave exactly as
+    /// before this fix -- a regression guard alongside the new rejection above.
+    #[test]
+    fn test_delete_node_detach_without_valid_time_unchanged() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+        parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+        }))
+        .unwrap();
+
+        let response = server.delete_node(DeleteNodeRequest {
+            node_id: n1.id,
+            detach: Some(true),
+            valid_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
+        assert_eq!(value.get("edges_removed"), Some(&serde_json::json!(1)));
+        assert_eq!(value.get("detached"), Some(&serde_json::json!(true)));
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -92,6 +92,17 @@ pub struct DeleteNodeRequest {
                        and the response reports the connected edge count so the caller can decide."
     )]
     pub detach: Option<bool>,
+
+    /// Optional valid time: when this fact stopped being true in the real world.
+    #[schemars(
+        description = "Optional valid time: when this fact stopped being true in the real world, \
+                       as an ISO 8601 / RFC 3339 timestamp (e.g., '2024-01-15T10:00:00Z') or integer \
+                       microseconds since epoch. Omit to default to the transaction time (today's \
+                       behavior). Must not precede the node's own creation time. Not supported \
+                       together with detach:true (cascade delete does not support backdating). \
+                       Transaction time is always system-assigned and cannot be set."
+    )]
+    pub valid_time: Option<String>,
 }
 
 /// Request to delete a node and all its connected edges (cascade delete).
@@ -227,6 +238,16 @@ pub struct DeleteEdgeRequest {
     /// The unique identifier of the edge to delete.
     #[schemars(description = "The unique identifier of the edge to delete")]
     pub edge_id: u64,
+
+    /// Optional valid time: when this fact stopped being true in the real world.
+    #[schemars(
+        description = "Optional valid time: when this fact stopped being true in the real world, \
+                       as an ISO 8601 / RFC 3339 timestamp (e.g., '2024-01-15T10:00:00Z') or integer \
+                       microseconds since epoch. Omit to default to the transaction time (today's \
+                       behavior). Must not precede the edge's own creation time. Transaction time \
+                       is always system-assigned and cannot be set."
+    )]
+    pub valid_time: Option<String>,
 }
 
 /// Request to list edges with optional filtering.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -37,6 +37,16 @@ pub struct CreateNodeRequest {
     /// Properties to set on the node as key-value pairs.
     #[schemars(description = "Properties to set on the node as key-value pairs")]
     pub properties: Option<HashMap<String, serde_json::Value>>,
+
+    /// Optional valid time: when this fact became true in the real world.
+    #[schemars(
+        description = "Optional valid time: when this fact became true in the real world, as an \
+                       ISO 8601 / RFC 3339 timestamp (e.g., '2024-01-15T10:00:00Z') or integer \
+                       microseconds since epoch. Omit to default to the transaction time (today's \
+                       behavior). Backdating records history; up to 1 year in the future is \
+                       allowed. Transaction time is always system-assigned and cannot be set."
+    )]
+    pub valid_time: Option<String>,
 }
 
 /// Request to update an existing node's properties.
@@ -49,6 +59,16 @@ pub struct UpdateNodeRequest {
     /// New properties to set (replaces all existing properties).
     #[schemars(description = "New properties to set (replaces all existing properties)")]
     pub properties: HashMap<String, serde_json::Value>,
+
+    /// Optional valid time: when this update became true in the real world.
+    #[schemars(
+        description = "Optional valid time: when this update became true in the real world, as an \
+                       ISO 8601 / RFC 3339 timestamp (e.g., '2024-01-15T10:00:00Z') or integer \
+                       microseconds since epoch. Omit to default to the transaction time (today's \
+                       behavior). Must not precede the node's own creation time. Transaction time \
+                       is always system-assigned and cannot be set."
+    )]
+    pub valid_time: Option<String>,
 }
 
 /// Request to delete a node.
@@ -167,6 +187,16 @@ pub struct CreateEdgeRequest {
     /// Properties to set on the edge as key-value pairs.
     #[schemars(description = "Properties to set on the edge as key-value pairs")]
     pub properties: Option<HashMap<String, serde_json::Value>>,
+
+    /// Optional valid time: when this relationship became true in the real world.
+    #[schemars(
+        description = "Optional valid time: when this relationship became true in the real world, \
+                       as an ISO 8601 / RFC 3339 timestamp (e.g., '2024-01-15T10:00:00Z') or integer \
+                       microseconds since epoch. Omit to default to the transaction time (today's \
+                       behavior). Backdating records history; up to 1 year in the future is \
+                       allowed. Transaction time is always system-assigned and cannot be set."
+    )]
+    pub valid_time: Option<String>,
 }
 
 /// Request to update an existing edge's properties.
@@ -179,6 +209,16 @@ pub struct UpdateEdgeRequest {
     /// New properties to set (replaces all existing properties).
     #[schemars(description = "New properties to set (replaces all existing properties)")]
     pub properties: HashMap<String, serde_json::Value>,
+
+    /// Optional valid time: when this update became true in the real world.
+    #[schemars(
+        description = "Optional valid time: when this update became true in the real world, as an \
+                       ISO 8601 / RFC 3339 timestamp (e.g., '2024-01-15T10:00:00Z') or integer \
+                       microseconds since epoch. Omit to default to the transaction time (today's \
+                       behavior). Must not precede the edge's own creation time. Transaction time \
+                       is always system-assigned and cannot be set."
+    )]
+    pub valid_time: Option<String>,
 }
 
 /// Request to delete an edge.

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1333,6 +1333,39 @@ impl HistoricalStorage {
         self.edge_version_heads.get(&edge_id).copied()
     }
 
+    /// Get the node's true creation time: the `valid_from` of its first-ever version.
+    ///
+    /// Walks `prev_version` links from the current head back to the terminal (oldest)
+    /// version. Unlike `get_current_node_version`, which returns the *latest* version,
+    /// this is the correct floor for "was this valid_from before the entity existed"
+    /// checks — the latest version's `valid_from` can be later than the entity's true
+    /// creation time when a prior write already backdated it.
+    pub(crate) fn node_creation_time(&self, node_id: NodeId) -> Option<Timestamp> {
+        let mut version_id = self.get_current_node_version(node_id)?;
+        loop {
+            let version = self.get_node_version(version_id)?;
+            match version.prev_version {
+                Some(prev) => version_id = prev,
+                None => return Some(version.temporal.valid_time().start()),
+            }
+        }
+    }
+
+    /// Get the edge's true creation time: the `valid_from` of its first-ever version.
+    ///
+    /// See [`Self::node_creation_time`] for why this must walk to the terminal version
+    /// rather than reading the current (latest) one.
+    pub(crate) fn edge_creation_time(&self, edge_id: EdgeId) -> Option<Timestamp> {
+        let mut version_id = self.get_current_edge_version(edge_id)?;
+        loop {
+            let version = self.get_edge_version(version_id)?;
+            match version.prev_version {
+                Some(prev) => version_id = prev,
+                None => return Some(version.temporal.valid_time().start()),
+            }
+        }
+    }
+
     /// Get the IDs of every node that has ever had at least one version recorded.
     ///
     /// Used for bi-temporal schema discovery (Issue #3214): the caller reconstructs


### PR DESCRIPTION
## Summary

Expose the existing `WriteOps::*_with_valid_time` trait methods on the top-level `AletheiaDB` convenience API and add optional `valid_time` fields to all MCP write tools (`create_node`, `create_edge`, `update_node`, `update_edge`, `delete_node`, `delete_edge`). This enables LLMs and other clients to record facts at their real-world effective dates without hand-writing transactions.

## Key Changes

- **Convenience API** (`src/db/ops.rs`):
  - Added `create_node_with_valid_time()`, `create_edge_with_valid_time()`, `update_node_with_valid_time()`, `update_edge_with_valid_time()`, `delete_node_with_valid_time()`, and `delete_edge_with_valid_time()` methods to `AletheiaDB`
  - Refactored existing `create_node()` and `create_edge()` to delegate to their `_with_valid_time` variants with `None`
  - Added comprehensive documentation with examples for each method

- **MCP Tools** (`src/mcp/tools.rs`):
  - Added optional `valid_time: Option<String>` field to `CreateNodeRequest`, `UpdateNodeRequest`, `CreateEdgeRequest`, `UpdateEdgeRequest`, `DeleteNodeRequest`, and `DeleteEdgeRequest`
  - Field accepts ISO 8601 / RFC 3339 timestamps or microseconds since epoch
  - Documented constraints: up to 1 year in the future allowed, transaction time always system-assigned

- **MCP Server** (`src/mcp/server.rs`):
  - Updated `create_node()`, `update_node()`, `delete_node()`, `create_edge()`, `update_edge()`, and `delete_edge()` handlers to parse and pass `valid_time` to the corresponding `_with_valid_time` methods
  - Added validation: `delete_node` with `detach: true` rejects `valid_time` (cascade delete does not support backdating)
  - Updated example in docstring to include `valid_time` field

- **Transaction Layer** (`src/api/transaction/write/mod.rs`):
  - Fixed bug where `create_edge_with_valid_time` was not validating far-future `valid_time` (now calls `validate_valid_from_future`)
  - Fixed bug where update/delete validation used latest version's `valid_from` instead of entity's true creation time as the floor for backfill checks
  - Added `node_creation_time()` and `edge_creation_time()` helpers to `HistoricalStorage` to retrieve the true creation time

- **Tests**:
  - Updated all test cases in `src/mcp/tests.rs` to explicitly set `valid_time: None` on all request structs
  - Added regression tests in `src/api/transaction/write/tests.rs`:
    - `test_create_edge_rejects_far_future_valid_time`: Ensures edge creation validates far-future timestamps
    - `test_update_node_valid_time_backfill_between_existing_versions_succeeds`: Verifies backfill between existing versions works correctly
    - `test_update_edge_valid_time_backfill_between_existing_versions_succeeds`: Edge mirror of above
    - `test_delete_node_valid_time_backfill_between_existing_versions_succeeds`: Node deletion backfill test
    - `test_delete_edge_valid_time_backfill_between_existing_versions_succeeds`: Edge deletion backfill test
  - Added integration tests in `src/db/ops.rs` for round-trip backdated and future-dated node/edge creation

- **Documentation**:
  - Updated `docs/guides/mcp-query-tool.md` with example of recording facts at specific valid times via MCP
  - Updated `docs/guides/core-concepts.md` with Rust API examples for `_with_valid_time` methods
  - Updated `CHANGELOG.md` with feature description and issue reference

- **Version

https://claude.ai/code/session_01MoUDSWDTEu2HFomR1ZPN59