### PR TITLE
⚡ Bolt: Remove redundant vector clone and normalization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,9 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**[Archetype Similarity Optimization]**
+**Learning:**  computes vector magnitudes internally. Pre-normalizing input vectors is mathematically redundant and introduces expensive O(N) heap allocations ().
+**Action:** Remove redundant clones and in-place normalization when iterating over vectors to calculate cosine similarity.
+**[Archetype Similarity Optimization]**
+**Learning:** `ops::cosine_similarity` computes vector magnitudes internally. Pre-normalizing input vectors is mathematically redundant and introduces expensive O(N) heap allocations (`vec.clone()`).
+**Action:** Remove redundant clones and in-place normalization when iterating over vectors to calculate cosine similarity.

--- a/src/experimental/characterization/archetype.rs
+++ b/src/experimental/characterization/archetype.rs
@@ -90,10 +90,8 @@ impl<'a> Archetype<'a> {
         // 2. Calculate Purity Scores
         let mut node_results = Vec::with_capacity(valid_nodes.len());
         for (i, vec) in vectors.iter().enumerate() {
-            let mut normalized_vec = vec.clone();
-            ops::normalize_in_place(&mut normalized_vec);
-
-            let similarity = ops::cosine_similarity(&centroid, &normalized_vec)?;
+            // ⚡ Bolt Optimization: Removing redundant vector clone and normalization per node since cosine_similarity is scale-invariant and already computes magnitudes internally.
+            let similarity = ops::cosine_similarity(&centroid, vec)?;
             // Cosine similarity ranges from -1.0 to 1.0. We normalize it to 0.0 - 1.0 for purity.
             let purity_score = ((similarity + 1.0) / 2.0).clamp(0.0, 1.0);
 


### PR DESCRIPTION
### 💡 What:
Removed a redundant `vec.clone()` and `ops::normalize_in_place` call inside the purity score calculation loop in `src/experimental/characterization/archetype.rs`, directly passing the unnormalized vector reference to `ops::cosine_similarity`.

### 🎯 Why:
The `ops::cosine_similarity` algorithm inherently computes the dot product and divides by the product of both vectors' magnitudes. Therefore, cosine similarity is scale-invariant; passing a normalized vs unnormalized vector (provided the magnitudes aren't near zero, which is handled correctly) yields the exact same similarity score mathematically. Creating a heap allocation (`.clone()`) for every single node's vector and then doing an in-place normalization pass just to feed it to a function that normalizes internally is a waste of memory and CPU cycles.

### 📊 Impact:
Removes one `Vec<f32>` heap allocation and one O(N) mutation pass per valid node analyzed during archetype purity scoring. This is a pure zero-cost optimization that keeps memory allocations off the hot loop.

### 🔬 Measurement:
Run `cargo test --lib experimental::characterization::archetype::tests` to ensure that the centroid calculation and purity scoring logic works identically.

---
*PR created automatically by Jules for task [7156519173774198408](https://jules.google.com/task/7156519173774198408) started by @madmax983*