### PR TITLE
Expose queryable bi-temporal extent via temporal_extent MCP tool (Issue #3238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Queryable bi-temporal extent (Issue #3238):
+  `AletheiaDB::temporal_extent()` / `temporal_extent_by_label()` and the MCP
+  `temporal_extent` tool report the dataset's earliest/latest valid-time and
+  transaction-time coordinates across recorded history — including
+  expired/superseded versions and delete tombstones — so a caller (notably
+  an LLM over MCP) can calibrate `AS OF` queries to land inside real data.
+  Overall bounds are O(1) reads of an aggregate the temporal indexes
+  maintain at write time and only ever widen while the process runs; an
+  empty database returns explicit `null`s/`None`s, never epoch 0. Optional
+  `by_label: true` adds per-node-label / per-edge-type bounds folded from
+  hot-tier history. Known limitation: on databases with cold-storage
+  migration, versions migrated to the cold tier before the last restart are
+  not reflected (the indexes rebuild from hot-tier versions at startup).
+
 - Valid-time writes on the convenience API and MCP tools (Issue #3221):
   `AletheiaDB::create_node_with_valid_time`, `create_edge_with_valid_time`,
   `update_node_with_valid_time`, `update_edge_with_valid_time`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ cargo run --bin aletheia-mcp --features mcp-server
 | **Edges** | `get_edge`, `create_edge`, `update_edge`, `delete_edge`, `get_outgoing_edges`, `get_incoming_edges` |
 | **Traversal** | `traverse` (multi-hop graph traversal; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
 | **Vector** | `find_similar`, `enable_vector_index`, `list_vector_indexes` |
-| **Temporal** | `get_node_at_time`, `get_edge_at_time`, `temporal_extent` (dataset's queryable bi-temporal extent — earliest/latest valid-time and transaction-time bounds as RFC3339, explicit `null`s on an empty DB; optional `by_label: true` for per-label/per-edge-type bounds; covers all recorded history incl. expired/superseded versions) |
+| **Temporal** | `get_node_at_time`, `get_edge_at_time`, `temporal_extent` (dataset's queryable bi-temporal extent; optional by_label breakdown) |
 | **Hybrid** | `hybrid_query` (combined graph + vector + temporal) |
 | **Query** | `query` (execute a single read-only Cypher/AQL statement; see below) |
 | **Schema** | `get_schema` (node labels, edge types, and property keys, each with counts; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
@@ -394,6 +394,22 @@ not affect `find_similar`'s `score` or `hybrid_query`'s `similarity_score`,
 which are always returned in full, nor the write path (`create_node`,
 `update_node`, `create_edge`, `update_edge`) or temporal/history tools,
 which are unaffected by this flag and always return full vectors.
+
+**Temporal extent (Issue #3238)**: `temporal_extent` reports the dataset's
+queryable bi-temporal extent — the earliest/latest valid-time and
+transaction-time coordinates across recorded history (including
+expired/superseded versions and delete tombstones) as RFC3339 strings — so
+an LLM can calibrate `AS OF` queries to land inside real data instead of
+misreading an out-of-range empty result as "the fact never existed". An
+empty database returns explicit `null`s (never epoch 0); `latest` is the
+max of interval starts and *closed* ends, so the open-interval sentinel
+never leaks. Overall bounds are O(1) reads of a write-time-maintained
+aggregate and only ever widen while the server runs (cacheable per
+session). Optional `by_label: true` adds per-node-label / per-edge-type
+bounds folded from hot-tier history. Coverage caveat: bounds span the
+current process lifetime plus hot-tier history restored at startup —
+versions cold-migrated before the last restart are not reflected. See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#discovering-the-queryable-temporal-extent-temporal_extent).
 
 **Programmatic Usage:**
 ```rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ cargo run --bin aletheia-mcp --features mcp-server
 | **Edges** | `get_edge`, `create_edge`, `update_edge`, `delete_edge`, `get_outgoing_edges`, `get_incoming_edges` |
 | **Traversal** | `traverse` (multi-hop graph traversal; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
 | **Vector** | `find_similar`, `enable_vector_index`, `list_vector_indexes` |
-| **Temporal** | `get_node_at_time`, `get_edge_at_time` |
+| **Temporal** | `get_node_at_time`, `get_edge_at_time`, `temporal_extent` (dataset's queryable bi-temporal extent — earliest/latest valid-time and transaction-time bounds as RFC3339, explicit `null`s on an empty DB; optional `by_label: true` for per-label/per-edge-type bounds; covers all recorded history incl. expired/superseded versions) |
 | **Hybrid** | `hybrid_query` (combined graph + vector + temporal) |
 | **Query** | `query` (execute a single read-only Cypher/AQL statement; see below) |
 | **Schema** | `get_schema` (node labels, edge types, and property keys, each with counts; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,6 +370,13 @@ harness = false
 path = "benches/temporal_query.rs"
 required-features = []
 
+# Queryable bi-temporal extent (Issue #3238) - O(1) aggregate read + by-label fold
+[[bench]]
+name = "temporal_extent"
+harness = false
+path = "benches/temporal_extent.rs"
+required-features = []
+
 [[bench]]
 name = "changefeed"
 harness = false

--- a/benches/temporal_extent.rs
+++ b/benches/temporal_extent.rs
@@ -1,0 +1,113 @@
+//! Benchmarks for the queryable bi-temporal extent (Issue #3238).
+//!
+//! Covers:
+//! - `AletheiaDB::temporal_extent()` — must be O(1) regardless of the number
+//!   of recorded versions (it reads a write-time maintained aggregate).
+//! - `AletheiaDB::temporal_extent_by_label()` — O(hot-tier versions) fold
+//!   for the per-label breakdown.
+//! - `TemporalIndexes::extent()` — the underlying O(1) aggregate read.
+
+mod common;
+
+use aletheiadb::AletheiaDB;
+use aletheiadb::core::PropertyMapBuilder;
+use aletheiadb::core::id::{NodeId, VersionId};
+use aletheiadb::core::temporal::{BiTemporalInterval, TimeRange, Timestamp};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+/// Populate the database's temporal indexes directly with `count` versions
+/// spread across `count / 10` entities (10 versions each), so the aggregate
+/// observes a realistic mix of entities and versions.
+fn populate_index_versions(db: &AletheiaDB, count: u64) {
+    let indexes = db.__test_temporal_indexes();
+    let per_entity = 10;
+    for i in 0..count {
+        let node_id = NodeId::new(i / per_entity + 1).unwrap();
+        let version_id = VersionId::new(i + 1).unwrap();
+        let start = 1_000_000_000_000_000 + i as i64 * 1_000;
+        let interval = BiTemporalInterval::new(
+            TimeRange::from(Timestamp::from(start)),
+            TimeRange::from(Timestamp::from(start)),
+        );
+        indexes
+            .insert_node_version(node_id, version_id, interval)
+            .unwrap();
+    }
+}
+
+/// Overall extent: O(1) aggregate read, independent of version count.
+fn bench_temporal_extent_overall(c: &mut Criterion) {
+    let mut group = c.benchmark_group("temporal_extent_overall");
+
+    for count in [100_000u64, 1_000_000] {
+        let db = AletheiaDB::new().expect("db init");
+        populate_index_versions(&db, count);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{}_versions", count)),
+            &count,
+            |b, _| {
+                b.iter(|| black_box(db.temporal_extent().expect("extent")));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// The underlying index aggregate read (no db wrapper).
+fn bench_index_extent_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("temporal_extent_index_read");
+
+    let db = AletheiaDB::new().expect("db init");
+    populate_index_versions(&db, 1_000_000);
+    let indexes = db.__test_temporal_indexes();
+
+    group.bench_function("1000000_versions", |b| {
+        b.iter(|| black_box(indexes.extent()));
+    });
+
+    group.finish();
+}
+
+/// Per-label breakdown: O(hot-tier versions) fold over the historical store.
+fn bench_temporal_extent_by_label(c: &mut Criterion) {
+    let mut group = c.benchmark_group("temporal_extent_by_label");
+    // The full-store fold is comparatively slow; keep sample counts sane.
+    group.sample_size(20);
+
+    for count in [10_000u64, 100_000] {
+        let db = AletheiaDB::new().expect("db init");
+        let labels = ["Person", "Company", "Event", "Place"];
+        for i in 0..count {
+            let label = labels[(i % labels.len() as u64) as usize];
+            let valid = Timestamp::from(1_000_000_000_000_000 + i as i64 * 1_000);
+            db.create_node_with_valid_time(
+                label,
+                PropertyMapBuilder::new().insert("i", i.to_string()).build(),
+                Some(valid),
+            )
+            .expect("create node");
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{}_versions", count)),
+            &count,
+            |b, _| {
+                b.iter(|| black_box(db.temporal_extent_by_label().expect("extent")));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = common::configure_criterion();
+    targets = bench_temporal_extent_overall,
+    bench_index_extent_read,
+    bench_temporal_extent_by_label
+);
+criterion_main!(benches);

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -328,6 +328,76 @@ Legacy top-level fields that predate this contract (the DETACH refusal's
 `constraint_violation` / `existing_node_id`) remain present alongside
 `error.details`, so pre-#3234 consumers keep working.
 
+## Discovering the queryable temporal extent (`temporal_extent`)
+
+Every `AS OF` field above shares a silent failure mode: an instant *before
+the data begins* returns an empty result that is indistinguishable from "the
+fact never existed." The `temporal_extent` tool (Issue #3238) closes that gap
+by reporting, in one call, the calendar range the dataset actually covers, so
+a caller can check "does this dataset even reach time T?" *before* issuing an
+`AS OF` query. It is backed by the additive public API
+`AletheiaDB::temporal_extent()` / `temporal_extent_by_label()`.
+
+```jsonc
+// tools/call -> "temporal_extent" (no required arguments)
+{}
+// -> {
+//      "valid_time":       { "earliest": "2021-03-01T00:00:00.000000Z",
+//                            "latest":   "2026-07-01T09:15:00.123456Z" },
+//      "transaction_time": { "earliest": "2026-06-20T08:00:00.000000Z",
+//                            "latest":   "2026-07-01T09:15:00.123456Z" }
+//    }
+```
+
+Semantics (also stated in the tool's description so an LLM can interpret the
+snapshot without reading source):
+
+- **Extent, not current state.** Bounds cover **all recorded history**,
+  including expired/superseded versions and deletions. A fact written for
+  2019 and later corrected still counts toward `valid_time.earliest`. This is
+  a calendar *range*; for counts/magnitude use `database_stats`.
+- **Open-interval convention.** `earliest` is the minimum interval start in
+  that dimension. `latest` is the maximum of interval starts and *closed*
+  interval ends; open-ended intervals (still-valid facts / still-current
+  records) contribute only their start. `latest` is therefore the newest
+  finite recorded event coordinate — never `+infinity`, and never the
+  open-interval sentinel.
+- **Empty database.** All four bounds come back as explicit `null` — never
+  `0`/`1970-01-01` — so "no data" cannot be misread as "data since the epoch."
+
+Pass `by_label: true` to additionally receive the same
+`{valid_time, transaction_time}` bounds per node label (`node_labels`) and per
+edge type (`edge_types`), so calibration can be scoped to exactly the labels a
+query touches:
+
+```jsonc
+// tools/call -> "temporal_extent"
+{ "by_label": true }
+// -> {
+//      "valid_time": { ... }, "transaction_time": { ... },
+//      "node_labels": [
+//        { "label": "Company", "valid_time": { ... }, "transaction_time": { ... } },
+//        { "label": "Person",  "valid_time": { ... }, "transaction_time": { ... } }
+//      ],
+//      "edge_types": [
+//        { "edge_type": "WORKS_AT", "valid_time": { ... }, "transaction_time": { ... } }
+//      ]
+//    }
+```
+
+The overall bounds are read from the temporal indexes, which keep an entry
+for every version ever recorded (entries survive cold-tier migration). The
+per-label breakdown is folded from the hot-tier historical version store; on
+databases with cold-storage migration enabled, versions whose payload has
+moved to the cold tier are not attributed to a label (the overall bounds
+still cover them).
+
+**Calibration pattern:** if `temporal_extent` reports
+`valid_time.earliest = 2021-03-01`, an `AS OF '2019-01-01'` query is
+guaranteed to be out of recorded range — its empty result means "before our
+records begin," not "nothing existed." Rerun the query at an instant inside
+the extent (or report the range mismatch) instead of concluding absence.
+
 ## Notes
 
 - **AQL has no parameter binding.** Sending `params` with `language: "aql"`

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -352,10 +352,11 @@ a caller can check "does this dataset even reach time T?" *before* issuing an
 Semantics (also stated in the tool's description so an LLM can interpret the
 snapshot without reading source):
 
-- **Extent, not current state.** Bounds cover **all recorded history**,
-  including expired/superseded versions and deletions. A fact written for
-  2019 and later corrected still counts toward `valid_time.earliest`. This is
-  a calendar *range*; for counts/magnitude use `database_stats`.
+- **Extent, not current state.** Bounds cover recorded history — including
+  expired/superseded versions and deletions — not just the current state. A
+  fact written for 2019 and later corrected still counts toward
+  `valid_time.earliest`. This is a calendar *range*; for counts/magnitude use
+  `count_nodes` (a dedicated stats tool is tracked in issue #3222).
 - **Open-interval convention.** `earliest` is the minimum interval start in
   that dimension. `latest` is the maximum of interval starts and *closed*
   interval ends; open-ended intervals (still-valid facts / still-current
@@ -385,12 +386,22 @@ query touches:
 //    }
 ```
 
-The overall bounds are read from the temporal indexes, which keep an entry
-for every version ever recorded (entries survive cold-tier migration). The
-per-label breakdown is folded from the hot-tier historical version store; on
-databases with cold-storage migration enabled, versions whose payload has
-moved to the cold tier are not attributed to a label (the overall bounds
-still cover them).
+The overall bounds are read in O(1) from an aggregate the temporal indexes
+maintain at write time; bounds only ever widen while the server runs, so a
+caller can cache the result for the duration of a session. The per-label
+breakdown is folded from the hot-tier historical version store.
+
+**Coverage caveat (cold storage + restarts).** Bounds cover all history
+recorded during the **current process lifetime**, plus the hot-tier history
+restored at startup. On databases with cold-storage migration enabled,
+versions migrated to the cold tier *before the last restart* are **not**
+reflected — the temporal indexes (and their extent aggregate) are rebuilt at
+startup from hot-tier versions only. Within a single process lifetime,
+cold-tier migration never shrinks the bounds. The per-label breakdown is
+additionally hot-tier-only even within a process lifetime: after cold
+migration a label's bounds may be narrower than the overall bounds, or a
+label may be absent entirely. A follow-up could persist cold-tier bounds
+metadata to close the restart gap.
 
 **Calibration pattern:** if `temporal_extent` reports
 `valid_time.earliest = 2021-03-01`, an `AS OF '2019-01-01'` query is

--- a/src/db/extent.rs
+++ b/src/db/extent.rs
@@ -1,0 +1,466 @@
+//! Queryable bi-temporal extent of the dataset (Issue #3238).
+//!
+//! AletheiaDB lets a caller ask `AS OF <t>`, but nothing tells the caller what
+//! time range the data actually covers: an `AS OF` before the earliest
+//! recorded valid time returns an empty result that is indistinguishable from
+//! "nothing existed then". [`AletheiaDB::temporal_extent`] closes that gap by
+//! reporting the earliest and latest valid-time and transaction-time
+//! coordinates observed across **all recorded history** — including
+//! expired/superseded versions and delete tombstones — so a caller (notably
+//! an LLM over MCP) can calibrate `AS OF` queries to land inside real data.
+//!
+//! # Semantics
+//!
+//! - **Coverage**: bounds are computed over every version ever recorded, not
+//!   just the current state. A fact written for 2019 and later corrected
+//!   still counts toward `earliest`. This is a calendar *range*, not a
+//!   current-state count.
+//! - **`earliest`**: the minimum interval start observed in that dimension.
+//! - **`latest`**: the maximum *finite* coordinate observed in that
+//!   dimension — the max over every interval start and every **closed**
+//!   interval end. Open-ended intervals (still-valid facts / still-current
+//!   records, `end == TIMESTAMP_MAX`) contribute only their start, so
+//!   `latest` reports the newest recorded event coordinate and never the
+//!   open-interval sentinel (+infinity).
+//! - **Empty database**: all bounds are `None` — never `0`/epoch — so "no
+//!   data" cannot be misread as "data starting at 1970".
+
+use crate::core::error::Result;
+use crate::core::interning::{GLOBAL_INTERNER, InternedString};
+use crate::core::temporal::{TIMESTAMP_MAX, TimeRange, Timestamp};
+use crate::db::AletheiaDB;
+use std::collections::BTreeMap;
+
+/// Earliest/latest bounds observed in one temporal dimension.
+///
+/// Both fields are `None` when no versions have ever been recorded (empty
+/// database); otherwise both are `Some`. See the [module docs](self) for the
+/// exact `earliest`/`latest` convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TimeBounds {
+    /// Minimum interval start observed, or `None` if no data was recorded.
+    pub earliest: Option<Timestamp>,
+    /// Maximum finite coordinate observed (max of interval starts and closed
+    /// interval ends; open intervals contribute only their start), or `None`
+    /// if no data was recorded.
+    pub latest: Option<Timestamp>,
+}
+
+/// Bi-temporal bounds for a single node label or edge type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelExtent {
+    /// The node label or edge/relationship type.
+    pub label: String,
+    /// Valid-time bounds across all recorded versions with this label/type.
+    pub valid_time: TimeBounds,
+    /// Transaction-time bounds across all recorded versions with this
+    /// label/type.
+    pub transaction_time: TimeBounds,
+}
+
+/// The dataset's queryable bi-temporal extent.
+///
+/// Returned by [`AletheiaDB::temporal_extent`] (overall bounds only) and
+/// [`AletheiaDB::temporal_extent_by_label`] (overall bounds plus a per-label
+/// / per-edge-type breakdown). See the [module docs](self) for field
+/// semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemporalExtent {
+    /// Valid-time bounds across all recorded history.
+    pub valid_time: TimeBounds,
+    /// Transaction-time bounds across all recorded history.
+    pub transaction_time: TimeBounds,
+    /// Per-node-label bounds, sorted by label. `None` unless requested via
+    /// [`AletheiaDB::temporal_extent_by_label`].
+    pub node_labels: Option<Vec<LabelExtent>>,
+    /// Per-edge-type bounds, sorted by type. `None` unless requested via
+    /// [`AletheiaDB::temporal_extent_by_label`].
+    pub edge_types: Option<Vec<LabelExtent>>,
+}
+
+/// Accumulates min/max bounds for one temporal dimension.
+#[derive(Debug, Clone, Copy, Default)]
+struct DimAccumulator {
+    earliest: Option<Timestamp>,
+    latest: Option<Timestamp>,
+}
+
+impl DimAccumulator {
+    /// Fold one interval into the accumulator, applying the documented
+    /// convention: `earliest` tracks the min start; `latest` tracks the max
+    /// of starts and closed ends, never the `TIMESTAMP_MAX` open sentinel.
+    fn observe(&mut self, range: TimeRange) {
+        let start = range.start();
+        self.earliest = Some(self.earliest.map_or(start, |e| e.min(start)));
+
+        let mut candidate = start;
+        let end = range.end();
+        if end != TIMESTAMP_MAX {
+            candidate = candidate.max(end);
+        }
+        self.latest = Some(self.latest.map_or(candidate, |l| l.max(candidate)));
+    }
+
+    fn into_bounds(self) -> TimeBounds {
+        TimeBounds {
+            earliest: self.earliest,
+            latest: self.latest,
+        }
+    }
+}
+
+/// Accumulates both temporal dimensions for one label/type (or overall).
+#[derive(Debug, Clone, Copy, Default)]
+struct BoundsAccumulator {
+    valid: DimAccumulator,
+    tx: DimAccumulator,
+}
+
+impl BoundsAccumulator {
+    fn observe(&mut self, temporal: &crate::core::temporal::BiTemporalInterval) {
+        self.valid.observe(temporal.valid_time());
+        self.tx.observe(temporal.transaction_time());
+    }
+}
+
+/// Convert a per-label accumulator map into a sorted `Vec<LabelExtent>`.
+fn into_label_extents(acc: BTreeMap<InternedString, BoundsAccumulator>) -> Vec<LabelExtent> {
+    let mut extents: Vec<LabelExtent> = acc
+        .into_iter()
+        .map(|(label, bounds)| LabelExtent {
+            label: GLOBAL_INTERNER.resolve_or_else(label, String::new),
+            valid_time: bounds.valid.into_bounds(),
+            transaction_time: bounds.tx.into_bounds(),
+        })
+        .collect();
+    extents.sort_unstable_by(|a, b| a.label.cmp(&b.label));
+    extents
+}
+
+impl AletheiaDB {
+    /// Report the dataset's queryable bi-temporal extent: the earliest and
+    /// latest valid-time and transaction-time coordinates across **all
+    /// recorded history**, including expired/superseded versions and delete
+    /// tombstones.
+    ///
+    /// Use this to calibrate `AS OF` queries: an `AS OF` before
+    /// `valid_time.earliest` (or after reconstructing a transaction-time
+    /// coordinate outside `transaction_time`) is guaranteed to land outside
+    /// recorded data, so its empty result means "out of recorded range", not
+    /// "the fact never existed".
+    ///
+    /// # Conventions (see [module docs](self) for details)
+    ///
+    /// - `earliest` = min interval start per dimension.
+    /// - `latest` = max of interval starts and *closed* interval ends;
+    ///   open-ended (still-valid / still-current) intervals contribute only
+    ///   their start, so the open-interval sentinel never leaks out.
+    /// - An empty database yields `None` for every bound — never epoch 0.
+    ///
+    /// Bounds are read from the always-maintained temporal indexes, which
+    /// retain an entry for every version ever recorded (entries are kept
+    /// even after a version's payload migrates to cold storage), so this is
+    /// an O(total versions) in-memory fold with no storage I/O.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aletheiadb::AletheiaDB;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let db = AletheiaDB::new()?;
+    /// let extent = db.temporal_extent()?;
+    /// if extent.valid_time.earliest.is_none() {
+    ///     println!("no data recorded yet");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn temporal_extent(&self) -> Result<TemporalExtent> {
+        let (valid_time, transaction_time) = self.overall_extent_bounds();
+        Ok(TemporalExtent {
+            valid_time,
+            transaction_time,
+            node_labels: None,
+            edge_types: None,
+        })
+    }
+
+    /// Like [`temporal_extent`](Self::temporal_extent), but additionally
+    /// breaks the bounds down per node label and per edge/relationship type,
+    /// so a caller can scope `AS OF` calibration to exactly the labels it
+    /// queries.
+    ///
+    /// The overall bounds are identical to [`temporal_extent`](Self::temporal_extent)
+    /// (computed from the temporal indexes, which cover every version ever
+    /// recorded). The per-label breakdown is computed from the historical
+    /// version store, which retains all recorded versions **still resident in
+    /// the hot tier**; on databases with cold-storage migration enabled,
+    /// versions whose payload has been migrated to the cold tier are not
+    /// attributed to a label (the overall bounds still cover them).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn temporal_extent_by_label(&self) -> Result<TemporalExtent> {
+        // Overall bounds first (temporal indexes; transient DashMap shard
+        // guards only), then the historical read lock for the label scan —
+        // the two phases never overlap, so no lock-order interaction with
+        // the `historical` (3) → `temporal_indexes` (4) write-path ordering.
+        let (valid_time, transaction_time) = self.overall_extent_bounds();
+
+        let mut node_acc: BTreeMap<InternedString, BoundsAccumulator> = BTreeMap::new();
+        let mut edge_acc: BTreeMap<InternedString, BoundsAccumulator> = BTreeMap::new();
+        {
+            let historical = self.historical.read();
+            historical.visit_node_versions(|version| {
+                node_acc
+                    .entry(version.label)
+                    .or_default()
+                    .observe(&version.temporal);
+            });
+            historical.visit_edge_versions(|version| {
+                edge_acc
+                    .entry(version.label)
+                    .or_default()
+                    .observe(&version.temporal);
+            });
+        }
+
+        Ok(TemporalExtent {
+            valid_time,
+            transaction_time,
+            node_labels: Some(into_label_extents(node_acc)),
+            edge_types: Some(into_label_extents(edge_acc)),
+        })
+    }
+
+    /// Fold the temporal indexes into overall per-dimension bounds.
+    ///
+    /// The temporal indexes receive an entry for every committed write and
+    /// retain entries even after cold-tier migration, making them the
+    /// authoritative source for "all recorded history". An empty database
+    /// yields all-`None` bounds.
+    fn overall_extent_bounds(&self) -> (TimeBounds, TimeBounds) {
+        match self.temporal_indexes.extent() {
+            Some(extent) => (
+                TimeBounds {
+                    earliest: Some(extent.valid_earliest),
+                    latest: Some(extent.valid_latest),
+                },
+                TimeBounds {
+                    earliest: Some(extent.tx_earliest),
+                    latest: Some(extent.tx_latest),
+                },
+            ),
+            None => (TimeBounds::default(), TimeBounds::default()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::PropertyMapBuilder;
+    use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, time};
+
+    fn ts(micros: i64) -> Timestamp {
+        Timestamp::from(micros)
+    }
+
+    fn props(key: &str, value: &str) -> crate::core::PropertyMap {
+        PropertyMapBuilder::new().insert(key, value).build()
+    }
+
+    #[test]
+    fn empty_database_returns_all_none_bounds() {
+        let db = AletheiaDB::new().expect("db init");
+        let extent = db.temporal_extent().expect("extent");
+
+        assert_eq!(extent.valid_time.earliest, None);
+        assert_eq!(extent.valid_time.latest, None);
+        assert_eq!(extent.transaction_time.earliest, None);
+        assert_eq!(extent.transaction_time.latest, None);
+        assert_eq!(extent.node_labels, None);
+        assert_eq!(extent.edge_types, None);
+
+        // The by-label variant on an empty DB: explicit empty breakdown,
+        // still all-None overall bounds.
+        let extent = db.temporal_extent_by_label().expect("extent");
+        assert_eq!(extent.valid_time.earliest, None);
+        assert_eq!(extent.transaction_time.latest, None);
+        assert_eq!(extent.node_labels, Some(Vec::new()));
+        assert_eq!(extent.edge_types, Some(Vec::new()));
+    }
+
+    #[test]
+    fn populated_db_bounds_match_min_max_across_dimensions() {
+        let db = AletheiaDB::new().expect("db init");
+        let before = time::now();
+
+        // Backdated node: valid time well before "now".
+        let t1 = ts(1_000_000_000_000_000); // ~2001-09-09
+        let t2 = ts(1_200_000_000_000_000); // ~2008-01-10
+        db.create_node_with_valid_time("Person", props("name", "Alice"), Some(t1))
+            .expect("create node");
+        db.create_node_with_valid_time("Company", props("name", "Acme"), Some(t2))
+            .expect("create node");
+
+        let after = time::now();
+        let extent = db.temporal_extent().expect("extent");
+
+        // Valid time: earliest is the backdated t1; latest is the max valid
+        // event (t2 -- both intervals are open-ended so only starts count).
+        assert_eq!(extent.valid_time.earliest, Some(t1));
+        assert_eq!(extent.valid_time.latest, Some(t2));
+
+        // Transaction time: system-assigned, bracketed by the test run;
+        // must never be the open-interval sentinel or epoch.
+        let tx_earliest = extent.transaction_time.earliest.expect("tx earliest");
+        let tx_latest = extent.transaction_time.latest.expect("tx latest");
+        assert!(tx_earliest >= before, "tx earliest within test window");
+        assert!(tx_latest <= after, "tx latest within test window");
+        assert!(tx_earliest <= tx_latest);
+        assert!(tx_latest < TIMESTAMP_MAX, "sentinel must not leak");
+    }
+
+    #[test]
+    fn superseded_version_still_counts_toward_earliest() {
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000);
+        let node_id = db
+            .create_node_with_valid_time("Person", props("role", "engineer"), Some(t1))
+            .expect("create node");
+
+        // Supersede the original version: the first version's valid interval
+        // is closed, but its backdated start must still bound `earliest`.
+        db.update_node_with_valid_time(node_id, props("role", "manager"), None)
+            .expect("update node");
+
+        let extent = db.temporal_extent().expect("extent");
+        assert_eq!(
+            extent.valid_time.earliest,
+            Some(t1),
+            "expired/superseded version must still count toward earliest"
+        );
+        // The update happened at ~now, so latest moved past t1.
+        assert!(extent.valid_time.latest.expect("latest") > t1);
+    }
+
+    #[test]
+    fn open_valid_to_contributes_start_not_sentinel_to_latest() {
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000);
+        db.create_node_with_valid_time("Person", props("name", "Alice"), Some(t1))
+            .expect("create node");
+
+        let extent = db.temporal_extent().expect("extent");
+        // Single open-ended fact: latest == its start, never TIMESTAMP_MAX.
+        assert_eq!(extent.valid_time.latest, Some(t1));
+        assert!(extent.valid_time.latest.expect("latest") < TIMESTAMP_MAX);
+    }
+
+    #[test]
+    fn closed_valid_to_extends_latest_beyond_any_start() {
+        // Public write paths always close an interval at another version's
+        // start, so exercise the closed-end arm of the convention directly
+        // through the temporal index (the authority temporal_extent reads).
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000);
+        let t_end = ts(1_500_000_000_000_000); // closed end later than any start
+        let t_tx = ts(1_100_000_000_000_000);
+
+        let interval = BiTemporalInterval::new(
+            TimeRange::new(t1, t_end).expect("valid range"),
+            TimeRange::from(t_tx),
+        );
+        db.__test_temporal_indexes()
+            .insert_node_version(
+                crate::core::NodeId::new(1).expect("node id"),
+                crate::core::VersionId::new(1).expect("version id"),
+                interval,
+            )
+            .expect("insert version");
+
+        let extent = db.temporal_extent().expect("extent");
+        assert_eq!(extent.valid_time.earliest, Some(t1));
+        assert_eq!(
+            extent.valid_time.latest,
+            Some(t_end),
+            "closed valid_to must extend latest beyond every start"
+        );
+        assert_eq!(extent.transaction_time.earliest, Some(t_tx));
+        assert_eq!(extent.transaction_time.latest, Some(t_tx));
+    }
+
+    #[test]
+    fn by_label_breakdown_partitions_bounds_per_label_and_edge_type() {
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000);
+        let t2 = ts(1_200_000_000_000_000);
+        let t3 = ts(1_300_000_000_000_000);
+
+        let alice = db
+            .create_node_with_valid_time("Person", props("name", "Alice"), Some(t1))
+            .expect("create node");
+        let acme = db
+            .create_node_with_valid_time("Company", props("name", "Acme"), Some(t2))
+            .expect("create node");
+        db.create_edge_with_valid_time(alice, acme, "WORKS_AT", props("role", "eng"), Some(t3))
+            .expect("create edge");
+
+        let extent = db.temporal_extent_by_label().expect("extent");
+
+        // Overall bounds cover all labels.
+        assert_eq!(extent.valid_time.earliest, Some(t1));
+        assert_eq!(extent.valid_time.latest, Some(t3));
+
+        let node_labels = extent.node_labels.expect("node labels");
+        assert_eq!(node_labels.len(), 2);
+        // Sorted by label: Company before Person.
+        assert_eq!(node_labels[0].label, "Company");
+        assert_eq!(node_labels[0].valid_time.earliest, Some(t2));
+        assert_eq!(node_labels[0].valid_time.latest, Some(t2));
+        assert_eq!(node_labels[1].label, "Person");
+        assert_eq!(node_labels[1].valid_time.earliest, Some(t1));
+        assert_eq!(node_labels[1].valid_time.latest, Some(t1));
+
+        let edge_types = extent.edge_types.expect("edge types");
+        assert_eq!(edge_types.len(), 1);
+        assert_eq!(edge_types[0].label, "WORKS_AT");
+        assert_eq!(edge_types[0].valid_time.earliest, Some(t3));
+        assert_eq!(edge_types[0].valid_time.latest, Some(t3));
+        // Per-label transaction bounds are real timestamps too.
+        assert!(edge_types[0].transaction_time.earliest.is_some());
+        assert!(edge_types[0].transaction_time.latest.is_some());
+    }
+
+    #[test]
+    fn as_of_before_extent_is_empty_inside_extent_has_data() {
+        // The answerability contract: an AS OF query strictly before
+        // valid_time.earliest returns nothing, while the same query inside
+        // the extent returns data.
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000);
+        db.create_node_with_valid_time("Person", props("name", "Alice"), Some(t1))
+            .expect("create node");
+
+        let extent = db.temporal_extent().expect("extent");
+        let earliest = extent.valid_time.earliest.expect("earliest");
+
+        let before = ts(earliest.wallclock() - 1_000_000);
+        let now = time::now();
+
+        let schema_before = db.schema_as_of(before, now).expect("schema before");
+        assert!(
+            schema_before.node_labels.is_empty(),
+            "AS OF before valid_time.earliest must be empty"
+        );
+
+        let schema_inside = db.schema_as_of(earliest, now).expect("schema inside");
+        assert_eq!(schema_inside.node_labels.len(), 1);
+        assert_eq!(schema_inside.node_labels[0].label, "Person");
+    }
+}

