### PR TITLE
Return structured error codes with retriable flag from MCP tools (#3234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prior behavior exactly. On `delete_node`, `valid_time` is not supported
   together with `detach: true` (cascade delete does not support backdating).
 
+### Changed
+
+- MCP tool error responses are now structured (Issue #3234): every error is
+  `{"error": {"code", "message", "retriable", "details"?}}` instead of
+  `{"error": "<string>"}`. `code` is drawn from a stable seven-value enum
+  (`NOT_FOUND`, `INVALID_ARGUMENT`, `CONSTRAINT_VIOLATION`,
+  `FAILED_PRECONDITION`, `CONFLICT`, `UNAVAILABLE`, `INTERNAL`); `retriable`
+  is `true` only for transient classes (timeouts, clock skew,
+  serialization/write conflicts) and always `false` for caller-fault classes;
+  `details` carries optional per-code metadata (e.g. the DETACH refusal's
+  `connected_edges`, a unique violation's `existing_node_id`). The previous
+  free-text error message is preserved verbatim at `error.message`. The
+  `query` tool keeps its own `kind` field verbatim, with `code`/`retriable`
+  added additively alongside it. **Breaking for consumers that read `error`
+  as a string** (e.g. `error.as_str()`): the JSON type of the `error` value
+  changed from string to object. See
+  [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#structured-error-codes-and-the-retriable-contract).
+
 ### Fixed
 
 - `create_edge_with_valid_time` now enforces the same "not more than one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,8 +328,30 @@ before execution and never write. Errors come back as a structured
 `read_only_violation`, `language_unavailable`, `parse_error`,
 `unsupported_construct`, `invalid_params`, `runtime_error`) so the caller can
 self-correct. When the `cypher` feature is not compiled in, `language:"cypher"`
-returns `language_unavailable` (AQL is always available). See
+returns `language_unavailable` (AQL is always available). The query tool's
+`kind` field is preserved verbatim; the uniform `code`/`retriable` fields
+below are carried additively alongside it. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md).
+
+**Structured error codes with retriable flag (Issue #3234)**: Every MCP tool
+error response is `{"error": {"code", "message", "retriable", "details"?}}`.
+`code` is drawn from a small, stable enum -- `NOT_FOUND`, `INVALID_ARGUMENT`,
+`CONSTRAINT_VIOLATION`, `FAILED_PRECONDITION`, `CONFLICT`, `UNAVAILABLE`,
+`INTERNAL` -- so an LLM/caller branches on category (retry transient errors,
+repair invalid arguments, escalate the rest) with zero substring matching.
+`message` preserves the pre-existing free text (the change is additive);
+`retriable` is `true` **only** for transient classes (timeouts, clock skew,
+serialization/write conflicts -- `UNAVAILABLE` and most `CONFLICT`s), always
+`false` for caller-fault classes (not-found, invalid-argument, constraint,
+failed-precondition); `details` carries per-code structured metadata (e.g.
+the #3209 DETACH refusal is `FAILED_PRECONDITION` with
+`details.connected_edges`; a unique violation is `CONSTRAINT_VIOLATION` with
+`details.existing_node_id` -- the legacy top-level fields remain alongside).
+Recovery loop: `retriable: true` -> retry with backoff; `INVALID_ARGUMENT` /
+`FAILED_PRECONDITION` / `CONSTRAINT_VIOLATION` -> repair the call from
+`message` + `details` and re-issue; otherwise escalate. Codes may be added
+over time but never change meaning; treat unknown codes as non-retriable. See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#structured-error-codes-and-the-retriable-contract).
 
 **Valid-time writes (Issue #3221)**: `create_node`, `create_edge`,
 `update_node`, `update_edge`, `delete_node`, and `delete_edge` accept an

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -59,12 +59,23 @@ Errors are returned as a machine-readable payload so the LLM can self-correct:
 ```json
 { "error": { "kind": "read_only_violation", "clause": "CREATE",
              "language": "cypher",
+             "code": "INVALID_ARGUMENT", "retriable": false,
              "message": "The `query` tool is read-only; the `CREATE` clause ..." } }
 ```
 
 `kind` is one of: `invalid_request`, `read_only_violation`,
 `language_unavailable`, `parse_error`, `unsupported_construct`,
 `invalid_params`, `runtime_error`.
+
+`kind` is the query tool's own execution-layer contract (Issue #3213) and is
+preserved verbatim. The uniform `code` / `retriable` fields shared by **every**
+MCP tool (Issue #3234, see
+[Structured error codes](#structured-error-codes-and-the-retriable-contract))
+are carried additively alongside it: `invalid_request`, `read_only_violation`,
+`parse_error`, `unsupported_construct`, and `invalid_params` map to
+`INVALID_ARGUMENT`; `language_unavailable` maps to `FAILED_PRECONDITION`; and
+`runtime_error` is classified from the underlying engine error (`INTERNAL`,
+or `UNAVAILABLE`/retriable for a timeout).
 
 ## Supported read-only subset
 
@@ -154,7 +165,8 @@ absent before it:
 
 // tools/call -> "get_node_at_time"
 { "node_id": 7, "valid_time": "2021-01-01T00:00:00Z" }
-// -> { "error": "..." }  (not yet true at this valid time)
+// -> { "error": { "code": "NOT_FOUND", "retriable": false, "message": "..." } }
+//    (not yet true at this valid time)
 ```
 
 `valid_time` accepts the same formats as every other MCP temporal field
@@ -167,9 +179,12 @@ in-the-future, or before-entity-creation `valid_time` is rejected with a
 structured error, e.g.:
 
 ```jsonc
-{ "error": "Invalid valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." }
-{ "error": "valid_from ... is too far in future (current: ..., max offset: ...)" }
-{ "error": "valid_from ... is before entity creation time ... for node:7" }
+{ "error": { "code": "INVALID_ARGUMENT", "retriable": false,
+             "message": "Invalid valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." } }
+{ "error": { "code": "INVALID_ARGUMENT", "retriable": false,
+             "message": "valid_from ... is too far in future (current: ..., max offset: ...)" } }
+{ "error": { "code": "INVALID_ARGUMENT", "retriable": false,
+             "message": "valid_from ... is before entity creation time ... for node:7" } }
 ```
 
 ## Point-in-time (AS OF) graph traversal
@@ -229,11 +244,86 @@ As with every other `as_of_*` field, an unparseable timestamp
 returns a structured error instead of silently traversing current state:
 
 ```jsonc
-{ "error": "Invalid as_of_valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." }
+{ "error": { "code": "INVALID_ARGUMENT", "retriable": false,
+             "message": "Invalid as_of_valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." } }
 ```
 
 `MAX_TRAVERSAL_DEPTH` and `MAX_RESULT_LIMIT` apply identically whether or not
 a temporal coordinate is supplied.
+
+## Structured error codes and the retriable contract
+
+Every MCP tool error — across **all** tools, not just `query` — is a JSON
+object of this shape (Issue #3234):
+
+```json
+{
+  "error": {
+    "code": "FAILED_PRECONDITION",
+    "message": "Node 7 has 2 connected edge(s); refusing to delete. ...",
+    "retriable": false,
+    "details": { "node_id": 7, "connected_edges": 2, "detach_required": true }
+  }
+}
+```
+
+- **`code`** is drawn from a small, stable enum (below). Branch on `code`,
+  never on `message` — the free text may be reworded; the codes never change
+  meaning or spelling.
+- **`message`** preserves the human-readable text that older releases
+  returned as the entire `error` value (the change is additive — nothing is
+  lost).
+- **`retriable`** is the server's advisory classification: `true` **only**
+  for transient failure classes (timeouts, clock skew, serialization/write
+  conflicts) where an identical retry can succeed. It is always `false` for
+  caller-fault classes — retrying the same not-found lookup or malformed
+  argument cannot succeed. The client owns the retry loop (backoff, attempt
+  caps); the server never retries on its behalf.
+- **`details`** is optional structured metadata for specific codes, e.g. the
+  DETACH-delete refusal's `connected_edges` or a unique-constraint
+  violation's `existing_node_id`.
+
+### The code enum
+
+| Code | Meaning | `retriable` | What the caller should do |
+|------|---------|-------------|---------------------------|
+| `NOT_FOUND` | Entity (or tool) doesn't exist, or didn't exist at the requested bi-temporal coordinate | `false` | Re-check the ID / coordinate, or surface to the user |
+| `INVALID_ARGUMENT` | Malformed arguments: bad JSON, out-of-range ID, unparseable timestamp, invalid query text, inconsistent parameter combination | `false` | Fix the arguments and re-issue |
+| `CONSTRAINT_VIOLATION` | A declared uniqueness constraint rejected the write (`details` carries `label`, `property`, `value`, `existing_node_id`) | `false` | Use the existing entity or change the value |
+| `FAILED_PRECONDITION` | Valid request, wrong system state: vector index not enabled, node still has connected edges without `detach: true`, referenced edge endpoint missing, feature not compiled in | `false` | Change the state (enable the index, pass `detach`, create the endpoint), then re-issue |
+| `CONFLICT` | Concurrency conflict: serialization failure, write-write conflict, aborted transaction | usually `true` | Retry the operation (a duplicate-ID conflict is the exception: `retriable: false`) |
+| `UNAVAILABLE` | Transient condition: query timeout, clock skew | `true` | Retry, ideally with backoff |
+| `INTERNAL` | Unexpected internal failure: I/O, corruption, poisoned lock | `false` | Report; do not blind-retry |
+
+Codes may be **added** over time; existing codes never change. Treat an
+unrecognized code as non-retriable.
+
+### Recovery loop example (LLM-style)
+
+An agent driving AletheiaDB branches on `code` — zero substring matching:
+
+```jsonc
+// 1. tools/call -> "delete_node" { "node_id": 7 }
+// -> { "error": { "code": "FAILED_PRECONDITION", "retriable": false,
+//                 "message": "Node 7 has 2 connected edge(s); refusing to delete. ...",
+//                 "details": { "connected_edges": 2, "detach_required": true } },
+//      "connected_edges": 2, "detach_required": true, "success": false }
+
+// 2. code == "FAILED_PRECONDITION" and details.detach_required
+//    -> repair the call, don't retry blindly:
+// tools/call -> "delete_node" { "node_id": 7, "detach": true }
+// -> { "success": true, "deleted_node_id": 7, "edges_removed": 2 }
+```
+
+The general loop: `retriable: true` → retry with backoff (bounded attempts);
+`INVALID_ARGUMENT` / `FAILED_PRECONDITION` / `CONSTRAINT_VIOLATION` → repair
+the request using `message` + `details`, then re-issue; `NOT_FOUND` /
+`INTERNAL` → escalate to the user.
+
+Legacy top-level fields that predate this contract (the DETACH refusal's
+`connected_edges` / `detach_required`, the unique-violation's
+`constraint_violation` / `existing_node_id`) remain present alongside
+`error.details`, so pre-#3234 consumers keep working.
 
 ## Notes
 

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -74,8 +74,10 @@ MCP tool (Issue #3234, see
 are carried additively alongside it: `invalid_request`, `read_only_violation`,
 `parse_error`, `unsupported_construct`, and `invalid_params` map to
 `INVALID_ARGUMENT`; `language_unavailable` maps to `FAILED_PRECONDITION`; and
-`runtime_error` is classified from the underlying engine error (`INTERNAL`,
-or `UNAVAILABLE`/retriable for a timeout).
+`runtime_error` is classified from the underlying engine error, so **any**
+code from the enum is possible — e.g. `INTERNAL` for an unexpected execution
+failure, `UNAVAILABLE`/retriable for a timeout, or `NOT_FOUND` if an entity
+vanishes mid-execution.
 
 ## Supported read-only subset
 
@@ -281,18 +283,19 @@ object of this shape (Issue #3234):
   caps); the server never retries on its behalf.
 - **`details`** is optional structured metadata for specific codes, e.g. the
   DETACH-delete refusal's `connected_edges` or a unique-constraint
-  violation's `existing_node_id`.
+  violation's `existing_node_id`. When absent it is omitted entirely — never
+  `null`.
 
 ### The code enum
 
 | Code | Meaning | `retriable` | What the caller should do |
 |------|---------|-------------|---------------------------|
-| `NOT_FOUND` | Entity (or tool) doesn't exist, or didn't exist at the requested bi-temporal coordinate | `false` | Re-check the ID / coordinate, or surface to the user |
-| `INVALID_ARGUMENT` | Malformed arguments: bad JSON, out-of-range ID, unparseable timestamp, invalid query text, inconsistent parameter combination | `false` | Fix the arguments and re-issue |
+| `NOT_FOUND` | Entity doesn't exist, or didn't exist at the requested bi-temporal coordinate; also an unknown tool name | `false` | Re-check the ID / coordinate or the tool name, or surface to the user |
+| `INVALID_ARGUMENT` | Malformed arguments: bad JSON, out-of-range ID, unparseable timestamp, invalid query text, inconsistent parameter combination, unsupported constraint key type | `false` | Fix the arguments and re-issue |
 | `CONSTRAINT_VIOLATION` | A declared uniqueness constraint rejected the write (`details` carries `label`, `property`, `value`, `existing_node_id`) | `false` | Use the existing entity or change the value |
-| `FAILED_PRECONDITION` | Valid request, wrong system state: vector index not enabled, node still has connected edges without `detach: true`, referenced edge endpoint missing, feature not compiled in | `false` | Change the state (enable the index, pass `detach`, create the endpoint), then re-issue |
+| `FAILED_PRECONDITION` | Valid request, wrong system state: vector index not enabled, node still has connected edges without `detach: true`, referenced edge endpoint missing, enabling a unique constraint over already-existing duplicate values, feature not compiled in | `false` | Change the state (enable the index, pass `detach`, create the endpoint, dedupe the data), then re-issue |
 | `CONFLICT` | Concurrency conflict: serialization failure, write-write conflict, aborted transaction | usually `true` | Retry the operation (a duplicate-ID conflict is the exception: `retriable: false`) |
-| `UNAVAILABLE` | Transient condition: query timeout, clock skew | `true` | Retry, ideally with backoff |
+| `UNAVAILABLE` | Transient condition: query timeout, clock skew, and other clock-related hiccups (non-monotonic transaction time, logical counter overflow) | `true` | Retry, ideally with backoff |
 | `INTERNAL` | Unexpected internal failure: I/O, corruption, poisoned lock | `false` | Report; do not blind-retry |
 
 Codes may be **added** over time; existing codes never change. Treat an
@@ -306,13 +309,13 @@ An agent driving AletheiaDB branches on `code` — zero substring matching:
 // 1. tools/call -> "delete_node" { "node_id": 7 }
 // -> { "error": { "code": "FAILED_PRECONDITION", "retriable": false,
 //                 "message": "Node 7 has 2 connected edge(s); refusing to delete. ...",
-//                 "details": { "connected_edges": 2, "detach_required": true } },
-//      "connected_edges": 2, "detach_required": true, "success": false }
+//                 "details": { "node_id": 7, "connected_edges": 2, "detach_required": true } },
+//      "node_id": 7, "connected_edges": 2, "detach_required": true, "success": false }
 
 // 2. code == "FAILED_PRECONDITION" and details.detach_required
 //    -> repair the call, don't retry blindly:
 // tools/call -> "delete_node" { "node_id": 7, "detach": true }
-// -> { "success": true, "deleted_node_id": 7, "edges_removed": 2 }
+// -> { "success": true, "deleted_node_id": 7, "detached": true, "edges_removed": 2 }
 ```
 
 The general loop: `retriable: true` → retry with backoff (bounded attempts);

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -6,7 +6,7 @@
 //! {
 //!   "error": {
 //!     "code": "NOT_FOUND",
-//!     "message": "Node not found: Node(123)",
+//!     "message": "Storage error: Node not found: Node(123)",
 //!     "retriable": false,
 //!     "details": { "...": "optional, structured, per-code metadata" }
 //!   }
@@ -29,10 +29,8 @@
 //! codes happens only at this boundary — the library's `thiserror` enums are
 //! unchanged.
 
-use serde_json::json;
-
 use crate::core::error::{
-    Error, QueryError, StorageError, TemporalError, TransactionError, VectorError,
+    ConstraintError, Error, QueryError, StorageError, TemporalError, TransactionError, VectorError,
 };
 
 /// Stable, machine-readable error codes for the MCP surface.
@@ -155,9 +153,9 @@ impl McpError {
     /// Serialize the inner error object (the value of the `"error"` key).
     pub fn to_json(&self) -> serde_json::Value {
         let mut obj = serde_json::Map::new();
-        obj.insert("code".to_string(), json!(self.code.as_str()));
-        obj.insert("message".to_string(), json!(self.message));
-        obj.insert("retriable".to_string(), json!(self.retriable));
+        obj.insert("code".to_string(), self.code.as_str().into());
+        obj.insert("message".to_string(), self.message.clone().into());
+        obj.insert("retriable".to_string(), self.retriable.into());
         if let Some(details) = &self.details {
             obj.insert("details".to_string(), details.clone());
         }
@@ -195,7 +193,7 @@ fn classify_db_error(e: &Error) -> (McpErrorCode, bool) {
         Error::Query(qe) => classify_query_error(qe),
         Error::Transaction(te) => classify_transaction_error(te),
         Error::Vector(ve) => classify_vector_error(ve),
-        Error::Constraint(_) => (McpErrorCode::ConstraintViolation, false),
+        Error::Constraint(ce) => classify_constraint_error(ce),
         // A provenance bundle failing validation is a caller fault.
         Error::Provenance(_) => (McpErrorCode::InvalidArgument, false),
         Error::Io(_) | Error::Backup(_) => (McpErrorCode::Internal, false),
@@ -240,7 +238,6 @@ fn classify_temporal_error(e: &TemporalError) -> (McpErrorCode, bool) {
         }
         TemporalError::InvalidTimeRange { .. }
         | TemporalError::InvalidTimestamp { .. }
-        | TemporalError::TemporalParadox { .. }
         | TemporalError::ValidTimeBeforeCreation { .. }
         | TemporalError::ValidTimeTooFarInFuture { .. }
         | TemporalError::ValidTimeBeforeEntityCreation { .. } => {
@@ -251,9 +248,28 @@ fn classify_temporal_error(e: &TemporalError) -> (McpErrorCode, bool) {
         // later wallclock/logical tick can succeed.
         TemporalError::NonMonotonicTransactionTime { .. }
         | TemporalError::LogicalCounterOverflow { .. } => (McpErrorCode::Unavailable, true),
-        TemporalError::CorruptedVersionChain { .. }
+        // Despite its caller-fault-sounding name, `TemporalParadox` is only
+        // raised when the system clock reads before the Unix epoch — a
+        // server-environment fault, not something the caller can repair.
+        TemporalError::TemporalParadox { .. }
+        | TemporalError::CorruptedVersionChain { .. }
         | TemporalError::MissingAnchor { .. }
         | TemporalError::MaxDepthExceeded { .. } => (McpErrorCode::Internal, false),
+    }
+}
+
+/// Classify a [`ConstraintError`] per variant.
+///
+/// Only a `UniqueViolation` is a true `CONSTRAINT_VIOLATION` (a declared
+/// constraint rejecting *this* write). `UnsupportedKeyType` is a caller
+/// fault in the enable request itself, and `DuplicateOnEnable` is a state
+/// problem — duplicates already exist in the graph, so the caller must fix
+/// the data (or drop the request) before the enable can succeed.
+fn classify_constraint_error(e: &ConstraintError) -> (McpErrorCode, bool) {
+    match e {
+        ConstraintError::UniqueViolation { .. } => (McpErrorCode::ConstraintViolation, false),
+        ConstraintError::UnsupportedKeyType { .. } => (McpErrorCode::InvalidArgument, false),
+        ConstraintError::DuplicateOnEnable { .. } => (McpErrorCode::FailedPrecondition, false),
     }
 }
 
@@ -308,13 +324,19 @@ fn classify_vector_error(e: &VectorError) -> (McpErrorCode, bool) {
 /// request problem except `language_unavailable` (a build/deployment
 /// precondition) and `runtime_error` (engine-side, classified from the
 /// underlying error where available).
-pub fn query_kind_classification(kind: &str) -> (McpErrorCode, bool) {
+pub(crate) fn query_kind_classification(kind: &str) -> (McpErrorCode, bool) {
     match kind {
+        "invalid_request"
+        | "read_only_violation"
+        | "parse_error"
+        | "unsupported_construct"
+        | "invalid_params" => (McpErrorCode::InvalidArgument, false),
         "language_unavailable" => (McpErrorCode::FailedPrecondition, false),
         "runtime_error" => (McpErrorCode::Internal, false),
-        // invalid_request, read_only_violation, parse_error,
-        // unsupported_construct, invalid_params — all caller faults.
-        _ => (McpErrorCode::InvalidArgument, false),
+        // Fail-safe: a future kind added without updating this mapping is
+        // reported as INTERNAL (non-retriable) rather than silently blamed
+        // on the caller as INVALID_ARGUMENT.
+        _ => (McpErrorCode::Internal, false),
     }
 }
 
@@ -486,6 +508,37 @@ mod tests {
                 StorageError::CorruptedData("bad checksum".into()).into(),
                 McpErrorCode::Internal,
             ),
+            // TemporalParadox's only raise site is a system-clock-before-epoch
+            // fault — a server-environment problem, not a caller fault.
+            (
+                TemporalError::TemporalParadox {
+                    reason: "System clock is before Unix epoch".into(),
+                }
+                .into(),
+                McpErrorCode::Internal,
+            ),
+            // An unsupported constraint key type is a fault in the request.
+            (
+                ConstraintError::UnsupportedKeyType {
+                    label: "Person".into(),
+                    property: "avatar".into(),
+                    type_name: "Vector".into(),
+                }
+                .into(),
+                McpErrorCode::InvalidArgument,
+            ),
+            // Enabling over existing duplicates is a state problem: fix the
+            // data, then re-issue the enable.
+            (
+                ConstraintError::DuplicateOnEnable {
+                    label: "Person".into(),
+                    property: "email".into(),
+                    value: "dup".into(),
+                    node_ids: vec![NodeId::new(1).unwrap(), NodeId::new(2).unwrap()],
+                }
+                .into(),
+                McpErrorCode::FailedPrecondition,
+            ),
             (
                 VectorError::DimensionMismatch {
                     expected: 4,
@@ -536,5 +589,36 @@ mod tests {
             query_kind_classification("runtime_error"),
             (McpErrorCode::Internal, false)
         );
+    }
+
+    #[test]
+    fn query_kind_classification_unknown_kind_is_internal() {
+        // Fail-safe: a kind added in the future without updating the mapping
+        // must surface as INTERNAL, never be blamed on the caller.
+        assert_eq!(
+            query_kind_classification("some_future_kind"),
+            (McpErrorCode::Internal, false)
+        );
+    }
+
+    #[test]
+    fn retriable_true_serializes_through_to_json() {
+        // Transient classes must carry `retriable: true` all the way through
+        // the JSON serialization path, not just in the in-memory struct.
+        let timeout = McpError::from_db_error(&QueryError::Timeout { duration_ms: 5000 }.into());
+        let json = timeout.to_json();
+        assert_eq!(json["code"], "UNAVAILABLE");
+        assert_eq!(json["retriable"], true);
+
+        let serialization = McpError::from_db_error(
+            &TransactionError::SerializationFailure {
+                entity: "node-1".into(),
+                reason: "concurrent commit".into(),
+            }
+            .into(),
+        );
+        let json = serialization.to_json();
+        assert_eq!(json["code"], "CONFLICT");
+        assert_eq!(json["retriable"], true);
     }
 }

--- a/src/mcp/error.rs
+++ b/src/mcp/error.rs
@@ -1,0 +1,540 @@
+//! Structured MCP error codes with a retriable flag (Issue #3234).
+//!
+//! Every MCP tool error response is a JSON object of the shape:
+//!
+//! ```json
+//! {
+//!   "error": {
+//!     "code": "NOT_FOUND",
+//!     "message": "Node not found: Node(123)",
+//!     "retriable": false,
+//!     "details": { "...": "optional, structured, per-code metadata" }
+//!   }
+//! }
+//! ```
+//!
+//! - `code` is drawn from the small, stable [`McpErrorCode`] enum, modeled on
+//!   gRPC's canonical codes. Clients branch on `code`, never on `message`.
+//! - `message` preserves the human-readable free text previously returned as
+//!   the whole `error` value (additive change — no information lost).
+//! - `retriable` is an explicit, advisory server-side classification: `true`
+//!   only for transient failure classes (timeouts, clock skew, serialization
+//!   conflicts), `false` for caller-fault classes (not-found,
+//!   invalid-argument, constraint violations). The client owns the retry
+//!   loop; the server never retries on its behalf.
+//! - `details` carries optional structured metadata (e.g. the DETACH-delete
+//!   refusal's `connected_edges`, a unique violation's `existing_node_id`).
+//!
+//! The classification from AletheiaDB's internal [`Error`] taxonomy to MCP
+//! codes happens only at this boundary — the library's `thiserror` enums are
+//! unchanged.
+
+use serde_json::json;
+
+use crate::core::error::{
+    Error, QueryError, StorageError, TemporalError, TransactionError, VectorError,
+};
+
+/// Stable, machine-readable error codes for the MCP surface.
+///
+/// The wire representation ([`McpErrorCode::as_str`]) is SCREAMING_SNAKE_CASE
+/// and is a **stability contract**: codes may be added, but existing codes
+/// never change meaning or spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpErrorCode {
+    /// The referenced entity (node, edge, version, tool, ...) does not exist,
+    /// or did not exist at the requested bi-temporal coordinate.
+    NotFound,
+    /// The request itself is malformed: bad JSON arguments, an out-of-range
+    /// ID, an unparseable timestamp, inconsistent parameter combinations, or
+    /// an invalid query statement. Fix the arguments before retrying.
+    InvalidArgument,
+    /// A declared uniqueness constraint rejected the write.
+    ConstraintViolation,
+    /// The operation is valid but the system is not in the required state:
+    /// e.g. a vector index is not enabled, a node still has connected edges
+    /// and `detach` was not passed, or a required build feature is not
+    /// compiled in. Change the state (or the call), then retry.
+    FailedPrecondition,
+    /// A concurrency conflict: serialization failure, write-write conflict,
+    /// aborted transaction, or duplicate ID race. Usually retriable.
+    Conflict,
+    /// A transient condition: query timeout, clock skew, or other
+    /// should-heal-itself failure. Retriable.
+    Unavailable,
+    /// An unexpected internal failure (I/O, corruption, poisoned lock,
+    /// serialization of a response, ...). Not retriable; report it.
+    Internal,
+}
+
+impl McpErrorCode {
+    /// The stable wire representation of this code.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            McpErrorCode::NotFound => "NOT_FOUND",
+            McpErrorCode::InvalidArgument => "INVALID_ARGUMENT",
+            McpErrorCode::ConstraintViolation => "CONSTRAINT_VIOLATION",
+            McpErrorCode::FailedPrecondition => "FAILED_PRECONDITION",
+            McpErrorCode::Conflict => "CONFLICT",
+            McpErrorCode::Unavailable => "UNAVAILABLE",
+            McpErrorCode::Internal => "INTERNAL",
+        }
+    }
+
+    /// Default retriable classification for this code.
+    ///
+    /// `Conflict` and `Unavailable` are transient by default; every
+    /// caller-fault and internal class defaults to non-retriable. Individual
+    /// errors may override (e.g. a `DuplicateId` maps to `Conflict` but is
+    /// *not* retriable, because retrying the same ID cannot succeed).
+    pub fn default_retriable(self) -> bool {
+        matches!(self, McpErrorCode::Conflict | McpErrorCode::Unavailable)
+    }
+}
+
+impl std::fmt::Display for McpErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A structured MCP error payload: code + message + retriable (+ details).
+#[derive(Debug, Clone)]
+pub struct McpError {
+    code: McpErrorCode,
+    message: String,
+    retriable: bool,
+    details: Option<serde_json::Value>,
+}
+
+impl McpError {
+    /// Build an error with the code's default retriable classification.
+    pub fn new(code: McpErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            retriable: code.default_retriable(),
+            details: None,
+        }
+    }
+
+    /// Override the retriable flag (e.g. non-retriable `Conflict`).
+    pub fn retriable(mut self, retriable: bool) -> Self {
+        self.retriable = retriable;
+        self
+    }
+
+    /// Attach structured, per-code metadata under `error.details`.
+    pub fn details(mut self, details: serde_json::Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+
+    /// Replace the message (e.g. to add call-site context around the
+    /// classified error's own text) without changing the classification.
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = message.into();
+        self
+    }
+
+    /// The code assigned to this error.
+    pub fn code(&self) -> McpErrorCode {
+        self.code
+    }
+
+    /// Whether this error is advisorily retriable.
+    pub fn is_retriable(&self) -> bool {
+        self.retriable
+    }
+
+    /// The human-readable message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Serialize the inner error object (the value of the `"error"` key).
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert("code".to_string(), json!(self.code.as_str()));
+        obj.insert("message".to_string(), json!(self.message));
+        obj.insert("retriable".to_string(), json!(self.retriable));
+        if let Some(details) = &self.details {
+            obj.insert("details".to_string(), details.clone());
+        }
+        serde_json::Value::Object(obj)
+    }
+
+    /// Classify an internal database [`Error`] into an MCP error.
+    ///
+    /// This is the single boundary mapping from the library's `thiserror`
+    /// taxonomy to the stable MCP codes; the message is always
+    /// `e.to_string()`, preserving the pre-#3234 free text verbatim.
+    pub fn from_db_error(e: &Error) -> Self {
+        let (code, retriable) = classify_db_error(e);
+        Self {
+            code,
+            message: e.to_string(),
+            retriable,
+            details: None,
+        }
+    }
+}
+
+/// Map an internal error to `(code, retriable)`.
+///
+/// `retriable` is `true` **only** for transient classes: concurrency
+/// conflicts that a fresh attempt can win (serialization failures, write
+/// conflicts, aborted transactions) and self-healing conditions (timeouts,
+/// clock skew). Caller-fault classes (not-found, invalid-argument,
+/// constraint, failed-precondition) and persistent internal failures
+/// (corruption, poisoned locks, I/O) are never retriable.
+fn classify_db_error(e: &Error) -> (McpErrorCode, bool) {
+    match e {
+        Error::Storage(se) => classify_storage_error(se),
+        Error::Temporal(te) => classify_temporal_error(te),
+        Error::Query(qe) => classify_query_error(qe),
+        Error::Transaction(te) => classify_transaction_error(te),
+        Error::Vector(ve) => classify_vector_error(ve),
+        Error::Constraint(_) => (McpErrorCode::ConstraintViolation, false),
+        // A provenance bundle failing validation is a caller fault.
+        Error::Provenance(_) => (McpErrorCode::InvalidArgument, false),
+        Error::Io(_) | Error::Backup(_) => (McpErrorCode::Internal, false),
+        // The feature exists but this build/deployment doesn't provide it.
+        Error::NotImplemented { .. } => (McpErrorCode::FailedPrecondition, false),
+        Error::Other(_) => (McpErrorCode::Internal, false),
+    }
+}
+
+fn classify_storage_error(e: &StorageError) -> (McpErrorCode, bool) {
+    match e {
+        StorageError::NodeNotFound(_)
+        | StorageError::EdgeNotFound(_)
+        | StorageError::VersionNotFound(_)
+        | StorageError::PropertyNotFound(_) => (McpErrorCode::NotFound, false),
+        StorageError::InvalidId { .. } | StorageError::InvalidProperty { .. } => {
+            (McpErrorCode::InvalidArgument, false)
+        }
+        // A duplicate ID is a conflict, but retrying the identical request
+        // cannot succeed — override the code's default retriability.
+        StorageError::DuplicateId { .. } => (McpErrorCode::Conflict, false),
+        // Resource limits (DoS protection): the request is well-formed but
+        // the system refuses in its current state.
+        StorageError::CapacityExceeded { .. } => (McpErrorCode::FailedPrecondition, false),
+        StorageError::InconsistentState { .. }
+        | StorageError::WalError { .. }
+        | StorageError::CheckpointError { .. }
+        | StorageError::IoError(_)
+        | StorageError::CorruptedData(_)
+        | StorageError::PersistenceErrorWithKind { .. }
+        | StorageError::PersistenceError(_)
+        | StorageError::LockPoisoned { .. }
+        | StorageError::Encryption(_)
+        | StorageError::KeyProvider(_) => (McpErrorCode::Internal, false),
+    }
+}
+
+fn classify_temporal_error(e: &TemporalError) -> (McpErrorCode, bool) {
+    match e {
+        TemporalError::NodeNotFoundAtTime { .. } | TemporalError::VersionNotFound(_) => {
+            (McpErrorCode::NotFound, false)
+        }
+        TemporalError::InvalidTimeRange { .. }
+        | TemporalError::InvalidTimestamp { .. }
+        | TemporalError::TemporalParadox { .. }
+        | TemporalError::ValidTimeBeforeCreation { .. }
+        | TemporalError::ValidTimeTooFarInFuture { .. }
+        | TemporalError::ValidTimeBeforeEntityCreation { .. } => {
+            (McpErrorCode::InvalidArgument, false)
+        }
+        TemporalError::VersionAlreadyClosed { .. } => (McpErrorCode::FailedPrecondition, false),
+        // Clock-adjacent hiccups heal on their own; a fresh attempt at a
+        // later wallclock/logical tick can succeed.
+        TemporalError::NonMonotonicTransactionTime { .. }
+        | TemporalError::LogicalCounterOverflow { .. } => (McpErrorCode::Unavailable, true),
+        TemporalError::CorruptedVersionChain { .. }
+        | TemporalError::MissingAnchor { .. }
+        | TemporalError::MaxDepthExceeded { .. } => (McpErrorCode::Internal, false),
+    }
+}
+
+fn classify_query_error(e: &QueryError) -> (McpErrorCode, bool) {
+    match e {
+        QueryError::SyntaxError { .. }
+        | QueryError::UnsupportedFeature { .. }
+        | QueryError::InvalidParameter { .. }
+        | QueryError::LimitExceeded { .. }
+        | QueryError::InvalidTraversal { .. }
+        | QueryError::TypeMismatch { .. } => (McpErrorCode::InvalidArgument, false),
+        QueryError::Timeout { .. } => (McpErrorCode::Unavailable, true),
+        QueryError::IndexNotFound { .. } => (McpErrorCode::FailedPrecondition, false),
+        QueryError::ExecutionError { .. } => (McpErrorCode::Internal, false),
+    }
+}
+
+fn classify_transaction_error(e: &TransactionError) -> (McpErrorCode, bool) {
+    match e {
+        TransactionError::SerializationFailure { .. }
+        | TransactionError::WriteConflict { .. }
+        | TransactionError::Aborted { .. } => (McpErrorCode::Conflict, true),
+        TransactionError::InvalidState { .. }
+        | TransactionError::AlreadyCommitted { .. }
+        | TransactionError::ValidationFailed { .. } => (McpErrorCode::FailedPrecondition, false),
+        TransactionError::ClockSkew { .. } => (McpErrorCode::Unavailable, true),
+        TransactionError::CommitFailed { .. }
+        | TransactionError::RollbackFailed { .. }
+        | TransactionError::LockPoisoned { .. } => (McpErrorCode::Internal, false),
+    }
+}
+
+fn classify_vector_error(e: &VectorError) -> (McpErrorCode, bool) {
+    match e {
+        VectorError::NotFound { .. } => (McpErrorCode::NotFound, false),
+        VectorError::DimensionMismatch { .. }
+        | VectorError::ContainsNaN { .. }
+        | VectorError::ContainsInfinity { .. }
+        | VectorError::DimensionTooLarge { .. }
+        | VectorError::IndexOutOfBounds { .. }
+        | VectorError::InvalidVector { .. }
+        | VectorError::InvalidSparseVector { .. } => (McpErrorCode::InvalidArgument, false),
+        VectorError::IndexError(_) => (McpErrorCode::Internal, false),
+    }
+}
+
+/// Map a `query` tool error `kind` (Issue #3213) to `(code, retriable)`.
+///
+/// The query tool keeps its own `kind` field verbatim (its published
+/// contract); `code`/`retriable` are added additively so the tool also
+/// satisfies the uniform #3234 contract. Every kind is a caller-fixable
+/// request problem except `language_unavailable` (a build/deployment
+/// precondition) and `runtime_error` (engine-side, classified from the
+/// underlying error where available).
+pub fn query_kind_classification(kind: &str) -> (McpErrorCode, bool) {
+    match kind {
+        "language_unavailable" => (McpErrorCode::FailedPrecondition, false),
+        "runtime_error" => (McpErrorCode::Internal, false),
+        // invalid_request, read_only_violation, parse_error,
+        // unsupported_construct, invalid_params — all caller faults.
+        _ => (McpErrorCode::InvalidArgument, false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::error::ConstraintError;
+    use crate::core::id::NodeId;
+
+    #[test]
+    fn code_wire_representation_is_stable() {
+        assert_eq!(McpErrorCode::NotFound.as_str(), "NOT_FOUND");
+        assert_eq!(McpErrorCode::InvalidArgument.as_str(), "INVALID_ARGUMENT");
+        assert_eq!(
+            McpErrorCode::ConstraintViolation.as_str(),
+            "CONSTRAINT_VIOLATION"
+        );
+        assert_eq!(
+            McpErrorCode::FailedPrecondition.as_str(),
+            "FAILED_PRECONDITION"
+        );
+        assert_eq!(McpErrorCode::Conflict.as_str(), "CONFLICT");
+        assert_eq!(McpErrorCode::Unavailable.as_str(), "UNAVAILABLE");
+        assert_eq!(McpErrorCode::Internal.as_str(), "INTERNAL");
+    }
+
+    #[test]
+    fn to_json_carries_code_message_retriable_and_optional_details() {
+        let plain = McpError::new(McpErrorCode::NotFound, "Node not found: Node(1)");
+        let json = plain.to_json();
+        assert_eq!(json["code"], "NOT_FOUND");
+        assert_eq!(json["message"], "Node not found: Node(1)");
+        assert_eq!(json["retriable"], false);
+        assert!(json.get("details").is_none(), "details omitted when unset");
+
+        let with_details = McpError::new(McpErrorCode::FailedPrecondition, "refused")
+            .details(serde_json::json!({"connected_edges": 3}));
+        let json = with_details.to_json();
+        assert_eq!(json["details"]["connected_edges"], 3);
+    }
+
+    #[test]
+    fn retriable_true_only_for_transient_classes() {
+        // Transient: serialization failure, write conflict, timeout, clock skew.
+        let transient: Vec<Error> = vec![
+            TransactionError::SerializationFailure {
+                entity: "node-1".into(),
+                reason: "concurrent commit".into(),
+            }
+            .into(),
+            TransactionError::WriteConflict {
+                entity_id: "node-1".into(),
+                reason: "concurrent modification".into(),
+            }
+            .into(),
+            TransactionError::Aborted { tx_id: 7 }.into(),
+            TransactionError::ClockSkew {
+                wallclock: 1_000,
+                previous: 2_000,
+                drift_us: -1_000,
+                max_allowed: 500,
+            }
+            .into(),
+            QueryError::Timeout { duration_ms: 5000 }.into(),
+        ];
+        for e in &transient {
+            let err = McpError::from_db_error(e);
+            assert!(err.is_retriable(), "expected retriable for {e}");
+        }
+
+        // Caller-fault / persistent: never retriable.
+        let not_retriable: Vec<Error> = vec![
+            StorageError::NodeNotFound(NodeId::new(1).unwrap()).into(),
+            StorageError::InvalidId {
+                id: u64::MAX,
+                id_type: "node",
+            }
+            .into(),
+            StorageError::DuplicateId {
+                id: "1".into(),
+                kind: "node".into(),
+            }
+            .into(),
+            StorageError::LockPoisoned {
+                resource: "wal".into(),
+            }
+            .into(),
+            ConstraintError::UniqueViolation {
+                label: "Person".into(),
+                property: "email".into(),
+                value: "a".into(),
+                existing_node_id: NodeId::new(1).unwrap(),
+            }
+            .into(),
+            Error::not_implemented("feature", "reason"),
+            Error::Io(std::io::Error::other("disk on fire")),
+        ];
+        for e in &not_retriable {
+            let err = McpError::from_db_error(e);
+            assert!(!err.is_retriable(), "expected non-retriable for {e}");
+        }
+    }
+
+    #[test]
+    fn classification_covers_expected_codes() {
+        let cases: Vec<(Error, McpErrorCode)> = vec![
+            (
+                StorageError::NodeNotFound(NodeId::new(1).unwrap()).into(),
+                McpErrorCode::NotFound,
+            ),
+            (
+                TemporalError::NodeNotFoundAtTime {
+                    node_id: NodeId::new(1).unwrap(),
+                    valid_time: 1_000.into(),
+                    transaction_time: 2_000.into(),
+                }
+                .into(),
+                McpErrorCode::NotFound,
+            ),
+            (
+                StorageError::InvalidId {
+                    id: u64::MAX,
+                    id_type: "node",
+                }
+                .into(),
+                McpErrorCode::InvalidArgument,
+            ),
+            (
+                TemporalError::ValidTimeTooFarInFuture {
+                    valid_from: 2_000.into(),
+                    current_time: 1_000.into(),
+                    max_future_offset_us: 1,
+                }
+                .into(),
+                McpErrorCode::InvalidArgument,
+            ),
+            (
+                ConstraintError::UniqueViolation {
+                    label: "Person".into(),
+                    property: "email".into(),
+                    value: "a".into(),
+                    existing_node_id: NodeId::new(1).unwrap(),
+                }
+                .into(),
+                McpErrorCode::ConstraintViolation,
+            ),
+            (
+                QueryError::IndexNotFound {
+                    index_type: "vector".into(),
+                    property_name: "embedding".into(),
+                    hint: None,
+                }
+                .into(),
+                McpErrorCode::FailedPrecondition,
+            ),
+            (
+                TransactionError::SerializationFailure {
+                    entity: "n".into(),
+                    reason: "r".into(),
+                }
+                .into(),
+                McpErrorCode::Conflict,
+            ),
+            (
+                QueryError::Timeout { duration_ms: 1 }.into(),
+                McpErrorCode::Unavailable,
+            ),
+            (
+                StorageError::CorruptedData("bad checksum".into()).into(),
+                McpErrorCode::Internal,
+            ),
+            (
+                VectorError::DimensionMismatch {
+                    expected: 4,
+                    actual: 3,
+                }
+                .into(),
+                McpErrorCode::InvalidArgument,
+            ),
+        ];
+        for (e, expected) in &cases {
+            let err = McpError::from_db_error(e);
+            assert_eq!(err.code(), *expected, "wrong code for {e}");
+            assert_eq!(
+                err.message(),
+                e.to_string(),
+                "free text must be preserved verbatim as message"
+            );
+        }
+    }
+
+    #[test]
+    fn query_kind_classification_matches_contract() {
+        assert_eq!(
+            query_kind_classification("invalid_request"),
+            (McpErrorCode::InvalidArgument, false)
+        );
+        assert_eq!(
+            query_kind_classification("read_only_violation"),
+            (McpErrorCode::InvalidArgument, false)
+        );
+        assert_eq!(
+            query_kind_classification("parse_error"),
+            (McpErrorCode::InvalidArgument, false)
+        );
+        assert_eq!(
+            query_kind_classification("unsupported_construct"),
+            (McpErrorCode::InvalidArgument, false)
+        );
+        assert_eq!(
+            query_kind_classification("invalid_params"),
+            (McpErrorCode::InvalidArgument, false)
+        );
+        assert_eq!(
+            query_kind_classification("language_unavailable"),
+            (McpErrorCode::FailedPrecondition, false)
+        );
+        assert_eq!(
+            query_kind_classification("runtime_error"),
+            (McpErrorCode::Internal, false)
+        );
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -25,9 +25,11 @@
 //! server.serve_stdio().await?;
 //! ```
 
+mod error;
 mod server;
 mod tools;
 
+pub use error::{McpError, McpErrorCode};
 pub use server::AletheiaMcpServer;
 
 // Re-export tool request/response types for testing (alphabetically sorted)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -284,7 +284,7 @@ impl AletheiaMcpServer {
     /// {
     ///   "error": {
     ///     "code": "NOT_FOUND",
-    ///     "message": "Node not found: Node(123)",
+    ///     "message": "Storage error: Node not found: Node(123)",
     ///     "retriable": false
     ///   }
     /// }
@@ -1044,8 +1044,10 @@ impl AletheiaMcpServer {
     ) -> CallToolResult {
         top_level.insert("error".to_string(), err.to_json());
         let value = serde_json::Value::Object(top_level);
+        // Compact serialization, matching both the pre-#3234 error payloads
+        // and the query tool's error path (success payloads stay pretty).
         CallToolResult::error(vec![Content::text(
-            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+            serde_json::to_string(&value).unwrap_or_else(|_| value.to_string()),
         )])
     }
 
@@ -1152,7 +1154,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self.db.get_node(node_id) {
@@ -1224,7 +1230,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let properties = match self.json_to_property_map(&req.properties) {
@@ -1275,7 +1285,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let detach = req.detach.unwrap_or(false);
@@ -1377,7 +1391,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self.db.write(|tx| tx.delete_node_cascade(node_id)) {
@@ -1565,7 +1583,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self.db.get_edge(edge_id) {
@@ -1647,7 +1669,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let properties = match self.json_to_property_map(&req.properties) {
@@ -1698,7 +1724,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
@@ -1773,7 +1803,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let edge_ids = if let Some(label) = &req.label {
@@ -1809,7 +1843,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let edge_ids = self.db.get_incoming_edges(node_id);
@@ -1953,7 +1991,11 @@ impl AletheiaMcpServer {
 
         let start_id = match NodeId::new(req.start_node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let temporal = match self
@@ -2242,7 +2284,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
@@ -2276,7 +2322,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
@@ -2389,7 +2439,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
@@ -2417,7 +2471,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let tx_time = match self.parse_timestamp(&req.transaction_time) {
@@ -2445,7 +2503,11 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self.db.get_node_history(node_id) {
@@ -2474,17 +2536,29 @@ impl AletheiaMcpServer {
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let from_version = match crate::core::id::VersionId::new(req.from_version) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let to_version = match crate::core::id::VersionId::new(req.to_version) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self
@@ -2507,7 +2581,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
@@ -2535,7 +2613,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let tx_time = match self.parse_timestamp(&req.transaction_time) {
@@ -2563,7 +2645,11 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self.db.get_edge_history(edge_id) {
@@ -2592,17 +2678,29 @@ impl AletheiaMcpServer {
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let from_version = match crate::core::id::VersionId::new(req.from_version) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         let to_version = match crate::core::id::VersionId::new(req.to_version) {
             Ok(id) => id,
-            Err(e) => return self.db_error(e),
+            // An out-of-range ID is a caller fault; emit the bare
+            // `StorageError` text verbatim (`db_error` would wrap it in
+            // `Error::Storage`, prefixing "Storage error: " — a message
+            // regression vs pre-#3234 responses).
+            Err(e) => return self.invalid_argument(&e.to_string()),
         };
 
         match self
@@ -2831,7 +2929,9 @@ impl AletheiaMcpServer {
         if let Some(start_id) = req.start_node_id {
             let node_id = match NodeId::new(start_id) {
                 Ok(id) => id,
-                Err(e) => return self.db_error(e),
+                // Bare StorageError text verbatim — see the note on the other
+                // ID-validation sites.
+                Err(e) => return self.invalid_argument(&e.to_string()),
             };
 
             // If temporal filtering requested, use temporal query
@@ -3802,6 +3902,15 @@ mod server_unit_tests {
         val["error"]["kind"].as_str().unwrap_or("").to_string()
     }
 
+    /// Like [`error_kind`], but returning the whole serialized `error` object
+    /// so tests can assert `code`/`retriable` alongside `kind`.
+    fn error_payload(server: &AletheiaMcpServer, err: Error) -> serde_json::Value {
+        let result = server.map_query_error(err, "aql");
+        let text = AletheiaMcpServer::extract_text(result);
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        val["error"].clone()
+    }
+
     #[test]
     fn map_query_error_unsupported_feature_yields_unsupported_construct() {
         let server = make_server();
@@ -3836,6 +3945,22 @@ mod server_unit_tests {
         // Error::Other is a variant not matched by any specific arm — falls through to `other`.
         let err = Error::Other("unexpected situation".to_string());
         assert_eq!(error_kind(&server, err), "runtime_error");
+    }
+
+    #[test]
+    fn map_query_error_timeout_yields_retriable_unavailable_runtime_error() {
+        // A timeout keeps the query tool's own `kind` contract
+        // ("runtime_error") but is classified UNAVAILABLE/retriable from the
+        // underlying engine error — and `retriable: true` must survive the
+        // query-tool serialization path, not just the in-memory struct.
+        let server = make_server();
+        let error = error_payload(
+            &server,
+            Error::Query(QueryError::Timeout { duration_ms: 5000 }),
+        );
+        assert_eq!(error["kind"], "runtime_error", "got: {error}");
+        assert_eq!(error["code"], "UNAVAILABLE", "got: {error}");
+        assert_eq!(error["retriable"], true, "got: {error}");
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -132,7 +132,7 @@ use std::sync::Arc;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use rmcp::{
-    ErrorData as McpError, ServerHandler,
+    ErrorData as RmcpErrorData, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult,
         PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
@@ -151,6 +151,7 @@ use crate::db::AletheiaDB;
 use crate::index::vector::{DistanceMetric, HnswConfig};
 use crate::query::executor::{EntityId as ResultEntityId, EntityResult};
 
+use super::error::{McpError, McpErrorCode, query_kind_classification};
 use super::tools::*;
 
 // ============================================================================
@@ -249,7 +250,13 @@ impl AletheiaMcpServer {
             .content
             .first()
             .and_then(|c| c.as_text().map(|s| s.text.clone()))
-            .unwrap_or_else(|| r#"{"error": "No content in response"}"#.to_string())
+            .unwrap_or_else(|| {
+                json!({
+                    "error": McpError::new(McpErrorCode::Internal, "No content in response")
+                        .to_json()
+                })
+                .to_string()
+            })
     }
 
     /// Get a node by its ID.
@@ -271,9 +278,16 @@ impl AletheiaMcpServer {
     ///
     /// # Errors
     ///
-    /// Returns a JSON object with an "error" key if the node is not found.
+    /// Returns a JSON object with a structured "error" object if the node is
+    /// not found (Issue #3234 error contract):
     /// ```json
-    /// { "error": "Node not found: 123" }
+    /// {
+    ///   "error": {
+    ///     "code": "NOT_FOUND",
+    ///     "message": "Node not found: Node(123)",
+    ///     "retriable": false
+    ///   }
+    /// }
     /// ```
     pub fn get_node(&self, req: GetNodeRequest) -> String {
         Self::extract_text(self.handle_get_node(
@@ -677,8 +691,10 @@ impl AletheiaMcpServer {
     /// Execute a read-only declarative query (Cypher or AQL).
     ///
     /// Returns the engine's structured rows plus column metadata as JSON, or a
-    /// structured `{error:{kind,message,clause?,language}}` payload. Mutating
-    /// statements are rejected before execution and never write.
+    /// structured `{error:{kind,code,retriable,message,clause?,language}}`
+    /// payload (`kind` per the query tool's own contract, `code`/`retriable`
+    /// per the uniform Issue #3234 error contract). Mutating statements are
+    /// rejected before execution and never write.
     pub fn query(&self, req: QueryRequest) -> String {
         Self::extract_text(self.handle_query(
             serde_json::to_value(req).expect("request serialization should not fail"),
@@ -887,7 +903,7 @@ impl AletheiaMcpServer {
         ))
     }
 
-    /// Parse an optional timestamp argument, returning an `error_json` result on a parse failure.
+    /// Parse an optional timestamp argument, returning a structured INVALID_ARGUMENT error result on a parse failure.
     ///
     /// Collapses the otherwise-duplicated "if present, parse, else None" handling for the
     /// changefeed's optional time bounds.
@@ -900,7 +916,7 @@ impl AletheiaMcpServer {
             .as_deref()
             .map(|s| self.parse_timestamp(s))
             .transpose()
-            .map_err(|e| self.error_json(&format!("Invalid {label}: {e}")))
+            .map_err(|e| self.invalid_argument(&format!("Invalid {label}: {e}")))
     }
 
     /// Resolve a pair of independently-optional `as_of_valid_time` /
@@ -933,7 +949,7 @@ impl AletheiaMcpServer {
     /// core [`Provenance`](crate::core::provenance::Provenance).
     ///
     /// Mirrors [`parse_opt_timestamp`](Self::parse_opt_timestamp): returns
-    /// `Err(error_json(...))` with a clear message when `confidence` is out
+    /// `Err(invalid_argument(...))` with a clear message when `confidence` is out
     /// of `[0.0, 1.0]` (Issue #3224), rather than a generic deserialization
     /// error. An entirely empty bundle (all fields omitted) is normalized to
     /// `None` -- never persisted as a fabricated empty object.
@@ -947,7 +963,7 @@ impl AletheiaMcpServer {
         let provenance =
             Provenance::from_parts(req.source, req.confidence, req.note, req.correlation_id)
                 .map_err(|e| {
-                    self.error_json(&format!(
+                    self.invalid_argument(&format!(
                         "Invalid provenance: confidence must be between 0.0 and 1.0 ({e})"
                     ))
                 })?;
@@ -1011,8 +1027,76 @@ impl AletheiaMcpServer {
         )])
     }
 
-    fn error_json(&self, msg: &str) -> CallToolResult {
-        CallToolResult::error(vec![Content::text(json!({"error": msg}).to_string())])
+    /// Serialize a structured [`McpError`] into an error `CallToolResult`
+    /// with the Issue #3234 shape:
+    /// `{"error": {"code", "message", "retriable", "details"?}}`.
+    fn error_result(&self, err: McpError) -> CallToolResult {
+        Self::error_result_with_top_level(err, serde_json::Map::new())
+    }
+
+    /// Like [`error_result`](Self::error_result), but preserving additional
+    /// legacy top-level fields alongside the structured `error` object (e.g.
+    /// the #3209 DETACH refusal's `connected_edges`), so pre-#3234 consumers
+    /// lose nothing.
+    fn error_result_with_top_level(
+        err: McpError,
+        mut top_level: serde_json::Map<String, serde_json::Value>,
+    ) -> CallToolResult {
+        top_level.insert("error".to_string(), err.to_json());
+        let value = serde_json::Value::Object(top_level);
+        CallToolResult::error(vec![Content::text(
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+        )])
+    }
+
+    /// Caller-fault error: malformed arguments, bad IDs, unparseable
+    /// timestamps, inconsistent parameter combinations. Never retriable.
+    fn invalid_argument(&self, msg: &str) -> CallToolResult {
+        self.error_result(McpError::new(McpErrorCode::InvalidArgument, msg))
+    }
+
+    /// The request is well-formed but the system is not in the required
+    /// state (e.g. a vector index is not enabled). Never retriable as-is.
+    fn failed_precondition(&self, msg: &str) -> CallToolResult {
+        self.error_result(McpError::new(McpErrorCode::FailedPrecondition, msg))
+    }
+
+    /// Classify an internal database error into the structured MCP shape.
+    ///
+    /// A `UniqueViolation` additionally carries its constraint metadata under
+    /// `error.details` and (for backward compatibility) as legacy top-level
+    /// fields, exactly as before #3234.
+    fn db_error(&self, e: impl Into<crate::core::error::Error>) -> CallToolResult {
+        let e = e.into();
+        if let Some(crate::core::error::ConstraintError::UniqueViolation {
+            label,
+            property,
+            value,
+            existing_node_id,
+        }) = e.as_constraint()
+        {
+            let details = json!({
+                "label": label,
+                "property": property,
+                "value": value,
+                "existing_node_id": existing_node_id.as_u64()
+            });
+            let mut top_level = serde_json::Map::new();
+            top_level.insert("success".to_string(), json!(false));
+            top_level.insert("constraint_violation".to_string(), json!(true));
+            top_level.insert("label".to_string(), json!(label));
+            top_level.insert("property".to_string(), json!(property));
+            top_level.insert("value".to_string(), json!(value));
+            top_level.insert(
+                "existing_node_id".to_string(),
+                json!(existing_node_id.as_u64()),
+            );
+            return Self::error_result_with_top_level(
+                McpError::from_db_error(&e).details(details),
+                top_level,
+            );
+        }
+        self.error_result(McpError::from_db_error(&e))
     }
 
     /// Attach result-completeness signals (Issue #3226) to a bounded read
@@ -1056,33 +1140,6 @@ impl AletheiaMcpServer {
         }
     }
 
-    /// Build a structured `CallToolResult` for a `UniqueViolation` constraint error.
-    /// Returns `None` if `e` is not a `UniqueViolation`.
-    fn constraint_violation_result(&self, e: &crate::core::error::Error) -> Option<CallToolResult> {
-        if let Some(crate::core::error::ConstraintError::UniqueViolation {
-            label,
-            property,
-            value,
-            existing_node_id,
-        }) = e.as_constraint()
-        {
-            Some(CallToolResult::error(vec![Content::text(
-                serde_json::to_string_pretty(&json!({
-                    "error": e.to_string(),
-                    "success": false,
-                    "constraint_violation": true,
-                    "label": label,
-                    "property": property,
-                    "value": value,
-                    "existing_node_id": existing_node_id.as_u64()
-                }))
-                .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
-            )]))
-        } else {
-            None
-        }
-    }
-
     // ========================================================================
     // Tool Implementations
     // ========================================================================
@@ -1090,12 +1147,12 @@ impl AletheiaMcpServer {
     fn handle_get_node(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetNodeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self.db.get_node(node_id) {
@@ -1106,20 +1163,20 @@ impl AletheiaMcpServer {
                         .expect("response serialization should not fail"),
                 )
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_create_node(&self, args: serde_json::Value) -> CallToolResult {
         let req: CreateNodeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let properties = match req.properties {
             Some(p) => match self.json_to_property_map(&p) {
                 Ok(map) => map,
-                Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+                Err(e) => return self.invalid_argument(&format!("Invalid properties: {}", e)),
             },
             None => PropertyMap::default(),
         };
@@ -1153,31 +1210,26 @@ impl AletheiaMcpServer {
                             .expect("response serialization should not fail"),
                     )
                 }
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             },
-            Err(ref e) => {
-                if let Some(result) = self.constraint_violation_result(e) {
-                    return result;
-                }
-                self.error_json(&e.to_string())
-            }
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_update_node(&self, args: serde_json::Value) -> CallToolResult {
         let req: UpdateNodeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let properties = match self.json_to_property_map(&req.properties) {
             Ok(map) => map,
-            Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid properties: {}", e)),
         };
 
         let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
@@ -1209,26 +1261,21 @@ impl AletheiaMcpServer {
                             .expect("response serialization should not fail"),
                     )
                 }
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             },
-            Err(ref e) => {
-                if let Some(result) = self.constraint_violation_result(e) {
-                    return result;
-                }
-                self.error_json(&e.to_string())
-            }
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_delete_node(&self, args: serde_json::Value) -> CallToolResult {
         let req: DeleteNodeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let detach = req.detach.unwrap_or(false);
@@ -1239,7 +1286,7 @@ impl AletheiaMcpServer {
         };
 
         if detach && valid_from.is_some() {
-            return self.error_json(
+            return self.invalid_argument(
                 "valid_time is not supported together with detach:true; cascade delete does \
                  not support backdating. Delete the connected edges individually with \
                  valid_time, or omit valid_time to cascade-delete at now.",
@@ -1285,25 +1332,34 @@ impl AletheiaMcpServer {
 
         let outcome = match outcome {
             Ok(o) => o,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match outcome {
-            Outcome::Refused { connected_edges } => CallToolResult::error(vec![Content::text(
-                serde_json::to_string_pretty(&json!({
-                    "error": format!(
-                        "Node {} has {} connected edge(s); refusing to delete. \
-                         Pass `detach: true` to delete the node and its connected edges, \
-                         or remove the edges first.",
-                        req.node_id, connected_edges
-                    ),
-                    "success": false,
-                    "node_id": req.node_id,
-                    "connected_edges": connected_edges,
-                    "detach_required": true
-                }))
-                .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string()),
-            )]),
+            // The #3209 refusal in the #3234 structured shape:
+            // `FAILED_PRECONDITION` with `details.connected_edges`, while the
+            // legacy top-level fields are preserved additively (no loss).
+            Outcome::Refused { connected_edges } => {
+                let message = format!(
+                    "Node {} has {} connected edge(s); refusing to delete. \
+                     Pass `detach: true` to delete the node and its connected edges, \
+                     or remove the edges first.",
+                    req.node_id, connected_edges
+                );
+                let mut top_level = serde_json::Map::new();
+                top_level.insert("success".to_string(), json!(false));
+                top_level.insert("node_id".to_string(), json!(req.node_id));
+                top_level.insert("connected_edges".to_string(), json!(connected_edges));
+                top_level.insert("detach_required".to_string(), json!(true));
+                Self::error_result_with_top_level(
+                    McpError::new(McpErrorCode::FailedPrecondition, message).details(json!({
+                        "node_id": req.node_id,
+                        "connected_edges": connected_edges,
+                        "detach_required": true
+                    })),
+                    top_level,
+                )
+            }
             Outcome::Deleted { edges_removed } => self.success_json(json!({
                 "success": true,
                 "deleted_node_id": req.node_id,
@@ -1316,12 +1372,12 @@ impl AletheiaMcpServer {
     fn handle_delete_node_cascade(&self, args: serde_json::Value) -> CallToolResult {
         let req: DeleteNodeCascadeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self.db.write(|tx| tx.delete_node_cascade(node_id)) {
@@ -1330,14 +1386,14 @@ impl AletheiaMcpServer {
                 "deleted_node_id": req.node_id,
                 "cascade": true
             })),
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_list_nodes(&self, args: serde_json::Value) -> CallToolResult {
         let req: ListNodesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         // Apply resource limits. A page must be able to carry a continuation
@@ -1352,11 +1408,12 @@ impl AletheiaMcpServer {
 
         // Validate property filter: both key and value are required together with label
         if req.property_key.is_some() != req.property_value.is_some() {
-            return self
-                .error_json("Both 'property_key' and 'property_value' are required together");
+            return self.invalid_argument(
+                "Both 'property_key' and 'property_value' are required together",
+            );
         }
         if req.property_key.is_some() && req.label.is_none() {
-            return self.error_json("Property filtering requires 'label' to be specified");
+            return self.invalid_argument("Property filtering requires 'label' to be specified");
         }
 
         // Property-based lookup: label + property_key + property_value
@@ -1366,7 +1423,7 @@ impl AletheiaMcpServer {
             let property_value =
                 match self.json_to_property_value(prop_val) {
                     Some(v) => v,
-                    None => return self.error_json(
+                    None => return self.invalid_argument(
                         "Unsupported property_value type. Use strings, numbers, booleans, or null.",
                     ),
                 };
@@ -1437,7 +1494,7 @@ impl AletheiaMcpServer {
                                     nodes.push(self.node_to_response(&node, include_vectors));
                                 }
                             }
-                            Err(e) => return self.error_json(&e.to_string()),
+                            Err(e) => return self.db_error(e),
                         }
                     }
 
@@ -1453,7 +1510,7 @@ impl AletheiaMcpServer {
                     Self::attach_completeness(&mut response, offset, nodes.len(), has_more, None);
                     self.success_json(response)
                 }
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             }
         } else {
             // Without a label filter, we cannot efficiently list all nodes
@@ -1474,7 +1531,7 @@ impl AletheiaMcpServer {
     fn handle_count_nodes(&self, args: serde_json::Value) -> CallToolResult {
         let req: CountNodesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         if let Some(label) = &req.label {
@@ -1485,16 +1542,15 @@ impl AletheiaMcpServer {
                     // Efficiently count without allocating a Vec
                     match results.try_fold(0usize, |acc, row| row.map(|_| acc + 1)) {
                         Ok(count) => self.success_json(json!({"count": count, "label": label})),
-                        Err(e) => self.error_json(&format!(
-                            "Error counting nodes with label '{}': {}",
-                            label, e
+                        Err(e) => self.error_result(McpError::from_db_error(&e).with_message(
+                            format!("Error counting nodes with label '{}': {}", label, e),
                         )),
                     }
                 }
-                Err(e) => self.error_json(&format!(
+                Err(e) => self.error_result(McpError::from_db_error(&e).with_message(format!(
                     "Error executing count query for label '{}': {}",
                     label, e
-                )),
+                ))),
             }
         } else {
             self.success_json(json!({"count": self.db.node_count()}))
@@ -1504,12 +1560,12 @@ impl AletheiaMcpServer {
     fn handle_get_edge(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetEdgeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self.db.get_edge(edge_id) {
@@ -1520,30 +1576,30 @@ impl AletheiaMcpServer {
                         .expect("response serialization should not fail"),
                 )
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_create_edge(&self, args: serde_json::Value) -> CallToolResult {
         let req: CreateEdgeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let source_id = match NodeId::new(req.source_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&format!("Invalid source_id: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid source_id: {}", e)),
         };
 
         let target_id = match NodeId::new(req.target_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&format!("Invalid target_id: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid target_id: {}", e)),
         };
 
         let properties = match req.properties {
             Some(p) => match self.json_to_property_map(&p) {
                 Ok(map) => map,
-                Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+                Err(e) => return self.invalid_argument(&format!("Invalid properties: {}", e)),
             },
             None => PropertyMap::default(),
         };
@@ -1577,26 +1633,26 @@ impl AletheiaMcpServer {
                             .expect("response serialization should not fail"),
                     )
                 }
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             },
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_update_edge(&self, args: serde_json::Value) -> CallToolResult {
         let req: UpdateEdgeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let properties = match self.json_to_property_map(&req.properties) {
             Ok(map) => map,
-            Err(e) => return self.error_json(&format!("Invalid properties: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid properties: {}", e)),
         };
 
         let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
@@ -1628,21 +1684,21 @@ impl AletheiaMcpServer {
                             .expect("response serialization should not fail"),
                     )
                 }
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             },
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_delete_edge(&self, args: serde_json::Value) -> CallToolResult {
         let req: DeleteEdgeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let valid_from = match self.parse_opt_timestamp("valid_time", &req.valid_time) {
@@ -1658,14 +1714,14 @@ impl AletheiaMcpServer {
                 "success": true,
                 "deleted_edge_id": req.edge_id
             })),
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_list_edges(&self, args: serde_json::Value) -> CallToolResult {
         let req: ListEdgesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         // Apply resource limits
@@ -1693,7 +1749,7 @@ impl AletheiaMcpServer {
     fn handle_count_edges(&self, args: serde_json::Value) -> CallToolResult {
         let req: CountEdgesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         // Note: Counting by label is not efficiently supported without iterating all edges.
@@ -1712,12 +1768,12 @@ impl AletheiaMcpServer {
     fn handle_get_outgoing_edges(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetOutgoingEdgesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let edge_ids = if let Some(label) = &req.label {
@@ -1748,12 +1804,12 @@ impl AletheiaMcpServer {
     fn handle_get_incoming_edges(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetIncomingEdgesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let edge_ids = self.db.get_incoming_edges(node_id);
@@ -1892,12 +1948,12 @@ impl AletheiaMcpServer {
     fn handle_traverse(&self, args: serde_json::Value) -> CallToolResult {
         let req: TraverseRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let start_id = match NodeId::new(req.start_node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let temporal = match self
@@ -2028,7 +2084,7 @@ impl AletheiaMcpServer {
     fn handle_find_similar(&self, args: serde_json::Value) -> CallToolResult {
         let req: FindSimilarRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         // Apply resource limits. A page must be able to carry a continuation
@@ -2049,7 +2105,7 @@ impl AletheiaMcpServer {
             .min(MAX_VECTOR_K.saturating_sub(k));
 
         if !self.db.is_vector_index_enabled_for(&req.property_name) {
-            return self.error_json(&format!(
+            return self.failed_precondition(&format!(
                 "Vector index not enabled for property '{}'. Use enable_vector_index first.",
                 req.property_name
             ));
@@ -2057,7 +2113,7 @@ impl AletheiaMcpServer {
 
         // Validate embedding dimensions
         if let Err(e) = self.validate_embedding_dimensions(&req.embedding, &req.property_name) {
-            return self.error_json(&e);
+            return self.invalid_argument(&e);
         }
 
         // Over-fetch one past the requested page (offset + k + 1, capped at
@@ -2099,14 +2155,14 @@ impl AletheiaMcpServer {
                 Self::attach_completeness(&mut response, offset, k, has_more, None);
                 self.success_json(response)
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_enable_vector_index(&self, args: serde_json::Value) -> CallToolResult {
         let req: EnableVectorIndexRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let distance_metric = match req.distance_metric.as_deref().unwrap_or("cosine") {
@@ -2124,7 +2180,7 @@ impl AletheiaMcpServer {
                 "dimensions": req.dimensions,
                 "distance_metric": req.distance_metric.unwrap_or_else(|| "cosine".to_string())
             })),
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
@@ -2149,7 +2205,7 @@ impl AletheiaMcpServer {
     fn handle_enable_unique_constraint(&self, args: serde_json::Value) -> CallToolResult {
         let req: EnableUniqueConstraintRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         match self
@@ -2162,7 +2218,7 @@ impl AletheiaMcpServer {
                 "label": req.label,
                 "property": req.property
             })),
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
@@ -2181,22 +2237,22 @@ impl AletheiaMcpServer {
     fn handle_get_node_at_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetNodeAtTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         let tx_time = match self.parse_optional_tx_time(req.transaction_time.as_deref()) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         match self.db.get_node_at_time(node_id, valid_time, tx_time) {
@@ -2208,29 +2264,29 @@ impl AletheiaMcpServer {
                     "transaction_time": Self::format_tx_time_response(req.transaction_time)
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_get_edge_at_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetEdgeAtTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         let tx_time = match self.parse_optional_tx_time(req.transaction_time.as_deref()) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         match self.db.get_edge_at_time(edge_id, valid_time, tx_time) {
@@ -2242,23 +2298,23 @@ impl AletheiaMcpServer {
                     "transaction_time": Self::format_tx_time_response(req.transaction_time)
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_list_changes(&self, args: serde_json::Value) -> CallToolResult {
         let req: ListChangesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let tx_from = match self.parse_timestamp(&req.tx_from) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&format!("Invalid tx_from: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid tx_from: {}", e)),
         };
         let tx_to = match self.parse_timestamp(&req.tx_to) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&format!("Invalid tx_to: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid tx_to: {}", e)),
         };
 
         let valid_from = match self.parse_opt_timestamp("valid_from", &req.valid_from) {
@@ -2317,7 +2373,7 @@ impl AletheiaMcpServer {
                     "next_cursor": page.next_cursor,
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
@@ -2328,17 +2384,17 @@ impl AletheiaMcpServer {
     fn handle_get_node_at_valid_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetNodeAtValidTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         match self.db.get_node_at_valid_time(node_id, valid_time) {
@@ -2349,24 +2405,24 @@ impl AletheiaMcpServer {
                     "valid_time": req.valid_time
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_get_node_at_transaction_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetNodeAtTransactionTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let tx_time = match self.parse_timestamp(&req.transaction_time) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         match self.db.get_node_at_transaction_time(node_id, tx_time) {
@@ -2377,19 +2433,19 @@ impl AletheiaMcpServer {
                     "transaction_time": req.transaction_time
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_get_node_history(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetNodeHistoryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self.db.get_node_history(node_id) {
@@ -2406,29 +2462,29 @@ impl AletheiaMcpServer {
                     "version_count": versions.len()
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_diff_node_versions(&self, args: serde_json::Value) -> CallToolResult {
         let req: DiffNodeVersionsRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let node_id = match NodeId::new(req.node_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let from_version = match crate::core::id::VersionId::new(req.from_version) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let to_version = match crate::core::id::VersionId::new(req.to_version) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self
@@ -2439,24 +2495,24 @@ impl AletheiaMcpServer {
                 let response = self.version_diff_to_response(&diff);
                 self.success_json(json!(response))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_get_edge_at_valid_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetEdgeAtValidTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let valid_time = match self.parse_timestamp(&req.valid_time) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         match self.db.get_edge_at_valid_time(edge_id, valid_time) {
@@ -2467,24 +2523,24 @@ impl AletheiaMcpServer {
                     "valid_time": req.valid_time
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_get_edge_at_transaction_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetEdgeAtTransactionTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let tx_time = match self.parse_timestamp(&req.transaction_time) {
             Ok(t) => t,
-            Err(e) => return self.error_json(&e),
+            Err(e) => return self.invalid_argument(&e),
         };
 
         match self.db.get_edge_at_transaction_time(edge_id, tx_time) {
@@ -2495,19 +2551,19 @@ impl AletheiaMcpServer {
                     "transaction_time": req.transaction_time
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_get_edge_history(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetEdgeHistoryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self.db.get_edge_history(edge_id) {
@@ -2524,29 +2580,29 @@ impl AletheiaMcpServer {
                     "version_count": versions.len()
                 }))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_diff_edge_versions(&self, args: serde_json::Value) -> CallToolResult {
         let req: DiffEdgeVersionsRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let edge_id = match EdgeId::new(req.edge_id) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let from_version = match crate::core::id::VersionId::new(req.from_version) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         let to_version = match crate::core::id::VersionId::new(req.to_version) {
             Ok(id) => id,
-            Err(e) => return self.error_json(&e.to_string()),
+            Err(e) => return self.db_error(e),
         };
 
         match self
@@ -2557,7 +2613,7 @@ impl AletheiaMcpServer {
                 let response = self.version_diff_to_response(&diff);
                 self.success_json(json!(response))
             }
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
@@ -2687,7 +2743,7 @@ impl AletheiaMcpServer {
     fn handle_get_schema(&self, args: serde_json::Value) -> CallToolResult {
         let req: GetSchemaRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         let temporal = match self
@@ -2704,14 +2760,14 @@ impl AletheiaMcpServer {
 
         match result {
             Ok(schema) => self.success_json(self.schema_to_json(&schema)),
-            Err(e) => self.error_json(&e.to_string()),
+            Err(e) => self.db_error(e),
         }
     }
 
     fn handle_hybrid_query(&self, args: serde_json::Value) -> CallToolResult {
         let req: HybridQueryRequest = match serde_json::from_value(args) {
             Ok(r) => r,
-            Err(e) => return self.error_json(&format!("Invalid arguments: {}", e)),
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
         };
 
         // Apply resource limits
@@ -2726,7 +2782,7 @@ impl AletheiaMcpServer {
         let valid_time = if let Some(ref vt) = req.valid_time {
             match self.parse_timestamp(vt) {
                 Ok(t) => Some(t),
-                Err(e) => return self.error_json(&format!("Invalid valid_time: {}", e)),
+                Err(e) => return self.invalid_argument(&format!("Invalid valid_time: {}", e)),
             }
         } else {
             None
@@ -2735,7 +2791,9 @@ impl AletheiaMcpServer {
         let tx_time = if let Some(ref tt) = req.transaction_time {
             match self.parse_timestamp(tt) {
                 Ok(t) => Some(t),
-                Err(e) => return self.error_json(&format!("Invalid transaction_time: {}", e)),
+                Err(e) => {
+                    return self.invalid_argument(&format!("Invalid transaction_time: {}", e));
+                }
             }
         } else {
             None
@@ -2773,7 +2831,7 @@ impl AletheiaMcpServer {
         if let Some(start_id) = req.start_node_id {
             let node_id = match NodeId::new(start_id) {
                 Ok(id) => id,
-                Err(e) => return self.error_json(&e.to_string()),
+                Err(e) => return self.db_error(e),
             };
 
             // If temporal filtering requested, use temporal query
@@ -2796,7 +2854,7 @@ impl AletheiaMcpServer {
                             }
                         }))
                     }
-                    Err(e) => self.error_json(&e.to_string()),
+                    Err(e) => self.db_error(e),
                 };
             }
 
@@ -2824,7 +2882,7 @@ impl AletheiaMcpServer {
                             "count": 1
                         }))
                     }
-                    Err(e) => self.error_json(&e.to_string()),
+                    Err(e) => self.db_error(e),
                 };
             };
 
@@ -2838,9 +2896,9 @@ impl AletheiaMcpServer {
                             "count": hybrid_results.len()
                         }))
                     }
-                    Err(e) => self.error_json(&e.to_string()),
+                    Err(e) => self.db_error(e),
                 },
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             }
         } else if let Some(ref embedding) = req.query_embedding {
             // Vector-first query
@@ -2849,7 +2907,7 @@ impl AletheiaMcpServer {
 
             // Check if vector index is enabled for the property
             if !self.db.is_vector_index_enabled_for(property_name) {
-                return self.error_json(&format!(
+                return self.failed_precondition(&format!(
                     "Vector index not enabled for property '{}'. Use enable_vector_index first.",
                     property_name
                 ));
@@ -2857,7 +2915,7 @@ impl AletheiaMcpServer {
 
             // Validate embedding dimensions
             if let Err(e) = self.validate_embedding_dimensions(embedding, property_name) {
-                return self.error_json(&e);
+                return self.invalid_argument(&e);
             }
 
             let builder = crate::query::QueryBuilder::new().find_similar(embedding, k);
@@ -2872,9 +2930,9 @@ impl AletheiaMcpServer {
                             "vector_property": property_name
                         }))
                     }
-                    Err(e) => self.error_json(&e.to_string()),
+                    Err(e) => self.db_error(e),
                 },
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             }
         } else if let Some(ref label) = req.filter_label {
             // Label scan query
@@ -2889,12 +2947,14 @@ impl AletheiaMcpServer {
                             "count": hybrid_results.len()
                         }))
                     }
-                    Err(e) => self.error_json(&e.to_string()),
+                    Err(e) => self.db_error(e),
                 },
-                Err(e) => self.error_json(&e.to_string()),
+                Err(e) => self.db_error(e),
             }
         } else {
-            self.error_json("Must specify either start_node_id, query_embedding, or filter_label")
+            self.invalid_argument(
+                "Must specify either start_node_id, query_embedding, or filter_label",
+            )
         }
     }
 
@@ -2907,6 +2967,10 @@ impl AletheiaMcpServer {
     /// Distinct `kind`s let an LLM self-correct on retry: `invalid_request`,
     /// `read_only_violation`, `language_unavailable`, `parse_error`,
     /// `unsupported_construct`, `invalid_params`, `runtime_error`.
+    ///
+    /// The `kind` field is the query tool's own published contract (Issue
+    /// #3213) and is preserved verbatim; the uniform `code`/`retriable`
+    /// fields (Issue #3234) are added additively, derived from `kind`.
     fn query_error(
         &self,
         kind: &str,
@@ -2914,8 +2978,27 @@ impl AletheiaMcpServer {
         clause: Option<&str>,
         language: Option<&str>,
     ) -> CallToolResult {
+        let (code, retriable) = query_kind_classification(kind);
+        self.query_error_classified(kind, code, retriable, message, clause, language)
+    }
+
+    /// [`query_error`](Self::query_error) with an explicit `code`/`retriable`
+    /// classification, for callers that can classify more precisely than the
+    /// kind-derived default (e.g. a `runtime_error` caused by a timeout is
+    /// `UNAVAILABLE`/retriable rather than `INTERNAL`).
+    fn query_error_classified(
+        &self,
+        kind: &str,
+        code: McpErrorCode,
+        retriable: bool,
+        message: &str,
+        clause: Option<&str>,
+        language: Option<&str>,
+    ) -> CallToolResult {
         let mut obj = serde_json::Map::new();
         obj.insert("kind".to_string(), json!(kind));
+        obj.insert("code".to_string(), json!(code.as_str()));
+        obj.insert("retriable".to_string(), json!(retriable));
         obj.insert("message".to_string(), json!(message));
         if let Some(clause) = clause {
             obj.insert("clause".to_string(), json!(clause));
@@ -2950,7 +3033,20 @@ impl AletheiaMcpServer {
             Error::Query(QueryError::ExecutionError { message }) => {
                 self.query_error("runtime_error", &message, None, Some(language))
             }
-            other => self.query_error("runtime_error", &other.to_string(), None, Some(language)),
+            // Anything else keeps kind "runtime_error" (the tool's own
+            // contract) but classifies code/retriable from the actual error,
+            // so e.g. a timeout is UNAVAILABLE/retriable, not INTERNAL.
+            other => {
+                let classified = McpError::from_db_error(&other);
+                self.query_error_classified(
+                    "runtime_error",
+                    classified.code(),
+                    classified.is_retriable(),
+                    &other.to_string(),
+                    None,
+                    Some(language),
+                )
+            }
         }
     }
 
@@ -3189,6 +3285,58 @@ impl AletheiaMcpServer {
             .iter()
             .map(|tool| tool.name.to_string())
             .collect()
+    }
+
+    /// Dispatch a tool call by name to its handler.
+    ///
+    /// Shared between [`ServerHandler::call_tool`] and tests so that every
+    /// advertised tool (including ones added later) can be driven through the
+    /// exact same dispatch table the MCP transport uses — e.g. the
+    /// registry-driven error-shape test iterates [`tool_definitions`] and
+    /// calls this for each tool, guaranteeing new tools are automatically
+    /// covered by the structured-error contract (Issue #3234).
+    pub(crate) fn dispatch_tool(&self, name: &str, args: serde_json::Value) -> CallToolResult {
+        match name {
+            "get_node" => self.handle_get_node(args),
+            "create_node" => self.handle_create_node(args),
+            "update_node" => self.handle_update_node(args),
+            "delete_node" => self.handle_delete_node(args),
+            "delete_node_cascade" => self.handle_delete_node_cascade(args),
+            "list_nodes" => self.handle_list_nodes(args),
+            "count_nodes" => self.handle_count_nodes(args),
+            "get_edge" => self.handle_get_edge(args),
+            "create_edge" => self.handle_create_edge(args),
+            "update_edge" => self.handle_update_edge(args),
+            "delete_edge" => self.handle_delete_edge(args),
+            "list_edges" => self.handle_list_edges(args),
+            "count_edges" => self.handle_count_edges(args),
+            "get_outgoing_edges" => self.handle_get_outgoing_edges(args),
+            "get_incoming_edges" => self.handle_get_incoming_edges(args),
+            "traverse" => self.handle_traverse(args),
+            "find_similar" => self.handle_find_similar(args),
+            "enable_vector_index" => self.handle_enable_vector_index(args),
+            "list_vector_indexes" => self.handle_list_vector_indexes(args),
+            "enable_unique_constraint" => self.handle_enable_unique_constraint(args),
+            "list_unique_constraints" => self.handle_list_unique_constraints(args),
+            "get_node_at_time" => self.handle_get_node_at_time(args),
+            "get_edge_at_time" => self.handle_get_edge_at_time(args),
+            "list_changes" => self.handle_list_changes(args),
+            "get_node_at_valid_time" => self.handle_get_node_at_valid_time(args),
+            "get_node_at_transaction_time" => self.handle_get_node_at_transaction_time(args),
+            "get_node_history" => self.handle_get_node_history(args),
+            "diff_node_versions" => self.handle_diff_node_versions(args),
+            "get_edge_at_valid_time" => self.handle_get_edge_at_valid_time(args),
+            "get_edge_at_transaction_time" => self.handle_get_edge_at_transaction_time(args),
+            "get_edge_history" => self.handle_get_edge_history(args),
+            "diff_edge_versions" => self.handle_diff_edge_versions(args),
+            "hybrid_query" => self.handle_hybrid_query(args),
+            "query" => self.handle_query(args),
+            "get_schema" => self.handle_get_schema(args),
+            _ => self.error_result(
+                McpError::new(McpErrorCode::NotFound, format!("Unknown tool: {}", name))
+                    .details(json!({ "tool": name })),
+            ),
+        }
     }
 }
 
@@ -3575,9 +3723,10 @@ fn tool_definitions() -> Vec<Tool> {
              Mutating statements (CREATE/MERGE/SET/DELETE/REMOVE/DETACH/DROP/CALL/FOREACH/LOAD) \
              are rejected before execution and never write. Results are capped (default 100, \
              max 10000 rows; `truncated` indicates a cap hit). Errors are returned as a \
-             structured {error:{kind,message,clause?,language}} payload \
+             structured {error:{kind,code,retriable,message,clause?,language}} payload \
              (kinds: invalid_request, read_only_violation, language_unavailable, parse_error, \
-             unsupported_construct, invalid_params, runtime_error) so callers can self-correct.",
+             unsupported_construct, invalid_params, runtime_error; code/retriable follow the \
+             uniform MCP error contract) so callers can self-correct.",
             make_input_schema::<QueryRequest>(),
         ),
         Tool::new(
@@ -3610,7 +3759,7 @@ impl ServerHandler for AletheiaMcpServer {
         &self,
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
-    ) -> Result<ListToolsResult, McpError> {
+    ) -> Result<ListToolsResult, RmcpErrorData> {
         Ok(ListToolsResult {
             tools: tool_definitions(),
             next_cursor: None,
@@ -3622,52 +3771,13 @@ impl ServerHandler for AletheiaMcpServer {
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResult, RmcpErrorData> {
         let args = request
             .arguments
             .map(serde_json::Value::Object)
             .unwrap_or(serde_json::Value::Null);
 
-        let result = match request.name.as_ref() {
-            "get_node" => self.handle_get_node(args),
-            "create_node" => self.handle_create_node(args),
-            "update_node" => self.handle_update_node(args),
-            "delete_node" => self.handle_delete_node(args),
-            "delete_node_cascade" => self.handle_delete_node_cascade(args),
-            "list_nodes" => self.handle_list_nodes(args),
-            "count_nodes" => self.handle_count_nodes(args),
-            "get_edge" => self.handle_get_edge(args),
-            "create_edge" => self.handle_create_edge(args),
-            "update_edge" => self.handle_update_edge(args),
-            "delete_edge" => self.handle_delete_edge(args),
-            "list_edges" => self.handle_list_edges(args),
-            "count_edges" => self.handle_count_edges(args),
-            "get_outgoing_edges" => self.handle_get_outgoing_edges(args),
-            "get_incoming_edges" => self.handle_get_incoming_edges(args),
-            "traverse" => self.handle_traverse(args),
-            "find_similar" => self.handle_find_similar(args),
-            "enable_vector_index" => self.handle_enable_vector_index(args),
-            "list_vector_indexes" => self.handle_list_vector_indexes(args),
-            "enable_unique_constraint" => self.handle_enable_unique_constraint(args),
-            "list_unique_constraints" => self.handle_list_unique_constraints(args),
-            "get_node_at_time" => self.handle_get_node_at_time(args),
-            "get_edge_at_time" => self.handle_get_edge_at_time(args),
-            "list_changes" => self.handle_list_changes(args),
-            "get_node_at_valid_time" => self.handle_get_node_at_valid_time(args),
-            "get_node_at_transaction_time" => self.handle_get_node_at_transaction_time(args),
-            "get_node_history" => self.handle_get_node_history(args),
-            "diff_node_versions" => self.handle_diff_node_versions(args),
-            "get_edge_at_valid_time" => self.handle_get_edge_at_valid_time(args),
-            "get_edge_at_transaction_time" => self.handle_get_edge_at_transaction_time(args),
-            "get_edge_history" => self.handle_get_edge_history(args),
-            "diff_edge_versions" => self.handle_diff_edge_versions(args),
-            "hybrid_query" => self.handle_hybrid_query(args),
-            "query" => self.handle_query(args),
-            "get_schema" => self.handle_get_schema(args),
-            _ => self.error_json(&format!("Unknown tool: {}", request.name)),
-        };
-
-        Ok(result)
+        Ok(self.dispatch_tool(request.name.as_ref(), args))
     }
 }
 
@@ -3748,7 +3858,7 @@ mod server_unit_tests {
 
     #[test]
     fn handle_enable_unique_constraint_invalid_json_returns_error() {
-        // Covers the `Err(e) => return self.error_json(...)` parse-error arm of
+        // Covers the `Err(e) => return self.invalid_argument(...)` parse-error arm of
         // handle_enable_unique_constraint (added for Issue #3218).  The public
         // `enable_unique_constraint(req)` API always serialises a valid struct,
         // so this arm is only reachable via the internal handle_ function.

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -4279,14 +4279,14 @@ mod constraint_tests {
 
     #[test]
     fn test_update_node_non_constraint_error_fallthrough() {
-        // Covers server.rs:
-        //   • constraint_violation_result() `else { None }` branch (non-constraint error)
-        //   • handle_update_node `self.error_json(...)` fallthrough (when
-        //     constraint_violation_result returns None)
+        // Covers server.rs: the `db_error(...)` fallthrough in
+        // handle_update_node for non-constraint errors — db_error only emits
+        // the legacy constraint top-level fields (constraint_violation,
+        // existing_node_id, ...) for a ConstraintError::UniqueViolation.
         //
         // We call update_node with a valid-format but non-existent node ID so that
         // `tx.update_node` returns StorageError::NodeNotFound — which is NOT a
-        // ConstraintError::UniqueViolation — and constraint_violation_result returns None.
+        // ConstraintError::UniqueViolation — and db_error takes the plain path.
         let server = create_test_server();
 
         let response = server.update_node(UpdateNodeRequest {
@@ -5311,7 +5311,7 @@ mod valid_time_write_tests {
     }
 
     #[test]
-    fn test_create_node_malformed_valid_time_error_json() {
+    fn test_create_node_malformed_valid_time_structured_error() {
         let server = create_test_server();
 
         let response = server.create_node(CreateNodeRequest {
@@ -7767,7 +7767,21 @@ mod structured_error_tests {
             let (value, is_error) = dispatch(&server, &tool, serde_json::Value::Null);
             if is_error {
                 errored += 1;
-                assert_structured_error(&value, &tool);
+                let (code, _, message) = assert_structured_error(&value, &tool);
+                // A tool present in tool_definitions() but missing from
+                // dispatch_tool's match would fall into the "Unknown tool"
+                // NOT_FOUND arm and silently pass a shape-only sweep. Catch
+                // that drift explicitly.
+                assert!(
+                    !message.contains("Unknown tool"),
+                    "[{tool}] advertised but not dispatched: {message}"
+                );
+                // Null args can only fail argument deserialization, so the
+                // code must be exactly INVALID_ARGUMENT.
+                assert_eq!(
+                    code, "INVALID_ARGUMENT",
+                    "[{tool}] null args must classify as INVALID_ARGUMENT: {value}"
+                );
             }
         }
         assert!(
@@ -7809,17 +7823,41 @@ mod structured_error_tests {
     #[test]
     fn out_of_range_id_returns_invalid_argument() {
         let server = create_test_server();
-        assert_error_code(
+        let value = assert_error_code(
             &server,
             "get_node",
             json!({"node_id": u64::MAX}),
             "INVALID_ARGUMENT",
         );
-        assert_error_code(
+        // Message fidelity: the bare StorageError text, byte-for-byte
+        // identical to what pre-#3234 releases returned as the whole `error`
+        // value — no "Storage error: " wrapper prefix.
+        let (_, _, message) = assert_structured_error(&value, "get_node out-of-range");
+        let expected = crate::core::error::StorageError::InvalidId {
+            id: u64::MAX,
+            id_type: "node",
+        }
+        .to_string();
+        assert_eq!(message, expected, "got: {message}");
+        assert!(
+            message.starts_with("Invalid node ID"),
+            "message must be the bare StorageError text: {message}"
+        );
+        assert!(
+            !message.starts_with("Storage error: "),
+            "message must not gain a Storage error prefix: {message}"
+        );
+
+        let value = assert_error_code(
             &server,
             "get_edge",
             json!({"edge_id": u64::MAX}),
             "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "get_edge out-of-range");
+        assert!(
+            message.starts_with("Invalid edge ID"),
+            "message must be the bare StorageError text: {message}"
         );
     }
 
@@ -8103,7 +8141,10 @@ mod structured_error_tests {
     }
 
     #[test]
-    fn enable_constraint_over_duplicates_returns_constraint_violation() {
+    fn enable_constraint_over_duplicates_returns_failed_precondition() {
+        // DuplicateOnEnable is a *state* problem — duplicates already exist
+        // in the graph, so the enable cannot succeed until the data is fixed.
+        // That is FAILED_PRECONDITION, not a constraint rejecting this write.
         let server = create_test_server();
         for _ in 0..2 {
             let (_, is_error) = dispatch(
@@ -8117,7 +8158,7 @@ mod structured_error_tests {
             &server,
             "enable_unique_constraint",
             json!({"label": "Person", "property": "email"}),
-            "CONSTRAINT_VIOLATION",
+            "FAILED_PRECONDITION",
         );
     }
 
@@ -8164,7 +8205,255 @@ mod structured_error_tests {
             json!({"language": "aql", "query": "THIS IS NOT A QUERY"}),
         );
         assert!(is_error);
-        assert!(value["error"]["kind"].is_string(), "got: {value}");
-        assert_structured_error(&value, "query parse error");
+        assert_eq!(
+            value["error"]["kind"].as_str(),
+            Some("parse_error"),
+            "got: {value}"
+        );
+        let (code, _, _) = assert_structured_error(&value, "query parse error");
+        assert_eq!(code, "INVALID_ARGUMENT");
+    }
+
+    // ------------------------------------------------------------------
+    // History / independent-dimension temporal tools (Phase 11)
+    // ------------------------------------------------------------------
+
+    fn seed_edge(server: &AletheiaMcpServer, source: u64, target: u64) -> u64 {
+        let (value, is_error) = dispatch(
+            server,
+            "create_edge",
+            json!({"source_id": source, "target_id": target, "label": "KNOWS"}),
+        );
+        assert!(!is_error, "seed edge should succeed: {value}");
+        value["id"].as_u64().expect("created edge must carry an id")
+    }
+
+    /// Every history/temporal tool must classify a missing entity as
+    /// NOT_FOUND. Note the message here still flows through `db_error` (the
+    /// storage lookup fails, not the ID parse), so assert the code, not the
+    /// message text.
+    #[test]
+    fn history_tools_missing_entity_returns_not_found() {
+        let server = create_test_server();
+        let ts = "2026-01-01T00:00:00Z";
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            (
+                "get_node_at_valid_time",
+                json!({"node_id": 424242, "valid_time": ts}),
+            ),
+            (
+                "get_node_at_transaction_time",
+                json!({"node_id": 424242, "transaction_time": ts}),
+            ),
+            ("get_node_history", json!({"node_id": 424242})),
+            (
+                "diff_node_versions",
+                json!({"node_id": 424242, "from_version": 1, "to_version": 2}),
+            ),
+            (
+                "get_edge_at_valid_time",
+                json!({"edge_id": 424242, "valid_time": ts}),
+            ),
+            (
+                "get_edge_at_transaction_time",
+                json!({"edge_id": 424242, "transaction_time": ts}),
+            ),
+            ("get_edge_history", json!({"edge_id": 424242})),
+            (
+                "diff_edge_versions",
+                json!({"edge_id": 424242, "from_version": 1, "to_version": 2}),
+            ),
+        ];
+        for (tool, args) in cases {
+            assert_error_code(&server, tool, args, "NOT_FOUND");
+        }
+    }
+
+    /// Every history/temporal tool that takes a timestamp must classify an
+    /// unparseable one as INVALID_ARGUMENT — even when the entity exists.
+    #[test]
+    fn history_tools_bad_timestamp_returns_invalid_argument() {
+        let server = create_test_server();
+        let a = seed_node(&server, "Person", "Alice");
+        let b = seed_node(&server, "Person", "Bob");
+        let edge_id = seed_edge(&server, a, b);
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            (
+                "get_node_at_valid_time",
+                json!({"node_id": a, "valid_time": "not-a-timestamp"}),
+            ),
+            (
+                "get_node_at_transaction_time",
+                json!({"node_id": a, "transaction_time": "not-a-timestamp"}),
+            ),
+            (
+                "get_edge_at_valid_time",
+                json!({"edge_id": edge_id, "valid_time": "not-a-timestamp"}),
+            ),
+            (
+                "get_edge_at_transaction_time",
+                json!({"edge_id": edge_id, "transaction_time": "not-a-timestamp"}),
+            ),
+        ];
+        for (tool, args) in cases {
+            assert_error_code(&server, tool, args, "INVALID_ARGUMENT");
+        }
+    }
+
+    #[test]
+    fn edge_absent_at_temporal_coordinate_returns_not_found() {
+        let server = create_test_server();
+        let a = seed_node(&server, "Person", "Alice");
+        let b = seed_node(&server, "Person", "Bob");
+        let edge_id = seed_edge(&server, a, b);
+        // Long before the edge's creation: not found at that coordinate.
+        assert_error_code(
+            &server,
+            "get_edge_at_time",
+            json!({"edge_id": edge_id, "valid_time": "2000-01-01T00:00:00Z"}),
+            "NOT_FOUND",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // hybrid_query argument classification
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn hybrid_query_bad_temporal_arguments_return_invalid_argument() {
+        let server = create_test_server();
+        let node_id = seed_node(&server, "Person", "Alice");
+        let value = assert_error_code(
+            &server,
+            "hybrid_query",
+            json!({"start_node_id": node_id, "valid_time": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "hybrid_query bad valid_time");
+        assert!(message.contains("Invalid valid_time"), "got: {message}");
+
+        let value = assert_error_code(
+            &server,
+            "hybrid_query",
+            json!({"start_node_id": node_id, "transaction_time": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "hybrid_query bad tx_time");
+        assert!(
+            message.contains("Invalid transaction_time"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn hybrid_query_embedding_dimension_mismatch_returns_invalid_argument() {
+        let server = create_test_server();
+        let (_, is_error) = dispatch(
+            &server,
+            "enable_vector_index",
+            json!({"property_name": "embedding", "dimensions": 4}),
+        );
+        assert!(!is_error, "enabling the index should succeed");
+        assert_error_code(
+            &server,
+            "hybrid_query",
+            json!({"query_embedding": [0.1, 0.2, 0.3], "vector_property": "embedding"}),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    #[test]
+    fn hybrid_query_missing_start_node_returns_not_found() {
+        let server = create_test_server();
+        assert_error_code(
+            &server,
+            "hybrid_query",
+            json!({"start_node_id": 424242}),
+            "NOT_FOUND",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Adjacency, schema, create_edge endpoint parsing, list_changes
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn adjacency_tools_out_of_range_id_returns_invalid_argument() {
+        let server = create_test_server();
+        for tool in ["get_outgoing_edges", "get_incoming_edges"] {
+            let value = assert_error_code(
+                &server,
+                tool,
+                json!({"node_id": u64::MAX}),
+                "INVALID_ARGUMENT",
+            );
+            let (_, _, message) = assert_structured_error(&value, tool);
+            assert!(
+                message.starts_with("Invalid node ID"),
+                "[{tool}] bare StorageError text expected: {message}"
+            );
+        }
+        // Pin the current contract for an in-range but *missing* node: the
+        // adjacency tools return an empty adjacency (success), not NOT_FOUND.
+        for tool in ["get_outgoing_edges", "get_incoming_edges"] {
+            let (value, is_error) = dispatch(&server, tool, json!({"node_id": 424242}));
+            assert!(
+                !is_error,
+                "[{tool}] missing node currently yields an empty adjacency: {value}"
+            );
+            assert_eq!(value["count"].as_u64(), Some(0), "got: {value}");
+        }
+    }
+
+    #[test]
+    fn get_schema_bad_as_of_returns_invalid_argument() {
+        let server = create_test_server();
+        assert_error_code(
+            &server,
+            "get_schema",
+            json!({"as_of_valid_time": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+        assert_error_code(
+            &server,
+            "get_schema",
+            json!({"as_of_transaction_time": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    #[test]
+    fn create_edge_out_of_range_endpoints_return_invalid_argument() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "create_edge",
+            json!({"source_id": u64::MAX, "target_id": 1, "label": "KNOWS"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "create_edge bad source_id");
+        assert!(message.contains("Invalid source_id"), "got: {message}");
+
+        let value = assert_error_code(
+            &server,
+            "create_edge",
+            json!({"source_id": 1, "target_id": u64::MAX, "label": "KNOWS"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "create_edge bad target_id");
+        assert!(message.contains("Invalid target_id"), "got: {message}");
+    }
+
+    #[test]
+    fn list_changes_bad_tx_to_returns_invalid_argument() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "list_changes",
+            json!({"tx_from": "2026-01-01T00:00:00Z", "tx_to": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "list_changes bad tx_to");
+        assert!(message.contains("Invalid tx_to"), "got: {message}");
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -40,7 +40,12 @@ fn parse_response<T: serde::de::DeserializeOwned>(response: &str) -> Result<T, S
         serde_json::from_str(response).map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
     if let Some(error) = value.get("error") {
-        return Err(error.as_str().unwrap_or("Unknown error").to_string());
+        // Structured error shape (Issue #3234): `{code, message, retriable}`.
+        return Err(error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("Unknown error")
+            .to_string());
     }
 
     serde_json::from_value(value).map_err(|e| format!("Failed to deserialize: {}", e))
@@ -1750,7 +1755,7 @@ mod coverage_tests {
         // Either we get the node back or a "not found" type error (since we're querying at a past time)
         // but we should NOT get a timestamp parsing error
         if let Some(error) = value.get("error") {
-            let err_str = error.as_str().unwrap_or("");
+            let err_str = error["message"].as_str().unwrap_or("");
             assert!(
                 !err_str.contains("Invalid timestamp format"),
                 "ISO 8601 timestamp should be parsed correctly, got error: {}",
@@ -1782,7 +1787,7 @@ mod coverage_tests {
         // Should not contain a parsing error
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         if let Some(error) = value.get("error") {
-            let err_str = error.as_str().unwrap_or("");
+            let err_str = error["message"].as_str().unwrap_or("");
             assert!(
                 !err_str.contains("Invalid timestamp format"),
                 "ISO 8601 timestamp without TZ should be parsed correctly, got error: {}",
@@ -2341,7 +2346,7 @@ mod temporal_extended_tests {
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert!(value.get("error").is_some());
-        let error_str = value["error"].as_str().unwrap();
+        let error_str = value["error"]["message"].as_str().unwrap();
         assert!(
             error_str.contains("Invalid timestamp format"),
             "Should report invalid timestamp: {}",
@@ -2412,7 +2417,7 @@ mod temporal_extended_tests {
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         if let Some(error) = value.get("error") {
-            let err_str = error.as_str().unwrap_or("");
+            let err_str = error["message"].as_str().unwrap_or("");
             assert!(
                 !err_str.contains("Invalid timestamp format"),
                 "Offset timezone should be parsed correctly, got error: {}",
@@ -2833,7 +2838,7 @@ mod hybrid_extended_tests {
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert!(value.get("error").is_some());
-        let error = value["error"].as_str().unwrap();
+        let error = value["error"]["message"].as_str().unwrap();
         assert!(
             error.contains("Invalid valid_time"),
             "Should report invalid valid_time"
@@ -2869,7 +2874,7 @@ mod hybrid_extended_tests {
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert!(value.get("error").is_some());
-        let error = value["error"].as_str().unwrap();
+        let error = value["error"]["message"].as_str().unwrap();
         assert!(
             error.contains("Invalid transaction_time"),
             "Should report invalid transaction_time"
@@ -2938,7 +2943,7 @@ mod hybrid_extended_tests {
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert!(value.get("error").is_some());
-        let error = value["error"].as_str().unwrap();
+        let error = value["error"]["message"].as_str().unwrap();
         assert!(
             error.contains("Vector index not enabled"),
             "Should report missing vector index"
@@ -5317,7 +5322,10 @@ mod valid_time_write_tests {
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
-        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        let error = value
+            .get("error")
+            .and_then(|e| e["message"].as_str())
+            .unwrap();
         assert!(error.contains("Invalid valid_time"), "got: {error}");
         assert_eq!(server.db().node_count(), 0, "no node should be created");
     }
@@ -5335,7 +5343,10 @@ mod valid_time_write_tests {
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
-        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        let error = value
+            .get("error")
+            .and_then(|e| e["message"].as_str())
+            .unwrap();
         assert!(error.contains("too far in future"), "got: {error}");
         assert_eq!(server.db().node_count(), 0);
     }
@@ -5454,7 +5465,10 @@ mod valid_time_write_tests {
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
-        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        let error = value
+            .get("error")
+            .and_then(|e| e["message"].as_str())
+            .unwrap();
         assert!(error.contains("before entity creation"), "got: {error}");
     }
 
@@ -5586,7 +5600,10 @@ mod valid_time_write_tests {
         });
 
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
-        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        let error = value
+            .get("error")
+            .and_then(|e| e["message"].as_str())
+            .unwrap();
         assert!(error.contains("too far in future"), "got: {error}");
         assert_eq!(server.db().edge_count(), 0);
     }
@@ -5894,7 +5911,10 @@ mod provenance_write_tests {
             }),
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
-        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        let error = value
+            .get("error")
+            .and_then(|e| e["message"].as_str())
+            .unwrap();
         assert!(error.contains("confidence"), "got: {error}");
         assert!(
             error.contains("0.0") && error.contains("1.0"),
@@ -5919,7 +5939,10 @@ mod provenance_write_tests {
             }),
         });
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
-        let error = value.get("error").and_then(|e| e.as_str()).unwrap();
+        let error = value
+            .get("error")
+            .and_then(|e| e["message"].as_str())
+            .unwrap();
         assert!(error.contains("confidence"), "got: {error}");
         assert_eq!(server.db().node_count(), 0);
     }
@@ -6645,7 +6668,7 @@ mod traverse_as_of_tests {
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         let error = value
             .get("error")
-            .and_then(|e| e.as_str())
+            .and_then(|e| e["message"].as_str())
             .expect("expected a structured error, got no error field");
         assert!(
             error.contains("as_of_valid_time"),
@@ -6672,7 +6695,7 @@ mod traverse_as_of_tests {
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         let error = value
             .get("error")
-            .and_then(|e| e.as_str())
+            .and_then(|e| e["message"].as_str())
             .expect("expected a structured error, got no error field");
         assert!(
             error.contains("as_of_transaction_time"),
@@ -7612,5 +7635,536 @@ mod completeness_tests {
             "a pending (even if unresolved) frontier candidate must not be silently \
              reported as has_more:false: {response}"
         );
+    }
+}
+
+// ============================================================================
+// Structured Error Codes with Retriable Flag (Issue #3234)
+// ============================================================================
+//
+// Every MCP error response must be `{ "error": { "code", "message",
+// "retriable", "details"? } }` where `code` is drawn from the documented,
+// stable enum and `retriable` is `true` only for transient failure classes.
+// These tests drive every distinct MCP error path and assert the exact code,
+// plus a registry-driven sweep that automatically covers newly added tools.
+
+mod structured_error_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Every code documented for the MCP error contract (Issue #3234).
+    const DOCUMENTED_CODES: &[&str] = &[
+        "NOT_FOUND",
+        "INVALID_ARGUMENT",
+        "CONSTRAINT_VIOLATION",
+        "FAILED_PRECONDITION",
+        "CONFLICT",
+        "UNAVAILABLE",
+        "INTERNAL",
+    ];
+
+    /// Dispatch a tool through the same table `call_tool` uses and parse the
+    /// JSON payload. Returns `(parsed_json, is_error)`.
+    fn dispatch(
+        server: &AletheiaMcpServer,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> (serde_json::Value, bool) {
+        let result = server.dispatch_tool(tool, args);
+        let is_error = result.is_error.unwrap_or(false);
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("tool result should carry text content");
+        let value = serde_json::from_str(&text).expect("tool response should be valid JSON");
+        (value, is_error)
+    }
+
+    /// Assert the response carries the Issue #3234 structured error shape and
+    /// return `(code, retriable, message)`.
+    fn assert_structured_error(value: &serde_json::Value, context: &str) -> (String, bool, String) {
+        let error = value
+            .get("error")
+            .unwrap_or_else(|| panic!("[{context}] expected an `error` payload, got: {value}"));
+        let obj = error.as_object().unwrap_or_else(|| {
+            panic!("[{context}] `error` must be a structured object, not free text: {error}")
+        });
+        let code = obj
+            .get("code")
+            .and_then(|c| c.as_str())
+            .unwrap_or_else(|| panic!("[{context}] error must carry a string `code`: {error}"))
+            .to_string();
+        assert!(
+            DOCUMENTED_CODES.contains(&code.as_str()),
+            "[{context}] code {code:?} is not in the documented enum"
+        );
+        let retriable = obj
+            .get("retriable")
+            .and_then(|r| r.as_bool())
+            .unwrap_or_else(|| {
+                panic!("[{context}] error must carry a boolean `retriable`: {error}")
+            });
+        let message = obj
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or_else(|| panic!("[{context}] error must carry a string `message`: {error}"))
+            .to_string();
+        assert!(
+            !message.is_empty(),
+            "[{context}] error message must not be empty"
+        );
+        (code, retriable, message)
+    }
+
+    /// Convenience: dispatch, require an error, assert shape + expected code.
+    fn assert_error_code(
+        server: &AletheiaMcpServer,
+        tool: &str,
+        args: serde_json::Value,
+        expected_code: &str,
+    ) -> serde_json::Value {
+        let (value, is_error) = dispatch(server, tool, args);
+        assert!(is_error, "[{tool}] expected an error result, got: {value}");
+        let (code, retriable, _msg) = assert_structured_error(&value, tool);
+        assert_eq!(code, expected_code, "[{tool}] wrong code: {value}");
+        // Caller-fault classes are never advisorily retriable.
+        if matches!(
+            expected_code,
+            "NOT_FOUND" | "INVALID_ARGUMENT" | "CONSTRAINT_VIOLATION" | "FAILED_PRECONDITION"
+        ) {
+            assert!(!retriable, "[{tool}] {expected_code} must not be retriable");
+        }
+        value
+    }
+
+    fn seed_node(server: &AletheiaMcpServer, label: &str, name: &str) -> u64 {
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: label.to_string(),
+            properties: Some(HashMap::from([(
+                "name".to_string(),
+                serde_json::Value::String(name.to_string()),
+            )])),
+            valid_time: None,
+            provenance: None,
+        }))
+        .expect("seed node should succeed");
+        node.id
+    }
+
+    // ------------------------------------------------------------------
+    // Registry-driven sweep: every advertised tool, present and future,
+    // must return the structured shape on its invalid-arguments path.
+    // A tool added to `tool_definitions()`/`dispatch_tool` is covered
+    // here automatically, with zero test changes.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn every_advertised_tool_returns_structured_error_on_invalid_arguments() {
+        let server = create_test_server();
+        let mut errored = 0;
+        for tool in server.list_tools_for_test() {
+            let (value, is_error) = dispatch(&server, &tool, serde_json::Value::Null);
+            if is_error {
+                errored += 1;
+                assert_structured_error(&value, &tool);
+            }
+        }
+        assert!(
+            errored > 0,
+            "sweep must exercise at least one error path (null args should fail deserialization)"
+        );
+    }
+
+    #[test]
+    fn unknown_tool_returns_not_found() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "definitely_not_a_tool",
+            serde_json::Value::Null,
+            "NOT_FOUND",
+        );
+        let (_, _, message) = assert_structured_error(&value, "unknown tool");
+        assert!(message.contains("Unknown tool"), "got: {message}");
+    }
+
+    // ------------------------------------------------------------------
+    // INVALID_ARGUMENT paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn malformed_arguments_return_invalid_argument() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "get_node",
+            json!({"node_id": "not-a-number"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "get_node malformed");
+        assert!(message.contains("Invalid arguments"), "got: {message}");
+    }
+
+    #[test]
+    fn out_of_range_id_returns_invalid_argument() {
+        let server = create_test_server();
+        assert_error_code(
+            &server,
+            "get_node",
+            json!({"node_id": u64::MAX}),
+            "INVALID_ARGUMENT",
+        );
+        assert_error_code(
+            &server,
+            "get_edge",
+            json!({"edge_id": u64::MAX}),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    #[test]
+    fn invalid_timestamp_returns_invalid_argument() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "create_node",
+            json!({"label": "Person", "valid_time": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "create_node bad valid_time");
+        assert!(message.contains("Invalid valid_time"), "got: {message}");
+
+        let node_id = seed_node(&server, "Person", "Alice");
+        assert_error_code(
+            &server,
+            "get_node_at_time",
+            json!({"node_id": node_id, "valid_time": "not-a-timestamp"}),
+            "INVALID_ARGUMENT",
+        );
+        assert_error_code(
+            &server,
+            "traverse",
+            json!({
+                "start_node_id": node_id,
+                "edge_label": "KNOWS",
+                "as_of_valid_time": "not-a-timestamp"
+            }),
+            "INVALID_ARGUMENT",
+        );
+        assert_error_code(
+            &server,
+            "list_changes",
+            json!({"tx_from": "not-a-timestamp", "tx_to": "2026-01-01T00:00:00Z"}),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    #[test]
+    fn invalid_provenance_confidence_returns_invalid_argument() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "create_node",
+            json!({"label": "Person", "provenance": {"confidence": 1.5}}),
+            "INVALID_ARGUMENT",
+        );
+        let (_, _, message) = assert_structured_error(&value, "create_node bad provenance");
+        assert!(message.contains("confidence"), "got: {message}");
+    }
+
+    #[test]
+    fn list_nodes_inconsistent_property_filter_returns_invalid_argument() {
+        let server = create_test_server();
+        assert_error_code(
+            &server,
+            "list_nodes",
+            json!({"label": "Person", "property_key": "name"}),
+            "INVALID_ARGUMENT",
+        );
+        // Property filter without label is likewise a caller fault.
+        assert_error_code(
+            &server,
+            "list_nodes",
+            json!({"property_key": "name", "property_value": "Alice"}),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    #[test]
+    fn delete_node_valid_time_with_detach_returns_invalid_argument() {
+        let server = create_test_server();
+        let node_id = seed_node(&server, "Person", "Alice");
+        assert_error_code(
+            &server,
+            "delete_node",
+            json!({
+                "node_id": node_id,
+                "detach": true,
+                "valid_time": "2024-01-01T00:00:00Z"
+            }),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    #[test]
+    fn hybrid_query_without_entry_point_returns_invalid_argument() {
+        let server = create_test_server();
+        assert_error_code(&server, "hybrid_query", json!({}), "INVALID_ARGUMENT");
+    }
+
+    #[test]
+    fn find_similar_dimension_mismatch_returns_invalid_argument() {
+        let server = create_test_server();
+        let (_, is_error) = dispatch(
+            &server,
+            "enable_vector_index",
+            json!({"property_name": "embedding", "dimensions": 4}),
+        );
+        assert!(!is_error, "enabling the index should succeed");
+        assert_error_code(
+            &server,
+            "find_similar",
+            json!({"property_name": "embedding", "embedding": [0.1, 0.2, 0.3]}),
+            "INVALID_ARGUMENT",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // NOT_FOUND paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn missing_entities_return_not_found() {
+        let server = create_test_server();
+        let value = assert_error_code(&server, "get_node", json!({"node_id": 424242}), "NOT_FOUND");
+        let (_, _, message) = assert_structured_error(&value, "get_node missing");
+        assert!(message.contains("Node not found"), "got: {message}");
+
+        assert_error_code(&server, "get_edge", json!({"edge_id": 424242}), "NOT_FOUND");
+        assert_error_code(
+            &server,
+            "update_node",
+            json!({"node_id": 424242, "properties": {"a": 1}}),
+            "NOT_FOUND",
+        );
+        assert_error_code(
+            &server,
+            "update_edge",
+            json!({"edge_id": 424242, "properties": {"a": 1}}),
+            "NOT_FOUND",
+        );
+        assert_error_code(
+            &server,
+            "delete_node",
+            json!({"node_id": 424242}),
+            "NOT_FOUND",
+        );
+        assert_error_code(
+            &server,
+            "delete_edge",
+            json!({"edge_id": 424242}),
+            "NOT_FOUND",
+        );
+        // A missing endpoint surfaces from the transaction layer as a
+        // validation failure: the request is well-formed, but the graph is
+        // not in the state it requires -> FAILED_PRECONDITION.
+        assert_error_code(
+            &server,
+            "create_edge",
+            json!({"source_id": 424242, "target_id": 424243, "label": "KNOWS"}),
+            "FAILED_PRECONDITION",
+        );
+    }
+
+    #[test]
+    fn node_absent_at_temporal_coordinate_returns_not_found() {
+        let server = create_test_server();
+        let node_id = seed_node(&server, "Person", "Alice");
+        // Long before the node's creation: not found at that coordinate.
+        assert_error_code(
+            &server,
+            "get_node_at_time",
+            json!({"node_id": node_id, "valid_time": "2000-01-01T00:00:00Z"}),
+            "NOT_FOUND",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // FAILED_PRECONDITION paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn find_similar_without_index_returns_failed_precondition() {
+        let server = create_test_server();
+        let value = assert_error_code(
+            &server,
+            "find_similar",
+            json!({"property_name": "missing_prop", "embedding": [0.1, 0.2]}),
+            "FAILED_PRECONDITION",
+        );
+        let (_, _, message) = assert_structured_error(&value, "find_similar no index");
+        assert!(
+            message.contains("Vector index not enabled"),
+            "got: {message}"
+        );
+
+        // Same precondition through the hybrid query path.
+        assert_error_code(
+            &server,
+            "hybrid_query",
+            json!({"query_embedding": [0.1, 0.2], "vector_property": "missing_prop"}),
+            "FAILED_PRECONDITION",
+        );
+    }
+
+    /// Issue #3209's DETACH-delete refusal migrated to the structured shape:
+    /// `FAILED_PRECONDITION` with `details.connected_edges`, while the legacy
+    /// top-level `connected_edges` / `detach_required` fields remain (no loss).
+    #[test]
+    fn detach_refusal_returns_failed_precondition_with_connected_edges_details() {
+        let server = create_test_server();
+        let a = seed_node(&server, "Person", "Alice");
+        let b = seed_node(&server, "Person", "Bob");
+        let (_, is_error) = dispatch(
+            &server,
+            "create_edge",
+            json!({"source_id": a, "target_id": b, "label": "KNOWS"}),
+        );
+        assert!(!is_error, "edge creation should succeed");
+
+        let value = assert_error_code(
+            &server,
+            "delete_node",
+            json!({"node_id": a}),
+            "FAILED_PRECONDITION",
+        );
+
+        // Structured details carry the machine-readable count.
+        assert_eq!(
+            value["error"]["details"]["connected_edges"].as_u64(),
+            Some(1),
+            "details.connected_edges must report the edge count: {value}"
+        );
+        // Legacy #3209 fields are preserved additively at the top level.
+        assert_eq!(value["connected_edges"].as_u64(), Some(1), "got: {value}");
+        assert_eq!(value["detach_required"].as_bool(), Some(true));
+        assert_eq!(value["success"].as_bool(), Some(false));
+        assert_eq!(value["node_id"].as_u64(), Some(a));
+        // Free text is preserved as error.message.
+        let (_, _, message) = assert_structured_error(&value, "detach refusal");
+        assert!(message.contains("connected edge"), "got: {message}");
+        assert!(message.contains("detach"), "got: {message}");
+    }
+
+    // ------------------------------------------------------------------
+    // CONSTRAINT_VIOLATION paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn unique_violation_returns_constraint_violation_with_details() {
+        let server = create_test_server();
+        let (_, is_error) = dispatch(
+            &server,
+            "enable_unique_constraint",
+            json!({"label": "Person", "property": "email"}),
+        );
+        assert!(!is_error, "enabling the constraint should succeed");
+
+        let (_, is_error) = dispatch(
+            &server,
+            "create_node",
+            json!({"label": "Person", "properties": {"email": "a@example.com"}}),
+        );
+        assert!(!is_error, "first node should succeed");
+
+        let value = assert_error_code(
+            &server,
+            "create_node",
+            json!({"label": "Person", "properties": {"email": "a@example.com"}}),
+            "CONSTRAINT_VIOLATION",
+        );
+        // Structured details carry the constraint metadata.
+        assert_eq!(
+            value["error"]["details"]["label"].as_str(),
+            Some("Person"),
+            "got: {value}"
+        );
+        assert_eq!(
+            value["error"]["details"]["property"].as_str(),
+            Some("email")
+        );
+        assert!(value["error"]["details"]["existing_node_id"].is_u64());
+        // Legacy top-level fields are preserved additively.
+        assert_eq!(value["constraint_violation"].as_bool(), Some(true));
+        assert_eq!(value["label"].as_str(), Some("Person"));
+        assert_eq!(value["property"].as_str(), Some("email"));
+        assert!(value["existing_node_id"].is_u64());
+    }
+
+    #[test]
+    fn enable_constraint_over_duplicates_returns_constraint_violation() {
+        let server = create_test_server();
+        for _ in 0..2 {
+            let (_, is_error) = dispatch(
+                &server,
+                "create_node",
+                json!({"label": "Person", "properties": {"email": "dup@example.com"}}),
+            );
+            assert!(!is_error);
+        }
+        assert_error_code(
+            &server,
+            "enable_unique_constraint",
+            json!({"label": "Person", "property": "email"}),
+            "CONSTRAINT_VIOLATION",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // The `query` tool: `kind` is preserved verbatim (its own contract,
+    // Issue #3213) while `code`/`retriable` are added additively.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn query_tool_errors_keep_kind_and_gain_code_and_retriable() {
+        let server = create_test_server();
+
+        // read_only_violation
+        let (value, is_error) = dispatch(
+            &server,
+            "query",
+            json!({"language": "aql", "query": "CREATE (n:Person) RETURN n"}),
+        );
+        assert!(is_error);
+        assert_eq!(
+            value["error"]["kind"].as_str(),
+            Some("read_only_violation"),
+            "the query tool's kind field must be preserved: {value}"
+        );
+        let (code, retriable, _) = assert_structured_error(&value, "query read-only");
+        assert_eq!(code, "INVALID_ARGUMENT");
+        assert!(!retriable);
+
+        // invalid_request (unsupported language)
+        let (value, is_error) = dispatch(
+            &server,
+            "query",
+            json!({"language": "sparql", "query": "SELECT ?s WHERE { ?s ?p ?o }"}),
+        );
+        assert!(is_error);
+        assert_eq!(value["error"]["kind"].as_str(), Some("invalid_request"));
+        let (code, _, _) = assert_structured_error(&value, "query bad language");
+        assert_eq!(code, "INVALID_ARGUMENT");
+
+        // parse_error
+        let (value, is_error) = dispatch(
+            &server,
+            "query",
+            json!({"language": "aql", "query": "THIS IS NOT A QUERY"}),
+        );
+        assert!(is_error);
+        assert!(value["error"]["kind"].is_string(), "got: {value}");
+        assert_structured_error(&value, "query parse error");
     }
 }


### PR DESCRIPTION
## Before / After

**Before:** every MCP tool error was free text — `{"error": "Node not found: Node(123)"}`. A not-found, an invalid argument, and a constraint violation were indistinguishable except by brittle substring matching, so an LLM/agent driving `aletheia-mcp` could not reliably decide whether to retry, fix its arguments, or escalate.

**After:** every MCP error response is

```json
{
  "error": {
    "code": "FAILED_PRECONDITION",
    "message": "Node 7 has 2 connected edge(s); refusing to delete. ...",
    "retriable": false,
    "details": { "node_id": 7, "connected_edges": 2, "detach_required": true }
  }
}
```

- `code` is drawn from a small, stable, documented enum: `NOT_FOUND`, `INVALID_ARGUMENT`, `CONSTRAINT_VIOLATION`, `FAILED_PRECONDITION`, `CONFLICT`, `UNAVAILABLE`, `INTERNAL` (modeled on gRPC's canonical codes, per the issue's gap analysis).
- `message` preserves the previous free text verbatim — the change is additive, no information lost.
- `retriable` is `true` **only** for transient classes (timeouts, clock skew, serialization/write conflicts); always `false` for caller-fault classes (not-found, invalid-argument, constraint, failed-precondition).
- `details` carries structured per-code metadata: the #3209 DETACH refusal is now `FAILED_PRECONDITION` with `details.connected_edges`, and a unique violation is `CONSTRAINT_VIOLATION` with `details.{label,property,value,existing_node_id}` — in both cases the legacy top-level fields remain alongside, so pre-existing consumers lose nothing.

## How

- New `src/mcp/error.rs`: `McpErrorCode` enum + `McpError` payload builder + a single boundary-only classification function from the library's internal `Error` taxonomy to `(code, retriable)`. The library's `thiserror` enums are untouched (per the issue's out-of-scope).
- `error_json()` is removed; all ~130 call sites in `src/mcp/server.rs` migrated to typed helpers (`invalid_argument`, `failed_precondition`, `db_error`, `error_result[_with_top_level]`), so a code-less error can no longer be constructed.
- The `query` tool's execution-layer `kind` field (its own #3213 contract) is preserved verbatim; the uniform `code`/`retriable` fields are added additively alongside it (a `runtime_error` caused by a timeout classifies as `UNAVAILABLE`/retriable rather than `INTERNAL`).
- `call_tool`'s dispatch table is extracted into `dispatch_tool`, and a registry-driven test sweeps **every advertised tool** through it asserting the structured shape on any error — a tool added to `tool_definitions()`/`dispatch_tool` (e.g. by #3222/#3238) is covered automatically with zero test changes. Explicit per-path tests additionally assert the exact `code` on each distinct error path, and unit tests pin the code wire-representation and the retriable classification table.
- Docs: CLAUDE.md's MCP section and `docs/guides/mcp-query-tool.md` document the enum, the retriable contract, and a recovery-loop example; stale free-text error examples in the guide were updated to the new shape.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo test --features mcp-server,cypher --no-fail-fast`: lib `3666 passed; 0 failed` (232 MCP tests, including 17 new structured-error integration tests + 5 classification unit tests); 136 test targets pass. Two failing targets (`havoc::havoc_flush_deadlock`, `regression_flush_corruption`) are pre-existing environment artifacts — they inject I/O errors via read-only directory permissions, which the root user in this environment bypasses; verified they fail identically on the unmodified tree.

Closes #3234

Note for reviewers: this is the foundation PR for the error contract — sibling PRs adding new MCP tools (#3222, #3238) should land on top of it; their error paths get swept by the registry-driven test automatically.

## Follow-ups

- **Panic-path hardening in `dispatch_tool`**: wrap handler dispatch in `catch_unwind` so a handler panic also yields a structured `INTERNAL` error instead of tearing down the transport (tracked as a follow-up issue; deliberately out of scope here).
- **Pre-existing `expect()` serialization sites**: several success-path `serde_json::to_value(...).expect(...)` calls predate this PR and can panic on a pathological response; migrate them to the structured `INTERNAL` path alongside the `catch_unwind` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoNELi9AjhYjYLtrnZW3VB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoNELi9AjhYjYLtrnZW3VB)_