### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -174,7 +174,7 @@ AletheiaDB stores dense vector embeddings as node properties and indexes them
 with HNSW for fast k-NN search. Enable the index before inserting nodes.
 
 ```rust
-use aletheiadb::{AletheiaDB, HnswConfig, DistanceMetric};
+use aletheiadb::{AletheiaDB, HnswConfig, DistanceMetric, SimilarityQuery};
 
 let db = AletheiaDB::new()?;
 
@@ -198,7 +198,7 @@ let _doc2 = db.create_node("Document", properties! {
 
 // Find the 10 nodes most similar to doc1
 // (doc1 itself is excluded from results)
-let similar = db.find_similar(doc1, 10)?;
+let similar = db.similarity_search(SimilarityQuery::from_node(doc1).k(10))?;
 for (node_id, score) in similar {
     println!("Node {:?} similarity: {:.3}", node_id, score);
 }


### PR DESCRIPTION
Fixing a deprecated function call `find_similar` in the Getting Started guide which caused a deprecation warning on copy-pasted code. Updated to use the new unified `SimilarityQuery` builder as per the Echo persona requirements.

---
*PR created automatically by Jules for task [4845407913028303820](https://jules.google.com/task/4845407913028303820) started by @madmax983*