### PR TITLE
Signal result completeness on MCP list & traverse tools (Issue #3226)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1026,10 +1026,19 @@ impl AletheiaMcpServer {
     /// - `total_matching` is set only when a matching total is cheaply known;
     ///   it is omitted (never faked) when computing it would require an
     ///   expensive full scan.
+    ///
+    /// `consumed` is the number of underlying candidates the page advanced
+    /// past -- i.e. the requested page window (e.g. `limit` or `k`), NOT the
+    /// number of items actually returned in the body. These differ when an
+    /// id resolved from an index (property lookup, vector search) turns out
+    /// to be a since-deleted node and is dropped: the page still consumed a
+    /// full window of candidates, so `next_offset` must advance by the window
+    /// size, not the smaller returned count, or the next call would re-skip
+    /// into already-consumed candidates and duplicate a row across pages.
     fn attach_completeness(
         value: &mut serde_json::Value,
         offset: usize,
-        count: usize,
+        consumed: usize,
         has_more: bool,
         total_matching: Option<usize>,
     ) {
@@ -1038,7 +1047,7 @@ impl AletheiaMcpServer {
             if has_more {
                 obj.insert(
                     "next_offset".to_string(),
-                    json!(offset.saturating_add(count)),
+                    json!(offset.saturating_add(consumed)),
                 );
             }
             if let Some(total) = total_matching {
@@ -1331,11 +1340,14 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
         };
 
-        // Apply resource limits
+        // Apply resource limits. A page must be able to carry a continuation
+        // cursor, so the limit is at least 1 (limit:0 would otherwise report
+        // has_more:true with next_offset==offset, a non-progressing page that
+        // traps a paginating caller in an infinite loop).
         let limit = req
             .limit
             .unwrap_or(DEFAULT_RESULT_LIMIT)
-            .min(MAX_RESULT_LIMIT);
+            .clamp(1, MAX_RESULT_LIMIT);
         let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
 
         // Validate property filter: both key and value are required together with label
@@ -1374,20 +1386,21 @@ impl AletheiaMcpServer {
                 }
             }
 
-            let has_more = offset.saturating_add(nodes.len()) < total_matching;
+            // `has_more`/`next_offset` are derived from the requested window
+            // (`limit`) against `total_matching`, not from `nodes.len()`: a
+            // stale property-index entry pointing at a since-deleted node is
+            // still one of the `limit` ids this page consumed, so basing
+            // `next_offset` on the (possibly smaller) resolved count would
+            // re-skip into already-consumed ids and duplicate a row on the
+            // next page.
+            let has_more = offset.saturating_add(limit) < total_matching;
             let mut response = json!({
                 "nodes": nodes,
                 "count": nodes.len(),
                 "offset": offset,
                 "limit": limit
             });
-            Self::attach_completeness(
-                &mut response,
-                offset,
-                nodes.len(),
-                has_more,
-                Some(total_matching),
-            );
+            Self::attach_completeness(&mut response, offset, limit, has_more, Some(total_matching));
             return self.success_json(response);
         }
 
@@ -1445,15 +1458,16 @@ impl AletheiaMcpServer {
         } else {
             // Without a label filter, we cannot efficiently list all nodes
             // Return a helpful message
-            self.success_json(json!({
+            let mut response = json!({
                 "message": "Use 'label' filter to list nodes by type, or use 'count_nodes' for total count",
                 "total_count": self.db.node_count(),
                 "nodes": [],
                 "count": 0,
                 "offset": offset,
-                "limit": limit,
-                "has_more": false
-            }))
+                "limit": limit
+            });
+            Self::attach_completeness(&mut response, offset, 0, false, None);
+            self.success_json(response)
         }
     }
 
