### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 **Pre-allocating Vec Capacities in Hot Paths**
 **Learning:** Pre-allocating standard Rust `Vec` objects using `Vec::with_capacity` in hot-paths like parsers and query planners eliminates unnecessary heap reallocations (0 -> 4 -> 8 -> 16 etc.), without changing semantics or causing borrow checker issues. However, if the expected bounds are wildly incorrect it could lead to memory bloat. A small capacity for small collections minimizes performance impacts in hot loops.
 **Action:** When a loop dynamically pushes elements to a new empty Vector (especially in repeated execution domains like parsers and network/storage iterators), replace `Vec::new()` with `Vec::with_capacity(n)` if a typical or max size `n` is roughly known.
+**[In-place mutations]
+**Learning:** Reuse existing intermediate vectors like `sum` by mutating them in-place for scalar divisions and blending instead of allocating new vectors via `.collect::<Vec<_>>()`.
+**Action:** When calculating averages or combining states, perform the operations directly on existing buffers to avoid heap allocations on hot paths.

--- a/src/experimental/characterization/sybil.rs
+++ b/src/experimental/characterization/sybil.rs
@@ -111,7 +111,10 @@ impl PropagationModel for LinearPropagation {
             return current_self.map(|v| v.to_vec());
         }
 
-        let avg: Vec<f32> = sum.iter().map(|x| x / count as f32).collect();
+        // ⚡ Bolt Optimization: Perform scalar division in-place to avoid allocating a new vector for the average.
+        for val in &mut sum {
+            *val /= count as f32;
+        }
 
         match current_self {
             Some(self_vec) => {
@@ -121,19 +124,17 @@ impl PropagationModel for LinearPropagation {
                     return Some(self_vec.to_vec());
                 }
 
-                // Blend: (1 - alpha) * self + alpha * avg
-                let new_vec: Vec<f32> = self_vec
-                    .iter()
-                    .zip(avg.iter())
-                    .map(|(s, a)| (1.0 - self.alpha) * s + self.alpha * a)
-                    .collect();
-                Some(new_vec)
+                // ⚡ Bolt Optimization: Reuse the `sum` vector to store the blended state, eliminating another heap allocation via .collect().
+                for (s_val, self_val) in sum.iter_mut().zip(self_vec.iter()) {
+                    *s_val = (1.0 - self.alpha) * self_val + self.alpha * (*s_val);
+                }
+                Some(sum)
             }
             None => {
                 // If we didn't have a state, we "adopt" the average (if alpha allows adoption)
                 // Interpretation: If I have no opinion, do I adopt neighbors'?
                 // For this model, yes, let's say we adopt the average directly.
-                Some(avg)
+                Some(sum)
             }
         }
     }


### PR DESCRIPTION
💡 What: Modified `LinearPropagation::next_state` in `src/experimental/characterization/sybil.rs` to perform scalar division directly on the existing `sum` vector, and subsequently reused it to store the final blended state vector.
🎯 Why: The original implementation chained `.iter().map().collect::<Vec<_>>()` and `.zip().map().collect::<Vec<_>>()`, which forced two O(N) heap allocations per node iteration on the graph's simulation hot path.
📊 Impact: Reduces intermediate heap allocations by 2 per node during simulation steps, which scales heavily with node count and step iterations.
🔬 Measurement: Verified the logic correctness by ensuring that `test_linear_propagation_consensus` and `test_propagation_chain` inside `sybil.rs` still pass.

---
*PR created automatically by Jules for task [16375804019609849850](https://jules.google.com/task/16375804019609849850) started by @madmax983*