### PR TITLE
🗣️ Echo: Fix NarrativeGenerator compilation behavior and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -475,7 +475,7 @@ required-features = []
 # Experimental features
 [[example]]
 name = "story_demo"
-required-features = ["semantic-temporal"]
+required-features = ["nova"]
 
 [[example]]
 name = "russian_writers"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Averages across 30–212 datapoints of continuous CI runs:
 
 ## Feature Flags
 
+> **⚠️ REQUIRES FEATURE: nova**
+> The experimental Narrative Generation example (and others like it) requires the `nova` feature. Add `features = ["nova"]` to your `Cargo.toml` before running the example.
+
+
 All features are off by default except `config-toml`.
 
 | Flag | What it enables |


### PR DESCRIPTION
Addressed the DX Audit report by:
1. Adding a prominent warning banner to README.md specifying that the 'nova' feature is required for Narrative Generation.
2. Updating Cargo.toml to idiomatically enforce `required-features = ["nova"]` on the story_demo example so that `cargo run` explicitly tells the user they need the 'nova' feature instead of failing with missing struct errors.

---
*PR created automatically by Jules for task [1279126366403847501](https://jules.google.com/task/1279126366403847501) started by @madmax983*