@@ -1663,16 +1677,17 @@ impl AletheiaMcpServer {
 
         // Edges cannot be efficiently listed without knowing source/target nodes.
         // Provide helpful guidance to use get_outgoing_edges or get_incoming_edges.
-        self.success_json(json!({
+        let mut response = json!({
             "message": "Use 'get_outgoing_edges' or 'get_incoming_edges' from a known node to list edges",
             "total_count": self.db.edge_count(),
             "edges": [],
             "count": 0,
             "offset": offset,
             "limit": limit,
-            "label_filter": req.label,
-            "has_more": false
-        }))
+            "label_filter": req.label
+        });
+        Self::attach_completeness(&mut response, offset, 0, false, None);
+        self.success_json(response)
     }
 
     fn handle_count_edges(&self, args: serde_json::Value) -> CallToolResult {
@@ -1722,12 +1737,12 @@ impl AletheiaMcpServer {
         // result is never truncated: `has_more` is always false and
         // `total_matching` equals the returned count.
         let count = edges.len();
-        self.success_json(json!({
+        let mut response = json!({
             "edges": edges,
-            "count": count,
-            "has_more": false,
-            "total_matching": count
-        }))
+            "count": count
+        });
+        Self::attach_completeness(&mut response, 0, 0, false, Some(count));
+        self.success_json(response)
     }
 
     fn handle_get_incoming_edges(&self, args: serde_json::Value) -> CallToolResult {
@@ -1760,12 +1775,12 @@ impl AletheiaMcpServer {
         // Complete adjacency (no limit/offset): never truncated, so
         // `has_more` is always false and `total_matching` equals the count.
         let count = edges.len();
-        self.success_json(json!({
+        let mut response = json!({
             "edges": edges,
-            "count": count,
-            "has_more": false,
-            "total_matching": count
-        }))
+            "count": count
+        });
+        Self::attach_completeness(&mut response, 0, 0, false, Some(count));
+        self.success_json(response)
     }
 
     /// Fetch a node, optionally as of a bi-temporal coordinate.
@@ -1892,12 +1907,15 @@ impl AletheiaMcpServer {
             Err(result) => return result,
         };
 
-        // Apply resource limits to prevent DoS
+        // Apply resource limits to prevent DoS. A page must be able to carry a
+        // continuation cursor, so the limit is at least 1 (limit:0 would
+        // otherwise report has_more:true with next_offset==offset, a
+        // non-progressing page that traps a paginating caller in a loop).
         let depth = req.depth.unwrap_or(1).min(MAX_TRAVERSAL_DEPTH);
         let limit = req
             .limit
             .unwrap_or(DEFAULT_RESULT_LIMIT)
-            .min(MAX_RESULT_LIMIT);
+            .clamp(1, MAX_RESULT_LIMIT);
         let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
         let direction = req.direction.as_deref().unwrap_or("outgoing");
 
@@ -1920,8 +1938,19 @@ impl AletheiaMcpServer {
             std::collections::HashMap::new();
         // Offset pagination + completeness: `produced` counts every resolved
         // result node in traversal order; the first `offset` are skipped (a
-        // prior page), the next `limit` are collected, and resolving one more
-        // beyond a full page sets `has_more` (the has-more sentinel).
+        // prior page), the next `limit` are collected. Once the page is full
+        // we expand the last collected node's own out-edges as usual (so
+        // graph structure discovery for this hop isn't cut short), then stop:
+        // `has_more` is read off whatever remains on `frontier` rather than by
+        // resolving one further node. That peek-by-resolution would otherwise
+        // force expansion through dangling/orphaned edges (current-state mode
+        // keeps expanding past unresolvable nodes -- see the Err(_) arm below)
+        // in search of a single confirmable result, which can walk the entire
+        // remaining reachable subgraph just to answer `has_more`. Reading the
+        // frontier instead is O(1) and conservative: it may say `true` when
+        // the remaining candidates are all dangling and the next page would
+        // in fact be empty, but it never requires unbounded work and never
+        // under-reports.
         let mut produced: usize = 0;
         let mut has_more = false;
 
@@ -1932,21 +1961,13 @@ impl AletheiaMcpServer {
                 match self.get_node_maybe_at(current_id, temporal) {
                     Ok(node) => {
                         produced += 1;
-                        if produced > offset {
-                            if results.len() < limit {
-                                results.push(TraversalResult {
-                                    node: self.node_to_response(
-                                        &node,
-                                        req.include_vectors.unwrap_or(false),
-                                    ),
-                                    path: path.clone(),
-                                    depth: current_depth,
-                                });
-                            } else {
-                                // One result beyond the page exists.
-                                has_more = true;
-                                break;
-                            }
+                        if produced > offset && results.len() < limit {
+                            results.push(TraversalResult {
+                                node: self
+                                    .node_to_response(&node, req.include_vectors.unwrap_or(false)),
+                                path: path.clone(),
+                                depth: current_depth,
+                            });
                         }
                     }
                     // Non-temporal: preserve the historical "keep expanding
@@ -1977,6 +1998,11 @@ impl AletheiaMcpServer {
                     }
                 }
             }
+
+            if results.len() >= limit {
+                has_more = !frontier.is_empty();
+                break;
+            }
         }
 
         let count = results.len();
@@ -2005,9 +2031,22 @@ impl AletheiaMcpServer {
             Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
         };
 
-        // Apply resource limits
-        let k = req.k.unwrap_or(DEFAULT_VECTOR_K).min(MAX_VECTOR_K);
-        let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
+        // Apply resource limits. A page must be able to carry a continuation
+        // cursor, so k is at least 1 (k:0 would otherwise report
+        // has_more:true with next_offset==offset, a non-progressing page).
+        let k = req.k.unwrap_or(DEFAULT_VECTOR_K).clamp(1, MAX_VECTOR_K);
+        // Bound the total pagination window (offset+k) by MAX_VECTOR_K so the
+        // over-fetch below never asks the vector index for more than
+        // MAX_VECTOR_K+1 candidates regardless of offset -- otherwise a large
+        // offset could force a search far past the MAX_VECTOR_K resource
+        // budget the cap is meant to enforce. Vector-similarity pagination is
+        // therefore bounded to the top MAX_VECTOR_K matches; an offset beyond
+        // that horizon returns an empty, complete (`has_more: false`) page.
+        let offset = req
+            .offset
+            .unwrap_or(0)
+            .min(MAX_PAGINATION_OFFSET)
+            .min(MAX_VECTOR_K.saturating_sub(k));
 
         if !self.db.is_vector_index_enabled_for(&req.property_name) {
             return self.error_json(&format!(
@@ -2021,9 +2060,10 @@ impl AletheiaMcpServer {
             return self.error_json(&e);
         }
 
-        // Over-fetch one past the requested page (offset + k + 1) so we can tell
-        // whether more similar nodes exist beyond this page (`has_more`) without
-        // a second query. The matching total would need a full index scan, so
+        // Over-fetch one past the requested page (offset + k + 1, capped at
+        // MAX_VECTOR_K + 1 by the offset bound above) so we can tell whether
+        // more similar nodes exist beyond this page (`has_more`) without a
+        // second query. The matching total would need a full index scan, so
         // `total_matching` is omitted.
         let fetch_k = k.saturating_add(offset).saturating_add(1);
         match self
@@ -2050,7 +2090,13 @@ impl AletheiaMcpServer {
                     "results": similarity_results,
                     "count": count
                 });
-                Self::attach_completeness(&mut response, offset, count, has_more, None);
+                // `next_offset` advances by the requested window `k`, not the
+                // (possibly smaller) resolved `count`: a since-deleted node
+                // behind a stale vector-index entry is still one of the `k`
+                // candidates this page consumed, so basing next_offset on
+                // `count` would re-skip into already-consumed candidates and
+                // duplicate a row on the next page.
+                Self::attach_completeness(&mut response, offset, k, has_more, None);
                 self.success_json(response)
             }
             Err(e) => self.error_json(&e.to_string()),
@@ -3420,7 +3466,10 @@ fn tool_definitions() -> Vec<Tool> {
             "find_similar",
             "Find nodes similar to a query embedding. The response carries `has_more` \
                      (true when more similar nodes exist beyond the returned `k`); when true, \
-                     `next_offset` gives the `offset` to pass for the next page. The similarity \
+                     `next_offset` gives the `offset` to pass for the next page. Pagination via \
+                     `offset` only reaches the top-ranked matches up to the server's k cap \
+                     (`offset + k` bounded); querying past that horizon returns an empty page with \
+                     `has_more: false` rather than an unbounded search. The similarity \
                      `score` is always returned in full. Vector/embedding properties on the \
                      returned nodes are elided by default (replaced with a \
                      `{type, dim, elided:true}` descriptor) to protect LLM context; pass \

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1015,6 +1015,38 @@ impl AletheiaMcpServer {
         CallToolResult::error(vec![Content::text(json!({"error": msg}).to_string())])
     }
 
+    /// Attach result-completeness signals (Issue #3226) to a bounded read
+    /// tool's response object so a single MCP call reveals whether the returned
+    /// page is the whole truth.
+    ///
+    /// - `has_more` is always set: `true` when at least one matching result
+    ///   exists beyond the returned page, `false` otherwise.
+    /// - `next_offset` (the value to pass as `offset` for the next page) is set
+    ///   only when `has_more` is `true`; it is omitted otherwise.
+    /// - `total_matching` is set only when a matching total is cheaply known;
+    ///   it is omitted (never faked) when computing it would require an
+    ///   expensive full scan.
+    fn attach_completeness(
+        value: &mut serde_json::Value,
+        offset: usize,
+        count: usize,
+        has_more: bool,
+        total_matching: Option<usize>,
+    ) {
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("has_more".to_string(), json!(has_more));
+            if has_more {
+                obj.insert(
+                    "next_offset".to_string(),
+                    json!(offset.saturating_add(count)),
+                );
+            }
+            if let Some(total) = total_matching {
+                obj.insert("total_matching".to_string(), json!(total));
+            }
+        }
+    }
+
     /// Build a structured `CallToolResult` for a `UniqueViolation` constraint error.
     /// Returns `None` if `e` is not a `UniqueViolation`.
     fn constraint_violation_result(&self, e: &crate::core::error::Error) -> Option<CallToolResult> {
@@ -1331,6 +1363,9 @@ impl AletheiaMcpServer {
                 .db
                 .find_nodes_by_property(label, prop_key, &property_value);
 
+            // The full matching id list is already materialized, so the total
+            // is cheap to report and `has_more` is exact.
+            let total_matching = node_ids.len();
             let include_vectors = req.include_vectors.unwrap_or(false);
             let mut nodes = Vec::with_capacity(limit);
             for node_id in node_ids.into_iter().skip(offset).take(limit) {
@@ -1339,26 +1374,38 @@ impl AletheiaMcpServer {
                 }
             }
 
-            return self.success_json(json!({
+            let has_more = offset.saturating_add(nodes.len()) < total_matching;
+            let mut response = json!({
                 "nodes": nodes,
                 "count": nodes.len(),
                 "offset": offset,
                 "limit": limit
-            }));
+            });
+            Self::attach_completeness(
+                &mut response,
+                offset,
+                nodes.len(),
+                has_more,
+                Some(total_matching),
+            );
+            return self.success_json(response);
         }
 
         // Label-only scan
         if let Some(label) = &req.label {
             let builder = crate::query::QueryBuilder::new().scan_label(label);
 
-            // Note: We fetch offset+limit rows then skip offset.
-            // Offset is capped to prevent excessive memory use.
-            match builder.limit(limit + offset).execute(&self.db) {
+            // Note: We fetch offset+limit rows then skip offset. We fetch one
+            // extra row (offset+limit+1) purely to detect whether more matching
+            // nodes exist beyond this page (`has_more`) without paying for a
+            // full-scan count. Offset is capped to prevent excessive memory use.
+            match builder.limit(limit + offset + 1).execute(&self.db) {
                 Ok(results) => {
                     // Use iterator-based approach to avoid allocating full Vec
                     let include_vectors = req.include_vectors.unwrap_or(false);
                     let mut nodes = Vec::with_capacity(limit);
                     let mut skipped = 0;
+                    let mut has_more = false;
 
                     for row_result in results {
                         match row_result {
@@ -1368,22 +1415,30 @@ impl AletheiaMcpServer {
                                     continue;
                                 }
                                 if let EntityResult::Node(node) = row.entity {
-                                    nodes.push(self.node_to_response(&node, include_vectors));
                                     if nodes.len() >= limit {
+                                        // The extra (offset+limit+1)th matching
+                                        // row proves more results remain.
+                                        has_more = true;
                                         break;
                                     }
+                                    nodes.push(self.node_to_response(&node, include_vectors));
                                 }
                             }
                             Err(e) => return self.error_json(&e.to_string()),
                         }
                     }
 
-                    self.success_json(json!({
+                    // A label scan cannot cheaply know the matching total
+                    // (that needs a full scan), so `total_matching` is omitted;
+                    // `has_more` alone carries the completeness signal.
+                    let mut response = json!({
                         "nodes": nodes,
                         "count": nodes.len(),
                         "offset": offset,
                         "limit": limit
-                    }))
+                    });
+                    Self::attach_completeness(&mut response, offset, nodes.len(), has_more, None);
+                    self.success_json(response)
                 }
                 Err(e) => self.error_json(&e.to_string()),
             }
@@ -1396,7 +1451,8 @@ impl AletheiaMcpServer {
                 "nodes": [],
                 "count": 0,
                 "offset": offset,
-                "limit": limit
+                "limit": limit,
+                "has_more": false
             }))
         }
     }
@@ -1614,7 +1670,8 @@ impl AletheiaMcpServer {
             "count": 0,
             "offset": offset,
             "limit": limit,
-            "label_filter": req.label
+            "label_filter": req.label,
+            "has_more": false
         }))
     }
 
