### PR TITLE
🛡️ Sentry: [test coverage improvement] PropertyMapBuilder panic tests

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+## PropertyMapBuilder Panic Testing
+**Learning:** `PropertyMapBuilder::insert` and `remove` correctly wrap their fallible counterparts (`try_insert` and `try_remove`) but expected a panic via `.expect()` on recursion depth exceeded, or failures.
+**Action:** Wrote explicit `#[should_panic]` unit tests ensuring that recursion limits are safely caught before crashing with an unexpected error message or causing UB.

--- a/src/core/property/tests.rs
+++ b/src/core/property/tests.rs
@@ -2578,4 +2578,57 @@ mod sentry_tests {
             "semantically_equal should treat NaN as equal"
         );
     }
+
+    #[test]
+    #[should_panic(expected = "Property insertion failed (recursion depth limit exceeded)")]
+    fn test_property_map_builder_insert_panics_on_deep_recursion() {
+        let mut value = PropertyValue::Int(42);
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            value = PropertyValue::Array(Arc::new(vec![value]));
+        }
+        let _ = PropertyMapBuilder::new().insert("deep", value);
+    }
+
+    #[test]
+    #[should_panic(expected = "Property insertion failed (recursion depth limit exceeded)")]
+    fn test_property_map_builder_insert_by_key_panics_on_deep_recursion() {
+        let mut value = PropertyValue::Int(42);
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            value = PropertyValue::Array(Arc::new(vec![value]));
+        }
+        let key = GLOBAL_INTERNER.intern("deep").unwrap();
+        let _ = PropertyMapBuilder::new().insert_by_key(key, value);
+    }
+
+    #[test]
+    #[should_panic(expected = "Property removal failed")]
+    fn test_property_map_builder_remove_panics_on_deep_recursion() {
+        let mut value = PropertyValue::Int(42);
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            value = PropertyValue::Array(Arc::new(vec![value]));
+        }
+
+        let mut builder = PropertyMapBuilder::new();
+        // Insert directly to bypass try_insert's checks
+        let key = GLOBAL_INTERNER.intern("deep").unwrap();
+        builder.map.insert(key, value);
+
+        let _ = builder.remove("deep");
+    }
+
+    #[test]
+    #[should_panic(expected = "Property removal failed")]
+    fn test_property_map_builder_remove_by_key_panics_on_deep_recursion() {
+        let mut value = PropertyValue::Int(42);
+        for _ in 0..MAX_RECURSION_DEPTH + 1 {
+            value = PropertyValue::Array(Arc::new(vec![value]));
+        }
+
+        let mut builder = PropertyMapBuilder::new();
+        // Insert directly to bypass try_insert's checks
+        let key = GLOBAL_INTERNER.intern("deep").unwrap();
+        builder.map.insert(key, value);
+
+        let _ = builder.remove_by_key(&key);
+    }
 }


### PR DESCRIPTION
🎯 Target: `PropertyMapBuilder` `insert`, `insert_by_key`, `remove`, and `remove_by_key`
💣 Risk: Methods rely on `.expect()` which could panic unconditionally. We want to ensure they crash gracefully with correct panic messages.
🧪 Strategy: Trigger recursion depth limit by manually constructing a deeply nested array property value and ensuring `expect()` calls fail safely.
🔬 Verification: Run `cargo test --lib core::property::tests`

---
*PR created automatically by Jules for task [11458216893130774996](https://jules.google.com/task/11458216893130774996) started by @madmax983*