### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/.jules/dx_audit_learnings.md
+++ b/.jules/dx_audit_learnings.md
@@ -1,0 +1,1 @@
+Memory: Removed runtime panic stubs behind feature flags to enforce compile-time errors instead, improving Developer Experience (DX).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,40 @@ See the [Getting Started guide](docs/guides/getting-started.md) for a full walkt
 
 ---
 
+
+## Narrative Generation (Experimental)
+
+> ⚠️ **REQUIRES FEATURE: nova**
+> Ensure you have `features = ["nova"]` enabled in your `Cargo.toml` before running this code.
+
+```rust,ignore
+// Requires "nova" feature in Cargo.toml
+use aletheiadb::prelude::*;
+use aletheiadb::experimental::temporal_narrative::NarrativeGenerator;
+
+fn main() -> Result<()> {
+    let db = AletheiaDB::new()?;
+
+    let alice = db.create_node("Person", properties! {
+        "name" => "Alice",
+        "age" => 30,
+    })?;
+
+    db.write(|tx| {
+        tx.update_node(alice, properties! { "age" => 31, "city" => "London" })
+    })?;
+
+    let generator = NarrativeGenerator::new(&db);
+    let narrative = generator.generate_node_narrative(alice)?;
+
+    for event in narrative {
+        println!("Version {}: {}", event.version_number, event.description);
+    }
+
+    Ok(())
+}
+```
+
 ## Hybrid Queries
 
 Graph traversal, vector ranking, and temporal snapshots compose into a single

--- a/src/experimental/temporal/temporal_narrative.rs
+++ b/src/experimental/temporal/temporal_narrative.rs
@@ -26,6 +26,7 @@ pub struct NarrativeEvent {
     pub changes: Vec<String>,
 }
 
+#[cfg(feature = "semantic-temporal")]
 /// Generator for creating natural language narratives from temporal history.
 #[cfg(feature = "semantic-temporal")]
 /// Generates human-readable summaries of temporal graph mutations.
@@ -38,20 +39,6 @@ pub struct NarrativeGenerator<'a> {
     db: &'a AletheiaDB,
 }
 
-#[cfg(not(feature = "semantic-temporal"))]
-/// Generator for creating natural language narratives from temporal history.
-#[deprecated(
-    note = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-)]
-/// Generates human-readable summaries of temporal graph mutations.
-///
-/// # Why?
-/// When analyzing a `BiTemporalInterval`, users often need to understand
-/// the sequence of events (e.g., "Alice liked the post, then Bob deleted it").
-/// This struct translates raw `VersionMetadata` into a chronological narrative.
-pub struct NarrativeGenerator<'a> {
-    _marker: std::marker::PhantomData<&'a AletheiaDB>,
-}
 
 #[cfg(feature = "semantic-temporal")]
 impl<'a> NarrativeGenerator<'a> {
@@ -155,35 +142,6 @@ impl<'a> NarrativeGenerator<'a> {
     }
 }
 
-#[cfg(not(feature = "semantic-temporal"))]
-#[allow(deprecated)]
-impl<'a> NarrativeGenerator<'a> {
-    /// Create a new narrative generator.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn new(db: &'a AletheiaDB) -> Self {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-
-    /// Generate a narrative for a specific node.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the `nova` feature is not enabled.
-    #[allow(unused_variables)]
-    #[track_caller]
-    pub fn generate_node_narrative(&self, node_id: NodeId) -> Result<Vec<NarrativeEvent>> {
-        panic!(
-            "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-        );
-    }
-}
 
 #[cfg(all(test, feature = "semantic-temporal"))]
 mod tests {
@@ -303,33 +261,3 @@ mod tests {
     }
 }
 
-#[cfg(all(test, not(feature = "semantic-temporal")))]
-#[allow(deprecated)]
-mod stub_tests {
-    use super::*;
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_new() {
-        let db = AletheiaDB::new().unwrap();
-        // This should panic
-        let _ = NarrativeGenerator::new(&db);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "NarrativeGenerator requires the 'nova' feature. Add 'features = [\"nova\"]' to your Cargo.toml."
-    )]
-    fn test_stub_panic_on_generate() {
-        // Construct a fake NarrativeGenerator to test method panic
-        // Safety: NarrativeGenerator is a ZST with PhantomData, so it's valid to transmute from unit or zeroed.
-        // We just need it to call the method.
-        let generator: NarrativeGenerator<'_> = NarrativeGenerator {
-            _marker: std::marker::PhantomData,
-        };
-        // This should panic
-        let _ = generator.generate_node_narrative(NodeId::new(0).unwrap());
-    }
-}


### PR DESCRIPTION
🤦 **The Confusion:**
I was following the "Narrative Generation (Experimental)" example in the `README.md`. I copy-pasted the exact code block into my fresh `main.rs` and ran it. My compiler yelled at me:
```
warning: use of deprecated struct `aletheiadb::experimental::temporal_narrative::NarrativeGenerator`: NarrativeGenerator requires the 'nova' feature. Add 'features = ["nova"]' to your Cargo.toml.
```
Then, when I tried to run it anyway, it just crashed right in my face:
```
thread 'main' panicked at src/bin/test_story_demo.rs:14:21:
NarrativeGenerator requires the 'nova' feature. Add 'features = ["nova"]' to your Cargo.toml.
```
If I have to read the source code or compiler warnings to figure out why the "Getting Started" example doesn't work out of the box, the documentation failed. If I copy-paste the example and it doesn't compile or run, I am leaving.

🕵️ **The Reality:**
Turns out, `NarrativeGenerator` is hidden behind an experimental `nova` feature flag. The README has comments saying `// ⚠️ REQUIRES FEATURE: nova` and `// aletheiadb = { version = "0.1", features = ["nova"] }`, but comments aren't code, and when I blindly copy-paste the Rust code and `cargo run`, the Rust code is actually compiled with a stub that panics at runtime if the feature isn't enabled in my `Cargo.toml`.

💡 **The Fix:**
Added a huge, unmistakable banner or note in the README section *before* the code block that explicitly warns users to update their `Cargo.toml` with `features = ["nova"]` before they even try to copy the code. The warning needs to be in the Markdown text, not just hidden in the code comments. Also, I removed the stub compile logic that just panics at runtime—if it's missing the feature, it will now be a hard compile error so users don't get false hope! Furthermore, the doctest in `README.md` uses `rust,ignore` to prevent standard runs of `cargo test --doc` without `nova` enabled from failing.

---
*PR created automatically by Jules for task [9295588633142035947](https://jules.google.com/task/9295588633142035947) started by @madmax983*