@@ -1661,9 +1718,15 @@ impl AletheiaMcpServer {
             .map(|e| self.edge_to_response(&e, include_vectors))
             .collect();
 
+        // This handler returns the complete adjacency (no limit/offset), so the
+        // result is never truncated: `has_more` is always false and
+        // `total_matching` equals the returned count.
+        let count = edges.len();
         self.success_json(json!({
             "edges": edges,
-            "count": edges.len()
+            "count": count,
+            "has_more": false,
+            "total_matching": count
         }))
     }
 
@@ -1694,9 +1757,14 @@ impl AletheiaMcpServer {
             .map(|e| self.edge_to_response(&e, include_vectors))
             .collect();
 
+        // Complete adjacency (no limit/offset): never truncated, so
+        // `has_more` is always false and `total_matching` equals the count.
+        let count = edges.len();
         self.success_json(json!({
             "edges": edges,
-            "count": edges.len()
+            "count": count,
+            "has_more": false,
+            "total_matching": count
         }))
     }
 
@@ -1830,6 +1898,7 @@ impl AletheiaMcpServer {
             .limit
             .unwrap_or(DEFAULT_RESULT_LIMIT)
             .min(MAX_RESULT_LIMIT);
+        let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
         let direction = req.direction.as_deref().unwrap_or("outgoing");
 
         // Use depth-first search (DFS) traversal.
@@ -1849,6 +1918,12 @@ impl AletheiaMcpServer {
         // see CLAUDE.md's "Orphaned Edges" section -- and stays unchanged).
         let mut node_exists_cache: std::collections::HashMap<u64, bool> =
             std::collections::HashMap::new();
+        // Offset pagination + completeness: `produced` counts every resolved
+        // result node in traversal order; the first `offset` are skipped (a
+        // prior page), the next `limit` are collected, and resolving one more
+        // beyond a full page sets `has_more` (the has-more sentinel).
+        let mut produced: usize = 0;
+        let mut has_more = false;
 
         while let Some((current_id, path, current_depth)) = frontier.pop() {
             let mut current_exists = true;
@@ -1856,14 +1931,22 @@ impl AletheiaMcpServer {
                 visited.insert(current_id.as_u64());
                 match self.get_node_maybe_at(current_id, temporal) {
                     Ok(node) => {
-                        results.push(TraversalResult {
-                            node: self
-                                .node_to_response(&node, req.include_vectors.unwrap_or(false)),
-                            path: path.clone(),
-                            depth: current_depth,
-                        });
-                        if results.len() >= limit {
-                            break;
+                        produced += 1;
+                        if produced > offset {
+                            if results.len() < limit {
+                                results.push(TraversalResult {
+                                    node: self.node_to_response(
+                                        &node,
+                                        req.include_vectors.unwrap_or(false),
+                                    ),
+                                    path: path.clone(),
+                                    depth: current_depth,
+                                });
+                            } else {
+                                // One result beyond the page exists.
+                                has_more = true;
+                                break;
+                            }
                         }
                     }
                     // Non-temporal: preserve the historical "keep expanding
@@ -1896,18 +1979,24 @@ impl AletheiaMcpServer {
             }
         }
 
-        match temporal {
-            Some((vt, tt)) => self.success_json(json!({
+        let count = results.len();
+        let mut response = match temporal {
+            Some((vt, tt)) => json!({
                 "results": results,
-                "count": results.len(),
+                "count": count,
                 "as_of_valid_time": time::to_iso8601(vt),
                 "as_of_transaction_time": time::to_iso8601(tt),
-            })),
-            None => self.success_json(json!({
+            }),
+            None => json!({
                 "results": results,
-                "count": results.len()
-            })),
-        }
+                "count": count
+            }),
+        };
+        // The matching total would require exhausting the traversal, so
+        // `total_matching` is omitted; `has_more`/`next_offset` carry the
+        // completeness signal.
+        Self::attach_completeness(&mut response, offset, count, has_more, None);
+        self.success_json(response)
     }
 
     fn handle_find_similar(&self, args: serde_json::Value) -> CallToolResult {
@@ -1918,6 +2007,7 @@ impl AletheiaMcpServer {
 
         // Apply resource limits
         let k = req.k.unwrap_or(DEFAULT_VECTOR_K).min(MAX_VECTOR_K);
+        let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
 
         if !self.db.is_vector_index_enabled_for(&req.property_name) {
             return self.error_json(&format!(
@@ -1931,14 +2021,22 @@ impl AletheiaMcpServer {
             return self.error_json(&e);
         }
 
+        // Over-fetch one past the requested page (offset + k + 1) so we can tell
+        // whether more similar nodes exist beyond this page (`has_more`) without
+        // a second query. The matching total would need a full index scan, so
+        // `total_matching` is omitted.
+        let fetch_k = k.saturating_add(offset).saturating_add(1);
         match self
             .db
-            .similarity_search(crate::SimilarityQuery::from_embedding(req.embedding).k(k))
+            .similarity_search(crate::SimilarityQuery::from_embedding(req.embedding).k(fetch_k))
         {
             Ok(results) => {
+                let has_more = results.len() > offset.saturating_add(k);
                 let include_vectors = req.include_vectors.unwrap_or(false);
                 let similarity_results: Vec<SimilarityResult> = results
                     .into_iter()
+                    .skip(offset)
+                    .take(k)
                     .filter_map(|(node_id, score)| {
                         self.db.get_node(node_id).ok().map(|node| SimilarityResult {
                             node: self.node_to_response(&node, include_vectors),
@@ -1947,10 +2045,13 @@ impl AletheiaMcpServer {
                     })
                     .collect();
 
-                self.success_json(json!({
+                let count = similarity_results.len();
+                let mut response = json!({
                     "results": similarity_results,
-                    "count": similarity_results.len()
-                }))
+                    "count": count
+                });
+                Self::attach_completeness(&mut response, offset, count, has_more, None);
+                self.success_json(response)
             }
             Err(e) => self.error_json(&e.to_string()),
         }
@@ -3220,10 +3321,14 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "list_nodes",
-            "List nodes with optional label filter and pagination. Vector/embedding \
-                     properties are elided by default (replaced with a `{type, dim, elided:true}` \
-                     descriptor) to protect LLM context; pass `include_vectors: true` to receive \
-                     the full float arrays.",
+            "List nodes with optional label filter and pagination. The response carries \
+                     `has_more` (true when more matching nodes exist beyond this page — always \
+                     check it before trusting a count); when true, `next_offset` gives the \
+                     `offset` to pass for the next page. `total_matching` is included when cheap \
+                     (property-filtered queries) and omitted for plain label scans. \
+                     Vector/embedding properties are elided by default (replaced with a \
+                     `{type, dim, elided:true}` descriptor) to protect LLM context; pass \
+                     `include_vectors: true` to receive the full float arrays.",
             make_input_schema::<ListNodesRequest>(),
         ),
         Tool::new(
@@ -3263,10 +3368,12 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "list_edges",
-            "List edges with optional label filter and pagination. Vector/embedding \
-                     properties are elided by default (replaced with a `{type, dim, elided:true}` \
-                     descriptor) to protect LLM context; pass `include_vectors: true` to receive \
-                     the full float arrays.",
+            "List edges with optional label filter and pagination. Edges cannot be listed \
+                     without a start node, so this returns guidance (use get_outgoing_edges / \
+                     get_incoming_edges) with `has_more: false` for response-shape consistency. \
+                     Vector/embedding properties are elided by default (replaced with a \
+                     `{type, dim, elided:true}` descriptor) to protect LLM context; pass \
+                     `include_vectors: true` to receive the full float arrays.",
             make_input_schema::<ListEdgesRequest>(),
         ),
         Tool::new(
@@ -3276,7 +3383,9 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "get_outgoing_edges",
-            "Get all outgoing edges from a node. Vector/embedding properties are elided \
+            "Get all outgoing edges from a node. Returns the complete set (never \
+                     truncated), so the response carries `has_more: false` and \
+                     `total_matching` equal to `count`. Vector/embedding properties are elided \
                      by default (replaced with a `{type, dim, elided:true}` descriptor) to \
                      protect LLM context; pass `include_vectors: true` to receive the full float \
                      arrays.",
@@ -3284,14 +3393,19 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "get_incoming_edges",
-            "Get all incoming edges to a node. Vector/embedding properties are elided by \
+            "Get all incoming edges to a node. Returns the complete set (never truncated), \
+                     so the response carries `has_more: false` and `total_matching` equal to \
+                     `count`. Vector/embedding properties are elided by \
                      default (replaced with a `{type, dim, elided:true}` descriptor) to protect \
                      LLM context; pass `include_vectors: true` to receive the full float arrays.",
             make_input_schema::<GetIncomingEdgesRequest>(),
         ),
         Tool::new(
             "traverse",
-            "Traverse the graph starting from a node. Vector/embedding properties are \
+            "Traverse the graph starting from a node. The response carries `has_more` \
+                     (true when the traversal was truncated by `limit` — check it before trusting \
+                     `count`); when true, `next_offset` gives the `offset` to pass for the next \
+                     page. Vector/embedding properties are \
                      elided by default (replaced with a `{type, dim, elided:true}` descriptor) to \
                      protect LLM context; pass `include_vectors: true` to receive the full float \
                      arrays. Accepts optional as_of_valid_time / as_of_transaction_time (ISO 8601 \
@@ -3304,11 +3418,13 @@ fn tool_definitions() -> Vec<Tool> {
         ),
         Tool::new(
             "find_similar",
-            "Find nodes similar to a query embedding. The similarity `score` is always \
-                     returned in full. Vector/embedding properties on the returned nodes are \
-                     elided by default (replaced with a `{type, dim, elided:true}` descriptor) to \
-                     protect LLM context; pass `include_vectors: true` to receive the full float \
-                     arrays.",
+            "Find nodes similar to a query embedding. The response carries `has_more` \
+                     (true when more similar nodes exist beyond the returned `k`); when true, \
+                     `next_offset` gives the `offset` to pass for the next page. The similarity \
+                     `score` is always returned in full. Vector/embedding properties on the \
+                     returned nodes are elided by default (replaced with a \
+                     `{type, dim, elided:true}` descriptor) to protect LLM context; pass \
+                     `include_vectors: true` to receive the full float arrays.",
             make_input_schema::<FindSimilarRequest>(),
         ),
         Tool::new(

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -992,6 +992,7 @@ mod traversal_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -1014,6 +1015,7 @@ mod traversal_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(3),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -1037,6 +1039,7 @@ mod traversal_tests {
             direction: Some("incoming".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -1058,6 +1061,7 @@ mod traversal_tests {
             direction: None,
             depth: Some(3),
             limit: Some(2),
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -1122,6 +1126,7 @@ mod vector_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(5),
+            offset: None,
             include_vectors: None,
         });
 
@@ -1167,6 +1172,7 @@ mod vector_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
+            offset: None,
             include_vectors: None,
         });
 
@@ -1666,6 +1672,7 @@ mod coverage_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3], // Wrong: 3 dimensions instead of 4
             k: Some(5),
+            offset: None,
             include_vectors: None,
         });
 
@@ -1914,6 +1921,7 @@ mod coverage_tests {
             depth: Some(100), // Very large depth, should be capped
             direction: Some("outgoing".to_string()),
             limit: Some(50),
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -2196,6 +2204,7 @@ mod vector_distance_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(10000), // Much larger than MAX_VECTOR_K,
+            offset: None,
             include_vectors: None,
         });
 
@@ -2474,6 +2483,7 @@ mod traversal_extended_tests {
             direction: Some("both".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -2534,6 +2544,7 @@ mod traversal_extended_tests {
             direction: Some("both".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -2569,6 +2580,7 @@ mod traversal_extended_tests {
             direction: None,
             depth: Some(3),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -2617,6 +2629,7 @@ mod traversal_extended_tests {
             direction: None, // Default to outgoing
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -2670,6 +2683,7 @@ mod traversal_extended_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: Some(5),
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -4851,6 +4865,7 @@ mod vector_elision_tests {
             direction: None,
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -4869,6 +4884,7 @@ mod vector_elision_tests {
             direction: None,
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: Some(true),
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -4916,6 +4932,7 @@ mod vector_elision_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
+            offset: None,
             include_vectors: None,
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -4933,6 +4950,7 @@ mod vector_elision_tests {
             property_name: "embedding".to_string(),
             embedding: vec![0.1, 0.2, 0.3, 0.4],
             k: Some(3),
+            offset: None,
             include_vectors: Some(true),
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
@@ -6266,6 +6284,7 @@ mod provenance_write_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: None,
@@ -6402,6 +6421,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 5)),
                 as_of_transaction_time: None,
@@ -6421,6 +6441,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 1)),
                 as_of_transaction_time: None,
@@ -6467,6 +6488,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 3)),
                 as_of_transaction_time: Some(tx_time_before_delete),
@@ -6486,6 +6508,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 1)),
                 as_of_transaction_time: None,
@@ -6518,6 +6541,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 5)),
                 as_of_transaction_time: Some(hours_ago(now, 20)),
@@ -6539,6 +6563,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 8)),
                 as_of_transaction_time: None,
@@ -6559,6 +6584,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 5)),
                 as_of_transaction_time: None,
@@ -6588,6 +6614,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 5)),
                 as_of_transaction_time: None,
@@ -6610,6 +6637,7 @@ mod traverse_as_of_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: Some("not-a-timestamp".to_string()),
             as_of_transaction_time: None,
@@ -6636,6 +6664,7 @@ mod traverse_as_of_tests {
             direction: Some("outgoing".to_string()),
             depth: Some(1),
             limit: None,
+            offset: None,
             include_vectors: None,
             as_of_valid_time: None,
             as_of_transaction_time: Some("not-a-timestamp".to_string()),
@@ -6680,6 +6709,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(100),
                 limit: Some(50),
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 1)),
                 as_of_transaction_time: None,
@@ -6705,6 +6735,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: None,
                 as_of_transaction_time: None,
@@ -6719,6 +6750,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(now_after_creation.to_rfc3339()),
                 as_of_transaction_time: Some(now_after_creation.to_rfc3339()),
@@ -6754,6 +6786,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(2),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 1)),
                 as_of_transaction_time: None,