--- a/src/db/extent.rs
+++ b/src/db/extent.rs
@@ -5,16 +5,22 @@
 //! recorded valid time returns an empty result that is indistinguishable from
 //! "nothing existed then". [`AletheiaDB::temporal_extent`] closes that gap by
 //! reporting the earliest and latest valid-time and transaction-time
-//! coordinates observed across **all recorded history** — including
+//! coordinates observed across recorded history — including
 //! expired/superseded versions and delete tombstones — so a caller (notably
 //! an LLM over MCP) can calibrate `AS OF` queries to land inside real data.
 //!
 //! # Semantics
 //!
-//! - **Coverage**: bounds are computed over every version ever recorded, not
-//!   just the current state. A fact written for 2019 and later corrected
-//!   still counts toward `earliest`. This is a calendar *range*, not a
-//!   current-state count.
+//! - **Coverage**: bounds are computed over every version recorded during
+//!   the current process lifetime, plus the hot-tier history restored at
+//!   startup — not just the current state. A fact written for 2019 and
+//!   later corrected still counts toward `earliest`. This is a calendar
+//!   *range*, not a current-state count.
+//! - **Cold-storage caveat**: on databases with cold-storage migration
+//!   enabled, versions migrated to the cold tier **before the last restart**
+//!   are not reflected — the temporal indexes (and their extent aggregate)
+//!   are rebuilt at startup from hot-tier versions only. A follow-up could
+//!   persist cold-tier bounds metadata to close this gap.
 //! - **`earliest`**: the minimum interval start observed in that dimension.
 //! - **`latest`**: the maximum *finite* coordinate observed in that
 //!   dimension — the max over every interval start and every **closed**
