### PR TITLE
⚖️ Elenchus: src/storage/sharding/executor.rs Test Quality Audit

### DIFF
--- a/.jules/elenchus.md
+++ b/.jules/elenchus.md
@@ -346,3 +346,17 @@
 **Finding:** The `LimitPushdown` tests originally missed several behavioral edge cases and logic checks, particularly regarding the propagation limits in BinaryOp combinations (`||`), updating limit values correctly against child bounds, and setting vector rank limits.
 **Evidence:** `cargo mutants` caught mutants in `LimitPushdown::push_down` specifically targeting the changed boolean condition logic and bounds assignment.
 **Recommendation:** Added `sentry_tests` to `LimitPushdown` that explicitly trigger tests enforcing the boolean change propagation, verifying that updated properties reflect correct nested limits, and vector bounds assignment. Tests now prevent `||` to `&&` mutations and correct top-k modifications.
+
+**[Execute Traversal Coverage Gap]**
+**Module:** `src/storage/sharding/executor.rs`
+**Severity:** 🔴 Critical
+**Finding:** The tests for `execute_traversal` lacked assertions on the actual query data dispatched to mock shards, and they failed to properly exercise the result aggregation strategy (`MergeNodes`), allowing mutations that replaced `MergeNodes` with `Concat` and mutations that zeroed out the query payload to survive.
+**Evidence:** `cargo mutants` showed that replacing `plan.involved_shards` logic, replacing `AggregationStrategy::MergeNodes`, and dropping the serialized payload entirely would not fail the test suite because the mocks weren't validated for exact payloads, and identical mock responses obscured aggregation differences.
+**Recommendation:** Captured raw query data via `MockShardClient::query_received` and asserted it strictly matches the serialized `TraversalPlan`. Configured distinct mock responses to distinguish between `Concat` and `MergeNodes` aggregation.
+
+**[Execute Traversal Hardcoded Shards Mutant]**
+**Module:** `src/storage/sharding/executor.rs`
+**Severity:** 🟡 Suspect
+**Finding:** The traversal execution test `test_execute_traversal` only verified query routing from `Person` -> `Place`, which maps exactly to shards 0 and 1. This allowed a mutation that hardcodes the target shards to `vec![ShardId::new(0).unwrap(), ShardId::new(1).unwrap()]` to survive.
+**Evidence:** A custom python script mutating `target_shards` collection to the hardcoded `0, 1` array passed the test suite.
+**Recommendation:** Changed the test logic to start from `Place` and target `Event`, shifting the execution to shards 1 and 2, which successfully killed the hardcoded `0, 1` array mutant.

--- a/src/storage/sharding/executor.rs
+++ b/src/storage/sharding/executor.rs
@@ -1119,19 +1119,41 @@ mod tests {
         let config = ExecutorConfig::default();
         let mut executor = QueryExecutor::new(config, router);
 
-        let shard0 = make_shard_id(0);
-        let shard1 = make_shard_id(1);
+        let shard0 = make_shard_id(1);
+        let shard1 = make_shard_id(2);
 
-        executor.register_client(shard0, Arc::new(MockShardClient::new(shard0)));
-        executor.register_client(shard1, Arc::new(MockShardClient::new(shard1)));
+        let client0 = Arc::new(MockShardClient::new(shard0));
+        let client1 = Arc::new(MockShardClient::new(shard1));
+
+        // Setup distinct mock responses to verify MergeNodes behavior over Concat
+        client0.set_query_response(vec![1, 2, 3]);
+        client1.set_query_response(vec![1, 2, 3, 4, 5]);
+
+        executor.register_client(shard0, Arc::clone(&client0));
+        executor.register_client(shard1, Arc::clone(&client1));
 
         let start_node = NodeId::new(42).unwrap();
         // Person maps to shard0. Place maps to shard1. Company is not in test_config, so it won't map to anything and route_node probably hashes it or falls back?
         // Let's use "Place" to ensure we hit shard1 as well.
         let result = executor
-            .execute_traversal(start_node, "Person", &["Place"])
+            .execute_traversal(start_node, "Place", &["Event"])
             .unwrap();
 
         assert_eq!(result.shards_queried, 2);
+
+        // Verify the exact query data serialized and sent
+        let expected_query_data =
+            executor.serialize_traversal_plan(&test_router().route_traversal("Place", &["Event"]));
+        assert_eq!(
+            client0.query_received.read().unwrap().as_ref().unwrap(),
+            &expected_query_data
+        );
+        assert_eq!(
+            client1.query_received.read().unwrap().as_ref().unwrap(),
+            &expected_query_data
+        );
+
+        // Verify aggregation strategy used MergeNodes instead of Concat (Concat would be len 8)
+        assert_eq!(result.data, vec![1, 2, 3, 4, 5]);
     }
 }

--- a/src/storage/sharding/network.rs
+++ b/src/storage/sharding/network.rs
@@ -659,6 +659,8 @@ pub struct MockShardClient {
     latency: RwLock<Duration>,
     fail_next: RwLock<Option<NetworkError>>,
     call_counts: RwLock<HashMap<String, usize>>,
+    /// The last query data received by this mock client.
+    pub query_received: RwLock<Option<Vec<u8>>>,
 }
 
 impl MockShardClient {
@@ -678,6 +680,7 @@ impl MockShardClient {
             latency: RwLock::new(Duration::from_micros(100)),
             fail_next: RwLock::new(None),
             call_counts: RwLock::new(HashMap::new()),
+            query_received: RwLock::new(None),
         }
     }
 
@@ -828,6 +831,8 @@ impl ShardClient for MockShardClient {
         if !self.is_healthy() {
             return Err(NetworkError::ShardUnavailable(self.shard_id));
         }
+
+        *self.query_received.write().unwrap() = Some(_query_data.to_vec());
 
         self.simulate_latency();
         Ok(self.query_response.read().unwrap().clone())


### PR DESCRIPTION
*   **Mock Network Tracing:** Added `pub query_received: RwLock<Option<Vec<u8>>>` to `MockShardClient` in `src/storage/sharding/network.rs`. This correctly captures the dispatched `_query_data` bytes for strict assertion against expected serialized `TraversalPlan`s.
*   **MergeNodes Validation:** In `test_execute_traversal`, distinct payload sizes (`vec![1, 2, 3]` and `vec![1, 2, 3, 4, 5]`) are provided by the `MockShardClient` instances. We now explicitly assert the final query output equals `vec![1, 2, 3, 4, 5]`, thus confirming that `AggregationStrategy::MergeNodes` is active. An `AggregationStrategy::Concat` mutant now rightfully fails.
*   **Hardcoded Shards Mutant Killed:** Modified the traversal routing test query from `Person -> Place` to `Place -> Event`, shifting the hit shards from `[0, 1]` to `[1, 2]`. This kills the mutation analysis false positive where target shards were hardcoded.
*   **Documentation:** Fully journalled the discovery and resolution in `.jules/elenchus.md` as required by the persona.

---
*PR created automatically by Jules for task [14870168834736778657](https://jules.google.com/task/14870168834736778657) started by @madmax983*