### PR TITLE
⚡ Bolt: Pre-allocate vectors in check_constraints

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+
+**[Pre-allocate vectors in check_constraints hot path]**
+**Learning:** In `src/api/transaction/write/constraint.rs`, the `check_constraints` function creates two vectors (`added_refs` and `removed_nodes`) without pre-allocating capacity. Since this function runs on the transaction commit hot path and iterates over `tx.buffer.operations()`, these vectors can experience unnecessary heap reallocations.
+**Action:** Initialize the vectors with `Vec::with_capacity(tx.buffer.len())` since the maximum number of items added is strictly bounded by the transaction buffer length.

--- a/src/api/transaction/write/constraint.rs
+++ b/src/api/transaction/write/constraint.rs
@@ -25,11 +25,14 @@ pub(crate) fn check_constraints(
     tx: &WriteTransaction,
     registry: &Arc<ConstraintRegistry>,
 ) -> std::result::Result<ReservationGuard, ConstraintError> {
+    // ⚡ Bolt Optimization: Pre-allocate vectors based on buffer size to prevent heap reallocations during constraint checking on the hot commit path.
+
     // Borrow property maps directly from the buffer to avoid cloning on the hot path.
-    let mut added_refs: Vec<(InternedString, &PropertyMap, NodeId)> = Vec::new();
+    let mut added_refs: Vec<(InternedString, &PropertyMap, NodeId)> =
+        Vec::with_capacity(tx.buffer.len());
 
     // Pre-tx nodes whose constraint keys are freed on a successful commit.
-    let mut removed_nodes: Vec<Node> = Vec::new();
+    let mut removed_nodes: Vec<Node> = Vec::with_capacity(tx.buffer.len());
 
     for op in tx.buffer.operations() {
         match op {


### PR DESCRIPTION
💡 **What:** Replaced `Vec::new()` with `Vec::with_capacity(tx.buffer.len())` for `added_refs` and `removed_nodes` in `check_constraints`.

🎯 **Why:** The `check_constraints` function runs on the transaction commit hot path. The elements pushed into these vectors are directly proportional to the number of operations in the transaction buffer. Pre-allocating capacity based on `tx.buffer.len()` eliminates intermediate heap reallocations when processing large batches of constraints.

📊 **Impact:** Reduces heap reallocations during large write transactions, slightly lowering CPU and memory overhead during commit validation.

🔬 **Measurement:** Verify by running write transaction benchmarks or testing node creations with constraints in `cargo test check_constraints --lib`.

---
*PR created automatically by Jules for task [805768876421579671](https://jules.google.com/task/805768876421579671) started by @madmax983*