### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ aletheiadb = { version = "0.1", features = ["nova", "semantic-search"] }
 
 ---
 
+## ⚠️ Experimental Features (Nova)
+
+> **REQUIRES FEATURE NOVA:** Examples and APIs in the experimental `nova` module (such as the NarrativeGenerator in `story_demo.rs`) require the `nova` feature flag to be enabled in your `Cargo.toml`. Attempting to run `cargo run --example story_demo` or use these APIs without this flag will result in a hard panic.
+
+```toml
+aletheiadb = { version = "0.1", features = ["nova"] }
+```
+
+---
+
 ## MCP Server (Claude / LLM Integration)
 
 ```bash

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -198,7 +198,7 @@ let _doc2 = db.create_node("Document", properties! {
 
 // Find the 10 nodes most similar to doc1
 // (doc1 itself is excluded from results)
-let similar = db.find_similar(doc1, 10)?;
+let similar = db.similarity_search(aletheiadb::SimilarityQuery::from_node(doc1).k(10))?;
 for (node_id, score) in similar {
     println!("Node {:?} similarity: {:.3}", node_id, score);
 }


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the examples from the README.md and ran into several confusing issues. The `story_demo` code crashes if the `nova` feature is not enabled. 

🕵️ **The Reality:** 
1. The `NarrativeGenerator` APIs require the `nova` feature to be explicitly enabled in `Cargo.toml`. Otherwise, they panic at runtime when used, and `cargo run --example story_demo` fails entirely if the feature is not active.

💡 **The Fix:** 
1. Added a highly visible "⚠️ Experimental Features (Nova)" warning banner and code block into the `README.md` explicitly stating that these APIs and examples require enabling the `nova` feature, preventing a copy-paste trap.

---
*PR created automatically by Jules for task [1004002018403618091](https://jules.google.com/task/1004002018403618091) started by @madmax983*