@@ -29,7 +35,7 @@ use crate::core::error::Result;
 use crate::core::interning::{GLOBAL_INTERNER, InternedString};
 use crate::core::temporal::{TIMESTAMP_MAX, TimeRange, Timestamp};
 use crate::db::AletheiaDB;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 /// Earliest/latest bounds observed in one temporal dimension.
 ///
@@ -93,11 +99,10 @@ impl DimAccumulator {
         let start = range.start();
         self.earliest = Some(self.earliest.map_or(start, |e| e.min(start)));
 
-        let mut candidate = start;
+        // TimeRange guarantees end >= start, so a closed end is itself the
+        // latest candidate; no max(start, end) needed.
         let end = range.end();
-        if end != TIMESTAMP_MAX {
-            candidate = candidate.max(end);
-        }
+        let candidate = if end == TIMESTAMP_MAX { start } else { end };
         self.latest = Some(self.latest.map_or(candidate, |l| l.max(candidate)));
     }
 
@@ -124,7 +129,7 @@ impl BoundsAccumulator {
 }
 
 /// Convert a per-label accumulator map into a sorted `Vec<LabelExtent>`.
-fn into_label_extents(acc: BTreeMap<InternedString, BoundsAccumulator>) -> Vec<LabelExtent> {
+fn into_label_extents(acc: HashMap<InternedString, BoundsAccumulator>) -> Vec<LabelExtent> {
     let mut extents: Vec<LabelExtent> = acc
         .into_iter()
         .map(|(label, bounds)| LabelExtent {
@@ -139,9 +144,8 @@ fn into_label_extents(acc: BTreeMap<InternedString, BoundsAccumulator>) -> Vec<L
 
 impl AletheiaDB {
     /// Report the dataset's queryable bi-temporal extent: the earliest and
-    /// latest valid-time and transaction-time coordinates across **all
-    /// recorded history**, including expired/superseded versions and delete
-    /// tombstones.
+    /// latest valid-time and transaction-time coordinates across recorded
+    /// history, including expired/superseded versions and delete tombstones.
     ///
     /// Use this to calibrate `AS OF` queries: an `AS OF` before
     /// `valid_time.earliest` (or after reconstructing a transaction-time
@@ -157,10 +161,19 @@ impl AletheiaDB {
     ///   their start, so the open-interval sentinel never leaks out.
     /// - An empty database yields `None` for every bound — never epoch 0.
     ///
-    /// Bounds are read from the always-maintained temporal indexes, which
-    /// retain an entry for every version ever recorded (entries are kept
-    /// even after a version's payload migrates to cold storage), so this is
-    /// an O(total versions) in-memory fold with no storage I/O.
+    /// Bounds are read O(1) from a write-time maintained aggregate in the
+    /// temporal indexes; no index traversal, no storage I/O. Bounds only
+    /// ever widen while the process runs, so callers may cache the result
+    /// for the duration of a session.
+    ///
+    /// # Coverage across restarts (cold-storage caveat)
+    ///
+    /// Bounds cover all history recorded during the current process
+    /// lifetime plus the hot-tier history restored at startup. On databases
+    /// with cold-storage migration enabled, versions migrated to the cold
+    /// tier **before the last restart** are not reflected (the temporal
+    /// indexes rebuild from hot-tier versions only). See the
+    /// [module docs](self) for details.
     ///
     /// # Example
     ///
@@ -191,38 +204,45 @@ impl AletheiaDB {
     /// so a caller can scope `AS OF` calibration to exactly the labels it
     /// queries.
     ///
-    /// The overall bounds are identical to [`temporal_extent`](Self::temporal_extent)
-    /// (computed from the temporal indexes, which cover every version ever
-    /// recorded). The per-label breakdown is computed from the historical
-    /// version store, which retains all recorded versions **still resident in
-    /// the hot tier**; on databases with cold-storage migration enabled,
+    /// The overall bounds are identical to [`temporal_extent`](Self::temporal_extent).
+    /// The per-label breakdown is computed from the historical version
+    /// store, which retains all recorded versions **still resident in the
+    /// hot tier**; on databases with cold-storage migration enabled,
     /// versions whose payload has been migrated to the cold tier are not
-    /// attributed to a label (the overall bounds still cover them).
+    /// attributed to a label, and after a restart neither the per-label
+    /// bounds nor the overall bounds reflect versions cold-migrated before
+    /// that restart (see [module docs](self)). On a hot-only database every
+    /// per-label bound lies within the overall bounds.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn temporal_extent_by_label(&self) -> Result<TemporalExtent> {
-        // Overall bounds first (temporal indexes; transient DashMap shard
-        // guards only), then the historical read lock for the label scan —
-        // the two phases never overlap, so no lock-order interaction with
-        // the `historical` (3) → `temporal_indexes` (4) write-path ordering.
+        // Take the historical read lock FIRST, then read the overall bounds
+        // while holding it: commits mutate the temporal indexes while
+        // holding `historical.write()`, so holding the read lock across
+        // both phases yields one consistent snapshot (a write can no longer
+        // slip between "read overall bounds" and "scan per-label versions"
+        // and make a per-label bound exceed the overall bounds). Lock order
+        // is respected: `historical` (3) is acquired before the temporal
+        // indexes' internal extent aggregate (4), and `extent()` acquires
+        // nothing ordered before `historical`.
+        let historical = self.historical.read();
+
         let (valid_time, transaction_time) = self.overall_extent_bounds();
 
-        let mut node_acc: BTreeMap<InternedString, BoundsAccumulator> = BTreeMap::new();
-        let mut edge_acc: BTreeMap<InternedString, BoundsAccumulator> = BTreeMap::new();
-        {
-            let historical = self.historical.read();
-            historical.visit_node_versions(|version| {
-                node_acc
-                    .entry(version.label)
-                    .or_default()
-                    .observe(&version.temporal);
-            });
-            historical.visit_edge_versions(|version| {
-                edge_acc
-                    .entry(version.label)
-                    .or_default()
-                    .observe(&version.temporal);
-            });
-        }
+        let mut node_acc: HashMap<InternedString, BoundsAccumulator> = HashMap::new();
+        let mut edge_acc: HashMap<InternedString, BoundsAccumulator> = HashMap::new();
+        historical.visit_node_versions(|version| {
+            node_acc
+                .entry(version.label)
+                .or_default()
+                .observe(&version.temporal);
+        });
+        historical.visit_edge_versions(|version| {
+            edge_acc
+                .entry(version.label)
+                .or_default()
+                .observe(&version.temporal);
+        });
+        drop(historical);
 
         Ok(TemporalExtent {
             valid_time,
@@ -232,12 +252,13 @@ impl AletheiaDB {
         })
     }
 
-    /// Fold the temporal indexes into overall per-dimension bounds.
+    /// Read the temporal indexes' O(1) extent aggregate as overall
+    /// per-dimension bounds.
     ///
-    /// The temporal indexes receive an entry for every committed write and
-    /// retain entries even after cold-tier migration, making them the
-    /// authoritative source for "all recorded history". An empty database
-    /// yields all-`None` bounds.
+    /// The temporal indexes observe every committed write (and interval
+    /// close) at write time and never remove entries while the process
+    /// runs, making them the authoritative in-process source for recorded
+    /// history. An empty database yields all-`None` bounds.
     fn overall_extent_bounds(&self) -> (TimeBounds, TimeBounds) {
         match self.temporal_indexes.extent() {
             Some(extent) => (
@@ -312,11 +333,17 @@ mod tests {
         assert_eq!(extent.valid_time.latest, Some(t2));
 
         // Transaction time: system-assigned, bracketed by the test run;
-        // must never be the open-interval sentinel or epoch.
+        // must never be the open-interval sentinel or epoch. The upper
+        // bound compares wallclocks with a small slack: a commit HLC and
+        // the `after` capture can share a microsecond, in which case the
+        // commit's logical counter makes it compare greater than `after`.
         let tx_earliest = extent.transaction_time.earliest.expect("tx earliest");
         let tx_latest = extent.transaction_time.latest.expect("tx latest");
         assert!(tx_earliest >= before, "tx earliest within test window");
-        assert!(tx_latest <= after, "tx latest within test window");
+        assert!(
+            tx_latest.wallclock() <= after.wallclock() + 10,
+            "tx latest within test window (with HLC same-microsecond slack)"
+        );
         assert!(tx_earliest <= tx_latest);
         assert!(tx_latest < TIMESTAMP_MAX, "sentinel must not leak");
     }
@@ -393,6 +420,67 @@ mod tests {
         assert_eq!(extent.transaction_time.latest, Some(t_tx));
     }
 
+    /// Assert every per-label bound lies within the overall bounds, and
+    /// that the overall bounds equal the fold of the per-label breakdown.
+    /// Both properties hold on hot-only databases (no cold-tier migration),
+    /// which is what `AletheiaDB::new()` provides.
+    fn assert_breakdown_consistent_with_overall(extent: &TemporalExtent) {
+        let mut folded_valid = DimAccumulator::default();
+        let mut folded_tx = DimAccumulator::default();
+
+        let all_labels = extent
+            .node_labels
+            .as_deref()
+            .expect("node labels")
+            .iter()
+            .chain(extent.edge_types.as_deref().expect("edge types"));
+
+        for label_extent in all_labels {
+            for (bounds, overall, folded) in [
+                (
+                    &label_extent.valid_time,
+                    &extent.valid_time,
+                    &mut folded_valid,
+                ),
+                (
+                    &label_extent.transaction_time,
+                    &extent.transaction_time,
+                    &mut folded_tx,
+                ),
+            ] {
+                let earliest = bounds.earliest.expect("label earliest");
+                let latest = bounds.latest.expect("label latest");
+                assert!(
+                    earliest >= overall.earliest.expect("overall earliest"),
+                    "label '{}' earliest must be within overall bounds",
+                    label_extent.label
+                );
+                assert!(
+                    latest <= overall.latest.expect("overall latest"),
+                    "label '{}' latest must be within overall bounds",
+                    label_extent.label
+                );
+                folded.earliest = Some(folded.earliest.map_or(earliest, |e| e.min(earliest)));
+                folded.latest = Some(folded.latest.map_or(latest, |l| l.max(latest)));
+            }
+        }
+
+        // On a hot-only DB the breakdown covers every version the overall
+        // bounds cover, so folding it back must reproduce them exactly —
+        // guarding against the write-time aggregate and the per-label fold
+        // ever drifting apart in convention.
+        assert_eq!(
+            folded_valid.into_bounds(),
+            extent.valid_time,
+            "overall valid bounds must equal fold of the by_label breakdown"
+        );
+        assert_eq!(
+            folded_tx.into_bounds(),
+            extent.transaction_time,
+            "overall tx bounds must equal fold of the by_label breakdown"
+        );
+    }
+
     #[test]
     fn by_label_breakdown_partitions_bounds_per_label_and_edge_type() {
         let db = AletheiaDB::new().expect("db init");
@@ -416,7 +504,7 @@ mod tests {
         assert_eq!(extent.valid_time.earliest, Some(t1));
         assert_eq!(extent.valid_time.latest, Some(t3));
 
-        let node_labels = extent.node_labels.expect("node labels");
+        let node_labels = extent.node_labels.as_deref().expect("node labels");
         assert_eq!(node_labels.len(), 2);
         // Sorted by label: Company before Person.
         assert_eq!(node_labels[0].label, "Company");
@@ -426,7 +514,7 @@ mod tests {
         assert_eq!(node_labels[1].valid_time.earliest, Some(t1));
         assert_eq!(node_labels[1].valid_time.latest, Some(t1));
 
-        let edge_types = extent.edge_types.expect("edge types");
+        let edge_types = extent.edge_types.as_deref().expect("edge types");
         assert_eq!(edge_types.len(), 1);
         assert_eq!(edge_types[0].label, "WORKS_AT");
         assert_eq!(edge_types[0].valid_time.earliest, Some(t3));
@@ -434,6 +522,135 @@ mod tests {
         // Per-label transaction bounds are real timestamps too.
         assert!(edge_types[0].transaction_time.earliest.is_some());
         assert!(edge_types[0].transaction_time.latest.is_some());
+
+        // Hot-only DB: every per-label bound lies within the overall
+        // bounds, and folding the breakdown reproduces the overall bounds.
+        assert_breakdown_consistent_with_overall(&extent);
+    }
+
+    #[test]
+    fn by_label_multi_version_label_bounds_span_backdated_start_and_closed_end() {
+        // Kills two DimAccumulator mutants that a single-version-per-label
+        // dataset cannot distinguish:
+        //   (b) earliest computed with max(start) instead of min(start)
+        //       would report t2 instead of the backdated t1;
+        //   and exercises the superseded (closed) first version's interval
+        //   alongside the open second one.
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000); // backdated original
+        let t2 = ts(1_400_000_000_000_000); // later correction
+        let node_id = db
+            .create_node_with_valid_time("Person", props("role", "engineer"), Some(t1))
+            .expect("create node");
+        db.update_node_with_valid_time(node_id, props("role", "manager"), Some(t2))
+            .expect("update node");
+
+        let extent = db.temporal_extent_by_label().expect("extent");
+        let node_labels = extent.node_labels.as_deref().expect("node labels");
+        assert_eq!(node_labels.len(), 1);
+        let person = &node_labels[0];
+        assert_eq!(person.label, "Person");
+
+        // The superseded version's backdated start still bounds earliest
+        // (min of starts, not max).
+        assert_eq!(
+            person.valid_time.earliest,
+            Some(t1),
+            "per-label earliest must be the min start (backdated t1), not the newest"
+        );
+        // The superseded version's valid interval was closed at t2 (the
+        // update's valid start); latest must reach it.
+        assert_eq!(
+            person.valid_time.latest,
+            Some(t2),
+            "per-label latest must reach the superseded version's closed end"
+        );
+
+        assert_breakdown_consistent_with_overall(&extent);
+    }
+
+    #[test]
+    fn by_label_closed_end_beyond_every_start_extends_label_latest() {
+        // Kills the DimAccumulator mutant that drops the closed-end
+        // contribution to `latest`: public write paths always close an
+        // interval at another same-label version's start (so max(starts)
+        // masks the mutant); force a closed transaction-time end strictly
+        // greater than every start via the historical storage API.
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_000_000_000_000_000);
+        let node_id = db
+            .create_node_with_valid_time("Person", props("name", "Alice"), Some(t1))
+            .expect("create node");
+
+        let version_id = db
+            .historical
+            .read()
+            .get_current_node_version(node_id)
+            .expect("current version");
+        // A finite close strictly after every recorded coordinate.
+        let t_close = ts(time::now().wallclock() + 3_600_000_000); // now + 1h
+        db.historical
+            .write()
+            .close_node_version_transaction_time(version_id, t_close)
+            .expect("close tx time");
+
+        let extent = db.temporal_extent_by_label().expect("extent");
+        let node_labels = extent.node_labels.as_deref().expect("node labels");
+        assert_eq!(node_labels.len(), 1);
+        let person = &node_labels[0];
+
+        // Without the closed-end contribution, latest would be the max tx
+        // *start* (the creation commit), not t_close.
+        assert_eq!(
+            person.transaction_time.latest,
+            Some(t_close),
+            "per-label latest must include closed ends beyond every start"
+        );
+        // The close path also extends the overall (write-time) aggregate.
+        assert_eq!(
+            extent.transaction_time.latest,
+            Some(t_close),
+            "overall latest must include closed ends beyond every start"
+        );
+
+        assert_breakdown_consistent_with_overall(&extent);
+    }
+
+    #[test]
+    fn deleted_backdated_node_still_bounds_extent() {
+        // Delete tombstones count toward the extent: a node backdated to t1
+        // and then deleted must still report valid_time.earliest == t1, and
+        // both dimensions' latest must reflect the deletion event.
+        let db = AletheiaDB::new().expect("db init");
+
+        let t1 = ts(1_600_000_000_000_000); // ~2020-09-13, backdated creation
+        let node_id = db
+            .create_node_with_valid_time("Person", props("name", "Alice"), Some(t1))
+            .expect("create node");
+
+        let before_delete = time::now();
+        db.delete_node_with_valid_time(node_id, None)
+            .expect("delete node");
+
+        let extent = db.temporal_extent().expect("extent");
+        assert_eq!(
+            extent.valid_time.earliest,
+            Some(t1),
+            "a deleted node's backdated start must still bound earliest"
+        );
+        // The deletion closed the version's valid interval at ~now and
+        // recorded a tombstone; latest in both dimensions reaches it.
+        assert!(
+            extent.valid_time.latest.expect("valid latest") >= before_delete,
+            "valid latest must reflect the deletion coordinate"
+        );
+        assert!(
+            extent.transaction_time.latest.expect("tx latest") >= before_delete,
+            "tx latest must reflect the deletion commit"
+        );
+        assert!(extent.valid_time.latest.expect("valid latest") < TIMESTAMP_MAX);
     }
 
     #[test]
@@ -450,16 +667,21 @@ mod tests {
         let extent = db.temporal_extent().expect("extent");
         let earliest = extent.valid_time.earliest.expect("earliest");
 
+        // Use the extent's own transaction-time latest as the tx coordinate:
+        // it is exactly the commit HLC, so — unlike a fresh `time::now()`
+        // capture, which can land in the same microsecond as the commit and
+        // compare *less* via the HLC logical counter — it is guaranteed to
+        // see the committed version.
+        let tx_at = extent.transaction_time.latest.expect("tx latest");
         let before = ts(earliest.wallclock() - 1_000_000);
-        let now = time::now();
 
-        let schema_before = db.schema_as_of(before, now).expect("schema before");
+        let schema_before = db.schema_as_of(before, tx_at).expect("schema before");
         assert!(
             schema_before.node_labels.is_empty(),
             "AS OF before valid_time.earliest must be empty"
         );
 
-        let schema_inside = db.schema_as_of(earliest, now).expect("schema inside");
+        let schema_inside = db.schema_as_of(earliest, tx_at).expect("schema inside");
         assert_eq!(schema_inside.node_labels.len(), 1);
         assert_eq!(schema_inside.node_labels[0].label, "Person");
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -25,6 +25,8 @@ pub mod backup;
 pub mod config;
 /// Uniqueness constraint builder.
 pub mod constraint_builder;
+/// Queryable bi-temporal extent of the dataset (Issue #3238).
+pub mod extent;
 /// GraphView implementation.
 pub mod graph_view;
 /// Basic graph operations (CRUD).
@@ -49,6 +51,7 @@ pub mod vector_builder;
 
 pub use crate::storage::backup::BackupSummary;
 pub use constraint_builder::UniqueConstraintBuilder;
+pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
 pub use vector_builder::VectorIndexBuilder;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -20,7 +20,7 @@ pub use incremental_adjacency::{
     CompactionScheduler, FrozenAdjacencyView, IncrementalAdjacencyIndex, IncrementalConfig,
     Tombstone,
 };
-pub use temporal::TemporalIndexes;
+pub use temporal::{IndexTemporalExtent, TemporalIndexes};
 pub use temporal_adjacency::{TemporalAdjacencyConfig, TemporalAdjacencyIndex};
 pub use vector::{DistanceMetric, VectorIndex};
 pub use vector::{HnswIndex, HnswIndexBuilder};

--- a/src/index/temporal/mod.rs
+++ b/src/index/temporal/mod.rs
@@ -39,6 +39,7 @@ use crate::core::error::{Result, StorageError};
 use crate::core::id::{EdgeId, EntityId, NodeId, VersionId};
 use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp};
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use smallvec::SmallVec;
 
 /// The earliest/latest finite temporal coordinates observed across every
@@ -58,6 +59,126 @@ pub struct IndexTemporalExtent {
     pub tx_earliest: Timestamp,
     /// Maximum finite transaction-time coordinate observed.
     pub tx_latest: Timestamp,
+}
+
+/// Write-time maintained bi-temporal extent aggregate (Issue #3238).
+///
+/// Updated on every version insertion and interval close, so
+/// [`TemporalIndexes::extent`] is O(1) instead of an O(total versions) fold
+/// that would hold DashMap shard read-guards for whole-shard traversals
+/// (and, via the commit path's `historical` write lock, could stall the
+/// commit pipeline on large datasets).
+///
+/// # Why this is sound (monotonicity)
+///
+/// Every production mutation of the temporal indexes only *widens* the
+/// extent:
+///
+/// - Insertions add intervals; entries are never removed (there is no
+///   removal API besides [`TemporalIndexes::clear`], which resets this
+///   aggregate). Aborted transactions may leave already-inserted index
+///   entries behind, but those entries stay in the index, so the aggregate
+///   still matches a from-scratch fold.
+/// - Interval closes (`update_*_time_end`) only tighten *open* ends
+///   (`TIMESTAMP_MAX`, which never contributes to `latest`) to a finite
+///   value `>= start` — enforced by `TimeRange::close_at` and the
+///   `is_currently_valid`/`is_currently_recorded` guards on every close
+///   path — so a close can only extend `latest`, never shrink it.
+/// - The retention policy rejects writes over the version limit; it never
+///   prunes existing entries.
+///
+/// # Why a `Mutex` and not four atomics
+///
+/// [`Timestamp`] is a 96-bit [`HybridTimestamp`](crate::core::hlc::HybridTimestamp)
+/// (`i64` wallclock + `u32` logical counter, ordered lexicographically), so
+/// it does not fit a stable `AtomicI64`/`AtomicU64` and Rust has no stable
+/// 128-bit atomics. A `parking_lot::Mutex` around this 4-field struct has a
+/// critical section of a few comparisons — the same single-cache-line
+/// contention profile four CAS-loop atomics would have — and is a strict
+/// leaf lock: nothing else is ever acquired while it is held.
+#[derive(Debug, Clone, Copy, Default)]
+struct ExtentAggregate {
+    valid_earliest: Option<Timestamp>,
+    valid_latest: Option<Timestamp>,
+    tx_earliest: Option<Timestamp>,
+    tx_latest: Option<Timestamp>,
+}
+
+impl ExtentAggregate {
+    /// Fold one `[start, end)` range into one dimension's bounds, per the
+    /// extent convention: `earliest` = min start; `latest` = max of starts
+    /// and *closed* ends (`TIMESTAMP_MAX` open ends contribute only their
+    /// start, so the sentinel never leaks into bounds).
+    fn observe_range(
+        earliest: &mut Option<Timestamp>,
+        latest: &mut Option<Timestamp>,
+        start: Timestamp,
+        end: Timestamp,
+    ) {
+        *earliest = Some(earliest.map_or(start, |e| e.min(start)));
+        // TimeRange guarantees end >= start, so a closed end is itself the
+        // candidate; no max(start, end) needed.
+        let candidate = if end == TIMESTAMP_MAX { start } else { end };
+        *latest = Some(latest.map_or(candidate, |l| l.max(candidate)));
+    }
+
+    /// Fold one bi-temporal interval (both dimensions) into the aggregate.
+    fn observe_interval(&mut self, temporal: &BiTemporalInterval) {
+        let valid = temporal.valid_time();
+        Self::observe_range(
+            &mut self.valid_earliest,
+            &mut self.valid_latest,
+            valid.start(),
+            valid.end(),
+        );
+        let tx = temporal.transaction_time();
+        Self::observe_range(
+            &mut self.tx_earliest,
+            &mut self.tx_latest,
+            tx.start(),
+            tx.end(),
+        );
+    }
+
+    /// Fold another aggregate into this one (used to publish a batch's
+    /// locally-accumulated bounds in one lock acquisition).
+    fn merge(&mut self, other: ExtentAggregate) {
+        Self::merge_dim(
+            &mut self.valid_earliest,
+            &mut self.valid_latest,
+            other.valid_earliest,
+            other.valid_latest,
+        );
+        Self::merge_dim(
+            &mut self.tx_earliest,
+            &mut self.tx_latest,
+            other.tx_earliest,
+            other.tx_latest,
+        );
+    }
+
+    fn merge_dim(
+        earliest: &mut Option<Timestamp>,
+        latest: &mut Option<Timestamp>,
+        other_earliest: Option<Timestamp>,
+        other_latest: Option<Timestamp>,
+    ) {
+        if let Some(e) = other_earliest {
+            *earliest = Some(earliest.map_or(e, |cur| cur.min(e)));
+        }
+        if let Some(l) = other_latest {
+            *latest = Some(latest.map_or(l, |cur| cur.max(l)));
+        }
+    }
+
+    /// Extend one dimension's `latest` with a newly-closed finite end.
+    /// A `TIMESTAMP_MAX` end is ignored (open ends never bound `latest`).
+    fn observe_closed_end(latest: &mut Option<Timestamp>, new_end: Timestamp) {
+        if new_end == TIMESTAMP_MAX {
+            return;
+        }
+        *latest = Some(latest.map_or(new_end, |l| l.max(new_end)));
+    }
 }
 
 /// Policy for handling duplicate versions during batch insertion.
@@ -433,23 +554,6 @@ impl EntityTimeline {
             .map(|entry| entry.metadata_idx)
     }
 
-    /// Fold this timeline's `(start, end)` intervals into running
-    /// earliest/latest bounds per the extent convention (Issue #3238):
-    /// `earliest` tracks the minimum start; `latest` tracks the maximum of
-    /// starts and *closed* ends — an open end (`TIMESTAMP_MAX`) contributes
-    /// only its interval's start, so the sentinel never leaks into bounds.
-    fn fold_extent(&self, earliest: &mut Option<Timestamp>, latest: &mut Option<Timestamp>) {
-        for entry in &self.versions {
-            *earliest = Some(earliest.map_or(entry.start, |e| e.min(entry.start)));
-
-            let mut candidate = entry.start;
-            if entry.end != TIMESTAMP_MAX {
-                candidate = candidate.max(entry.end);
-            }
-            *latest = Some(latest.map_or(candidate, |l| l.max(candidate)));
-        }
-    }
-
     /// Find all metadata indices in this timeline that overlap with the given time range.
     ///
     /// Returns indices into the consolidated version metadata storage.
@@ -760,6 +864,12 @@ pub struct TemporalIndexes {
     index: DashMap<EntityId, EntityTimelines>,
     /// Configuration for temporal indexes.
     config: TemporalIndexConfig,
+    /// Write-time maintained bi-temporal extent (Issue #3238).
+    ///
+    /// Leaf lock: nothing else is ever acquired while it is held; held only
+    /// for a few comparisons per write. See [`ExtentAggregate`] for the
+    /// soundness argument (all index mutations are extent-monotone).
+    extent_aggregate: Mutex<ExtentAggregate>,
 }
 
 impl Default for TemporalIndexes {
@@ -779,6 +889,7 @@ impl TemporalIndexes {
         Self {
             index: DashMap::new(),
             config,
+            extent_aggregate: Mutex::new(ExtentAggregate::default()),
         }
     }
 
@@ -918,6 +1029,14 @@ impl TemporalIndexes {
         let tx = temporal.transaction_time();
         timelines.tx.insert(tx.start(), tx.end(), metadata_idx);
 
+        // Release the shard entry guard before taking the extent leaf lock.
+        drop(timelines);
+
+        // Maintain the O(1) extent aggregate (Issue #3238). Inserted
+        // intervals may already carry closed ends (startup rebuild from
+        // historical versions), so both start and end are observed.
+        self.extent_aggregate.lock().observe_interval(&temporal);
+
         Ok(())
     }
 
@@ -965,6 +1084,13 @@ impl TemporalIndexes {
         // This ensures that deduplication in EntityTimeline works for the same VersionId.
         let mut v_id_to_idx = std::collections::HashMap::with_capacity(versions.len());
 
+        // Accumulate the batch's extent locally; published under one lock
+        // acquisition after both timeline inserts succeed. Duplicate
+        // VersionIds carrying *conflicting* intervals (a data anomaly —
+        // idempotent WAL replay always re-sends identical intervals) may
+        // widen the aggregate beyond the deduplicated timeline contents.
+        let mut batch_extent = ExtentAggregate::default();
+
         for (v_id, temporal) in versions {
             // Store version metadata once in consolidated storage or reuse existing one
             let metadata_idx = if let Some(&idx) = v_id_to_idx.get(&v_id) {
@@ -981,6 +1107,7 @@ impl TemporalIndexes {
 
             let valid = temporal.valid_time();
             let tx = temporal.transaction_time();
+            batch_extent.observe_interval(&temporal);
 
             // Both timeline entries reference the same metadata via index
             valid_entries.push(TimelineEntry {
@@ -997,6 +1124,11 @@ impl TemporalIndexes {
 
         timelines.valid.insert_batch(valid_entries, policy)?;
         timelines.tx.insert_batch(tx_entries, policy)?;
+
+        // Release the shard entry guard before taking the extent leaf lock,
+        // then publish the batch's bounds (only after full success).
+        drop(timelines);
+        self.extent_aggregate.lock().merge(batch_extent);
 
         Ok(())
     }
@@ -1019,7 +1151,12 @@ impl TemporalIndexes {
         new_end: Timestamp,
     ) {
         if let Some(mut timelines) = self.index.get_mut(&EntityId::Node(node_id)) {
-            timelines.update_valid_time_end(version_id, new_end);
+            let updated = timelines.update_valid_time_end(version_id, new_end);
+            drop(timelines);
+            if updated {
+                let mut agg = self.extent_aggregate.lock();
+                ExtentAggregate::observe_closed_end(&mut agg.valid_latest, new_end);
+            }
         }
     }
 
@@ -1040,7 +1177,12 @@ impl TemporalIndexes {
         new_end: Timestamp,
     ) {
         if let Some(mut timelines) = self.index.get_mut(&EntityId::Node(node_id)) {
-            timelines.update_transaction_time_end(version_id, new_end);
+            let updated = timelines.update_transaction_time_end(version_id, new_end);
+            drop(timelines);
+            if updated {
+                let mut agg = self.extent_aggregate.lock();
+                ExtentAggregate::observe_closed_end(&mut agg.tx_latest, new_end);
+            }
         }
     }
 
@@ -1062,7 +1204,12 @@ impl TemporalIndexes {
         new_end: Timestamp,
     ) {
         if let Some(mut timelines) = self.index.get_mut(&EntityId::Edge(edge_id)) {
-            timelines.update_valid_time_end(version_id, new_end);
+            let updated = timelines.update_valid_time_end(version_id, new_end);
+            drop(timelines);
+            if updated {
+                let mut agg = self.extent_aggregate.lock();
+                ExtentAggregate::observe_closed_end(&mut agg.valid_latest, new_end);
+            }
         }
     }
 
@@ -1083,7 +1230,12 @@ impl TemporalIndexes {
         new_end: Timestamp,
     ) {
         if let Some(mut timelines) = self.index.get_mut(&EntityId::Edge(edge_id)) {
-            timelines.update_transaction_time_end(version_id, new_end);
+            let updated = timelines.update_transaction_time_end(version_id, new_end);
+            drop(timelines);
+            if updated {
+                let mut agg = self.extent_aggregate.lock();
+                ExtentAggregate::observe_closed_end(&mut agg.tx_latest, new_end);
+            }
         }
     }
 
@@ -1363,13 +1515,16 @@ impl TemporalIndexes {
         }
     }
 
-    /// Compute the bi-temporal extent across every version ever recorded in
-    /// these indexes (Issue #3238).
+    /// Report the bi-temporal extent across every version recorded in these
+    /// indexes during the current process lifetime (Issue #3238).
     ///
     /// Index entries are inserted for every committed write (including
-    /// delete tombstones) and are retained even after a version's payload
-    /// migrates to cold storage, so the returned bounds cover **all recorded
-    /// history** — including expired/superseded versions.
+    /// delete tombstones) and, once inserted, are never removed — a
+    /// version's payload migrating to cold storage does not shrink the
+    /// bounds while the process runs. Note that at **startup** the indexes
+    /// (and therefore these bounds) are rebuilt from hot-tier historical
+    /// versions only: versions migrated to cold storage before the last
+    /// restart are not reflected.
     ///
     /// Returns `None` when no versions have ever been recorded (empty
     /// database), so callers can report explicit "no data" instead of a
@@ -1379,24 +1534,18 @@ impl TemporalIndexes {
     ///
     /// # Performance
     ///
-    /// A single O(total versions) pass over the in-memory timeline vectors;
-    /// no storage I/O. DashMap shard guards are held only transiently per
-    /// entity.
+    /// O(1): reads a write-time maintained aggregate under a leaf mutex —
+    /// no index traversal, no DashMap shard guards, no storage I/O. Bounds
+    /// only ever widen while the process runs, so callers may cache the
+    /// result for the duration of a session.
     pub fn extent(&self) -> Option<IndexTemporalExtent> {
-        let mut valid_earliest = None;
-        let mut valid_latest = None;
-        let mut tx_earliest = None;
-        let mut tx_latest = None;
-
-        for entry in self.index.iter() {
-            let timelines = entry.value();
-            timelines
-                .valid
-                .fold_extent(&mut valid_earliest, &mut valid_latest);
-            timelines.tx.fold_extent(&mut tx_earliest, &mut tx_latest);
-        }
-
-        match (valid_earliest, valid_latest, tx_earliest, tx_latest) {
+        let agg = *self.extent_aggregate.lock();
+        match (
+            agg.valid_earliest,
+            agg.valid_latest,
+            agg.tx_earliest,
+            agg.tx_latest,
+        ) {
             (Some(valid_earliest), Some(valid_latest), Some(tx_earliest), Some(tx_latest)) => {
                 Some(IndexTemporalExtent {
                     valid_earliest,
@@ -1429,9 +1578,10 @@ impl TemporalIndexes {
         self.index.iter().map(|entry| *entry.key())
     }
 
-    /// Clear all indexes.
+    /// Clear all indexes (and reset the extent aggregate).
     pub fn clear(&self) {
         self.index.clear();
+        *self.extent_aggregate.lock() = ExtentAggregate::default();
     }
 }
 

--- a/src/index/temporal/mod.rs
+++ b/src/index/temporal/mod.rs
@@ -37,9 +37,28 @@
 
 use crate::core::error::{Result, StorageError};
 use crate::core::id::{EdgeId, EntityId, NodeId, VersionId};
-use crate::core::temporal::{BiTemporalInterval, TimeRange, Timestamp};
+use crate::core::temporal::{BiTemporalInterval, TIMESTAMP_MAX, TimeRange, Timestamp};
 use dashmap::DashMap;
 use smallvec::SmallVec;
+
+/// The earliest/latest finite temporal coordinates observed across every
+/// version recorded in the indexes, per temporal dimension (Issue #3238).
+///
+/// Produced by [`TemporalIndexes::extent`]. `*_latest` follows the extent
+/// convention: the maximum of interval starts and *closed* interval ends;
+/// open-ended intervals (`end == TIMESTAMP_MAX`) contribute only their
+/// start, so the open-interval sentinel never appears here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexTemporalExtent {
+    /// Minimum valid-time interval start observed.
+    pub valid_earliest: Timestamp,
+    /// Maximum finite valid-time coordinate observed.
+    pub valid_latest: Timestamp,
+    /// Minimum transaction-time interval start observed.
+    pub tx_earliest: Timestamp,
+    /// Maximum finite transaction-time coordinate observed.
+    pub tx_latest: Timestamp,
+}
 
 /// Policy for handling duplicate versions during batch insertion.
 ///
@@ -412,6 +431,23 @@ impl EntityTimeline {
             .iter()
             .filter(move |entry| entry.end > range_start)
             .map(|entry| entry.metadata_idx)
+    }
+
+    /// Fold this timeline's `(start, end)` intervals into running
+    /// earliest/latest bounds per the extent convention (Issue #3238):
+    /// `earliest` tracks the minimum start; `latest` tracks the maximum of
+    /// starts and *closed* ends — an open end (`TIMESTAMP_MAX`) contributes
+    /// only its interval's start, so the sentinel never leaks into bounds.
+    fn fold_extent(&self, earliest: &mut Option<Timestamp>, latest: &mut Option<Timestamp>) {
+        for entry in &self.versions {
+            *earliest = Some(earliest.map_or(entry.start, |e| e.min(entry.start)));
+
+            let mut candidate = entry.start;
+            if entry.end != TIMESTAMP_MAX {
+                candidate = candidate.max(entry.end);
+            }
+            *latest = Some(latest.map_or(candidate, |l| l.max(candidate)));
+        }
     }
 
     /// Find all metadata indices in this timeline that overlap with the given time range.
@@ -1324,6 +1360,52 @@ impl TemporalIndexes {
             use std::collections::HashSet;
             let b_set: HashSet<_> = b.iter().copied().collect();
             a.iter().copied().filter(|v| b_set.contains(v)).collect()
+        }
+    }
+
+    /// Compute the bi-temporal extent across every version ever recorded in
+    /// these indexes (Issue #3238).
+    ///
+    /// Index entries are inserted for every committed write (including
+    /// delete tombstones) and are retained even after a version's payload
+    /// migrates to cold storage, so the returned bounds cover **all recorded
+    /// history** — including expired/superseded versions.
+    ///
+    /// Returns `None` when no versions have ever been recorded (empty
+    /// database), so callers can report explicit "no data" instead of a
+    /// misleading epoch-0 bound. See [`IndexTemporalExtent`] for the
+    /// `latest` convention (closed ends count; open ends contribute only
+    /// their start).
+    ///
+    /// # Performance
+    ///
+    /// A single O(total versions) pass over the in-memory timeline vectors;
+    /// no storage I/O. DashMap shard guards are held only transiently per
+    /// entity.
+    pub fn extent(&self) -> Option<IndexTemporalExtent> {
+        let mut valid_earliest = None;
+        let mut valid_latest = None;
+        let mut tx_earliest = None;
+        let mut tx_latest = None;
+
+        for entry in self.index.iter() {
+            let timelines = entry.value();
+            timelines
+                .valid
+                .fold_extent(&mut valid_earliest, &mut valid_latest);
+            timelines.tx.fold_extent(&mut tx_earliest, &mut tx_latest);
+        }
+
+        match (valid_earliest, valid_latest, tx_earliest, tx_latest) {
+            (Some(valid_earliest), Some(valid_latest), Some(tx_earliest), Some(tx_latest)) => {
+                Some(IndexTemporalExtent {
+                    valid_earliest,
+                    valid_latest,
+                    tx_earliest,
+                    tx_latest,
+                })
+            }
+            _ => None,
         }
     }
 

--- a/src/index/temporal/tests.rs
+++ b/src/index/temporal/tests.rs
@@ -2854,3 +2854,159 @@ fn test_batch_insert_exact_capacity_sentinel() {
         "Should accept batch that fits exactly into capacity"
     );
 }
+
+// ============================================================================
+// Extent aggregate tests (Issue #3238): write-time maintained O(1) bounds
+// ============================================================================
+
+/// Convenience: build an interval with the given valid/tx ranges.
+fn extent_interval(valid: (i64, i64), tx: (i64, i64)) -> BiTemporalInterval {
+    BiTemporalInterval::new(
+        TimeRange::new(valid.0.into(), valid.1.into()).unwrap(),
+        TimeRange::new(tx.0.into(), tx.1.into()).unwrap(),
+    )
+}
+
+#[test]
+fn extent_batch_insert_publishes_aggregated_bounds() {
+    // Batch insertion accumulates locally and publishes via merge();
+    // the resulting extent must equal a per-version fold, including a
+    // closed valid end beyond every start.
+    let indexes = TemporalIndexes::new();
+    let node_id = NodeId::new(1).unwrap();
+
+    let batch = vec![
+        (
+            VersionId::new(1).unwrap(),
+            extent_interval((100, 500), (10, TIMESTAMP_MAX.wallclock())),
+        ),
+        (
+            VersionId::new(2).unwrap(),
+            // Closed valid end (900) strictly beyond every start.
+            extent_interval((200, 900), (20, TIMESTAMP_MAX.wallclock())),
+        ),
+    ];
+    indexes.insert_node_versions_batch(node_id, batch).unwrap();
+
+    let extent = indexes.extent().expect("non-empty extent");
+    assert_eq!(extent.valid_earliest, 100.into());
+    assert_eq!(
+        extent.valid_latest,
+        900.into(),
+        "closed end must bound latest"
+    );
+    assert_eq!(extent.tx_earliest, 10.into());
+    assert_eq!(
+        extent.tx_latest,
+        20.into(),
+        "open tx intervals contribute only their start"
+    );
+
+    // A second batch merges into the already-Some aggregate (both
+    // merge_dim arms with an existing value).
+    let batch2 = vec![(
+        VersionId::new(3).unwrap(),
+        extent_interval((50, TIMESTAMP_MAX.wallclock()), (5, 30)),
+    )];
+    indexes.insert_node_versions_batch(node_id, batch2).unwrap();
+
+    let extent = indexes.extent().expect("non-empty extent");
+    assert_eq!(
+        extent.valid_earliest,
+        50.into(),
+        "batch merge must lower earliest"
+    );
+    assert_eq!(extent.valid_latest, 900.into());
+    assert_eq!(extent.tx_earliest, 5.into());
+    assert_eq!(
+        extent.tx_latest,
+        30.into(),
+        "closed tx end must raise latest"
+    );
+}
+
+#[test]
+fn extent_close_with_open_sentinel_is_ignored() {
+    // Closing an interval "to" TIMESTAMP_MAX (re-opening) must not leak the
+    // sentinel into `latest`: observe_closed_end ignores open ends.
+    let indexes = TemporalIndexes::new();
+    let node_id = NodeId::new(1).unwrap();
+    let v1 = VersionId::new(1).unwrap();
+
+    indexes
+        .insert_node_version(node_id, v1, extent_interval((100, 500), (10, 40)))
+        .unwrap();
+    let before = indexes.extent().expect("non-empty extent");
+
+    indexes.update_node_valid_time_end(node_id, v1, TIMESTAMP_MAX);
+    indexes.update_node_transaction_time_end(node_id, v1, TIMESTAMP_MAX);
+
+    let after = indexes.extent().expect("non-empty extent");
+    assert_eq!(
+        after, before,
+        "TIMESTAMP_MAX closes must not move the extent"
+    );
+    assert!(after.valid_latest < TIMESTAMP_MAX);
+    assert!(after.tx_latest < TIMESTAMP_MAX);
+}
+
+#[test]
+fn extent_edge_interval_closes_extend_latest() {
+    // The edge close paths must extend `latest` exactly like the node ones.
+    let indexes = TemporalIndexes::new();
+    let edge_id = EdgeId::new(7).unwrap();
+    let v1 = VersionId::new(1).unwrap();
+
+    indexes
+        .insert_edge_version(
+            edge_id,
+            v1,
+            extent_interval(
+                (100, TIMESTAMP_MAX.wallclock()),
+                (10, TIMESTAMP_MAX.wallclock()),
+            ),
+        )
+        .unwrap();
+
+    indexes.update_edge_valid_time_end(edge_id, v1, 700.into());
+    indexes.update_edge_transaction_time_end(edge_id, v1, 800.into());
+
+    let extent = indexes.extent().expect("non-empty extent");
+    assert_eq!(
+        extent.valid_latest,
+        700.into(),
+        "edge valid close must extend latest"
+    );
+    assert_eq!(
+        extent.tx_latest,
+        800.into(),
+        "edge tx close must extend latest"
+    );
+
+    // Closing an absent entity/version is a no-op on the extent.
+    indexes.update_edge_valid_time_end(EdgeId::new(999).unwrap(), v1, 5_000.into());
+    let unchanged = indexes.extent().expect("non-empty extent");
+    assert_eq!(unchanged.valid_latest, 700.into());
+}
+
+#[test]
+fn extent_clear_resets_aggregate_to_empty() {
+    let indexes = TemporalIndexes::new();
+    let node_id = NodeId::new(1).unwrap();
+
+    indexes
+        .insert_node_version(
+            node_id,
+            VersionId::new(1).unwrap(),
+            extent_interval((100, 500), (10, TIMESTAMP_MAX.wallclock())),
+        )
+        .unwrap();
+    assert!(indexes.extent().is_some());
+
+    indexes.clear();
+    assert_eq!(
+        indexes.extent(),
+        None,
+        "clear() must reset the extent aggregate, not just the index"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,8 +122,9 @@ pub use core::error::{
     ConstraintError, Error, QueryError, Result, StorageError, TemporalError, TransactionError,
 };
 pub use db::{
-    AletheiaDB, BackupSummary, EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant,
-    SimilarityQuery, SimilaritySource, UniqueConstraintBuilder, VectorIndexBuilder,
+    AletheiaDB, BackupSummary, EdgeTypeSchema, GraphSchema, LabelExtent, LabelSchema,
+    SchemaInstant, SimilarityQuery, SimilaritySource, TemporalExtent, TimeBounds,
+    UniqueConstraintBuilder, VectorIndexBuilder,
 };
 pub use index::{
     AdjacencyIndex, CurrentIndexes, TemporalIndexes,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -22,7 +22,7 @@
 //! | **Nodes** | `get_node`, `create_node`, `update_node` | CRUD operations for nodes |
 //! | **Edges** | `get_edge`, `create_edge`, `traverse` | CRUD and traversal for edges |
 //! | **Vector** | `find_similar`, `enable_vector_index` | Semantic similarity search |
-//! | **Temporal** | `get_node_at_time`, `get_node_history` | Time-travel queries and history |
+//! | **Temporal** | `get_node_at_time`, `get_node_history`, `temporal_extent` | Time-travel queries, history, and dataset extent |
 //! | **Hybrid** | `hybrid_query` | Combined graph + vector + temporal queries |
 //! | **Schema** | `get_schema` | Discover node labels, edge types, and property keys (optionally bi-temporal) |
 //!
@@ -626,6 +626,18 @@ impl AletheiaMcpServer {
     /// instant. Never errors on an empty database.
     pub fn get_schema(&self, req: GetSchemaRequest) -> String {
         Self::extract_text(self.handle_get_schema(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
+    /// Report the dataset's queryable bi-temporal extent: earliest/latest
+    /// valid-time and transaction-time bounds across all recorded history
+    /// (including expired/superseded versions), as RFC3339 strings.
+    ///
+    /// Pass `by_label: true` for a per-node-label / per-edge-type breakdown.
+    /// An empty database returns explicit `null` bounds, never epoch 0.
+    pub fn temporal_extent(&self, req: TemporalExtentRequest) -> String {
+        Self::extract_text(self.handle_temporal_extent(
             serde_json::to_value(req).expect("request serialization should not fail"),
         ))
     }
@@ -2862,6 +2874,95 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Render a finite timestamp as an RFC3339 string (UTC, microsecond
+    /// precision). Falls back to a raw microsecond form for coordinates
+    /// outside chrono's representable range rather than panicking.
+    fn timestamp_to_rfc3339(ts: Timestamp) -> String {
+        let micros = ts.wallclock();
+        DateTime::<Utc>::from_timestamp_micros(micros)
+            .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true))
+            .unwrap_or_else(|| format!("{micros}us"))
+    }
+
+    /// Serialize one dimension's bounds; `None` bounds become explicit JSON
+    /// `null`s (never `0`/epoch), so an empty database is unambiguous.
+    fn time_bounds_to_json(bounds: &crate::db::TimeBounds) -> serde_json::Value {
+        json!({
+            "earliest": bounds.earliest.map(Self::timestamp_to_rfc3339),
+            "latest": bounds.latest.map(Self::timestamp_to_rfc3339),
+        })
+    }
+
+    /// Convert a [`crate::db::TemporalExtent`] into its JSON wire
+    /// representation. Serialization only — all bounds are computed by
+    /// [`AletheiaDB::temporal_extent`]/[`AletheiaDB::temporal_extent_by_label`].
+    fn temporal_extent_to_json(extent: &crate::db::TemporalExtent) -> serde_json::Value {
+        let mut value = json!({
+            "valid_time": Self::time_bounds_to_json(&extent.valid_time),
+            "transaction_time": Self::time_bounds_to_json(&extent.transaction_time),
+        });
+
+        let label_extents_to_json = |extents: &[crate::db::LabelExtent], key: &str| {
+            extents
+                .iter()
+                .map(|e| {
+                    json!({
+                        key: e.label,
+                        "valid_time": Self::time_bounds_to_json(&e.valid_time),
+                        "transaction_time": Self::time_bounds_to_json(&e.transaction_time),
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+
+        if let Some(obj) = value.as_object_mut() {
+            if let Some(node_labels) = &extent.node_labels {
+                obj.insert(
+                    "node_labels".to_string(),
+                    serde_json::Value::Array(label_extents_to_json(node_labels, "label")),
+                );
+            }
+            if let Some(edge_types) = &extent.edge_types {
+                obj.insert(
+                    "edge_types".to_string(),
+                    serde_json::Value::Array(label_extents_to_json(edge_types, "edge_type")),
+                );
+            }
+        }
+
+        value
+    }
+
+    /// Report the dataset's queryable bi-temporal extent (Issue #3238).
+    ///
+    /// The handler only serializes: bounds come from the public
+    /// `AletheiaDB::temporal_extent` / `temporal_extent_by_label` API.
+    fn handle_temporal_extent(&self, args: serde_json::Value) -> CallToolResult {
+        // The tool has no required arguments: a call with no `arguments`
+        // object at all must behave like `{}`.
+        let args = if args.is_null() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            args
+        };
+
+        let req: TemporalExtentRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        let result = if req.by_label.unwrap_or(false) {
+            self.db.temporal_extent_by_label()
+        } else {
+            self.db.temporal_extent()
+        };
+
+        match result {
+            Ok(extent) => self.success_json(Self::temporal_extent_to_json(&extent)),
+            Err(e) => self.db_error(e),
+        }
+    }
+
     fn handle_hybrid_query(&self, args: serde_json::Value) -> CallToolResult {
         let req: HybridQueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -3432,6 +3533,7 @@ impl AletheiaMcpServer {
             "hybrid_query" => self.handle_hybrid_query(args),
             "query" => self.handle_query(args),
             "get_schema" => self.handle_get_schema(args),
+            "temporal_extent" => self.handle_temporal_extent(args),
             _ => self.error_result(
                 McpError::new(McpErrorCode::NotFound, format!("Unknown tool: {}", name))
                     .details(json!({ "tool": name })),
@@ -3840,6 +3942,24 @@ fn tool_definitions() -> Vec<Tool> {
              Returns a well-formed empty summary on an empty database, never an error.",
             make_input_schema::<GetSchemaRequest>(),
         ),
+        Tool::new(
+            "temporal_extent",
+            "Report the dataset's queryable bi-temporal extent: valid_time {earliest, latest} \
+             and transaction_time {earliest, latest} as RFC3339 strings, in one call. Call \
+             this BEFORE issuing AS OF queries so the target instant lands inside recorded \
+             data — an AS OF before valid_time.earliest returns empty results that are \
+             otherwise indistinguishable from 'the fact never existed'. Bounds cover ALL \
+             recorded history, including expired/superseded versions and deletions (a 2019 \
+             fact later corrected still counts toward earliest); this is a calendar RANGE, \
+             not a current-state count. Convention: earliest = the minimum interval start in \
+             that dimension; latest = the maximum of interval starts and CLOSED interval \
+             ends. Open-ended intervals (still-valid facts / still-current records) \
+             contribute only their start, so latest is the newest finite recorded event \
+             coordinate, never +infinity. An empty database returns explicit nulls for every \
+             bound, never 0/epoch-1970. Pass by_label: true to also receive the same bounds \
+             per node label (node_labels) and per edge type (edge_types).",
+            make_input_schema::<TemporalExtentRequest>(),
+        ),
     ]
 }
 
@@ -3994,5 +4114,51 @@ mod server_unit_tests {
             result.is_error.unwrap_or(false),
             "Null JSON input must produce an error result"
         );
+    }
+
+    #[test]
+    fn handle_temporal_extent_invalid_by_label_type_routes_through_invalid_argument() {
+        // A mistyped argument (string instead of bool) must produce the
+        // structured Issue #3234 error payload with code INVALID_ARGUMENT
+        // (Issue #3238).
+        let server = make_server();
+        let result = server.handle_temporal_extent(serde_json::json!({"by_label": "yes"}));
+        assert!(
+            result.is_error.unwrap_or(false),
+            "mistyped by_label must produce an error result"
+        );
+        let text = AletheiaMcpServer::extract_text(result);
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["error"]["code"], "INVALID_ARGUMENT",
+            "mistyped by_label must classify as INVALID_ARGUMENT: {val}"
+        );
+        assert_eq!(
+            val["error"]["retriable"], false,
+            "INVALID_ARGUMENT must not be retriable: {val}"
+        );
+        assert!(
+            val["error"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("Invalid arguments")),
+            "message must preserve the free-text detail: {val}"
+        );
+    }
+
+    #[test]
+    fn handle_temporal_extent_null_args_behaves_like_no_arguments() {
+        // The tool has no required arguments: an MCP call with the
+        // `arguments` object omitted entirely (routed here as Null) must
+        // succeed exactly like `{}`.
+        let server = make_server();
+        let result = server.handle_temporal_extent(serde_json::Value::Null);
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "temporal_extent with no arguments must succeed"
+        );
+        let text = AletheiaMcpServer::extract_text(result);
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert!(val["valid_time"]["earliest"].is_null());
+        assert!(val["transaction_time"]["latest"].is_null());
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3956,8 +3956,14 @@ fn tool_definitions() -> Vec<Tool> {
              ends. Open-ended intervals (still-valid facts / still-current records) \
              contribute only their start, so latest is the newest finite recorded event \
              coordinate, never +infinity. An empty database returns explicit nulls for every \
-             bound, never 0/epoch-1970. Pass by_label: true to also receive the same bounds \
-             per node label (node_labels) and per edge type (edge_types).",
+             bound, never 0/epoch-1970. Bounds only ever widen while the server runs, so \
+             callers can cache the result for a session. Coverage caveat: bounds span all \
+             history recorded during the current process lifetime plus hot-tier history \
+             restored at startup; on databases with cold-storage migration, versions migrated \
+             to cold storage before the last restart are not reflected. Pass by_label: true \
+             to also receive the same bounds per node label (node_labels) and per edge type \
+             (edge_types); per-label bounds are computed from hot-tier history only and may \
+             be narrower than the overall bounds (or a label absent) after cold migration.",
             make_input_schema::<TemporalExtentRequest>(),
         ),
     ]
@@ -4114,6 +4120,22 @@ mod server_unit_tests {
             result.is_error.unwrap_or(false),
             "Null JSON input must produce an error result"
         );
+    }
+
+    #[test]
+    fn timestamp_to_rfc3339_out_of_chrono_range_falls_back_to_micros() {
+        // Coordinates outside chrono's representable range must render as
+        // the raw-microseconds fallback instead of panicking. Timestamps up
+        // to MAX_VALID_TIMESTAMP (i64::MAX - 1000 µs) are storable but far
+        // beyond chrono's ~year-262143 ceiling.
+        let ts = crate::core::temporal::Timestamp::from(i64::MAX - 1000);
+        let rendered = AletheiaMcpServer::timestamp_to_rfc3339(ts);
+        assert_eq!(rendered, format!("{}us", i64::MAX - 1000));
+
+        // Sanity: an in-range coordinate renders as RFC3339, not the fallback.
+        let ts = crate::core::temporal::Timestamp::from(1_614_556_800_000_000); // 2021-03-01
+        let rendered = AletheiaMcpServer::timestamp_to_rfc3339(ts);
+        assert_eq!(rendered, "2021-03-01T00:00:00.000000Z");
     }
 
     #[test]

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8457,3 +8457,261 @@ mod structured_error_tests {
         assert!(message.contains("Invalid tx_to"), "got: {message}");
     }
 }
+
+// ============================================================================
+// Temporal Extent Tests (temporal_extent, Issue #3238)
+// ============================================================================
+
+mod temporal_extent_tests {
+    use super::*;
+
+    fn extent_req(by_label: Option<bool>) -> TemporalExtentRequest {
+        TemporalExtentRequest { by_label }
+    }
+
+    fn create_node_at(server: &AletheiaMcpServer, label: &str, valid_time: &str) -> NodeResponse {
+        let response = server.create_node(CreateNodeRequest {
+            valid_time: Some(valid_time.to_string()),
+            label: label.to_string(),
+            properties: Some({
+                let mut m = HashMap::new();
+                m.insert("name".to_string(), serde_json::json!("x"));
+                m
+            }),
+            provenance: None,
+        });
+        parse_response(&response).expect("create node")
+    }
+
+    fn assert_rfc3339(value: &serde_json::Value, context: &str) {
+        let s = value
+            .as_str()
+            .unwrap_or_else(|| panic!("{context} must be a string: {value}"));
+        chrono::DateTime::parse_from_rfc3339(s)
+            .unwrap_or_else(|e| panic!("{context} must be RFC3339, got '{s}': {e}"));
+    }
+
+    #[test]
+    fn test_temporal_extent_tool_listed_in_registry() {
+        let server = create_test_server();
+        let tools = server.list_tools_for_test();
+        assert!(
+            tools.iter().any(|name| name == "temporal_extent"),
+            "temporal_extent must be registered in the tool list"
+        );
+    }
+
+    #[test]
+    fn test_temporal_extent_empty_database_returns_null_bounds() {
+        let server = create_test_server();
+
+        let response = server.temporal_extent(extent_req(None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        // Bounds must be explicit nulls -- present in the payload, and
+        // definitely not epoch/1970 strings.
+        for dim in ["valid_time", "transaction_time"] {
+            for bound in ["earliest", "latest"] {
+                let b = value[dim]
+                    .get(bound)
+                    .unwrap_or_else(|| panic!("{dim}.{bound} must be present"));
+                assert!(
+                    b.is_null(),
+                    "{dim}.{bound} on an empty DB must be null, got {b}"
+                );
+            }
+        }
+        // Without by_label, no breakdown keys appear at all.
+        assert!(value.get("node_labels").is_none());
+        assert!(value.get("edge_types").is_none());
+    }
+
+    #[test]
+    fn test_temporal_extent_empty_database_by_label_returns_empty_breakdown() {
+        let server = create_test_server();
+
+        let response = server.temporal_extent(extent_req(Some(true)));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        assert!(value["valid_time"]["earliest"].is_null());
+        assert!(value["transaction_time"]["latest"].is_null());
+        assert_eq!(value["node_labels"].as_array().unwrap().len(), 0);
+        assert_eq!(value["edge_types"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_temporal_extent_populated_shape_and_rfc3339() {
+        let server = create_test_server();
+
+        let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
+        let acme = create_node_at(&server, "Company", "2023-06-15T00:00:00Z");
+        server.create_edge(CreateEdgeRequest {
+            valid_time: Some("2024-01-01T00:00:00Z".to_string()),
+            source_id: alice.id,
+            target_id: acme.id,
+            label: "WORKS_AT".to_string(),
+            properties: None,
+            provenance: None,
+        });
+
+        let response = server.temporal_extent(extent_req(None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+
+        // Valid-time bounds reflect the backdated writes exactly (all
+        // intervals are open-ended, so only their starts count).
+        assert_eq!(
+            value["valid_time"]["earliest"],
+            serde_json::json!("2021-03-01T00:00:00.000000Z")
+        );
+        assert_eq!(
+            value["valid_time"]["latest"],
+            serde_json::json!("2024-01-01T00:00:00.000000Z")
+        );
+
+        // Transaction-time bounds are system-assigned but must be real,
+        // parseable RFC3339 strings (not sentinels, not micros integers).
+        assert_rfc3339(&value["transaction_time"]["earliest"], "tx earliest");
+        assert_rfc3339(&value["transaction_time"]["latest"], "tx latest");
+
+        // No breakdown without by_label.
+        assert!(value.get("node_labels").is_none());
+        assert!(value.get("edge_types").is_none());
+    }
+
+    #[test]
+    fn test_temporal_extent_expired_version_still_counts_toward_earliest() {
+        let server = create_test_server();
+
+        let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
+        // Supersede the original version: its interval is closed, but its
+        // backdated start must still bound `earliest` (extent covers ALL
+        // recorded history, not just current state).
+        server.update_node(UpdateNodeRequest {
+            valid_time: Some("2025-01-01T00:00:00Z".to_string()),
+            node_id: alice.id,
+            properties: {
+                let mut m = HashMap::new();
+                m.insert("name".to_string(), serde_json::json!("Alice v2"));
+                m
+            },
+            provenance: None,
+        });
+
+        let response = server.temporal_extent(extent_req(None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+        assert_eq!(
+            value["valid_time"]["earliest"],
+            serde_json::json!("2021-03-01T00:00:00.000000Z"),
+            "superseded version must still count toward earliest"
+        );
+        assert_eq!(
+            value["valid_time"]["latest"],
+            serde_json::json!("2025-01-01T00:00:00.000000Z")
+        );
+    }
+
+    #[test]
+    fn test_temporal_extent_by_label_breakdown() {
+        let server = create_test_server();
+
+        let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
+        let acme = create_node_at(&server, "Company", "2023-06-15T00:00:00Z");
+        server.create_edge(CreateEdgeRequest {
+            valid_time: Some("2024-01-01T00:00:00Z".to_string()),
+            source_id: alice.id,
+            target_id: acme.id,
+            label: "WORKS_AT".to_string(),
+            properties: None,
+            provenance: None,
+        });
+
+        let response = server.temporal_extent(extent_req(Some(true)));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+
+        let node_labels = value["node_labels"].as_array().unwrap();
+        assert_eq!(node_labels.len(), 2);
+        // Sorted by label: Company before Person.
+        assert_eq!(node_labels[0]["label"], serde_json::json!("Company"));
+        assert_eq!(
+            node_labels[0]["valid_time"]["earliest"],
+            serde_json::json!("2023-06-15T00:00:00.000000Z")
+        );
+        assert_eq!(node_labels[1]["label"], serde_json::json!("Person"));
+        assert_eq!(
+            node_labels[1]["valid_time"]["earliest"],
+            serde_json::json!("2021-03-01T00:00:00.000000Z")
+        );
+        assert_rfc3339(
+            &node_labels[1]["transaction_time"]["earliest"],
+            "Person tx earliest",
+        );
+
+        let edge_types = value["edge_types"].as_array().unwrap();
+        assert_eq!(edge_types.len(), 1);
+        assert_eq!(edge_types[0]["edge_type"], serde_json::json!("WORKS_AT"));
+        assert_eq!(
+            edge_types[0]["valid_time"]["earliest"],
+            serde_json::json!("2024-01-01T00:00:00.000000Z")
+        );
+
+        // Overall bounds still cover the union of all labels.
+        assert_eq!(
+            value["valid_time"]["earliest"],
+            serde_json::json!("2021-03-01T00:00:00.000000Z")
+        );
+        assert_eq!(
+            value["valid_time"]["latest"],
+            serde_json::json!("2024-01-01T00:00:00.000000Z")
+        );
+    }
+
+    #[test]
+    fn test_as_of_before_extent_is_empty_inside_extent_has_data() {
+        // The answerability contract the extent exists to provide: an AS OF
+        // query strictly before valid_time.earliest returns empty, while the
+        // same query inside the extent returns data.
+        let server = create_test_server();
+
+        create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
+
+        let response = server.temporal_extent(extent_req(None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["valid_time"]["earliest"],
+            serde_json::json!("2021-03-01T00:00:00.000000Z")
+        );
+
+        // AS OF before the extent: empty (indistinguishable from "never
+        // existed" -- exactly why temporal_extent must be consulted first).
+        let before = server.get_schema(GetSchemaRequest {
+            as_of_valid_time: Some("2019-01-01T00:00:00Z".to_string()),
+            as_of_transaction_time: None,
+        });
+        let before: serde_json::Value = serde_json::from_str(&before).unwrap();
+        assert!(before.get("error").is_none(), "unexpected error: {before}");
+        assert_eq!(
+            before["node_labels"].as_array().unwrap().len(),
+            0,
+            "AS OF before valid_time.earliest must return empty"
+        );
+
+        // The same query inside the extent returns the data.
+        let inside = server.get_schema(GetSchemaRequest {
+            as_of_valid_time: Some("2022-01-01T00:00:00Z".to_string()),
+            as_of_transaction_time: None,
+        });
+        let inside: serde_json::Value = serde_json::from_str(&inside).unwrap();
+        assert!(inside.get("error").is_none(), "unexpected error: {inside}");
+        let labels = inside["node_labels"].as_array().unwrap();
+        assert_eq!(labels.len(), 1, "AS OF inside the extent must return data");
+        assert_eq!(labels[0]["label"], serde_json::json!("Person"));
+    }
+}

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8674,6 +8674,50 @@ mod temporal_extent_tests {
     }
 
     #[test]
+    fn test_temporal_extent_deleted_node_tombstone_still_counts() {
+        // Deletions count toward the extent: a node backdated to 2021 and
+        // then deleted must still bound valid_time.earliest, and both
+        // dimensions' latest must reflect the deletion event.
+        let server = create_test_server();
+
+        let alice = create_node_at(&server, "Person", "2021-03-01T00:00:00Z");
+        let delete_response = server.delete_node(DeleteNodeRequest {
+            node_id: alice.id,
+            detach: None,
+            valid_time: None,
+        });
+        let delete_value: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
+        assert!(
+            delete_value.get("error").is_none(),
+            "unexpected delete error: {delete_value}"
+        );
+
+        let response = server.temporal_extent(extent_req(None));
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("error").is_none(), "unexpected error: {value}");
+
+        assert_eq!(
+            value["valid_time"]["earliest"],
+            serde_json::json!("2021-03-01T00:00:00.000000Z"),
+            "a deleted node's backdated start must still bound earliest"
+        );
+
+        // The deletion closed the valid interval at ~now and recorded the
+        // tombstone: both latest bounds move past the 2021 backdate.
+        for dim in ["valid_time", "transaction_time"] {
+            assert_rfc3339(&value[dim]["latest"], &format!("{dim} latest"));
+            let latest =
+                chrono::DateTime::parse_from_rfc3339(value[dim]["latest"].as_str().unwrap())
+                    .unwrap();
+            let backdate = chrono::DateTime::parse_from_rfc3339("2022-01-01T00:00:00Z").unwrap();
+            assert!(
+                latest > backdate,
+                "{dim} latest must reflect the deletion event, got {latest}"
+            );
+        }
+    }
+
+    #[test]
     fn test_as_of_before_extent_is_empty_inside_extent_has_data() {
         // The answerability contract the extent exists to provide: an AS OF
         // query strictly before valid_time.earliest returns empty, while the

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -893,8 +893,11 @@ pub struct GetSchemaRequest {
 // ============================================================================
 
 /// Request for the dataset's queryable bi-temporal extent: the earliest and
-/// latest valid-time and transaction-time coordinates across all recorded
-/// history (including expired/superseded versions).
+/// latest valid-time and transaction-time coordinates across recorded
+/// history (including expired/superseded versions), covering everything
+/// recorded during the current process lifetime plus hot-tier history
+/// restored at startup (versions cold-migrated before the last restart are
+/// excluded).
 ///
 /// No required arguments. Pass `by_label: true` to additionally receive the
 /// same bounds per node label and per edge type.
@@ -902,8 +905,12 @@ pub struct GetSchemaRequest {
 pub struct TemporalExtentRequest {
     /// When `true`, additionally break the bounds down per node label and
     /// per edge/relationship type. Defaults to `false` (overall bounds only).
+    ///
+    /// Per-label bounds are computed from hot-tier history only: on
+    /// databases with cold-storage migration they may be narrower than the
+    /// overall bounds (or a label may be absent entirely).
     #[schemars(
-        description = "When true, additionally return the same {valid_time, transaction_time} bounds per node label (node_labels) and per edge type (edge_types), so calibration can be scoped to the labels being queried. Defaults to false."
+        description = "When true, additionally return the same {valid_time, transaction_time} bounds per node label (node_labels) and per edge type (edge_types), so calibration can be scoped to the labels being queried. Defaults to false. Per-label bounds are computed from hot-tier history only and may be narrower than the overall bounds (or a label absent) after cold-storage migration."
     )]
     pub by_label: Option<bool>,
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -889,6 +889,26 @@ pub struct GetSchemaRequest {
 }
 
 // ============================================================================
+// Temporal Extent (Issue #3238)
+// ============================================================================
+
+/// Request for the dataset's queryable bi-temporal extent: the earliest and
+/// latest valid-time and transaction-time coordinates across all recorded
+/// history (including expired/superseded versions).
+///
+/// No required arguments. Pass `by_label: true` to additionally receive the
+/// same bounds per node label and per edge type.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct TemporalExtentRequest {
+    /// When `true`, additionally break the bounds down per node label and
+    /// per edge/relationship type. Defaults to `false` (overall bounds only).
+    #[schemars(
+        description = "When true, additionally return the same {valid_time, transaction_time} bounds per node label (node_labels) and per edge type (edge_types), so calibration can be scoped to the labels being queried. Defaults to false."
+    )]
+    pub by_label: Option<bool>,
+}
+
+// ============================================================================
 // Response Types (for serialization)
 // ============================================================================
 

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1560,6 +1560,32 @@ impl HistoricalStorage {
         result
     }
 
+    /// Visit every node version retained in hot historical storage
+    /// (read-only, unordered).
+    ///
+    /// Includes expired/superseded versions and delete tombstones — hot
+    /// storage never prunes versions (the retention policy only rejects
+    /// over-limit writes). Versions whose payload has been migrated to cold
+    /// storage are not visited. Used by `AletheiaDB::temporal_extent_by_label`
+    /// (Issue #3238) to fold per-label temporal bounds without allocating an
+    /// intermediate map.
+    pub fn visit_node_versions(&self, mut f: impl FnMut(&NodeVersion)) {
+        for version in self.node_versions.values() {
+            f(version);
+        }
+    }
+
+    /// Visit every edge version retained in hot historical storage
+    /// (read-only, unordered).
+    ///
+    /// Edge counterpart of [`visit_node_versions`](Self::visit_node_versions);
+    /// the same coverage notes apply.
+    pub fn visit_edge_versions(&self, mut f: impl FnMut(&EdgeVersion)) {
+        for version in self.edge_versions.values() {
+            f(version);
+        }
+    }
+
     /// Collect changefeed records for every committed version that falls within the given
     /// transaction-time window, optionally constrained by a valid-time window and/or a
     /// node-label / edge-type filter (Issue #3216).


### PR DESCRIPTION
# Expose queryable bi-temporal extent (`temporal_extent`) — Issue #3238

## Before / After

**Before:** Nothing tells a caller what time range the data actually covers. If an LLM asks "what did we know in 2019?" and the dataset only goes back to 2023, the `AS OF '2019-...'` query returns an empty result that is indistinguishable from "nothing existed in 2019" — the model confidently reports absence of facts when the truth is "out of recorded range." The only workarounds were per-entity `get_node_history` dumps or full scans.

**After:** One call — the new `temporal_extent` MCP tool (backed by the additive public API `AletheiaDB::temporal_extent()`) — reports the dataset's queryable bi-temporal extent: `valid_time: {earliest, latest}` and `transaction_time: {earliest, latest}` as RFC3339 strings. A caller checks "does this dataset even reach time T?" before issuing an `AS OF`, turning an ambiguous empty result into a self-correcting signal. `by_label: true` scopes the same bounds per node label and per edge type. An empty database returns explicit `null`s, never epoch-1970.

## How

- **`AletheiaDB::temporal_extent()` / `temporal_extent_by_label()`** (new `src/db/extent.rs`, re-exported from `db` and crate root): overall bounds are **O(1) reads of a write-time maintained aggregate** in the temporal indexes (`TemporalIndexes::extent()` reading a leaf-mutex `ExtentAggregate` in `src/index/temporal/mod.rs`, updated on every version insertion, batch insertion, and interval close, reset by `clear()`). Index entries are written for every committed write — including delete tombstones — and are never removed while the process runs, so bounds only ever widen and callers may cache them per session.
- **Coverage caveat (documented everywhere)**: bounds span all history recorded during the current process lifetime **plus hot-tier history restored at startup**. On databases with cold-storage migration enabled, versions migrated to the cold tier **before the last restart** are not reflected (the indexes rebuild from hot-tier versions at startup). A follow-up could persist cold-tier bounds metadata.
- **Convention** (documented in rustdoc, the tool description, and the guide): `earliest` = min interval start per dimension; `latest` = max of interval starts and *closed* interval ends; open-ended intervals contribute only their start, so the `TIMESTAMP_MAX` open-interval sentinel never leaks into output.
- **`by_label` breakdown**: folded from the hot-tier historical version store via read-only visitors (`HistoricalStorage::visit_node_versions` / `visit_edge_versions`) — the only label-aware source. `temporal_extent_by_label` takes the `historical` read lock **before** reading the overall bounds and holds it across the per-label scan, so a concurrent commit cannot make a per-label bound exceed the overall bounds (lock order `historical` (3) → temporal-index aggregate (4) respected). Cold-migrated version payloads aren't attributed to a label (documented); a hot-only database's breakdown folds back exactly to the overall bounds (tested).
- **MCP layer serializes only** (`src/mcp/server.rs`): `handle_temporal_extent` deserializes `TemporalExtentRequest { by_label }`, calls the public API, and renders timestamps via chrono RFC3339 (microsecond precision, `Z`); coordinates beyond chrono's range fall back to a raw-microseconds rendering instead of panicking (tested). Errors use the Issue #3234 structured shape (`{"error": {"code", "message", "retriable", "details"?}}`): malformed arguments classify as `INVALID_ARGUMENT` via the shared `invalid_argument` helper, and (defensively) API errors would route through `db_error`. A call with no `arguments` object at all is treated as `{}` (the tool has no required arguments).
- **Docs:** CLAUDE.md MCP tool table (Temporal row) + a "Discovering the queryable temporal extent" section in `docs/guides/mcp-query-tool.md` covering purpose (AS OF calibration), the open-interval convention, the extent-vs-current-state distinction, and the cold-storage/restart coverage caveat.

## Review follow-up (commit `abe259d`, formerly 6e9392e pre-rebase)

A code-review pass on the initial commit produced these changes:

1. **Perf**: replaced the O(total versions) index fold (which held DashMap shard guards, and — via the commit path — could stall commits on large datasets) with the write-time `ExtentAggregate`; `extent()` is now O(1). Monotonicity/soundness argument documented on the type.
2. **Race**: `temporal_extent_by_label` previously read the overall bounds and scanned per-label versions in two non-overlapping phases, so a write between them could make a per-label bound exceed the overall bounds; it now holds the `historical` read lock across both.
3. **Docs accuracy**: "covers **all recorded history**" overstated coverage across restarts with cold-storage migration; every surface (rustdoc, tool description, request schema, guide, CLAUDE.md, CHANGELOG) now states the process-lifetime + hot-tier-restore coverage and the cold-migration caveat.
4. **Simplification**: `DimAccumulator`/`ExtentAggregate` `latest` computation uses the `TimeRange` `end >= start` invariant (no redundant `max(start, end)`); per-label accumulation uses `HashMap` instead of `BTreeMap` (results are sorted afterwards anyway).
5. **Test flakiness**: HLC same-microsecond comparisons deflaked (slack on the tx-latest window assertion; the AS OF answerability test anchors to the extent's own `transaction_time.latest` instead of a fresh `time::now()`).
6. **New tests**: RFC3339 out-of-chrono-range fallback; delete-tombstone extent coverage (Rust + MCP); mutant-killing `DimAccumulator` tests (backdated min-start; closed end beyond every start, forced via `close_node_version_transaction_time`); a breakdown-vs-overall consistency helper asserted in every by-label test.
7. **Benchmarks** (`benches/temporal_extent.rs`, registered in `Cargo.toml`), sanity run in this environment (criterion `--quick`):
   - `temporal_extent_overall/100000_versions`: ~26.1 ns; `/1000000_versions`: ~25.1 ns — flat 100K→1M, O(1) confirmed.
   - `temporal_extent_index_read/1000000_versions`: ~24.3 ns.
   - `temporal_extent_by_label/10000_versions`: ~239 µs; `/100000_versions`: ~2.61 ms — linear in hot-tier versions, as documented.

## Rebase onto #3342 (structured MCP error codes, Issue #3234) — commits `452c944` + `abe259d` + `0838a65`

The branch was rebased onto trunk after #3342 merged (it deleted `error_json` and introduced typed error helpers plus a registry-driven error-shape sweep):

- `handle_temporal_extent`'s error paths migrated to the typed helpers: argument parse failures → `self.invalid_argument(...)` (`INVALID_ARGUMENT`, `retriable: false`, message preserves the free-text detail); the API-error arm → `self.db_error(...)` (defensive; the extent API is infallible in practice).
- `temporal_extent` added to the new `dispatch_tool` registry table, so the #3342 registry sweep (`every_advertised_tool_returns_structured_error_on_invalid_arguments`) covers it automatically — verified passing.
- The unit test `handle_temporal_extent_invalid_by_label_type_routes_through_error_json` was renamed to `..._routes_through_invalid_argument` and now asserts the structured shape (`error.code == "INVALID_ARGUMENT"`, `error.retriable == false`, message contains `Invalid arguments`).
- The guide keeps both new sections: "Structured error codes and the retriable contract" (#3234) followed by "Discovering the queryable temporal extent" (#3238).
- Coverage follow-up (`0838a65`): index-level tests for the extent aggregate's remaining edge branches — batch-insert publication via `merge()`, the `TIMESTAMP_MAX` guard in `observe_closed_end`, edge-interval close observers, absent-entity close no-op, and `clear()` resetting the aggregate. The remaining uncovered handler lines are defensive branches unreachable by construction (infallible extent API; success serialization of an in-memory JSON object cannot fail).

## Acceptance criteria

- [x] **AC1** — MCP tool `temporal_extent` (no required arguments) returns `valid_time: {earliest, latest}` and `transaction_time: {earliest, latest}` as RFC3339 strings in one call. Evidence: `test_temporal_extent_populated_shape_and_rfc3339`, `handle_temporal_extent_null_args_behaves_like_no_arguments`, `test_temporal_extent_tool_listed_in_registry`.
- [x] **AC2** — Additive public API `AletheiaDB::temporal_extent() -> TemporalExtent` backs the tool; the MCP handler only serializes (see `handle_temporal_extent` — request parse → API call → JSON render, no storage logic).
- [x] **AC3** — Optional `by_label: true` returns the same bounds per node label and per edge type. Evidence: `by_label_breakdown_partitions_bounds_per_label_and_edge_type` (db), `test_temporal_extent_by_label_breakdown` (MCP), plus `assert_breakdown_consistent_with_overall` invariant checks.
- [x] **AC4** — Empty database returns explicit `null` bounds, never 0/epoch. Evidence: `empty_database_returns_all_none_bounds` (db), `test_temporal_extent_empty_database_returns_null_bounds`, `test_temporal_extent_empty_database_by_label_returns_empty_breakdown` (MCP).
- [x] **AC5** — Open-ended facts accounted for in `latest` per a documented convention; semantics documented inline in the tool description and schema. Evidence: `open_valid_to_contributes_start_not_sentinel_to_latest`, `closed_valid_to_extends_latest_beyond_any_start`, `by_label_closed_end_beyond_every_start_extends_label_latest`, `extent_close_with_open_sentinel_is_ignored` (index); tool description in `tool_definitions()`.
- [x] **AC6** — Documented as covering recorded history including expired/superseded versions and delete tombstones, distinguishing extent from current-state counts (with the cold-storage restart caveat stated). Evidence: rustdoc on `src/db/extent.rs`, tool description, guide section; behavior proven by `superseded_version_still_counts_toward_earliest`, `deleted_backdated_node_still_bounds_extent` (db) and `test_temporal_extent_expired_version_still_counts_toward_earliest`, `test_temporal_extent_deleted_node_tombstone_still_counts` (MCP).
- [x] **AC7** — Tests: MCP-surface shape+correctness on a populated multi-label DB; empty-DB null bounds; and the answerability proof — an `AS OF` before `valid_time.earliest` returns empty while the same query inside the extent returns data: `as_of_before_extent_is_empty_inside_extent_has_data` (db) and `test_as_of_before_extent_is_empty_inside_extent_has_data` (MCP).

## Out of scope (respected)

No counts/magnitude in the payload (that's `database_stats` #3222); no structural schema (#3214); no per-record temporal stamps (#3232); single-instance extent only. Persisting cold-tier extent metadata across restarts is suggested as a follow-up, not implemented here.

## Gates (re-run at `0838a65`, post-rebase onto #3342)

- `cargo clippy --all-targets --all-features -- -D warnings` — clean (`Finished dev profile`, exit 0).
- `cargo fmt --all` — applied; `cargo fmt --all --check` clean.
- `cargo test --features mcp-server` — 138 binaries, **4987 passed, 0 failed**, 122 ignored (incl. 410 doctests). Two WAL fault-injection tests skipped (`havoc::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`): both inject I/O errors by chmod-ing a directory read-only, which cannot fail under this sandbox's root user (verified: root writes into a 0444 directory succeed). Both are **pre-existing** failures reproduced identically on untouched trunk; this branch touches no WAL code.
- `cargo bench --bench temporal_extent -- --quick` — runs clean; numbers above.
- Coverage check not run locally (`cargo-llvm-cov` not installed); the codecov-flagged extent-aggregate lines are now exercised by the `0838a65` tests.

Closes #3238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdHVR8dp7Xg8Gy1ksR8ons

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdHVR8dp7Xg8Gy1ksR8ons)_