### PR TITLE
Expose database stats and storage-tier health via MCP + API (Issue #3222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ cargo run --bin aletheia-mcp --features mcp-server
 | **Hybrid** | `hybrid_query` (combined graph + vector + temporal) |
 | **Query** | `query` (execute a single read-only Cypher/AQL statement; see below) |
 | **Schema** | `get_schema` (node labels, edge types, and property keys, each with counts; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
+| **Stats** | `database_stats` (holistic snapshot: current size, bi-temporal depth + anchor/delta compression, hot/warm/cold tier distribution, WAL state; no arguments) |
 
 **`query` tool (read-only Cypher/AQL):** Lets an LLM answer a multi-hop,
 filtered, temporally-scoped question with **one declarative statement** instead
@@ -352,6 +353,19 @@ Recovery loop: `retriable: true` -> retry with backoff; `INVALID_ARGUMENT` /
 `message` + `details` and re-issue; otherwise escalate. Codes may be added
 over time but never change meaning; treat unknown codes as non-retriable. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#structured-error-codes-and-the-retriable-contract).
+
+**Database stats (Issue #3222)**: `database_stats` (no arguments) returns a
+holistic snapshot in one call so an LLM/operator can orient itself before
+querying: `current` (node/edge counts), `historical` (total/unique version
+counts plus anchor/delta breakdown and `compression_ratio` — the bi-temporal
+depth available for time travel), `cold_storage` (`{enabled: false}` when the
+disk tier is not configured — never misleading zeros — or counters plus a
+`tier_access` hot/warm/cold read distribution when it is), and `wal`
+(`enabled`, `durability_mode` token, `current_lsn`, `total_appends`,
+`healthy`). Backed by the public `AletheiaDB::stats()` returning a
+serializable `DatabaseStats`; every field is an O(1)/cached counter read
+(no version scans; see Issue #212), so it is safe to call frequently. See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#database-stats-and-storage-tier-health-database_stats).
 
 **Valid-time writes (Issue #3221)**: `create_node`, `create_edge`,
 `update_node`, `update_edge`, `delete_node`, and `delete_edge` accept an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,8 @@ over time but never change meaning; treat unknown codes as non-retriable. See
 holistic snapshot in one call so an LLM/operator can orient itself before
 querying: `current` (node/edge counts), `historical` (total/unique version
 counts plus anchor/delta breakdown and `compression_ratio` — the bi-temporal
-depth available for time travel), `cold_storage` (`{enabled: false}` when the
+depth held **in RAM**; versions migrated to the cold tier are counted under
+`cold_storage` instead), `cold_storage` (`{enabled: false}` when the
 disk tier is not configured — never misleading zeros — or counters plus a
 `tier_access` hot/warm/cold read distribution when it is), and `wal`
 (`enabled`, `durability_mode` token, `current_lsn`, `total_appends`,

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -409,6 +409,92 @@ guaranteed to be out of recorded range — its empty result means "before our
 records begin," not "nothing existed." Rerun the query at an instant inside
 the extent (or report the range mismatch) instead of concluding absence.
 
+## Database stats and storage-tier health (`database_stats`)
+
+*(Issue #3222)* The `database_stats` tool takes **no arguments** and returns a
+holistic snapshot of dataset size, bi-temporal depth, storage-tier
+distribution, and WAL state in a single call. Use it to orient yourself before
+querying ("how big is this dataset? is there history to time-travel through?
+is cold migration even on?") instead of stitching together `count_nodes` +
+`count_edges` — which cannot reveal version depth, tier distribution, or WAL
+state at all. It is backed by the public Rust API `AletheiaDB::stats()`, which
+returns the same data as a serializable `DatabaseStats`; the MCP handler only
+serializes that snapshot.
+
+### Response shape
+
+```jsonc
+{
+  "current": {                    // current-state (hot, in-RAM) graph size
+    "node_count": 10000,
+    "edge_count": 50000
+  },
+  "historical": {                 // bi-temporal depth of the in-RAM store
+    "total_node_versions": 12500, // every recorded node state, ever
+    "total_edge_versions": 50000,
+    "unique_nodes": 10000,        // distinct nodes with any history
+    "unique_edges": 50000,
+    "anchor_count": 11000,        // full property snapshots (node + edge)
+    "delta_count": 51500,         // change-only versions (node + edge)
+    "node_anchor_count": 10500,   // per-entity-type breakdowns of the above
+    "node_delta_count": 2000,
+    "edge_anchor_count": 500,
+    "edge_delta_count": 49500,
+    "compression_ratio": 0.176    // anchors / total versions; LOWER = better
+  },
+  "cold_storage": {               // disk tier; see "disabled tiers" below
+    "enabled": true,
+    "node_versions_stored": 800,  // versions migrated to disk
+    "edge_versions_stored": 3200,
+    "compression_ratio": 3.8,     // raw/compressed bytes; HIGHER = better
+    "tier_access": {              // where historical reads were served from
+      "hot_hits": 90210,
+      "warm_hits": 4310,
+      "cold_hits": 122,
+      "misses": 0
+    }
+  },
+  "wal": {
+    "enabled": true,              // always true in current builds
+    "durability_mode": "group_commit", // synchronous | async | group_commit | async_batched
+    "current_lsn": 62501,         // latest (next-to-be-allocated) LSN
+    "total_appends": 62500,
+    "healthy": true               // false = outstanding WAL flush errors
+  }
+}
+```
+
+### Disabled tiers are tagged, never zero-reported
+
+When no cold-storage tier is configured, the response contains exactly
+`"cold_storage": { "enabled": false }` — the count fields are **absent**, not
+zero. Never interpret a disabled tier as "0 cold versions"; it means the
+database retains history only in RAM (`historical`) and nothing has been (or
+can be) migrated to disk. The same contract applies to `wal.enabled`, which is
+always `true` in current builds (AletheiaDB has no no-WAL construction path)
+but is emitted explicitly so consumers never have to infer WAL presence.
+
+### Every field is O(1) — safe to call frequently
+
+All values are reads of counters the storage engines already maintain
+incrementally: current counts are index-length reads, historical counts come
+from `HistoricalStorage::stats()` (cached counters per Issue #212 — never a
+version scan), tier counters are atomic snapshots, and WAL fields are atomic
+loads. A `database_stats` call completes in microseconds regardless of
+database size.
+
+Note the two `compression_ratio` fields measure different things:
+`historical.compression_ratio` is the anchor share of versions (lower is
+better delta compression); `cold_storage.compression_ratio` is the byte-level
+Zstd/LZ4 ratio on disk (higher is better).
+
+### Scope
+
+`database_stats` reports magnitude/counts and tier health at a point in time.
+It does **not** report the calendar range of stored history (earliest/latest
+timestamps) — use `temporal_extent` for that — and it does not break counts
+down per label; use `get_schema` for per-label/per-edge-type counts.
+
 ## Notes
 
 - **AQL has no parameter binding.** Sending `params` with `language: "aql"`

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -430,7 +430,9 @@ serializes that snapshot.
     "edge_count": 50000
   },
   "historical": {                 // bi-temporal depth of the in-RAM store
-    "total_node_versions": 12500, // every recorded node state, ever
+    "total_node_versions": 12500, // node states retained in RAM (versions
+                                  // migrated to the cold tier are counted
+                                  // under cold_storage, not here)
     "total_edge_versions": 50000,
     "unique_nodes": 10000,        // distinct nodes with any history
     "unique_edges": 50000,
@@ -444,10 +446,12 @@ serializes that snapshot.
   },
   "cold_storage": {               // disk tier; see "disabled tiers" below
     "enabled": true,
-    "node_versions_stored": 800,  // versions migrated to disk
+    "node_versions_stored": 800,  // versions on disk (persists across restarts)
     "edge_versions_stored": 3200,
-    "compression_ratio": 3.8,     // raw/compressed bytes; HIGHER = better
-    "tier_access": {              // where historical reads were served from
+    "compression_ratio": 3.8,     // raw/compressed bytes written since this
+                                  // process opened the DB; HIGHER = better
+    "tier_access": {              // where historical reads were served from,
+                                  // counted since this process opened the DB
       "hot_hits": 90210,
       "warm_hits": 4310,
       "cold_hits": 122,
@@ -457,12 +461,19 @@ serializes that snapshot.
   "wal": {
     "enabled": true,              // always true in current builds
     "durability_mode": "group_commit", // synchronous | async | group_commit | async_batched
-    "current_lsn": 62501,         // latest (next-to-be-allocated) LSN
+    "current_lsn": 62501,         // NEXT LSN to be allocated
     "total_appends": 62500,
     "healthy": true               // false = outstanding WAL flush errors
   }
 }
 ```
+
+The cold-tier version counts are seeded from the persisted tables when the
+database is opened (an O(1) metadata read), so a restarted process reports its
+full on-disk cold history rather than zero. The byte-level
+`compression_ratio` and the `tier_access` counters are **not** persisted:
+they describe activity since the current process opened the database
+(`compression_ratio` is `1.0` until this process writes to the cold tier).
 
 ### Disabled tiers are tagged, never zero-reported
 
@@ -492,7 +503,9 @@ Zstd/LZ4 ratio on disk (higher is better).
 
 `database_stats` reports magnitude/counts and tier health at a point in time.
 It does **not** report the calendar range of stored history (earliest/latest
-timestamps) — use `temporal_extent` for that — and it does not break counts
+timestamps) — use
+[`temporal_extent`](#discovering-the-queryable-temporal-extent-temporal_extent)
+for that — and it does not break counts
 down per label; use `get_schema` for per-label/per-edge-type counts.
 
 ## Notes

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -37,6 +37,8 @@ pub mod query;
 pub mod schema;
 /// Unified vector similarity query builder.
 pub mod similarity_query;
+/// Database-wide statistics snapshot (Issue #3222).
+pub mod stats;
 /// Temporal query operations.
 pub mod temporal;
 #[cfg(test)]
@@ -54,6 +56,10 @@ pub use constraint_builder::UniqueConstraintBuilder;
 pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
+pub use stats::{
+    ColdStorageDetails, ColdStorageTierStats, CurrentStateStats, DatabaseStats,
+    HistoricalDepthStats, TierAccessStats, WalStateStats,
+};
 pub use vector_builder::VectorIndexBuilder;
 
 /// Main AletheiaDB database.

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -21,7 +21,10 @@
 //!   (see `src/storage/historical/mod.rs`).
 //! - Cold-tier counters and hot/warm/cold access distribution: atomic
 //!   counter snapshots from `TieredStorage::metrics()` and
-//!   `RedbColdStorage::stats()`.
+//!   `RedbColdStorage::stats()`. The cold version counts are seeded from the
+//!   persisted tables when the database is opened (an O(1) B-tree metadata
+//!   read), so they survive restarts; byte and access counters are
+//!   process-lifetime.
 //! - WAL state: a field copy (`durability_mode`) plus atomic loads
 //!   (`current_lsn`, `total_appends`, `consecutive_flush_errors`).
 //!
@@ -54,6 +57,7 @@ use crate::storage::wal::DurabilityMode;
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct DatabaseStats {
     /// Current-state graph size (the hot, in-RAM tier queried by
     /// current-state operations).
@@ -75,6 +79,7 @@ pub struct DatabaseStats {
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct CurrentStateStats {
     /// Number of nodes in the current state. O(1) index-length read.
     pub node_count: usize,
@@ -93,6 +98,7 @@ pub struct CurrentStateStats {
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct HistoricalDepthStats {
     /// Total node versions retained in the hot historical store.
     pub total_node_versions: usize,
@@ -133,6 +139,7 @@ pub struct HistoricalDepthStats {
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct ColdStorageTierStats {
     /// Whether a cold-storage tier (tiered storage + Redb backend) is
     /// configured for this database.
@@ -149,15 +156,24 @@ pub struct ColdStorageTierStats {
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct ColdStorageDetails {
-    /// Node versions migrated to the cold (disk) tier.
+    /// Node versions in the cold (disk) tier. Seeded from the persisted
+    /// tables when the database is opened (an O(1) metadata read), then
+    /// incremented per migration — a restarted process reports its full
+    /// on-disk cold history, not zero.
     pub node_versions_stored: u64,
-    /// Edge versions migrated to the cold (disk) tier.
+    /// Edge versions in the cold (disk) tier. Seeded from the persisted
+    /// tables at open, like [`node_versions_stored`](Self::node_versions_stored).
     pub edge_versions_stored: u64,
-    /// Cold-tier write compression ratio (raw bytes / compressed bytes;
-    /// 1.0 when nothing has been written). Higher is better.
+    /// Cold-tier write compression ratio (raw bytes / compressed bytes).
+    /// Higher is better. The underlying byte counters are **not** persisted,
+    /// so this covers writes since the current process opened the database
+    /// (1.0 when this process has not written anything yet).
     pub compression_ratio: f64,
-    /// Distribution of historical-version reads across storage tiers.
+    /// Distribution of historical-version reads across storage tiers,
+    /// counted since the current process opened the database (access
+    /// counters are not persisted).
     pub tier_access: TierAccessStats,
 }
 
@@ -168,6 +184,7 @@ pub struct ColdStorageDetails {
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct TierAccessStats {
     /// Reads served from the hot (in-RAM) tier.
     pub hot_hits: u64,
@@ -190,6 +207,7 @@ pub struct TierAccessStats {
     any(feature = "config-toml", feature = "mcp-server"),
     derive(serde::Serialize)
 )]
+#[non_exhaustive]
 pub struct WalStateStats {
     /// Whether a WAL is active. Always `true` in current builds (see type
     /// docs); a hypothetical no-WAL build would report `false` here instead
@@ -198,7 +216,8 @@ pub struct WalStateStats {
     /// Active durability mode as a stable token: `"synchronous"`,
     /// `"async"`, `"group_commit"`, or `"async_batched"`.
     pub durability_mode: String,
-    /// Latest (next-to-be-allocated) log sequence number. Atomic read.
+    /// The **next** log sequence number to be allocated (one past the most
+    /// recently assigned LSN; starts at 1 on an empty log). Atomic read.
     pub current_lsn: u64,
     /// Total WAL entries appended since startup. Atomic read.
     pub total_appends: u64,
@@ -358,6 +377,30 @@ mod tests {
             }),
             "async_batched"
         );
+    }
+
+    /// WAL counters are `u64`; extreme values must survive JSON
+    /// serialization without precision loss or sign flips.
+    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[test]
+    fn wal_stats_u64_max_survives_json_round_trip() {
+        let stats = WalStateStats {
+            enabled: true,
+            durability_mode: "synchronous".to_string(),
+            current_lsn: u64::MAX,
+            total_appends: u64::MAX,
+            healthy: true,
+        };
+        let value = serde_json::to_value(&stats).unwrap();
+        assert_eq!(value["current_lsn"].as_u64(), Some(u64::MAX));
+        assert_eq!(value["total_appends"].as_u64(), Some(u64::MAX));
+
+        // Through text and back: serde_json must keep full u64 precision
+        // (arbitrary-precision integer handling, not f64).
+        let text = serde_json::to_string(&stats).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["current_lsn"].as_u64(), Some(u64::MAX));
+        assert_eq!(parsed["total_appends"].as_u64(), Some(u64::MAX));
     }
 
     /// Disabled cold storage serializes as exactly `{"enabled": false}` —

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -1,0 +1,375 @@
+//! Database-wide statistics snapshot (Issue #3222).
+//!
+//! Aggregates the already-maintained internal counters — [`CurrentStats`],
+//! [`HistoricalStats`], [`TieredStorageMetrics`]/[`ColdStorageStats`], and the
+//! WAL system's atomic counters — into a single serializable
+//! [`DatabaseStats`] value so callers (including the MCP `database_stats`
+//! tool) can orient themselves in one call: how much graph is here, how much
+//! history can be time-traveled through, where that history lives
+//! (hot / warm-cache / cold), and what durability guarantees are active.
+//!
+//! # Performance: O(1) by construction — no version scans
+//!
+//! Every numeric field is read from a counter that the storage engines
+//! already maintain incrementally:
+//!
+//! - Current node/edge counts: index length reads
+//!   (`CurrentStorage::node_count`/`edge_count`).
+//! - Historical version/anchor/delta/unique counts:
+//!   `HistoricalStorage::stats()`, which per Issue #212 "returns cached
+//!   counters in O(1) time instead of iterating through all versions"
+//!   (see `src/storage/historical/mod.rs`).
+//! - Cold-tier counters and hot/warm/cold access distribution: atomic
+//!   counter snapshots from `TieredStorage::metrics()` and
+//!   `RedbColdStorage::stats()`.
+//! - WAL state: a field copy (`durability_mode`) plus atomic loads
+//!   (`current_lsn`, `total_appends`, `consecutive_flush_errors`).
+//!
+//! Calling [`AletheiaDB::stats`] therefore never triggers a full version
+//! scan, regardless of database size.
+//!
+//! # Disabled subsystems are tagged, never zero-reported
+//!
+//! A disabled tier is reported as `{"enabled": false}` with **no** count
+//! fields, so a consumer (human or LLM) can never mistake "cold storage is
+//! not configured" for "cold storage holds 0 versions".
+//!
+//! [`CurrentStats`]: crate::storage::current::CurrentStats
+//! [`HistoricalStats`]: crate::storage::historical::HistoricalStats
+//! [`TieredStorageMetrics`]: crate::storage::tiered_storage::TieredStorageMetrics
+//! [`ColdStorageStats`]: crate::storage::redb_cold_storage::ColdStorageStats
+
+use crate::db::AletheiaDB;
+use crate::storage::wal::DurabilityMode;
+
+/// Point-in-time snapshot of database size, temporal depth, storage-tier
+/// distribution, and WAL state.
+///
+/// Produced by [`AletheiaDB::stats`]. All counters are O(1)/cached reads
+/// (see the module docs); this is a consistent-enough operational snapshot,
+/// not a transactionally frozen view — concurrent writers may advance
+/// individual counters between reads.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct DatabaseStats {
+    /// Current-state graph size (the hot, in-RAM tier queried by
+    /// current-state operations).
+    pub current: CurrentStateStats,
+    /// Bi-temporal depth of the in-RAM historical store, including
+    /// anchor/delta compression effectiveness.
+    pub historical: HistoricalDepthStats,
+    /// Cold-tier (disk) presence and, when enabled, counters plus the
+    /// hot/warm/cold read distribution. `enabled: false` means the tier is
+    /// not configured — it does NOT mean zero cold versions.
+    pub cold_storage: ColdStorageTierStats,
+    /// Write-ahead-log durability state.
+    pub wal: WalStateStats,
+}
+
+/// Current-state (hot tier) graph size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct CurrentStateStats {
+    /// Number of nodes in the current state. O(1) index-length read.
+    pub node_count: usize,
+    /// Number of edges in the current state. O(1) index-length read.
+    pub edge_count: usize,
+}
+
+/// Temporal depth and anchor/delta compression effectiveness of the in-RAM
+/// historical store.
+///
+/// All counts come from `HistoricalStorage::stats()`, whose counters are
+/// maintained incrementally (Issue #212) — reading them is O(1) and never
+/// iterates versions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct HistoricalDepthStats {
+    /// Total node versions retained in the hot historical store.
+    pub total_node_versions: usize,
+    /// Total edge versions retained in the hot historical store.
+    pub total_edge_versions: usize,
+    /// Number of distinct nodes that have version history.
+    pub unique_nodes: usize,
+    /// Number of distinct edges that have version history.
+    pub unique_edges: usize,
+    /// Total anchor versions (node + edge). Anchors store full property
+    /// snapshots; a lower anchor share means better delta compression.
+    /// Always: `anchor_count + delta_count ==
+    /// total_node_versions + total_edge_versions`.
+    pub anchor_count: usize,
+    /// Total delta versions (node + edge). Deltas store only changes
+    /// relative to the previous version.
+    pub delta_count: usize,
+    /// Anchor versions among node versions only.
+    pub node_anchor_count: usize,
+    /// Delta versions among node versions only.
+    pub node_delta_count: usize,
+    /// Anchor versions among edge versions only.
+    pub edge_anchor_count: usize,
+    /// Delta versions among edge versions only.
+    pub edge_delta_count: usize,
+    /// Anchors as a fraction of total versions (0.0–1.0; 1.0 when empty).
+    /// Lower is better compression. Computed from the cached counters above.
+    pub compression_ratio: f64,
+}
+
+/// Cold-tier (disk) storage state.
+///
+/// When the tier is disabled this serializes as exactly `{"enabled": false}`
+/// — count fields are structurally absent so they can never be misread as
+/// "zero cold versions".
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct ColdStorageTierStats {
+    /// Whether a cold-storage tier (tiered storage + Redb backend) is
+    /// configured for this database.
+    pub enabled: bool,
+    /// Counters for the enabled tier; absent when `enabled` is false.
+    #[cfg_attr(any(feature = "config-toml", feature = "mcp-server"), serde(flatten))]
+    pub details: Option<ColdStorageDetails>,
+}
+
+/// Counters for an enabled cold-storage tier. All values are atomic counter
+/// snapshots — O(1) reads, no disk access.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct ColdStorageDetails {
+    /// Node versions migrated to the cold (disk) tier.
+    pub node_versions_stored: u64,
+    /// Edge versions migrated to the cold (disk) tier.
+    pub edge_versions_stored: u64,
+    /// Cold-tier write compression ratio (raw bytes / compressed bytes;
+    /// 1.0 when nothing has been written). Higher is better.
+    pub compression_ratio: f64,
+    /// Distribution of historical-version reads across storage tiers.
+    pub tier_access: TierAccessStats,
+}
+
+/// Where historical-version reads were served from. Together these reveal
+/// the hot / warm-cache / cold distribution of temporal query traffic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct TierAccessStats {
+    /// Reads served from the hot (in-RAM) tier.
+    pub hot_hits: u64,
+    /// Reads served from the warm (LRU cache) tier.
+    pub warm_hits: u64,
+    /// Reads served from the cold (disk) tier.
+    pub cold_hits: u64,
+    /// Reads that found the version in no tier.
+    pub misses: u64,
+}
+
+/// Write-ahead-log durability state.
+///
+/// AletheiaDB currently always runs with a WAL (there is no no-WAL
+/// construction path), so `enabled` is always `true` today. The flag is
+/// still emitted explicitly so the schema contract covers any future no-WAL
+/// build and a consumer never has to infer WAL presence from other fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize)
+)]
+pub struct WalStateStats {
+    /// Whether a WAL is active. Always `true` in current builds (see type
+    /// docs); a hypothetical no-WAL build would report `false` here instead
+    /// of omitting the object.
+    pub enabled: bool,
+    /// Active durability mode as a stable token: `"synchronous"`,
+    /// `"async"`, `"group_commit"`, or `"async_batched"`.
+    pub durability_mode: String,
+    /// Latest (next-to-be-allocated) log sequence number. Atomic read.
+    pub current_lsn: u64,
+    /// Total WAL entries appended since startup. Atomic read.
+    pub total_appends: u64,
+    /// `true` when the last WAL flush succeeded (no outstanding
+    /// consecutive flush errors). Atomic read.
+    pub healthy: bool,
+}
+
+/// Stable, machine-readable token for a durability mode.
+///
+/// Deliberately NOT the `Debug` representation, so the MCP/API contract
+/// cannot drift if variant fields change.
+fn durability_mode_token(mode: DurabilityMode) -> &'static str {
+    match mode {
+        DurabilityMode::Synchronous => "synchronous",
+        DurabilityMode::Async { .. } => "async",
+        DurabilityMode::GroupCommit { .. } => "group_commit",
+        DurabilityMode::AsyncBatched { .. } => "async_batched",
+    }
+}
+
+impl AletheiaDB {
+    /// Get a holistic, serializable snapshot of database statistics:
+    /// current-state size, bi-temporal depth (with anchor/delta compression
+    /// effectiveness), storage-tier presence/distribution, and WAL state.
+    ///
+    /// This is the aggregator behind the MCP `database_stats` tool. It adds
+    /// no storage logic of its own — every field is read from an existing
+    /// O(1)/cached counter (see the [module docs](self) for per-field
+    /// provenance), so this call never scans versions and completes in
+    /// microseconds regardless of database size.
+    ///
+    /// # Lock behavior
+    ///
+    /// Follows the write-path lock acquisition order (`wal` before
+    /// `historical`): WAL fields are lock-free atomic reads, then the
+    /// `historical` read lock is taken briefly for the cached counters and
+    /// released *before* the tiered/cold-storage counters are read (via the
+    /// cloned tiered-storage handle). No adjacency or ID-generator locks are
+    /// touched.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use aletheiadb::AletheiaDB;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let stats = db.stats();
+    /// assert_eq!(stats.current.node_count, 0);
+    /// assert!(!stats.cold_storage.enabled); // disabled, not "0 versions"
+    /// assert!(stats.wal.enabled);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "the statistics snapshot should be used"]
+    pub fn stats(&self) -> DatabaseStats {
+        // Current-state counts: lock-free index length reads (not part of
+        // the ordered write-path primitives).
+        let current_stats = self.current.stats();
+
+        // WAL (lock order #2): field copy + atomic loads, acquired before
+        // `historical` per the lock-order contract.
+        let wal = WalStateStats {
+            enabled: true,
+            durability_mode: durability_mode_token(self.wal.durability_mode()).to_string(),
+            current_lsn: self.wal.current_lsn().0,
+            total_appends: self.wal.total_appends(),
+            healthy: self.wal.is_healthy(),
+        };
+
+        // Historical (lock order #3): take the read guard only long enough
+        // to snapshot the cached counters and clone the tiered-storage
+        // handle; tiered/cold counters are read after the guard is dropped.
+        let (hist, tiered) = {
+            let historical = self.historical.read();
+            (historical.stats(), historical.tiered_storage_arc())
+        };
+
+        let historical = HistoricalDepthStats {
+            total_node_versions: hist.total_node_versions,
+            total_edge_versions: hist.total_edge_versions,
+            unique_nodes: hist.unique_nodes,
+            unique_edges: hist.unique_edges,
+            anchor_count: hist.node_anchor_count + hist.edge_anchor_count,
+            delta_count: hist.node_delta_count + hist.edge_delta_count,
+            node_anchor_count: hist.node_anchor_count,
+            node_delta_count: hist.node_delta_count,
+            edge_anchor_count: hist.edge_anchor_count,
+            edge_delta_count: hist.edge_delta_count,
+            compression_ratio: hist.compression_ratio(),
+        };
+
+        let cold_storage = match tiered {
+            Some(tiered) => {
+                let metrics = tiered.metrics();
+                let cold = tiered.cold_stats();
+                ColdStorageTierStats {
+                    enabled: true,
+                    details: Some(ColdStorageDetails {
+                        node_versions_stored: cold.node_versions_stored,
+                        edge_versions_stored: cold.edge_versions_stored,
+                        compression_ratio: cold.compression_ratio(),
+                        tier_access: TierAccessStats {
+                            hot_hits: metrics.hot_hits,
+                            warm_hits: metrics.warm_hits,
+                            cold_hits: metrics.cold_hits,
+                            misses: metrics.misses,
+                        },
+                    }),
+                }
+            }
+            None => ColdStorageTierStats {
+                enabled: false,
+                details: None,
+            },
+        };
+
+        DatabaseStats {
+            current: CurrentStateStats {
+                node_count: current_stats.node_count,
+                edge_count: current_stats.edge_count,
+            },
+            historical,
+            cold_storage,
+            wal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn durability_mode_tokens_are_stable() {
+        assert_eq!(
+            durability_mode_token(DurabilityMode::Synchronous),
+            "synchronous"
+        );
+        assert_eq!(
+            durability_mode_token(DurabilityMode::Async {
+                flush_interval_ms: 10
+            }),
+            "async"
+        );
+        assert_eq!(
+            durability_mode_token(DurabilityMode::GroupCommit {
+                max_delay_ms: 10,
+                max_batch_size: 200
+            }),
+            "group_commit"
+        );
+        assert_eq!(
+            durability_mode_token(DurabilityMode::AsyncBatched {
+                max_delay_ms: 10,
+                max_batch_size: 200
+            }),
+            "async_batched"
+        );
+    }
+
+    /// Disabled cold storage serializes as exactly `{"enabled": false}` —
+    /// no count keys an LLM could misread as "0 cold versions".
+    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+    #[test]
+    fn disabled_cold_storage_serializes_without_count_fields() {
+        let value = serde_json::to_value(ColdStorageTierStats {
+            enabled: false,
+            details: None,
+        })
+        .unwrap();
+        assert_eq!(value, serde_json::json!({ "enabled": false }));
+    }
+}

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2529,3 +2529,108 @@ fn test_schema_as_of_entity_cap_is_configurable_and_discloses_sampling() {
     assert!(!current.sampled);
     assert_eq!(current.total_nodes, 3);
 }
+
+// ============================================================================
+// DatabaseStats unit tests (Issue #3222)
+// ============================================================================
+
+/// `AletheiaDB::stats()` must serialize to the documented shape, with
+/// disabled subsystems explicitly tagged (`enabled: false`, no count keys)
+/// and enabled subsystems carrying their counters.
+#[test]
+fn test_stats_serialization_shape_empty_db() {
+    let db = AletheiaDB::new().unwrap();
+    let stats = db.stats();
+    let value = serde_json::to_value(&stats).expect("DatabaseStats must be serializable");
+
+    assert_eq!(value["current"]["node_count"], serde_json::json!(0));
+    assert_eq!(value["current"]["edge_count"], serde_json::json!(0));
+    assert_eq!(
+        value["historical"]["total_node_versions"],
+        serde_json::json!(0)
+    );
+    assert_eq!(value["historical"]["anchor_count"], serde_json::json!(0));
+    assert_eq!(value["historical"]["delta_count"], serde_json::json!(0));
+
+    let cold = value["cold_storage"].as_object().unwrap();
+    assert_eq!(cold["enabled"], serde_json::json!(false));
+    assert!(
+        !cold.contains_key("node_versions_stored"),
+        "disabled cold storage must not report counts: {value}"
+    );
+
+    let wal = value["wal"].as_object().unwrap();
+    assert_eq!(wal["enabled"], serde_json::json!(true));
+    assert!(wal["current_lsn"].as_u64().unwrap() >= 1);
+    assert!(wal["durability_mode"].is_string());
+}
+
+/// Populated DB: `stats()` mirrors the underlying O(1) counters exactly.
+#[test]
+fn test_stats_populated_matches_underlying_counters() {
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    let _n2 = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.update_node_with_valid_time(
+        n1,
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+        None,
+    )
+    .unwrap();
+
+    let stats = db.stats();
+    assert_eq!(stats.current.node_count, 2);
+    assert_eq!(stats.current.edge_count, 0);
+
+    let hist = db.historical_stats().unwrap();
+    assert_eq!(
+        stats.historical.total_node_versions,
+        hist.total_node_versions
+    );
+    assert_eq!(stats.historical.unique_nodes, hist.unique_nodes);
+    assert_eq!(
+        stats.historical.anchor_count,
+        hist.node_anchor_count + hist.edge_anchor_count
+    );
+    assert_eq!(
+        stats.historical.delta_count,
+        hist.node_delta_count + hist.edge_delta_count
+    );
+}
+
+/// With cold storage configured, `stats()` reports the cold tier as enabled
+/// with counters and the hot/warm/cold access distribution.
+#[test]
+fn test_stats_cold_storage_enabled() {
+    use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(temp_dir.path().join("wal"))
+                .build(),
+        )
+        .persistence(crate::storage::index_persistence::PersistenceConfig {
+            enabled: false,
+            ..Default::default()
+        })
+        .historical(
+            HistoricalConfigBuilder::new()
+                .enable_cold_storage(true)
+                .cold_storage_path(temp_dir.path().join("cold.redb"))
+                .build(),
+        )
+        .build();
+    let db = AletheiaDB::with_unified_config(config).unwrap();
+
+    let value = serde_json::to_value(db.stats()).unwrap();
+    let cold = value["cold_storage"].as_object().unwrap();
+    assert_eq!(cold["enabled"], serde_json::json!(true));
+    assert_eq!(cold["node_versions_stored"], serde_json::json!(0));
+    assert!(cold["tier_access"].is_object());
+}

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2537,6 +2537,12 @@ fn test_schema_as_of_entity_cap_is_configurable_and_discloses_sampling() {
 /// `AletheiaDB::stats()` must serialize to the documented shape, with
 /// disabled subsystems explicitly tagged (`enabled: false`, no count keys)
 /// and enabled subsystems carrying their counters.
+///
+/// Serialization (`serde::Serialize` on `DatabaseStats`) only exists when
+/// `config-toml` or `mcp-server` is enabled, so this test is gated the same
+/// way; `test_stats_populated_matches_underlying_counters` keeps the
+/// non-serde behavior covered in minimal builds.
+#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
 #[test]
 fn test_stats_serialization_shape_empty_db() {
     let db = AletheiaDB::new().unwrap();
@@ -2591,6 +2597,8 @@ fn test_stats_populated_matches_underlying_counters() {
         stats.historical.total_node_versions,
         hist.total_node_versions
     );
+    // 2 creates + 1 update = exactly 3 node versions.
+    assert_eq!(stats.historical.total_node_versions, 3);
     assert_eq!(stats.historical.unique_nodes, hist.unique_nodes);
     assert_eq!(
         stats.historical.anchor_count,
@@ -2600,10 +2608,25 @@ fn test_stats_populated_matches_underlying_counters() {
         stats.historical.delta_count,
         hist.node_delta_count + hist.edge_delta_count
     );
+    // With the default anchor interval (10), the update after a create is
+    // stored as a delta — the compression machinery must actually engage.
+    assert!(
+        stats.historical.delta_count >= 1,
+        "an update following a create must produce at least one delta, got: {stats:?}"
+    );
+    assert!(
+        stats.historical.compression_ratio < 1.0,
+        "with >= 1 delta the anchor share must drop below 1.0, got: {}",
+        stats.historical.compression_ratio
+    );
 }
 
 /// With cold storage configured, `stats()` reports the cold tier as enabled
 /// with counters and the hot/warm/cold access distribution.
+///
+/// Gated like `test_stats_serialization_shape_empty_db`: the serde derive
+/// this test exercises only exists under `config-toml`/`mcp-server`.
+#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
 #[test]
 fn test_stats_cold_storage_enabled() {
     use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
@@ -2633,4 +2656,64 @@ fn test_stats_cold_storage_enabled() {
     assert_eq!(cold["enabled"], serde_json::json!(true));
     assert_eq!(cold["node_versions_stored"], serde_json::json!(0));
     assert!(cold["tier_access"].is_object());
+}
+
+/// After versions actually migrate to the cold tier, `stats()` must report
+/// them under `cold_storage` (and the hot historical counters must shrink
+/// accordingly) — the enabled-tier path with nonzero counters.
+#[test]
+fn test_stats_cold_storage_reports_migrated_versions() {
+    use crate::storage::migration::{MigrationPolicyBuilder, MigrationService};
+    use crate::storage::redb_cold_storage::RedbColdStorage;
+    use crate::storage::tiered_storage::TieredStorage;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let db = AletheiaDB::new().unwrap();
+    let n1 = db
+        .create_node("Person", PropertyMapBuilder::new().build())
+        .unwrap();
+    db.update_node_with_valid_time(
+        n1,
+        PropertyMapBuilder::new().insert("name", "Alice").build(),
+        None,
+    )
+    .unwrap();
+
+    // Attach a cold tier and migrate everything older than the head version.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cold =
+        Arc::new(RedbColdStorage::with_default_config(temp_dir.path().join("cold.redb")).unwrap());
+    let tiered = Arc::new(TieredStorage::with_default_config(Arc::clone(&cold)));
+    db.__test_historical_storage()
+        .write()
+        .set_tiered_storage(tiered);
+
+    let policy = MigrationPolicyBuilder::new()
+        .age_threshold(Duration::ZERO)
+        .build();
+    let service = MigrationService::new(Arc::clone(&cold), policy);
+    let hot_versions_before = db.stats().historical.total_node_versions;
+    let migrated = db
+        .__test_historical_storage()
+        .write()
+        .migrate_to_cold(&service)
+        .unwrap();
+    assert!(migrated >= 1, "at least the non-head version must migrate");
+
+    let stats = db.stats();
+    assert!(stats.cold_storage.enabled);
+    let details = stats
+        .cold_storage
+        .details
+        .expect("enabled cold storage must carry details");
+    assert_eq!(
+        details.node_versions_stored, migrated as u64,
+        "cold tier must report exactly the migrated versions"
+    );
+    assert_eq!(
+        stats.historical.total_node_versions,
+        hot_versions_before - migrated,
+        "migrated versions must leave the hot historical counters"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,10 @@ pub use core::error::{
     ConstraintError, Error, QueryError, Result, StorageError, TemporalError, TransactionError,
 };
 pub use db::{
-    AletheiaDB, BackupSummary, EdgeTypeSchema, GraphSchema, LabelExtent, LabelSchema,
-    SchemaInstant, SimilarityQuery, SimilaritySource, TemporalExtent, TimeBounds,
-    UniqueConstraintBuilder, VectorIndexBuilder,
+    AletheiaDB, BackupSummary, ColdStorageDetails, ColdStorageTierStats, CurrentStateStats,
+    DatabaseStats, EdgeTypeSchema, GraphSchema, HistoricalDepthStats, LabelExtent, LabelSchema,
+    SchemaInstant, SimilarityQuery, SimilaritySource, TemporalExtent, TierAccessStats, TimeBounds,
+    UniqueConstraintBuilder, VectorIndexBuilder, WalStateStats,
 };
 pub use index::{
     AdjacencyIndex, CurrentIndexes, TemporalIndexes,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -642,6 +642,19 @@ impl AletheiaMcpServer {
         ))
     }
 
+    /// Get a holistic database statistics snapshot.
+    ///
+    /// Returns current graph size, bi-temporal depth (version counts and
+    /// anchor/delta compression), storage-tier presence/distribution
+    /// (hot / warm-cache / cold), and WAL durability state in a single call.
+    /// Thin aggregator over [`AletheiaDB::stats`] — all values are O(1)/cached
+    /// counter reads, never a version scan.
+    pub fn database_stats(&self, req: DatabaseStatsRequest) -> String {
+        Self::extract_text(self.handle_database_stats(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
     /// List graph-wide changes within a transaction-time window.
     ///
     /// Enumerates the nodes and edges whose versions were committed in `[tx_from, tx_to)`,
@@ -2963,6 +2976,35 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Handle the `database_stats` tool (Issue #3222).
+    ///
+    /// Thin aggregator: delegates entirely to the public
+    /// [`AletheiaDB::stats`] snapshot and serializes it — no storage logic
+    /// lives here. The underlying getters are all O(1)/cached (see
+    /// `src/db/stats.rs`), so this never triggers a version scan.
+    fn handle_database_stats(&self, args: serde_json::Value) -> CallToolResult {
+        // The tool takes no required arguments; clients may send no
+        // `arguments` at all (surfaced here as JSON null) or an empty
+        // object. Normalize null so both forms are accepted.
+        let args = if args.is_null() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            args
+        };
+        let _req: DatabaseStatsRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        match serde_json::to_value(self.db.stats()) {
+            Ok(value) => self.success_json(value),
+            Err(e) => self.error_result(McpError::new(
+                McpErrorCode::Internal,
+                format!("Failed to serialize database stats: {}", e),
+            )),
+        }
+    }
+
     fn handle_hybrid_query(&self, args: serde_json::Value) -> CallToolResult {
         let req: HybridQueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -3534,6 +3576,7 @@ impl AletheiaMcpServer {
             "query" => self.handle_query(args),
             "get_schema" => self.handle_get_schema(args),
             "temporal_extent" => self.handle_temporal_extent(args),
+            "database_stats" => self.handle_database_stats(args),
             _ => self.error_result(
                 McpError::new(McpErrorCode::NotFound, format!("Unknown tool: {}", name))
                     .details(json!({ "tool": name })),
@@ -3965,6 +4008,29 @@ fn tool_definitions() -> Vec<Tool> {
              (edge_types); per-label bounds are computed from hot-tier history only and may \
              be narrower than the overall bounds (or a label absent) after cold migration.",
             make_input_schema::<TemporalExtentRequest>(),
+        ),
+        Tool::new(
+            "database_stats",
+            "Get a holistic database statistics snapshot in one call (no arguments). Use it \
+             to orient yourself before querying: how big is the dataset, how much history \
+             exists to time-travel through, where that history lives, and what durability \
+             is active. Returns: `current` {node_count, edge_count} (current-state graph \
+             size); `historical` {total_node_versions, total_edge_versions, unique_nodes, \
+             unique_edges, anchor_count, delta_count, node/edge anchor+delta breakdowns, \
+             compression_ratio} (bi-temporal depth of the in-RAM store; anchors are full \
+             snapshots, deltas are changes — anchor_count + delta_count always equals total \
+             versions, and compression_ratio = anchors/total, lower is better); \
+             `cold_storage` — `{enabled: false}` when no cold (disk) tier is configured \
+             (this means NOT CONFIGURED, never '0 cold versions'), or `{enabled: true, \
+             node_versions_stored, edge_versions_stored, compression_ratio, tier_access: \
+             {hot_hits, warm_hits, cold_hits, misses}}` showing how many versions migrated \
+             to disk and how reads distribute across the hot/warm-cache/cold tiers; `wal` \
+             {enabled, durability_mode (synchronous|async|group_commit|async_batched), \
+             current_lsn (latest log sequence number), total_appends, healthy}. All values \
+             are O(1)/cached counter reads — this call never scans versions and is safe to \
+             call frequently. Counts only, point-in-time: for the calendar RANGE of stored \
+             history use temporal_extent; for per-label breakdowns use get_schema.",
+            make_input_schema::<DatabaseStatsRequest>(),
         ),
     ]
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -655,6 +655,15 @@ impl AletheiaMcpServer {
         ))
     }
 
+    /// Test-only access to the raw `database_stats` handler, bypassing typed
+    /// request construction so tests can exercise wire-level argument edge
+    /// cases (null arguments, non-object arguments, unknown keys) exactly as
+    /// `call_tool` delivers them.
+    #[cfg(test)]
+    pub(crate) fn database_stats_raw(&self, args: serde_json::Value) -> String {
+        Self::extract_text(self.handle_database_stats(args))
+    }
+
     /// List graph-wide changes within a transaction-time window.
     ///
     /// Enumerates the nodes and edges whose versions were committed in `[tx_from, tx_to)`,
@@ -4023,13 +4032,16 @@ fn tool_definitions() -> Vec<Tool> {
              `cold_storage` — `{enabled: false}` when no cold (disk) tier is configured \
              (this means NOT CONFIGURED, never '0 cold versions'), or `{enabled: true, \
              node_versions_stored, edge_versions_stored, compression_ratio, tier_access: \
-             {hot_hits, warm_hits, cold_hits, misses}}` showing how many versions migrated \
-             to disk and how reads distribute across the hot/warm-cache/cold tiers; `wal` \
-             {enabled, durability_mode (synchronous|async|group_commit|async_batched), \
-             current_lsn (latest log sequence number), total_appends, healthy}. All values \
-             are O(1)/cached counter reads — this call never scans versions and is safe to \
-             call frequently. Counts only, point-in-time: for the calendar RANGE of stored \
-             history use temporal_extent; for per-label breakdowns use get_schema.",
+             {hot_hits, warm_hits, cold_hits, misses}}` showing how many versions live on \
+             disk (counts persist across restarts) and how reads distribute across the \
+             hot/warm-cache/cold tiers (compression_ratio and tier_access count activity \
+             since the current process opened the database); `wal` {enabled, \
+             durability_mode (synchronous|async|group_commit|async_batched), current_lsn \
+             (the NEXT log sequence number to be allocated), total_appends, healthy}. All \
+             values are O(1)/cached counter reads — this call never scans versions and is \
+             safe to call frequently. Counts only, point-in-time: for the calendar RANGE \
+             of stored history (earliest/latest timestamps) use temporal_extent; \
+             for per-label breakdowns use get_schema.",
             make_input_schema::<DatabaseStatsRequest>(),
         ),
     ]

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -9051,16 +9051,30 @@ mod database_stats_tests {
         assert!(value.get("wal").is_some());
 
         // A non-object argument value is a malformed request: structured
-        // error, never a panic or silent success.
+        // error (Issue #3234 shape), never a panic or silent success.
         let value: serde_json::Value =
             serde_json::from_str(&server.database_stats_raw(serde_json::json!("bogus")))
                 .expect("invalid args must still yield valid JSON");
         let error = value
             .get("error")
-            .and_then(|e| e.as_str())
-            .expect("non-object arguments must produce an error");
+            .and_then(|e| e.as_object())
+            .expect("non-object arguments must produce a structured error object");
+        assert_eq!(
+            error.get("code").and_then(|c| c.as_str()),
+            Some("INVALID_ARGUMENT"),
+            "malformed arguments must be INVALID_ARGUMENT: {value}"
+        );
+        assert_eq!(
+            error.get("retriable").and_then(|r| r.as_bool()),
+            Some(false),
+            "INVALID_ARGUMENT is never retriable: {value}"
+        );
+        let message = error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .expect("structured error must carry a message");
         assert!(
-            error.contains("Invalid arguments"),
+            message.contains("Invalid arguments"),
             "error must identify the argument problem: {value}"
         );
     }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8852,9 +8852,9 @@ mod database_stats_tests {
         assert_eq!(hist["unique_nodes"], serde_json::json!(2));
         assert_eq!(hist["unique_edges"], serde_json::json!(1));
         let total_node_versions = hist["total_node_versions"].as_u64().unwrap();
-        assert!(
-            total_node_versions >= 3,
-            "2 creates + 1 update must yield >= 3 node versions: {value}"
+        assert_eq!(
+            total_node_versions, 3,
+            "2 creates + 1 update must yield exactly 3 node versions: {value}"
         );
         assert_eq!(hist["total_edge_versions"], serde_json::json!(1));
 
@@ -8868,9 +8868,17 @@ mod database_stats_tests {
             "anchors + deltas must equal total versions: {value}"
         );
         assert!(anchors >= 1, "at least one anchor expected: {value}");
+        // With the default anchor interval (10), the update after a create is
+        // stored as a delta: the anchor/delta split must actually engage, and
+        // the anchor share must therefore drop below 1.0.
         assert!(
-            hist["compression_ratio"].as_f64().unwrap() > 0.0,
-            "compression_ratio must be present and positive: {value}"
+            deltas >= 1,
+            "an update following a create must be stored as a delta: {value}"
+        );
+        let ratio = hist["compression_ratio"].as_f64().unwrap();
+        assert!(
+            ratio > 0.0 && ratio < 1.0,
+            "compression_ratio must be in (0.0, 1.0) once a delta exists: {value}"
         );
     }
 
@@ -8944,8 +8952,8 @@ mod database_stats_tests {
         }
     }
 
-    /// AC5 (WAL state): durability mode is a stable token and the latest LSN
-    /// is reported and advances with writes.
+    /// AC5 (WAL state): durability mode is a stable token and the
+    /// next-to-be-allocated LSN is reported and advances with writes.
     #[test]
     fn test_database_stats_wal_state_reported() {
         let server = create_test_server();
@@ -9006,6 +9014,229 @@ mod database_stats_tests {
         assert_eq!(
             value, api_value,
             "MCP response must be exactly the serialized public DatabaseStats"
+        );
+    }
+
+    /// Wire-level argument handling: `call_tool` delivers missing arguments
+    /// as JSON null, and clients may also send an empty object or extra
+    /// unknown keys — all must succeed. A non-object argument value must be
+    /// rejected with a structured error, not a panic.
+    #[test]
+    fn test_database_stats_raw_argument_edge_cases() {
+        let server = create_test_server();
+
+        // No `arguments` at all (call_tool surfaces this as null).
+        let value: serde_json::Value =
+            serde_json::from_str(&server.database_stats_raw(serde_json::Value::Null))
+                .expect("null args must yield valid JSON");
+        assert!(
+            value.get("error").is_none(),
+            "null arguments must succeed: {value}"
+        );
+        assert!(value.get("current").is_some());
+
+        // Empty object.
+        let value: serde_json::Value =
+            serde_json::from_str(&server.database_stats_raw(serde_json::json!({})))
+                .expect("empty-object args must yield valid JSON");
+        assert!(
+            value.get("error").is_none(),
+            "empty-object arguments must succeed: {value}"
+        );
+
+        // Unknown keys are tolerated (the request struct is not
+        // deny_unknown_fields), so a slightly-wrong client still gets stats.
+        let value: serde_json::Value =
+            serde_json::from_str(&server.database_stats_raw(serde_json::json!({"unexpected": 1})))
+                .expect("unknown-key args must yield valid JSON");
+        assert!(
+            value.get("error").is_none(),
+            "unknown keys must be tolerated: {value}"
+        );
+        assert!(value.get("wal").is_some());
+
+        // A non-object argument value is a malformed request: structured
+        // error, never a panic or silent success.
+        let value: serde_json::Value =
+            serde_json::from_str(&server.database_stats_raw(serde_json::json!("bogus")))
+                .expect("invalid args must still yield valid JSON");
+        let error = value
+            .get("error")
+            .and_then(|e| e.as_str())
+            .expect("non-object arguments must produce an error");
+        assert!(
+            error.contains("Invalid arguments"),
+            "error must identify the argument problem: {value}"
+        );
+    }
+
+    /// Schema contract: the exact key sets of every response object are
+    /// load-bearing for MCP consumers — a renamed or dropped key is a
+    /// breaking change that must fail this test.
+    #[test]
+    fn test_database_stats_key_sets_are_stable() {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+
+        fn keys(value: &serde_json::Value) -> Vec<&str> {
+            let mut keys: Vec<&str> = value
+                .as_object()
+                .expect("expected a JSON object")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            keys.sort_unstable();
+            keys
+        }
+
+        // Cold-enabled server so the flattened details keys are present too.
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(temp_dir.path().join("wal"))
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: false,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(temp_dir.path().join("cold.redb"))
+                    .build(),
+            )
+            .build();
+        let db = Arc::new(AletheiaDB::with_unified_config(config).expect("db init"));
+        let server = AletheiaMcpServer::new(db);
+
+        let value = stats_response(&server);
+        assert_eq!(
+            keys(&value),
+            vec!["cold_storage", "current", "historical", "wal"]
+        );
+        assert_eq!(keys(&value["current"]), vec!["edge_count", "node_count"]);
+        assert_eq!(
+            keys(&value["historical"]),
+            vec![
+                "anchor_count",
+                "compression_ratio",
+                "delta_count",
+                "edge_anchor_count",
+                "edge_delta_count",
+                "node_anchor_count",
+                "node_delta_count",
+                "total_edge_versions",
+                "total_node_versions",
+                "unique_edges",
+                "unique_nodes",
+            ]
+        );
+        assert_eq!(
+            keys(&value["cold_storage"]),
+            vec![
+                "compression_ratio",
+                "edge_versions_stored",
+                "enabled",
+                "node_versions_stored",
+                "tier_access",
+            ]
+        );
+        assert_eq!(
+            keys(&value["cold_storage"]["tier_access"]),
+            vec!["cold_hits", "hot_hits", "misses", "warm_hits"]
+        );
+        assert_eq!(
+            keys(&value["wal"]),
+            vec![
+                "current_lsn",
+                "durability_mode",
+                "enabled",
+                "healthy",
+                "total_appends",
+            ]
+        );
+    }
+
+    /// Deletions through the MCP surface must be reflected coherently:
+    /// current-state counts shrink, while the bi-temporal record (unique
+    /// entities and their versions) is retained and grows — a delete is a
+    /// recorded change, not an erasure.
+    #[test]
+    fn test_database_stats_reflects_deletions() {
+        let server = create_test_server();
+
+        let (a, b) = {
+            let a: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Person".to_string(),
+                properties: None,
+                provenance: None,
+            }))
+            .unwrap();
+            let b: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Person".to_string(),
+                properties: None,
+                provenance: None,
+            }))
+            .unwrap();
+            (a.id, b.id)
+        };
+        let edge: EdgeResponse = parse_response(&server.create_edge(CreateEdgeRequest {
+            valid_time: None,
+            source_id: a,
+            target_id: b,
+            label: "KNOWS".to_string(),
+            properties: None,
+            provenance: None,
+        }))
+        .unwrap();
+
+        let before = stats_response(&server);
+        assert_eq!(before["current"]["node_count"], serde_json::json!(2));
+        assert_eq!(before["current"]["edge_count"], serde_json::json!(1));
+        let node_versions_before = before["historical"]["total_node_versions"]
+            .as_u64()
+            .unwrap();
+        let edge_versions_before = before["historical"]["total_edge_versions"]
+            .as_u64()
+            .unwrap();
+
+        // Delete the edge, then node `a` (now unconnected).
+        let del_edge: serde_json::Value =
+            serde_json::from_str(&server.delete_edge(DeleteEdgeRequest {
+                edge_id: edge.id,
+                valid_time: None,
+            }))
+            .unwrap();
+        assert_eq!(del_edge.get("success"), Some(&serde_json::json!(true)));
+        let del_node: serde_json::Value =
+            serde_json::from_str(&server.delete_node(DeleteNodeRequest {
+                node_id: a,
+                detach: None,
+                valid_time: None,
+            }))
+            .unwrap();
+        assert_eq!(del_node.get("success"), Some(&serde_json::json!(true)));
+
+        let after = stats_response(&server);
+        assert_eq!(after["current"]["node_count"], serde_json::json!(1));
+        assert_eq!(after["current"]["edge_count"], serde_json::json!(0));
+
+        // The bi-temporal record is retained: both nodes and the edge still
+        // have history, and the deletions were recorded as new versions.
+        assert_eq!(after["historical"]["unique_nodes"], serde_json::json!(2));
+        assert_eq!(after["historical"]["unique_edges"], serde_json::json!(1));
+        assert!(
+            after["historical"]["total_node_versions"].as_u64().unwrap() > node_versions_before,
+            "a node deletion must be recorded as a version, not an erasure: \
+             before={node_versions_before}, after={after}"
+        );
+        assert!(
+            after["historical"]["total_edge_versions"].as_u64().unwrap() > edge_versions_before,
+            "an edge deletion must be recorded as a version, not an erasure: \
+             before={edge_versions_before}, after={after}"
         );
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8759,3 +8759,253 @@ mod temporal_extent_tests {
         assert_eq!(labels[0]["label"], serde_json::json!("Person"));
     }
 }
+
+// ============================================================================
+// Database Stats Tests (Issue #3222)
+// ============================================================================
+
+mod database_stats_tests {
+    use super::*;
+
+    fn stats_response(server: &AletheiaMcpServer) -> serde_json::Value {
+        let response = server.database_stats(DatabaseStatsRequest {});
+        serde_json::from_str(&response).expect("database_stats must return valid JSON")
+    }
+
+    /// AC1 + AC9 (empty DB well-formed): the tool takes no required arguments
+    /// and returns a single well-formed JSON object even on an empty database.
+    #[test]
+    fn test_database_stats_empty_db_well_formed() {
+        let server = create_test_server();
+        let value = stats_response(&server);
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        assert_eq!(value["current"]["node_count"], serde_json::json!(0));
+        assert_eq!(value["current"]["edge_count"], serde_json::json!(0));
+        assert_eq!(
+            value["historical"]["total_node_versions"],
+            serde_json::json!(0)
+        );
+        assert_eq!(
+            value["historical"]["total_edge_versions"],
+            serde_json::json!(0)
+        );
+        assert_eq!(value["historical"]["unique_nodes"], serde_json::json!(0));
+        assert_eq!(value["historical"]["unique_edges"], serde_json::json!(0));
+        assert_eq!(value["historical"]["anchor_count"], serde_json::json!(0));
+        assert_eq!(value["historical"]["delta_count"], serde_json::json!(0));
+        // Disabled subsystems must be tagged, never zero-reported (AC7).
+        assert_eq!(value["cold_storage"]["enabled"], serde_json::json!(false));
+        assert_eq!(value["wal"]["enabled"], serde_json::json!(true));
+    }
+
+    /// AC3 + AC9 (populated DB shape): counts reflect data, version counters
+    /// track updates, and anchors + deltas always sum to the version totals.
+    #[test]
+    fn test_database_stats_populated_db_shape() {
+        let server = create_test_server();
+
+        let (a, b) = {
+            let a: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Person".to_string(),
+                properties: None,
+                provenance: None,
+            }))
+            .unwrap();
+            let b: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+                valid_time: None,
+                label: "Person".to_string(),
+                properties: None,
+                provenance: None,
+            }))
+            .unwrap();
+            (a.id, b.id)
+        };
+        server.create_edge(CreateEdgeRequest {
+            valid_time: None,
+            source_id: a,
+            target_id: b,
+            label: "KNOWS".to_string(),
+            properties: None,
+            provenance: None,
+        });
+        // An update creates an extra node version beyond the creates.
+        server.update_node(UpdateNodeRequest {
+            valid_time: None,
+            node_id: a,
+            properties: {
+                let mut m = HashMap::new();
+                m.insert("name".to_string(), serde_json::json!("Alice"));
+                m
+            },
+            provenance: None,
+        });
+
+        let value = stats_response(&server);
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+
+        assert_eq!(value["current"]["node_count"], serde_json::json!(2));
+        assert_eq!(value["current"]["edge_count"], serde_json::json!(1));
+
+        let hist = &value["historical"];
+        assert_eq!(hist["unique_nodes"], serde_json::json!(2));
+        assert_eq!(hist["unique_edges"], serde_json::json!(1));
+        let total_node_versions = hist["total_node_versions"].as_u64().unwrap();
+        assert!(
+            total_node_versions >= 3,
+            "2 creates + 1 update must yield >= 3 node versions: {value}"
+        );
+        assert_eq!(hist["total_edge_versions"], serde_json::json!(1));
+
+        // Compression accounting must be internally consistent.
+        let anchors = hist["anchor_count"].as_u64().unwrap();
+        let deltas = hist["delta_count"].as_u64().unwrap();
+        let total_versions = total_node_versions + hist["total_edge_versions"].as_u64().unwrap();
+        assert_eq!(
+            anchors + deltas,
+            total_versions,
+            "anchors + deltas must equal total versions: {value}"
+        );
+        assert!(anchors >= 1, "at least one anchor expected: {value}");
+        assert!(
+            hist["compression_ratio"].as_f64().unwrap() > 0.0,
+            "compression_ratio must be present and positive: {value}"
+        );
+    }
+
+    /// AC4 + AC7 + AC9 (disabled tier tagged): a database without cold
+    /// storage must report `cold_storage: {"enabled": false}` with NO count
+    /// fields, so an LLM can never mistake "disabled" for "0 cold versions".
+    #[test]
+    fn test_database_stats_cold_storage_disabled_is_tagged_not_zero() {
+        let server = create_test_server();
+        let value = stats_response(&server);
+
+        let cold = value["cold_storage"]
+            .as_object()
+            .expect("cold_storage must always be present as an object");
+        assert_eq!(cold["enabled"], serde_json::json!(false));
+        assert!(
+            !cold.contains_key("node_versions_stored"),
+            "disabled tier must not report counts: {value}"
+        );
+        assert!(
+            !cold.contains_key("tier_access"),
+            "disabled tier must not report tier distribution: {value}"
+        );
+    }
+
+    /// AC4 (enabled tier reports distribution): with cold storage configured,
+    /// the snapshot reports cold counts and the hot/warm/cold access
+    /// distribution.
+    #[test]
+    fn test_database_stats_cold_storage_enabled_reports_tiers() {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder, WalConfigBuilder};
+
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(temp_dir.path().join("wal"))
+                    .build(),
+            )
+            .persistence(crate::storage::index_persistence::PersistenceConfig {
+                enabled: false,
+                ..Default::default()
+            })
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .enable_cold_storage(true)
+                    .cold_storage_path(temp_dir.path().join("cold.redb"))
+                    .build(),
+            )
+            .build();
+        let db = Arc::new(AletheiaDB::with_unified_config(config).expect("db init"));
+        let server = AletheiaMcpServer::new(db);
+
+        let value = stats_response(&server);
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+
+        let cold = value["cold_storage"]
+            .as_object()
+            .expect("cold_storage must be an object");
+        assert_eq!(cold["enabled"], serde_json::json!(true));
+        assert_eq!(cold["node_versions_stored"], serde_json::json!(0));
+        assert_eq!(cold["edge_versions_stored"], serde_json::json!(0));
+        let tier_access = cold["tier_access"]
+            .as_object()
+            .expect("enabled cold storage must report tier_access distribution");
+        for key in ["hot_hits", "warm_hits", "cold_hits", "misses"] {
+            assert!(
+                tier_access.contains_key(key),
+                "tier_access must contain {key}: {value}"
+            );
+        }
+    }
+
+    /// AC5 (WAL state): durability mode is a stable token and the latest LSN
+    /// is reported and advances with writes.
+    #[test]
+    fn test_database_stats_wal_state_reported() {
+        let server = create_test_server();
+        let value = stats_response(&server);
+
+        let wal = value["wal"].as_object().expect("wal must be an object");
+        assert_eq!(wal["enabled"], serde_json::json!(true));
+        let mode = wal["durability_mode"].as_str().unwrap();
+        assert!(
+            ["synchronous", "async", "group_commit", "async_batched"].contains(&mode),
+            "durability_mode must be a stable token, got: {mode}"
+        );
+        let lsn_before = wal["current_lsn"].as_u64().unwrap();
+        assert!(lsn_before >= 1, "LSN starts at 1: {value}");
+
+        server.create_node(CreateNodeRequest {
+            valid_time: None,
+            label: "Person".to_string(),
+            properties: None,
+            provenance: None,
+        });
+
+        let value_after = stats_response(&server);
+        let lsn_after = value_after["wal"]["current_lsn"].as_u64().unwrap();
+        assert!(
+            lsn_after > lsn_before,
+            "LSN must advance after a write: {lsn_before} -> {lsn_after}"
+        );
+        assert!(value_after["wal"]["healthy"].as_bool().unwrap());
+    }
+
+    /// AC1: the tool is advertised in the MCP tool list.
+    #[test]
+    fn test_database_stats_registered_in_tool_list() {
+        let server = create_test_server();
+        let tools = server.list_tools_for_test();
+        assert!(
+            tools.iter().any(|t| t == "database_stats"),
+            "database_stats must be advertised: {tools:?}"
+        );
+    }
+
+    /// AC2: the MCP tool is a thin aggregator over the public API — both
+    /// surfaces must report identical numbers on the same database.
+    #[test]
+    fn test_database_stats_matches_public_api() {
+        let server = create_test_server();
+        server.create_node(CreateNodeRequest {
+            valid_time: None,
+            label: "Person".to_string(),
+            properties: None,
+            provenance: None,
+        });
+
+        let value = stats_response(&server);
+        let api_stats = server.db().stats();
+        let api_value = serde_json::to_value(&api_stats).expect("DatabaseStats must serialize");
+        assert_eq!(
+            value, api_value,
+            "MCP response must be exactly the serialized public DatabaseStats"
+        );
+    }
+}

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8890,17 +8890,12 @@ mod database_stats_tests {
         let server = create_test_server();
         let value = stats_response(&server);
 
-        let cold = value["cold_storage"]
-            .as_object()
-            .expect("cold_storage must always be present as an object");
-        assert_eq!(cold["enabled"], serde_json::json!(false));
-        assert!(
-            !cold.contains_key("node_versions_stored"),
-            "disabled tier must not report counts: {value}"
-        );
-        assert!(
-            !cold.contains_key("tier_access"),
-            "disabled tier must not report tier distribution: {value}"
+        // Exact shape: no counts, no tier distribution, no extra keys --
+        // anything beyond the tag could be mistaken for real (zero) data.
+        assert_eq!(
+            value["cold_storage"],
+            serde_json::json!({"enabled": false}),
+            "disabled cold_storage must be exactly {{\"enabled\": false}}: {value}"
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -916,6 +916,17 @@ pub struct TemporalExtentRequest {
 }
 
 // ============================================================================
+// Database Stats (Issue #3222)
+// ============================================================================
+
+/// Request for a holistic database statistics snapshot.
+///
+/// Takes no arguments — the tool always returns the full snapshot in a
+/// single call.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct DatabaseStatsRequest {}
+
+// ============================================================================
 // Response Types (for serialization)
 // ============================================================================
 

--- a/src/storage/redb_cold_storage/mod.rs
+++ b/src/storage/redb_cold_storage/mod.rs
@@ -56,7 +56,7 @@ use crate::core::id::VersionId;
 use crate::core::version::{EdgeVersion, EntityVersion, NodeVersion};
 use crate::storage::wal::LSN;
 use rayon::prelude::*;
-use redb::{ReadableDatabase, ReadableTable, TableHandle};
+use redb::{ReadableDatabase, ReadableTable, ReadableTableMetadata, TableHandle};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -214,9 +214,11 @@ impl Default for ColdStorageConfig {
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct ColdStorageStats {
-    /// Total number of node versions stored.
+    /// Total number of node versions stored. Seeded from the persisted table
+    /// length when an existing database is opened, then incremented per store.
     pub node_versions_stored: u64,
-    /// Total number of edge versions stored.
+    /// Total number of edge versions stored. Seeded from the persisted table
+    /// length when an existing database is opened, then incremented per store.
     pub edge_versions_stored: u64,
     /// Total number of node version reads.
     pub node_version_reads: u64,
@@ -241,6 +243,10 @@ impl ColdStorageStats {
     ///
     /// This helps monitor the effectiveness of the chosen compression algorithm
     /// in the cold storage tier. A higher ratio indicates better compression.
+    ///
+    /// The underlying byte counters are not persisted, so this ratio covers
+    /// writes made since the storage was opened (1.0 when nothing has been
+    /// written yet by this process).
     ///
     /// ## Examples
     ///
@@ -556,6 +562,13 @@ impl RedbColdStorage {
     ///
     /// If the parent directories do not exist, this method will attempt to create them.
     ///
+    /// When opening an existing database, the `node_versions_stored` and
+    /// `edge_versions_stored` statistics counters are seeded from the
+    /// persisted table lengths (an O(1) metadata read), so
+    /// [`stats`](Self::stats) reflects the full on-disk history rather than
+    /// only writes made by the current process. Byte and read counters are
+    /// not persisted and always start at zero.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -586,26 +599,51 @@ impl RedbColdStorage {
             .begin_write()
             .map_err(map_transaction_error("Failed to begin write transaction"))?;
 
-        // Open tables to create them
-        write_txn
-            .open_table(NODE_VERSIONS_TABLE)
-            .map_err(map_table_error("Failed to create node_versions table"))?;
-        write_txn
-            .open_table(EDGE_VERSIONS_TABLE)
-            .map_err(map_table_error("Failed to create edge_versions table"))?;
-        write_txn
-            .open_table(METADATA_TABLE)
-            .map_err(map_table_error("Failed to create metadata table"))?;
+        // Open tables to create them, and read their persisted entry counts so
+        // the version counters can be seeded below. `Table::len()` is an O(1)
+        // read of the B-tree root's cached length — no scan.
+        let (persisted_node_versions, persisted_edge_versions) = {
+            let node_table = write_txn
+                .open_table(NODE_VERSIONS_TABLE)
+                .map_err(map_table_error("Failed to create node_versions table"))?;
+            let edge_table = write_txn
+                .open_table(EDGE_VERSIONS_TABLE)
+                .map_err(map_table_error("Failed to create edge_versions table"))?;
+            write_txn
+                .open_table(METADATA_TABLE)
+                .map_err(map_table_error("Failed to create metadata table"))?;
+            (
+                node_table
+                    .len()
+                    .map_err(map_storage_error("Failed to read node_versions length"))?,
+                edge_table
+                    .len()
+                    .map_err(map_storage_error("Failed to read edge_versions length"))?,
+            )
+        };
 
         write_txn
             .commit()
             .map_err(map_commit_error("Failed to commit table creation"))?;
 
+        // Seed the version counters from the persisted tables so a reopened
+        // database reports its full cold history instead of misleading zeros
+        // (Issue #3222). Byte counters (raw/compressed) are not recoverable
+        // from table metadata, so `compression_ratio()` and the read counters
+        // remain since-process-start.
+        let stats = AtomicColdStorageStats::new();
+        stats
+            .node_versions_stored
+            .store(persisted_node_versions, Ordering::Relaxed);
+        stats
+            .edge_versions_stored
+            .store(persisted_edge_versions, Ordering::Relaxed);
+
         Ok(Self {
             path,
             db,
             config,
-            stats: AtomicColdStorageStats::new(),
+            stats,
             cipher: None,
             #[cfg(test)]
             fail_writes: AtomicBool::new(false),

--- a/src/storage/redb_cold_storage/tests.rs
+++ b/src/storage/redb_cold_storage/tests.rs
@@ -2282,3 +2282,53 @@ fn test_no_cipher_backward_compatible() {
 
     assert_eq!(loaded.version_id(), version.version_id());
 }
+
+// ========================================================================
+// Version-counter seeding at open (Issue #3222 review follow-up)
+// ========================================================================
+
+/// Reopening an existing cold store must seed `node_versions_stored` /
+/// `edge_versions_stored` from the persisted tables — a restarted process
+/// must never report `0` cold versions over a database that holds history.
+#[test]
+fn test_stats_version_counters_seeded_on_reopen() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("reopen.redb");
+
+    {
+        let storage = RedbColdStorage::with_default_config(&db_path).unwrap();
+        for i in 1..=3 {
+            storage
+                .store_node_version(&create_test_node_version(i))
+                .unwrap();
+        }
+        storage
+            .store_edge_version(&create_test_edge_version(10))
+            .unwrap();
+
+        let stats = storage.stats();
+        assert_eq!(stats.node_versions_stored, 3);
+        assert_eq!(stats.edge_versions_stored, 1);
+    } // drop: close the database
+
+    let reopened = RedbColdStorage::with_default_config(&db_path).unwrap();
+    let stats = reopened.stats();
+    assert_eq!(
+        stats.node_versions_stored, 3,
+        "reopened store must report persisted node versions, not 0"
+    );
+    assert_eq!(
+        stats.edge_versions_stored, 1,
+        "reopened store must report persisted edge versions, not 0"
+    );
+    // Byte counters are process-lifetime (not persisted): the ratio is 1.0
+    // until this process writes something.
+    assert_eq!(stats.bytes_written_raw, 0);
+    assert_eq!(stats.compression_ratio(), 1.0);
+
+    // Storing more versions on the reopened handle continues from the seed.
+    reopened
+        .store_node_version(&create_test_node_version(4))
+        .unwrap();
+    assert_eq!(reopened.stats().node_versions_stored, 4);
+}


### PR DESCRIPTION
# Expose database stats and storage-tier health via MCP + API

Closes #3222

## Before / After

**Before:** An LLM (or ops operator) driving AletheiaDB through the MCP server could only learn `count_nodes` + `count_edges` — two calls that still reveal nothing about temporal depth ("is there history to time-travel through?"), storage-tier distribution ("is cold migration even on?"), or WAL durability state. All of this data was already computed internally but unreachable.

**After:** A single no-argument MCP call `database_stats` (backed by the new public `AletheiaDB::stats()` returning a serializable `DatabaseStats`) returns the full snapshot: current graph size, bi-temporal version depth with anchor/delta compression effectiveness, hot/warm-cache/cold tier presence and read distribution, and WAL state (durability mode token + the next-to-be-allocated LSN). Disabled subsystems are explicitly tagged — `cold_storage: {"enabled": false}` with count fields structurally absent — so a consumer can never mistake "not configured" for "0 cold versions".

## How

- **`src/db/stats.rs` (new):** `DatabaseStats` + substructs (`CurrentStateStats`, `HistoricalDepthStats`, `ColdStorageTierStats` with serde-flattened `Option`, `TierAccessStats`, `WalStateStats`), all doc-commented with per-field O(1)/cached provenance, and `AletheiaDB::stats()`. All seven structs are `#[non_exhaustive]` so future fields are not breaking changes for downstream matchers/constructors.
  - **O(1) by construction:** only calls existing cached getters — `CurrentStorage::node_count/edge_count` (index-length reads), `HistoricalStorage::stats()` (cached counters per Issue #212, explicitly "O(1) … instead of iterating through all versions"), `TieredStorage::metrics()`/`RedbColdStorage::stats()` (atomic snapshots), and WAL atomics (`current_lsn`, `total_appends`, `is_healthy`) plus a `durability_mode` field copy. No version scan anywhere; comfortably meets the <5ms success metric.
  - **Lock order respected:** WAL fields (order #2, lock-free) are read before the `historical` read guard (order #3), which is held only to snapshot counters and clone the tiered-storage handle; tiered/cold counters are read after the guard is dropped via `tiered_storage_arc()` (the accessor that exists precisely for post-guard access). No adjacency/ID-generator locks touched.
  - **Stable durability token:** `synchronous | async | group_commit | async_batched` via an explicit match (not `Debug` formatting), so the contract can't drift with variant fields.
  - **WAL `enabled` flag:** AletheiaDB has no no-WAL construction path today, so it is always `true`; the flag is still emitted explicitly so the schema contract covers a future no-WAL build and a consumer never infers WAL presence.
- **Cold-tier counters survive restarts (`src/storage/redb_cold_storage/mod.rs`):** `RedbColdStorage::new()` now seeds `node_versions_stored` / `edge_versions_stored` from the persisted redb table lengths at open — an O(1) B-tree-root metadata read (`Table::len()` reads the cached root length, no scan). A restarted process therefore reports its full on-disk cold history instead of misleading zeros. Byte counters (raw/compressed) and tier-access counters are not recoverable from table metadata, so `compression_ratio` and `tier_access` are documented as since-process-start (ratio is `1.0` until the process writes).
- **MCP surface (`src/mcp/`):** `DatabaseStatsRequest` (empty schema), `handle_database_stats` — a thin aggregator (normalize null args, parse, `serde_json::to_value(self.db.stats())`, `success_json`), tool registration in `tool_definitions()` with a field-semantics description an LLM can act on without reading source, and the `call_tool` dispatch arm. After the rebase onto trunk (which merged #3234 via PR #3342), error paths use the typed `McpError` helpers in `src/mcp/error.rs`: invalid arguments return a structured `INVALID_ARGUMENT` error with `retriable: false`, and serialization failure maps to `Internal`; the argument-edge-case test pins the structured error shape. No timestamp-range fields (calendar range is #3238 `temporal_extent`'s scope).
- **Docs:** new "Database stats and storage-tier health (`database_stats`)" section in `docs/guides/mcp-query-tool.md` (annotated response shape, disabled-tier contract, restart/seeding semantics, O(1) note, the two different `compression_ratio` semantics, scope boundary vs `get_schema`); CLAUDE.md MCP tool table row + summary paragraph (clarifies `historical` counts are the **in-RAM** depth; cold-migrated versions are counted under `cold_storage`).
- **Feature flags:** `serde::Serialize` derives are gated on `any(feature = "config-toml", feature = "mcp-server")` (the serde-enabling features of both consumers), so `just check-features` cohorts still compile standalone; serde-dependent tests carry the same gate.

## Approaches considered

1. **Flat `DatabaseStats`** (one level, ~20 fields) — simplest, but disabled-subsystem tagging degenerates into top-level `Option` soup and field provenance becomes illegible to an LLM.
2. **Nested struct-of-substructs with `enabled` + serde-flattened `Option` (chosen)** — mirrors the architecture (hot / warm+cold / WAL), makes "disabled ≠ zero" a type-level guarantee, keeps the MCP handler a 5-line serializer over a reusable public API.
3. **Build `serde_json::Value` directly in the MCP handler** — least code, but violates the AC that a public serializable `DatabaseStats` backs the tool, and puts logic in the wrong layer.

For the restart-visibility fix, seeding at open (chosen) was preferred over reading `table.len()` on every `stats()` call: both are O(1), but seeding keeps `stats()` a pure atomic snapshot with no redb transaction, and keeps the counter meaningful between calls (migration deltas remain observable).

## Review follow-ups (second commit, 9f6aa0d)

- **M1 — cold counters after restart:** seed `node_versions_stored`/`edge_versions_stored` from persisted table lengths in `RedbColdStorage::new()`; re-documented `compression_ratio`/`tier_access` as process-lifetime (rustdoc + guide + tool description).
- **M2 — compression assertions:** populated-DB tests now require `delta_count >= 1` and `compression_ratio < 1.0` (the update-after-create is deterministically a delta at the default anchor interval of 10), plus exact version counts (2 creates + 1 update == 3 node versions).
- **M3 — wire-level argument handling:** test-only `database_stats_raw()` accessor + tests for null arguments (as `call_tool` delivers them), empty object, unknown keys (tolerated), and non-object arguments (structured `Invalid arguments` error).
- **N1:** serde-dependent db-level stats tests gated on `any(config-toml, mcp-server)` so `--no-default-features` test builds aren't broken by this PR.
- **N2:** `current_lsn` consistently documented as the **next** LSN to be allocated (rustdoc, tool description, guide, PR body).
- **N3:** `#[non_exhaustive]` on all seven stats structs.
- **N4:** docs clarify `historical` counts are in-RAM depth (cold-migrated versions counted under `cold_storage`).
- **N5:** scope wording for calendar range now points at `temporal_extent` (Issue #3238, since merged to trunk and picked up in the rebase), which reports the earliest/latest timestamps directly.
- **N7:** key-set stability test pins the exact JSON keys of every response object (rename/drop = test failure).
- **N8:** deletion-coherence test (current counts shrink; unique entities and version history are retained and grow — deletes are recorded, not erased).
- **N9:** db-level test drives a real `migrate_to_cold()` and asserts the migrated versions appear under `cold_storage` and leave the hot counters.
- **N10:** `u64::MAX` WAL counters survive JSON round-trip without precision loss.

## Tests

- `src/db/tests.rs`: `test_stats_serialization_shape_empty_db` (empty DB well-formed; disabled tier tagged), `test_stats_populated_matches_underlying_counters` (parity with `HistoricalStats` cached counters + exact counts + delta/ratio assertions), `test_stats_cold_storage_enabled` (enabled tier reports counters + `tier_access`), `test_stats_cold_storage_reports_migrated_versions` (real migration reflected in cold counters).
- `src/db/stats.rs`: `durability_mode_tokens_are_stable`, `disabled_cold_storage_serializes_without_count_fields` (serializes as exactly `{"enabled": false}`), `wal_stats_u64_max_survives_json_round_trip`.
- `src/storage/redb_cold_storage/tests.rs`: `test_stats_version_counters_seeded_on_reopen` (persisted counts visible after reopen; byte counters process-lifetime; post-reopen stores continue from the seed).
- `src/mcp/tests.rs` (`database_stats_tests`): `test_database_stats_empty_db_well_formed`, `test_database_stats_populated_db_shape` (anchors + deltas == total versions; delta engaged; ratio in (0,1)), `test_database_stats_cold_storage_disabled_is_tagged_not_zero`, `test_database_stats_cold_storage_enabled_reports_tiers`, `test_database_stats_wal_state_reported` (stable mode token; LSN advances after a write), `test_database_stats_registered_in_tool_list`, `test_database_stats_matches_public_api` (MCP response == serialized public `DatabaseStats`), `test_database_stats_raw_argument_edge_cases`, `test_database_stats_key_sets_are_stable`, `test_database_stats_reflects_deletions`.

**Gates (re-run after review follow-ups, commit 9f6aa0d):**

- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo test --features mcp-server --no-fail-fast` — lib suite `3550 passed; 0 failed; 2 ignored` (of 3552); doc-tests `410 passed; 0 failed; 111 ignored`; all test targets combined `4945 passed; 2 failed`. The 2 failures are the same two pre-existing I/O fault-injection failures documented at PR creation (`havoc::…::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`); `test_flush_deadlock_on_io_error` was re-verified to fail identically on the unmodified base commit in this environment (tests run as root, so chmod-based read-only-directory fault injection cannot trigger I/O errors). Unrelated to this change.
- `cargo check --no-default-features --tests` — the stats tests added by this PR now compile under this configuration (N1). The build as a whole still fails, but only in `src/core/provenance.rs` (ungated `serde` derives) — a pre-existing trunk issue from #3312, untouched by this PR.

**Rebase onto trunk @ 8b7b2ff (2026-07-08):** picked up #3341 (`temporal_extent`, Issue #3238) and #3345 (provenance serde gating — the `--no-default-features` issue noted above is now fixed on trunk). Conflicts in the MCP tool registry/dispatch, tests, and docs were resolved additively (both `temporal_extent` and `database_stats` retained); the `database_stats` tool description and guide scope note now point at `temporal_extent` for the calendar range of stored history. Gates re-run post-rebase: clippy clean, fmt clean, `cargo test --features mcp-server --lib` `3610 passed; 0 failed; 2 ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZwfbrGyAtHA9NcrPoKRKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZwfbrGyAtHA9NcrPoKRKb)_