### PR TITLE
Add write-time attributive provenance support (Issue #3224)

### DIFF
--- a/benches/checkpoints.rs
+++ b/benches/checkpoints.rs
@@ -139,6 +139,7 @@ fn bench_recovery(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
                 wal.append_async(operation).unwrap();
             }
@@ -164,6 +165,7 @@ fn bench_recovery(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
                 wal.append_async(operation).unwrap();
             }

--- a/benches/durability_modes.rs
+++ b/benches/durability_modes.rs
@@ -651,6 +651,7 @@ fn bench_wal_append(c: &mut Criterion) {
                         label: GLOBAL_INTERNER.intern("Person").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         valid_from: time::now(),
+                        provenance: None,
                     },
                     "create_edge" => WalOperation::CreateEdge {
                         edge_id: black_box(aletheiadb::core::id::EdgeId::new(1).unwrap()),
@@ -659,6 +660,7 @@ fn bench_wal_append(c: &mut Criterion) {
                         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         valid_from: time::now(),
+                        provenance: None,
                     },
                     _ => WalOperation::UpdateNode {
                         node_id: aletheiadb::core::id::NodeId::new(1).unwrap(),
@@ -666,6 +668,7 @@ fn bench_wal_append(c: &mut Criterion) {
                         label: GLOBAL_INTERNER.intern("Person").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         valid_from: time::now(),
+                        provenance: None,
                     },
                 };
                 // Guard against sync-mode append_async footgun: in synchronous mode
@@ -707,6 +710,7 @@ fn bench_wal_throughput(c: &mut Criterion) {
                         label: GLOBAL_INTERNER.intern("Person").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         valid_from: time::now(),
+                        provenance: None,
                     };
                     black_box(wal.append_async(operation).unwrap());
                 }
@@ -753,6 +757,7 @@ fn bench_wal_with_sync(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
                 wal.append_async(operation).unwrap();
                 wal.commit().unwrap(); // ✅ Commit with configured durability mode

--- a/benches/recovery_benchmarks.rs
+++ b/benches/recovery_benchmarks.rs
@@ -184,6 +184,7 @@ fn create_wal_only_database(operation_count: usize) -> (TempDir, ConcurrentWalSy
                 label: GLOBAL_INTERNER.intern("WalNode").unwrap(),
                 properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
                 valid_from: time::now(),
+                provenance: None,
             }
         } else {
             // Update node operation (update the previous node)
@@ -200,6 +201,7 @@ fn create_wal_only_database(operation_count: usize) -> (TempDir, ConcurrentWalSy
                     .insert("updated", true)
                     .build(),
                 valid_from: time::now(),
+                provenance: None,
             }
         };
 

--- a/benches/wal_batch_append.rs
+++ b/benches/wal_batch_append.rs
@@ -47,6 +47,7 @@ fn create_test_operations(count: usize) -> Vec<WalOperation> {
                 .insert("name", format!("Node {}", i))
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })
         .collect()
 }
@@ -59,6 +60,7 @@ fn create_minimal_operations(count: usize) -> Vec<WalOperation> {
             label: GLOBAL_INTERNER.intern("N").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: time::now(),
+            provenance: None,
         })
         .collect()
 }

