### PR TITLE
Add AletheiaDB::open(path) one-liner for durable databases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,17 +531,33 @@ let config = AletheiaDBConfig::builder()
 
 ## Persistence Quickstart
 
-**⚠️ Common Mistake:** There is **NO `AletheiaDB::open()` method**. Use `with_unified_config()` instead.
-
 AletheiaDB provides **two persistence systems** (cold storage requires manual setup):
 
 | System | Purpose | Setup |
 |--------|---------|-------|
-| **WAL** | Transaction durability | ✅ Via config |
-| **Index Persistence** | Fast restarts (6-30x) | ✅ Via config |
+| **WAL** | Transaction durability | ✅ Via `open()` |
+| **Index Persistence** | Fast restarts (6-30x) | ✅ Via `open()` |
 | **Cold Storage (Redb)** | Unlimited history | ⚙️ Manual (see guide) |
 
 ### Quick Setup (WAL + Index Persistence)
+
+The one-line entry point for a durable database is `AletheiaDB::open(path)`:
+
+```rust
+use aletheiadb::AletheiaDB;
+
+let db_path = std::env::current_dir()?.join(".my-app-data");
+
+// ✅ Creates directories automatically! Idempotent across restarts.
+let db = AletheiaDB::open(&db_path)?;
+```
+
+`open(path)` is the durable counterpart to `AletheiaDB::new()` (which is
+ephemeral/tempdir-backed). It is exactly
+`with_unified_config(durable_config_for_data_dir(path))` under the hood —
+WAL + index persistence with `load_on_startup`, group-commit durability —
+so power users who need to tune those settings can still call
+`with_unified_config` directly with a custom config:
 
 ```rust
 use aletheiadb::{AletheiaDB, AletheiaDBConfig};

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Requires Rust 1.92+.
 use aletheiadb::prelude::*;
 
 fn main() -> Result<()> {
-    let db = AletheiaDB::new()?;
+    // Durable: persists across restarts at this path. For an ephemeral,
+    // in-memory-only database (tests, scratch sessions), use `AletheiaDB::new()`.
+    let db = AletheiaDB::open("./mydb")?;
 
     // Create nodes and a relationship
     let alice = db.create_node("Person", properties! { "name" => "Alice" })?;

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Requires Rust 1.92+.
 use aletheiadb::prelude::*;
 
 fn main() -> Result<()> {
-    // Durable: persists across restarts at this path. For an ephemeral,
-    // in-memory-only database (tests, scratch sessions), use `AletheiaDB::new()`.
+    // Durable: persists across restarts at this path, so rerunning this
+    // example against the same `./mydb` directory adds more nodes each time
+    // (delete `./mydb` to start fresh). For an ephemeral, in-memory-only
+    // database (tests, scratch sessions), use `AletheiaDB::new()`.
     let db = AletheiaDB::open("./mydb")?;
 
     // Create nodes and a relationship

--- a/docs/guides/PERSISTENCE.md
+++ b/docs/guides/PERSISTENCE.md
@@ -58,6 +58,10 @@ Equivalent explicit config (useful if you later need to layer in Pattern 3):
 let config = AletheiaDBConfig::builder()
     .wal(WalConfigBuilder::new()
         .wal_dir("data/wal")
+        .durability_mode(DurabilityMode::GroupCommit {
+            max_delay_ms: 10,
+            max_batch_size: 200,
+        })
         .build())
     .persistence(PersistenceConfig {
         enabled: true,

--- a/docs/guides/PERSISTENCE.md
+++ b/docs/guides/PERSISTENCE.md
@@ -14,7 +14,10 @@ AletheiaDB provides **three complementary persistence systems** for different us
 | **Index Persistence** | Fast cold starts | Current state indexes | 6-30x faster startup |
 | **Cold Storage (Redb)** | Unlimited history | Historical versions (bi-temporal) | Enables unlimited depth |
 
-**⚠️ Common Mistake:** Trying to call `AletheiaDB::open()`. That API does not exist. For restart, use `with_unified_config()` with persistence enabled.
+**Quickest path:** `AletheiaDB::open(path)` gives you Pattern 2 (WAL + Index
+Persistence) in one line — see below. Reach for `with_unified_config()`
+directly only when you need to tune durability mode, stripe counts, or add
+cold storage (Pattern 3).
 
 ## Current Reality (Important)
 
@@ -44,6 +47,13 @@ let config = AletheiaDBConfig::builder()
 
 ### Pattern 2: Fast Restarts (WAL + Index Persistence)
 **Use when:** You need fast startup and data persistence
+
+The one-liner:
+```rust
+let db = AletheiaDB::open("data")?;
+```
+
+Equivalent explicit config (useful if you later need to layer in Pattern 3):
 ```rust
 let config = AletheiaDBConfig::builder()
     .wal(WalConfigBuilder::new()
@@ -56,6 +66,7 @@ let config = AletheiaDBConfig::builder()
         ..Default::default()
     })
     .build();
