### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -10,3 +10,9 @@
 ## 2024-05-14 - [Adding Examples to HLC and documenting src/main.rs]
 **Confusion:** The `src/main.rs` file was missing module-level documentation (`//!`), which triggers the `missing_docs` lint, but was hidden by the lint configurations inside `src/lib.rs` affecting `src/main.rs`. Also `HybridTimestamp::send` lacked an example showing the behavior of its logical counter.
 **Clarification:** Added `//! The AletheiaDB binary.` to `src/main.rs` and added an executable `## Examples` block to `HybridTimestamp::send` in `src/core/hlc.rs`.
+## 2024-05-15 - [Intra-doc links broken path and redundancy warnings]
+**Confusion:** Sometimes using explicit paths for intra-doc links can cause issues. For instance, linking to conditionally available items, or putting explicit paths when the item is already in scope, triggers `rustdoc::redundant_explicit_links`. In addition, links to `pub(crate)` items trigger `rustdoc::private_intra_doc_links`.
+**Clarification:** Fixed various broken or redundant links across the codebase:
+- Replaced the redundant explicit path `[`Provenance`](crate::core::provenance::Provenance)` with just `[`Provenance`]` in `src/storage/historical/mod.rs` since it was already imported. Same for `[`ChangeRecord`]` in `src/db/temporal.rs`.
+- Fixed the broken explicit link `crate::storage::StorageError` to `crate::core::error::StorageError` in `src/db/ops.rs`.
+- Replaced the intra-doc link `[`BackupPayloadV1`]` to private item with standard backticks `` `BackupPayloadV1` ``.

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -286,7 +286,7 @@ impl AletheiaDB {
     }
 
     /// Create a node with an optional [`WriteRequestOptions`](crate::api::transaction::WriteRequestOptions)
-    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`] bundle (Issue #3224).
+    /// bundle: a backdated `valid_from` and/or a write-time [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
     ///
     /// Passing `WriteRequestOptions::default()` is identical to [`create_node`](Self::create_node).
     ///
@@ -581,7 +581,7 @@ impl AletheiaDB {
     /// decide whether a detach/cascade delete is required to avoid orphaning
     /// edges.
     ///
-    /// Returns [`StorageError::NodeNotFound`](crate::storage::StorageError::NodeNotFound)
+    /// Returns [`StorageError::NodeNotFound`](crate::core::error::StorageError::NodeNotFound)
     /// if the node does not exist in the current state, so callers never receive
     /// a misleading zero count for a missing node.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]

--- a/src/db/temporal.rs
+++ b/src/db/temporal.rs
@@ -506,7 +506,7 @@ impl AletheiaDB {
     ///
     /// This is the *discovery* counterpart to the per-entity history/diff APIs: it answers
     /// "**which** entities were created, modified, or deleted between T1 and T2?" without the
-    /// caller already knowing any IDs. Each returned [`ChangeRecord`](crate::core::ChangeRecord)
+    /// caller already knowing any IDs. Each returned [`ChangeRecord`]
     /// carries the entity id, kind, change type, and the version's transaction- and valid-time
     /// bounds, so a caller can then drill in with `get_node_history` / `diff_node_versions`.
     ///

--- a/src/storage/backup/mod.rs
+++ b/src/storage/backup/mod.rs
@@ -46,7 +46,7 @@ pub const BACKUP_MAGIC: [u8; 4] = *b"ALBK";
 /// Bumped to 2 for write-time provenance on temporal versions (Issue #3224):
 /// the embedded `TemporalIndexData`'s `NodeVersionEntry`/`EdgeVersionEntry`
 /// gained an optional `provenance` field. Version 1 artifacts are still
-/// restorable -- see [`BackupPayloadV1`] and `read_artifact`.
+/// restorable -- see `BackupPayloadV1` and `read_artifact`.
 pub const BACKUP_FORMAT_VERSION: u16 = 2;
 
 /// Maximum allowed decompressed payload size (5 GiB).

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -545,7 +545,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of a node, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_node_version`](Self::add_node_version) other
     /// than persisting `provenance` on the created version (anchor or delta).
@@ -774,7 +774,7 @@ impl HistoricalStorage {
     }
 
     /// Add a new version of an edge, optionally attaching a write-time
-    /// [`Provenance`](crate::core::provenance::Provenance) bundle (Issue #3224).
+    /// [`Provenance`] bundle (Issue #3224).
     ///
     /// Behaves identically to [`add_edge_version`](Self::add_edge_version) other
     /// than persisting `provenance` on the created version (anchor or delta).


### PR DESCRIPTION
📖 Chapter: Fixing broken intra-doc links across the DB, Historical, and Storage submodules.

🔦 Insight: The `cargo rustdoc` lint flagged multiple warnings about broken links (`crate::storage::StorageError` instead of `crate::core::error::StorageError`, missing `Provenance` path in `ops.rs`), redundant explicit targets when items were already in scope (`ChangeRecord`, `Provenance` in historical/temporal), and linking to a `pub(crate)` private struct (`BackupPayloadV1`). These have all been corrected.

🧪 Example: Changed `[`BackupPayloadV1`]` to standard markdown backticks `` `BackupPayloadV1` `` for the private backup payload item, and cleaned up explicit target paths in doc links.

🖼️ Preview: `cargo rustdoc` now passes completely cleanly with zero warnings under `-D warnings`.

---
*PR created automatically by Jules for task [6455767214530649557](https://jules.google.com/task/6455767214530649557) started by @madmax983*