### PR TITLE
🎸 Bard: Fix rustdoc warnings and broken links

### DIFF
--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -286,7 +286,7 @@ impl AletheiaDB {
     }
 
     /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
-    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
+    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
     ///
     /// Passing `WriteRequestOptions::default()` is identical to [`create_node`](Self::create_node).
     ///
@@ -581,7 +581,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -46,7 +46,7 @@ pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 /// Bumped to 2 for write-time provenance on temporal versions (Issue #3224):
 /// the embedded `TemporalIndexData`'s `NodeVersionEntry`/`EdgeVersionEntry`
 /// gained an optional `provenance` field. Version 1 artifacts are still
-/// restorable -- see [`BackupPayloadV1`] and `read_artifact`.
+/// restorable -- see `BackupPayloadV1` and `read_artifact`.
 pub const BACKUP_FORMAT_VERSION: u16 = 2;
 
 /// Maximum allowed decompressed payload size (5 GiB).

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -545,7 +545,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of a node, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_node_version`](Self::add_node_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -774,7 +774,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of an edge, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
     /// than persisting `provenance` on the created version (anchor or delta).


### PR DESCRIPTION
📖 Chapter: The core, db, and storage modules.
💡 Insight: Fixed multiple broken intra-doc links, private intra-doc links, and redundant explicit link targets flagged by `cargo doc`. Resolved missing scope issues (e.g., `Provenance`, `StorageError`) and updated redundant link targets `[`ChangeRecord`](crate::core::ChangeRecord)` to just `[`ChangeRecord`]`. Removed private link `BackupPayloadV1` in favor of standard backticks.
🧪 Example: Cleaned up rustdoc warnings for `ops.rs`, `temporal.rs`, `historical/mod.rs`, and `backup/mod.rs`.
🖼️ Preview: `cargo rustdoc --lib -- -W missing_docs` now succeeds with 0 warnings.

---
*PR created automatically by Jules for task [11484239292457958905](https://jules.google.com/task/11484239292457958905) started by @madmax983*