+let db = AletheiaDB::with_unified_config(config)?;
 ```
 - ✅ Data survives crashes
 - ✅ Fast startup (6-30x faster)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -29,6 +29,12 @@ path you choose, use `AletheiaDB::open(path)` instead:
 let db = AletheiaDB::open("./mydb")?;
 ```
 
+> **Note on leftover state**: Unlike `new()`, data at a path passed to
+> `open()` survives between runs. If you run this guide's examples against
+> the same `./mydb` directory more than once, each run adds its own nodes on
+> top of the last rather than starting fresh. Delete `./mydb` between runs,
+> or point each run at its own path, if you want a clean slate.
+
 For custom durability settings or cold storage, use
 `AletheiaDB::with_unified_config()` — see [Persistence Guide](PERSISTENCE.md).
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -20,15 +20,17 @@ fn main() -> Result<()> {
 }
 ```
 
-`AletheiaDB::new()` creates a **disk-backed** database in `./aletheiadb/wal`
-(relative to the current working directory) with Group Commit durability. Data
-survives process restart. For a different path, in-memory testing, or custom
-durability settings, use `AletheiaDB::with_unified_config()` — see
-[Persistence Guide](PERSISTENCE.md).
+`AletheiaDB::new()` creates an **ephemeral**, tempdir-backed database — it
+does not survive process restart. That's the right choice for this guide's
+examples, tests, and scratch sessions. For a database that persists at a
+path you choose, use `AletheiaDB::open(path)` instead:
 
-> **Note on leftover state**: If you run examples in the same directory repeatedly,
-> you may see `InvalidTimeRange` errors from previous runs. Clear `./aletheiadb`
-> between runs, or point each run at its own directory via `AletheiaDBConfig`.
+```rust
+let db = AletheiaDB::open("./mydb")?;
+```
+
+For custom durability settings or cold storage, use
+`AletheiaDB::with_unified_config()` — see [Persistence Guide](PERSISTENCE.md).
 
 ---
 

--- a/docs/guides/index-persistence-guide.md
+++ b/docs/guides/index-persistence-guide.md
@@ -31,13 +31,21 @@ As of 2026-02, the active restart/recovery path is:
 Notes:
 - `StringInterner` is persisted and restored; interned IDs survive restart.
 - Legacy references to `storage::persistence` / `PersistenceManager` are obsolete.
-- `AletheiaDB::open()` is not an API in this codebase.
+- `AletheiaDB::open(path)` is the one-line entry point for this restart/recovery path with default settings.
 
 ## File-Based Persistence Quickstart
 
-**⚠️ Common Mistake:** Trying to use `AletheiaDB::open()` for startup. That API does not exist. Use `with_unified_config()` for full index/interner restore.
+The default settings above are exactly what `AletheiaDB::open(path)` gives you:
 
-### The Right Way (File-Based Persistence)
+```rust
+let db = AletheiaDB::open(std::env::current_dir()?.join(".my-app-data"))?;
+```
+
+### Custom Paths and Tuning (Full Control)
+
+Reach for `with_unified_config()` directly when you need to override
+defaults — e.g. a non-default `auto_persist_interval` — for full
+index/interner restore:
 
 ```rust
 use aletheiadb::{AletheiaDB, AletheiaDBConfig};

