### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,6 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-15 - [Resolving explicit and broken rustdoc links]
+**Confusion:** Some files had broken intra-doc links resulting in `cargo doc` warnings, like `[`Provenance`]` which wasn't in scope, and `[`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)` which pointed to the wrong path. Other links were redundant explicit link targets, such as `[`ChangeRecord`](crate::core::ChangeRecord)`, or links to private types, such as `[`BackupPayloadV1`]`.
+**Clarification:** Fixed unresolved links by specifying the exact path (e.g., `[`Provenance`](crate::core::provenance::Provenance)`). Fixed redundant targets by removing the redundant path (e.g., `[`ChangeRecord`]`). Changed links to private types into backticks (e.g., ``` `BackupPayloadV1` ```).

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -286,7 +286,7 @@ impl AletheiaDB {
     }
 
     /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
-    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
+    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
     ///
     /// Passing `WriteRequestOptions::default()` is identical to [`create_node`](Self::create_node).
     ///
@@ -581,7 +581,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -46,7 +46,7 @@ pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 /// Bumped to 2 for write-time provenance on temporal versions (Issue #3224):
 /// the embedded `TemporalIndexData`'s `NodeVersionEntry`/`EdgeVersionEntry`
 /// gained an optional `provenance` field. Version 1 artifacts are still
-/// restorable -- see [`BackupPayloadV1`] and `read_artifact`.
+/// restorable -- see `BackupPayloadV1` and `read_artifact`.
 pub const BACKUP_FORMAT_VERSION: u16 = 2;
 
 /// Maximum allowed decompressed payload size (5 GiB).

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -545,7 +545,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of a node, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_node_version`](Self::add_node_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -774,7 +774,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of an edge, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
     /// than persisting `provenance` on the created version (anchor or delta).


### PR DESCRIPTION
📖 Chapter: General core structures and API interactions.
💡 Insight: Fixed various rustdoc warnings such as broken intra-doc links, redundant explicit link targets, and linking to private items. These were causing `cargo doc` to output warnings and rendering non-clickable or invalid links.
🧪 Example: Fixed links for `Provenance`, `StorageError`, `ChangeRecord`, and `BackupPayloadV1`.
🖼️ Preview: Documentation renders successfully without warnings via `cargo rustdoc`.

---
*PR created automatically by Jules for task [4845377304348229848](https://jules.google.com/task/4845377304348229848) started by @madmax983*