### PR TITLE
⚡ Bolt: Optimize node propagation blending algorithm in sybil

### DIFF
--- a/src/experimental/characterization/sybil.rs
+++ b/src/experimental/characterization/sybil.rs
@@ -111,29 +111,32 @@ impl PropagationModel for LinearPropagation {
             return current_self.map(|v| v.to_vec());
         }
 
-        let avg: Vec<f32> = sum.iter().map(|x| x / count as f32).collect();
+        let mut sum = sum;
+        // Convert sum in-place to avg
+        // Reuse intermediate vector to avoid 2 allocations per node evaluation.
+        for x in sum.iter_mut() {
+            *x /= count as f32;
+        }
 
         match current_self {
             Some(self_vec) => {
-                if self_vec.len() != dim {
+                if self_vec.len() != sum.len() {
                     // Dimension mismatch, just return self (or handle error?)
                     // For simulation robustness, we ignore mismatched neighbors/self.
                     return Some(self_vec.to_vec());
                 }
 
                 // Blend: (1 - alpha) * self + alpha * avg
-                let new_vec: Vec<f32> = self_vec
-                    .iter()
-                    .zip(avg.iter())
-                    .map(|(s, a)| (1.0 - self.alpha) * s + self.alpha * a)
-                    .collect();
-                Some(new_vec)
+                for (a, s) in sum.iter_mut().zip(self_vec.iter()) {
+                    *a = (1.0 - self.alpha) * s + self.alpha * (*a);
+                }
+                Some(sum)
             }
             None => {
                 // If we didn't have a state, we "adopt" the average (if alpha allows adoption)
                 // Interpretation: If I have no opinion, do I adopt neighbors'?
                 // For this model, yes, let's say we adopt the average directly.
-                Some(avg)
+                Some(sum)
             }
         }
     }


### PR DESCRIPTION
## What
Optimizes the `LinearPropagation::propagate` method in the Sybil experimental algorithms module by executing blending functions in-place on the existing intermediate variable instead of cloning and `.collect::<Vec<_>>()`ing at two separate stages.

## Why
This removes two unnecessary heap allocations per evaluation frame, addressing an unneeded allocator pressure during simulation passes on densely connected graphs where the hotpath triggers these computations heavily. 

## Impact
Reduces allocations significantly per graph node in iterations avoiding dynamically sizing up arrays inside `map(...).collect()`.

## Measurement
Verify using `cargo bench` or run tests with `cargo test --lib experimental::characterization::sybil::tests`. The `cargo check` and `.jules/bolt.md` logic has been preserved successfully.

---
*PR created automatically by Jules for task [5007058485436800501](https://jules.google.com/task/5007058485436800501) started by @madmax983*