@@ -6788,6 +6821,7 @@ mod traverse_as_of_tests {
                 direction: Some("both".to_string()),
                 depth: Some(1),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(hours_ago(now, 1)),
                 as_of_transaction_time: None,
@@ -6835,6 +6869,7 @@ mod traverse_as_of_tests {
                 direction: Some("outgoing".to_string()),
                 depth: Some(2),
                 limit: None,
+                offset: None,
                 include_vectors: None,
                 as_of_valid_time: Some(after_delete),
                 as_of_transaction_time: None,
@@ -6844,5 +6879,607 @@ mod traverse_as_of_tests {
             count, 0,
             "traversal must not continue past a node absent at the coordinate: {value}"
         );
+    }
+}
+
+// ============================================================================
+// Result-Completeness Signal Tests (Issue #3226)
+//
+// Every bounded MCP read tool must let a single call reveal whether more
+// results exist (`has_more`), how to fetch them (`next_offset`, for
+// offset-paginated tools), and, where cheaply derivable, the total matching
+// count (`total_matching`). These tests pin that contract per tool.
+// ============================================================================
+
+mod completeness_tests {
+    use super::*;
+
+    /// Read `has_more` as a bool (defaults to a sentinel that fails assertions
+    /// when the field is entirely absent, so the red phase is meaningful).
+    fn has_more(value: &serde_json::Value) -> Option<bool> {
+        value.get("has_more").and_then(|v| v.as_bool())
+    }
+
+    /// Read `next_offset` as a number when present; `None` when absent or null.
+    fn next_offset(value: &serde_json::Value) -> Option<u64> {
+        value.get("next_offset").and_then(|v| v.as_u64())
+    }
+
+    fn parse(response: &str) -> serde_json::Value {
+        serde_json::from_str(response).expect("valid JSON response")
+    }
+
+    fn seed_labeled(server: &AletheiaMcpServer, label: &str, n: usize) {
+        for i in 0..n {
+            let mut props = HashMap::new();
+            props.insert("index".to_string(), serde_json::json!(i));
+            server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: label.to_string(),
+                properties: Some(props),
+                provenance: None,
+            });
+        }
+    }
+
+    // --- list_nodes: label scan ------------------------------------------
+
+    #[test]
+    fn test_list_nodes_has_more_and_next_offset() {
+        let server = create_test_server();
+        seed_labeled(&server, "PersonHM", 250);
+
+        // Page 1: full page, more remains.
+        let page1 = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("PersonHM".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: Some(100),
+            offset: Some(0),
+            include_vectors: None,
+        }));
+        assert_eq!(page1.get("count"), Some(&serde_json::json!(100)));
+        assert_eq!(
+            has_more(&page1),
+            Some(true),
+            "page 1 of 250 has more: {page1}"
+        );
+        assert_eq!(
+            next_offset(&page1),
+            Some(100),
+            "next_offset points at page 2"
+        );
+
+        // Page 2: full page, still more.
+        let page2 = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("PersonHM".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: Some(100),
+            offset: Some(100),
+            include_vectors: None,
+        }));
+        assert_eq!(has_more(&page2), Some(true));
+        assert_eq!(next_offset(&page2), Some(200));
+
+        // Page 3: partial final page, no more.
+        let page3 = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("PersonHM".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: Some(100),
+            offset: Some(200),
+            include_vectors: None,
+        }));
+        assert_eq!(page3.get("count"), Some(&serde_json::json!(50)));
+        assert_eq!(
+            has_more(&page3),
+            Some(false),
+            "final page has no more: {page3}"
+        );
+        assert_eq!(next_offset(&page3), None, "no next_offset on final page");
+    }
+
+    #[test]
+    fn test_list_nodes_label_scan_omits_total_matching() {
+        // A label scan cannot cheaply know the total without a full scan, so
+        // `total_matching` is omitted (not faked); `has_more` carries the signal.
+        let server = create_test_server();
+        seed_labeled(&server, "ScanHM", 5);
+
+        let value = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("ScanHM".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: Some(2),
+            offset: Some(0),
+            include_vectors: None,
+        }));
+        assert_eq!(has_more(&value), Some(true));
+        assert!(
+            value.get("total_matching").is_none(),
+            "label scan must omit total_matching: {value}"
+        );
+    }
+
+    // --- list_nodes: property path ---------------------------------------
+
+    #[test]
+    fn test_list_nodes_property_path_reports_total_matching() {
+        let server = create_test_server();
+        for _ in 0..150 {
+            server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "WidgetHM".to_string(),
+                properties: Some({
+                    let mut m = HashMap::new();
+                    m.insert("status".to_string(), serde_json::json!("active"));
+                    m
+                }),
+                provenance: None,
+            });
+        }
+
+        let page1 = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("WidgetHM".to_string()),
+            property_key: Some("status".to_string()),
+            property_value: Some(serde_json::json!("active")),
+            limit: Some(100),
+            offset: Some(0),
+            include_vectors: None,
+        }));
+        assert_eq!(page1.get("count"), Some(&serde_json::json!(100)));
+        assert_eq!(
+            page1.get("total_matching"),
+            Some(&serde_json::json!(150)),
+            "property path materializes the full id list, so total is cheap: {page1}"
+        );
+        assert_eq!(has_more(&page1), Some(true));
+        assert_eq!(next_offset(&page1), Some(100));
+
+        let page2 = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("WidgetHM".to_string()),
+            property_key: Some("status".to_string()),
+            property_value: Some(serde_json::json!("active")),
+            limit: Some(100),
+            offset: Some(100),
+            include_vectors: None,
+        }));
+        assert_eq!(page2.get("count"), Some(&serde_json::json!(50)));
+        assert_eq!(page2.get("total_matching"), Some(&serde_json::json!(150)));
+        assert_eq!(has_more(&page2), Some(false));
+        assert_eq!(next_offset(&page2), None);
+    }
+
+    // --- list_nodes / list_edges guidance paths --------------------------
+
+    #[test]
+    fn test_list_nodes_unfiltered_has_more_false() {
+        let server = create_test_server();
+        seed_labeled(&server, "AnyHM", 3);
+        let value = parse(&server.list_nodes(ListNodesRequest {
+            label: None,
+            property_key: None,
+            property_value: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+        }));
+        assert_eq!(
+            has_more(&value),
+            Some(false),
+            "unfiltered guidance path carries has_more:false for shape consistency: {value}"
+        );
+        assert_eq!(next_offset(&value), None);
+    }
+
+    #[test]
+    fn test_list_edges_has_more_false() {
+        let server = create_test_server();
+        let value = parse(&server.list_edges(ListEdgesRequest {
+            label: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+        }));
+        assert_eq!(
+            has_more(&value),
+            Some(false),
+            "list_edges guidance: {value}"
+        );
+        assert_eq!(next_offset(&value), None);
+    }
+
+    // --- outgoing / incoming edges (additive only, never truncated) ------
+
+    fn seed_star(server: &AletheiaMcpServer, out: usize) -> u64 {
+        let center = {
+            let r = server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Hub".to_string(),
+                properties: None,
+                provenance: None,
+            });
+            let n: NodeResponse = parse_response(&r).unwrap();
+            n.id
+        };
+        for _ in 0..out {
+            let leaf = {
+                let r = server.create_node(CreateNodeRequest {
+                    valid_time: None,
+                    label: "Leaf".to_string(),
+                    properties: None,
+                    provenance: None,
+                });
+                let n: NodeResponse = parse_response(&r).unwrap();
+                n.id
+            };
+            server.create_edge(CreateEdgeRequest {
+                valid_time: None,
+                source_id: center,
+                target_id: leaf,
+                label: "LINK".to_string(),
+                properties: None,
+                provenance: None,
+            });
+        }
+        center
+    }
+
+    #[test]
+    fn test_get_outgoing_edges_completeness() {
+        let server = create_test_server();
+        let center = seed_star(&server, 3);
+        let value = parse(&server.get_outgoing_edges(GetOutgoingEdgesRequest {
+            node_id: center,
+            label: None,
+            include_vectors: None,
+        }));
+        assert_eq!(value.get("count"), Some(&serde_json::json!(3)));
+        assert_eq!(
+            has_more(&value),
+            Some(false),
+            "outgoing edges return the full set: {value}"
+        );
+        assert_eq!(
+            value.get("total_matching"),
+            Some(&serde_json::json!(3)),
+            "total_matching equals the complete count: {value}"
+        );
+    }
+
+    #[test]
+    fn test_get_incoming_edges_completeness() {
+        let server = create_test_server();
+        // Build a hub with 2 incoming edges.
+        let sink = {
+            let r = server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Sink".to_string(),
+                properties: None,
+                provenance: None,
+            });
+            let n: NodeResponse = parse_response(&r).unwrap();
+            n.id
+        };
+        for _ in 0..2 {
+            let src = {
+                let r = server.create_node(CreateNodeRequest {
+                    valid_time: None,
+                    label: "Src".to_string(),
+                    properties: None,
+                    provenance: None,
+                });
+                let n: NodeResponse = parse_response(&r).unwrap();
+                n.id
+            };
+            server.create_edge(CreateEdgeRequest {
+                valid_time: None,
+                source_id: src,
+                target_id: sink,
+                label: "LINK".to_string(),
+                properties: None,
+                provenance: None,
+            });
+        }
+        let value = parse(&server.get_incoming_edges(GetIncomingEdgesRequest {
+            node_id: sink,
+            label: None,
+            include_vectors: None,
+        }));
+        assert_eq!(value.get("count"), Some(&serde_json::json!(2)));
+        assert_eq!(has_more(&value), Some(false));
+        assert_eq!(value.get("total_matching"), Some(&serde_json::json!(2)));
+    }
+
+    // --- traverse ---------------------------------------------------------
+
+    /// Build a chain start -> n1 -> n2 -> ... of `len` NEXT edges; return ids.
+    fn seed_chain(server: &AletheiaMcpServer, len: usize) -> Vec<u64> {
+        let ids: Vec<u64> = (0..=len)
+            .map(|_| {
+                let r = server.create_node(CreateNodeRequest {
+                    valid_time: None,
+                    label: "ChainHM".to_string(),
+                    properties: None,
+                    provenance: None,
+                });
+                let n: NodeResponse = parse_response(&r).unwrap();
+                n.id
+            })
+            .collect();
+        for w in ids.windows(2) {
+            server.create_edge(CreateEdgeRequest {
+                valid_time: None,
+                source_id: w[0],
+                target_id: w[1],
+                label: "NEXT".to_string(),
+                properties: None,
+                provenance: None,
+            });
+        }
+        ids
+    }
+
+    #[test]
+    fn test_traverse_has_more_and_next_offset_when_truncated() {
+        let server = create_test_server();
+        // start -> 5 further nodes reachable via NEXT.
+        let ids = seed_chain(&server, 5);
+
+        // Truncate at 2 of the 5 reachable nodes.
+        let truncated = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(5),
+            limit: Some(2),
+            offset: None,
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        assert_eq!(truncated.get("count"), Some(&serde_json::json!(2)));
+        assert_eq!(
+            has_more(&truncated),
+            Some(true),
+            "traversal truncated by limit signals more: {truncated}"
+        );
+        assert_eq!(next_offset(&truncated), Some(2));
+
+        // A limit above the reachable count exhausts the traversal.
+        let complete = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(5),
+            limit: Some(100),
+            offset: None,
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        assert_eq!(complete.get("count"), Some(&serde_json::json!(5)));
+        assert_eq!(has_more(&complete), Some(false), "exhausted: {complete}");
+        assert_eq!(next_offset(&complete), None);
+    }
+
+    #[test]
+    fn test_traverse_offset_paginates() {
+        let server = create_test_server();
+        let ids = seed_chain(&server, 5); // 5 reachable nodes
+
+        // Collect the ids returned across two offset pages of size 2 plus a
+        // final page; the union must equal the single-shot full traversal.
+        let full = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(5),
+            limit: Some(100),
+            offset: None,
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        let full_count = full.get("count").and_then(|c| c.as_u64()).unwrap();
+        assert_eq!(full_count, 5);
+
+        let page2 = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(5),
+            limit: Some(2),
+            offset: Some(2),
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        assert_eq!(page2.get("count"), Some(&serde_json::json!(2)));
+        assert_eq!(
+            has_more(&page2),
+            Some(true),
+            "offset 2 of 5 has more: {page2}"
+        );
+        assert_eq!(next_offset(&page2), Some(4));
+
+        let page3 = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(5),
+            limit: Some(2),
+            offset: Some(4),
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        assert_eq!(page3.get("count"), Some(&serde_json::json!(1)));
+        assert_eq!(has_more(&page3), Some(false), "last page: {page3}");
+        assert_eq!(next_offset(&page3), None);
+    }
+
+    // --- find_similar -----------------------------------------------------
+
+    fn seed_vectors(server: &AletheiaMcpServer, n: usize) {
+        server.enable_vector_index(EnableVectorIndexRequest {
+            property_name: "embedding".to_string(),
+            dimensions: 4,
+            distance_metric: Some("cosine".to_string()),
+        });
+        for i in 0..n {
+            let mut props = HashMap::new();
+            props.insert("name".to_string(), serde_json::json!(format!("Doc{i}")));
+            props.insert(
+                "embedding".to_string(),
+                serde_json::json!([
+                    (i as f32) * 0.1 + 0.01,
+                    (i as f32) * 0.2 + 0.01,
+                    (i as f32) * 0.3 + 0.01,
+                    (i as f32) * 0.4 + 0.01
+                ]),
+            );
+            server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Document".to_string(),
+                properties: Some(props),
+                provenance: None,
+            });
+        }
+    }
+
+    #[test]
+    fn test_find_similar_has_more_and_offset_paginates() {
+        let server = create_test_server();
+        seed_vectors(&server, 5);
+        let query = vec![0.1_f32, 0.2, 0.3, 0.4];
+
+        // k=2 of 5 available -> more remains.
+        let page1 = parse(&server.find_similar(FindSimilarRequest {
+            property_name: "embedding".to_string(),
+            embedding: query.clone(),
+            k: Some(2),
+            offset: None,
+            include_vectors: None,
+        }));
+        assert_eq!(page1.get("count"), Some(&serde_json::json!(2)));
+        assert_eq!(has_more(&page1), Some(true), "2 of 5 similar: {page1}");
+        assert_eq!(next_offset(&page1), Some(2));
+
+        // Offset into the middle.
+        let page2 = parse(&server.find_similar(FindSimilarRequest {
+            property_name: "embedding".to_string(),
+            embedding: query.clone(),
+            k: Some(2),
+            offset: Some(2),
+            include_vectors: None,
+        }));
+        assert_eq!(page2.get("count"), Some(&serde_json::json!(2)));
+        assert_eq!(has_more(&page2), Some(true));
+        assert_eq!(next_offset(&page2), Some(4));
+
+        // k beyond the available set exhausts it.
+        let complete = parse(&server.find_similar(FindSimilarRequest {
+            property_name: "embedding".to_string(),
+            embedding: query,
+            k: Some(50),
+            offset: None,
+            include_vectors: None,
+        }));
+        assert_eq!(has_more(&complete), Some(false), "exhausted: {complete}");
+        assert_eq!(next_offset(&complete), None);
+    }
+
+    // --- success-metric sweep --------------------------------------------
+
+    #[test]
+    fn test_all_bounded_read_tools_carry_has_more() {
+        let server = create_test_server();
+        // Minimal data touching every tool.
+        let center = seed_star(&server, 2);
+        seed_vectors(&server, 2);
+
+        let responses = vec![
+            (
+                "list_nodes(label)",
+                server.list_nodes(ListNodesRequest {
+                    label: Some("Leaf".to_string()),
+                    property_key: None,
+                    property_value: None,
+                    limit: Some(1),
+                    offset: None,
+                    include_vectors: None,
+                }),
+            ),
+            (
+                "list_nodes(unfiltered)",
+                server.list_nodes(ListNodesRequest {
+                    label: None,
+                    property_key: None,
+                    property_value: None,
+                    limit: None,
+                    offset: None,
+                    include_vectors: None,
+                }),
+            ),
+            (
+                "list_edges",
+                server.list_edges(ListEdgesRequest {
+                    label: None,
+                    limit: None,
+                    offset: None,
+                    include_vectors: None,
+                }),
+            ),
+            (
+                "get_outgoing_edges",
+                server.get_outgoing_edges(GetOutgoingEdgesRequest {
+                    node_id: center,
+                    label: None,
+                    include_vectors: None,
+                }),
+            ),
+            (
+                "get_incoming_edges",
+                server.get_incoming_edges(GetIncomingEdgesRequest {
+                    node_id: center,
+                    label: None,
+                    include_vectors: None,
+                }),
+            ),
+            (
+                "traverse",
+                server.traverse(TraverseRequest {
+                    start_node_id: center,
+                    edge_label: "LINK".to_string(),
+                    direction: None,
+                    depth: Some(1),
+                    limit: Some(1),
+                    offset: None,
+                    include_vectors: None,
+                    as_of_valid_time: None,
+                    as_of_transaction_time: None,
+                }),
+            ),
+            (
+                "find_similar",
+                server.find_similar(FindSimilarRequest {
+                    property_name: "embedding".to_string(),
+                    embedding: vec![0.1, 0.2, 0.3, 0.4],
+                    k: Some(1),
+                    offset: None,
+                    include_vectors: None,
+                }),
+            ),
+        ];
+
+        for (name, resp) in responses {
+            let value = parse(&resp);
+            assert!(
+                value.get("has_more").and_then(|v| v.as_bool()).is_some(),
+                "{name} response must carry a boolean has_more: {value}"
+            );
+        }
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -7322,7 +7322,18 @@ mod completeness_tests {
 
     // --- find_similar -----------------------------------------------------
 
+    /// Seed up to 5 documents with well-separated (near-orthogonal) 4-dim
+    /// embeddings: the four axis-aligned unit vectors plus the all-ones
+    /// vector. Against a query embedding like `[0.1, 0.2, 0.3, 0.4]`, cosine
+    /// similarity to each is strictly distinct (0.183, 0.365, 0.548, 0.730,
+    /// 0.913) with wide gaps between them, so ranking is unambiguous and a
+    /// deterministic count/`has_more` assertion never depends on HNSW
+    /// (approximate) search resolving a near-tied score consistently.
     fn seed_vectors(server: &AletheiaMcpServer, n: usize) {
+        assert!(
+            n <= 5,
+            "seed_vectors only defines 5 well-separated directions"
+        );
         server.enable_vector_index(EnableVectorIndexRequest {
             property_name: "embedding".to_string(),
             dimensions: 4,
@@ -7331,15 +7342,14 @@ mod completeness_tests {
         for i in 0..n {
             let mut props = HashMap::new();
             props.insert("name".to_string(), serde_json::json!(format!("Doc{i}")));
-            props.insert(
-                "embedding".to_string(),
-                serde_json::json!([
-                    (i as f32) * 0.1 + 0.01,
-                    (i as f32) * 0.2 + 0.01,
-                    (i as f32) * 0.3 + 0.01,
-                    (i as f32) * 0.4 + 0.01
-                ]),
-            );
+            let embedding: [f32; 4] = if i < 4 {
+                let mut e = [0.0_f32; 4];
+                e[i] = 1.0;
+                e
+            } else {
+                [1.0; 4]
+            };
+            props.insert("embedding".to_string(), serde_json::json!(embedding));
             server.create_node(CreateNodeRequest {
                 valid_time: None,
                 label: "Document".to_string(),
@@ -7481,5 +7491,126 @@ mod completeness_tests {
                 "{name} response must carry a boolean has_more: {value}"
             );
         }
+    }
+
+    // --- limit/k==0 must not produce a non-progressing page --------------
+    //
+    // A page must be able to carry a continuation cursor: limit/k:0 with
+    // has_more:true and next_offset==offset (an unchanged offset) would trap
+    // a paginating caller in an infinite loop. `limit`/`k` are clamped to a
+    // minimum of 1 so a page always advances.
+
+    #[test]
+    fn test_list_nodes_limit_zero_is_clamped_to_one() {
+        let server = create_test_server();
+        seed_labeled(&server, "ClampHM", 3);
+        let value = parse(&server.list_nodes(ListNodesRequest {
+            label: Some("ClampHM".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: Some(0),
+            offset: None,
+            include_vectors: None,
+        }));
+        assert_eq!(
+            value.get("count"),
+            Some(&serde_json::json!(1)),
+            "limit:0 must be clamped to at least 1, not return an empty page: {value}"
+        );
+        assert_eq!(has_more(&value), Some(true));
+        assert_eq!(next_offset(&value), Some(1), "page must advance: {value}");
+    }
+
+    #[test]
+    fn test_traverse_limit_zero_is_clamped_to_one() {
+        let server = create_test_server();
+        let ids = seed_chain(&server, 3);
+        let value = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(3),
+            limit: Some(0),
+            offset: None,
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        assert_eq!(
+            value.get("count"),
+            Some(&serde_json::json!(1)),
+            "limit:0 must be clamped to at least 1, not return an empty page: {value}"
+        );
+        assert_eq!(has_more(&value), Some(true));
+        assert_eq!(next_offset(&value), Some(1), "page must advance: {value}");
+    }
+
+    #[test]
+    fn test_find_similar_k_zero_is_clamped_to_one() {
+        let server = create_test_server();
+        seed_vectors(&server, 3);
+        let value = parse(&server.find_similar(FindSimilarRequest {
+            property_name: "embedding".to_string(),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            k: Some(0),
+            offset: None,
+            include_vectors: None,
+        }));
+        assert_eq!(
+            value.get("count"),
+            Some(&serde_json::json!(1)),
+            "k:0 must be clamped to at least 1, not return an empty page: {value}"
+        );
+        assert_eq!(has_more(&value), Some(true));
+        assert_eq!(next_offset(&value), Some(1), "page must advance: {value}");
+    }
+
+    // --- traverse must not walk unboundedly through dangling edges -------
+
+    #[test]
+    fn test_traverse_bounded_peek_past_dangling_edges() {
+        let server = create_test_server();
+        // start -> n1 -> n2 -> n3 -> n4, then n2..n4 are deleted via the
+        // low-level (non-cascade) API, which per CLAUDE.md's "Orphaned
+        // Edges" section leaves their connecting edges dangling in storage.
+        let ids = seed_chain(&server, 4);
+        for &dangling_id in &ids[2..=4] {
+            server
+                .db()
+                .delete_node_with_valid_time(
+                    crate::core::id::NodeId::new(dangling_id).unwrap(),
+                    None,
+                )
+                .unwrap();
+        }
+
+        // n1 is the sole live node beyond `start` and becomes the one-item
+        // page (limit:1). Before this fix, proving `has_more` required
+        // resolving one MORE node beyond the page -- but every node past n1
+        // is dangling, so the old code would walk the entire dangling chain
+        // (n2, n3, n4) via "keep expanding regardless", find nothing
+        // resolvable, and wrongly report has_more:false. The fix instead
+        // reads `has_more` off whatever `traversal_next_hops` already queued
+        // for n1 (the edge to n2) without resolving it, so it correctly
+        // reports uncertainty as has_more:true in O(1) extra work rather
+        // than an O(dangling-chain-length) walk that still gets it wrong.
+        let response = parse(&server.traverse(TraverseRequest {
+            start_node_id: ids[0],
+            edge_label: "NEXT".to_string(),
+            direction: None,
+            depth: Some(10),
+            limit: Some(1),
+            offset: None,
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        }));
+        assert_eq!(response.get("count"), Some(&serde_json::json!(1)));
+        assert_eq!(
+            has_more(&response),
+            Some(true),
+            "a pending (even if unresolved) frontier candidate must not be silently \
+             reported as has_more:false: {response}"
+        );
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -429,6 +429,14 @@ pub struct TraverseRequest {
     #[schemars(description = "Maximum number of results to return (default: 100)")]
     pub limit: Option<usize>,
 
+    /// Number of results to skip (for pagination).
+    #[schemars(
+        description = "Number of results to skip (for pagination). Pass the `next_offset` from a \
+                       prior response to fetch the next page; the response's `has_more` tells you \
+                       whether another page exists."
+    )]
+    pub offset: Option<usize>,
+
     /// When true, return full vector/embedding properties instead of the
     /// elided descriptor (default: false).
     #[schemars(
@@ -478,6 +486,14 @@ pub struct FindSimilarRequest {
     /// Number of similar results to return.
     #[schemars(description = "Number of similar results to return (default: 10)")]
     pub k: Option<usize>,
+
+    /// Number of results to skip (for pagination).
+    #[schemars(
+        description = "Number of results to skip (for pagination). Pass the `next_offset` from a \
+                       prior response to fetch the next page; the response's `has_more` tells you \
+                       whether another page exists."
+    )]
+    pub offset: Option<usize>,
 
     /// When true, return full vector/embedding properties instead of the
     /// elided descriptor (default: false). Does not affect the similarity

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -405,7 +405,13 @@ pub struct GetIncomingEdgesRequest {
 /// excluded, and node properties reflect their state at that instant. Each
 /// dimension defaults independently to the current time when the *other* one
 /// is supplied but it isn't, mirroring `get_schema`'s `as_of_*` convention.
+///
+/// Marked `#[non_exhaustive]` because Issue #3226 added the `offset` field
+/// after this struct's initial release; struct-literal construction from
+/// outside this crate would otherwise be a semver break on every future
+/// field addition.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct TraverseRequest {
     /// Starting node ID for traversal.
     #[schemars(description = "Starting node ID for traversal")]
@@ -471,7 +477,13 @@ pub struct TraverseRequest {
 // ============================================================================
 
 /// Request to find similar nodes by vector embedding.
+///
+/// Marked `#[non_exhaustive]` because Issue #3226 added the `offset` field
+/// after this struct's initial release; struct-literal construction from
+/// outside this crate would otherwise be a semver break on every future
+/// field addition.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[non_exhaustive]
 pub struct FindSimilarRequest {
     /// The property name that contains the vector embedding.
     #[schemars(


### PR DESCRIPTION
Bounded MCP read tools capped their result sets but the response carried
only `count`/`offset`/`limit`, with no completeness signal. An LLM that
received exactly `limit` items could not tell a complete set from a
silently-truncated slice, producing confidently-wrong cardinality answers.

Add, additively, to the six bounded read tools:

- `has_more` (all six): true when matching results exist beyond the
  returned page, false otherwise. list_nodes/list_edges guidance paths and
  the never-truncated get_outgoing_edges/get_incoming_edges carry
  `has_more: false` for shape consistency.
- `next_offset` (offset-paginated tools): the `offset` for the next page,
  present only when `has_more`. Adds an `offset` input to traverse and
  find_similar so their pagination is usable.
- `total_matching`: reported where cheap (list_nodes property path and the
  edge handlers, which already materialize the full set); omitted, never
  faked, for label scans / traverse / find_similar where it would need an
  expensive full scan.

Mechanics: property path derives the total from the materialized id list;
label scan over-fetches `limit+offset+1` to peek one extra row; traverse
counts produced nodes to skip `offset`, collect `limit`, and detect one
beyond; find_similar over-fetches `k+offset+1`. A shared
`attach_completeness` helper writes the fields uniformly. Tool descriptions
document the new fields. No change to limit/offset constants or the Rust
API; MCP response payloads only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UWXCNZxp6KqRXhGuUD69hi