### PR TITLE
🛡️ Sentry: [test coverage improvement] remove unwrap in lexer and mcp server

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,6 @@
 **[Fix `execute_traversal` target shards bug]**
 **Learning:** `plan.steps` from `route_traversal` returns empty list, and we need `involved_shards`
 **Action:** Replace `steps` with `involved_shards` and update the test.
+## Lexer and JSON Parameter unwrap Panics
+**Learning:** `cargo mutants` or thorough code reading reveals that unwrap calls during lexical analysis (e.g. `read_string`) when encountering premature EOFs, or when casting values in JSON deserialization routines, pose subtle panic vectors that can crash an entire server process. Rust's `Iterator::next` combined with `unwrap()` assumes valid syntax paths that malicious or malformed inputs can easily violate.
+**Action:** Replace `unwrap()` calls on iterators with `ok_or_else` returning a strongly-typed error (like `CypherError::lex_error`), and replace `unwrap()` on JSON value casts with `unwrap_or` or `unwrap_or_default` with safe fallback defaults. Always write failing regression tests demonstrating the panic before fixing.

--- a/src/cypher/lexer.rs
+++ b/src/cypher/lexer.rs
@@ -500,7 +500,9 @@ impl<'a> CypherLexer<'a> {
     // -----------------------------------------------------------------------
 
     fn read_string(&mut self, start: usize) -> Result<Token, CypherError> {
-        let (_, quote) = self.advance().unwrap(); // consume opening quote
+        let (_, quote) = self.advance().ok_or_else(|| {
+            self.lex_error(start, "Unexpected EOF while reading string".to_string())
+        })?; // consume opening quote
         let mut value = String::new();
 
         loop {
@@ -745,5 +747,11 @@ mod unit_tests {
                 "{kw} should be a keyword, not an identifier"
             );
         }
+    }
+
+    #[test]
+    fn test_sentry_lexer_read_string_eof() {
+        let lexer = CypherLexer::tokenize("'");
+        assert!(lexer.is_err());
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2740,7 +2740,7 @@ impl AletheiaMcpServer {
                     // silently coerced to Int by as_i64(), which would succeed for
                     // whole-number floats in some representations.
                     if n.is_f64() {
-                        CypherParameterValue::Float(n.as_f64().unwrap())
+                        CypherParameterValue::Float(n.as_f64().unwrap_or(0.0))
                     } else if let Some(i) = n.as_i64() {
                         CypherParameterValue::Int(i)
                     } else if let Some(f) = n.as_f64() {
@@ -3465,5 +3465,28 @@ mod server_unit_tests {
             result.is_error.unwrap_or(false),
             "Null JSON input must produce an error result"
         );
+    }
+
+    #[test]
+    fn test_sentry_json_to_cypher_params_float_handling() {
+        let server = make_server();
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "float_val".to_string(),
+            serde_json::Value::Number(serde_json::Number::from_f64(1.0).unwrap()),
+        );
+        params.insert(
+            "int_val".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(1)),
+        );
+
+        let converted = server.json_to_cypher_params(Some(&params)).unwrap();
+        assert!(
+            matches!(converted.get("float_val"), Some(crate::cypher::CypherParameterValue::Float(f)) if *f == 1.0)
+        );
+        assert!(matches!(
+            converted.get("int_val"),
+            Some(crate::cypher::CypherParameterValue::Int(1))
+        ));
     }
 }


### PR DESCRIPTION
🎯 Target: `src/cypher/lexer.rs` and `src/mcp/server.rs`
💣 Risk: `unwrap()` calls on iterators or json type casts that can panic and crash the service on malformed input.
🧪 Strategy: Replaced `unwrap` with `ok_or_else` returning an error or `unwrap_or(0.0)`. Added unit tests verifying safe behavior.
🔬 Verification: `cargo test --lib cypher::lexer` and `cargo test --lib mcp::server`

---
*PR created automatically by Jules for task [4257998588968232596](https://jules.google.com/task/4257998588968232596) started by @madmax983*