--- a/benches/wal_serialization.rs
+++ b/benches/wal_serialization.rs
@@ -58,6 +58,7 @@ fn bench_serialize_create_node(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: props.build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
 
                 // This will call serialize_entry internally
@@ -93,6 +94,7 @@ fn bench_serialize_create_edge(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
                     properties: props.build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
 
                 black_box(wal.append_async(operation).unwrap());
@@ -126,6 +128,7 @@ fn bench_serialize_update_node(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: props.build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
 
                 black_box(wal.append_async(operation).unwrap());
@@ -153,6 +156,7 @@ fn bench_serialize_batch(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Person").unwrap(),
                     properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
                 black_box(wal.append_async(operation).unwrap());
             }
@@ -180,6 +184,7 @@ fn bench_serialize_high_frequency(c: &mut Criterion) {
                     label: GLOBAL_INTERNER.intern("Test").unwrap(),
                     properties: PropertyMapBuilder::new().build(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
                 black_box(wal.append_async(operation).unwrap());
             }

--- a/examples/recovery/basic_recovery.rs
+++ b/examples/recovery/basic_recovery.rs
@@ -105,6 +105,7 @@ fn main() -> Result<()> {
                 .insert("age", (20 + i) as i64)
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     println!("✓ Created 50 nodes");
@@ -123,6 +124,7 @@ fn main() -> Result<()> {
                 .insert("since", 2020 + (i as i64))
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     println!("✓ Created 49 edges (chain: 1→2→3→...→50)");
@@ -140,6 +142,7 @@ fn main() -> Result<()> {
             .insert("updated", true)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     println!("✓ Updated node 1 properties");
 

--- a/examples/recovery/manual_recovery.rs
+++ b/examples/recovery/manual_recovery.rs
@@ -143,6 +143,7 @@ fn main() -> Result<()> {
                 .insert("name", format!("Node {}", i))
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -158,6 +159,7 @@ fn main() -> Result<()> {
             label: GLOBAL_INTERNER.intern("LINKS_TO").unwrap(),
             properties: PropertyMapBuilder::new().insert("weight", i as i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -174,6 +176,7 @@ fn main() -> Result<()> {
             .insert("updated", 1)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Flush WAL to ensure all entries are persisted

--- a/examples/recovery/progress_callback.rs
+++ b/examples/recovery/progress_callback.rs
@@ -194,6 +194,7 @@ fn main() -> Result<()> {
             label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMapBuilder::new().insert("id", i as i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -210,6 +211,7 @@ fn main() -> Result<()> {
             label: GLOBAL_INTERNER.intern("EDGE").unwrap(),
             properties: PropertyMapBuilder::new().insert("weight", i as i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "aletheiadb"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "arbitrary",

--- a/fuzz/fuzz_targets/wal_replay.rs
+++ b/fuzz/fuzz_targets/wal_replay.rs
@@ -52,6 +52,7 @@ fuzz_target!(|case: WalReplayCase| {
                         label,
                         properties: int_properties(value),
                         valid_from: timestamp_from_step(step),
+                        provenance: None,
                     })
                 }
             }
@@ -68,6 +69,7 @@ fuzz_target!(|case: WalReplayCase| {
                         label,
                         properties: int_properties(value),
                         valid_from: timestamp_from_step(step),
+                        provenance: None,
                     })
                 } else {
                     None

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -83,17 +83,17 @@ use crate::core::temporal::Timestamp;
 /// Optional per-write settings: backdated `valid_from` and/or a write-time
 /// [`Provenance`] bundle (Issue #3224).
 ///
-/// Constructed via [`WriteOptions::new`] (or its [`Default`] impl) and the
-/// `with_*` builder methods. Passing `WriteOptions::default()` reproduces the
+/// Constructed via [`WriteRequestOptions::new`] (or its [`Default`] impl) and the
+/// `with_*` builder methods. Passing `WriteRequestOptions::default()` reproduces the
 /// behavior of the plain `create_node`/`update_node`/etc. convenience methods
 /// exactly (valid time defaults to transaction start time, no provenance).
 #[derive(Debug, Clone, Default)]
-pub struct WriteOptions {
+pub struct WriteRequestOptions {
     pub(crate) valid_from: Option<Timestamp>,
     pub(crate) provenance: Option<Provenance>,
 }
 
-impl WriteOptions {
+impl WriteRequestOptions {
     /// Create an empty set of options (equivalent to [`Default::default`]).
     pub fn new() -> Self {
         Self::default()
@@ -353,24 +353,24 @@ pub trait WriteOps: ReadOps {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<NodeId> {
-        let options = WriteOptions {
+        let options = WriteRequestOptions {
             valid_from,
             provenance: None,
         };
         self.create_node_with_options(label, properties, options)
     }
 
-    /// Create a new node with an optional [`WriteOptions`] bundle (backdated
+    /// Create a new node with an optional [`WriteRequestOptions`] bundle (backdated
     /// `valid_from` and/or a write-time [`Provenance`] bundle, Issue #3224).
     ///
     /// This is the most general node-creation method; all other
-    /// `create_node*` methods delegate to it. Passing `WriteOptions::default()`
+    /// `create_node*` methods delegate to it. Passing `WriteRequestOptions::default()`
     /// is identical to [`create_node`](Self::create_node).
     ///
     /// # Example
     ///
     /// ```rust,no_run
-    /// # use aletheiadb::{AletheiaDB, properties, Provenance, api::transaction::{WriteOps, WriteOptions}};
+    /// # use aletheiadb::{AletheiaDB, properties, Provenance, api::transaction::{WriteOps, WriteRequestOptions}};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let db = AletheiaDB::new()?;
     /// # let mut tx = db.write_transaction()?;
@@ -378,7 +378,7 @@ pub trait WriteOps: ReadOps {
     /// let node_id = tx.create_node_with_options(
     ///     "Person",
     ///     properties! { "name" => "Alice" },
-    ///     WriteOptions::new().with_provenance(provenance),
+    ///     WriteRequestOptions::new().with_provenance(provenance),
     /// )?;
     /// # Ok(())
     /// # }
@@ -387,7 +387,7 @@ pub trait WriteOps: ReadOps {
         &mut self,
         label: &str,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<NodeId>;
 
     /// Create a new node.
@@ -446,14 +446,14 @@ pub trait WriteOps: ReadOps {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<EdgeId> {
-        let options = WriteOptions {
+        let options = WriteRequestOptions {
             valid_from,
             provenance: None,
         };
         self.create_edge_with_options(source, target, label, properties, options)
     }
 
-    /// Create a new edge with an optional [`WriteOptions`] bundle (backdated
+    /// Create a new edge with an optional [`WriteRequestOptions`] bundle (backdated
     /// `valid_from` and/or a write-time [`Provenance`] bundle, Issue #3224).
     ///
     /// This is the most general edge-creation method; all other
@@ -464,7 +464,7 @@ pub trait WriteOps: ReadOps {
         target: NodeId,
         label: &str,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<EdgeId>;
 
     /// Create a new edge.
@@ -531,14 +531,14 @@ pub trait WriteOps: ReadOps {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<()> {
-        let options = WriteOptions {
+        let options = WriteRequestOptions {
             valid_from,
             provenance: None,
         };
         self.update_node_with_options(node_id, properties, options)
     }
 
-    /// Update a node's properties with an optional [`WriteOptions`] bundle
+    /// Update a node's properties with an optional [`WriteRequestOptions`] bundle
     /// (backdated `valid_from` and/or a write-time [`Provenance`] bundle,
     /// Issue #3224).
     ///
@@ -550,7 +550,7 @@ pub trait WriteOps: ReadOps {
         &mut self,
         node_id: NodeId,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<()>;
 
     /// Update a node's properties.
@@ -609,14 +609,14 @@ pub trait WriteOps: ReadOps {
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
     ) -> Result<()> {
-        let options = WriteOptions {
+        let options = WriteRequestOptions {
             valid_from,
             provenance: None,
         };
         self.update_edge_with_options(edge_id, properties, options)
     }
 
-    /// Update an edge's properties with an optional [`WriteOptions`] bundle
+    /// Update an edge's properties with an optional [`WriteRequestOptions`] bundle
     /// (backdated `valid_from` and/or a write-time [`Provenance`] bundle,
     /// Issue #3224).
     ///
@@ -628,7 +628,7 @@ pub trait WriteOps: ReadOps {
         &mut self,
         edge_id: EdgeId,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<()>;
 
     /// Update an edge's properties.

--- a/src/api/transaction/mod.rs
+++ b/src/api/transaction/mod.rs
@@ -77,7 +77,42 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::MAX_VALID_ID;
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::property::{PropertyMap, PropertyValue};
+use crate::core::provenance::Provenance;
 use crate::core::temporal::Timestamp;
+
+/// Optional per-write settings: backdated `valid_from` and/or a write-time
+/// [`Provenance`] bundle (Issue #3224).
+///
+/// Constructed via [`WriteOptions::new`] (or its [`Default`] impl) and the
+/// `with_*` builder methods. Passing `WriteOptions::default()` reproduces the
+/// behavior of the plain `create_node`/`update_node`/etc. convenience methods
+/// exactly (valid time defaults to transaction start time, no provenance).
+#[derive(Debug, Clone, Default)]
+pub struct WriteOptions {
+    pub(crate) valid_from: Option<Timestamp>,
+    pub(crate) provenance: Option<Provenance>,
+}
+
+impl WriteOptions {
+    /// Create an empty set of options (equivalent to [`Default::default`]).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set when the fact became valid in reality (`None` = transaction start time).
+    #[must_use]
+    pub fn with_valid_from(mut self, valid_from: Timestamp) -> Self {
+        self.valid_from = Some(valid_from);
+        self
+    }
+
+    /// Attach a write-time provenance bundle to this write.
+    #[must_use]
+    pub fn with_provenance(mut self, provenance: Provenance) -> Self {
+        self.provenance = Some(provenance);
+        self
+    }
+}
 
 /// Common read operations available in all transaction types
 pub trait ReadOps {
@@ -317,6 +352,42 @@ pub trait WriteOps: ReadOps {
         label: &str,
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
+    ) -> Result<NodeId> {
+        let options = WriteOptions {
+            valid_from,
+            provenance: None,
+        };
+        self.create_node_with_options(label, properties, options)
+    }
+
+    /// Create a new node with an optional [`WriteOptions`] bundle (backdated
+    /// `valid_from` and/or a write-time [`Provenance`] bundle, Issue #3224).
+    ///
+    /// This is the most general node-creation method; all other
+    /// `create_node*` methods delegate to it. Passing `WriteOptions::default()`
+    /// is identical to [`create_node`](Self::create_node).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, properties, Provenance, api::transaction::{WriteOps, WriteOptions}};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// # let mut tx = db.write_transaction()?;
+    /// let provenance = Provenance::builder().source("hr-system").confidence(0.95).build()?;
+    /// let node_id = tx.create_node_with_options(
+    ///     "Person",
+    ///     properties! { "name" => "Alice" },
+    ///     WriteOptions::new().with_provenance(provenance),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn create_node_with_options(
+        &mut self,
+        label: &str,
+        properties: PropertyMap,
+        options: WriteOptions,
     ) -> Result<NodeId>;
 
     /// Create a new node.
@@ -374,6 +445,26 @@ pub trait WriteOps: ReadOps {
         label: &str,
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
+    ) -> Result<EdgeId> {
+        let options = WriteOptions {
+            valid_from,
+            provenance: None,
+        };
+        self.create_edge_with_options(source, target, label, properties, options)
+    }
+
+    /// Create a new edge with an optional [`WriteOptions`] bundle (backdated
+    /// `valid_from` and/or a write-time [`Provenance`] bundle, Issue #3224).
+    ///
+    /// This is the most general edge-creation method; all other
+    /// `create_edge*` methods delegate to it.
+    fn create_edge_with_options(
+        &mut self,
+        source: NodeId,
+        target: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        options: WriteOptions,
     ) -> Result<EdgeId>;
 
     /// Create a new edge.
@@ -439,6 +530,27 @@ pub trait WriteOps: ReadOps {
         node_id: NodeId,
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        let options = WriteOptions {
+            valid_from,
+            provenance: None,
+        };
+        self.update_node_with_options(node_id, properties, options)
+    }
+
+    /// Update a node's properties with an optional [`WriteOptions`] bundle
+    /// (backdated `valid_from` and/or a write-time [`Provenance`] bundle,
+    /// Issue #3224).
+    ///
+    /// This is the most general node-update method; all other
+    /// `update_node*` methods delegate to it. The provenance recorded here
+    /// describes *this* version only -- it is not inherited from the
+    /// version being updated.
+    fn update_node_with_options(
+        &mut self,
+        node_id: NodeId,
+        properties: PropertyMap,
+        options: WriteOptions,
     ) -> Result<()>;
 
     /// Update a node's properties.
@@ -496,6 +608,27 @@ pub trait WriteOps: ReadOps {
         edge_id: EdgeId,
         properties: PropertyMap,
         valid_from: Option<Timestamp>,
+    ) -> Result<()> {
+        let options = WriteOptions {
+            valid_from,
+            provenance: None,
+        };
+        self.update_edge_with_options(edge_id, properties, options)
+    }
+
+    /// Update an edge's properties with an optional [`WriteOptions`] bundle
+    /// (backdated `valid_from` and/or a write-time [`Provenance`] bundle,
+    /// Issue #3224).
+    ///
+    /// This is the most general edge-update method; all other
+    /// `update_edge*` methods delegate to it. The provenance recorded here
+    /// describes *this* version only -- it is not inherited from the
+    /// version being updated.
+    fn update_edge_with_options(
+        &mut self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        options: WriteOptions,
     ) -> Result<()>;
 
     /// Update an edge's properties.

--- a/src/api/transaction/write/apply.rs
+++ b/src/api/transaction/write/apply.rs
@@ -42,9 +42,11 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
+use crate::core::provenance::Provenance;
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use crate::core::version::VersionMetadata;
 use crate::storage::historical::HistoricalStorage;
+use std::sync::Arc;
 
 /// Helper function to create a bi-temporal interval with proper closing logic.
 ///
@@ -84,6 +86,7 @@ pub(crate) fn apply_node_write(
     valid_from: Timestamp,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
+    provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
     // Create node with pending metadata (commit_timestamp finalized after full apply_changes).
     // Using uncommitted here prevents phantom visibility if apply_changes fails partway through.
@@ -102,7 +105,7 @@ pub(crate) fn apply_node_write(
     }
 
     // Store in historical storage (consume properties, avoiding second clone)
-    historical.add_node_version(
+    historical.add_node_version_with_provenance(
         node_id,
         version_id,
         valid_from,
@@ -110,6 +113,7 @@ pub(crate) fn apply_node_write(
         label,
         properties,
         false, // not a tombstone
+        provenance,
     )?;
 
     // Index in temporal indexes with bi-temporal interval
@@ -143,6 +147,7 @@ pub(crate) fn apply_edge_write(
     valid_from: Timestamp,
     commit_timestamp: Timestamp,
     historical: &mut HistoricalStorage,
+    provenance: Option<Arc<Provenance>>,
 ) -> Result<()> {
     // Create edge with pending metadata (commit_timestamp finalized after full apply_changes).
     let metadata = VersionMetadata::uncommitted(tx.tx_id);
@@ -168,7 +173,7 @@ pub(crate) fn apply_edge_write(
     }
 
     // Store in historical storage (consume properties, avoiding second clone)
-    historical.add_edge_version(
+    historical.add_edge_version_with_provenance(
         edge_id,
         version_id,
         valid_from,
@@ -178,6 +183,7 @@ pub(crate) fn apply_edge_write(
         target,
         properties,
         false, // not a tombstone
+        provenance,
     )?;
 
     // Index in temporal indexes with bi-temporal interval
@@ -308,6 +314,7 @@ pub(crate) fn apply_single_write(
             label,
             properties,
             valid_from,
+            provenance,
         }
         | crate::api::transaction::BufferedWrite::UpdateNode {
             node_id,
@@ -315,6 +322,7 @@ pub(crate) fn apply_single_write(
             label,
             properties,
             valid_from,
+            provenance,
         } => {
             let is_create = matches!(
                 write,
@@ -330,6 +338,7 @@ pub(crate) fn apply_single_write(
                 *valid_from,
                 commit_timestamp,
                 historical,
+                provenance.clone(),
             )?;
         }
         crate::api::transaction::BufferedWrite::CreateEdge {
@@ -340,6 +349,7 @@ pub(crate) fn apply_single_write(
             label,
             properties,
             valid_from,
+            provenance,
         }
         | crate::api::transaction::BufferedWrite::UpdateEdge {
             edge_id,
@@ -349,6 +359,7 @@ pub(crate) fn apply_single_write(
             label,
             properties,
             valid_from,
+            provenance,
         } => {
             let is_create = matches!(
                 write,
@@ -366,6 +377,7 @@ pub(crate) fn apply_single_write(
                 *valid_from,
                 commit_timestamp,
                 historical,
+                provenance.clone(),
             )?;
         }
         crate::api::transaction::BufferedWrite::DeleteNode {

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -11,7 +11,7 @@
 
 use super::{
     ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager, WriteBuffer,
-    WriteOps,
+    WriteOps, WriteOptions,
 };
 use crate::core::error::{Result, ResultExt, StorageError, TransactionError};
 use crate::core::graph::{Edge, Node};
@@ -947,11 +947,11 @@ impl ReadOps for WriteTransaction {
 }
 
 impl WriteOps for WriteTransaction {
-    fn create_node_with_valid_time(
+    fn create_node_with_options(
         &mut self,
         label: &str,
         properties: PropertyMap,
-        valid_from: Option<Timestamp>,
+        options: WriteOptions,
     ) -> Result<NodeId> {
         let result = (|| {
             // Check transaction state
@@ -970,10 +970,17 @@ impl WriteOps for WriteTransaction {
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
-            let valid_from = valid_from.unwrap_or(timestamp);
+            let valid_from = options.valid_from.unwrap_or(timestamp);
 
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
+
+            // Normalize an all-absent provenance bundle to `None` -- never
+            // persist a fabricated empty object (Issue #3224).
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
 
             // Buffer the write
             self.buffer.add(super::BufferedWrite::CreateNode {
@@ -982,6 +989,7 @@ impl WriteOps for WriteTransaction {
                 label: label_interned,
                 properties,
                 valid_from,
+                provenance,
             })?;
 
             Ok(node_id)
@@ -990,13 +998,13 @@ impl WriteOps for WriteTransaction {
         result.record_error_metric()
     }
 
-    fn create_edge_with_valid_time(
+    fn create_edge_with_options(
         &mut self,
         source: NodeId,
         target: NodeId,
         label: &str,
         properties: PropertyMap,
-        valid_from: Option<Timestamp>,
+        options: WriteOptions,
     ) -> Result<EdgeId> {
         let result = (|| {
             // Check transaction state
@@ -1015,10 +1023,17 @@ impl WriteOps for WriteTransaction {
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
-            let valid_from = valid_from.unwrap_or(timestamp);
+            let valid_from = options.valid_from.unwrap_or(timestamp);
 
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
+
+            // Normalize an all-absent provenance bundle to `None` -- never
+            // persist a fabricated empty object (Issue #3224).
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
 
             // Buffer the write
             self.buffer.add(super::BufferedWrite::CreateEdge {
@@ -1029,6 +1044,7 @@ impl WriteOps for WriteTransaction {
                 label: label_interned,
                 properties,
                 valid_from,
+                provenance,
             })?;
 
             Ok(edge_id)
@@ -1037,11 +1053,11 @@ impl WriteOps for WriteTransaction {
         result.record_error_metric()
     }
 
-    fn update_node_with_valid_time(
+    fn update_node_with_options(
         &mut self,
         node_id: NodeId,
         properties: PropertyMap,
-        valid_from: Option<Timestamp>,
+        options: WriteOptions,
     ) -> Result<()> {
         let result = (|| {
             // Check transaction state
@@ -1071,7 +1087,7 @@ impl WriteOps for WriteTransaction {
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
-            let valid_from = valid_from.unwrap_or(timestamp);
+            let valid_from = options.valid_from.unwrap_or(timestamp);
 
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
@@ -1089,6 +1105,14 @@ impl WriteOps for WriteTransaction {
                 )?;
             }
 
+            // Normalize an all-absent provenance bundle to `None` -- never
+            // persist a fabricated empty object (Issue #3224). This update's
+            // provenance is independent of whatever the prior version carried.
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
+
             // Buffer the write with merged properties
             self.buffer.add(super::BufferedWrite::UpdateNode {
                 node_id,
@@ -1096,6 +1120,7 @@ impl WriteOps for WriteTransaction {
                 label: node.label,
                 properties: merged_properties,
                 valid_from,
+                provenance,
             })?;
 
             Ok(())
@@ -1104,11 +1129,11 @@ impl WriteOps for WriteTransaction {
         result.record_error_metric()
     }
 
-    fn update_edge_with_valid_time(
+    fn update_edge_with_options(
         &mut self,
         edge_id: EdgeId,
         properties: PropertyMap,
-        valid_from: Option<Timestamp>,
+        options: WriteOptions,
     ) -> Result<()> {
         let result = (|| {
             // Check transaction state
@@ -1138,7 +1163,7 @@ impl WriteOps for WriteTransaction {
 
             // Get timestamp: use provided valid_from or default to transaction start time
             let timestamp = self.start_timestamp;
-            let valid_from = valid_from.unwrap_or(timestamp);
+            let valid_from = options.valid_from.unwrap_or(timestamp);
 
             // Validate valid_from is not too far in future
             validation::validate_valid_from_future(valid_from)?;
@@ -1156,6 +1181,14 @@ impl WriteOps for WriteTransaction {
                 )?;
             }
 
+            // Normalize an all-absent provenance bundle to `None` -- never
+            // persist a fabricated empty object (Issue #3224). This update's
+            // provenance is independent of whatever the prior version carried.
+            let provenance = options
+                .provenance
+                .filter(|p| !p.is_empty())
+                .map(std::sync::Arc::new);
+
             // Buffer the write with merged properties
             self.buffer.add(super::BufferedWrite::UpdateEdge {
                 edge_id,
@@ -1165,6 +1198,7 @@ impl WriteOps for WriteTransaction {
                 label: edge.label,
                 properties: merged_properties,
                 valid_from,
+                provenance,
             })?;
 
             Ok(())

--- a/src/api/transaction/write/mod.rs
+++ b/src/api/transaction/write/mod.rs
@@ -11,7 +11,7 @@
 
 use super::{
     ReadOps, TransactionSnapshot, TxId, TxMetadata, TxState, TxVisibilityManager, WriteBuffer,
-    WriteOps, WriteOptions,
+    WriteOps, WriteRequestOptions,
 };
 use crate::core::error::{Result, ResultExt, StorageError, TransactionError};
 use crate::core::graph::{Edge, Node};
@@ -951,7 +951,7 @@ impl WriteOps for WriteTransaction {
         &mut self,
         label: &str,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<NodeId> {
         let result = (|| {
             // Check transaction state
@@ -1004,7 +1004,7 @@ impl WriteOps for WriteTransaction {
         target: NodeId,
         label: &str,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<EdgeId> {
         let result = (|| {
             // Check transaction state
@@ -1057,7 +1057,7 @@ impl WriteOps for WriteTransaction {
         &mut self,
         node_id: NodeId,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<()> {
         let result = (|| {
             // Check transaction state
@@ -1133,7 +1133,7 @@ impl WriteOps for WriteTransaction {
         &mut self,
         edge_id: EdgeId,
         properties: PropertyMap,
-        options: WriteOptions,
+        options: WriteRequestOptions,
     ) -> Result<()> {
         let result = (|| {
             // Check transaction state

--- a/src/api/transaction/write_buffer.rs
+++ b/src/api/transaction/write_buffer.rs
@@ -5,9 +5,11 @@ use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyMap;
+use crate::core::provenance::Provenance;
 use crate::core::temporal::Timestamp;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
+use std::sync::Arc;
 
 type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<IdentityHasher>>;
 
@@ -36,6 +38,8 @@ pub enum BufferedWrite {
         properties: PropertyMap,
         /// When the node became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Create a new edge
     CreateEdge {
@@ -53,6 +57,8 @@ pub enum BufferedWrite {
         properties: PropertyMap,
         /// When the edge became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Update an existing node (creates new version)
     UpdateNode {
@@ -66,6 +72,8 @@ pub enum BufferedWrite {
         properties: PropertyMap,
         /// When this update became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Update an existing edge (creates new version)
     UpdateEdge {
@@ -83,6 +91,8 @@ pub enum BufferedWrite {
         properties: PropertyMap,
         /// When this update became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Arc<Provenance>>,
     },
     /// Delete a node
     DeleteNode {
@@ -269,6 +279,7 @@ impl WriteBuffer {
     ///     label,
     ///     properties: PropertyMap::new(),
     ///     valid_from: time::now(),
+    ///     provenance: None,
     /// }).unwrap();
     ///
     /// assert_eq!(buffer.len(), 1);
@@ -397,12 +408,14 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label,
                 properties,
                 valid_from,
+                provenance,
                 ..
             } => crate::storage::wal::WalOperation::CreateNode {
                 node_id: *node_id,
                 label: *label,
                 properties: properties.clone(),
                 valid_from: *valid_from,
+                provenance: provenance.as_deref().cloned(),
             },
             BufferedWrite::CreateEdge {
                 edge_id,
@@ -411,6 +424,7 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label,
                 properties,
                 valid_from,
+                provenance,
                 ..
             } => crate::storage::wal::WalOperation::CreateEdge {
                 edge_id: *edge_id,
@@ -419,6 +433,7 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label: *label,
                 properties: properties.clone(),
                 valid_from: *valid_from,
+                provenance: provenance.as_deref().cloned(),
             },
             BufferedWrite::UpdateNode {
                 node_id,
@@ -426,6 +441,7 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label,
                 properties,
                 valid_from,
+                provenance,
                 ..
             } => crate::storage::wal::WalOperation::UpdateNode {
                 node_id: *node_id,
@@ -433,6 +449,7 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label: *label,
                 properties: properties.clone(),
                 valid_from: *valid_from,
+                provenance: provenance.as_deref().cloned(),
             },
             BufferedWrite::UpdateEdge {
                 edge_id,
@@ -440,6 +457,7 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label,
                 properties,
                 valid_from,
+                provenance,
                 ..
             } => crate::storage::wal::WalOperation::UpdateEdge {
                 edge_id: *edge_id,
@@ -447,6 +465,7 @@ impl From<&BufferedWrite> for crate::storage::wal::WalOperation {
                 label: *label,
                 properties: properties.clone(),
                 valid_from: *valid_from,
+                provenance: provenance.as_deref().cloned(),
             },
             BufferedWrite::DeleteNode {
                 node_id,
@@ -496,6 +515,7 @@ mod tests {
                 label,
                 properties,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -527,6 +547,7 @@ mod tests {
                 label,
                 properties,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -555,6 +576,7 @@ mod tests {
                 label,
                 properties: properties.clone(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -568,6 +590,7 @@ mod tests {
                 label,
                 properties,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -594,6 +617,7 @@ mod tests {
                 label,
                 properties,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -626,6 +650,7 @@ mod tests {
                 label,
                 properties: properties.clone(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -637,6 +662,7 @@ mod tests {
                 label,
                 properties,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -666,6 +692,7 @@ mod tests {
                 label,
                 properties: properties.clone(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -677,6 +704,7 @@ mod tests {
                 label,
                 properties: properties.clone(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -687,6 +715,7 @@ mod tests {
             label,
             properties,
             valid_from,
+            provenance: None,
         });
 
         assert!(result.is_err());
@@ -740,6 +769,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -772,6 +802,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -804,6 +835,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -847,6 +879,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -879,6 +912,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -915,6 +949,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -953,6 +988,7 @@ mod tests {
                     label,
                     properties: PropertyMap::new().builder().insert("id", i as i64).build(),
                     valid_from,
+                    provenance: None,
                 })
                 .unwrap();
         }
@@ -972,6 +1008,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -987,6 +1024,7 @@ mod tests {
                     label,
                     properties: PropertyMap::new().builder().insert("id", i as i64).build(),
                     valid_from,
+                    provenance: None,
                 })
                 .unwrap();
         }
@@ -1019,6 +1057,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1051,6 +1090,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1098,6 +1138,7 @@ mod tests {
                 label,
                 properties: props,
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1127,6 +1168,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1160,6 +1202,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1176,6 +1219,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1190,6 +1234,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1222,6 +1267,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1237,6 +1283,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1256,6 +1303,7 @@ mod tests {
                 label,
                 properties: PropertyMap::new(),
                 valid_from,
+                provenance: None,
             })
             .unwrap();
 
@@ -1290,6 +1338,7 @@ mod tests {
                 .unwrap(),
             properties: PropertyMap::new(),
             valid_from,
+            provenance: None,
         };
 
         match write {
@@ -1314,6 +1363,7 @@ mod tests {
                 .unwrap(),
             properties: PropertyMap::new(),
             valid_from,
+            provenance: None,
         };
 
         match write {
@@ -1340,6 +1390,7 @@ mod tests {
                 .unwrap(),
             properties: PropertyMap::new(),
             valid_from,
+            provenance: None,
         };
 
         match write {
@@ -1366,6 +1417,7 @@ mod tests {
                 .unwrap(),
             properties: PropertyMap::new(),
             valid_from,
+            provenance: None,
         };
 
         match write {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
     /// Temporal constraint violations.
     #[error("Temporal error: {0}")]
     Temporal(TemporalError),
+    /// Provenance bundle validation errors.
+    #[error("Provenance error: {0}")]
+    Provenance(crate::core::provenance::ProvenanceError),
     /// Query-related errors.
     #[error("Query error: {0}")]
     Query(QueryError),
@@ -79,6 +82,7 @@ impl Error {
             let category = match self {
                 Error::Storage(_) => crate::observability::ErrorCategory::Storage,
                 Error::Temporal(_) => crate::observability::ErrorCategory::Temporal,
+                Error::Provenance(_) => crate::observability::ErrorCategory::Other,
                 Error::Query(_) => crate::observability::ErrorCategory::Query,
                 Error::Transaction(_) => crate::observability::ErrorCategory::Transaction,
                 Error::Vector(_) => crate::observability::ErrorCategory::Vector,
@@ -127,6 +131,12 @@ impl From<StorageError> for Error {
 impl From<TemporalError> for Error {
     fn from(e: TemporalError) -> Self {
         Error::Temporal(e)
+    }
+}
+
+impl From<crate::core::provenance::ProvenanceError> for Error {
+    fn from(e: crate::core::provenance::ProvenanceError) -> Self {
+        Error::Provenance(e)
     }
 }
 

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -6,6 +6,7 @@
 use crate::core::id::VersionId;
 use crate::core::interning::InternedString;
 use crate::core::property::{PropertyMap, PropertyValue};
+use crate::core::provenance::Provenance;
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
 
 /// Information about a specific version of an entity (node or edge).
@@ -31,6 +32,7 @@ use crate::core::temporal::{BiTemporalInterval, Timestamp};
 ///     temporal: BiTemporalInterval::current(now),
 ///     properties: PropertyMap::new(),
 ///     label: "Person".to_string(),
+///     provenance: None,
 /// };
 ///
 /// let recorded_at = version.temporal.transaction_time().start();
@@ -51,6 +53,11 @@ pub struct VersionInfo {
     pub properties: PropertyMap,
     /// Entity label
     pub label: String,
+    /// Write-time attributive provenance (source, confidence, note, correlation_id).
+    ///
+    /// `None` if this version's write did not supply a bundle -- never a
+    /// fabricated default (Issue #3224).
+    pub provenance: Option<Provenance>,
 }
 
 /// Complete history of an entity (node or edge).
@@ -73,6 +80,7 @@ pub struct VersionInfo {
 ///     temporal: BiTemporalInterval::current(now),
 ///     properties: PropertyMap::new(),
 ///     label: "Person".to_string(),
+///     provenance: None,
 /// };
 ///
 /// let history = EntityHistory { versions: vec![v1] };
@@ -113,6 +121,7 @@ impl EntityHistory {
     ///     temporal: BiTemporalInterval::current(now),
     ///     properties: PropertyMap::new(),
     ///     label: "Person".to_string(),
+    ///     provenance: None,
     /// };
     /// let history = EntityHistory { versions: vec![v1] };
     /// assert_eq!(history.version_count(), 1);
@@ -142,6 +151,7 @@ impl EntityHistory {
     ///     temporal: BiTemporalInterval::current(now),
     ///     properties: PropertyMap::new(),
     ///     label: "Person".to_string(),
+    ///     provenance: None,
     /// };
     /// let history = EntityHistory { versions: vec![v1] };
     /// assert_eq!(history.current_version().unwrap().version_number, 1);
@@ -171,6 +181,7 @@ impl EntityHistory {
     ///     temporal: BiTemporalInterval::current(now),
     ///     properties: PropertyMap::new(),
     ///     label: "Person".to_string(),
+    ///     provenance: None,
     /// };
     /// let history = EntityHistory { versions: vec![v1] };
     /// assert_eq!(history.first_version().unwrap().version_number, 1);
@@ -824,6 +835,7 @@ mod tests {
                 .insert("version", version_num as i64)
                 .build(),
             label: "Test".to_string(),
+            provenance: None,
         }
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -37,6 +37,7 @@ pub mod id;
 pub mod interning;
 pub mod observer;
 pub mod property;
+pub mod provenance;
 pub mod temporal;
 pub mod vector;
 
@@ -50,6 +51,7 @@ pub use interning::{
     StringInterner,
 };
 pub use property::{PropertyKey, PropertyMap, PropertyMapBuilder, PropertyValue};
+pub use provenance::{Provenance, ProvenanceBuilder, ProvenanceError};
 pub use temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp};
 pub use vector::{
     // Types and constants

--- a/src/core/provenance.rs
+++ b/src/core/provenance.rs
@@ -81,6 +81,43 @@ impl Provenance {
             && self.note.is_none()
             && self.correlation_id.is_none()
     }
+
+    /// Construct and validate a [`Provenance`] bundle from four independently
+    /// optional fields.
+    ///
+    /// This is the single shared implementation of "feed whichever fields are
+    /// present through [`Provenance::builder`]" -- every storage tier that
+    /// restores a persisted provenance record (WAL replay, index-persistence
+    /// temporal index, Redb cold storage) and the MCP layer that parses a
+    /// caller-supplied provenance request should call this instead of
+    /// re-deriving the same builder chain, so a future field addition or
+    /// validation change only needs to happen in one place.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProvenanceError::InvalidConfidence`] if `confidence` is
+    /// `Some` and outside `[0.0, 1.0]` or is NaN.
+    pub fn from_parts(
+        source: Option<String>,
+        confidence: Option<f64>,
+        note: Option<String>,
+        correlation_id: Option<String>,
+    ) -> Result<Provenance, ProvenanceError> {
+        let mut builder = ProvenanceBuilder::default();
+        if let Some(source) = source {
+            builder = builder.source(source);
+        }
+        if let Some(confidence) = confidence {
+            builder = builder.confidence(confidence);
+        }
+        if let Some(note) = note {
+            builder = builder.note(note);
+        }
+        if let Some(correlation_id) = correlation_id {
+            builder = builder.correlation_id(correlation_id);
+        }
+        builder.build()
+    }
 }
 
 /// Builder for [`Provenance`], validating `confidence` on [`build`](ProvenanceBuilder::build).
@@ -157,20 +194,7 @@ impl TryFrom<ProvenanceRaw> for Provenance {
     type Error = ProvenanceError;
 
     fn try_from(raw: ProvenanceRaw) -> Result<Self, Self::Error> {
-        let mut builder = ProvenanceBuilder::default();
-        if let Some(source) = raw.source {
-            builder = builder.source(source);
-        }
-        if let Some(confidence) = raw.confidence {
-            builder = builder.confidence(confidence);
-        }
-        if let Some(note) = raw.note {
-            builder = builder.note(note);
-        }
-        if let Some(correlation_id) = raw.correlation_id {
-            builder = builder.correlation_id(correlation_id);
-        }
-        builder.build()
+        Provenance::from_parts(raw.source, raw.confidence, raw.note, raw.correlation_id)
     }
 }
 

--- a/src/core/provenance.rs
+++ b/src/core/provenance.rs
@@ -1,0 +1,259 @@
+//! Write-time attributive provenance for versions (Issue #3224).
+//!
+//! A [`Provenance`] bundle records *who/what* wrote a fact, *why*, and *how
+//! confident* the writer was — complementing the bi-temporal axes ([`crate::core::temporal`])
+//! that already record *when* a fact was valid and *when* it was recorded.
+//!
+//! Provenance is optional and attaches at the version granularity: every
+//! historical version of a node or edge may carry its own bundle, distinct
+//! from the versions before and after it.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors that can occur when constructing a [`Provenance`] bundle.
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum ProvenanceError {
+    /// Confidence was outside the valid `[0.0, 1.0]` range (or NaN).
+    #[error("confidence must be between 0.0 and 1.0, got {confidence}")]
+    InvalidConfidence {
+        /// The out-of-range (or NaN) confidence value that was rejected.
+        confidence: f64,
+    },
+}
+
+/// Write-time attributive provenance for a single version.
+///
+/// All fields are individually optional — a caller may supply only a
+/// `source`, only a `confidence`, or any combination. An entirely empty
+/// bundle (all fields `None`) is not distinguishable from "no provenance
+/// supplied"; see [`Provenance::is_empty`].
+///
+/// Constructed via [`Provenance::builder`], which validates `confidence`
+/// against `[0.0, 1.0]` (NaN is rejected).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "ProvenanceRaw")]
+pub struct Provenance {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confidence: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    correlation_id: Option<String>,
+}
+
+impl Provenance {
+    /// Start building a new [`Provenance`] bundle.
+    pub fn builder() -> ProvenanceBuilder {
+        ProvenanceBuilder::default()
+    }
+
+    /// The source system/identifier that produced this write, if any.
+    pub fn source(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+
+    /// The writer's confidence in this fact, in `[0.0, 1.0]`, if any.
+    pub fn confidence(&self) -> Option<f64> {
+        self.confidence
+    }
+
+    /// Free-text explanation of the write, if any.
+    pub fn note(&self) -> Option<&str> {
+        self.note.as_deref()
+    }
+
+    /// Correlation ID grouping all writes made in one logical operation, if any.
+    pub fn correlation_id(&self) -> Option<&str> {
+        self.correlation_id.as_deref()
+    }
+
+    /// Returns `true` if every field is absent.
+    ///
+    /// Used at API boundaries to normalize an all-`None` bundle to "no
+    /// provenance" (`Option<Provenance>::None`), so callers never observe a
+    /// fabricated empty object.
+    pub fn is_empty(&self) -> bool {
+        self.source.is_none()
+            && self.confidence.is_none()
+            && self.note.is_none()
+            && self.correlation_id.is_none()
+    }
+}
+
+/// Builder for [`Provenance`], validating `confidence` on [`build`](ProvenanceBuilder::build).
+#[derive(Debug, Clone, Default)]
+pub struct ProvenanceBuilder {
+    source: Option<String>,
+    confidence: Option<f64>,
+    note: Option<String>,
+    correlation_id: Option<String>,
+}
+
+impl ProvenanceBuilder {
+    /// Set the source system/identifier.
+    pub fn source<S: Into<String>>(mut self, source: S) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    /// Set the writer's confidence. Validated on [`build`](Self::build).
+    pub fn confidence(mut self, confidence: f64) -> Self {
+        self.confidence = Some(confidence);
+        self
+    }
+
+    /// Set a free-text note.
+    pub fn note<S: Into<String>>(mut self, note: S) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    /// Set the correlation ID.
+    pub fn correlation_id<S: Into<String>>(mut self, correlation_id: S) -> Self {
+        self.correlation_id = Some(correlation_id.into());
+        self
+    }
+
+    /// Validate and construct the [`Provenance`] bundle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProvenanceError::InvalidConfidence`] if `confidence` was set
+    /// and is outside `[0.0, 1.0]` or is NaN.
+    pub fn build(self) -> Result<Provenance, ProvenanceError> {
+        if let Some(confidence) = self.confidence
+            && !(0.0..=1.0).contains(&confidence)
+        {
+            return Err(ProvenanceError::InvalidConfidence { confidence });
+        }
+        Ok(Provenance {
+            source: self.source,
+            confidence: self.confidence,
+            note: self.note,
+            correlation_id: self.correlation_id,
+        })
+    }
+}
+
+/// Unvalidated wire representation used only as the `serde` deserialization
+/// target; [`Provenance`] itself has private fields so it cannot be
+/// deserialized directly without going through validation.
+#[derive(Debug, Deserialize)]
+struct ProvenanceRaw {
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    confidence: Option<f64>,
+    #[serde(default)]
+    note: Option<String>,
+    #[serde(default)]
+    correlation_id: Option<String>,
+}
+
+impl TryFrom<ProvenanceRaw> for Provenance {
+    type Error = ProvenanceError;
+
+    fn try_from(raw: ProvenanceRaw) -> Result<Self, Self::Error> {
+        let mut builder = ProvenanceBuilder::default();
+        if let Some(source) = raw.source {
+            builder = builder.source(source);
+        }
+        if let Some(confidence) = raw.confidence {
+            builder = builder.confidence(confidence);
+        }
+        if let Some(note) = raw.note {
+            builder = builder.note(note);
+        }
+        if let Some(correlation_id) = raw.correlation_id {
+            builder = builder.correlation_id(correlation_id);
+        }
+        builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provenance_builder_valid_all_fields() {
+        let p = Provenance::builder()
+            .source("hr-system")
+            .confidence(0.95)
+            .note("Verified by HR sync")
+            .correlation_id("batch-2026-06")
+            .build()
+            .unwrap();
+
+        assert_eq!(p.source(), Some("hr-system"));
+        assert_eq!(p.confidence(), Some(0.95));
+        assert_eq!(p.note(), Some("Verified by HR sync"));
+        assert_eq!(p.correlation_id(), Some("batch-2026-06"));
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn test_provenance_confidence_above_one_rejected() {
+        let err = Provenance::builder().confidence(1.5).build().unwrap_err();
+        assert_eq!(err, ProvenanceError::InvalidConfidence { confidence: 1.5 });
+    }
+
+    #[test]
+    fn test_provenance_confidence_below_zero_rejected() {
+        let err = Provenance::builder().confidence(-0.1).build().unwrap_err();
+        assert_eq!(err, ProvenanceError::InvalidConfidence { confidence: -0.1 });
+    }
+
+    #[test]
+    fn test_provenance_confidence_nan_rejected() {
+        let err = Provenance::builder()
+            .confidence(f64::NAN)
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, ProvenanceError::InvalidConfidence { confidence } if confidence.is_nan())
+        );
+    }
+
+    #[test]
+    fn test_provenance_confidence_boundaries_accepted() {
+        assert!(Provenance::builder().confidence(0.0).build().is_ok());
+        assert!(Provenance::builder().confidence(1.0).build().is_ok());
+    }
+
+    #[test]
+    fn test_provenance_empty_bundle_is_empty() {
+        let p = Provenance::builder().build().unwrap();
+        assert!(p.is_empty());
+        assert_eq!(p.source(), None);
+        assert_eq!(p.confidence(), None);
+    }
+
+    #[test]
+    fn test_provenance_json_omits_absent_fields() {
+        let p = Provenance::builder().source("csv-import").build().unwrap();
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"source\":\"csv-import\""));
+        assert!(!json.contains("confidence"));
+        assert!(!json.contains("note"));
+        assert!(!json.contains("correlation_id"));
+    }
+
+    #[test]
+    fn test_provenance_deserialize_valid_round_trips() {
+        let json = r#"{"source":"claude-mcp","confidence":0.8}"#;
+        let p: Provenance = serde_json::from_str(json).unwrap();
+        assert_eq!(p.source(), Some("claude-mcp"));
+        assert_eq!(p.confidence(), Some(0.8));
+    }
+
+    #[test]
+    fn test_provenance_deserialize_rejects_invalid_confidence() {
+        let json = r#"{"confidence":2.0}"#;
+        let result: Result<Provenance, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -14,6 +14,7 @@ use crate::core::hasher::IdentityHasher;
 use crate::core::id::{EdgeId, NodeId, TxId, VersionId};
 use crate::core::interning::InternedString;
 use crate::core::property::{MAX_VECTOR_DIMENSIONS, PropertyKey, PropertyMap, PropertyValue};
+use crate::core::provenance::Provenance;
 use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
@@ -800,6 +801,13 @@ pub struct NodeVersion {
     pub next_version: Option<VersionId>,
     /// Link to the previous version (for reverse traversal)
     pub prev_version: Option<VersionId>,
+    /// Write-time attributive provenance (source, confidence, note, correlation_id).
+    ///
+    /// `None` unless the write that created this version supplied a
+    /// [`Provenance`] bundle (Issue #3224). Distinct from `commit_timestamp`
+    /// (which records *when* this version was written): provenance records
+    /// *who/what* wrote it and *how confident* the writer was.
+    pub provenance: Option<Arc<Provenance>>,
 }
 
 impl NodeVersion {
@@ -821,6 +829,7 @@ impl NodeVersion {
             commit_timestamp,
             next_version: None,
             prev_version: None,
+            provenance: None,
         }
     }
 
@@ -844,7 +853,15 @@ impl NodeVersion {
             commit_timestamp,
             next_version: None,
             prev_version: Some(prev_version),
+            provenance: None,
         }
+    }
+
+    /// Attach a provenance bundle to this version, replacing any previous value.
+    #[must_use]
+    pub fn with_provenance(mut self, provenance: Option<Arc<Provenance>>) -> Self {
+        self.provenance = provenance;
+        self
     }
 
     /// Returns true if this is an anchor version.
@@ -910,6 +927,11 @@ pub struct EdgeVersion {
     pub next_version: Option<VersionId>,
     /// Link to the previous version
     pub prev_version: Option<VersionId>,
+    /// Write-time attributive provenance (source, confidence, note, correlation_id).
+    ///
+    /// `None` unless the write that created this version supplied a
+    /// [`Provenance`] bundle (Issue #3224).
+    pub provenance: Option<Arc<Provenance>>,
 }
 
 impl EdgeVersion {
@@ -935,7 +957,15 @@ impl EdgeVersion {
             commit_timestamp,
             next_version: None,
             prev_version: None,
+            provenance: None,
         }
+    }
+
+    /// Attach a provenance bundle to this version, replacing any previous value.
+    #[must_use]
+    pub fn with_provenance(mut self, provenance: Option<Arc<Provenance>>) -> Self {
+        self.provenance = provenance;
+        self
     }
 
     /// Create a new delta version (incremental change).
@@ -963,6 +993,7 @@ impl EdgeVersion {
             commit_timestamp,
             next_version: None,
             prev_version: Some(prev_version),
+            provenance: None,
         }
     }
 

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -4,7 +4,7 @@
 use crate::api::transaction::WriteOps;
 use crate::core::error::{Result, ResultExt};
 use crate::core::graph::{Edge, Node};
-use crate::core::id::{EdgeId, NodeId};
+use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyValue};
 use crate::core::temporal::Timestamp;
@@ -285,23 +285,23 @@ impl AletheiaDB {
         self.write(|tx| tx.delete_edge_with_valid_time(edge_id, valid_from))
     }
 
-    /// Create a node with an optional [`WriteOptions`](crate::api::transaction::WriteOptions)
+    /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
     /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
     ///
-    /// Passing `WriteOptions::default()` is identical to [`create_node`](Self::create_node).
+    /// Passing `WriteRequestOptions::default()` is identical to [`create_node`](Self::create_node).
     ///
     /// # Example
     ///
     /// ```rust,no_run
     /// # use aletheiadb::{AletheiaDB, PropertyMapBuilder, Provenance};
-    /// # use aletheiadb::api::transaction::WriteOptions;
+    /// # use aletheiadb::api::transaction::WriteRequestOptions;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let db = AletheiaDB::new()?;
     /// let provenance = Provenance::builder().source("hr-system").confidence(0.95).build()?;
     /// let node_id = db.create_node_with_options(
     ///     "Person",
     ///     PropertyMapBuilder::new().insert("name", "Alice").build(),
-    ///     WriteOptions::new().with_provenance(provenance),
+    ///     WriteRequestOptions::new().with_provenance(provenance),
     /// )?;
     /// # Ok(())
     /// # }
@@ -311,12 +311,12 @@ impl AletheiaDB {
         &self,
         label: &str,
         properties: PropertyMap,
-        options: crate::api::transaction::WriteOptions,
+        options: crate::api::transaction::WriteRequestOptions,
     ) -> Result<NodeId> {
         self.write(|tx| tx.create_node_with_options(label, properties, options))
     }
 
-    /// Create an edge with an optional [`WriteOptions`](crate::api::transaction::WriteOptions)
+    /// Create an edge with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
     /// bundle. See [`create_node_with_options`](Self::create_node_with_options).
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn create_edge_with_options(
@@ -325,13 +325,13 @@ impl AletheiaDB {
         target: NodeId,
         label: &str,
         properties: PropertyMap,
-        options: crate::api::transaction::WriteOptions,
+        options: crate::api::transaction::WriteRequestOptions,
     ) -> Result<EdgeId> {
         self.write(|tx| tx.create_edge_with_options(source, target, label, properties, options))
     }
 
     /// Update a node's properties (PATCH semantics) with an optional
-    /// [`WriteOptions`](crate::api::transaction::WriteOptions) bundle.
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions) bundle.
     ///
     /// The provenance recorded here describes *this* version only -- it is
     /// not inherited from the version being updated.
@@ -341,13 +341,13 @@ impl AletheiaDB {
         &self,
         node_id: NodeId,
         properties: PropertyMap,
-        options: crate::api::transaction::WriteOptions,
+        options: crate::api::transaction::WriteRequestOptions,
     ) -> Result<()> {
         self.write(|tx| tx.update_node_with_options(node_id, properties, options))
     }
 
     /// Update an edge's properties (PATCH semantics) with an optional
-    /// [`WriteOptions`](crate::api::transaction::WriteOptions) bundle.
+    /// [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions) bundle.
     ///
     /// The provenance recorded here describes *this* version only -- it is
     /// not inherited from the version being updated.
@@ -357,7 +357,7 @@ impl AletheiaDB {
         &self,
         edge_id: EdgeId,
         properties: PropertyMap,
-        options: crate::api::transaction::WriteOptions,
+        options: crate::api::transaction::WriteRequestOptions,
     ) -> Result<()> {
         self.write(|tx| tx.update_edge_with_options(edge_id, properties, options))
     }
@@ -388,6 +388,41 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_current_edge_provenance(edge_id)
+            .record_error_metric()
+    }
+
+    /// Get the provenance bundle attached to a *specific* node version, if any.
+    ///
+    /// Unlike [`get_node_provenance`](Self::get_node_provenance), this looks
+    /// up an exact version rather than re-resolving "whichever version is
+    /// current right now". Callers that already hold a [`Node`] snapshot
+    /// (e.g. from [`get_node`](Self::get_node)) should pass that snapshot's
+    /// `current_version` here to get a consistent, race-free provenance read
+    /// for the exact version they already have, rather than risking a
+    /// concurrent write shifting "current" between two independent reads.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_node_version_provenance(
+        &self,
+        version_id: VersionId,
+    ) -> Result<Option<crate::core::provenance::Provenance>> {
+        self.historical
+            .read()
+            .get_node_version_provenance(version_id)
+            .record_error_metric()
+    }
+
+    /// Get the provenance bundle attached to a *specific* edge version, if any.
+    ///
+    /// See [`get_node_version_provenance`](Self::get_node_version_provenance)
+    /// for semantics.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_edge_version_provenance(
+        &self,
+        version_id: VersionId,
+    ) -> Result<Option<crate::core::provenance::Provenance>> {
+        self.historical
+            .read()
+            .get_edge_version_provenance(version_id)
             .record_error_metric()
     }
 

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -285,6 +285,112 @@ impl AletheiaDB {
         self.write(|tx| tx.delete_edge_with_valid_time(edge_id, valid_from))
     }
 
+    /// Create a node with an optional [`WriteOptions`](crate::api::transaction::WriteOptions)
+    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
+    ///
+    /// Passing `WriteOptions::default()` is identical to [`create_node`](Self::create_node).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::{AletheiaDB, PropertyMapBuilder, Provenance};
+    /// # use aletheiadb::api::transaction::WriteOptions;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let db = AletheiaDB::new()?;
+    /// let provenance = Provenance::builder().source("hr-system").confidence(0.95).build()?;
+    /// let node_id = db.create_node_with_options(
+    ///     "Person",
+    ///     PropertyMapBuilder::new().insert("name", "Alice").build(),
+    ///     WriteOptions::new().with_provenance(provenance),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_node_with_options(
+        &self,
+        label: &str,
+        properties: PropertyMap,
+        options: crate::api::transaction::WriteOptions,
+    ) -> Result<NodeId> {
+        self.write(|tx| tx.create_node_with_options(label, properties, options))
+    }
+
+    /// Create an edge with an optional [`WriteOptions`](crate::api::transaction::WriteOptions)
+    /// bundle. See [`create_node_with_options`](Self::create_node_with_options).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn create_edge_with_options(
+        &self,
+        source: NodeId,
+        target: NodeId,
+        label: &str,
+        properties: PropertyMap,
+        options: crate::api::transaction::WriteOptions,
+    ) -> Result<EdgeId> {
+        self.write(|tx| tx.create_edge_with_options(source, target, label, properties, options))
+    }
+
+    /// Update a node's properties (PATCH semantics) with an optional
+    /// [`WriteOptions`](crate::api::transaction::WriteOptions) bundle.
+    ///
+    /// The provenance recorded here describes *this* version only -- it is
+    /// not inherited from the version being updated.
+    /// See [`create_node_with_options`](Self::create_node_with_options).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn update_node_with_options(
+        &self,
+        node_id: NodeId,
+        properties: PropertyMap,
+        options: crate::api::transaction::WriteOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.update_node_with_options(node_id, properties, options))
+    }
+
+    /// Update an edge's properties (PATCH semantics) with an optional
+    /// [`WriteOptions`](crate::api::transaction::WriteOptions) bundle.
+    ///
+    /// The provenance recorded here describes *this* version only -- it is
+    /// not inherited from the version being updated.
+    /// See [`create_node_with_options`](Self::create_node_with_options).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn update_edge_with_options(
+        &self,
+        edge_id: EdgeId,
+        properties: PropertyMap,
+        options: crate::api::transaction::WriteOptions,
+    ) -> Result<()> {
+        self.write(|tx| tx.update_edge_with_options(edge_id, properties, options))
+    }
+
+    /// Get the provenance bundle attached to a node's *current* version, if any.
+    ///
+    /// Returns `Ok(None)` (not an error) if the node has no provenance --
+    /// never a fabricated default (Issue #3224).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_node_provenance(
+        &self,
+        node_id: NodeId,
+    ) -> Result<Option<crate::core::provenance::Provenance>> {
+        self.historical
+            .read()
+            .get_current_node_provenance(node_id)
+            .record_error_metric()
+    }
+
+    /// Get the provenance bundle attached to an edge's *current* version, if any.
+    ///
+    /// See [`get_node_provenance`](Self::get_node_provenance) for semantics.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_edge_provenance(
+        &self,
+        edge_id: EdgeId,
+    ) -> Result<Option<crate::core::provenance::Provenance>> {
+        self.historical
+            .read()
+            .get_current_edge_provenance(edge_id)
+            .record_error_metric()
+    }
+
     /// Get the current state of a node.
     ///
     /// This uses the fast path (current storage) for O(1) lookup.

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -21,7 +21,7 @@ pub mod wal {
     /// The wrapper intentionally starts at offset zero. Fuzz targets that need to
     /// test segment headers should use the public segment-reader API instead.
     pub fn parse_current_entry(bytes: &[u8]) -> Result<(WalEntry, usize)> {
-        segment_reader::parse_entry_at(bytes, 0, segment_reader::WAL_VERSION)
+        segment_reader::parse_entry_at(bytes, 0, segment_reader::WAL_VERSION_PROVENANCE)
     }
 
     /// Serialize a parsed WAL entry back to bytes with a fresh checksum.
@@ -74,5 +74,49 @@ impl<'a> arbitrary::Arbitrary<'a> for HybridTimestamp {
         let wallclock = (u64::arbitrary(unstructured)? % max) as i64;
         let logical = u32::arbitrary(unstructured)?;
         Ok(HybridTimestamp::new(wallclock, logical).expect("bounded fuzz timestamp must be valid"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wal::{parse_current_entry, serialize_entry};
+    use crate::core::NodeId;
+    use crate::core::interning::InternedString;
+    use crate::core::property::PropertyMap;
+    use crate::core::provenance::Provenance;
+    use crate::core::temporal::time;
+    use crate::storage::wal::entry::{LSN, WalEntry, WalOperation};
+
+    /// Regression test for a bug where `parse_current_entry` hardcoded the
+    /// pre-provenance `WAL_VERSION` (1) even though `serialize_entry` always
+    /// writes the provenance presence byte for Create/Update ops (Issue
+    /// #3224). Parsing at the stale version left a trailing byte unconsumed,
+    /// breaking round-trip byte-count fidelity for every Create/Update op --
+    /// exactly the invariant `fuzz/fuzz_targets/wal_entry_parsing.rs` checks.
+    #[test]
+    fn create_node_roundtrip_consumes_all_bytes() {
+        let entry = WalEntry::new(
+            LSN(1),
+            WalOperation::CreateNode {
+                node_id: NodeId::new(1).unwrap(),
+                label: InternedString::from_raw(0),
+                properties: PropertyMap::new(),
+                valid_from: time::now(),
+                provenance: Some(
+                    Provenance::builder()
+                        .source("test")
+                        .confidence(0.9)
+                        .build()
+                        .unwrap(),
+                ),
+            },
+        );
+
+        let canonical = serialize_entry(&entry).expect("entry must serialize");
+        let (roundtrip, roundtrip_consumed) =
+            parse_current_entry(&canonical).expect("serialized entry must parse");
+
+        assert_eq!(roundtrip_consumed, canonical.len());
+        assert_eq!(roundtrip.lsn, entry.lsn);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,8 @@ pub use core::temporal::time;
 pub use core::{
     BiTemporalInterval, ChangeFeedPage, ChangeFeedQuery, ChangeRecord, ChangeType, Edge, EdgeId,
     EntityId, EntityKind, GLOBAL_INTERNER, InternedString, Node, NodeHeader, NodeId, PropertyKey,
-    PropertyMap, PropertyMapBuilder, PropertyValue, StringInterner, TimeRange, Timestamp,
-    VersionId,
+    PropertyMap, PropertyMapBuilder, PropertyValue, Provenance, StringInterner, TimeRange,
+    Timestamp, VersionId,
 };
 
 pub use api::{ReadOps, ReadTransaction, TxId, TxState, WriteOps, WriteTransaction};

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -145,7 +145,7 @@ use crate::api::transaction::WriteOps;
 use crate::core::temporal::time;
 use crate::core::{
     ChangeFeedQuery, EdgeId, GLOBAL_INTERNER, NodeId, PropertyMap, PropertyMapBuilder,
-    PropertyValue, Timestamp,
+    PropertyValue, Provenance, Timestamp, VersionId,
 };
 use crate::db::AletheiaDB;
 use crate::index::vector::{DistanceMetric, HnswConfig};
@@ -693,12 +693,54 @@ impl AletheiaMcpServer {
         GLOBAL_INTERNER.resolve_or_else(interned, || format!("<unknown:{}>", interned.as_u32()))
     }
 
+    /// Look up the provenance bundle for the *exact* version already captured
+    /// in `version_id` (a `Node`/`Edge` snapshot's `current_version`), rather
+    /// than re-resolving "whichever version is current now". This keeps the
+    /// returned provenance consistent with the properties already read from
+    /// that same snapshot, even under a concurrent write.
+    ///
+    /// A lookup failure (e.g. a corrupted or unreachable cold-storage record)
+    /// is logged rather than silently treated as "no provenance": that
+    /// distinction matters because an MCP caller has no other way to learn
+    /// the two cases apart. Best-effort here (returning `None` rather than
+    /// failing the whole response) is deliberate: a single-node lookup or a
+    /// bulk endpoint like `list_nodes`/`traverse` should not fail entirely
+    /// because one entry's provenance couldn't be read.
+    fn lookup_node_provenance(&self, version_id: VersionId) -> Option<Provenance> {
+        match self.db.get_node_version_provenance(version_id) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to load provenance for node version {}: {}",
+                    version_id.as_u64(),
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Edge counterpart of [`lookup_node_provenance`](Self::lookup_node_provenance).
+    fn lookup_edge_provenance(&self, version_id: VersionId) -> Option<Provenance> {
+        match self.db.get_edge_version_provenance(version_id) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to load provenance for edge version {}: {}",
+                    version_id.as_u64(),
+                    e
+                );
+                None
+            }
+        }
+    }
+
     fn node_to_response(&self, node: &crate::core::Node, include_vectors: bool) -> NodeResponse {
         NodeResponse {
             id: node.id.as_u64(),
             label: self.interned_to_string(node.label),
             properties: self.property_map_to_json(&node.properties, include_vectors),
-            provenance: None,
+            provenance: self.lookup_node_provenance(node.current_version),
         }
     }
 
@@ -709,7 +751,7 @@ impl AletheiaMcpServer {
             target_id: edge.target.as_u64(),
             label: self.interned_to_string(edge.label),
             properties: self.property_map_to_json(&edge.properties, include_vectors),
-            provenance: None,
+            provenance: self.lookup_edge_provenance(edge.current_version),
         }
     }
 
@@ -872,28 +914,17 @@ impl AletheiaMcpServer {
     fn parse_opt_provenance(
         &self,
         value: Option<crate::mcp::tools::ProvenanceRequest>,
-    ) -> std::result::Result<Option<crate::core::provenance::Provenance>, CallToolResult> {
+    ) -> std::result::Result<Option<Provenance>, CallToolResult> {
         let Some(req) = value else {
             return Ok(None);
         };
-        let mut builder = crate::core::provenance::Provenance::builder();
-        if let Some(source) = req.source {
-            builder = builder.source(source);
-        }
-        if let Some(confidence) = req.confidence {
-            builder = builder.confidence(confidence);
-        }
-        if let Some(note) = req.note {
-            builder = builder.note(note);
-        }
-        if let Some(correlation_id) = req.correlation_id {
-            builder = builder.correlation_id(correlation_id);
-        }
-        let provenance = builder.build().map_err(|e| {
-            self.error_json(&format!(
-                "Invalid provenance: confidence must be between 0.0 and 1.0 ({e})"
-            ))
-        })?;
+        let provenance =
+            Provenance::from_parts(req.source, req.confidence, req.note, req.correlation_id)
+                .map_err(|e| {
+                    self.error_json(&format!(
+                        "Invalid provenance: confidence must be between 0.0 and 1.0 ({e})"
+                    ))
+                })?;
         if provenance.is_empty() {
             return Ok(None);
         }
@@ -1002,9 +1033,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_node(node_id) {
             Ok(node) => {
-                let mut response =
-                    self.node_to_response(&node, req.include_vectors.unwrap_or(false));
-                response.provenance = self.db.get_node_provenance(node_id).unwrap_or(None);
+                let response = self.node_to_response(&node, req.include_vectors.unwrap_or(false));
                 self.success_json(
                     serde_json::to_value(&response)
                         .expect("response serialization should not fail"),
@@ -1037,7 +1066,7 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
-        let mut options = crate::api::transaction::WriteOptions::new();
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
         if let Some(valid_from) = valid_from {
             options = options.with_valid_from(valid_from);
         }
@@ -1051,8 +1080,7 @@ impl AletheiaMcpServer {
         {
             Ok(node_id) => match self.db.get_node(node_id) {
                 Ok(node) => {
-                    let mut response = self.node_to_response(&node, true);
-                    response.provenance = self.db.get_node_provenance(node_id).unwrap_or(None);
+                    let response = self.node_to_response(&node, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1094,7 +1122,7 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
-        let mut options = crate::api::transaction::WriteOptions::new();
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
         if let Some(valid_from) = valid_from {
             options = options.with_valid_from(valid_from);
         }
@@ -1108,8 +1136,7 @@ impl AletheiaMcpServer {
         {
             Ok(()) => match self.db.get_node(node_id) {
                 Ok(node) => {
-                    let mut response = self.node_to_response(&node, true);
-                    response.provenance = self.db.get_node_provenance(node_id).unwrap_or(None);
+                    let response = self.node_to_response(&node, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1391,9 +1418,7 @@ impl AletheiaMcpServer {
 
         match self.db.get_edge(edge_id) {
             Ok(edge) => {
-                let mut response =
-                    self.edge_to_response(&edge, req.include_vectors.unwrap_or(false));
-                response.provenance = self.db.get_edge_provenance(edge_id).unwrap_or(None);
+                let response = self.edge_to_response(&edge, req.include_vectors.unwrap_or(false));
                 self.success_json(
                     serde_json::to_value(&response)
                         .expect("response serialization should not fail"),
@@ -1436,7 +1461,7 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
-        let mut options = crate::api::transaction::WriteOptions::new();
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
         if let Some(valid_from) = valid_from {
             options = options.with_valid_from(valid_from);
         }
@@ -1450,8 +1475,7 @@ impl AletheiaMcpServer {
         {
             Ok(edge_id) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
-                    let mut response = self.edge_to_response(&edge, true);
-                    response.provenance = self.db.get_edge_provenance(edge_id).unwrap_or(None);
+                    let response = self.edge_to_response(&edge, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1488,7 +1512,7 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
-        let mut options = crate::api::transaction::WriteOptions::new();
+        let mut options = crate::api::transaction::WriteRequestOptions::new();
         if let Some(valid_from) = valid_from {
             options = options.with_valid_from(valid_from);
         }
@@ -1502,8 +1526,7 @@ impl AletheiaMcpServer {
         {
             Ok(()) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
-                    let mut response = self.edge_to_response(&edge, true);
-                    response.provenance = self.db.get_edge_provenance(edge_id).unwrap_or(None);
+                    let response = self.edge_to_response(&edge, true);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -300,6 +300,7 @@ impl AletheiaMcpServer {
     ///     label: "Person".to_string(),
     ///     properties: Some(props),
     ///     valid_time: None,
+    ///     provenance: None,
     /// };
     /// ```
     ///
@@ -450,6 +451,26 @@ impl AletheiaMcpServer {
     /// Returns all edges ending at the specified node. Can be filtered by edge label.
     pub fn get_incoming_edges(&self, req: GetIncomingEdgesRequest) -> String {
         Self::extract_text(self.handle_get_incoming_edges(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
+    /// Get the complete version history of a node.
+    ///
+    /// Returns all versions in chronological order (oldest first), including
+    /// each version's write-time provenance bundle when present (Issue #3224).
+    pub fn get_node_history(&self, req: GetNodeHistoryRequest) -> String {
+        Self::extract_text(self.handle_get_node_history(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
+    /// Get the complete version history of an edge.
+    ///
+    /// Returns all versions in chronological order (oldest first), including
+    /// each version's write-time provenance bundle when present (Issue #3224).
+    pub fn get_edge_history(&self, req: GetEdgeHistoryRequest) -> String {
+        Self::extract_text(self.handle_get_edge_history(
             serde_json::to_value(req).expect("request serialization should not fail"),
         ))
     }
@@ -677,6 +698,7 @@ impl AletheiaMcpServer {
             id: node.id.as_u64(),
             label: self.interned_to_string(node.label),
             properties: self.property_map_to_json(&node.properties, include_vectors),
+            provenance: None,
         }
     }
 
@@ -687,6 +709,7 @@ impl AletheiaMcpServer {
             target_id: edge.target.as_u64(),
             label: self.interned_to_string(edge.label),
             properties: self.property_map_to_json(&edge.properties, include_vectors),
+            provenance: None,
         }
     }
 
@@ -838,6 +861,45 @@ impl AletheiaMcpServer {
             .map_err(|e| self.error_json(&format!("Invalid {label}: {e}")))
     }
 
+    /// Validate and convert an optional MCP [`ProvenanceRequest`] into a
+    /// core [`Provenance`](crate::core::provenance::Provenance).
+    ///
+    /// Mirrors [`parse_opt_timestamp`](Self::parse_opt_timestamp): returns
+    /// `Err(error_json(...))` with a clear message when `confidence` is out
+    /// of `[0.0, 1.0]` (Issue #3224), rather than a generic deserialization
+    /// error. An entirely empty bundle (all fields omitted) is normalized to
+    /// `None` -- never persisted as a fabricated empty object.
+    fn parse_opt_provenance(
+        &self,
+        value: Option<crate::mcp::tools::ProvenanceRequest>,
+    ) -> std::result::Result<Option<crate::core::provenance::Provenance>, CallToolResult> {
+        let Some(req) = value else {
+            return Ok(None);
+        };
+        let mut builder = crate::core::provenance::Provenance::builder();
+        if let Some(source) = req.source {
+            builder = builder.source(source);
+        }
+        if let Some(confidence) = req.confidence {
+            builder = builder.confidence(confidence);
+        }
+        if let Some(note) = req.note {
+            builder = builder.note(note);
+        }
+        if let Some(correlation_id) = req.correlation_id {
+            builder = builder.correlation_id(correlation_id);
+        }
+        let provenance = builder.build().map_err(|e| {
+            self.error_json(&format!(
+                "Invalid provenance: confidence must be between 0.0 and 1.0 ({e})"
+            ))
+        })?;
+        if provenance.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(provenance))
+    }
+
     /// Parse an optional transaction time, returning the current time if not specified.
     fn parse_optional_tx_time(&self, tx_time: Option<&str>) -> Result<Timestamp, String> {
         match tx_time {
@@ -940,7 +1002,9 @@ impl AletheiaMcpServer {
 
         match self.db.get_node(node_id) {
             Ok(node) => {
-                let response = self.node_to_response(&node, req.include_vectors.unwrap_or(false));
+                let mut response =
+                    self.node_to_response(&node, req.include_vectors.unwrap_or(false));
+                response.provenance = self.db.get_node_provenance(node_id).unwrap_or(None);
                 self.success_json(
                     serde_json::to_value(&response)
                         .expect("response serialization should not fail"),
@@ -968,14 +1032,27 @@ impl AletheiaMcpServer {
             Ok(v) => v,
             Err(result) => return result,
         };
+        let provenance = match self.parse_opt_provenance(req.provenance) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+
+        let mut options = crate::api::transaction::WriteOptions::new();
+        if let Some(valid_from) = valid_from {
+            options = options.with_valid_from(valid_from);
+        }
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
 
         match self
             .db
-            .create_node_with_valid_time(&req.label, properties, valid_from)
+            .create_node_with_options(&req.label, properties, options)
         {
             Ok(node_id) => match self.db.get_node(node_id) {
                 Ok(node) => {
-                    let response = self.node_to_response(&node, true);
+                    let mut response = self.node_to_response(&node, true);
+                    response.provenance = self.db.get_node_provenance(node_id).unwrap_or(None);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1012,14 +1089,27 @@ impl AletheiaMcpServer {
             Ok(v) => v,
             Err(result) => return result,
         };
+        let provenance = match self.parse_opt_provenance(req.provenance) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+
+        let mut options = crate::api::transaction::WriteOptions::new();
+        if let Some(valid_from) = valid_from {
+            options = options.with_valid_from(valid_from);
+        }
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
 
         match self
             .db
-            .update_node_with_valid_time(node_id, properties, valid_from)
+            .update_node_with_options(node_id, properties, options)
         {
             Ok(()) => match self.db.get_node(node_id) {
                 Ok(node) => {
-                    let response = self.node_to_response(&node, true);
+                    let mut response = self.node_to_response(&node, true);
+                    response.provenance = self.db.get_node_provenance(node_id).unwrap_or(None);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1301,7 +1391,9 @@ impl AletheiaMcpServer {
 
         match self.db.get_edge(edge_id) {
             Ok(edge) => {
-                let response = self.edge_to_response(&edge, req.include_vectors.unwrap_or(false));
+                let mut response =
+                    self.edge_to_response(&edge, req.include_vectors.unwrap_or(false));
+                response.provenance = self.db.get_edge_provenance(edge_id).unwrap_or(None);
                 self.success_json(
                     serde_json::to_value(&response)
                         .expect("response serialization should not fail"),
@@ -1339,14 +1431,27 @@ impl AletheiaMcpServer {
             Ok(v) => v,
             Err(result) => return result,
         };
+        let provenance = match self.parse_opt_provenance(req.provenance) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+
+        let mut options = crate::api::transaction::WriteOptions::new();
+        if let Some(valid_from) = valid_from {
+            options = options.with_valid_from(valid_from);
+        }
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
 
         match self
             .db
-            .create_edge_with_valid_time(source_id, target_id, &req.label, properties, valid_from)
+            .create_edge_with_options(source_id, target_id, &req.label, properties, options)
         {
             Ok(edge_id) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
-                    let response = self.edge_to_response(&edge, true);
+                    let mut response = self.edge_to_response(&edge, true);
+                    response.provenance = self.db.get_edge_provenance(edge_id).unwrap_or(None);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -1378,14 +1483,27 @@ impl AletheiaMcpServer {
             Ok(v) => v,
             Err(result) => return result,
         };
+        let provenance = match self.parse_opt_provenance(req.provenance) {
+            Ok(p) => p,
+            Err(result) => return result,
+        };
+
+        let mut options = crate::api::transaction::WriteOptions::new();
+        if let Some(valid_from) = valid_from {
+            options = options.with_valid_from(valid_from);
+        }
+        if let Some(provenance) = provenance {
+            options = options.with_provenance(provenance);
+        }
 
         match self
             .db
-            .update_edge_with_valid_time(edge_id, properties, valid_from)
+            .update_edge_with_options(edge_id, properties, options)
         {
             Ok(()) => match self.db.get_edge(edge_id) {
                 Ok(edge) => {
-                    let response = self.edge_to_response(&edge, true);
+                    let mut response = self.edge_to_response(&edge, true);
+                    response.provenance = self.db.get_edge_provenance(edge_id).unwrap_or(None);
                     self.success_json(
                         serde_json::to_value(&response)
                             .expect("response serialization should not fail"),
@@ -2165,7 +2283,7 @@ impl AletheiaMcpServer {
             }
         };
 
-        json!({
+        let mut value = json!({
             "version_number": info.version_number,
             "version_id": info.version_id.as_u64(),
             "valid_from": info.temporal.valid_time().start().wallclock().to_string(),
@@ -2174,7 +2292,20 @@ impl AletheiaMcpServer {
             "transaction_to": transaction_to,
             "properties": properties,
             "label": info.label
-        })
+        });
+
+        // Provenance is omitted entirely when absent -- never a fabricated
+        // default (Issue #3224).
+        if let Some(provenance) = &info.provenance
+            && let Some(obj) = value.as_object_mut()
+        {
+            obj.insert(
+                "provenance".to_string(),
+                serde_json::to_value(provenance).unwrap_or(serde_json::Value::Null),
+            );
+        }
+
+        value
     }
 
     fn version_diff_to_response(&self, diff: &crate::query::VersionDiff) -> serde_json::Value {

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -86,12 +86,14 @@ mod node_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
         (n1.id, n2.id)
@@ -105,6 +107,7 @@ mod node_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         };
 
         let response = server.create_node(req);
@@ -126,6 +129,7 @@ mod node_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
+            provenance: None,
         };
 
         let response = server.create_node(req);
@@ -151,6 +155,7 @@ mod node_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
+            provenance: None,
         };
 
         let create_response = server.create_node(create_req);
@@ -201,6 +206,7 @@ mod node_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
+            provenance: None,
         };
 
         let create_response = server.create_node(create_req);
@@ -215,6 +221,7 @@ mod node_tests {
             valid_time: None,
             node_id: created.id,
             properties: new_props,
+            provenance: None,
         };
 
         let update_response = server.update_node(update_req);
@@ -236,6 +243,7 @@ mod node_tests {
             valid_time: None,
             label: "ToDelete".to_string(),
             properties: None,
+            provenance: None,
         };
 
         let create_response = server.create_node(create_req);
@@ -279,6 +287,7 @@ mod node_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let delete_response = server.delete_node(DeleteNodeRequest {
@@ -314,6 +323,7 @@ mod node_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let third_id: NodeResponse = parse_response(&third).unwrap();
         let third_id = third_id.id;
@@ -324,6 +334,7 @@ mod node_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
             valid_time: None,
@@ -331,6 +342,7 @@ mod node_tests {
             target_id: source_id,
             label: "FOLLOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let delete_response = server.delete_node(DeleteNodeRequest {
@@ -389,6 +401,7 @@ mod node_tests {
             valid_time: None,
             label: "Lonely".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -416,6 +429,7 @@ mod node_tests {
                 valid_time: None,
                 label: "ListTest".to_string(),
                 properties: Some(props),
+                provenance: None,
             };
             server.create_node(req);
         }
@@ -446,6 +460,7 @@ mod node_tests {
                 valid_time: None,
                 label: "TypeA".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -454,6 +469,7 @@ mod node_tests {
                 valid_time: None,
                 label: "TypeB".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -486,6 +502,7 @@ mod node_tests {
                 valid_time: None,
                 label: "Paginated".to_string(),
                 properties: Some(props),
+                provenance: None,
             });
         }
 
@@ -536,6 +553,7 @@ mod node_tests {
                 valid_time: None,
                 label: "Counted".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -555,6 +573,7 @@ mod node_tests {
                 valid_time: None,
                 label: "CountA".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -563,6 +582,7 @@ mod node_tests {
                 valid_time: None,
                 label: "CountB".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -596,6 +616,7 @@ mod edge_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&node1).unwrap();
 
@@ -607,6 +628,7 @@ mod edge_tests {
                 m.insert("name".to_string(), serde_json::json!("Bob"));
                 m
             }),
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&node2).unwrap();
 
@@ -624,6 +646,7 @@ mod edge_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         };
 
         let response = server.create_edge(req);
@@ -649,6 +672,7 @@ mod edge_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: Some(props),
+            provenance: None,
         };
 
         let response = server.create_edge(req);
@@ -675,6 +699,7 @@ mod edge_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         let created: EdgeResponse = parse_response(&create_response).unwrap();
 
@@ -700,6 +725,7 @@ mod edge_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         let created: EdgeResponse = parse_response(&create_response).unwrap();
 
@@ -710,6 +736,7 @@ mod edge_tests {
             valid_time: None,
             edge_id: created.id,
             properties: new_props,
+            provenance: None,
         });
         let updated: EdgeResponse = parse_response(&update_response).unwrap();
 
@@ -730,6 +757,7 @@ mod edge_tests {
             target_id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         let created: EdgeResponse = parse_response(&create_response).unwrap();
 
@@ -759,6 +787,7 @@ mod edge_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n3: NodeResponse = parse_response(&node3).unwrap();
 
@@ -769,6 +798,7 @@ mod edge_tests {
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
             valid_time: None,
@@ -776,6 +806,7 @@ mod edge_tests {
             target_id: n3.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Note: list_edges doesn't support listing all edges without a node
@@ -808,6 +839,7 @@ mod edge_tests {
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let count_response = server.count_edges(CountEdgesRequest { label: None });
@@ -825,6 +857,7 @@ mod edge_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n3: NodeResponse = parse_response(&node3).unwrap();
 
@@ -835,6 +868,7 @@ mod edge_tests {
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
             valid_time: None,
@@ -842,6 +876,7 @@ mod edge_tests {
             target_id: n3.id,
             label: "WORKS_WITH".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Get all outgoing edges
@@ -873,6 +908,7 @@ mod edge_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n3: NodeResponse = parse_response(&node3).unwrap();
 
@@ -883,6 +919,7 @@ mod edge_tests {
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
             valid_time: None,
@@ -890,6 +927,7 @@ mod edge_tests {
             target_id: n2,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let response = server.get_incoming_edges(GetIncomingEdgesRequest {
@@ -921,6 +959,7 @@ mod traversal_tests {
                         m.insert("name".to_string(), serde_json::json!(format!("Node{}", i)));
                         m
                     }),
+                    provenance: None,
                 });
                 let node: NodeResponse = parse_response(&response).unwrap();
                 node.id
@@ -935,6 +974,7 @@ mod traversal_tests {
                 target_id: nodes[i + 1],
                 label: "NEXT".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -1110,6 +1150,7 @@ mod vector_tests {
                 valid_time: None,
                 label: "Document".to_string(),
                 properties: Some(props),
+                provenance: None,
             });
         }
 
@@ -1143,6 +1184,7 @@ mod temporal_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -1170,6 +1212,7 @@ mod temporal_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -1199,6 +1242,7 @@ mod temporal_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -1206,6 +1250,7 @@ mod temporal_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -1215,6 +1260,7 @@ mod temporal_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         let edge: EdgeResponse = parse_response(&edge_response).unwrap();
 
@@ -1256,6 +1302,7 @@ mod temporal_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let response = server.list_changes(list_changes_req());
@@ -1294,6 +1341,7 @@ mod temporal_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let mut req = list_changes_req();
         req.tx_from = "1000000".to_string();
@@ -1356,6 +1404,7 @@ mod hybrid_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -1367,6 +1416,7 @@ mod hybrid_tests {
                 m.insert("name".to_string(), serde_json::json!("Bob"));
                 m
             }),
+            provenance: None,
         });
         let _n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -1399,6 +1449,7 @@ mod hybrid_tests {
                 valid_time: None,
                 label: "Person".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -1407,6 +1458,7 @@ mod hybrid_tests {
                 valid_time: None,
                 label: "Document".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -1469,6 +1521,7 @@ mod hybrid_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -1476,6 +1529,7 @@ mod hybrid_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -1485,6 +1539,7 @@ mod hybrid_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Query with traversal
@@ -1530,6 +1585,7 @@ mod conversion_tests {
             valid_time: None,
             label: "Test".to_string(),
             properties: Some(props),
+            provenance: None,
         });
 
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
@@ -1563,6 +1619,7 @@ mod conversion_tests {
             valid_time: None,
             label: "Document".to_string(),
             properties: Some(props),
+            provenance: None,
         });
 
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
@@ -1662,6 +1719,7 @@ mod coverage_tests {
             valid_time: None,
             label: "Event".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
 
@@ -1695,6 +1753,7 @@ mod coverage_tests {
             valid_time: None,
             label: "Event".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
 
@@ -1726,6 +1785,7 @@ mod coverage_tests {
             valid_time: None,
             label: "Event".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
 
@@ -1784,6 +1844,7 @@ mod coverage_tests {
                     props.insert("index".to_string(), serde_json::json!(i));
                     props
                 }),
+                provenance: None,
             });
         }
 
@@ -1821,6 +1882,7 @@ mod coverage_tests {
                     props.insert("level".to_string(), serde_json::json!(i));
                     props
                 }),
+                provenance: None,
             });
             let node: NodeResponse = parse_response(&response).unwrap();
 
@@ -1831,6 +1893,7 @@ mod coverage_tests {
                     target_id: node.id,
                     label: "NEXT".to_string(),
                     properties: None,
+                    provenance: None,
                 });
             }
             prev_id = Some(node.id);
@@ -1904,6 +1967,7 @@ mod error_handling_tests {
             valid_time: None,
             node_id: 999999,
             properties: HashMap::new(),
+            provenance: None,
         };
 
         let response = server.update_node(req);
@@ -1951,6 +2015,7 @@ mod error_handling_tests {
             valid_time: None,
             edge_id: 999999,
             properties: HashMap::new(),
+            provenance: None,
         };
 
         let response = server.update_edge(req);
@@ -1983,6 +2048,7 @@ mod error_handling_tests {
             valid_time: None,
             label: "Target".to_string(),
             properties: None,
+            provenance: None,
         });
         let target: NodeResponse = parse_response(&target_resp).unwrap();
 
@@ -1993,6 +2059,7 @@ mod error_handling_tests {
             target_id: target.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         };
 
         let response = server.create_edge(req);
@@ -2010,6 +2077,7 @@ mod error_handling_tests {
             valid_time: None,
             label: "Source".to_string(),
             properties: None,
+            provenance: None,
         });
         let source: NodeResponse = parse_response(&source_resp).unwrap();
 
@@ -2020,6 +2088,7 @@ mod error_handling_tests {
             target_id: 999999,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         };
 
         let response = server.create_edge(req);
@@ -2151,6 +2220,7 @@ mod temporal_extended_tests {
                 m.insert("title".to_string(), serde_json::json!("Conference"));
                 m
             }),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2190,6 +2260,7 @@ mod temporal_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -2197,6 +2268,7 @@ mod temporal_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -2206,6 +2278,7 @@ mod temporal_extended_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         let edge: EdgeResponse = parse_response(&edge_response).unwrap();
 
@@ -2236,6 +2309,7 @@ mod temporal_extended_tests {
             valid_time: None,
             label: "Test".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2265,6 +2339,7 @@ mod temporal_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -2272,6 +2347,7 @@ mod temporal_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -2281,6 +2357,7 @@ mod temporal_extended_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         let edge: EdgeResponse = parse_response(&edge_response).unwrap();
 
@@ -2303,6 +2380,7 @@ mod temporal_extended_tests {
             valid_time: None,
             label: "Event".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2344,6 +2422,7 @@ mod traversal_extended_tests {
                         m.insert("name".to_string(), serde_json::json!(format!("Node{}", i)));
                         m
                     }),
+                    provenance: None,
                 });
                 let node: NodeResponse = parse_response(&response).unwrap();
                 node.id
@@ -2358,6 +2437,7 @@ mod traversal_extended_tests {
                 target_id: nodes[i + 1],
                 label: "CONNECTED".to_string(),
                 properties: None,
+                provenance: None,
             });
             server.create_edge(CreateEdgeRequest {
                 valid_time: None,
@@ -2365,6 +2445,7 @@ mod traversal_extended_tests {
                 target_id: nodes[i],
                 label: "CONNECTED".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -2404,6 +2485,7 @@ mod traversal_extended_tests {
             valid_time: None,
             label: "Lonely".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2432,6 +2514,7 @@ mod traversal_extended_tests {
             valid_time: None,
             label: "Node".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -2439,6 +2522,7 @@ mod traversal_extended_tests {
             valid_time: None,
             label: "Node".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -2448,6 +2532,7 @@ mod traversal_extended_tests {
             target_id: n2.id,
             label: "NEXT".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Traverse without specifying direction (should default to outgoing)
@@ -2474,6 +2559,7 @@ mod traversal_extended_tests {
             valid_time: None,
             label: "Center".to_string(),
             properties: None,
+            provenance: None,
         });
         let center: NodeResponse = parse_response(&center_response).unwrap();
 
@@ -2486,6 +2572,7 @@ mod traversal_extended_tests {
                     m.insert("index".to_string(), serde_json::json!(i));
                     m
                 }),
+                provenance: None,
             });
             let spoke: NodeResponse = parse_response(&spoke_response).unwrap();
 
@@ -2495,6 +2582,7 @@ mod traversal_extended_tests {
                 target_id: spoke.id,
                 label: "SPOKE".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -2534,6 +2622,7 @@ mod hybrid_extended_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2582,6 +2671,7 @@ mod hybrid_extended_tests {
                         m.insert("level".to_string(), serde_json::json!(i));
                         m
                     }),
+                    provenance: None,
                 });
                 let node: NodeResponse = parse_response(&response).unwrap();
                 node.id
@@ -2595,6 +2685,7 @@ mod hybrid_extended_tests {
                 target_id: nodes[i + 1],
                 label: "CHAIN".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -2628,6 +2719,7 @@ mod hybrid_extended_tests {
             valid_time: None,
             label: "Test".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2663,6 +2755,7 @@ mod hybrid_extended_tests {
             valid_time: None,
             label: "Test".to_string(),
             properties: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&node_response).unwrap();
 
@@ -2704,6 +2797,7 @@ mod hybrid_extended_tests {
                     m.insert("index".to_string(), serde_json::json!(i));
                     m
                 }),
+                provenance: None,
             });
         }
 
@@ -2775,6 +2869,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -2782,6 +2877,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -2792,6 +2888,7 @@ mod edge_extended_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
             valid_time: None,
@@ -2799,6 +2896,7 @@ mod edge_extended_tests {
             target_id: n2.id,
             label: "WORKS_WITH".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // List edges with label filter
@@ -2824,6 +2922,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -2831,6 +2930,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -2840,6 +2940,7 @@ mod edge_extended_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Count edges with label (should return message about not being supported)
@@ -2868,6 +2969,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n1: NodeResponse = parse_response(&n1_response).unwrap();
 
@@ -2875,6 +2977,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n2: NodeResponse = parse_response(&n2_response).unwrap();
 
@@ -2882,6 +2985,7 @@ mod edge_extended_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         });
         let n3: NodeResponse = parse_response(&n3_response).unwrap();
 
@@ -2892,6 +2996,7 @@ mod edge_extended_tests {
             target_id: n2.id,
             label: "KNOWS".to_string(),
             properties: None,
+            provenance: None,
         });
         server.create_edge(CreateEdgeRequest {
             valid_time: None,
@@ -2899,6 +3004,7 @@ mod edge_extended_tests {
             target_id: n2.id,
             label: "WORKS_WITH".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Get incoming edges with label filter
@@ -2934,6 +3040,7 @@ mod list_nodes_extended_tests {
                 valid_time: None,
                 label: format!("Type{}", i),
                 properties: None,
+                provenance: None,
             });
         }
 
@@ -2970,6 +3077,7 @@ mod list_nodes_extended_tests {
                     m.insert("index".to_string(), serde_json::json!(i));
                     m
                 }),
+                provenance: None,
             });
         }
 
@@ -3008,6 +3116,7 @@ mod list_nodes_extended_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
         server.create_node(CreateNodeRequest {
             valid_time: None,
@@ -3017,6 +3126,7 @@ mod list_nodes_extended_tests {
                 m.insert("name".to_string(), serde_json::json!("Bob"));
                 m
             }),
+            provenance: None,
         });
         server.create_node(CreateNodeRequest {
             valid_time: None,
@@ -3026,6 +3136,7 @@ mod list_nodes_extended_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
 
         // Filter by property
@@ -3055,6 +3166,7 @@ mod list_nodes_extended_tests {
                 m.insert("reading".to_string(), serde_json::json!(42));
                 m
             }),
+            provenance: None,
         });
         server.create_node(CreateNodeRequest {
             valid_time: None,
@@ -3064,6 +3176,7 @@ mod list_nodes_extended_tests {
                 m.insert("reading".to_string(), serde_json::json!(99));
                 m
             }),
+            provenance: None,
         });
 
         let response = server.list_nodes(ListNodesRequest {
@@ -3096,6 +3209,7 @@ mod list_nodes_extended_tests {
                 m.insert("color".to_string(), serde_json::json!("red"));
                 m
             }),
+            provenance: None,
         });
 
         let response = server.list_nodes(ListNodesRequest {
@@ -3168,6 +3282,7 @@ mod list_nodes_extended_tests {
                     m.insert("status".to_string(), serde_json::json!("active"));
                     m
                 }),
+                provenance: None,
             });
         }
 
@@ -3230,6 +3345,7 @@ mod query_tool_tests {
             valid_time: None,
             label: label.to_string(),
             properties: Some(props),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&resp).expect("seed node should succeed");
         node.id
@@ -3909,11 +4025,13 @@ mod constraint_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props.clone()),
+            provenance: None,
         });
         server.create_node(CreateNodeRequest {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
+            provenance: None,
         });
 
         let response = server.enable_unique_constraint(EnableUniqueConstraintRequest {
@@ -3985,6 +4103,7 @@ mod constraint_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props.clone()),
+            provenance: None,
         });
         let first: NodeResponse =
             parse_response(&first_response).expect("first create must succeed");
@@ -3993,6 +4112,7 @@ mod constraint_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
+            provenance: None,
         });
 
         let v = parse_json(&dup_response);
@@ -4027,6 +4147,7 @@ mod constraint_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props_a),
+            provenance: None,
         });
         let node_a: NodeResponse = parse_response(&resp_a).expect("node A must be created");
 
@@ -4036,6 +4157,7 @@ mod constraint_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props_b),
+            provenance: None,
         });
 
         let mut collision = HashMap::new();
@@ -4044,6 +4166,7 @@ mod constraint_tests {
             valid_time: None,
             node_id: node_a.id,
             properties: collision,
+            provenance: None,
         });
 
         let v = parse_json(&update_response);
@@ -4072,6 +4195,7 @@ mod constraint_tests {
             valid_time: None,
             node_id: 99999,
             properties: HashMap::new(),
+            provenance: None,
         });
 
         let v = parse_json(&response);
@@ -4132,6 +4256,7 @@ mod schema_tests {
                 m.insert("name".to_string(), serde_json::json!("Alice"));
                 m
             }),
+            provenance: None,
         });
         let alice: NodeResponse = parse_response(&alice_response).unwrap();
 
@@ -4143,6 +4268,7 @@ mod schema_tests {
                 m.insert("email".to_string(), serde_json::json!("bob@example.com"));
                 m
             }),
+            provenance: None,
         });
         let bob: NodeResponse = parse_response(&bob_response).unwrap();
 
@@ -4156,6 +4282,7 @@ mod schema_tests {
                 m.insert("since".to_string(), serde_json::json!(2020));
                 m
             }),
+            provenance: None,
         });
 
         let response = server.get_schema(schema_req(None, None));
@@ -4209,6 +4336,7 @@ mod schema_tests {
             valid_time: None,
             label: "Report".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let now_micros = std::time::SystemTime::now()
@@ -4244,6 +4372,7 @@ mod schema_tests {
             valid_time: None,
             label: "Invoice".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let now_micros = std::time::SystemTime::now()
@@ -4283,6 +4412,7 @@ mod schema_tests {
             valid_time: None,
             label: "Gadget".to_string(),
             properties: None,
+            provenance: None,
         });
 
         // Still as of the epoch: "Gadget" must remain absent (recorded later).
@@ -4333,6 +4463,7 @@ mod schema_tests {
                 valid_time: None,
                 label: "Person".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
         for _ in 0..2 {
@@ -4340,18 +4471,21 @@ mod schema_tests {
                 valid_time: None,
                 label: "Company".to_string(),
                 properties: None,
+                provenance: None,
             });
         }
         let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             valid_time: None,
             label: "Company".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
         server.create_edge(CreateEdgeRequest {
@@ -4360,6 +4494,7 @@ mod schema_tests {
             target_id: n2.id,
             label: "WORKS_AT".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let schema_value: serde_json::Value =
@@ -4417,6 +4552,7 @@ mod vector_elision_tests {
             valid_time: None,
             label: "Document".to_string(),
             properties: Some(props),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
         (node.id, embedding)
@@ -4518,12 +4654,14 @@ mod vector_elision_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             valid_time: None,
             label: "Person".to_string(),
             properties: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -4536,6 +4674,7 @@ mod vector_elision_tests {
             target_id: n2.id,
             label: "SIMILAR_TO".to_string(),
             properties: Some(props),
+            provenance: None,
         });
         let edge: EdgeResponse = parse_response(&edge_response).unwrap();
 
@@ -4624,6 +4763,7 @@ mod vector_elision_tests {
             target_id: n2_id,
             label: "NEXT".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let response = server.traverse(TraverseRequest {
@@ -4685,6 +4825,7 @@ mod vector_elision_tests {
                 valid_time: None,
                 label: "Document".to_string(),
                 properties: Some(props),
+                provenance: None,
             });
         }
 
@@ -4747,6 +4888,7 @@ mod vector_elision_tests {
                 valid_time: None,
                 label: "Document".to_string(),
                 properties: Some(props),
+                provenance: None,
             });
         }
 
@@ -4810,6 +4952,7 @@ mod vector_elision_tests {
             target_id: n2_id,
             label: "NEXT".to_string(),
             properties: None,
+            provenance: None,
         });
 
         let response = server.hybrid_query(HybridQueryRequest {
@@ -4911,6 +5054,7 @@ mod vector_elision_tests {
             valid_time: None,
             label: "Document".to_string(),
             properties: Some(props),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
         assert_eq!(
@@ -4932,6 +5076,7 @@ mod vector_elision_tests {
             valid_time: None,
             node_id: node.id,
             properties: new_props,
+            provenance: None,
         });
         let updated: NodeResponse =
             parse_response(&update_response).expect("Failed to update node");
@@ -4960,6 +5105,7 @@ mod vector_elision_tests {
             valid_time: None,
             label: "Person".to_string(),
             properties: Some(props),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("Failed to create node");
 
@@ -5008,6 +5154,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_ago(now, 1)),
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("create should succeed");
 
@@ -5043,6 +5190,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         });
         let node: NodeResponse = parse_response(&response).expect("create should succeed");
         assert_eq!(node.label, "Person");
@@ -5064,6 +5212,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: Some("not-a-timestamp".to_string()),
+            provenance: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5081,6 +5230,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_from_now(now, 24 * 400)), // > 1 year
+            provenance: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5098,12 +5248,14 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -5113,6 +5265,7 @@ mod valid_time_write_tests {
             label: "KNOWS".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_ago(now, 1)),
+            provenance: None,
         });
         let edge: EdgeResponse = parse_response(&response).expect("create_edge should succeed");
 
@@ -5144,6 +5297,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: Some(props),
             valid_time: Some(rfc3339_hours_ago(now, 2)),
+            provenance: None,
         }))
         .unwrap();
 
@@ -5154,6 +5308,7 @@ mod valid_time_write_tests {
             node_id: node.id,
             properties: update_props,
             valid_time: Some(update_valid_time.clone()),
+            provenance: None,
         });
         let updated: NodeResponse = parse_response(&response).expect("update should succeed");
         assert_eq!(
@@ -5183,6 +5338,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -5193,6 +5349,7 @@ mod valid_time_write_tests {
             properties: update_props,
             // Far enough in the past to precede the node's creation time.
             valid_time: Some("1970-01-01T00:00:01Z".to_string()),
+            provenance: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5209,6 +5366,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_ago(now, 1)),
+            provenance: None,
         }))
         .unwrap();
 
@@ -5242,12 +5400,14 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -5259,6 +5419,7 @@ mod valid_time_write_tests {
             label: "KNOWS".to_string(),
             properties: Some(props),
             valid_time: Some(rfc3339_hours_ago(now, 2)),
+            provenance: None,
         }))
         .unwrap();
 
@@ -5269,6 +5430,7 @@ mod valid_time_write_tests {
             edge_id: edge.id,
             properties: update_props,
             valid_time: Some(update_valid_time.clone()),
+            provenance: None,
         });
         let updated: EdgeResponse = parse_response(&response).expect("update should succeed");
         assert_eq!(
@@ -5302,12 +5464,14 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -5317,6 +5481,7 @@ mod valid_time_write_tests {
             label: "KNOWS".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_from_now(now, 24 * 400)), // > 1 year
+            provenance: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -5340,6 +5505,7 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_ago(now, 2)),
+            provenance: None,
         }))
         .unwrap();
 
@@ -5388,12 +5554,14 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
@@ -5402,6 +5570,7 @@ mod valid_time_write_tests {
             label: "KNOWS".to_string(),
             properties: None,
             valid_time: Some(rfc3339_hours_ago(now, 2)),
+            provenance: None,
         }))
         .unwrap();
 
@@ -5450,12 +5619,14 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
@@ -5464,6 +5635,7 @@ mod valid_time_write_tests {
             label: "KNOWS".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -5495,12 +5667,14 @@ mod valid_time_write_tests {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
             label: "Person".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
         parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
@@ -5509,6 +5683,7 @@ mod valid_time_write_tests {
             label: "KNOWS".to_string(),
             properties: None,
             valid_time: None,
+            provenance: None,
         }))
         .unwrap();
 
@@ -5521,5 +5696,414 @@ mod valid_time_write_tests {
         assert_eq!(value.get("success"), Some(&serde_json::json!(true)));
         assert_eq!(value.get("edges_removed"), Some(&serde_json::json!(1)));
         assert_eq!(value.get("detached"), Some(&serde_json::json!(true)));
+    }
+}
+
+// ============================================================================
+// Write-Time Provenance Tests (Issue #3224)
+// ============================================================================
+
+mod provenance_write_tests {
+    use super::*;
+
+    #[test]
+    fn test_create_node_with_provenance_persists() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("hr-system".to_string()),
+                confidence: Some(0.95),
+                note: None,
+                correlation_id: Some("batch-2026-06".to_string()),
+            }),
+        }))
+        .unwrap();
+
+        // Returned directly on the create response.
+        let provenance = node.provenance.expect("provenance should be present");
+        assert_eq!(provenance.source(), Some("hr-system"));
+        assert_eq!(provenance.confidence(), Some(0.95));
+        assert_eq!(provenance.correlation_id(), Some("batch-2026-06"));
+
+        // And retrievable via history (per-version).
+        let history = server.get_node_history(GetNodeHistoryRequest { node_id: node.id });
+        let value: serde_json::Value = serde_json::from_str(&history).unwrap();
+        let versions = value["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["provenance"]["source"], "hr-system");
+        assert_eq!(versions[0]["provenance"]["confidence"], 0.95);
+    }
+
+    #[test]
+    fn test_create_node_without_provenance_response_unchanged() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            value.get("provenance").is_none(),
+            "provenance key must be omitted, not null, when absent; got {value}"
+        );
+    }
+
+    #[test]
+    fn test_create_node_empty_provenance_object_treated_as_absent() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: None,
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            value.get("provenance").is_none(),
+            "an all-absent bundle must never be persisted/returned as a fabricated object; got {value}"
+        );
+    }
+
+    #[test]
+    fn test_create_node_provenance_confidence_above_one_rejected() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: None,
+                confidence: Some(1.5),
+                note: None,
+                correlation_id: None,
+            }),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        assert!(error.contains("confidence"), "got: {error}");
+        assert!(
+            error.contains("0.0") && error.contains("1.0"),
+            "got: {error}"
+        );
+        assert_eq!(server.db().node_count(), 0, "no node should be created");
+    }
+
+    #[test]
+    fn test_create_node_provenance_confidence_below_zero_rejected() {
+        let server = create_test_server();
+
+        let response = server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: None,
+                confidence: Some(-0.1),
+                note: None,
+                correlation_id: None,
+            }),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        assert!(error.contains("confidence"), "got: {error}");
+        assert_eq!(server.db().node_count(), 0);
+    }
+
+    #[test]
+    fn test_create_node_provenance_confidence_boundaries_accepted() {
+        let server = create_test_server();
+
+        for confidence in [0.0, 1.0] {
+            let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                label: "Person".to_string(),
+                properties: None,
+                valid_time: None,
+                provenance: Some(ProvenanceRequest {
+                    source: None,
+                    confidence: Some(confidence),
+                    note: None,
+                    correlation_id: None,
+                }),
+            }))
+            .expect("boundary confidence should be accepted");
+            assert_eq!(node.provenance.unwrap().confidence(), Some(confidence));
+        }
+    }
+
+    #[test]
+    fn test_update_node_with_provenance_history_per_version() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let updated: NodeResponse = parse_response(&server.update_node(UpdateNodeRequest {
+            node_id: node.id,
+            properties: HashMap::new(),
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("csv-import:2026-06".to_string()),
+                confidence: Some(0.4),
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+        assert_eq!(
+            updated.provenance.unwrap().source(),
+            Some("csv-import:2026-06")
+        );
+
+        let history = server.get_node_history(GetNodeHistoryRequest { node_id: node.id });
+        let value: serde_json::Value = serde_json::from_str(&history).unwrap();
+        let versions = value["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 2);
+        assert!(
+            versions[0].get("provenance").is_none(),
+            "v1 (plain create) should have no provenance"
+        );
+        assert_eq!(versions[1]["provenance"]["source"], "csv-import:2026-06");
+    }
+
+    #[test]
+    fn test_update_node_provenance_confidence_out_of_range_rejected() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let response = server.update_node(UpdateNodeRequest {
+            node_id: node.id,
+            properties: HashMap::new(),
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: None,
+                confidence: Some(2.0),
+                note: None,
+                correlation_id: None,
+            }),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("error").is_some());
+
+        // The node's properties must be unchanged by the rejected update.
+        let history = server.get_node_history(GetNodeHistoryRequest { node_id: node.id });
+        let history_value: serde_json::Value = serde_json::from_str(&history).unwrap();
+        assert_eq!(history_value["versions"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_create_edge_with_provenance_persists() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("claude-mcp".to_string()),
+                confidence: Some(0.7),
+                note: Some("inferred from document".to_string()),
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+
+        let provenance = edge.provenance.expect("provenance should be present");
+        assert_eq!(provenance.source(), Some("claude-mcp"));
+        assert_eq!(provenance.note(), Some("inferred from document"));
+
+        let history = server.get_edge_history(GetEdgeHistoryRequest { edge_id: edge.id });
+        let value: serde_json::Value = serde_json::from_str(&history).unwrap();
+        assert_eq!(value["versions"][0]["provenance"]["source"], "claude-mcp");
+    }
+
+    #[test]
+    fn test_create_edge_provenance_confidence_above_one_rejected() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let response = server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: None,
+                confidence: Some(1.1),
+                note: None,
+                correlation_id: None,
+            }),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("error").is_some());
+        assert_eq!(server.db().edge_count(), 0, "no edge should be created");
+    }
+
+    #[test]
+    fn test_update_edge_with_provenance_history_per_version() {
+        let server = create_test_server();
+
+        let n1: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+        let n2: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+        let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            source_id: n1.id,
+            target_id: n2.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let _updated: EdgeResponse = parse_response(&server.update_edge(UpdateEdgeRequest {
+            edge_id: edge.id,
+            properties: HashMap::new(),
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("hr-system".to_string()),
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+
+        let history = server.get_edge_history(GetEdgeHistoryRequest { edge_id: edge.id });
+        let value: serde_json::Value = serde_json::from_str(&history).unwrap();
+        let versions = value["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 2);
+        assert!(versions[0].get("provenance").is_none());
+        assert_eq!(versions[1]["provenance"]["source"], "hr-system");
+    }
+
+    #[test]
+    fn test_get_node_returns_current_provenance() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("hr-system".to_string()),
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+
+        let fetched: NodeResponse = parse_response(&server.get_node(GetNodeRequest {
+            node_id: node.id,
+            include_vectors: None,
+        }))
+        .unwrap();
+        assert_eq!(fetched.provenance.unwrap().source(), Some("hr-system"));
+    }
+
+    #[test]
+    fn test_get_node_without_provenance_omits_key() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let response = server.get_node(GetNodeRequest {
+            node_id: node.id,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("provenance").is_none());
+    }
+
+    #[test]
+    fn test_get_node_history_omits_provenance_when_absent() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let history = server.get_node_history(GetNodeHistoryRequest { node_id: node.id });
+        let value: serde_json::Value = serde_json::from_str(&history).unwrap();
+        assert!(value["versions"][0].get("provenance").is_none());
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -6106,4 +6106,139 @@ mod provenance_write_tests {
         let value: serde_json::Value = serde_json::from_str(&history).unwrap();
         assert!(value["versions"][0].get("provenance").is_none());
     }
+
+    /// Regression test: `node_to_response`/`edge_to_response` used to
+    /// hardcode `provenance: None`, and only `get_node`/`create_node`/
+    /// `update_node` (and edge equivalents) patched it back in afterward.
+    /// `list_nodes` (and every other read path built on `node_to_response`)
+    /// silently omitted provenance even when it existed. See Issue #3224.
+    #[test]
+    fn test_list_nodes_returns_provenance() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "ListProvenanceTest".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("csv-import".to_string()),
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+
+        let response = server.list_nodes(ListNodesRequest {
+            label: Some("ListProvenanceTest".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let nodes = value["nodes"].as_array().unwrap();
+        let found = nodes.iter().find(|n| n["id"] == node.id).unwrap();
+        assert_eq!(found["provenance"]["source"], "csv-import");
+    }
+
+    /// See [`test_list_nodes_returns_provenance`] -- same gap, `traverse` path.
+    #[test]
+    fn test_traverse_returns_provenance() {
+        let server = create_test_server();
+
+        let start: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+        let end: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("graph-import".to_string()),
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+        parse_response::<EdgeResponse>(&server.create_edge(CreateEdgeRequest {
+            source_id: start.id,
+            target_id: end.id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let response = server.traverse(TraverseRequest {
+            start_node_id: start.id,
+            edge_label: "KNOWS".to_string(),
+            direction: Some("outgoing".to_string()),
+            depth: Some(1),
+            limit: None,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let results = value["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["node"]["provenance"]["source"], "graph-import");
+    }
+
+    /// See [`test_list_nodes_returns_provenance`] -- same gap, the bi-temporal
+    /// `get_node_at_time` path. This one matters especially: `get_node_at_time`
+    /// resolves the *as-of* version, not necessarily the node's current head,
+    /// so the returned provenance must be attached to that exact historical
+    /// version rather than "whatever is current now".
+    #[test]
+    fn test_get_node_at_time_returns_provenance_for_that_version() {
+        let server = create_test_server();
+
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Person".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("initial-load".to_string()),
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+
+        let as_of_micros = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as i64;
+
+        // Update with different provenance; the as-of query above must still
+        // report the *original* version's provenance, not this new one.
+        parse_response::<NodeResponse>(&server.update_node(UpdateNodeRequest {
+            node_id: node.id,
+            properties: HashMap::new(),
+            valid_time: None,
+            provenance: Some(ProvenanceRequest {
+                source: Some("manual-correction".to_string()),
+                confidence: None,
+                note: None,
+                correlation_id: None,
+            }),
+        }))
+        .unwrap();
+
+        let response = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id: node.id,
+            valid_time: as_of_micros.to_string(),
+            transaction_time: Some(as_of_micros.to_string()),
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["node"]["provenance"]["source"], "initial-load");
+    }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -8,6 +8,42 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // ============================================================================
+// Provenance (Issue #3224)
+// ============================================================================
+
+/// Optional write-time attributive provenance bundle.
+///
+/// Attach this to a write to record *who/what* wrote a fact, *why*, and *how
+/// confident* the writer was -- complementing the bi-temporal axes (valid
+/// time / transaction time) that already record *when*. Every field is
+/// independently optional; an entirely empty bundle (all fields omitted) is
+/// treated as no provenance at all. `confidence`, if present, is validated
+/// to be in `[0.0, 1.0]` and rejected with a clear error otherwise.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ProvenanceRequest {
+    /// Source system/identifier that produced this write (e.g. "hr-system",
+    /// "csv-import:2026-06", "claude-mcp").
+    #[schemars(
+        description = "Source system/identifier that produced this write (e.g. 'hr-system', 'csv-import:2026-06', 'claude-mcp')"
+    )]
+    pub source: Option<String>,
+
+    /// Confidence in this fact, in `[0.0, 1.0]`. Out-of-range values are rejected.
+    #[schemars(
+        description = "Confidence in this fact, in [0.0, 1.0]. Out-of-range values are rejected with a clear error"
+    )]
+    pub confidence: Option<f64>,
+
+    /// Free-text explanation of the write.
+    #[schemars(description = "Free-text explanation of the write")]
+    pub note: Option<String>,
+
+    /// Correlation ID grouping all writes made in one logical operation.
+    #[schemars(description = "Correlation ID grouping all writes made in one logical operation")]
+    pub correlation_id: Option<String>,
+}
+
+// ============================================================================
 // Node Operations
 // ============================================================================
 
@@ -47,6 +83,14 @@ pub struct CreateNodeRequest {
                        allowed. Transaction time is always system-assigned and cannot be set."
     )]
     pub valid_time: Option<String>,
+
+    /// Optional write-time provenance bundle (source, confidence, note, correlation_id).
+    #[schemars(
+        description = "Optional write-time provenance bundle recording source, confidence \
+                       ([0.0, 1.0]), a free-text note, and/or a correlation_id grouping co-committed \
+                       writes. Retrievable later via get_node/get_node_history. Omit for no provenance."
+    )]
+    pub provenance: Option<ProvenanceRequest>,
 }
 
 /// Request to update an existing node's properties.
@@ -69,6 +113,15 @@ pub struct UpdateNodeRequest {
                        is always system-assigned and cannot be set."
     )]
     pub valid_time: Option<String>,
+
+    /// Optional write-time provenance bundle for this version. Independent of
+    /// whatever provenance the prior version carried.
+    #[schemars(
+        description = "Optional write-time provenance bundle recording source, confidence \
+                       ([0.0, 1.0]), a free-text note, and/or a correlation_id for this version. \
+                       Not inherited from the version being updated. Omit for no provenance."
+    )]
+    pub provenance: Option<ProvenanceRequest>,
 }
 
 /// Request to delete a node.
@@ -208,6 +261,14 @@ pub struct CreateEdgeRequest {
                        allowed. Transaction time is always system-assigned and cannot be set."
     )]
     pub valid_time: Option<String>,
+
+    /// Optional write-time provenance bundle (source, confidence, note, correlation_id).
+    #[schemars(
+        description = "Optional write-time provenance bundle recording source, confidence \
+                       ([0.0, 1.0]), a free-text note, and/or a correlation_id grouping co-committed \
+                       writes. Retrievable later via get_edge_history. Omit for no provenance."
+    )]
+    pub provenance: Option<ProvenanceRequest>,
 }
 
 /// Request to update an existing edge's properties.
@@ -230,6 +291,15 @@ pub struct UpdateEdgeRequest {
                        is always system-assigned and cannot be set."
     )]
     pub valid_time: Option<String>,
+
+    /// Optional write-time provenance bundle for this version. Independent of
+    /// whatever provenance the prior version carried.
+    #[schemars(
+        description = "Optional write-time provenance bundle recording source, confidence \
+                       ([0.0, 1.0]), a free-text note, and/or a correlation_id for this version. \
+                       Not inherited from the version being updated. Omit for no provenance."
+    )]
+    pub provenance: Option<ProvenanceRequest>,
 }
 
 /// Request to delete an edge.
@@ -772,6 +842,10 @@ pub struct NodeResponse {
     pub id: u64,
     pub label: String,
     pub properties: HashMap<String, serde_json::Value>,
+    /// The current version's write-time provenance bundle, if any. Omitted
+    /// (never a fabricated `null`) when the version has none (Issue #3224).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub provenance: Option<crate::core::provenance::Provenance>,
 }
 
 /// Serializable edge representation for MCP responses.
@@ -782,6 +856,10 @@ pub struct EdgeResponse {
     pub target_id: u64,
     pub label: String,
     pub properties: HashMap<String, serde_json::Value>,
+    /// The current version's write-time provenance bundle, if any. Omitted
+    /// (never a fabricated `null`) when the version has none (Issue #3224).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub provenance: Option<crate::core::provenance::Provenance>,
 }
 
 /// Similarity search result.

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -434,17 +434,31 @@ pub(crate) fn read_artifact(path: &Path) -> Result<BackupPayload, BackupError> {
     // and not itself part of the bitcode blob) tells us unambiguously which
     // payload shape to expect -- no try-decode-and-fallback needed here,
     // unlike the temporal index file's embedded version (Issue #3224).
-    if found_version == 1 {
-        let legacy: BackupPayloadV1 = bitcode::decode(&decoded_bytes).map_err(|e| {
-            BackupError::Serialization(format!("bitcode deserialization failed: {e}"))
-        })?;
-        return Ok(legacy.into());
+    //
+    // This matches exhaustively on every version this build actually knows
+    // how to decode, rather than treating "not the legacy version" as
+    // synonymous with "current version": a corrupted or hand-crafted header
+    // claiming an unassigned value (e.g. 0, or a version skipped by a future
+    // release) is rejected with a clear `IncompatibleVersion` error instead
+    // of being silently routed through the current-shape decoder.
+    match found_version {
+        1 => {
+            let legacy: BackupPayloadV1 = bitcode::decode(&decoded_bytes).map_err(|e| {
+                BackupError::Serialization(format!("bitcode deserialization failed: {e}"))
+            })?;
+            Ok(legacy.into())
+        }
+        v if v == BACKUP_FORMAT_VERSION => {
+            let payload: BackupPayload = bitcode::decode(&decoded_bytes).map_err(|e| {
+                BackupError::Serialization(format!("bitcode deserialization failed: {e}"))
+            })?;
+            Ok(payload)
+        }
+        other => Err(BackupError::IncompatibleVersion {
+            found: other,
+            supported: BACKUP_FORMAT_VERSION,
+        }),
     }
-
-    let payload: BackupPayload = bitcode::decode(&decoded_bytes)
-        .map_err(|e| BackupError::Serialization(format!("bitcode deserialization failed: {e}")))?;
-
-    Ok(payload)
 }
 
 // ============================================================================
@@ -851,6 +865,77 @@ mod tests {
         assert!(restored.temporal.node_versions.is_empty());
     }
 
+    /// Regression test for a bug where restoring a legacy (`BACKUP_FORMAT_VERSION
+    /// == 1`) artifact with actual version data produced a `TemporalIndexData`
+    /// whose entries were upgraded to the current (provenance-carrying) shape
+    /// but whose `version` field still said `1` (copied verbatim from the V1
+    /// struct). Persisting that mismatched struct and reloading it would then
+    /// misdetect it as legacy and misdecode every entry. See Issue #3224.
+    #[test]
+    fn restoring_legacy_v1_backup_with_versions_stamps_current_manifest_version() {
+        use crate::storage::index_persistence::formats::legacy_v1::{
+            NodeVersionEntryV1, TemporalIndexDataV1,
+        };
+        use crate::storage::index_persistence::formats::{
+            PersistedPropertyMap, PersistedVersionType,
+        };
+        use crate::storage::index_persistence::temporal::{
+            load_temporal_index, save_temporal_index,
+        };
+        use crate::storage::index_persistence::{MANIFEST_VERSION, TEMPORAL_MAGIC};
+
+        let dir = TempDir::new().unwrap();
+        let artifact_path = dir.path().join("legacy_with_data.albk");
+
+        let mut payload = empty_payload_v1();
+        payload.node_version_count = 1;
+        payload.temporal = TemporalIndexDataV1 {
+            magic: TEMPORAL_MAGIC,
+            version: 1,
+            node_versions: vec![NodeVersionEntryV1 {
+                version_id: 1,
+                node_id: 1,
+                label_idx: 0,
+                valid_from: 1000,
+                valid_to: None,
+                valid_from_logical: 0,
+                valid_to_logical: None,
+                tx_time: 1000,
+                tx_time_logical: 0,
+                version_type: PersistedVersionType::Anchor,
+                properties: PersistedPropertyMap { entries: vec![] },
+                vector_snapshot_id: None,
+            }],
+            node_anchors: vec![],
+            edge_versions: vec![],
+            edge_anchors: vec![],
+        };
+
+        std::fs::write(&artifact_path, encode_artifact_v1(&payload)).unwrap();
+
+        let restored = read_artifact(&artifact_path).unwrap();
+
+        // The upgraded struct must claim the *current* format version, not
+        // the legacy one it was originally decoded as, since its entries are
+        // already current-shape.
+        assert_eq!(restored.temporal.version, MANIFEST_VERSION);
+        assert_eq!(restored.temporal.node_versions.len(), 1);
+        assert!(restored.temporal.node_versions[0].provenance.is_none());
+
+        // Persist the restored (upgraded) temporal index and reload it, as
+        // `restore_to_data_dir`/normal operation would. Before the fix, this
+        // would silently take the legacy-decode fallback path and either
+        // error or corrupt the entry.
+        let temporal_path = dir.path().join("temporal.idx");
+        save_temporal_index(&restored.temporal, &temporal_path).unwrap();
+        let reloaded = load_temporal_index(&temporal_path).unwrap();
+
+        assert_eq!(reloaded.version, MANIFEST_VERSION);
+        assert_eq!(reloaded.node_versions.len(), 1);
+        assert_eq!(reloaded.node_versions[0].node_id, 1);
+        assert!(reloaded.node_versions[0].provenance.is_none());
+    }
+
     #[test]
     fn read_artifact_rejects_future_version() {
         let dir = TempDir::new().unwrap();
@@ -862,5 +947,26 @@ mod tests {
 
         let err = read_artifact(&path).unwrap_err();
         assert!(matches!(err, BackupError::IncompatibleVersion { .. }));
+    }
+
+    /// Regression test: the version dispatch must explicitly reject any
+    /// `found_version` it doesn't recognize (e.g. 0, or any value skipped by
+    /// a future release) rather than silently treating "not the legacy
+    /// version" as synonymous with "current version".
+    #[test]
+    fn read_artifact_rejects_unassigned_version_zero() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("zero.albk");
+        let mut bytes = encode_artifact(&empty_payload()).unwrap();
+        // Corrupt the header to claim an unassigned version (below the
+        // legacy version-1 floor, not a valid value in either scheme).
+        bytes[4..6].copy_from_slice(&0u16.to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let err = read_artifact(&path).unwrap_err();
+        assert!(matches!(
+            err,
+            BackupError::IncompatibleVersion { found: 0, .. }
+        ));
     }
 }

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -42,7 +42,12 @@ use crate::storage::snapshot::{CurrentStorageSnapshot, HistoricalStorageSnapshot
 pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 
 /// Current backup format version.
-pub const BACKUP_FORMAT_VERSION: u16 = 1;
+///
+/// Bumped to 2 for write-time provenance on temporal versions (Issue #3224):
+/// the embedded `TemporalIndexData`'s `NodeVersionEntry`/`EdgeVersionEntry`
+/// gained an optional `provenance` field. Version 1 artifacts are still
+/// restorable -- see [`BackupPayloadV1`] and `read_artifact`.
+pub const BACKUP_FORMAT_VERSION: u16 = 2;
 
 /// Maximum allowed decompressed payload size (5 GiB).
 ///
@@ -135,6 +140,49 @@ pub(crate) struct BackupPayload {
     pub graph: GraphIndexData,
     /// Complete temporal version history.
     pub temporal: TemporalIndexData,
+}
+
+/// Pre-provenance (Issue #3224) `BackupPayload` shape, i.e. `BACKUP_FORMAT_VERSION == 1`.
+///
+/// Identical to [`BackupPayload`] except `temporal` uses the frozen
+/// [`crate::storage::index_persistence::formats::legacy_v1::TemporalIndexDataV1`]
+/// shape. Kept only so `read_artifact` can restore version-1 artifacts.
+#[derive(Debug, Clone, Encode, Decode)]
+pub(crate) struct BackupPayloadV1 {
+    /// Unix timestamp (microseconds) when the backup was created.
+    pub created_at_micros: i64,
+    /// WAL LSN at which the consistent snapshot was taken.
+    pub source_lsn: u64,
+    /// Number of current nodes.
+    pub current_node_count: u64,
+    /// Number of current edges.
+    pub current_edge_count: u64,
+    /// Number of node versions (hot + cold).
+    pub node_version_count: u64,
+    /// Number of edge versions (hot + cold).
+    pub edge_version_count: u64,
+    /// String interner state.
+    pub interner: StringInternerData,
+    /// Current graph state (nodes and edges).
+    pub graph: GraphIndexData,
+    /// Complete temporal version history (pre-provenance shape).
+    pub temporal: crate::storage::index_persistence::formats::legacy_v1::TemporalIndexDataV1,
+}
+
+impl From<BackupPayloadV1> for BackupPayload {
+    fn from(v1: BackupPayloadV1) -> Self {
+        BackupPayload {
+            created_at_micros: v1.created_at_micros,
+            source_lsn: v1.source_lsn,
+            current_node_count: v1.current_node_count,
+            current_edge_count: v1.current_edge_count,
+            node_version_count: v1.node_version_count,
+            edge_version_count: v1.edge_version_count,
+            interner: v1.interner,
+            graph: v1.graph,
+            temporal: v1.temporal.into(),
+        }
+    }
 }
 
 // ============================================================================
@@ -352,9 +400,12 @@ pub(crate) fn read_artifact(path: &Path) -> Result<BackupPayload, BackupError> {
         return Err(BackupError::BadMagic);
     }
 
-    // Validate format version.
+    // Validate format version. Older (but still-decodable) versions are
+    // accepted -- see `BackupPayloadV1` below for the version-1 fallback
+    // (Issue #3224); only a version newer than this build understands is
+    // rejected.
     let found_version = u16::from_le_bytes([header[4], header[5]]);
-    if found_version != BACKUP_FORMAT_VERSION {
+    if found_version > BACKUP_FORMAT_VERSION {
         return Err(BackupError::IncompatibleVersion {
             found: found_version,
             supported: BACKUP_FORMAT_VERSION,
@@ -379,7 +430,17 @@ pub(crate) fn read_artifact(path: &Path) -> Result<BackupPayload, BackupError> {
         ));
     }
 
-    // Decode bitcode.
+    // Decode bitcode. The header's `found_version` (already validated above,
+    // and not itself part of the bitcode blob) tells us unambiguously which
+    // payload shape to expect -- no try-decode-and-fallback needed here,
+    // unlike the temporal index file's embedded version (Issue #3224).
+    if found_version == 1 {
+        let legacy: BackupPayloadV1 = bitcode::decode(&decoded_bytes).map_err(|e| {
+            BackupError::Serialization(format!("bitcode deserialization failed: {e}"))
+        })?;
+        return Ok(legacy.into());
+    }
+
     let payload: BackupPayload = bitcode::decode(&decoded_bytes)
         .map_err(|e| BackupError::Serialization(format!("bitcode deserialization failed: {e}")))?;
 
@@ -714,5 +775,92 @@ mod tests {
         let restored = read_artifact(&path).unwrap();
         assert_eq!(restored.source_lsn, 0);
         assert_eq!(restored.current_node_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Version-1 (pre-provenance, Issue #3224) backup compatibility
+    // -----------------------------------------------------------------------
+
+    fn empty_payload_v1() -> BackupPayloadV1 {
+        use crate::storage::index_persistence::formats::legacy_v1::TemporalIndexDataV1;
+        use crate::storage::index_persistence::formats::{GraphIndexData, StringInternerData};
+        use crate::storage::index_persistence::{
+            GRAPH_MAGIC, INTERNER_MAGIC, MANIFEST_VERSION, TEMPORAL_MAGIC,
+        };
+        BackupPayloadV1 {
+            created_at_micros: 42,
+            source_lsn: 7,
+            current_node_count: 0,
+            current_edge_count: 0,
+            node_version_count: 0,
+            edge_version_count: 0,
+            interner: StringInternerData {
+                magic: INTERNER_MAGIC,
+                version: MANIFEST_VERSION,
+                string_count: 0,
+                strings: vec![],
+            },
+            graph: GraphIndexData {
+                magic: GRAPH_MAGIC,
+                version: MANIFEST_VERSION,
+                node_count: 0,
+                edge_count: 0,
+                nodes: vec![],
+                edges: vec![],
+                outgoing_node_ids: vec![],
+                outgoing_offsets: vec![],
+                outgoing_neighbors: vec![],
+                incoming_node_ids: vec![],
+                incoming_offsets: vec![],
+                incoming_neighbors: vec![],
+            },
+            temporal: TemporalIndexDataV1 {
+                magic: TEMPORAL_MAGIC,
+                version: 1,
+                node_versions: vec![],
+                node_anchors: vec![],
+                edge_versions: vec![],
+                edge_anchors: vec![],
+            },
+        }
+    }
+
+    /// Encode a version-1 artifact byte-for-byte the way pre-#3224 AletheiaDB
+    /// would have: `[MAGIC][version=1][zstd(bitcode(BackupPayloadV1))]`.
+    fn encode_artifact_v1(payload: &BackupPayloadV1) -> Vec<u8> {
+        let encoded = bitcode::encode(payload);
+        let compressed = zstd::encode_all(encoded.as_slice(), 3).unwrap();
+        let mut out = Vec::with_capacity(6 + compressed.len());
+        out.extend_from_slice(&BACKUP_MAGIC);
+        out.extend_from_slice(&1u16.to_le_bytes());
+        out.extend_from_slice(&compressed);
+        out
+    }
+
+    #[test]
+    fn read_artifact_accepts_legacy_v1_format() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy.albk");
+        let bytes = encode_artifact_v1(&empty_payload_v1());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let restored = read_artifact(&path).unwrap();
+
+        assert_eq!(restored.source_lsn, 7);
+        assert_eq!(restored.created_at_micros, 42);
+        assert!(restored.temporal.node_versions.is_empty());
+    }
+
+    #[test]
+    fn read_artifact_rejects_future_version() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("future.albk");
+        let mut bytes = encode_artifact(&empty_payload()).unwrap();
+        // Corrupt the header to claim a version newer than this build supports.
+        bytes[4..6].copy_from_slice(&(BACKUP_FORMAT_VERSION + 1).to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let err = read_artifact(&path).unwrap_err();
+        assert!(matches!(err, BackupError::IncompatibleVersion { .. }));
     }
 }

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -715,6 +715,7 @@ impl CheckpointManager {
             EdgeAnchorEntry, EdgeVersionEntry, NodeAnchorEntry, NodeVersionEntry,
             PersistedVersionType,
         };
+        use crate::storage::index_persistence::temporal::persist_provenance;
 
         let mut node_versions = Vec::with_capacity(snapshot.node_version_count());
         let mut node_anchors = Vec::with_capacity(snapshot.node_version_count());
@@ -794,6 +795,7 @@ impl CheckpointManager {
                 version_type,
                 properties,
                 vector_snapshot_id,
+                provenance: persist_provenance(version.provenance.as_deref()),
             };
             node_versions.push(entry);
         }
@@ -866,6 +868,7 @@ impl CheckpointManager {
                 tx_time_logical: version.temporal.transaction_time().start().logical(),
                 version_type,
                 properties,
+                provenance: persist_provenance(version.provenance.as_deref()),
             };
             edge_versions.push(entry);
         }
@@ -1041,6 +1044,10 @@ impl CheckpointManager {
                     data,
                     next_version: None,
                     prev_version: None,
+                    provenance: crate::storage::index_persistence::temporal::restore_provenance(
+                        entry.provenance.clone(),
+                    )
+                    .map_err(persistence_err)?,
                 };
 
                 historical.insert_restored_node_version(version)?;
@@ -1113,6 +1120,10 @@ impl CheckpointManager {
                     data,
                     next_version: None,
                     prev_version: None,
+                    provenance: crate::storage::index_persistence::temporal::restore_provenance(
+                        entry.provenance.clone(),
+                    )
+                    .map_err(persistence_err)?,
                 };
 
                 historical.insert_restored_edge_version(version)?;
@@ -1352,6 +1363,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: props,
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
         wal.flush()?;
@@ -1396,6 +1408,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: props,
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
         wal.flush()?;
@@ -1495,6 +1508,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern("Test").unwrap(),
                 properties: props,
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
         wal.flush()?;
@@ -1891,6 +1905,7 @@ mod tests {
                     .insert("name", format!("Person{}", i))
                     .build(),
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
 
@@ -1902,6 +1917,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("since", 2023i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
         wal.flush()?;
 
@@ -1945,6 +1961,7 @@ mod tests {
                 .insert("age", 30i64)
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         // Update node
@@ -1957,6 +1974,7 @@ mod tests {
                 .insert("age", 31i64)
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
         wal.flush()?;
 
@@ -1996,6 +2014,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
 
@@ -2009,6 +2028,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("strength", 5i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         // Update edge
@@ -2018,6 +2038,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMapBuilder::new().insert("strength", 10i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
         wal.flush()?;
 
@@ -2056,6 +2077,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("ToDelete").unwrap(),
             properties: PropertyMapBuilder::new().insert("temp", true).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         // Delete node
@@ -2099,6 +2121,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern("Person").unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
 
@@ -2112,6 +2135,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("TEMP_EDGE").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         // Delete edge
@@ -2154,6 +2178,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         // Add checkpoint marker
@@ -2168,6 +2193,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
         wal.flush()?;
 
@@ -2580,6 +2606,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("HighId").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         // Add entry with high edge ID
@@ -2590,6 +2617,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("HighEdge").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
         wal.flush()?;
 
@@ -2775,6 +2803,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 valid_from: time::now(),
+                provenance: None,
             };
             wal.append_async(op)?;
         }
@@ -2884,6 +2913,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 valid_from: time::now(),
+                provenance: None,
             };
             wal.append_async(op)?;
         }
@@ -2994,6 +3024,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMapBuilder::new().build(),
                 valid_from: time::now(),
+                provenance: None,
             };
             wal.append_async(op)?;
         }

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -18,6 +18,7 @@ use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::{GLOBAL_INTERNER, InternedString};
 use crate::core::observer::{Observer, StorageEvent, notify_observers};
 use crate::core::property::PropertyMap;
+use crate::core::provenance::Provenance;
 use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp};
 use crate::core::version::{
     AnchorConfig, EdgeVersion, EntityVersion, FastHashMap, NodeVersion, TemporalVersion,
@@ -517,6 +518,9 @@ impl HistoricalStorage {
     /// This will automatically determine whether to create an anchor or delta
     /// based on the version chain length.
     /// Returns an error if the version limit for this entity is exceeded (DoS protection).
+    ///
+    /// Equivalent to [`add_node_version_with_provenance`](Self::add_node_version_with_provenance)
+    /// with `provenance: None`.
     #[allow(clippy::too_many_arguments)]
     pub fn add_node_version(
         &mut self,
@@ -527,6 +531,35 @@ impl HistoricalStorage {
         label: InternedString,
         properties: PropertyMap,
         is_tombstone: bool,
+    ) -> Result<()> {
+        self.add_node_version_with_provenance(
+            node_id,
+            version_id,
+            valid_from,
+            tx_time,
+            label,
+            properties,
+            is_tombstone,
+            None,
+        )
+    }
+
+    /// Add a new version of a node, optionally attaching a write-time
+    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    ///
+    /// Behaves identically to [`add_node_version`](Self::add_node_version) other
+    /// than persisting `provenance` on the created version (anchor or delta).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_node_version_with_provenance(
+        &mut self,
+        node_id: NodeId,
+        version_id: VersionId,
+        valid_from: Timestamp,
+        tx_time: Timestamp,
+        label: InternedString,
+        properties: PropertyMap,
+        is_tombstone: bool,
+        provenance: Option<Arc<Provenance>>,
     ) -> Result<()> {
         // Construct bi-temporal interval from separate dimensions
         let mut temporal = BiTemporalInterval::with_valid_time(valid_from, tx_time);
@@ -603,6 +636,7 @@ impl HistoricalStorage {
             self.node_versions_since_anchor.insert(node_id, 0);
             NodeVersion::new_anchor(version_id, node_id, temporal, label, properties.clone())
         };
+        version.provenance = provenance;
 
         // Handle pre-anchor hook (BEFORE storing)
         if version.is_anchor() {
@@ -709,6 +743,9 @@ impl HistoricalStorage {
 
     /// Add a new version of an edge.
     /// Returns an error if the version limit for this entity is exceeded (DoS protection).
+    ///
+    /// Equivalent to [`add_edge_version_with_provenance`](Self::add_edge_version_with_provenance)
+    /// with `provenance: None`.
     #[allow(clippy::too_many_arguments)]
     pub fn add_edge_version(
         &mut self,
@@ -721,6 +758,39 @@ impl HistoricalStorage {
         target: NodeId,
         properties: PropertyMap,
         is_tombstone: bool,
+    ) -> Result<()> {
+        self.add_edge_version_with_provenance(
+            edge_id,
+            version_id,
+            valid_from,
+            tx_time,
+            label,
+            source,
+            target,
+            properties,
+            is_tombstone,
+            None,
+        )
+    }
+
+    /// Add a new version of an edge, optionally attaching a write-time
+    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    ///
+    /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
+    /// than persisting `provenance` on the created version (anchor or delta).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_edge_version_with_provenance(
+        &mut self,
+        edge_id: EdgeId,
+        version_id: VersionId,
+        valid_from: Timestamp,
+        tx_time: Timestamp,
+        label: InternedString,
+        source: NodeId,
+        target: NodeId,
+        properties: PropertyMap,
+        is_tombstone: bool,
+        provenance: Option<Arc<Provenance>>,
     ) -> Result<()> {
         // Construct bi-temporal interval from separate dimensions
         let mut temporal = BiTemporalInterval::with_valid_time(valid_from, tx_time);
@@ -809,6 +879,7 @@ impl HistoricalStorage {
                 properties.clone(),
             )
         };
+        version.provenance = provenance;
 
         // Handle pre-anchor hook (BEFORE storing)
         if version.is_anchor() {
@@ -1331,6 +1402,46 @@ impl HistoricalStorage {
     /// Get the current version ID for an edge.
     pub fn get_current_edge_version(&self, edge_id: EdgeId) -> Option<VersionId> {
         self.edge_version_heads.get(&edge_id).copied()
+    }
+
+    /// Get the provenance bundle attached to a node's *current* version, if any.
+    ///
+    /// Returns `Ok(None)` (not an error) if the node exists but its current
+    /// version carries no provenance -- this is the common case for writes
+    /// that never supplied a bundle (Issue #3224). Falls back to cold/tiered
+    /// storage if the current version has been migrated out of hot storage.
+    pub fn get_current_node_provenance(&self, node_id: NodeId) -> Result<Option<Provenance>> {
+        let Some(version_id) = self.get_current_node_version(node_id) else {
+            return Ok(None);
+        };
+        let provenance = if let Some(v) = self.node_versions.get(&version_id) {
+            v.provenance.as_deref().cloned()
+        } else {
+            self.get_node_version_any_tier(version_id)?
+                .provenance
+                .as_deref()
+                .cloned()
+        };
+        Ok(provenance)
+    }
+
+    /// Get the provenance bundle attached to an edge's *current* version, if any.
+    ///
+    /// See [`get_current_node_provenance`](Self::get_current_node_provenance)
+    /// for semantics.
+    pub fn get_current_edge_provenance(&self, edge_id: EdgeId) -> Result<Option<Provenance>> {
+        let Some(version_id) = self.get_current_edge_version(edge_id) else {
+            return Ok(None);
+        };
+        let provenance = if let Some(v) = self.edge_versions.get(&version_id) {
+            v.provenance.as_deref().cloned()
+        } else {
+            self.get_edge_version_any_tier(version_id)?
+                .provenance
+                .as_deref()
+                .cloned()
+        };
+        Ok(provenance)
     }
 
     /// Get the node's true creation time: the `valid_from` of its first-ever version.
@@ -2226,6 +2337,7 @@ impl HistoricalStorage {
                     label: GLOBAL_INTERNER
                         .resolve_with(version.label, |s| s.to_string())
                         .unwrap_or_else(|| version.label.to_string()),
+                    provenance: version.provenance.as_deref().cloned(),
                 });
             }
         }
@@ -2375,6 +2487,7 @@ impl HistoricalStorage {
                     label: GLOBAL_INTERNER
                         .resolve_with(version.label, |s| s.to_string())
                         .unwrap_or_else(|| version.label.to_string()),
+                    provenance: version.provenance.as_deref().cloned(),
                 });
             }
         }

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1410,10 +1410,29 @@ impl HistoricalStorage {
     /// version carries no provenance -- this is the common case for writes
     /// that never supplied a bundle (Issue #3224). Falls back to cold/tiered
     /// storage if the current version has been migrated out of hot storage.
+    ///
+    /// This re-resolves "whichever version is current right now", which is a
+    /// separate lookup from any node snapshot the caller may already hold --
+    /// prefer [`get_node_version_provenance`](Self::get_node_version_provenance)
+    /// with an already-fetched `Node`'s `current_version` when consistency
+    /// with that snapshot matters (e.g. a concurrent write must not be able
+    /// to return one version's properties paired with a different version's
+    /// provenance).
     pub fn get_current_node_provenance(&self, node_id: NodeId) -> Result<Option<Provenance>> {
         let Some(version_id) = self.get_current_node_version(node_id) else {
             return Ok(None);
         };
+        self.get_node_version_provenance(version_id)
+    }
+
+    /// Get the provenance bundle attached to a specific node version, if any.
+    ///
+    /// Unlike [`get_current_node_provenance`](Self::get_current_node_provenance),
+    /// this looks up an exact, caller-supplied version rather than
+    /// re-resolving "whichever version is current right now" -- callers that
+    /// already hold a `Node` snapshot (e.g. from `get_node`) should pass that
+    /// snapshot's `current_version` here for a consistent, race-free read.
+    pub fn get_node_version_provenance(&self, version_id: VersionId) -> Result<Option<Provenance>> {
         let provenance = if let Some(v) = self.node_versions.get(&version_id) {
             v.provenance.as_deref().cloned()
         } else {
@@ -1428,11 +1447,21 @@ impl HistoricalStorage {
     /// Get the provenance bundle attached to an edge's *current* version, if any.
     ///
     /// See [`get_current_node_provenance`](Self::get_current_node_provenance)
-    /// for semantics.
+    /// for semantics, including the race-condition note about
+    /// [`get_edge_version_provenance`](Self::get_edge_version_provenance).
     pub fn get_current_edge_provenance(&self, edge_id: EdgeId) -> Result<Option<Provenance>> {
         let Some(version_id) = self.get_current_edge_version(edge_id) else {
             return Ok(None);
         };
+        self.get_edge_version_provenance(version_id)
+    }
+
+    /// Get the provenance bundle attached to a specific edge version, if any.
+    ///
+    /// See [`get_node_version_provenance`](Self::get_node_version_provenance)
+    /// for why callers holding an `Edge` snapshot should prefer this over
+    /// [`get_current_edge_provenance`](Self::get_current_edge_provenance).
+    pub fn get_edge_version_provenance(&self, version_id: VersionId) -> Result<Option<Provenance>> {
         let provenance = if let Some(v) = self.edge_versions.get(&version_id) {
             v.provenance.as_deref().cloned()
         } else {

--- a/src/storage/index_persistence/common.rs
+++ b/src/storage/index_persistence/common.rs
@@ -42,7 +42,15 @@ pub fn save_encoded_with_crc<T: Encode>(data: &T, path: &Path) -> Result<()> {
     atomic_write(path, &data_with_checksum)
 }
 
-/// Load encoded data from disk and validate CRC32 checksum.
+/// Read a file from disk and validate its trailing CRC32 checksum, returning
+/// the checksum-verified payload bytes (with the checksum suffix stripped)
+/// without decoding them.
+///
+/// Exposed separately from [`load_encoded_with_crc`] so callers that may need
+/// to try decoding the same verified bytes as more than one candidate shape
+/// (e.g. a current format falling back to a frozen legacy shape) can read the
+/// file and validate its checksum exactly once, rather than re-reading from
+/// disk and re-verifying the checksum for each candidate decode attempt.
 ///
 /// # Arguments
 ///
@@ -56,12 +64,7 @@ pub fn save_encoded_with_crc<T: Encode>(data: &T, path: &Path) -> Result<()> {
 /// - File size exceeds `max_size`
 /// - File is too small (missing checksum)
 /// - CRC32 checksum mismatch
-/// - Deserialization fails
-pub fn load_encoded_with_crc<T: for<'a> Decode<'a>>(
-    path: &Path,
-    max_size: u64,
-    context: &str,
-) -> Result<T> {
+pub fn read_and_verify_crc(path: &Path, max_size: u64, context: &str) -> Result<Vec<u8>> {
     // Check file size before reading to prevent OOM/DoS
     let metadata = fs::metadata(path)?;
     if metadata.len() > max_size {
@@ -110,8 +113,33 @@ pub fn load_encoded_with_crc<T: for<'a> Decode<'a>>(
         });
     }
 
-    // Decode
-    let decoded: T = bitcode::decode(data)?;
+    let mut data = bytes;
+    data.truncate(data.len() - 4);
+    Ok(data)
+}
+
+/// Load encoded data from disk and validate CRC32 checksum.
+///
+/// # Arguments
+///
+/// * `path` - The file path to read from
+/// * `max_size` - Maximum allowed file size (DoS protection)
+/// * `context` - Context name for error messages (e.g., "Vector index")
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - File size exceeds `max_size`
+/// - File is too small (missing checksum)
+/// - CRC32 checksum mismatch
+/// - Deserialization fails
+pub fn load_encoded_with_crc<T: for<'a> Decode<'a>>(
+    path: &Path,
+    max_size: u64,
+    context: &str,
+) -> Result<T> {
+    let data = read_and_verify_crc(path, max_size, context)?;
+    let decoded: T = bitcode::decode(&data)?;
     Ok(decoded)
 }
 

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -258,6 +258,23 @@ pub enum PersistedPropertyValue {
 // Temporal Index Format
 // ============================================================================
 
+/// Persisted write-time attributive provenance bundle (Issue #3224).
+///
+/// Mirrors [`crate::core::provenance::Provenance`]'s fields exactly; kept as
+/// a separate bitcode-encodable type since `Provenance` itself has private
+/// fields and validates on construction (not on persistence).
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct PersistedProvenance {
+    /// Source system/identifier that produced the write, if any.
+    pub source: Option<String>,
+    /// Confidence in `[0.0, 1.0]`, if any.
+    pub confidence: Option<f64>,
+    /// Free-text note, if any.
+    pub note: Option<String>,
+    /// Correlation ID grouping co-committed writes, if any.
+    pub correlation_id: Option<String>,
+}
+
 /// Persisted temporal index data.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct TemporalIndexData {
@@ -304,6 +321,8 @@ pub struct NodeVersionEntry {
     pub properties: PersistedPropertyMap,
     /// Vector snapshot ID for provenance tracking
     pub vector_snapshot_id: Option<u64>,
+    /// Write-time attributive provenance bundle (Issue #3224), if supplied.
+    pub provenance: Option<PersistedProvenance>,
 }
 
 /// Persisted node anchor entry.
@@ -364,6 +383,8 @@ pub struct EdgeVersionEntry {
     pub version_type: PersistedVersionType,
     /// Properties
     pub properties: PersistedPropertyMap,
+    /// Write-time attributive provenance bundle (Issue #3224), if supplied.
+    pub provenance: Option<PersistedProvenance>,
 }
 
 /// Persisted edge anchor entry.
@@ -633,6 +654,157 @@ impl Default for StringPersistencePolicy {
         Self {
             new_strings_threshold: 500,
             time_interval_secs: 600, // 10 minutes
+        }
+    }
+}
+
+// ============================================================================
+// Legacy (pre-provenance) Temporal Index Format (Issue #3224)
+// ============================================================================
+
+/// Frozen copies of the temporal index structs as they existed before
+/// write-time provenance (Issue #3224) was added, i.e. `MANIFEST_VERSION == 1`.
+///
+/// `bitcode` is a positional, non-self-describing format: appending a field
+/// to [`NodeVersionEntry`]/[`EdgeVersionEntry`] changes their wire layout, so
+/// files written by older binaries can no longer decode as the current
+/// structs. These frozen shapes let [`super::temporal::load_temporal_index`]
+/// fall back to the old layout and upgrade in memory (`provenance: None`).
+///
+/// Do not modify these types after they're introduced -- they exist purely
+/// to describe historical on-disk bytes.
+pub mod legacy_v1 {
+    use super::{EdgeAnchorEntry, NodeAnchorEntry, PersistedPropertyMap, PersistedVersionType};
+    use bitcode::{Decode, Encode};
+
+    /// Pre-provenance `TemporalIndexData` (`version == 1`).
+    #[derive(Debug, Clone, Encode, Decode)]
+    pub struct TemporalIndexDataV1 {
+        /// Magic bytes: "GTMP"
+        pub magic: [u8; 4],
+        /// Format version (always 1 for this shape)
+        pub version: u16,
+        /// Node version entries
+        pub node_versions: Vec<NodeVersionEntryV1>,
+        /// Node anchor entries (unchanged since v1)
+        pub node_anchors: Vec<NodeAnchorEntry>,
+        /// Edge version entries
+        pub edge_versions: Vec<EdgeVersionEntryV1>,
+        /// Edge anchor entries (unchanged since v1)
+        pub edge_anchors: Vec<EdgeAnchorEntry>,
+    }
+
+    /// Pre-provenance `NodeVersionEntry` (no `provenance` field).
+    #[derive(Debug, Clone, Encode, Decode)]
+    pub struct NodeVersionEntryV1 {
+        /// Unique version identifier (preserved from original)
+        pub version_id: u64,
+        /// Node ID
+        pub node_id: u64,
+        /// Label index in string interner
+        pub label_idx: u32,
+        /// Valid time start (unix timestamp)
+        pub valid_from: i64,
+        /// Valid time end (None = still valid)
+        pub valid_to: Option<i64>,
+        /// Valid time start (logical counter)
+        pub valid_from_logical: u32,
+        /// Valid time end (logical counter)
+        pub valid_to_logical: Option<u32>,
+        /// Transaction time (unix timestamp)
+        pub tx_time: i64,
+        /// Transaction time (logical counter)
+        pub tx_time_logical: u32,
+        /// Version type (delta or anchor)
+        pub version_type: PersistedVersionType,
+        /// Properties at this version
+        pub properties: PersistedPropertyMap,
+        /// Vector snapshot ID for provenance tracking
+        pub vector_snapshot_id: Option<u64>,
+    }
+
+    /// Pre-provenance `EdgeVersionEntry` (no `provenance` field).
+    #[derive(Debug, Clone, Encode, Decode)]
+    pub struct EdgeVersionEntryV1 {
+        /// Unique version identifier (preserved from original)
+        pub version_id: u64,
+        /// Edge ID
+        pub edge_id: u64,
+        /// Source node ID
+        pub source_id: u64,
+        /// Target node ID
+        pub target_id: u64,
+        /// Label index in string interner
+        pub label_idx: u32,
+        /// Valid time start
+        pub valid_from: i64,
+        /// Valid time end
+        pub valid_to: Option<i64>,
+        /// Valid time start (logical counter)
+        pub valid_from_logical: u32,
+        /// Valid time end (logical counter)
+        pub valid_to_logical: Option<u32>,
+        /// Transaction time
+        pub tx_time: i64,
+        /// Transaction time (logical counter)
+        pub tx_time_logical: u32,
+        /// Version type
+        pub version_type: PersistedVersionType,
+        /// Properties
+        pub properties: PersistedPropertyMap,
+    }
+
+    impl From<NodeVersionEntryV1> for super::NodeVersionEntry {
+        fn from(v1: NodeVersionEntryV1) -> Self {
+            super::NodeVersionEntry {
+                version_id: v1.version_id,
+                node_id: v1.node_id,
+                label_idx: v1.label_idx,
+                valid_from: v1.valid_from,
+                valid_to: v1.valid_to,
+                valid_from_logical: v1.valid_from_logical,
+                valid_to_logical: v1.valid_to_logical,
+                tx_time: v1.tx_time,
+                tx_time_logical: v1.tx_time_logical,
+                version_type: v1.version_type,
+                properties: v1.properties,
+                vector_snapshot_id: v1.vector_snapshot_id,
+                provenance: None,
+            }
+        }
+    }
+
+    impl From<EdgeVersionEntryV1> for super::EdgeVersionEntry {
+        fn from(v1: EdgeVersionEntryV1) -> Self {
+            super::EdgeVersionEntry {
+                version_id: v1.version_id,
+                edge_id: v1.edge_id,
+                source_id: v1.source_id,
+                target_id: v1.target_id,
+                label_idx: v1.label_idx,
+                valid_from: v1.valid_from,
+                valid_to: v1.valid_to,
+                valid_from_logical: v1.valid_from_logical,
+                valid_to_logical: v1.valid_to_logical,
+                tx_time: v1.tx_time,
+                tx_time_logical: v1.tx_time_logical,
+                version_type: v1.version_type,
+                properties: v1.properties,
+                provenance: None,
+            }
+        }
+    }
+
+    impl From<TemporalIndexDataV1> for super::TemporalIndexData {
+        fn from(v1: TemporalIndexDataV1) -> Self {
+            super::TemporalIndexData {
+                magic: v1.magic,
+                version: v1.version,
+                node_versions: v1.node_versions.into_iter().map(Into::into).collect(),
+                node_anchors: v1.node_anchors,
+                edge_versions: v1.edge_versions.into_iter().map(Into::into).collect(),
+                edge_anchors: v1.edge_anchors,
+            }
         }
     }
 }

--- a/src/storage/index_persistence/formats.rs
+++ b/src/storage/index_persistence/formats.rs
@@ -799,7 +799,13 @@ pub mod legacy_v1 {
         fn from(v1: TemporalIndexDataV1) -> Self {
             super::TemporalIndexData {
                 magic: v1.magic,
-                version: v1.version,
+                // The converted entries are current-shape (provenance field
+                // added by the `NodeVersionEntryV1`/`EdgeVersionEntryV1` `From`
+                // impls above), so the upgraded struct must be stamped with
+                // the current format version, not the legacy one it was read
+                // as. Otherwise `decode_temporal_blob` would misdetect this
+                // struct as legacy on the next load and misdecode it.
+                version: super::super::MANIFEST_VERSION,
                 node_versions: v1.node_versions.into_iter().map(Into::into).collect(),
                 node_anchors: v1.node_anchors,
                 edge_versions: v1.edge_versions.into_iter().map(Into::into).collect(),

--- a/src/storage/index_persistence/mod.rs
+++ b/src/storage/index_persistence/mod.rs
@@ -110,7 +110,13 @@ pub use loader::IndexPersistenceManager;
 use rayon::prelude::*;
 
 /// Current manifest format version.
-pub const MANIFEST_VERSION: u16 = 1;
+///
+/// Bumped to 2 for write-time provenance on temporal versions (Issue #3224):
+/// `NodeVersionEntry`/`EdgeVersionEntry` gained an optional `provenance`
+/// field. Since `bitcode` is positional, files written at version 1 can no
+/// longer decode directly as the current structs; see
+/// `temporal::load_temporal_index` for the legacy fallback.
+pub const MANIFEST_VERSION: u16 = 2;
 
 /// Magic bytes for manifest files.
 pub const MANIFEST_MAGIC: [u8; 4] = *b"GIDX";

--- a/src/storage/index_persistence/strings.rs
+++ b/src/storage/index_persistence/strings.rs
@@ -74,7 +74,7 @@ pub fn save_string_interner(path: &Path) -> Result<()> {
 /// save_string_interner(&path).unwrap();
 ///
 /// let data = load_string_interner(&path).unwrap();
-/// assert_eq!(data.version, 1);
+/// assert_eq!(data.version, aletheiadb::storage::index_persistence::MANIFEST_VERSION);
 /// ```
 ///
 /// # Errors

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -71,22 +71,10 @@ pub(crate) fn restore_provenance(
     let Some(p) = persisted else {
         return Ok(None);
     };
-    let mut builder = Provenance::builder();
-    if let Some(source) = p.source {
-        builder = builder.source(source);
-    }
-    if let Some(confidence) = p.confidence {
-        builder = builder.confidence(confidence);
-    }
-    if let Some(note) = p.note {
-        builder = builder.note(note);
-    }
-    if let Some(correlation_id) = p.correlation_id {
-        builder = builder.correlation_id(correlation_id);
-    }
-    let provenance = builder.build().map_err(|e| {
-        IndexPersistenceError::Serialization(format!("Invalid persisted provenance: {}", e))
-    })?;
+    let provenance = Provenance::from_parts(p.source, p.confidence, p.note, p.correlation_id)
+        .map_err(|e| {
+            IndexPersistenceError::Serialization(format!("Invalid persisted provenance: {}", e))
+        })?;
     Ok(Some(Arc::new(provenance)))
 }
 

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -586,22 +586,30 @@ pub fn load_temporal_index(path: &Path) -> Result<TemporalIndexData> {
 /// (`provenance: None`) -- this is the same magic+version cross-check used
 /// throughout this module, just applied across two candidate shapes instead
 /// of one.
+///
+/// The file is read from disk and CRC32-verified exactly once via
+/// [`super::common::read_and_verify_crc`]; both candidate decodes are
+/// attempted against that single in-memory buffer, avoiding a second disk
+/// read and checksum pass on the (common, cheap) legacy-fallback path.
 fn decode_temporal_blob(path: &Path) -> Result<TemporalIndexData> {
-    if let Ok(data) = super::common::load_encoded_with_crc::<TemporalIndexData>(
+    let bytes = super::common::read_and_verify_crc(
         path,
         super::MAX_TEMPORAL_INDEX_FILE_SIZE,
         "Temporal index",
-    ) && data.magic == TEMPORAL_MAGIC
+    )?;
+
+    if let Ok(data) = bitcode::decode::<TemporalIndexData>(&bytes)
+        && data.magic == TEMPORAL_MAGIC
         && data.version == MANIFEST_VERSION
     {
         return Ok(data);
     }
 
-    let legacy: TemporalIndexDataV1 = super::common::load_encoded_with_crc(
-        path,
-        super::MAX_TEMPORAL_INDEX_FILE_SIZE,
-        "Temporal index",
-    )?;
+    let legacy: TemporalIndexDataV1 =
+        bitcode::decode(&bytes).map_err(|e| IndexPersistenceError::Corrupted {
+            path: path.to_path_buf(),
+            source: format!("Failed to decode temporal index: {e}").into(),
+        })?;
 
     if legacy.magic != TEMPORAL_MAGIC {
         return Err(IndexPersistenceError::InvalidMagic {

--- a/src/storage/index_persistence/temporal.rs
+++ b/src/storage/index_persistence/temporal.rs
@@ -33,17 +33,62 @@
 //!   materialized into a full vector before persistence using `PropertyDelta::materialize_vector_deltas()`.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::core::id::{EdgeId, NodeId};
 use crate::core::interning::InternedString;
 use crate::core::property::PropertyValue;
+use crate::core::provenance::Provenance;
 use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange};
 use crate::core::version::{EdgeVersion, NodeVersion, PropertyDelta, VersionData};
 
 use super::error::{IndexPersistenceError, Result};
-use super::formats::{EdgeVersionEntry, NodeVersionEntry, PersistedVersionType, TemporalIndexData};
+use super::formats::{
+    EdgeVersionEntry, NodeVersionEntry, PersistedProvenance, PersistedVersionType,
+    TemporalIndexData, legacy_v1::TemporalIndexDataV1,
+};
 use super::graph::{persist_property_map, restore_property_map};
 use super::{MANIFEST_VERSION, TEMPORAL_MAGIC};
+
+/// Convert an in-memory [`Provenance`] into its persisted representation.
+pub(crate) fn persist_provenance(provenance: Option<&Provenance>) -> Option<PersistedProvenance> {
+    provenance.map(|p| PersistedProvenance {
+        source: p.source().map(String::from),
+        confidence: p.confidence(),
+        note: p.note().map(String::from),
+        correlation_id: p.correlation_id().map(String::from),
+    })
+}
+
+/// Restore a persisted provenance bundle back into an in-memory [`Provenance`].
+///
+/// Returns an error if the persisted `confidence` is out of `[0.0, 1.0]`,
+/// which would indicate on-disk corruption (the writer always validates
+/// before persisting).
+pub(crate) fn restore_provenance(
+    persisted: Option<PersistedProvenance>,
+) -> Result<Option<Arc<Provenance>>> {
+    let Some(p) = persisted else {
+        return Ok(None);
+    };
+    let mut builder = Provenance::builder();
+    if let Some(source) = p.source {
+        builder = builder.source(source);
+    }
+    if let Some(confidence) = p.confidence {
+        builder = builder.confidence(confidence);
+    }
+    if let Some(note) = p.note {
+        builder = builder.note(note);
+    }
+    if let Some(correlation_id) = p.correlation_id {
+        builder = builder.correlation_id(correlation_id);
+    }
+    let provenance = builder.build().map_err(|e| {
+        IndexPersistenceError::Serialization(format!("Invalid persisted provenance: {}", e))
+    })?;
+    Ok(Some(Arc::new(provenance)))
+}
 
 /// Convert NodeVersion to NodeVersionEntry for persistence.
 ///
@@ -148,6 +193,7 @@ pub fn convert_node_version(version: &NodeVersion) -> Result<NodeVersionEntry> {
         version_type,
         properties,
         vector_snapshot_id,
+        provenance: persist_provenance(version.provenance.as_deref()),
     })
 }
 
@@ -235,6 +281,7 @@ pub fn convert_edge_version(version: &EdgeVersion) -> Result<EdgeVersionEntry> {
         tx_time_logical: tx_time.start().logical(),
         version_type,
         properties,
+        provenance: persist_provenance(version.provenance.as_deref()),
     })
 }
 
@@ -332,6 +379,7 @@ pub fn restore_node_version(entry: &NodeVersionEntry) -> Result<NodeVersion> {
         data,
         next_version: None,
         prev_version: None,
+        provenance: restore_provenance(entry.provenance.clone())?,
     })
 }
 
@@ -439,6 +487,7 @@ pub fn restore_edge_version(entry: &EdgeVersionEntry) -> Result<EdgeVersion> {
         data,
         next_version: None,
         prev_version: None,
+        provenance: restore_provenance(entry.provenance.clone())?,
     })
 }
 
@@ -534,28 +583,53 @@ pub fn save_temporal_index(data: &TemporalIndexData, path: &Path) -> Result<()> 
 ///
 /// Returns an error if the file is missing, corrupted, or incompatible.
 pub fn load_temporal_index(path: &Path) -> Result<TemporalIndexData> {
-    let data: TemporalIndexData = super::common::load_encoded_with_crc(
+    decode_temporal_blob(path)
+}
+
+/// Decode temporal index bytes, transparently upgrading pre-provenance
+/// (Issue #3224, `MANIFEST_VERSION == 1`) files.
+///
+/// `bitcode` is positional and non-self-describing, so a `version == 1` file
+/// cannot decode directly as the current [`TemporalIndexData`] (whose
+/// `NodeVersionEntry`/`EdgeVersionEntry` gained a `provenance` field). We
+/// first try decoding as the current shape; if that fails, or produces an
+/// implausible magic/version (a decode "succeeding" on bytes it wasn't meant
+/// for), we fall back to the frozen `legacy_v1` shape and convert
+/// (`provenance: None`) -- this is the same magic+version cross-check used
+/// throughout this module, just applied across two candidate shapes instead
+/// of one.
+fn decode_temporal_blob(path: &Path) -> Result<TemporalIndexData> {
+    if let Ok(data) = super::common::load_encoded_with_crc::<TemporalIndexData>(
+        path,
+        super::MAX_TEMPORAL_INDEX_FILE_SIZE,
+        "Temporal index",
+    ) && data.magic == TEMPORAL_MAGIC
+        && data.version == MANIFEST_VERSION
+    {
+        return Ok(data);
+    }
+
+    let legacy: TemporalIndexDataV1 = super::common::load_encoded_with_crc(
         path,
         super::MAX_TEMPORAL_INDEX_FILE_SIZE,
         "Temporal index",
     )?;
 
-    if data.magic != TEMPORAL_MAGIC {
+    if legacy.magic != TEMPORAL_MAGIC {
         return Err(IndexPersistenceError::InvalidMagic {
             path: path.to_path_buf(),
             expected: TEMPORAL_MAGIC,
-            got: data.magic,
+            got: legacy.magic,
         });
     }
-
-    if data.version > MANIFEST_VERSION {
+    if legacy.version > MANIFEST_VERSION {
         return Err(IndexPersistenceError::UnsupportedVersion {
-            found: data.version,
+            found: legacy.version,
             supported: MANIFEST_VERSION,
         });
     }
 
-    Ok(data)
+    Ok(legacy.into())
 }
 
 /// Create a new empty TemporalIndexData.
@@ -605,6 +679,7 @@ mod tests {
             version_type: PersistedVersionType::Anchor,
             properties: PersistedPropertyMap { entries: vec![] },
             vector_snapshot_id: Some(42),
+            provenance: None,
         });
         data.node_anchors.push(NodeAnchorEntry {
             node_id: 1,
@@ -619,6 +694,100 @@ mod tests {
         assert_eq!(loaded.node_versions.len(), 1);
         assert_eq!(loaded.node_anchors.len(), 1);
         assert_eq!(loaded.node_versions[0].vector_snapshot_id, Some(42));
+    }
+
+    #[test]
+    fn test_temporal_index_roundtrip_with_provenance() {
+        use crate::core::GLOBAL_INTERNER;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("temporal_provenance.idx");
+
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        let mut data = new_temporal_index_data();
+        data.node_versions.push(NodeVersionEntry {
+            version_id: 100,
+            node_id: 1,
+            label_idx: label.as_u32(),
+            valid_from: 1000,
+            valid_from_logical: 0,
+            valid_to: None,
+            valid_to_logical: None,
+            tx_time: 1000,
+            tx_time_logical: 0,
+            version_type: PersistedVersionType::Anchor,
+            properties: PersistedPropertyMap { entries: vec![] },
+            vector_snapshot_id: None,
+            provenance: Some(PersistedProvenance {
+                source: Some("hr-system".to_string()),
+                confidence: Some(0.95),
+                note: None,
+                correlation_id: Some("batch-42".to_string()),
+            }),
+        });
+
+        save_temporal_index(&data, &path).unwrap();
+        let loaded = load_temporal_index(&path).unwrap();
+
+        let provenance = loaded.node_versions[0].provenance.as_ref().unwrap();
+        assert_eq!(provenance.source.as_deref(), Some("hr-system"));
+        assert_eq!(provenance.confidence, Some(0.95));
+        assert_eq!(provenance.note, None);
+        assert_eq!(provenance.correlation_id.as_deref(), Some("batch-42"));
+
+        // And the version without provenance round-trips as None, not a
+        // fabricated default.
+        let version = restore_node_version(&loaded.node_versions[0]).unwrap();
+        assert!(version.provenance.is_some());
+        assert_eq!(version.provenance.unwrap().source(), Some("hr-system"));
+    }
+
+    #[test]
+    fn test_load_v1_temporal_index_file_defaults_provenance_none() {
+        use crate::core::GLOBAL_INTERNER;
+        use crate::storage::index_persistence::formats::legacy_v1::{
+            NodeVersionEntryV1, TemporalIndexDataV1,
+        };
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("legacy_temporal.idx");
+
+        let label = GLOBAL_INTERNER.intern("Person").unwrap();
+        let legacy = TemporalIndexDataV1 {
+            magic: TEMPORAL_MAGIC,
+            version: 1,
+            node_versions: vec![NodeVersionEntryV1 {
+                version_id: 100,
+                node_id: 1,
+                label_idx: label.as_u32(),
+                valid_from: 1000,
+                valid_from_logical: 0,
+                valid_to: None,
+                valid_to_logical: None,
+                tx_time: 1000,
+                tx_time_logical: 0,
+                version_type: PersistedVersionType::Anchor,
+                properties: PersistedPropertyMap { entries: vec![] },
+                vector_snapshot_id: Some(7),
+            }],
+            node_anchors: vec![],
+            edge_versions: vec![],
+            edge_anchors: vec![],
+        };
+
+        // Write bytes exactly as a pre-#3224 binary would have: no `provenance`
+        // field exists in this shape at all, so `super::common::save_encoded_with_crc`
+        // (which just bitcode-encodes whatever type it's given) reproduces that
+        // on-disk layout precisely.
+        crate::storage::index_persistence::common::save_encoded_with_crc(&legacy, &path).unwrap();
+
+        let loaded = load_temporal_index(&path).unwrap();
+
+        assert_eq!(loaded.node_versions.len(), 1);
+        assert_eq!(loaded.node_versions[0].vector_snapshot_id, Some(7));
+        assert!(loaded.node_versions[0].provenance.is_none());
+
+        let version = restore_node_version(&loaded.node_versions[0]).unwrap();
+        assert!(version.provenance.is_none());
     }
 
     #[test]
@@ -649,6 +818,7 @@ mod tests {
             },
             next_version: None,
             prev_version: None,
+            provenance: None,
         };
 
         let entry = convert_node_version(&version).unwrap();
@@ -689,6 +859,7 @@ mod tests {
             data: VersionData::Delta { delta },
             next_version: None,
             prev_version: Some(VersionId::new(1).unwrap()),
+            provenance: None,
         };
 
         let entry = convert_node_version(&version).unwrap();
@@ -734,6 +905,7 @@ mod tests {
             },
             next_version: None,
             prev_version: None,
+            provenance: None,
         };
 
         let entry = convert_edge_version(&version).unwrap();
@@ -780,6 +952,7 @@ mod tests {
             version_type: PersistedVersionType::Anchor,
             properties,
             vector_snapshot_id: Some(42),
+            provenance: None,
         };
 
         let version = restore_node_version(&entry).unwrap();
@@ -836,6 +1009,7 @@ mod tests {
             },
             properties,
             vector_snapshot_id: None,
+            provenance: None,
         };
 
         let version = restore_node_version(&entry).unwrap();
@@ -879,6 +1053,7 @@ mod tests {
             tx_time_logical: 0,
             version_type: PersistedVersionType::Anchor,
             properties,
+            provenance: None,
         };
 
         let version = restore_edge_version(&entry).unwrap();
@@ -935,6 +1110,7 @@ mod tests {
             version_type: PersistedVersionType::Anchor,
             properties,
             vector_snapshot_id: Some(42),
+            provenance: None,
         };
 
         // Create temporal data (labels are now stored in entries)
@@ -989,6 +1165,7 @@ mod tests {
             data: VersionData::Delta { delta },
             next_version: None,
             prev_version: Some(VersionId::new(1).unwrap()),
+            provenance: None,
         };
 
         // Should succeed - Full deltas can be persisted
@@ -1029,6 +1206,7 @@ mod tests {
             data: VersionData::Delta { delta },
             next_version: None,
             prev_version: Some(VersionId::new(1).unwrap()),
+            provenance: None,
         };
 
         // Should FAIL - Sparse deltas cannot be persisted without materialization
@@ -1170,6 +1348,7 @@ mod tests {
             data: VersionData::Delta { delta },
             next_version: None,
             prev_version: Some(VersionId::new(1).unwrap()),
+            provenance: None,
         };
 
         // Should succeed - delta is now materialized
@@ -1212,6 +1391,7 @@ mod tests {
             data: VersionData::Delta { delta },
             next_version: None,
             prev_version: Some(VersionId::new(1).unwrap()),
+            provenance: None,
         };
 
         // Convert to persisted entry
@@ -1274,6 +1454,7 @@ mod tests {
             },
             next_version: None,
             prev_version: None,
+            provenance: None,
         };
 
         // Persist

--- a/src/storage/index_persistence/temporal_adjacency.rs
+++ b/src/storage/index_persistence/temporal_adjacency.rs
@@ -95,8 +95,14 @@ pub fn load_temporal_adjacency_index(data_dir: &Path) -> Result<Arc<TemporalAdja
         ))
     })?;
 
-    // Validate version
-    if data.version != MANIFEST_VERSION {
+    // Validate version. Like the other index formats (graph, manifest,
+    // strings, vector), this only rejects strictly-newer versions: the
+    // on-disk shape of `TemporalAdjacencyData` has not changed since it was
+    // introduced, so any older file sharing the crate-wide `MANIFEST_VERSION`
+    // counter (e.g. bumped by an unrelated format's schema change, such as
+    // Issue #3224's provenance addition to the temporal-index format) is
+    // still byte-compatible and must keep loading correctly.
+    if data.version > MANIFEST_VERSION {
         return Err(IndexPersistenceError::Serialization(format!(
             "Unsupported temporal adjacency format version: {} (expected: {})",
             data.version, MANIFEST_VERSION
@@ -222,4 +228,67 @@ fn convert_from_persisted(
         tx_from,
         tx_to,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test: `TemporalAdjacencyData`'s on-disk shape has not
+    /// changed since it was introduced, but it shares the crate-wide
+    /// `MANIFEST_VERSION` counter with unrelated formats (e.g. the
+    /// temporal-index format bumped by Issue #3224's provenance addition).
+    /// A file written when `MANIFEST_VERSION` was 1 must still load
+    /// correctly after an unrelated format bump takes the shared constant
+    /// to 2 or higher, since this format's bytes are unaffected.
+    #[test]
+    fn load_accepts_older_manifest_version_with_unchanged_shape() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let adjacency_dir = data_dir.join("temporal_adjacency");
+        std::fs::create_dir_all(&adjacency_dir).unwrap();
+
+        // Simulate a file written by a build where MANIFEST_VERSION was
+        // still 1 (before some unrelated format's schema bump). The shape
+        // of `TemporalAdjacencyData` itself is unchanged, so this must
+        // still decode successfully.
+        let data = TemporalAdjacencyData {
+            magic: TEMPORAL_ADJACENCY_MAGIC,
+            version: 1,
+            outgoing: vec![],
+        };
+        let bytes = bitcode::encode(&data);
+        std::fs::write(adjacency_dir.join("adjacency.idx"), &bytes).unwrap();
+
+        let loaded = load_temporal_adjacency_index(&data_dir).unwrap();
+        let t = crate::core::temporal::time::now();
+        assert_eq!(
+            loaded
+                .get_outgoing_at_time(NodeId::new(1).unwrap(), t, t)
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn load_rejects_strictly_newer_manifest_version() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let adjacency_dir = data_dir.join("temporal_adjacency");
+        std::fs::create_dir_all(&adjacency_dir).unwrap();
+
+        let data = TemporalAdjacencyData {
+            magic: TEMPORAL_ADJACENCY_MAGIC,
+            version: MANIFEST_VERSION + 1,
+            outgoing: vec![],
+        };
+        let bytes = bitcode::encode(&data);
+        std::fs::write(adjacency_dir.join("adjacency.idx"), &bytes).unwrap();
+
+        match load_temporal_adjacency_index(&data_dir) {
+            Err(IndexPersistenceError::Serialization(_)) => {}
+            Err(other) => panic!("expected Serialization error, got {other:?}"),
+            Ok(_) => panic!("expected an error, but load succeeded"),
+        }
+    }
 }

--- a/src/storage/recovery.rs
+++ b/src/storage/recovery.rs
@@ -167,6 +167,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 label,
                 properties,
                 valid_from,
+                provenance,
             } => {
                 max_node_id = Some(match max_node_id {
                     Some(current_max) => current_max.max(node_id.as_u64()),
@@ -190,7 +191,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 );
 
                 current.insert_node_direct(node, commit_timestamp)?;
-                historical.add_node_version(
+                historical.add_node_version_with_provenance(
                     node_id,
                     version_id,
                     valid_from,
@@ -198,6 +199,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     interned_label,
                     properties,
                     false, // not a tombstone
+                    provenance.map(std::sync::Arc::new),
                 )?;
             }
             WalOperation::CreateEdge {
@@ -207,6 +209,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 label,
                 properties,
                 valid_from,
+                provenance,
             } => {
                 max_edge_id = Some(match max_edge_id {
                     Some(current_max) => current_max.max(edge_id.as_u64()),
@@ -231,7 +234,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 );
 
                 current.insert_edge_direct(edge)?;
-                historical.add_edge_version(
+                historical.add_edge_version_with_provenance(
                     edge_id,
                     version_id,
                     valid_from,
@@ -241,6 +244,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     target,
                     properties,
                     false, // not a tombstone
+                    provenance.map(std::sync::Arc::new),
                 )?;
             }
             WalOperation::UpdateNode {
@@ -249,6 +253,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 label,
                 properties,
                 valid_from,
+                provenance,
             } => {
                 next_version_id = next_version_id.max(version_id.as_u64() + 1);
 
@@ -272,7 +277,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                         .close_node_version_transaction_time(prev_version_id, commit_timestamp)?;
                 }
 
-                historical.add_node_version(
+                historical.add_node_version_with_provenance(
                     node_id,
                     version_id,
                     valid_from,
@@ -280,6 +285,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     interned_label,
                     properties,
                     false, // not a tombstone
+                    provenance.map(std::sync::Arc::new),
                 )?;
             }
             WalOperation::UpdateEdge {
@@ -288,6 +294,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                 label,
                 properties,
                 valid_from,
+                provenance,
             } => {
                 next_version_id = next_version_id.max(version_id.as_u64() + 1);
 
@@ -315,7 +322,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                         .close_edge_version_transaction_time(prev_version_id, commit_timestamp)?;
                 }
 
-                historical.add_edge_version(
+                historical.add_edge_version_with_provenance(
                     edge_id,
                     version_id,
                     valid_from,
@@ -325,6 +332,7 @@ pub(crate) fn replay_wal_into_storage_with_constraints(
                     current_edge.target,
                     properties,
                     false, // not a tombstone
+                    provenance.map(std::sync::Arc::new),
                 )?;
             }
             WalOperation::DeleteNode {

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -1749,6 +1749,17 @@ impl RedbColdStorage {
 // Serialization helpers using bitcode
 // ============================================================================
 
+/// Serializable wrapper for write-time provenance (Issue #3224).
+///
+/// Mirrors [`crate::core::provenance::Provenance`]'s fields exactly.
+#[derive(bitcode::Encode, bitcode::Decode)]
+struct SerializableProvenance {
+    source: Option<String>,
+    confidence: Option<f64>,
+    note: Option<String>,
+    correlation_id: Option<String>,
+}
+
 /// Serializable wrapper for NodeVersion.
 #[derive(bitcode::Encode, bitcode::Decode)]
 struct SerializableNodeVersion {
@@ -1762,6 +1773,7 @@ struct SerializableNodeVersion {
     data: SerializableVersionData,
     next_version: Option<u64>,
     prev_version: Option<u64>,
+    provenance: Option<SerializableProvenance>,
 }
 
 /// Serializable wrapper for EdgeVersion.
@@ -1779,7 +1791,52 @@ struct SerializableEdgeVersion {
     data: SerializableVersionData,
     next_version: Option<u64>,
     prev_version: Option<u64>,
+    provenance: Option<SerializableProvenance>,
 }
+
+/// Pre-provenance (Issue #3224) shape of [`SerializableNodeVersion`].
+///
+/// Cold-storage records have no version tag at all, so a legacy record is
+/// indistinguishable from a current one except by trying to decode it. This
+/// frozen shape is the fallback `decode_node_version` tries when the
+/// tag-prefixed current decode fails (see [`COLD_RECORD_TAG_V2`]).
+#[derive(bitcode::Encode, bitcode::Decode)]
+struct SerializableNodeVersionV1 {
+    id: u64,
+    node_id: u64,
+    temporal_valid_start: i64,
+    temporal_valid_end: i64,
+    temporal_tx_start: i64,
+    temporal_tx_end: i64,
+    label: String,
+    data: SerializableVersionData,
+    next_version: Option<u64>,
+    prev_version: Option<u64>,
+}
+
+/// Pre-provenance (Issue #3224) shape of [`SerializableEdgeVersion`].
+#[derive(bitcode::Encode, bitcode::Decode)]
+struct SerializableEdgeVersionV1 {
+    id: u64,
+    edge_id: u64,
+    temporal_valid_start: i64,
+    temporal_valid_end: i64,
+    temporal_tx_start: i64,
+    temporal_tx_end: i64,
+    label: String,
+    source: u64,
+    target: u64,
+    data: SerializableVersionData,
+    next_version: Option<u64>,
+    prev_version: Option<u64>,
+}
+
+/// Tag byte prepended to cold-storage records written with provenance
+/// support (Issue #3224). Legacy (pre-#3224) records have no tag at all --
+/// `decode_node_version`/`decode_edge_version` fall back to the untagged
+/// [`SerializableNodeVersionV1`]/[`SerializableEdgeVersionV1`] shape when the
+/// first byte isn't this tag (or the tagged decode fails).
+const COLD_RECORD_TAG_V2: u8 = 0x02;
 
 /// Serializable wrapper for VersionData.
 #[derive(bitcode::Encode, bitcode::Decode)]
@@ -1837,9 +1894,54 @@ pub fn encode_node_version(version: &NodeVersion) -> Vec<u8> {
         data: encode_version_data(&version.data),
         next_version: version.next_version.map(|v| v.as_u64()),
         prev_version: version.prev_version.map(|v| v.as_u64()),
+        provenance: encode_provenance(version.provenance.as_deref()),
     };
 
-    bitcode::encode(&serializable)
+    let mut out = Vec::with_capacity(1);
+    out.push(COLD_RECORD_TAG_V2);
+    out.extend_from_slice(&bitcode::encode(&serializable));
+    out
+}
+
+/// Convert an in-memory [`Provenance`](crate::core::provenance::Provenance)
+/// into its cold-storage representation.
+fn encode_provenance(
+    provenance: Option<&crate::core::provenance::Provenance>,
+) -> Option<SerializableProvenance> {
+    provenance.map(|p| SerializableProvenance {
+        source: p.source().map(String::from),
+        confidence: p.confidence(),
+        note: p.note().map(String::from),
+        correlation_id: p.correlation_id().map(String::from),
+    })
+}
+
+/// Restore a cold-storage provenance bundle back into an in-memory
+/// [`Provenance`](crate::core::provenance::Provenance).
+fn decode_provenance(
+    persisted: Option<SerializableProvenance>,
+) -> Result<Option<std::sync::Arc<crate::core::provenance::Provenance>>> {
+    let Some(p) = persisted else {
+        return Ok(None);
+    };
+    use crate::core::provenance::Provenance;
+    let mut builder = Provenance::builder();
+    if let Some(source) = p.source {
+        builder = builder.source(source);
+    }
+    if let Some(confidence) = p.confidence {
+        builder = builder.confidence(confidence);
+    }
+    if let Some(note) = p.note {
+        builder = builder.note(note);
+    }
+    if let Some(correlation_id) = p.correlation_id {
+        builder = builder.correlation_id(correlation_id);
+    }
+    let provenance = builder
+        .build()
+        .map_err(|e| StorageError::corruption(format!("Invalid persisted provenance: {}", e)))?;
+    Ok(Some(std::sync::Arc::new(provenance)))
 }
 
 /// Decode a `NodeVersion` from a previously serialized byte payload.
@@ -1854,41 +1956,88 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
     use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::temporal::{BiTemporalInterval, TimeRange};
 
-    let serializable: SerializableNodeVersion = bitcode::decode(data)
-        .map_err(|e| StorageError::corruption(format!("Failed to decode node version: {}", e)))?;
+    // Tagged (Issue #3224) records carry provenance; untagged records are
+    // pre-provenance and are decoded via the frozen `..V1` shape instead.
+    // There is no version byte on legacy records at all, so the tag itself
+    // is the only signal -- see `COLD_RECORD_TAG_V2`.
+    let (
+        label,
+        temporal_valid_start,
+        temporal_valid_end,
+        temporal_tx_start,
+        temporal_tx_end,
+        id,
+        node_id,
+        data_field,
+        next_version,
+        prev_version,
+        provenance,
+    ) = if data.first() == Some(&COLD_RECORD_TAG_V2)
+        && let Ok(s) = bitcode::decode::<SerializableNodeVersion>(&data[1..])
+    {
+        (
+            s.label,
+            s.temporal_valid_start,
+            s.temporal_valid_end,
+            s.temporal_tx_start,
+            s.temporal_tx_end,
+            s.id,
+            s.node_id,
+            s.data,
+            s.next_version,
+            s.prev_version,
+            decode_provenance(s.provenance)?,
+        )
+    } else {
+        let s: SerializableNodeVersionV1 = bitcode::decode(data).map_err(|e| {
+            StorageError::corruption(format!("Failed to decode node version: {}", e))
+        })?;
+        (
+            s.label,
+            s.temporal_valid_start,
+            s.temporal_valid_end,
+            s.temporal_tx_start,
+            s.temporal_tx_end,
+            s.id,
+            s.node_id,
+            s.data,
+            s.next_version,
+            s.prev_version,
+            None,
+        )
+    };
 
     let valid_time = TimeRange::new(
-        HybridTimestamp::new_unchecked(serializable.temporal_valid_start, 0),
-        HybridTimestamp::new_unchecked(serializable.temporal_valid_end, 0),
+        HybridTimestamp::new_unchecked(temporal_valid_start, 0),
+        HybridTimestamp::new_unchecked(temporal_valid_end, 0),
     )
     .map_err(|e| StorageError::corruption(format!("Invalid valid time range: {}", e)))?;
     let tx_time = TimeRange::new(
-        HybridTimestamp::new_unchecked(serializable.temporal_tx_start, 0),
-        HybridTimestamp::new_unchecked(serializable.temporal_tx_end, 0),
+        HybridTimestamp::new_unchecked(temporal_tx_start, 0),
+        HybridTimestamp::new_unchecked(temporal_tx_end, 0),
     )
     .map_err(|e| StorageError::corruption(format!("Invalid transaction time range: {}", e)))?;
 
     Ok(NodeVersion {
-        id: VersionId::new(serializable.id)
+        id: VersionId::new(id)
             .map_err(|e| StorageError::corruption(format!("Invalid version ID: {}", e)))?,
-        node_id: NodeId::new(serializable.node_id)
+        node_id: NodeId::new(node_id)
             .map_err(|e| StorageError::corruption(format!("Invalid node ID: {}", e)))?,
         commit_timestamp: tx_time.start(),
         temporal: BiTemporalInterval::new(valid_time, tx_time),
         label: GLOBAL_INTERNER
-            .intern(&serializable.label)
+            .intern(&label)
             .map_err(|e| StorageError::corruption(format!("Failed to intern label: {}", e)))?,
-        data: decode_version_data(serializable.data)?,
-        next_version: serializable
-            .next_version
+        data: decode_version_data(data_field)?,
+        next_version: next_version
             .map(VersionId::new)
             .transpose()
             .map_err(|e| StorageError::corruption(format!("Invalid next version ID: {}", e)))?,
-        prev_version: serializable
-            .prev_version
+        prev_version: prev_version
             .map(VersionId::new)
             .transpose()
             .map_err(|e| StorageError::corruption(format!("Invalid prev version ID: {}", e)))?,
+        provenance,
     })
 }
 
@@ -1916,9 +2065,13 @@ pub fn encode_edge_version(version: &EdgeVersion) -> Vec<u8> {
         data: encode_version_data(&version.data),
         next_version: version.next_version.map(|v| v.as_u64()),
         prev_version: version.prev_version.map(|v| v.as_u64()),
+        provenance: encode_provenance(version.provenance.as_deref()),
     };
 
-    bitcode::encode(&serializable)
+    let mut out = Vec::with_capacity(1);
+    out.push(COLD_RECORD_TAG_V2);
+    out.extend_from_slice(&bitcode::encode(&serializable));
+    out
 }
 
 /// Decode an `EdgeVersion` from a byte payload.
@@ -1933,45 +2086,97 @@ pub fn decode_edge_version(data: &[u8]) -> Result<EdgeVersion> {
     use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::temporal::{BiTemporalInterval, TimeRange};
 
-    let serializable: SerializableEdgeVersion = bitcode::decode(data)
-        .map_err(|e| StorageError::corruption(format!("Failed to decode edge version: {}", e)))?;
+    // See `decode_node_version` for why this tries the tagged (Issue #3224)
+    // shape first and falls back to the untagged legacy shape.
+    #[allow(clippy::type_complexity)]
+    let (
+        label,
+        temporal_valid_start,
+        temporal_valid_end,
+        temporal_tx_start,
+        temporal_tx_end,
+        id,
+        edge_id,
+        source,
+        target,
+        data_field,
+        next_version,
+        prev_version,
+        provenance,
+    ) = if data.first() == Some(&COLD_RECORD_TAG_V2)
+        && let Ok(s) = bitcode::decode::<SerializableEdgeVersion>(&data[1..])
+    {
+        (
+            s.label,
+            s.temporal_valid_start,
+            s.temporal_valid_end,
+            s.temporal_tx_start,
+            s.temporal_tx_end,
+            s.id,
+            s.edge_id,
+            s.source,
+            s.target,
+            s.data,
+            s.next_version,
+            s.prev_version,
+            decode_provenance(s.provenance)?,
+        )
+    } else {
+        let s: SerializableEdgeVersionV1 = bitcode::decode(data).map_err(|e| {
+            StorageError::corruption(format!("Failed to decode edge version: {}", e))
+        })?;
+        (
+            s.label,
+            s.temporal_valid_start,
+            s.temporal_valid_end,
+            s.temporal_tx_start,
+            s.temporal_tx_end,
+            s.id,
+            s.edge_id,
+            s.source,
+            s.target,
+            s.data,
+            s.next_version,
+            s.prev_version,
+            None,
+        )
+    };
 
     let valid_time = TimeRange::new(
-        HybridTimestamp::new_unchecked(serializable.temporal_valid_start, 0),
-        HybridTimestamp::new_unchecked(serializable.temporal_valid_end, 0),
+        HybridTimestamp::new_unchecked(temporal_valid_start, 0),
+        HybridTimestamp::new_unchecked(temporal_valid_end, 0),
     )
     .map_err(|e| StorageError::corruption(format!("Invalid valid time range: {}", e)))?;
     let tx_time = TimeRange::new(
-        HybridTimestamp::new_unchecked(serializable.temporal_tx_start, 0),
-        HybridTimestamp::new_unchecked(serializable.temporal_tx_end, 0),
+        HybridTimestamp::new_unchecked(temporal_tx_start, 0),
+        HybridTimestamp::new_unchecked(temporal_tx_end, 0),
     )
     .map_err(|e| StorageError::corruption(format!("Invalid transaction time range: {}", e)))?;
 
     Ok(EdgeVersion {
-        id: VersionId::new(serializable.id)
+        id: VersionId::new(id)
             .map_err(|e| StorageError::corruption(format!("Invalid version ID: {}", e)))?,
-        edge_id: EdgeId::new(serializable.edge_id)
+        edge_id: EdgeId::new(edge_id)
             .map_err(|e| StorageError::corruption(format!("Invalid edge ID: {}", e)))?,
         commit_timestamp: tx_time.start(),
         temporal: BiTemporalInterval::new(valid_time, tx_time),
         label: GLOBAL_INTERNER
-            .intern(&serializable.label)
+            .intern(&label)
             .map_err(|e| StorageError::corruption(format!("Failed to intern label: {}", e)))?,
-        source: NodeId::new(serializable.source)
+        source: NodeId::new(source)
             .map_err(|e| StorageError::corruption(format!("Invalid source ID: {}", e)))?,
-        target: NodeId::new(serializable.target)
+        target: NodeId::new(target)
             .map_err(|e| StorageError::corruption(format!("Invalid target ID: {}", e)))?,
-        data: decode_version_data(serializable.data)?,
-        next_version: serializable
-            .next_version
+        data: decode_version_data(data_field)?,
+        next_version: next_version
             .map(VersionId::new)
             .transpose()
             .map_err(|e| StorageError::corruption(format!("Invalid next version ID: {}", e)))?,
-        prev_version: serializable
-            .prev_version
+        prev_version: prev_version
             .map(VersionId::new)
             .transpose()
             .map_err(|e| StorageError::corruption(format!("Invalid prev version ID: {}", e)))?,
+        provenance,
     })
 }
 

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -1799,7 +1799,7 @@ struct SerializableEdgeVersion {
 /// Cold-storage records have no version tag at all, so a legacy record is
 /// indistinguishable from a current one except by trying to decode it. This
 /// frozen shape is the fallback `decode_node_version` tries when the
-/// tag-prefixed current decode fails (see [`COLD_RECORD_TAG_V2`]).
+/// tag-prefixed current decode fails (see [`COLD_RECORD_MAGIC_V2`]).
 #[derive(bitcode::Encode, bitcode::Decode)]
 struct SerializableNodeVersionV1 {
     id: u64,
@@ -1831,12 +1831,20 @@ struct SerializableEdgeVersionV1 {
     prev_version: Option<u64>,
 }
 
-/// Tag byte prepended to cold-storage records written with provenance
+/// Magic sequence prepended to cold-storage records written with provenance
 /// support (Issue #3224). Legacy (pre-#3224) records have no tag at all --
 /// `decode_node_version`/`decode_edge_version` fall back to the untagged
 /// [`SerializableNodeVersionV1`]/[`SerializableEdgeVersionV1`] shape when the
-/// first byte isn't this tag (or the tagged decode fails).
-const COLD_RECORD_TAG_V2: u8 = 0x02;
+/// leading bytes don't match this magic (or the tagged decode fails).
+///
+/// This is a 4-byte sequence rather than a single tag byte specifically to
+/// make an accidental collision with a legacy record's leading bytes (which
+/// start with a bitcode-encoded `id: u64`) astronomically unlikely rather
+/// than merely unlikely: a 1-in-256 chance (single byte) is a real risk over
+/// the lifetime of a large cold-storage table, a 1-in-4-billion chance is
+/// not. The value itself is arbitrary but deliberately not a small integer
+/// (to avoid any structural resemblance to a plausible bitcode-encoded id).
+const COLD_RECORD_MAGIC_V2: [u8; 4] = [0xA1, 0x37, 0xC0, 0xDE];
 
 /// Serializable wrapper for VersionData.
 #[derive(bitcode::Encode, bitcode::Decode)]
@@ -1897,8 +1905,8 @@ pub fn encode_node_version(version: &NodeVersion) -> Vec<u8> {
         provenance: encode_provenance(version.provenance.as_deref()),
     };
 
-    let mut out = Vec::with_capacity(1);
-    out.push(COLD_RECORD_TAG_V2);
+    let mut out = Vec::with_capacity(COLD_RECORD_MAGIC_V2.len());
+    out.extend_from_slice(&COLD_RECORD_MAGIC_V2);
     out.extend_from_slice(&bitcode::encode(&serializable));
     out
 }
@@ -1925,21 +1933,7 @@ fn decode_provenance(
         return Ok(None);
     };
     use crate::core::provenance::Provenance;
-    let mut builder = Provenance::builder();
-    if let Some(source) = p.source {
-        builder = builder.source(source);
-    }
-    if let Some(confidence) = p.confidence {
-        builder = builder.confidence(confidence);
-    }
-    if let Some(note) = p.note {
-        builder = builder.note(note);
-    }
-    if let Some(correlation_id) = p.correlation_id {
-        builder = builder.correlation_id(correlation_id);
-    }
-    let provenance = builder
-        .build()
+    let provenance = Provenance::from_parts(p.source, p.confidence, p.note, p.correlation_id)
         .map_err(|e| StorageError::corruption(format!("Invalid persisted provenance: {}", e)))?;
     Ok(Some(std::sync::Arc::new(provenance)))
 }
@@ -1958,8 +1952,8 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
 
     // Tagged (Issue #3224) records carry provenance; untagged records are
     // pre-provenance and are decoded via the frozen `..V1` shape instead.
-    // There is no version byte on legacy records at all, so the tag itself
-    // is the only signal -- see `COLD_RECORD_TAG_V2`.
+    // There is no version marker on legacy records at all, so the magic
+    // sequence itself is the only signal -- see `COLD_RECORD_MAGIC_V2`.
     let (
         label,
         temporal_valid_start,
@@ -1972,8 +1966,9 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
         next_version,
         prev_version,
         provenance,
-    ) = if data.first() == Some(&COLD_RECORD_TAG_V2)
-        && let Ok(s) = bitcode::decode::<SerializableNodeVersion>(&data[1..])
+    ) = if data.starts_with(&COLD_RECORD_MAGIC_V2)
+        && let Ok(s) =
+            bitcode::decode::<SerializableNodeVersion>(&data[COLD_RECORD_MAGIC_V2.len()..])
     {
         (
             s.label,
@@ -2068,8 +2063,8 @@ pub fn encode_edge_version(version: &EdgeVersion) -> Vec<u8> {
         provenance: encode_provenance(version.provenance.as_deref()),
     };
 
-    let mut out = Vec::with_capacity(1);
-    out.push(COLD_RECORD_TAG_V2);
+    let mut out = Vec::with_capacity(COLD_RECORD_MAGIC_V2.len());
+    out.extend_from_slice(&COLD_RECORD_MAGIC_V2);
     out.extend_from_slice(&bitcode::encode(&serializable));
     out
 }
@@ -2103,8 +2098,9 @@ pub fn decode_edge_version(data: &[u8]) -> Result<EdgeVersion> {
         next_version,
         prev_version,
         provenance,
-    ) = if data.first() == Some(&COLD_RECORD_TAG_V2)
-        && let Ok(s) = bitcode::decode::<SerializableEdgeVersion>(&data[1..])
+    ) = if data.starts_with(&COLD_RECORD_MAGIC_V2)
+        && let Ok(s) =
+            bitcode::decode::<SerializableEdgeVersion>(&data[COLD_RECORD_MAGIC_V2.len()..])
     {
         (
             s.label,

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -1954,6 +1954,12 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
     // pre-provenance and are decoded via the frozen `..V1` shape instead.
     // There is no version marker on legacy records at all, so the magic
     // sequence itself is the only signal -- see `COLD_RECORD_MAGIC_V2`.
+    //
+    // A magic-byte match means this is unambiguously a V2 record (legacy
+    // records never carry this prefix), so a decode failure past the magic
+    // indicates real corruption -- it must be surfaced directly rather than
+    // falling through to the V1 decoder, which would otherwise misinterpret
+    // the remaining bytes (magic-matched-but-corrupt is not "maybe legacy").
     let (
         label,
         temporal_valid_start,
@@ -1966,10 +1972,11 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
         next_version,
         prev_version,
         provenance,
-    ) = if data.starts_with(&COLD_RECORD_MAGIC_V2)
-        && let Ok(s) =
-            bitcode::decode::<SerializableNodeVersion>(&data[COLD_RECORD_MAGIC_V2.len()..])
-    {
+    ) = if data.starts_with(&COLD_RECORD_MAGIC_V2) {
+        let s: SerializableNodeVersion = bitcode::decode(&data[COLD_RECORD_MAGIC_V2.len()..])
+            .map_err(|e| {
+                StorageError::corruption(format!("Failed to decode node version V2: {}", e))
+            })?;
         (
             s.label,
             s.temporal_valid_start,
@@ -1985,7 +1992,7 @@ pub fn decode_node_version(data: &[u8]) -> Result<NodeVersion> {
         )
     } else {
         let s: SerializableNodeVersionV1 = bitcode::decode(data).map_err(|e| {
-            StorageError::corruption(format!("Failed to decode node version: {}", e))
+            StorageError::corruption(format!("Failed to decode node version V1: {}", e))
         })?;
         (
             s.label,
@@ -2081,8 +2088,9 @@ pub fn decode_edge_version(data: &[u8]) -> Result<EdgeVersion> {
     use crate::core::interning::GLOBAL_INTERNER;
     use crate::core::temporal::{BiTemporalInterval, TimeRange};
 
-    // See `decode_node_version` for why this tries the tagged (Issue #3224)
-    // shape first and falls back to the untagged legacy shape.
+    // See `decode_node_version` for why a magic-byte match means a decode
+    // failure past the magic must be surfaced immediately rather than
+    // falling back to the untagged legacy shape.
     #[allow(clippy::type_complexity)]
     let (
         label,
@@ -2098,10 +2106,11 @@ pub fn decode_edge_version(data: &[u8]) -> Result<EdgeVersion> {
         next_version,
         prev_version,
         provenance,
-    ) = if data.starts_with(&COLD_RECORD_MAGIC_V2)
-        && let Ok(s) =
-            bitcode::decode::<SerializableEdgeVersion>(&data[COLD_RECORD_MAGIC_V2.len()..])
-    {
+    ) = if data.starts_with(&COLD_RECORD_MAGIC_V2) {
+        let s: SerializableEdgeVersion = bitcode::decode(&data[COLD_RECORD_MAGIC_V2.len()..])
+            .map_err(|e| {
+                StorageError::corruption(format!("Failed to decode edge version V2: {}", e))
+            })?;
         (
             s.label,
             s.temporal_valid_start,
@@ -2119,7 +2128,7 @@ pub fn decode_edge_version(data: &[u8]) -> Result<EdgeVersion> {
         )
     } else {
         let s: SerializableEdgeVersionV1 = bitcode::decode(data).map_err(|e| {
-            StorageError::corruption(format!("Failed to decode edge version: {}", e))
+            StorageError::corruption(format!("Failed to decode edge version V1: {}", e))
         })?;
         (
             s.label,

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -1326,6 +1326,184 @@ fn test_edge_version_roundtrip_all_fields() {
     assert_eq!(retrieved.target, version.target);
 }
 
+// -----------------------------------------------------------------------
+// Provenance persistence (Issue #3224)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_encode_decode_node_version_with_provenance() {
+    use crate::core::provenance::Provenance;
+    use std::sync::Arc;
+
+    let provenance = Arc::new(
+        Provenance::builder()
+            .source("hr-system")
+            .confidence(0.95)
+            .correlation_id("batch-42")
+            .build()
+            .unwrap(),
+    );
+
+    let version = NodeVersion::new_anchor(
+        VersionId::new(1).unwrap(),
+        NodeId::new(1).unwrap(),
+        BiTemporalInterval::current(1000.into()),
+        GLOBAL_INTERNER.intern("Person").unwrap(),
+        PropertyMapBuilder::new().build(),
+    )
+    .with_provenance(Some(provenance.clone()));
+
+    let encoded = encode_node_version(&version);
+    assert_eq!(
+        encoded[0], COLD_RECORD_TAG_V2,
+        "new records must be tag-prefixed"
+    );
+
+    let decoded = decode_node_version(&encoded).unwrap();
+    let decoded_provenance = decoded.provenance.unwrap();
+    assert_eq!(decoded_provenance.source(), Some("hr-system"));
+    assert_eq!(decoded_provenance.confidence(), Some(0.95));
+    assert_eq!(decoded_provenance.correlation_id(), Some("batch-42"));
+}
+
+#[test]
+fn test_encode_decode_node_version_without_provenance() {
+    let version = NodeVersion::new_anchor(
+        VersionId::new(1).unwrap(),
+        NodeId::new(1).unwrap(),
+        BiTemporalInterval::current(1000.into()),
+        GLOBAL_INTERNER.intern("Person").unwrap(),
+        PropertyMapBuilder::new().build(),
+    );
+
+    let encoded = encode_node_version(&version);
+    let decoded = decode_node_version(&encoded).unwrap();
+    assert!(decoded.provenance.is_none());
+}
+
+#[test]
+fn test_encode_decode_edge_version_with_provenance() {
+    use crate::core::provenance::Provenance;
+    use std::sync::Arc;
+
+    let provenance = Arc::new(
+        Provenance::builder()
+            .source("csv-import")
+            .note("bulk load 2026-06")
+            .build()
+            .unwrap(),
+    );
+
+    let version = EdgeVersion::new_anchor(
+        VersionId::new(1).unwrap(),
+        EdgeId::new(1).unwrap(),
+        BiTemporalInterval::current(1000.into()),
+        GLOBAL_INTERNER.intern("KNOWS").unwrap(),
+        NodeId::new(1).unwrap(),
+        NodeId::new(2).unwrap(),
+        PropertyMapBuilder::new().build(),
+    )
+    .with_provenance(Some(provenance));
+
+    let encoded = encode_edge_version(&version);
+    assert_eq!(encoded[0], COLD_RECORD_TAG_V2);
+
+    let decoded = decode_edge_version(&encoded).unwrap();
+    let decoded_provenance = decoded.provenance.unwrap();
+    assert_eq!(decoded_provenance.source(), Some("csv-import"));
+    assert_eq!(decoded_provenance.note(), Some("bulk load 2026-06"));
+}
+
+#[test]
+fn test_decode_legacy_untagged_node_record_provenance_none() {
+    // Simulate a record written by a pre-#3224 binary: no tag byte, no
+    // `provenance` field in the wire struct at all.
+    let legacy = SerializableNodeVersionV1 {
+        id: 1,
+        node_id: 1,
+        temporal_valid_start: 1000,
+        temporal_valid_end: crate::core::temporal::TIMESTAMP_MAX.wallclock(),
+        temporal_tx_start: 1000,
+        temporal_tx_end: crate::core::temporal::TIMESTAMP_MAX.wallclock(),
+        label: "Person".to_string(),
+        data: SerializableVersionData::Anchor {
+            properties: vec![],
+            vector_snapshot_id: None,
+        },
+        next_version: None,
+        prev_version: None,
+    };
+    let legacy_bytes = bitcode::encode(&legacy);
+    assert_ne!(
+        legacy_bytes.first(),
+        Some(&COLD_RECORD_TAG_V2),
+        "legacy fixture must not accidentally collide with the new tag byte"
+    );
+
+    let decoded = decode_node_version(&legacy_bytes).unwrap();
+    assert_eq!(decoded.node_id.as_u64(), 1);
+    assert!(decoded.provenance.is_none());
+}
+
+#[test]
+fn test_decode_legacy_untagged_edge_record_provenance_none() {
+    let legacy = SerializableEdgeVersionV1 {
+        id: 1,
+        edge_id: 1,
+        temporal_valid_start: 1000,
+        temporal_valid_end: crate::core::temporal::TIMESTAMP_MAX.wallclock(),
+        temporal_tx_start: 1000,
+        temporal_tx_end: crate::core::temporal::TIMESTAMP_MAX.wallclock(),
+        label: "KNOWS".to_string(),
+        source: 1,
+        target: 2,
+        data: SerializableVersionData::Anchor {
+            properties: vec![],
+            vector_snapshot_id: None,
+        },
+        next_version: None,
+        prev_version: None,
+    };
+    let legacy_bytes = bitcode::encode(&legacy);
+
+    let decoded = decode_edge_version(&legacy_bytes).unwrap();
+    assert_eq!(decoded.edge_id.as_u64(), 1);
+    assert!(decoded.provenance.is_none());
+}
+
+#[test]
+fn test_migrate_to_cold_preserves_provenance() {
+    use crate::core::provenance::Provenance;
+    use std::sync::Arc;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.redb");
+    let storage = RedbColdStorage::with_default_config(&db_path).unwrap();
+
+    let provenance = Arc::new(
+        Provenance::builder()
+            .source("claude-mcp")
+            .confidence(0.8)
+            .build()
+            .unwrap(),
+    );
+    let version = NodeVersion::new_anchor(
+        VersionId::new(1).unwrap(),
+        NodeId::new(1).unwrap(),
+        BiTemporalInterval::current(1000.into()),
+        GLOBAL_INTERNER.intern("Person").unwrap(),
+        PropertyMapBuilder::new().build(),
+    )
+    .with_provenance(Some(provenance));
+
+    storage.store_node_version(&version).unwrap();
+    let retrieved = storage.get_node_version(version.id).unwrap().unwrap();
+
+    let retrieved_provenance = retrieved.provenance.unwrap();
+    assert_eq!(retrieved_provenance.source(), Some("claude-mcp"));
+    assert_eq!(retrieved_provenance.confidence(), Some(0.8));
+}
+
 #[test]
 fn test_batch_operations_preserve_order() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -1354,9 +1354,9 @@ fn test_encode_decode_node_version_with_provenance() {
     .with_provenance(Some(provenance.clone()));
 
     let encoded = encode_node_version(&version);
-    assert_eq!(
-        encoded[0], COLD_RECORD_TAG_V2,
-        "new records must be tag-prefixed"
+    assert!(
+        encoded.starts_with(&COLD_RECORD_MAGIC_V2),
+        "new records must be magic-prefixed"
     );
 
     let decoded = decode_node_version(&encoded).unwrap();
@@ -1406,7 +1406,7 @@ fn test_encode_decode_edge_version_with_provenance() {
     .with_provenance(Some(provenance));
 
     let encoded = encode_edge_version(&version);
-    assert_eq!(encoded[0], COLD_RECORD_TAG_V2);
+    assert!(encoded.starts_with(&COLD_RECORD_MAGIC_V2));
 
     let decoded = decode_edge_version(&encoded).unwrap();
     let decoded_provenance = decoded.provenance.unwrap();
@@ -1416,7 +1416,7 @@ fn test_encode_decode_edge_version_with_provenance() {
 
 #[test]
 fn test_decode_legacy_untagged_node_record_provenance_none() {
-    // Simulate a record written by a pre-#3224 binary: no tag byte, no
+    // Simulate a record written by a pre-#3224 binary: no tag prefix, no
     // `provenance` field in the wire struct at all.
     let legacy = SerializableNodeVersionV1 {
         id: 1,
@@ -1434,15 +1434,54 @@ fn test_decode_legacy_untagged_node_record_provenance_none() {
         prev_version: None,
     };
     let legacy_bytes = bitcode::encode(&legacy);
-    assert_ne!(
-        legacy_bytes.first(),
-        Some(&COLD_RECORD_TAG_V2),
-        "legacy fixture must not accidentally collide with the new tag byte"
+    assert!(
+        !legacy_bytes.starts_with(&COLD_RECORD_MAGIC_V2),
+        "legacy fixture must not accidentally collide with the new magic sequence"
     );
 
     let decoded = decode_node_version(&legacy_bytes).unwrap();
     assert_eq!(decoded.node_id.as_u64(), 1);
     assert!(decoded.provenance.is_none());
+}
+
+/// Regression test for a real (not merely theoretical) misdetection risk:
+/// before `COLD_RECORD_MAGIC_V2` was widened from a single tag byte to a
+/// 4-byte sequence, any legacy (untagged) record whose leading byte happened
+/// to equal that single tag byte would be misrouted into decoding as the new
+/// tagged shape, silently corrupting or erroring on a valid historical
+/// record. This fabricates a legacy record and prepends the *old* single-byte
+/// tag value the new decoder no longer recognizes, then confirms it still
+/// makes it down the legacy fallback path rather than being misdecoded as
+/// V2 -- this is inherently true for a 4-byte magic vs. a single leading
+/// byte, since matching one byte can never satisfy `starts_with` on four.
+#[test]
+fn test_legacy_record_with_leading_byte_matching_old_single_byte_tag_is_not_misdetected() {
+    let legacy = SerializableNodeVersionV1 {
+        id: 1,
+        node_id: 42,
+        temporal_valid_start: 1000,
+        temporal_valid_end: crate::core::temporal::TIMESTAMP_MAX.wallclock(),
+        temporal_tx_start: 1000,
+        temporal_tx_end: crate::core::temporal::TIMESTAMP_MAX.wallclock(),
+        label: "Person".to_string(),
+        data: SerializableVersionData::Anchor {
+            properties: vec![],
+            vector_snapshot_id: None,
+        },
+        next_version: None,
+        prev_version: None,
+    };
+    let mut legacy_bytes = bitcode::encode(&legacy);
+    // Force the leading byte to collide with what used to be the entire tag
+    // (0x02) -- a single-byte match must no longer be mistaken for the
+    // 4-byte `COLD_RECORD_MAGIC_V2` prefix.
+    legacy_bytes[0] = COLD_RECORD_MAGIC_V2[0];
+    assert!(!legacy_bytes.starts_with(&COLD_RECORD_MAGIC_V2));
+
+    // Decoding a mutated legacy record isn't expected to preserve field
+    // values (we corrupted a byte), but it must not panic and must not be
+    // silently routed through the V2 decoder.
+    let _ = decode_node_version(&legacy_bytes);
 }
 
 #[test]

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -1841,6 +1841,37 @@ fn test_node_version_decode_error_path() {
     assert!(result.is_err());
 }
 
+/// Regression test: a record whose leading bytes match `COLD_RECORD_MAGIC_V2`
+/// is unambiguously a V2 record. If the bytes *after* the magic fail to
+/// decode as `SerializableNodeVersion` (corruption), `decode_node_version`
+/// must surface that error immediately rather than falling through to the
+/// legacy V1 decoder, which would misinterpret the magic-prefixed buffer.
+#[test]
+fn test_decode_node_version_v2_magic_match_with_corrupt_payload_errors_immediately() {
+    let mut data = COLD_RECORD_MAGIC_V2.to_vec();
+    data.extend_from_slice(&[0xFF; 8]);
+    let err = decode_node_version(&data).unwrap_err();
+    let message = format!("{err}");
+    assert!(
+        message.contains("V2"),
+        "expected a V2-specific decode error, got: {message}"
+    );
+}
+
+/// Edge counterpart of
+/// [`test_decode_node_version_v2_magic_match_with_corrupt_payload_errors_immediately`].
+#[test]
+fn test_decode_edge_version_v2_magic_match_with_corrupt_payload_errors_immediately() {
+    let mut data = COLD_RECORD_MAGIC_V2.to_vec();
+    data.extend_from_slice(&[0xFF; 8]);
+    let err = decode_edge_version(&data).unwrap_err();
+    let message = format!("{err}");
+    assert!(
+        message.contains("V2"),
+        "expected a V2-specific decode error, got: {message}"
+    );
+}
+
 #[test]
 fn test_edge_version_decode_error_path() {
     // Test decode error for edges

--- a/src/storage/wal/concurrent.rs
+++ b/src/storage/wal/concurrent.rs
@@ -659,6 +659,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         }
     }
 
@@ -944,6 +945,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 valid_from: now,
+                provenance: None,
             })
             .collect();
 
@@ -1036,12 +1038,12 @@ mod sentry_tests {
         // 4 (count) + 4 (key_len) + key_bytes + 1 (tag_string) + 4 (val_len) + val_bytes
 
         // Let's use a key "k" (1 byte)
-        // Overhead = 24 + 25 + 4 + 4 + 1 + 1 + 4 = 63 bytes
-        // Total = 63 + val_bytes
+        // Overhead = 24 + 25 + 4 + 4 + 1 + 1 + 4 + 1 (provenance presence byte) = 64 bytes
+        // Total = 64 + val_bytes
         // Target = MAX_WAL_ENTRY_SIZE
-        // val_bytes = MAX_WAL_ENTRY_SIZE - 63
+        // val_bytes = MAX_WAL_ENTRY_SIZE - 64
 
-        let overhead = 63;
+        let overhead = 64;
         let target_val_len = MAX_WAL_ENTRY_SIZE - overhead;
 
         // Create a string of target length
@@ -1055,6 +1057,7 @@ mod sentry_tests {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties,
             valid_from: time::now(),
+            provenance: None,
         };
 
         // Verify our math was correct
@@ -1084,7 +1087,7 @@ mod sentry_tests {
         let wal = ConcurrentWal::new(config).unwrap();
 
         // Use same calculation as above but +1 byte
-        let overhead = 63;
+        let overhead = 64;
         let target_val_len = MAX_WAL_ENTRY_SIZE - overhead + 1;
 
         let big_string = "x".repeat(target_val_len);
@@ -1096,6 +1099,7 @@ mod sentry_tests {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties,
             valid_from: time::now(),
+            provenance: None,
         };
 
         // Verify size
@@ -1143,6 +1147,7 @@ mod sentry_tests {
                         label: GLOBAL_INTERNER.intern("Test").unwrap(),
                         properties: PropertyMapBuilder::new().build(),
                         valid_from: time::now(),
+                        provenance: None,
                     };
 
                     // This populates the thread-local cache with an index in [0, 31]

--- a/src/storage/wal/concurrent_system.rs
+++ b/src/storage/wal/concurrent_system.rs
@@ -775,6 +775,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern(format!("Node{}", id)).unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         }
     }
 

--- a/src/storage/wal/entry.rs
+++ b/src/storage/wal/entry.rs
@@ -4,6 +4,7 @@ use crate::core::{
     id::{EdgeId, NodeId, VersionId},
     interning::InternedString,
     property::PropertyMap,
+    provenance::Provenance,
     temporal::{Timestamp, time},
 };
 
@@ -47,6 +48,8 @@ pub enum WalOperation {
         properties: PropertyMap,
         /// When the node became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Provenance>,
     },
     /// Create a new edge
     CreateEdge {
@@ -62,6 +65,8 @@ pub enum WalOperation {
         properties: PropertyMap,
         /// When the edge became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Provenance>,
     },
     /// Update node (creates new version)
     UpdateNode {
@@ -75,6 +80,8 @@ pub enum WalOperation {
         properties: PropertyMap,
         /// When this update became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Provenance>,
     },
     /// Update edge (creates new version)
     UpdateEdge {
@@ -88,6 +95,8 @@ pub enum WalOperation {
         properties: PropertyMap,
         /// When this update became valid in reality (user-controlled)
         valid_from: Timestamp,
+        /// Write-time provenance bundle (Issue #3224), if supplied.
+        provenance: Option<Provenance>,
     },
     /// Delete a node
     DeleteNode {
@@ -263,6 +272,7 @@ mod sentry_tests {
             label: GLOBAL_INTERNER.intern("TestLabel").unwrap(),
             properties,
             valid_from,
+            provenance: None,
         };
 
         // Create the original entry
@@ -275,10 +285,15 @@ mod sentry_tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&original_entry, &mut buffer).expect("Serialization failed");
 
-        // Deserialize
-        // version 1 is current
-        let (parsed_entry, consumed) =
-            parse_entry_at(&buffer, 0, 1).expect("Deserialization failed");
+        // Deserialize. Serialization always writes the provenance-carrying
+        // payload shape now (Issue #3224), so parsing must use the matching
+        // version to consume the same bytes that were written.
+        let (parsed_entry, consumed) = parse_entry_at(
+            &buffer,
+            0,
+            crate::storage::wal::segment_reader::WAL_VERSION_PROVENANCE,
+        )
+        .expect("Deserialization failed");
 
         // Verify bytes consumed
         assert_eq!(consumed, buffer.len(), "Should consume entire buffer");

--- a/src/storage/wal/flush_coordinator.rs
+++ b/src/storage/wal/flush_coordinator.rs
@@ -44,7 +44,9 @@ use super::ring_buffer::PendingEntry;
 
 use crate::core::error::{Error, Result, StorageError};
 
-use super::segment_reader::{WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION, WAL_VERSION_ENCRYPTED};
+use super::segment_reader::{
+    WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION_ENCRYPTED_PROVENANCE, WAL_VERSION_PROVENANCE,
+};
 
 /// Metadata about a WAL segment's LSN range.
 ///
@@ -381,11 +383,12 @@ impl FlushCoordinator {
                     e
                 )))
             })?;
-            // Use version 2 for encrypted segments, version 1 for plaintext.
+            // New segments always use the provenance-carrying format (Issue #3224):
+            // version 4 for encrypted segments, version 3 for plaintext.
             let version = if self.config.wal_cipher.is_some() {
-                WAL_VERSION_ENCRYPTED
+                WAL_VERSION_ENCRYPTED_PROVENANCE
             } else {
-                WAL_VERSION
+                WAL_VERSION_PROVENANCE
             };
             writer.write_all(&[version]).map_err(|e| {
                 Error::Storage(StorageError::IoError(format!(
@@ -1176,7 +1179,7 @@ mod tests {
 
         assert!(data.len() >= WAL_HEADER_SIZE);
         assert_eq!(&data[0..4], &WAL_MAGIC);
-        assert_eq!(data[4], WAL_VERSION);
+        assert_eq!(data[4], WAL_VERSION_PROVENANCE);
     }
 
     #[test]

--- a/src/storage/wal/segment_reader.rs
+++ b/src/storage/wal/segment_reader.rs
@@ -52,6 +52,7 @@ use crate::core::error::{Error, Result, StorageError};
 use crate::core::hlc::HybridTimestamp;
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::property::PropertyMap;
+use crate::core::provenance::Provenance;
 
 use super::serialization::{
     OP_CHECKPOINT, OP_CREATE_EDGE, OP_CREATE_NODE, OP_DECLARE_UNIQUE_CONSTRAINT, OP_DELETE_EDGE,
@@ -72,8 +73,45 @@ pub(crate) const WAL_VERSION: u8 = 1;
 /// The header (magic + version) remains plaintext.
 pub(crate) const WAL_VERSION_ENCRYPTED: u8 = 2;
 
+/// WAL format version for plaintext segments whose `CreateNode`/`CreateEdge`/
+/// `UpdateNode`/`UpdateEdge` payloads carry an optional [`Provenance`] bundle
+/// after `valid_from` (Issue #3224).
+///
+/// Segments below this version simply lack the provenance bytes; parsing
+/// falls back to `provenance: None` for them (see `read_provenance`).
+pub(crate) const WAL_VERSION_PROVENANCE: u8 = 3;
+
+/// WAL format version for encrypted segments whose decrypted payload uses
+/// the provenance-carrying entry format (i.e. `WAL_VERSION_PROVENANCE`).
+///
+/// Mirrors the `WAL_VERSION` / `WAL_VERSION_ENCRYPTED` relationship: this is
+/// `WAL_VERSION_ENCRYPTED`'s counterpart once provenance was added.
+pub(crate) const WAL_VERSION_ENCRYPTED_PROVENANCE: u8 = 4;
+
 /// Maximum supported WAL version (inclusive).
-const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED;
+const WAL_VERSION_MAX: u8 = WAL_VERSION_ENCRYPTED_PROVENANCE;
+
+/// Returns `true` if `version` denotes an encrypted segment (either the
+/// original encrypted format or its provenance-carrying successor).
+#[inline]
+fn is_encrypted_version(version: u8) -> bool {
+    version == WAL_VERSION_ENCRYPTED || version == WAL_VERSION_ENCRYPTED_PROVENANCE
+}
+
+/// Map a segment/container format version to the logical *payload* version
+/// used to gate field parsing (e.g. `version >= WAL_VERSION_PROVENANCE`).
+///
+/// Encrypted versions describe the on-disk *container* (length-prefixed +
+/// encrypted), not the entry payload layout once decrypted; this maps them
+/// back to the plaintext version whose entry layout they share.
+#[inline]
+fn payload_version(version: u8) -> u8 {
+    match version {
+        WAL_VERSION_ENCRYPTED => WAL_VERSION,
+        WAL_VERSION_ENCRYPTED_PROVENANCE => WAL_VERSION_PROVENANCE,
+        v => v,
+    }
+}
 
 /// Size of the WAL segment header (magic + version).
 pub(crate) const WAL_HEADER_SIZE: usize = 5;
@@ -330,21 +368,30 @@ pub fn read_segment_with_cipher(
         return Ok(Vec::new()); // Empty segment
     };
 
-    // Version 2 (encrypted) segments require a cipher for decryption.
-    if version == WAL_VERSION_ENCRYPTED && cipher.is_none() {
-        return Err(StorageError::Encryption(
-            "Cannot read encrypted WAL segment (version 2) without a cipher".to_string(),
-        )
+    // Encrypted segments (version 2 or 4) require a cipher for decryption.
+    if is_encrypted_version(version) && cipher.is_none() {
+        return Err(StorageError::Encryption(format!(
+            "Cannot read encrypted WAL segment (version {}) without a cipher",
+            version
+        ))
         .into());
     }
 
     // Dispatch to the appropriate parsing loop based on version.
-    if version == WAL_VERSION_ENCRYPTED {
-        // Version 2: length-prefixed encrypted entries.
+    if is_encrypted_version(version) {
+        // Version 2/4: length-prefixed encrypted entries.
         let cipher = cipher.expect("cipher presence checked above");
-        parse_encrypted_entries(buffer, &mut offset, start_lsn, cipher, path, &mut entries)?;
+        parse_encrypted_entries(
+            buffer,
+            &mut offset,
+            start_lsn,
+            cipher,
+            path,
+            &mut entries,
+            version,
+        )?;
     } else {
-        // Version 1: plaintext entries (original format).
+        // Version 1/3: plaintext entries.
         parse_plaintext_entries(buffer, &mut offset, version, start_lsn, path, &mut entries)?;
     }
 
@@ -415,11 +462,12 @@ fn parse_plaintext_entries(
     Ok(())
 }
 
-/// Parse encrypted (version 2) entries from a WAL segment buffer.
+/// Parse encrypted (version 2 or 4) entries from a WAL segment buffer.
 ///
 /// Each entry is stored as `[4-byte LE length][encrypted entry bytes]`.
 /// The encrypted entry bytes are decrypted using the provided cipher,
-/// then parsed as a normal WAL entry (version 1 format).
+/// then parsed as a normal WAL entry using the payload version implied by
+/// `container_version` (see [`payload_version`]).
 fn parse_encrypted_entries(
     buffer: &[u8],
     offset: &mut usize,
@@ -427,7 +475,9 @@ fn parse_encrypted_entries(
     cipher: &Arc<dyn crate::encryption::cipher::Cipher>,
     path: &Path,
     entries: &mut Vec<WalEntry>,
+    container_version: u8,
 ) -> Result<()> {
+    let entry_version = payload_version(container_version);
     while *offset < buffer.len() {
         // Need at least 4 bytes for the length prefix
         if *offset + 4 > buffer.len() {
@@ -482,8 +532,9 @@ fn parse_encrypted_entries(
                     )))
                 })?;
 
-        // Parse the decrypted bytes as a normal (version 1) entry
-        match parse_entry_at(&decrypted, 0, WAL_VERSION) {
+        // Parse the decrypted bytes as a normal entry, using the payload
+        // version implied by the container version (plaintext-equivalent).
+        match parse_entry_at(&decrypted, 0, entry_version) {
             Ok((entry, _bytes_consumed)) => {
                 if entry.lsn >= start_lsn {
                     entries.push(entry);
@@ -540,6 +591,80 @@ fn require_bytes(buffer: &[u8], offset: usize, n: usize, context: &str) -> Resul
     Ok(())
 }
 
+/// Read an optional `String` field: `[1-byte presence][4-byte LE len][UTF-8 bytes]`.
+///
+/// The length and bytes are only present when the presence byte is nonzero.
+fn read_opt_string(buffer: &[u8], offset: &mut usize, context: &str) -> Result<Option<String>> {
+    require_bytes(buffer, *offset, 1, context)?;
+    let present = buffer[*offset];
+    advance(offset, 1)?;
+    if present == 0 {
+        return Ok(None);
+    }
+    require_bytes(buffer, *offset, 4, context)?;
+    let len = u32::from_le_bytes(buffer[*offset..*offset + 4].try_into().unwrap()) as usize;
+    advance(offset, 4)?;
+    require_bytes(buffer, *offset, len, context)?;
+    let s = std::str::from_utf8(&buffer[*offset..*offset + len])
+        .map_err(|e| StorageError::CorruptedData(format!("Invalid UTF-8 in {}: {}", context, e)))?
+        .to_string();
+    advance(offset, len)?;
+    Ok(Some(s))
+}
+
+/// Read an optional `f64` field: `[1-byte presence][8-byte LE value]`.
+fn read_opt_f64(buffer: &[u8], offset: &mut usize, context: &str) -> Result<Option<f64>> {
+    require_bytes(buffer, *offset, 1, context)?;
+    let present = buffer[*offset];
+    advance(offset, 1)?;
+    if present == 0 {
+        return Ok(None);
+    }
+    require_bytes(buffer, *offset, 8, context)?;
+    let v = f64::from_le_bytes(buffer[*offset..*offset + 8].try_into().unwrap());
+    advance(offset, 8)?;
+    Ok(Some(v))
+}
+
+/// Read an optional [`Provenance`] bundle written by `serialize_provenance_into`.
+///
+/// Segments below [`WAL_VERSION_PROVENANCE`] never contain these bytes at
+/// all; for those, this returns `Ok(None)` without touching `offset`.
+fn read_provenance(buffer: &[u8], offset: &mut usize, version: u8) -> Result<Option<Provenance>> {
+    if version < WAL_VERSION_PROVENANCE {
+        return Ok(None);
+    }
+    require_bytes(buffer, *offset, 1, "provenance presence")?;
+    let present = buffer[*offset];
+    advance(offset, 1)?;
+    if present == 0 {
+        return Ok(None);
+    }
+
+    let source = read_opt_string(buffer, offset, "provenance.source")?;
+    let confidence = read_opt_f64(buffer, offset, "provenance.confidence")?;
+    let note = read_opt_string(buffer, offset, "provenance.note")?;
+    let correlation_id = read_opt_string(buffer, offset, "provenance.correlation_id")?;
+
+    let mut builder = Provenance::builder();
+    if let Some(source) = source {
+        builder = builder.source(source);
+    }
+    if let Some(confidence) = confidence {
+        builder = builder.confidence(confidence);
+    }
+    if let Some(note) = note {
+        builder = builder.note(note);
+    }
+    if let Some(correlation_id) = correlation_id {
+        builder = builder.correlation_id(correlation_id);
+    }
+    let provenance = builder.build().map_err(|e| {
+        StorageError::CorruptedData(format!("Invalid provenance in WAL entry: {}", e))
+    })?;
+    Ok(Some(provenance))
+}
+
 /// Read a 4-byte InternedString label ID from `buffer` at `offset`, advancing `offset` by 4.
 #[inline]
 fn read_label(
@@ -585,11 +710,13 @@ fn parse_create_node_op(
     let label = read_label(buffer, offset, "CreateNode label")?;
     let (properties, valid_from) =
         read_props_and_valid_from(buffer, offset, version, tx_timestamp)?;
+    let provenance = read_provenance(buffer, offset, version)?;
     Ok(WalOperation::CreateNode {
         node_id,
         label,
         properties,
         valid_from,
+        provenance,
     })
 }
 
@@ -608,6 +735,7 @@ fn parse_create_edge_op(
     let label = read_label(buffer, offset, "CreateEdge label")?;
     let (properties, valid_from) =
         read_props_and_valid_from(buffer, offset, version, tx_timestamp)?;
+    let provenance = read_provenance(buffer, offset, version)?;
     Ok(WalOperation::CreateEdge {
         edge_id,
         source,
@@ -615,6 +743,7 @@ fn parse_create_edge_op(
         label,
         properties,
         valid_from,
+        provenance,
     })
 }
 
@@ -639,12 +768,14 @@ fn parse_update_node_op(
             tx_timestamp,
         )
     };
+    let provenance = read_provenance(buffer, offset, version)?;
     Ok(WalOperation::UpdateNode {
         node_id,
         version_id,
         label,
         properties,
         valid_from,
+        provenance,
     })
 }
 
@@ -674,12 +805,14 @@ fn parse_update_edge_op(
             tx_timestamp,
         )
     };
+    let provenance = read_provenance(buffer, offset, version)?;
     Ok(WalOperation::UpdateEdge {
         edge_id,
         version_id,
         label,
         properties,
         valid_from,
+        provenance,
     })
 }
 
@@ -943,6 +1076,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(1), operation);
 
@@ -950,8 +1084,11 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
-        // Parse it back
-        let (parsed_entry, bytes_consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        // Parse it back. Serialization always writes the provenance-carrying
+        // payload shape now (Issue #3224), so parsing must use the matching
+        // version to consume the same bytes that were written.
+        let (parsed_entry, bytes_consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(1));
@@ -982,6 +1119,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(2), operation);
 
@@ -989,8 +1127,11 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
-        // Parse it back
-        let (parsed_entry, bytes_consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        // Parse it back. Serialization always writes the provenance-carrying
+        // payload shape now (Issue #3224), so parsing must use the matching
+        // version to consume the same bytes that were written.
+        let (parsed_entry, bytes_consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(2));
@@ -1023,6 +1164,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("UpdatedPerson").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(3), operation);
 
@@ -1030,8 +1172,11 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
-        // Parse it back
-        let (parsed_entry, bytes_consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        // Parse it back. Serialization always writes the provenance-carrying
+        // payload shape now (Issue #3224), so parsing must use the matching
+        // version to consume the same bytes that were written.
+        let (parsed_entry, bytes_consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(3));
@@ -1062,6 +1207,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("UPDATED_KNOWS").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(4), operation);
 
@@ -1069,8 +1215,11 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_entry_into(&entry, &mut buffer).unwrap();
 
-        // Parse it back
-        let (parsed_entry, bytes_consumed) = parse_entry_at(&buffer, 0, WAL_VERSION).unwrap();
+        // Parse it back. Serialization always writes the provenance-carrying
+        // payload shape now (Issue #3224), so parsing must use the matching
+        // version to consume the same bytes that were written.
+        let (parsed_entry, bytes_consumed) =
+            parse_entry_at(&buffer, 0, WAL_VERSION_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(4));
@@ -1186,6 +1335,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("First").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry1 = WalEntry::new(LSN(1), operation1);
 
@@ -1194,6 +1344,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Second").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry2 = WalEntry::new(LSN(2), operation2);
 
@@ -1208,9 +1359,11 @@ mod tests {
         serialize_entry_into(&entry2, &mut buffer2).unwrap();
         buffer.extend_from_slice(&buffer2);
 
-        // Parse second entry using offset
+        // Parse second entry using offset. Serialization always writes the
+        // provenance-carrying payload shape now (Issue #3224), so parsing
+        // must use the matching version to consume the same bytes written.
         let (parsed_entry, bytes_consumed) =
-            parse_entry_at(&buffer, offset1_end, WAL_VERSION).unwrap();
+            parse_entry_at(&buffer, offset1_end, WAL_VERSION_PROVENANCE).unwrap();
 
         // Verify
         assert_eq!(parsed_entry.lsn, LSN(2));
@@ -1330,6 +1483,7 @@ mod tests {
                 label: parsed_label,
                 properties,
                 valid_from,
+                ..
             } => {
                 assert_eq!(node_id.as_u64(), 123);
                 assert_eq!(parsed_label, GLOBAL_INTERNER.intern("TestNode").unwrap());
@@ -1351,6 +1505,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(1), operation);
 
@@ -1477,9 +1632,11 @@ mod tests {
         // Create a segment file with many entries
         let mut file = File::create(&segment_path).unwrap();
 
-        // Write WAL header
+        // Write WAL header. Entries below are serialized with the modern
+        // (always-provenance-carrying) format, so the header must declare
+        // WAL_VERSION_PROVENANCE for the reader to parse them correctly.
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION]).unwrap();
+        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
 
         // Create and write many entries to simulate a large segment
         // We'll create 1000 entries, which should be several MB
@@ -1495,6 +1652,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern(format!("Node_{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 valid_from: time::now(),
+                provenance: None,
             };
 
             let entry = WalEntry::new(lsn, operation);
@@ -1534,9 +1692,12 @@ mod tests {
             let segment_path = dir.path().join(format!("{}.log", seg_id));
             let mut file = File::create(&segment_path).unwrap();
 
-            // Write WAL header
+            // Write WAL header. Entries below are serialized with the modern
+            // (always-provenance-carrying) format, so the header must
+            // declare WAL_VERSION_PROVENANCE for the reader to parse them
+            // correctly.
             file.write_all(&WAL_MAGIC).unwrap();
-            file.write_all(&[WAL_VERSION]).unwrap();
+            file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
 
             // Write entries for this segment
             for i in 0..entries_per_segment {
@@ -1549,6 +1710,7 @@ mod tests {
                         .unwrap(),
                     properties: PropertyMap::new(),
                     valid_from: time::now(),
+                    provenance: None,
                 };
 
                 let entry = WalEntry::new(lsn, operation);
@@ -1585,9 +1747,11 @@ mod tests {
 
         let mut file = File::create(&segment_path).unwrap();
 
-        // Write WAL header
+        // Write WAL header. Entries below are serialized with the modern
+        // (always-provenance-carrying) format, so the header must declare
+        // WAL_VERSION_PROVENANCE for the reader to parse them correctly.
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION]).unwrap();
+        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
 
         // Write 100 entries with LSN 1-100
         for i in 1..=100 {
@@ -1597,6 +1761,7 @@ mod tests {
                 label: GLOBAL_INTERNER.intern(format!("Node_{}", i)).unwrap(),
                 properties: PropertyMap::new(),
                 valid_from: time::now(),
+                provenance: None,
             };
 
             let entry = WalEntry::new(lsn, operation);
@@ -1653,9 +1818,11 @@ mod tests {
 
         let mut file = File::create(&segment_path).unwrap();
 
-        // Write WAL header
+        // Write WAL header. The entry below is serialized with the modern
+        // (always-provenance-carrying) format, so the header must declare
+        // WAL_VERSION_PROVENANCE for the reader to parse it correctly.
         file.write_all(&WAL_MAGIC).unwrap();
-        file.write_all(&[WAL_VERSION]).unwrap();
+        file.write_all(&[WAL_VERSION_PROVENANCE]).unwrap();
 
         // Write one complete entry
         let operation = WalOperation::CreateNode {
@@ -1663,6 +1830,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Node_1").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(1), operation);
         let mut buffer = Vec::new();
@@ -1768,6 +1936,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("UpdatedPerson").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(1), operation);
 
@@ -1802,6 +1971,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("UPDATED_KNOWS").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         };
         let entry = WalEntry::new(LSN(1), operation);
 

--- a/src/storage/wal/serialization.rs
+++ b/src/storage/wal/serialization.rs
@@ -36,6 +36,7 @@ use super::entry::WalEntry;
 use super::entry::{LSN, WalOperation};
 use crate::core::error::Result;
 use crate::core::interning::InternedString;
+use crate::core::provenance::Provenance;
 use crate::core::temporal::Timestamp;
 
 // WAL operation type tags for the binary format.
@@ -54,6 +55,80 @@ pub(crate) const OP_DROP_UNIQUE_CONSTRAINT: u8 = 9;
 #[inline(always)]
 fn serialize_interned_string(s: InternedString, buffer: &mut Vec<u8>) {
     buffer.extend_from_slice(&s.as_u32().to_le_bytes());
+}
+
+/// Serialize an optional `&str`: `[1-byte presence][4-byte LE len][UTF-8 bytes]`.
+#[inline]
+fn serialize_opt_str(s: Option<&str>, buffer: &mut Vec<u8>) {
+    match s {
+        None => buffer.push(0),
+        Some(s) => {
+            buffer.push(1);
+            let bytes = s.as_bytes();
+            buffer.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            buffer.extend_from_slice(bytes);
+        }
+    }
+}
+
+/// Serialize an optional `f64`: `[1-byte presence][8-byte LE value]`.
+#[inline]
+fn serialize_opt_f64(v: Option<f64>, buffer: &mut Vec<u8>) {
+    match v {
+        None => buffer.push(0),
+        Some(v) => {
+            buffer.push(1);
+            buffer.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+}
+
+/// Byte size of an optional `&str` as serialized by [`serialize_opt_str`].
+#[inline]
+fn opt_str_size(s: Option<&str>) -> usize {
+    1 + s.map(|s| 4 + s.len()).unwrap_or(0)
+}
+
+/// Byte size of an optional `f64` as serialized by [`serialize_opt_f64`].
+#[inline]
+fn opt_f64_size(v: Option<f64>) -> usize {
+    1 + if v.is_some() { 8 } else { 0 }
+}
+
+/// Serialize an optional [`Provenance`] bundle: `[1-byte presence][source][confidence][note][correlation_id]`.
+///
+/// The four fields are only present when the outer presence byte is nonzero;
+/// each is itself independently optional (see [`serialize_opt_str`] /
+/// [`serialize_opt_f64`]). Written unconditionally by writers on this format
+/// version -- readers on older WAL versions never look for these bytes at
+/// all (see `WAL_VERSION_PROVENANCE` in `segment_reader.rs`).
+#[inline]
+fn serialize_provenance_into(provenance: Option<&Provenance>, buffer: &mut Vec<u8>) {
+    match provenance {
+        None => buffer.push(0),
+        Some(p) => {
+            buffer.push(1);
+            serialize_opt_str(p.source(), buffer);
+            serialize_opt_f64(p.confidence(), buffer);
+            serialize_opt_str(p.note(), buffer);
+            serialize_opt_str(p.correlation_id(), buffer);
+        }
+    }
+}
+
+/// Byte size of an optional [`Provenance`] bundle as serialized by
+/// [`serialize_provenance_into`].
+#[inline]
+fn provenance_serialized_size(provenance: Option<&Provenance>) -> usize {
+    match provenance {
+        None => 1,
+        Some(p) => {
+            1 + opt_str_size(p.source())
+                + opt_f64_size(p.confidence())
+                + opt_str_size(p.note())
+                + opt_str_size(p.correlation_id())
+        }
+    }
 }
 
 /// Estimate the required buffer capacity for serializing a WAL entry.
@@ -129,25 +204,41 @@ pub(crate) fn estimate_entry_capacity(operation: &WalOperation) -> usize {
     const TIMESTAMP_SIZE: usize = 12;
 
     let variable_size = match operation {
-        WalOperation::CreateNode { properties, .. } => {
-            // op type (1) + node_id (8) + label (4-byte InternedString ID) + properties + valid_from (12)
+        WalOperation::CreateNode {
+            properties,
+            provenance,
+            ..
+        } => {
+            // op type (1) + node_id (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
             let base = 1 + 8 + 4 + TIMESTAMP_SIZE;
-            base + properties.serialized_size()
+            base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::CreateEdge { properties, .. } => {
-            // op type (1) + edge_id (8) + source (8) + target (8) + label (4-byte InternedString ID) + properties + valid_from (12)
+        WalOperation::CreateEdge {
+            properties,
+            provenance,
+            ..
+        } => {
+            // op type (1) + edge_id (8) + source (8) + target (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
             let base = 1 + 8 + 8 + 8 + 4 + TIMESTAMP_SIZE;
-            base + properties.serialized_size()
+            base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::UpdateNode { properties, .. } => {
-            // op type (1) + node_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12)
+        WalOperation::UpdateNode {
+            properties,
+            provenance,
+            ..
+        } => {
+            // op type (1) + node_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
             let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
-            base + properties.serialized_size()
+            base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
-        WalOperation::UpdateEdge { properties, .. } => {
-            // op type (1) + edge_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12)
+        WalOperation::UpdateEdge {
+            properties,
+            provenance,
+            ..
+        } => {
+            // op type (1) + edge_id (8) + version_id (8) + label (4-byte InternedString ID) + properties + valid_from (12) + provenance
             let base = 1 + 8 + 8 + 4 + TIMESTAMP_SIZE;
-            base + properties.serialized_size()
+            base + properties.serialized_size() + provenance_serialized_size(provenance.as_ref())
         }
         WalOperation::DeleteNode { .. } => {
             // op type (1) + node_id (8) + valid_from (12)
@@ -241,12 +332,14 @@ pub(crate) fn serialize_operation_into(
             label,
             properties,
             valid_from,
+            provenance,
         } => {
             buffer.push(OP_CREATE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
             serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::CreateEdge {
             edge_id,
@@ -255,6 +348,7 @@ pub(crate) fn serialize_operation_into(
             label,
             properties,
             valid_from,
+            provenance,
         } => {
             buffer.push(OP_CREATE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
@@ -263,6 +357,7 @@ pub(crate) fn serialize_operation_into(
             serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::UpdateNode {
             node_id,
@@ -270,6 +365,7 @@ pub(crate) fn serialize_operation_into(
             label,
             properties,
             valid_from,
+            provenance,
         } => {
             buffer.push(OP_UPDATE_NODE);
             buffer.extend_from_slice(&node_id.as_u64().to_le_bytes());
@@ -277,6 +373,7 @@ pub(crate) fn serialize_operation_into(
             serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::UpdateEdge {
             edge_id,
@@ -284,6 +381,7 @@ pub(crate) fn serialize_operation_into(
             label,
             properties,
             valid_from,
+            provenance,
         } => {
             buffer.push(OP_UPDATE_EDGE);
             buffer.extend_from_slice(&edge_id.as_u64().to_le_bytes());
@@ -291,6 +389,7 @@ pub(crate) fn serialize_operation_into(
             serialize_interned_string(*label, buffer);
             properties.serialize_into(buffer)?;
             valid_from.serialize_into(buffer);
+            serialize_provenance_into(provenance.as_ref(), buffer);
         }
         WalOperation::DeleteNode {
             node_id,
@@ -440,21 +539,23 @@ mod tests {
 
     #[test]
     fn test_estimate_capacity_create_node_empty_properties() {
-        // CreateNode with empty properties:
+        // CreateNode with empty properties, no provenance:
         // Fixed: 24 bytes (LSN + Timestamp + Checksum)
-        // op type (1) + node_id (8) + label (4-byte InternedString) + properties (4 for empty count) + valid_from (12)
-        // = 24 + 1 + 8 + 4 + 4 + 12 = 53 bytes
+        // op type (1) + node_id (8) + label (4-byte InternedString) + properties (4 for empty count)
+        // + valid_from (12) + provenance presence byte (1, absent)
+        // = 24 + 1 + 8 + 4 + 4 + 12 + 1 = 54 bytes
         let op = WalOperation::CreateNode {
             node_id: NodeId::new(1).unwrap(),
             label: GLOBAL_INTERNER.intern("test").unwrap(),
             properties: PropertyMapBuilder::new().build(),
             valid_from: test_timestamp(),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
         assert_eq!(
-            estimated, 53,
-            "CreateNode with empty properties should be 53 bytes"
+            estimated, 54,
+            "CreateNode with empty properties (no provenance) should be 54 bytes"
         );
 
         // Verify by actually serializing
@@ -483,6 +584,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties,
             valid_from: test_timestamp(),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
@@ -524,6 +626,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
             properties,
             valid_from: test_timestamp(),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
@@ -562,6 +665,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("Document").unwrap(),
             properties,
             valid_from: test_timestamp(),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
@@ -602,6 +706,7 @@ mod tests {
             label: GLOBAL_INTERNER.intern("LargeNode").unwrap(),
             properties,
             valid_from: test_timestamp(),
+            provenance: None,
         };
 
         let estimated = estimate_entry_capacity(&op);
@@ -692,6 +797,7 @@ mod prop_tests {
                         label,
                         properties,
                         valid_from,
+                        provenance: None,
                     }
                 }),
             // DeleteNode

--- a/tests/durability_modes.rs
+++ b/tests/durability_modes.rs
@@ -1314,6 +1314,7 @@ fn test_recovery_after_concurrent_writes() {
                             label: GLOBAL_INTERNER.intern("CrashTest").unwrap(),
                             properties: PropertyMap::new(),
                             valid_from: time::now(),
+                            provenance: None,
                         };
 
                         // Retry with backoff on backpressure
@@ -1448,6 +1449,7 @@ fn test_recovery_partial_flush_ordering() {
                             label: GLOBAL_INTERNER.intern("PartialCrashTest").unwrap(),
                             properties: PropertyMap::new(),
                             valid_from: time::now(),
+                            provenance: None,
                         };
                         let _ = wal_ref.append_async(operation);
                     }

--- a/tests/havoc/havoc_wal_gaps.rs
+++ b/tests/havoc/havoc_wal_gaps.rs
@@ -12,6 +12,7 @@ fn test_operation(id: u64) -> WalOperation {
         label: GLOBAL_INTERNER.intern("Test").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     }
 }
 
@@ -50,6 +51,7 @@ fn huge_operation(id: u64) -> WalOperation {
         label: GLOBAL_INTERNER.intern("Huge").unwrap(),
         properties: props,
         valid_from: time::now(),
+        provenance: None,
     }
 }
 

--- a/tests/index_persistence.rs
+++ b/tests/index_persistence.rs
@@ -159,7 +159,12 @@ fn test_full_persistence_cycle() {
     // Load manifest and strings (validates load order: interner → manifest)
     let loaded_manifest = manager.load_manifest_and_strings().unwrap();
     assert_eq!(loaded_manifest.lsn, 100);
-    assert_eq!(loaded_manifest.version, 1);
+    // Manifest version was bumped to 2 when write-time provenance
+    // (Issue #3224) was added to the persisted temporal index format.
+    assert_eq!(
+        loaded_manifest.version,
+        aletheiadb::storage::index_persistence::MANIFEST_VERSION
+    );
 
     // Verify string interner was restored correctly
     assert_eq!(
@@ -333,9 +338,15 @@ fn test_db_persist_indexes_mvp() {
             "Graph index file should exist"
         );
 
-        // Verify we can load manifest and strings back
+        // Verify we can load manifest and strings back. Manifest version was
+        // bumped to 2 when write-time provenance (Issue #3224) was added to
+        // the persisted temporal index format.
         let manifest = manager.load_manifest_and_strings().unwrap();
-        assert_eq!(manifest.version, 1, "Manifest version should be 1");
+        assert_eq!(
+            manifest.version,
+            aletheiadb::storage::index_persistence::MANIFEST_VERSION,
+            "Manifest version should match the current format version"
+        );
 
         // Verify strings were saved (we interned "Person", "name", "age", "Bob", "Alice", "KNOWS")
         use aletheiadb::core::GLOBAL_INTERNER;
@@ -1992,6 +2003,7 @@ fn test_temporal_version_round_trip() {
         },
         next_version: None,
         prev_version: None,
+        provenance: None,
     };
 
     // Create edge anchor version
@@ -2012,6 +2024,7 @@ fn test_temporal_version_round_trip() {
         data: VersionData::anchor(edge_props),
         next_version: None,
         prev_version: None,
+        provenance: None,
     };
 
     // ========================================================================
@@ -2338,6 +2351,7 @@ fn test_delta_removed_properties_persistence() {
         },
         next_version: None,
         prev_version: None,
+        provenance: None,
     };
 
     // Create delta that removes "city" property
@@ -2362,6 +2376,7 @@ fn test_delta_removed_properties_persistence() {
         },
         next_version: None,
         prev_version: Some(VersionId::new(1).unwrap()),
+        provenance: None,
     };
 
     println!("✓ Created delta with 1 changed property (age: 31) and 1 removed property (city)");
@@ -2476,6 +2491,7 @@ fn test_version_chain_reconstruction() {
             },
             properties: PersistedPropertyMap { entries: vec![] },
             vector_snapshot_id: None,
+            provenance: None,
         },
         // Version 3 (newest) - inserted second
         NodeVersionEntry {
@@ -2495,6 +2511,7 @@ fn test_version_chain_reconstruction() {
             },
             properties: PersistedPropertyMap { entries: vec![] },
             vector_snapshot_id: None,
+            provenance: None,
         },
         // Version 1 (oldest) - inserted last
         NodeVersionEntry {
@@ -2510,6 +2527,7 @@ fn test_version_chain_reconstruction() {
             version_type: PersistedVersionType::Anchor,
             properties: PersistedPropertyMap { entries: vec![] },
             vector_snapshot_id: None,
+            provenance: None,
         },
     ];
 

--- a/tests/recovery/checkpoint_recovery_tests.rs
+++ b/tests/recovery/checkpoint_recovery_tests.rs
@@ -51,6 +51,7 @@ fn test_checkpoint_recovery_basic() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Person").unwrap(),
             properties: props,
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -93,6 +94,7 @@ fn test_checkpoint_with_persisted_state_and_wal_replay() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: props,
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -124,6 +126,7 @@ fn test_checkpoint_with_persisted_state_and_wal_replay() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: props,
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -323,6 +326,7 @@ fn test_checkpoint_recovery_with_updates() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update node
@@ -334,6 +338,7 @@ fn test_checkpoint_recovery_with_updates() -> Result<()> {
             .insert("name", "Alice Updated")
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.flush()?;
@@ -376,6 +381,7 @@ fn test_checkpoint_recovery_with_deletes() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 

--- a/tests/recovery/large_dataset_recovery.rs
+++ b/tests/recovery/large_dataset_recovery.rs
@@ -58,6 +58,7 @@ fn test_large_dataset_recovery_10k_nodes() -> Result<()> {
                 .insert("batch", (i / 1000) as i64)
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         if i % 1000 == 0 {
@@ -144,6 +145,7 @@ fn test_large_dataset_recovery_50k_edges() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -162,6 +164,7 @@ fn test_large_dataset_recovery_50k_edges() -> Result<()> {
             label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMapBuilder::new().insert("index", i as i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         if i % 10000 == 0 {
@@ -258,6 +261,7 @@ fn test_large_dataset_full_recovery() -> Result<()> {
                 .insert("type", "node")
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         if i % 2000 == 0 {
@@ -285,6 +289,7 @@ fn test_large_dataset_full_recovery() -> Result<()> {
                 .insert("weight", (i % 100) as i64)
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
 
         if i % 10000 == 0 {
@@ -400,6 +405,7 @@ fn test_large_dataset_with_updates() -> Result<()> {
                 .insert("value", (i * 10) as i64)
                 .build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -416,6 +422,7 @@ fn test_large_dataset_with_updates() -> Result<()> {
                     .insert("value", (i * 10 + update_round) as i64)
                     .build(),
                 valid_from: time::now(),
+                provenance: None,
             })?;
             version_id += 1;
         }
@@ -497,6 +504,7 @@ fn test_large_dataset_with_deletions() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("index", i as i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -596,6 +604,7 @@ fn bench_recovery_throughput() -> Result<()> {
                 label: GLOBAL_INTERNER.intern("BenchNode").unwrap(),
                 properties: PropertyMapBuilder::new().insert("i", i as i64).build(),
                 valid_from: time::now(),
+                provenance: None,
             })?;
         }
         wal.flush()?;

--- a/tests/recovery/property_based_tests.rs
+++ b/tests/recovery/property_based_tests.rs
@@ -229,6 +229,7 @@ impl RecoveryTestHarness {
                             label: GLOBAL_INTERNER.intern(label).unwrap(),
                             properties: PropertyMapBuilder::new().insert("value", *value).build(),
                             valid_from: timestamp_counter,
+                            provenance: None,
                         })?;
                         created_nodes.insert(*id);
                     }
@@ -245,6 +246,7 @@ impl RecoveryTestHarness {
                                 .insert("value", *new_value)
                                 .build(),
                             valid_from: timestamp_counter,
+                            provenance: None,
                         })?;
                     }
                 }
@@ -274,6 +276,7 @@ impl RecoveryTestHarness {
                             label: GLOBAL_INTERNER.intern(label).unwrap(),
                             properties: PropertyMapBuilder::new().build(),
                             valid_from: timestamp_counter,
+                            provenance: None,
                         })?;
                         created_edges.insert(*id);
                     }
@@ -290,6 +293,7 @@ impl RecoveryTestHarness {
                                 .insert("value", *new_value)
                                 .build(),
                             valid_from: timestamp_counter,
+                            provenance: None,
                         })?;
                     }
                 }

--- a/tests/recovery/replay_create_tests.rs
+++ b/tests/recovery/replay_create_tests.rs
@@ -43,6 +43,7 @@ fn test_replay_create_node_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: timestamp,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -85,6 +86,7 @@ fn test_replay_create_node_with_properties() -> Result<()> {
         label: GLOBAL_INTERNER.intern("User").unwrap(),
         properties: properties.clone(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -132,6 +134,7 @@ fn test_replay_create_node_with_vector() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Document").unwrap(),
         properties: properties.clone(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -172,6 +175,7 @@ fn test_replay_create_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.append(WalOperation::CreateNode {
@@ -179,6 +183,7 @@ fn test_replay_create_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create edge
@@ -189,6 +194,7 @@ fn test_replay_create_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -230,6 +236,7 @@ fn test_replay_create_edge_with_properties() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.append(WalOperation::CreateNode {
@@ -237,6 +244,7 @@ fn test_replay_create_edge_with_properties() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create edge with properties
@@ -252,6 +260,7 @@ fn test_replay_create_edge_with_properties() -> Result<()> {
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: edge_properties.clone(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -290,6 +299,7 @@ fn test_replay_multiple_creates() -> Result<()> {
             label: GLOBAL_INTERNER.intern(format!("Node{}", i)).unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -302,6 +312,7 @@ fn test_replay_multiple_creates() -> Result<()> {
             label: GLOBAL_INTERNER.intern("LINKS_TO").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -338,6 +349,7 @@ fn test_replay_create_node_tracks_max_id() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -378,6 +390,7 @@ fn test_replay_preserves_temporal_interval() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Test").unwrap(),
         properties: PropertyMap::new(),
         valid_from: timestamp,
+        provenance: None,
     })?;
     wal.flush()?;
 

--- a/tests/recovery/replay_delete_tests.rs
+++ b/tests/recovery/replay_delete_tests.rs
@@ -44,6 +44,7 @@ fn test_replay_delete_node_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         valid_from: timestamp1,
+        provenance: None,
     })?;
 
     // Delete node
@@ -86,6 +87,7 @@ fn test_replay_delete_node_after_update() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update node
@@ -98,6 +100,7 @@ fn test_replay_delete_node_after_update() -> Result<()> {
             .insert("age", 30_i64)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Delete node
@@ -141,6 +144,7 @@ fn test_replay_delete_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.append(WalOperation::CreateNode {
@@ -148,6 +152,7 @@ fn test_replay_delete_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create edge
@@ -158,6 +163,7 @@ fn test_replay_delete_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Delete edge
@@ -205,6 +211,7 @@ fn test_replay_multiple_deletes() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -258,6 +265,7 @@ fn test_replay_delete_with_vector() -> Result<()> {
             .insert_vector("embedding", &embedding)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Delete node
@@ -297,6 +305,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 1_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create node 2
@@ -305,6 +314,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 2_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update node 1
@@ -314,6 +324,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 10_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Delete node 2
@@ -328,6 +339,7 @@ fn test_replay_mixed_creates_updates_deletes() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 3_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.flush()?;

--- a/tests/recovery/replay_id_tracking_tests.rs
+++ b/tests/recovery/replay_id_tracking_tests.rs
@@ -40,6 +40,7 @@ fn test_recover_initializes_node_id_generator() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -78,6 +79,7 @@ fn test_recover_initializes_edge_id_generator() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -90,6 +92,7 @@ fn test_recover_initializes_edge_id_generator() -> Result<()> {
             label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -133,6 +136,7 @@ fn test_recover_initializes_version_id_generator() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("count", 0_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update 4 times (versions 2, 3, 4, 5)
@@ -143,6 +147,7 @@ fn test_recover_initializes_version_id_generator() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("count", i).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -184,6 +189,7 @@ fn test_recover_handles_gaps_in_ids() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -221,6 +227,7 @@ fn test_recover_with_deletes_tracks_max_ids() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -289,6 +296,7 @@ fn test_recover_single_zero_node_id_advances_generator() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node")?,
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -324,6 +332,7 @@ fn test_recover_all_generators_independent() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -336,6 +345,7 @@ fn test_recover_all_generators_independent() -> Result<()> {
             label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -346,6 +356,7 @@ fn test_recover_all_generators_independent() -> Result<()> {
         label: GLOBAL_INTERNER.intern("UpdatedNode").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 

--- a/tests/recovery/replay_loop_tests.rs
+++ b/tests/recovery/replay_loop_tests.rs
@@ -74,6 +74,7 @@ fn test_recover_tracks_max_node_id() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -112,6 +113,7 @@ fn test_recover_tracks_max_edge_id() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -124,6 +126,7 @@ fn test_recover_tracks_max_edge_id() -> Result<()> {
             label: GLOBAL_INTERNER.intern("CONNECTS").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -168,6 +171,7 @@ fn test_recover_tracks_max_version_id() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Append updates with various version IDs
@@ -178,6 +182,7 @@ fn test_recover_tracks_max_version_id() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Updated").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -220,6 +225,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update with version 100 (large jump)
@@ -229,6 +235,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Updated").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update with version 50 (out of order - should still track max=100)
@@ -238,6 +245,7 @@ fn test_recover_handles_non_sequential_version_ids() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Another").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Delete creates tombstone (should get next version after max)
@@ -282,6 +290,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create edge
@@ -292,6 +301,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update node
@@ -301,6 +311,7 @@ fn test_recover_with_multiple_operation_types() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Delete node
@@ -341,6 +352,7 @@ fn test_recover_from_checkpoint_lsn() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -396,6 +408,7 @@ fn test_recover_handles_checkpoint_marker() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -412,6 +425,7 @@ fn test_recover_handles_checkpoint_marker() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Test").unwrap(),
             properties: PropertyMap::new(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 

--- a/tests/recovery/replay_update_tests.rs
+++ b/tests/recovery/replay_update_tests.rs
@@ -44,6 +44,7 @@ fn test_replay_update_node_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMapBuilder::new().insert("name", "Alice").build(),
         valid_from: timestamp1,
+        provenance: None,
     })?;
 
     // Update node with new properties
@@ -56,6 +57,7 @@ fn test_replay_update_node_basic() -> Result<()> {
             .insert("age", 30_i64)
             .build(),
         valid_from: timestamp2,
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -101,6 +103,7 @@ fn test_replay_update_node_label_change() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update node to "User" label
@@ -110,6 +113,7 @@ fn test_replay_update_node_label_change() -> Result<()> {
         label: GLOBAL_INTERNER.intern("User").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -146,6 +150,7 @@ fn test_replay_update_node_with_vector() -> Result<()> {
             .insert_vector("embedding", &embedding_v1)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update node with new embedding
@@ -157,6 +162,7 @@ fn test_replay_update_node_with_vector() -> Result<()> {
             .insert_vector("embedding", &embedding_v2)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -195,6 +201,7 @@ fn test_replay_multiple_updates_same_node() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Counter").unwrap(),
         properties: PropertyMapBuilder::new().insert("count", 0_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update 5 times
@@ -205,6 +212,7 @@ fn test_replay_multiple_updates_same_node() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Counter").unwrap(),
             properties: PropertyMapBuilder::new().insert("count", i).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
     wal.flush()?;
@@ -248,6 +256,7 @@ fn test_replay_update_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.append(WalOperation::CreateNode {
@@ -255,6 +264,7 @@ fn test_replay_update_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create edge
@@ -265,6 +275,7 @@ fn test_replay_update_edge_basic() -> Result<()> {
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMapBuilder::new().insert("since", 2020_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update edge
@@ -277,6 +288,7 @@ fn test_replay_update_edge_basic() -> Result<()> {
             .insert("strength", 0.8)
             .build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -322,6 +334,7 @@ fn test_replay_update_edge_label_change() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.append(WalOperation::CreateNode {
@@ -329,6 +342,7 @@ fn test_replay_update_edge_label_change() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Person").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Create edge with "KNOWS" label
@@ -339,6 +353,7 @@ fn test_replay_update_edge_label_change() -> Result<()> {
         label: GLOBAL_INTERNER.intern("KNOWS").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     // Update edge to "FRIENDS_WITH" label
@@ -348,6 +363,7 @@ fn test_replay_update_edge_label_change() -> Result<()> {
         label: GLOBAL_INTERNER.intern("FRIENDS_WITH").unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     })?;
     wal.flush()?;
 
@@ -379,6 +395,7 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
             label: GLOBAL_INTERNER.intern("Node").unwrap(),
             properties: PropertyMapBuilder::new().insert("value", i as i64).build(),
             valid_from: time::now(),
+            provenance: None,
         })?;
     }
 
@@ -389,6 +406,7 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 10_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.append(WalOperation::UpdateNode {
@@ -397,6 +415,7 @@ fn test_replay_mixed_creates_and_updates() -> Result<()> {
         label: GLOBAL_INTERNER.intern("Node").unwrap(),
         properties: PropertyMapBuilder::new().insert("value", 20_i64).build(),
         valid_from: time::now(),
+        provenance: None,
     })?;
 
     wal.flush()?;

--- a/tests/regressions/interner_wal_labels.rs
+++ b/tests/regressions/interner_wal_labels.rs
@@ -28,6 +28,7 @@ fn test_wal_create_node_uses_interned_string() {
         label, // Should accept InternedString directly
         properties,
         valid_from: temporal,
+        provenance: None,
     };
 
     // Verify the operation was created successfully
@@ -57,6 +58,7 @@ fn test_wal_create_edge_uses_interned_string() {
         label, // Should accept InternedString directly
         properties,
         valid_from: temporal,
+        provenance: None,
     };
 
     match op {
@@ -82,6 +84,7 @@ fn test_wal_update_node_uses_interned_string() {
         label, // Should accept InternedString directly
         properties,
         valid_from: temporal,
+        provenance: None,
     };
 
     match op {
@@ -107,6 +110,7 @@ fn test_wal_update_edge_uses_interned_string() {
         label, // Should accept InternedString directly
         properties,
         valid_from: temporal,
+        provenance: None,
     };
 
     match op {
@@ -130,6 +134,7 @@ fn test_wal_entry_creation_with_interned_string() {
         label,
         properties,
         valid_from: temporal,
+        provenance: None,
     };
 
     // Creating a WAL entry should work without any allocations
@@ -161,6 +166,7 @@ fn test_no_allocations_in_buffered_write_to_wal_operation() {
         label,
         properties: properties.clone(),
         valid_from: temporal,
+        provenance: None,
     };
 
     // When converting to WalOperation, the label should be copied directly
@@ -178,6 +184,7 @@ fn test_no_allocations_in_buffered_write_to_wal_operation() {
                 label, // Should copy InternedString directly (just a u32)
                 properties,
                 valid_from: temporal,
+                provenance: None,
             }
         }
         _ => panic!("Expected CreateNode"),
@@ -215,6 +222,7 @@ fn test_interned_string_size_independence() {
         label: short_label,
         properties: properties.clone(),
         valid_from: temporal,
+        provenance: None,
     };
 
     let op2 = WalOperation::CreateNode {
@@ -222,6 +230,7 @@ fn test_interned_string_size_independence() {
         label: long_label,
         properties,
         valid_from: temporal,
+        provenance: None,
     };
 
     // Both operations should use the same amount of memory for the label field

--- a/tests/shutdown_correctness.rs
+++ b/tests/shutdown_correctness.rs
@@ -16,6 +16,7 @@ fn create_test_operation(id: u64) -> WalOperation {
         label: GLOBAL_INTERNER.intern(format!("Node{}", id)).unwrap(),
         properties: PropertyMap::new(),
         valid_from: time::now(),
+        provenance: None,
     }
 }
 

--- a/tests/warden/warden_wal_dos.rs
+++ b/tests/warden/warden_wal_dos.rs
@@ -26,6 +26,7 @@ fn test_wal_entry_size_limit() {
         label: GLOBAL_INTERNER.intern("DoS").unwrap(),
         properties,
         valid_from: time::now(),
+        provenance: None,
     };
 
     // Attempt to append


### PR DESCRIPTION
## Summary

Implements write-time attributive provenance tracking for temporal versions, complementing the existing bi-temporal axes (valid time / transaction time). This allows recording *who/what* wrote a fact, *why*, and *how confident* the writer was at the version granularity.

## Key Changes

### Core Provenance Module
- **New `src/core/provenance.rs`**: Introduces `Provenance` struct with builder pattern, validating confidence in `[0.0, 1.0]` range
  - Fields: `source` (system identifier), `confidence` (0.0-1.0), `note` (free-text), `correlation_id` (batch grouping)
  - All fields individually optional; empty bundles normalize to `None`
  - Serde support with `skip_serializing_if` for compact JSON

### API & Transaction Layer
- **`WriteRequestOptions`** in `src/api/transaction/mod.rs`: New builder for per-write settings
  - Supports backdated `valid_from` and optional `Provenance` bundle
  - Replaces scattered `*_with_valid_time` methods with unified `*_with_options` interface
- **`AletheiaDB` convenience methods** in `src/db/ops.rs`: 
  - `create_node_with_options()`, `update_node_with_options()`, `create_edge_with_options()`, `update_edge_with_options()`
  - `delete_node_with_options()`, `delete_edge_with_options()`

### Storage & Persistence
- **WAL format versioning** (`src/storage/wal/segment_reader.rs`):
  - `WAL_VERSION_PROVENANCE = 3` (plaintext with provenance)
  - `WAL_VERSION_ENCRYPTED_PROVENANCE = 4` (encrypted with provenance)
  - Backward compatible: older segments parse with `provenance: None`
  - Helper functions: `is_encrypted_version()`, `payload_version()` for version mapping

- **Cold storage** (`src/storage/redb_cold_storage/mod.rs`):
  - `COLD_RECORD_MAGIC_V2` prefix for provenance-carrying records
  - `SerializableProvenance` wrapper for bitcode serialization
  - Legacy fallback: `SerializableNodeVersionV1`/`SerializableEdgeVersionV1` for pre-provenance records
  - Automatic detection via magic bytes; astronomically low collision risk (1-in-4-billion)

- **Index persistence** (`src/storage/index_persistence/formats.rs`):
  - `PersistedProvenance` struct for temporal index serialization
  - `NodeVersionEntry` and `EdgeVersionEntry` gain optional `provenance` field
  - `persist_provenance()` / `restore_provenance()` helpers in `temporal.rs`

- **Backup format** (`src/storage/backup/mod.rs`):
  - `BACKUP_FORMAT_VERSION` bumped to 2
  - `BackupPayloadV1` struct preserves pre-provenance shape for restoration
  - Automatic upgrade on load via `From<BackupPayloadV1> for BackupPayload`

### MCP Server & History API
- **`GetNodeHistoryRequest` / `GetEdgeHistoryRequest`** in `src/mcp/tools.rs`:
  - New endpoints to retrieve complete version history with provenance bundles
  - `get_node_history()` / `get_edge_history()` methods in `src/mcp/server.rs`
  - Provenance serialized in response JSON

### Version & History Tracking
- **`NodeVersion` / `EdgeVersion`** in `src/core/version.rs`:
  - `with_provenance()` builder method to attach provenance to versions
  - `provenance()` accessor for retrieval

- **`HistoricalStorage`** in `src/storage/historical/mod.rs`:
  - `add_node_version_with_provenance()` / `add_edge_version_with_provenance()` methods

https://claude.ai/code/session_019DVu2my3VT71KJqH5LDzvT