--- a/docs/guides/index-persistence-guide.md
+++ b/docs/guides/index-persistence-guide.md
@@ -44,14 +44,16 @@ let db = AletheiaDB::open(std::env::current_dir()?.join(".my-app-data"))?;
 ### Custom Paths and Tuning (Full Control)
 
 Reach for `with_unified_config()` directly when you need to override
-defaults — e.g. a non-default `auto_persist_interval` — for full
+defaults — e.g. non-default persistence trigger policies — for full
 index/interner restore:
 
 ```rust
 use aletheiadb::{AletheiaDB, AletheiaDBConfig};
 use aletheiadb::config::WalConfigBuilder;
 use aletheiadb::storage::index_persistence::PersistenceConfig;
-use std::time::Duration;
+use aletheiadb::storage::index_persistence::formats::{
+    GraphPersistencePolicy, PersistencePolicies,
+};
 
 // Configure database with custom paths
 let db_path = std::env::current_dir()?.join(".my-app-data");
@@ -64,7 +66,14 @@ let config = AletheiaDBConfig::builder()
         enabled: true,
         data_dir: db_path.join("indexes"),  // Index persistence location
         load_on_startup: true,  // Load existing indexes on startup
-        auto_persist_interval: Duration::from_secs(300),  // Save every 5min
+        policies: PersistencePolicies {
+            // Save the graph index every 5min instead of the 10min default
+            graph: GraphPersistencePolicy {
+                time_interval_secs: 300,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     })
     .build();

--- a/python/src/db.rs
+++ b/python/src/db.rs
@@ -54,6 +54,12 @@ impl PyAletheiaDB {
     }
 
     /// Open a database from a TOML config file.
+    ///
+    /// Note: `config_path` is a path to a **TOML config file**, not a data
+    /// directory — this is a different contract from the Rust-level
+    /// `AletheiaDB::open(path)` (which treats `path` as a durable data
+    /// directory root). Do not forward this method to the Rust `open()`;
+    /// they are intentionally distinct entry points.
     #[staticmethod]
     fn open(config_path: &str) -> PyResult<Self> {
         use aletheiadb::AletheiaDBConfig;

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -108,11 +108,13 @@ impl AletheiaDB {
     /// state survives the process; nothing is loaded from prior runs.
     ///
     /// This is the right constructor for tests, scratch sessions, and quick
-    /// experiments. For durable storage that replays prior state on restart,
-    /// use [`Self::with_unified_config`] with a config built from
-    /// [`crate::config::durable_config_for_data_dir`], or call
-    /// [`Self::open_from_env`] to honor the `ALETHEIADB_DATA_DIR` environment
-    /// variable.
+    /// experiments. For durable storage that persists across restarts, use
+    /// [`Self::open`] — the one-line durable counterpart to this
+    /// constructor. Power users needing full control can call
+    /// [`Self::with_unified_config`] with a config built from
+    /// [`crate::config::durable_config_for_data_dir`], or
+    /// [`Self::open_from_env`] to honor the `ALETHEIADB_DATA_DIR`
+    /// environment variable.
     ///
     /// # Errors
     ///
@@ -162,6 +164,59 @@ impl AletheiaDB {
             return Self::with_unified_config(crate::config::durable_config_for_data_dir(path));
         }
         Self::new()
+    }
+
+    /// Open (or create) a **durable** database rooted at `path`.
+    ///
+    /// This is the one-line entry point for embedding a durable AletheiaDB:
+    /// it creates the directory tree at `path` if absent, and opens an
+    /// existing one otherwise, replaying any prior state so calls are
+    /// idempotent across process restarts. Internally it is exactly
+    /// [`Self::with_unified_config`] with a config built by
+    /// [`crate::config::durable_config_for_data_dir`] — WAL + index
+    /// persistence with `load_on_startup`, group-commit durability — so
+    /// behavior stays in one canonical place and does not fork config
+    /// defaults. For an ephemeral, tempdir-backed database, use
+    /// [`Self::new`] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `path` is not writable, WAL initialization
+    /// fails, or index loading fails. Never falls back to an ephemeral
+    /// database on failure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let dir = tempfile::tempdir()?;
+    ///
+    /// let node_id = {
+    ///     let db = AletheiaDB::open(dir.path())?;
+    ///     db.create_node(
+    ///         "Person",
+    ///         PropertyMapBuilder::new().insert("name", "Alice").build(),
+    ///     )?
+    ///     // `db` drops here, persisting final state.
+    /// };
+    ///
+    /// // Reopening the same path replays the prior state.
+    /// let db = AletheiaDB::open(dir.path())?;
+    /// let node = db.get_node(node_id)?;
+    /// assert_eq!(
+    ///     node.properties.get("name").and_then(|v| v.as_str()),
+    ///     Some("Alice")
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        Self::with_unified_config(crate::config::durable_config_for_data_dir(
+            path.as_ref().to_path_buf(),
+        ))
     }
 
     /// Load a TOML config and open the database with it. Used by

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -144,8 +144,7 @@ impl AletheiaDB {
     ///    (enabled by default); without that feature this returns an error
     ///    when the variable is set.
     /// 2. `ALETHEIADB_DATA_DIR=/path` — open a durable database rooted at
-    ///    that path with the canonical config from
-    ///    [`crate::config::durable_config_for_data_dir`].
+    ///    that path via [`Self::open`].
     /// 3. Neither set — fall back to [`Self::new`] (ephemeral, tempdir-backed).
     ///
     /// This is the entry point every exposed binary (HTTP server, MCP server,
@@ -161,7 +160,7 @@ impl AletheiaDB {
             return Self::open_from_toml_path(&path);
         }
         if let Some(path) = crate::config::data_dir_from_env() {
-            return Self::with_unified_config(crate::config::durable_config_for_data_dir(path));
+            return Self::open(path);
         }
         Self::new()
     }

--- a/tests/open_durable.rs
+++ b/tests/open_durable.rs
@@ -1,0 +1,126 @@
+#![cfg(test)]
+
+//! Integration tests for `AletheiaDB::open(path)` (Issue #3227).
+//!
+//! These tests exercise the durable one-liner constructor: creating the
+//! directory tree if absent, round-tripping data across a drop + reopen,
+//! matching the canonical `with_unified_config(durable_config_for_data_dir)`
+//! shape exactly, and surfacing I/O failures as `Result::Err` rather than
+//! panicking.
+
+use aletheiadb::config::durable_config_for_data_dir;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use tempfile::tempdir;
+
+/// `open` on a nonexistent nested path creates the directory tree, and data
+/// written through one handle is visible after dropping it and reopening the
+/// same path in a fresh handle (round-trip durability, AC 1 & 2).
+#[test]
+fn open_write_drop_reopen_read_round_trip() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("nested").join("db");
+    assert!(!data_dir.exists(), "precondition: path must not pre-exist");
+
+    let node_id = {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        let node_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Alice").build(),
+            )
+            .unwrap();
+        let other_id = db
+            .create_node(
+                "Person",
+                PropertyMapBuilder::new().insert("name", "Bob").build(),
+            )
+            .unwrap();
+        db.create_edge(
+            node_id,
+            other_id,
+            "KNOWS",
+            PropertyMapBuilder::new().insert("since", 2024).build(),
+        )
+        .unwrap();
+        node_id
+        // db dropped here, triggering shutdown persistence
+    };
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    let node = db2.get_node(node_id).unwrap();
+    let name = node.properties.get("name").and_then(|v| v.as_str());
+    assert_eq!(name, Some("Alice"));
+
+    let outgoing = db2.get_outgoing_edges(node_id);
+    assert_eq!(outgoing.len(), 1);
+}
+
+/// The directory layout created by `open` matches the canonical
+/// `{path}/wal` and `{path}/indexes` shape (AC 3, no forked config).
+#[test]
+fn open_creates_canonical_layout() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    {
+        let db = AletheiaDB::open(&data_dir).unwrap();
+        db.create_node("Person", PropertyMapBuilder::new().build())
+            .unwrap();
+    }
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    assert!(data_dir.join("wal").exists(), "WAL dir should be created");
+    assert!(
+        data_dir.join("indexes").exists(),
+        "index persistence dir should be created"
+    );
+}
+
+/// `AletheiaDB::open(p)` is semantically equivalent to
+/// `with_unified_config(durable_config_for_data_dir(p))`: a data dir created
+/// through the explicit config path opens unchanged through `open` (AC 3 & 7).
+#[test]
+fn open_is_equivalent_to_durable_config() {
+    let dir = tempdir().unwrap();
+    let data_dir = dir.path().join("db");
+
+    let node_id = {
+        let config = durable_config_for_data_dir(data_dir.clone());
+        let db = AletheiaDB::with_unified_config(config).unwrap();
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Carol").build(),
+        )
+        .unwrap()
+    };
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let db2 = AletheiaDB::open(&data_dir).unwrap();
+    let node = db2.get_node(node_id).unwrap();
+    let name = node.properties.get("name").and_then(|v| v.as_str());
+    assert_eq!(name, Some("Carol"));
+}
+
+/// Opening at a path whose parent component is a regular file cannot
+/// possibly succeed; `open` must surface this as `Err`, never panic
+/// (AC 5).
+#[test]
+fn open_surfaces_io_error_not_panic() {
+    let dir = tempdir().unwrap();
+    let blocking_file = dir.path().join("not_a_directory");
+    std::fs::write(&blocking_file, b"i am a file, not a dir").unwrap();
+
+    let data_dir = blocking_file.join("db");
+    let result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| AletheiaDB::open(&data_dir)));
+
+    let result = result.expect("open() must not panic on an unusable path");
+    assert!(
+        result.is_err(),
+        "opening under a path whose parent is a regular file must return Err"
+    );
+}

--- a/tests/open_durable.rs
+++ b/tests/open_durable.rs
@@ -7,6 +7,18 @@
 //! matching the canonical `with_unified_config(durable_config_for_data_dir)`
 //! shape exactly, and surfacing I/O failures as `Result::Err` rather than
 //! panicking.
+//!
+//! `tests/http_persistence.rs` (feature-gated behind `http-server`) asserts
+//! similar durability/layout invariants through `ServerConfig`'s config
+//! construction path; the tests here cover the same invariants through the
+//! `AletheiaDB::open()` entry point directly, so this crate's durability
+//! contract is verified independent of whether the HTTP server is compiled
+//! in.
+//!
+//! None of these tests need to wait after dropping a database: `Drop` for
+//! `AletheiaDB` synchronously joins the background persistence thread (which
+//! performs a final flush as its last action) before returning, so state is
+//! guaranteed durable the moment a `db` handle's scope ends.
 
 use aletheiadb::config::durable_config_for_data_dir;
 use aletheiadb::{AletheiaDB, PropertyMapBuilder};
@@ -43,10 +55,8 @@ fn open_write_drop_reopen_read_round_trip() {
         )
         .unwrap();
         node_id
-        // db dropped here, triggering shutdown persistence
+        // db dropped here, synchronously persisting final state.
     };
-
-    std::thread::sleep(std::time::Duration::from_millis(200));
 
     let db2 = AletheiaDB::open(&data_dir).unwrap();
     let node = db2.get_node(node_id).unwrap();
@@ -68,9 +78,8 @@ fn open_creates_canonical_layout() {
         let db = AletheiaDB::open(&data_dir).unwrap();
         db.create_node("Person", PropertyMapBuilder::new().build())
             .unwrap();
+        // db dropped here, synchronously persisting final state.
     }
-
-    std::thread::sleep(std::time::Duration::from_millis(200));
 
     assert!(data_dir.join("wal").exists(), "WAL dir should be created");
     assert!(
@@ -95,9 +104,8 @@ fn open_is_equivalent_to_durable_config() {
             PropertyMapBuilder::new().insert("name", "Carol").build(),
         )
         .unwrap()
+        // db dropped here, synchronously persisting final state.
     };
-
-    std::thread::sleep(std::time::Duration::from_millis(200));
 
     let db2 = AletheiaDB::open(&data_dir).unwrap();
     let node = db2.get_node(node_id).unwrap();
@@ -107,7 +115,9 @@ fn open_is_equivalent_to_durable_config() {
 
 /// Opening at a path whose parent component is a regular file cannot
 /// possibly succeed; `open` must surface this as `Err`, never panic
-/// (AC 5).
+/// (AC 5). A direct call (rather than `catch_unwind`) is sufficient: if
+/// `open` panicked, the test runner would fail this test with a stack trace
+/// on its own.
 #[test]
 fn open_surfaces_io_error_not_panic() {
     let dir = tempdir().unwrap();
@@ -115,10 +125,7 @@ fn open_surfaces_io_error_not_panic() {
     std::fs::write(&blocking_file, b"i am a file, not a dir").unwrap();
 
     let data_dir = blocking_file.join("db");
-    let result =
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| AletheiaDB::open(&data_dir)));
-
-    let result = result.expect("open() must not panic on an unusable path");
+    let result = AletheiaDB::open(&data_dir);
     assert!(
         result.is_err(),
         "opening under a path whose parent is a regular file must return Err"


### PR DESCRIPTION
## Summary

Adds `AletheiaDB::open(path)` as the primary one-line entry point for creating durable, persistent databases. This method automatically creates the directory tree if absent and replays prior state on restart, making it the natural counterpart to the ephemeral `AletheiaDB::new()`.

## Key Changes

- **New API**: `AletheiaDB::open(path)` — creates/opens a durable database at the given path
  - Automatically creates nested directories if they don't exist
  - Idempotent across process restarts (replays prior state)
  - Internally uses `with_unified_config(durable_config_for_data_dir(path))` to ensure canonical WAL + index persistence configuration
  - Returns `Result` on I/O failures rather than panicking

- **Documentation updates**:
  - Updated `AletheiaDB::new()` docstring to clarify it's ephemeral and recommend `open()` for durable use
  - Updated CLAUDE.md, PERSISTENCE.md, getting-started.md, and index-persistence-guide.md to promote `open()` as the primary durable entry point
  - Removed outdated warnings about `open()` not existing
  - Added comprehensive docstring with example showing round-trip durability

- **Integration tests** (`tests/open_durable.rs`):
  - Round-trip durability: write data, drop handle, reopen, verify data persists
  - Canonical layout verification: confirms `{path}/wal` and `{path}/indexes` structure
  - Equivalence test: data created via explicit `durable_config_for_data_dir()` opens unchanged via `open()`
  - Error handling: verifies I/O errors surface as `Err` rather than panics

## Implementation Details

- `open()` is a thin wrapper around `with_unified_config(durable_config_for_data_dir(path))`, ensuring no forked configuration logic
- Uses `AsRef<Path>` for ergonomic path handling
- Marked with `#[must_use]` to encourage proper error handling
- All tests use `tempfile::tempdir()` for isolation and cleanup

https://claude.ai/code/session_01Mi3oEect2rGnMtnXimh2xA