### PR TITLE
Stamp bi-temporal bounds on MCP node/edge read responses (Issue #3232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,21 @@ convention -- note that recalling a since-deleted edge requires anchoring
 guide below for why). See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#point-in-time-as-of-graph-traversal).
 
+**Temporal bounds on read responses (Issue #3232)**: every node/edge read
+response (`get_node`, `create_node`, `update_node`, `get_edge`, `create_edge`,
+`update_edge`, `list_nodes`, `traverse`, `get_outgoing_edges`,
+`get_incoming_edges`, `find_similar`, `hybrid_query`, and all
+`get_*_at_time`/`at_valid_time`/`at_transaction_time` tools) carries an
+additive `temporal` block stamping the bi-temporal bounds of the exact
+version returned: `valid_from`/`valid_to`/`transaction_from`/`transaction_to`
+as RFC 3339 strings plus `is_current`. Open-ended bounds are explicit JSON
+`null` (present, never omitted); `is_current` is `true` iff both intervals
+contain the current time (false for superseded versions returned by
+point-in-time reads and for expired facts). The shape is identical for nodes
+and edges, current and point-in-time; `get_node_history` keeps its existing
+microseconds-as-string format. See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#temporal-bounds-on-read-responses).
+
 **Vector properties are elided by default (Issue #3220)**: `get_node`,
 `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,
 `get_incoming_edges`, `traverse`, `find_similar`, and `hybrid_query` replace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,10 +389,12 @@ response (`get_node`, `create_node`, `update_node`, `get_edge`, `create_edge`,
 `get_*_at_time`/`at_valid_time`/`at_transaction_time` tools) carries an
 additive `temporal` block stamping the bi-temporal bounds of the exact
 version returned: `valid_from`/`valid_to`/`transaction_from`/`transaction_to`
-as RFC 3339 strings plus `is_current`. Open-ended bounds are explicit JSON
-`null` (present, never omitted); `is_current` is `true` iff both intervals
-contain the current time (false for superseded versions returned by
-point-in-time reads and for expired facts). The shape is identical for nodes
+as RFC 3339 strings (UTC, `Z` suffix) plus `is_current`. Open-ended bounds are
+explicit JSON `null` (present, never omitted); `is_current` is `true` iff both
+intervals contain the current time (false for superseded versions returned by
+point-in-time reads and for expired facts). In the rare case version metadata
+cannot be loaded, the whole `temporal` block is omitted (mirroring
+`provenance`). The shape is identical for nodes
 and edges, current and point-in-time; `get_node_history` keeps its existing
 microseconds-as-string format. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#temporal-bounds-on-read-responses).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,9 +390,10 @@ response (`get_node`, `create_node`, `update_node`, `get_edge`, `create_edge`,
 additive `temporal` block stamping the bi-temporal bounds of the exact
 version returned: `valid_from`/`valid_to`/`transaction_from`/`transaction_to`
 as RFC 3339 strings (UTC, `Z` suffix) plus `is_current`. Open-ended bounds are
-explicit JSON `null` (present, never omitted); `is_current` is `true` iff both
-intervals contain the current time (false for superseded versions returned by
-point-in-time reads and for expired facts). In the rare case version metadata
+explicit JSON `null` (present, never omitted); `is_current` is `true` iff the
+version's transaction interval is open AND the wallclock now falls within its
+valid interval (false for superseded versions returned by point-in-time reads
+and for expired or not-yet-valid facts). In the rare case version metadata
 cannot be loaded, the whole `temporal` block is omitted (mirroring
 `provenance`). The shape is identical for nodes
 and edges, current and point-in-time; `get_node_history` keeps its existing

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -452,11 +452,15 @@ Conventions:
   entity cannot be loaded, the whole `temporal` block is omitted (mirroring
   `provenance`), while open bounds within a present block are always explicit
   `null`.
-- **`is_current`** is `true` iff both the valid-time and transaction-time
-  intervals contain the current time — i.e. the response reflects the live,
-  current version. A superseded version returned by a point-in-time read, or
-  a fact whose `valid_to` has passed, reports `is_current: false` with its
-  closed bounds:
+- **`is_current`** is `true` iff the version's transaction interval is still
+  open (it *is* the currently-recorded version) and the wallclock now falls
+  within its valid interval — i.e. the response reflects the live, current
+  version. A superseded version returned by a point-in-time read, or a fact
+  whose `valid_to` has passed (or whose `valid_from` has not yet arrived),
+  reports `is_current: false` with its closed bounds. The valid-time
+  comparison is at wallclock (microsecond) granularity, so the logical
+  component of a hybrid-logical-clock commit timestamp never affects the
+  answer:
 
 ```jsonc
 // tools/call -> "get_node_at_time" (anchored before an update)

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -433,9 +433,9 @@ reads alike.
 //      "label": "Person",
 //      "properties": { "name": "Alice" },
 //      "temporal": {
-//        "valid_from": "2026-07-07T12:00:00.000000+00:00",
+//        "valid_from": "2026-07-07T12:00:00.000000Z",
 //        "valid_to": null,
-//        "transaction_from": "2026-07-07T12:00:00.000000+00:00",
+//        "transaction_from": "2026-07-07T12:00:00.000000Z",
 //        "transaction_to": null,
 //        "is_current": true
 //      }
@@ -444,11 +444,14 @@ reads alike.
 
 Conventions:
 
-- **Timestamps are RFC 3339 strings** with microsecond precision. Intervals
-  are half-open (`[start, end)`).
+- **Timestamps are RFC 3339 strings** with microsecond precision and a `Z`
+  (UTC) suffix. Intervals are half-open (`[start, end)`).
 - **Open-ended bounds are explicit JSON `null`** — `valid_to`/`transaction_to`
   are always present, never omitted. `null` means "still valid" / "still the
-  recorded version".
+  recorded version". In the rare case the version metadata for a returned
+  entity cannot be loaded, the whole `temporal` block is omitted (mirroring
+  `provenance`), while open bounds within a present block are always explicit
+  `null`.
 - **`is_current`** is `true` iff both the valid-time and transaction-time
   intervals contain the current time — i.e. the response reflects the live,
   current version. A superseded version returned by a point-in-time read, or
@@ -464,10 +467,10 @@ Conventions:
 //        "label": "Person",
 //        "properties": { "name": "Alice" },
 //        "temporal": {
-//          "valid_from": "2026-06-01T09:30:00.000000+00:00",
-//          "valid_to": "2026-07-03T08:15:27.412000+00:00",
-//          "transaction_from": "2026-06-01T09:30:00.000000+00:00",
-//          "transaction_to": "2026-07-03T08:15:27.412000+00:00",
+//          "valid_from": "2026-06-01T09:30:00.000000Z",
+//          "valid_to": "2026-07-03T08:15:27.412000Z",
+//          "transaction_from": "2026-06-01T09:30:00.000000Z",
+//          "transaction_to": "2026-07-03T08:15:27.412000Z",
 //          "is_current": false
 //        }
 //      },

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -409,6 +409,78 @@ guaranteed to be out of recorded range — its empty result means "before our
 records begin," not "nothing existed." Rerun the query at an instant inside
 the extent (or report the range mismatch) instead of concluding absence.
 
+## Temporal bounds on read responses
+
+Every node/edge read response carries a `temporal` block describing the
+bi-temporal bounds of the *exact version* the response reflects
+(Issue #3232), so an LLM/caller always knows when the returned fact was true
+in reality (valid time) and when it was recorded (transaction time) without
+a follow-up `get_node_history` call.
+
+Covered tools: `get_node`, `create_node`, `update_node`, `get_edge`,
+`create_edge`, `update_edge`, `list_nodes`, `traverse`, `get_outgoing_edges`,
+`get_incoming_edges`, `find_similar`, `hybrid_query`, `get_node_at_time`,
+`get_edge_at_time`, `get_node_at_valid_time`, `get_node_at_transaction_time`,
+`get_edge_at_valid_time`, and `get_edge_at_transaction_time` — the block has
+the identical shape on nodes and edges, for current-state and point-in-time
+reads alike.
+
+```jsonc
+// tools/call -> "get_node"
+{ "node_id": 7 }
+// -> {
+//      "id": 7,
+//      "label": "Person",
+//      "properties": { "name": "Alice" },
+//      "temporal": {
+//        "valid_from": "2026-07-07T12:00:00.000000+00:00",
+//        "valid_to": null,
+//        "transaction_from": "2026-07-07T12:00:00.000000+00:00",
+//        "transaction_to": null,
+//        "is_current": true
+//      }
+//    }
+```
+
+Conventions:
+
+- **Timestamps are RFC 3339 strings** with microsecond precision. Intervals
+  are half-open (`[start, end)`).
+- **Open-ended bounds are explicit JSON `null`** — `valid_to`/`transaction_to`
+  are always present, never omitted. `null` means "still valid" / "still the
+  recorded version".
+- **`is_current`** is `true` iff both the valid-time and transaction-time
+  intervals contain the current time — i.e. the response reflects the live,
+  current version. A superseded version returned by a point-in-time read, or
+  a fact whose `valid_to` has passed, reports `is_current: false` with its
+  closed bounds:
+
+```jsonc
+// tools/call -> "get_node_at_time" (anchored before an update)
+{ "node_id": 7, "valid_time": "2026-07-01T00:00:00Z", "transaction_time": "2026-07-01T00:00:00Z" }
+// -> {
+//      "node": {
+//        "id": 7,
+//        "label": "Person",
+//        "properties": { "name": "Alice" },
+//        "temporal": {
+//          "valid_from": "2026-06-01T09:30:00.000000+00:00",
+//          "valid_to": "2026-07-03T08:15:27.412000+00:00",
+//          "transaction_from": "2026-06-01T09:30:00.000000+00:00",
+//          "transaction_to": "2026-07-03T08:15:27.412000+00:00",
+//          "is_current": false
+//        }
+//      },
+//      "valid_time": "...", "transaction_time": "..."
+//    }
+```
+
+The bounds always describe the version actually returned and decode to the
+same microsecond values `get_node_history` reports for that version (history
+keeps its existing microseconds-as-string format — that contract is
+unchanged). The block is purely additive: no existing field moved or changed
+shape.
+
 ## Notes
 
 - **AQL has no parameter binding.** Sending `params` with `language: "aql"`

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -7,7 +7,7 @@ use crate::core::graph::{Edge, Node};
 use crate::core::id::{EdgeId, NodeId, VersionId};
 use crate::core::interning::GLOBAL_INTERNER;
 use crate::core::property::{PropertyMap, PropertyValue};
-use crate::core::temporal::Timestamp;
+use crate::core::temporal::{BiTemporalInterval, Timestamp};
 use crate::db::AletheiaDB;
 use crate::storage::current::{IncomingEdgesIter, OutgoingEdgesIter};
 use crate::storage::wal::WalOperation;
@@ -423,6 +423,51 @@ impl AletheiaDB {
         self.historical
             .read()
             .get_edge_version_provenance(version_id)
+            .record_error_metric()
+    }
+
+    /// Get the provenance bundle and bi-temporal interval of a *specific*
+    /// node version in a single historical-storage read (Issue #3232).
+    ///
+    /// Like [`get_node_version_provenance`](Self::get_node_version_provenance),
+    /// this resolves the exact version already captured in a [`Node`]
+    /// snapshot's `current_version` -- which the point-in-time read paths set
+    /// to the matched historical version -- so the returned interval reflects
+    /// the version the caller is actually holding, for current-state and
+    /// at-time reads alike.
+    ///
+    /// Returns `Ok(None)` when the version cannot be found in any tier.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_node_version_read_metadata(
+        &self,
+        version_id: VersionId,
+    ) -> Result<
+        Option<(
+            Option<crate::core::provenance::Provenance>,
+            BiTemporalInterval,
+        )>,
+    > {
+        self.historical
+            .read()
+            .get_node_version_read_metadata(version_id)
+            .record_error_metric()
+    }
+
+    /// Edge counterpart of
+    /// [`get_node_version_read_metadata`](Self::get_node_version_read_metadata).
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn get_edge_version_read_metadata(
+        &self,
+        version_id: VersionId,
+    ) -> Result<
+        Option<(
+            Option<crate::core::provenance::Provenance>,
+            BiTemporalInterval,
+        )>,
+    > {
+        self.historical
+            .read()
+            .get_edge_version_read_metadata(version_id)
             .record_error_metric()
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -38,8 +38,8 @@ pub use tools::{
     DeleteNodeCascadeRequest, DeleteNodeRequest, EnableVectorIndexRequest, FindSimilarRequest,
     GetEdgeAtTimeRequest, GetEdgeRequest, GetIncomingEdgesRequest, GetNodeAtTimeRequest,
     GetNodeRequest, GetOutgoingEdgesRequest, HybridQueryRequest, ListChangesRequest,
-    ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest, QueryRequest, TraverseRequest,
-    UpdateEdgeRequest, UpdateNodeRequest,
+    ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest, QueryRequest, TemporalBounds,
+    TraverseRequest, UpdateEdgeRequest, UpdateNodeRequest,
 };
 
 #[cfg(test)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -721,65 +721,91 @@ impl AletheiaMcpServer {
         GLOBAL_INTERNER.resolve_or_else(interned, || format!("<unknown:{}>", interned.as_u32()))
     }
 
-    /// Look up the provenance bundle for the *exact* version already captured
-    /// in `version_id` (a `Node`/`Edge` snapshot's `current_version`), rather
-    /// than re-resolving "whichever version is current now". This keeps the
-    /// returned provenance consistent with the properties already read from
-    /// that same snapshot, even under a concurrent write.
+    /// Look up the provenance bundle and temporal bounds for the *exact*
+    /// version already captured in `version_id` (a `Node`/`Edge` snapshot's
+    /// `current_version`), rather than re-resolving "whichever version is
+    /// current now". This keeps the returned metadata consistent with the
+    /// properties already read from that same snapshot, even under a
+    /// concurrent write -- and makes the bounds correct for point-in-time
+    /// reads, which set `current_version` to the matched historical version.
     ///
     /// A lookup failure (e.g. a corrupted or unreachable cold-storage record)
-    /// is logged rather than silently treated as "no provenance": that
-    /// distinction matters because an MCP caller has no other way to learn
-    /// the two cases apart. Best-effort here (returning `None` rather than
+    /// is logged rather than silently treated as "no metadata": that
+    /// distinction matters because an MCP caller has no other way to tell
+    /// the two cases apart. Best-effort here (returning `None`s rather than
     /// failing the whole response) is deliberate: a single-node lookup or a
     /// bulk endpoint like `list_nodes`/`traverse` should not fail entirely
-    /// because one entry's provenance couldn't be read.
-    fn lookup_node_provenance(&self, version_id: VersionId) -> Option<Provenance> {
-        match self.db.get_node_version_provenance(version_id) {
-            Ok(p) => p,
+    /// because one entry's metadata couldn't be read.
+    fn lookup_node_read_metadata(
+        &self,
+        version_id: VersionId,
+    ) -> (Option<Provenance>, Option<TemporalBounds>) {
+        match self.db.get_node_version_read_metadata(version_id) {
+            Ok(Some((provenance, interval))) => (provenance, Some(TemporalBounds::from(&interval))),
+            Ok(None) => {
+                eprintln!(
+                    "Warning: node version {} not found in any tier; omitting provenance/temporal",
+                    version_id.as_u64()
+                );
+                (None, None)
+            }
             Err(e) => {
                 eprintln!(
-                    "Warning: failed to load provenance for node version {}: {}",
+                    "Warning: failed to load metadata for node version {}: {}",
                     version_id.as_u64(),
                     e
                 );
-                None
+                (None, None)
             }
         }
     }
 
-    /// Edge counterpart of [`lookup_node_provenance`](Self::lookup_node_provenance).
-    fn lookup_edge_provenance(&self, version_id: VersionId) -> Option<Provenance> {
-        match self.db.get_edge_version_provenance(version_id) {
-            Ok(p) => p,
+    /// Edge counterpart of [`lookup_node_read_metadata`](Self::lookup_node_read_metadata).
+    fn lookup_edge_read_metadata(
+        &self,
+        version_id: VersionId,
+    ) -> (Option<Provenance>, Option<TemporalBounds>) {
+        match self.db.get_edge_version_read_metadata(version_id) {
+            Ok(Some((provenance, interval))) => (provenance, Some(TemporalBounds::from(&interval))),
+            Ok(None) => {
+                eprintln!(
+                    "Warning: edge version {} not found in any tier; omitting provenance/temporal",
+                    version_id.as_u64()
+                );
+                (None, None)
+            }
             Err(e) => {
                 eprintln!(
-                    "Warning: failed to load provenance for edge version {}: {}",
+                    "Warning: failed to load metadata for edge version {}: {}",
                     version_id.as_u64(),
                     e
                 );
-                None
+                (None, None)
             }
         }
     }
 
     fn node_to_response(&self, node: &crate::core::Node, include_vectors: bool) -> NodeResponse {
+        let (provenance, temporal) = self.lookup_node_read_metadata(node.current_version);
         NodeResponse {
             id: node.id.as_u64(),
             label: self.interned_to_string(node.label),
             properties: self.property_map_to_json(&node.properties, include_vectors),
-            provenance: self.lookup_node_provenance(node.current_version),
+            provenance,
+            temporal,
         }
     }
 
     fn edge_to_response(&self, edge: &crate::core::Edge, include_vectors: bool) -> EdgeResponse {
+        let (provenance, temporal) = self.lookup_edge_read_metadata(edge.current_version);
         EdgeResponse {
             id: edge.id.as_u64(),
             source_id: edge.source.as_u64(),
             target_id: edge.target.as_u64(),
             label: self.interned_to_string(edge.label),
             properties: self.property_map_to_json(&edge.properties, include_vectors),
-            provenance: self.lookup_edge_provenance(edge.current_version),
+            provenance,
+            temporal,
         }
     }
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -9305,4 +9305,111 @@ mod temporal_bounds_tests {
             "a deleted version must report is_current: false: {temporal}"
         );
     }
+
+    // ------------------------------------------------------------------
+    // Conversion-level unit tests for `is_current` on hand-constructed
+    // `BiTemporalInterval`s (HLC-robust semantics: transaction dimension is
+    // judged by interval openness, valid dimension at wallclock granularity).
+    // ------------------------------------------------------------------
+
+    use crate::core::hlc::HybridTimestamp;
+    use crate::core::temporal::{BiTemporalInterval, TimeRange, time};
+
+    #[test]
+    fn test_is_current_true_for_hlc_logical_component_in_current_microsecond() {
+        // An HLC commit stamp in the CURRENT microsecond with logical > 0
+        // orders strictly after SystemTime-now (logical = 0) in the same
+        // microsecond. Under the old `contains(now)` rule this live,
+        // open-ended head version reported is_current: false; it must now
+        // report true.
+        let now = time::now();
+        let commit = HybridTimestamp::new(now.wallclock(), 5).expect("valid HLC stamp");
+        let interval = BiTemporalInterval::now(commit, commit);
+        let bounds = TemporalBounds::from(&interval);
+        assert!(
+            bounds.is_current,
+            "an open head version committed in the current microsecond with \
+             logical > 0 must be current: {bounds:?}"
+        );
+    }
+
+    #[test]
+    fn test_is_current_true_when_hlc_frontier_runs_ahead_of_wallclock() {
+        // After a tolerated backward OS-clock step, the HLC frontier runs
+        // AHEAD of SystemTime, so commit stamps land slightly in the
+        // wallclock future (here: +50ms) while the fact's valid time is not
+        // skewed. The transaction interval is open -- by definition the
+        // currently-recorded version -- so is_current must be true; the old
+        // tx_from-vs-now comparison misreported false for minutes.
+        let now = time::now();
+        let skewed_commit =
+            HybridTimestamp::new(now.wallclock() + 50_000, 0).expect("valid skewed stamp");
+        let interval = BiTemporalInterval::with_valid_time(now, skewed_commit);
+        let bounds = TemporalBounds::from(&interval);
+        assert!(
+            bounds.is_current,
+            "an open head version whose commit stamp runs ahead of the OS \
+             clock must be current: {bounds:?}"
+        );
+    }
+
+    #[test]
+    fn test_is_current_false_for_explicit_future_valid_time() {
+        // An explicitly backdated-to-the-future fact (valid_from = now + 1h)
+        // is not yet true in reality, so is_current must be false even
+        // though both intervals are open-ended.
+        let now = time::now();
+        let future_valid =
+            HybridTimestamp::new(now.wallclock() + 3_600_000_000, 0).expect("valid future stamp");
+        let interval = BiTemporalInterval::with_valid_time(future_valid, now);
+        let bounds = TemporalBounds::from(&interval);
+        assert!(
+            !bounds.is_current,
+            "a not-yet-valid fact must not be current even with open \
+             intervals: {bounds:?}"
+        );
+    }
+
+    #[test]
+    fn test_is_current_false_for_closed_transaction_interval() {
+        // A superseded version (closed transaction interval) is never
+        // current, even if its valid interval still contains now.
+        let now = time::now();
+        let hour_ago =
+            HybridTimestamp::new(now.wallclock() - 3_600_000_000, 0).expect("valid past stamp");
+        let second_ago =
+            HybridTimestamp::new(now.wallclock() - 1_000_000, 0).expect("valid past stamp");
+        let interval = BiTemporalInterval::new(
+            TimeRange::from(hour_ago),
+            TimeRange::new(hour_ago, second_ago).expect("valid closed range"),
+        );
+        let bounds = TemporalBounds::from(&interval);
+        assert!(
+            !bounds.is_current,
+            "a superseded (closed-transaction) version must not be current \
+             even while still valid: {bounds:?}"
+        );
+    }
+
+    #[test]
+    fn test_is_current_false_for_expired_valid_interval() {
+        // A fact whose valid time ended in the past is not current, even
+        // though its transaction interval is still open (it is still the
+        // recorded version of that fact).
+        let now = time::now();
+        let two_hours_ago =
+            HybridTimestamp::new(now.wallclock() - 7_200_000_000, 0).expect("valid past stamp");
+        let hour_ago =
+            HybridTimestamp::new(now.wallclock() - 3_600_000_000, 0).expect("valid past stamp");
+        let interval = BiTemporalInterval::new(
+            TimeRange::new(two_hours_ago, hour_ago).expect("valid closed range"),
+            TimeRange::from(two_hours_ago),
+        );
+        let bounds = TemporalBounds::from(&interval);
+        assert!(
+            !bounds.is_current,
+            "an expired fact must not be current even with an open \
+             transaction interval: {bounds:?}"
+        );
+    }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -9412,4 +9412,126 @@ mod temporal_bounds_tests {
              transaction interval: {bounds:?}"
         );
     }
+
+    #[test]
+    fn test_wallclock_beyond_chrono_range_falls_back_to_raw_micros() {
+        // chrono can only represent dates up to ~year 262143 (~8.2e18
+        // micros), while valid HLC wallclocks extend to MAX_VALID_TIMESTAMP
+        // (i64::MAX - 1000). A bound past chrono's range must fall back to
+        // the raw microsecond count as a string instead of silently
+        // rendering the 1970 epoch.
+        let huge_micros = 9_000_000_000_000_000_000i64;
+        let far_future = HybridTimestamp::new(huge_micros, 0).expect("legal HLC wallclock");
+        let interval = BiTemporalInterval::new(
+            TimeRange::from(far_future),
+            TimeRange::from(HybridTimestamp::new(1_000_000, 0).expect("valid stamp")),
+        );
+
+        let bounds = TemporalBounds::from(&interval);
+        assert_eq!(
+            bounds.valid_from,
+            huge_micros.to_string(),
+            "out-of-chrono-range wallclock must serialize as raw micros: {bounds:?}"
+        );
+        assert!(
+            bounds.valid_to.is_none(),
+            "open-ended valid_to must stay None: {bounds:?}"
+        );
+        // The in-range transaction bound must still be RFC3339.
+        assert_eq!(rfc3339_to_micros(&bounds.transaction_from), 1_000_000);
+        // A fact whose valid time hasn't begun is not current.
+        assert!(!bounds.is_current, "far-future fact is not current");
+    }
+
+    #[test]
+    fn test_node_with_unresolvable_version_omits_temporal_and_provenance() {
+        // Best-effort degrade path (mirrors provenance, Issue #3224): when
+        // the version metadata cannot be loaded from any tier, the read must
+        // still succeed with the `temporal` and `provenance` blocks omitted
+        // -- never a fabricated value, never a whole-response failure.
+        use crate::core::id::{NodeId, VersionId};
+
+        let server = create_test_server();
+        let created = create_person(&server, "Ghost");
+        let node_id = created["id"].as_u64().unwrap();
+
+        // Re-point the stored node's current_version at a version id that
+        // exists in no tier, simulating unreadable version metadata.
+        let mut node = server
+            .db()
+            .current
+            .get_node(NodeId::new(node_id).unwrap())
+            .unwrap();
+        node.current_version = VersionId::new(9_999_999).unwrap();
+        server
+            .db()
+            .current
+            .update_node_direct(node, time::now())
+            .unwrap();
+
+        let response = server.get_node(GetNodeRequest {
+            node_id,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            value.get("error").is_none(),
+            "read must still succeed when metadata is unreadable: {value}"
+        );
+        assert_eq!(value["id"].as_u64(), Some(node_id));
+        assert_eq!(value["label"], "Person");
+        assert_eq!(value["properties"]["name"], "Ghost");
+        assert!(
+            value.get("temporal").is_none(),
+            "temporal must be omitted, not fabricated: {value}"
+        );
+        assert!(
+            value.get("provenance").is_none(),
+            "provenance must be omitted, not fabricated: {value}"
+        );
+    }
+
+    #[test]
+    fn test_edge_with_unresolvable_version_omits_temporal_and_provenance() {
+        // Edge mirror of the node degrade case above.
+        use crate::core::id::{EdgeId, VersionId};
+
+        let server = create_test_server();
+        let alice = create_person(&server, "Alice");
+        let bob = create_person(&server, "Bob");
+        let edge = create_knows_edge(
+            &server,
+            alice["id"].as_u64().unwrap(),
+            bob["id"].as_u64().unwrap(),
+        );
+        let edge_id = edge["id"].as_u64().unwrap();
+
+        let mut stored = server
+            .db()
+            .current
+            .get_edge(EdgeId::new(edge_id).unwrap())
+            .unwrap();
+        stored.current_version = VersionId::new(9_999_998).unwrap();
+        server.db().current.update_edge_direct(stored).unwrap();
+
+        let response = server.get_edge(GetEdgeRequest {
+            edge_id,
+            include_vectors: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            value.get("error").is_none(),
+            "read must still succeed when metadata is unreadable: {value}"
+        );
+        assert_eq!(value["id"].as_u64(), Some(edge_id));
+        assert_eq!(value["label"], "KNOWS");
+        assert!(
+            value.get("temporal").is_none(),
+            "temporal must be omitted, not fabricated: {value}"
+        );
+        assert!(
+            value.get("provenance").is_none(),
+            "provenance must be omitted, not fabricated: {value}"
+        );
+    }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8894,11 +8894,13 @@ mod temporal_bounds_tests {
         assert_eq!(typed.source_id, a);
         assert_eq!(typed.target_id, b);
 
-        // Point-in-time edge read carries the block too.
+        // Point-in-time edge read carries the block too. Capture one shared
+        // "now" so both dimensions anchor the same bi-temporal instant.
+        let now = now_micros().to_string();
         let at_time_response = server.get_edge_at_time(GetEdgeAtTimeRequest {
             edge_id: created["id"].as_u64().unwrap(),
-            valid_time: now_micros().to_string(),
-            transaction_time: Some(now_micros().to_string()),
+            valid_time: now.clone(),
+            transaction_time: Some(now),
         });
         let at_time: serde_json::Value = serde_json::from_str(&at_time_response).unwrap();
         assert!(
@@ -9042,8 +9044,8 @@ mod temporal_bounds_tests {
         let transaction_to = superseded["transaction_to"].as_str().unwrap_or_else(|| {
             panic!("superseded transaction_to must be a closed RFC3339 bound: {superseded}")
         });
-        assert!(rfc3339_to_micros(valid_to) > anchor - 60_000_000);
-        assert!(rfc3339_to_micros(transaction_to) > anchor - 60_000_000);
+        assert!(rfc3339_to_micros(valid_to) > anchor);
+        assert!(rfc3339_to_micros(transaction_to) > anchor);
         assert_eq!(
             superseded["is_current"],
             serde_json::json!(false),
@@ -9152,5 +9154,155 @@ mod temporal_bounds_tests {
                 "current `{key}` must agree with history: {current_temporal} vs {current_history}"
             );
         }
+    }
+
+    #[test]
+    fn test_not_yet_valid_fact_reports_is_current_false() {
+        let server = create_test_server();
+
+        // A fact that only becomes true one hour from now: both bounds are
+        // open, yet the valid interval does not contain the current time, so
+        // is_current must be false. This isolates the valid-time conjunct of
+        // is_current -- a transaction-time-only implementation would wrongly
+        // report true here.
+        let future = now_micros() + 3_600_000_000;
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!("Alice"));
+        let response = server.create_node(CreateNodeRequest {
+            valid_time: Some(future.to_string()),
+            label: "Person".to_string(),
+            properties: Some(props),
+            provenance: None,
+        });
+        let created: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            created.get("error").is_none(),
+            "create_node with a future valid_time must succeed: {created}"
+        );
+
+        let assert_future_not_current = |temporal: &serde_json::Value| {
+            for key in ["valid_to", "transaction_to"] {
+                let v = temporal.get(key).unwrap_or_else(|| {
+                    panic!("`{key}` must be present (as null), not omitted: {temporal}")
+                });
+                assert!(
+                    v.is_null(),
+                    "`{key}` must be JSON null for open bounds: {temporal}"
+                );
+            }
+            assert_eq!(
+                rfc3339_to_micros(temporal["valid_from"].as_str().unwrap()),
+                future,
+                "valid_from must decode to the future valid time exactly: {temporal}"
+            );
+            assert_eq!(
+                temporal["is_current"],
+                serde_json::json!(false),
+                "a not-yet-valid fact must report is_current: false even though \
+                 both bounds are open: {temporal}"
+            );
+        };
+        assert_future_not_current(&temporal_of(&created));
+
+        let get_response = server.get_node(GetNodeRequest {
+            node_id: created["id"].as_u64().unwrap(),
+            include_vectors: None,
+        });
+        let retrieved: serde_json::Value = serde_json::from_str(&get_response).unwrap();
+        assert_future_not_current(&temporal_of(&retrieved));
+    }
+
+    #[test]
+    fn test_backdated_create_reflects_valid_time_in_temporal_block() {
+        let server = create_test_server();
+
+        // A fact backdated one hour: valid since then (and still valid), so
+        // it is current, but valid_from must reflect the caller-supplied
+        // valid time while transaction_from is the (later) system-assigned
+        // commit time.
+        let backdated = now_micros() - 3_600_000_000;
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!("Alice"));
+        let response = server.create_node(CreateNodeRequest {
+            valid_time: Some(backdated.to_string()),
+            label: "Person".to_string(),
+            properties: Some(props),
+            provenance: None,
+        });
+        let created: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            created.get("error").is_none(),
+            "create_node with a backdated valid_time must succeed: {created}"
+        );
+
+        let temporal = temporal_of(&created);
+        assert_current_open_bounds(&temporal);
+        assert_eq!(
+            rfc3339_to_micros(temporal["valid_from"].as_str().unwrap()),
+            backdated,
+            "valid_from must decode to the backdated valid time exactly: {temporal}"
+        );
+        assert!(
+            rfc3339_to_micros(temporal["transaction_from"].as_str().unwrap()) > backdated,
+            "transaction_from is system-assigned and must be later than the \
+             backdated valid time: {temporal}"
+        );
+    }
+
+    #[test]
+    fn test_deleted_node_at_time_read_has_closed_transaction_to() {
+        let server = create_test_server();
+
+        let node_id = create_person(&server, "Alice")["id"].as_u64().unwrap();
+
+        // Anchor a bi-temporal coordinate strictly after the create and
+        // strictly before the delete.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let anchor = now_micros();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        let delete_response = server.delete_node(DeleteNodeRequest {
+            node_id,
+            detach: None,
+            valid_time: None,
+        });
+        let deleted: serde_json::Value = serde_json::from_str(&delete_response).unwrap();
+        assert!(
+            deleted.get("error").is_none(),
+            "delete_node failed: {deleted}"
+        );
+
+        // The at-time read anchored before the delete returns the pre-delete
+        // version. The delete writer closes that version's transaction_time
+        // at the delete's commit timestamp, so transaction_to must be a
+        // closed RFC3339 bound strictly after the anchor and the version must
+        // no longer be current. (valid_to is implementation-dependent for
+        // deletes -- the tombstone carries the valid-time closure -- so it is
+        // deliberately not asserted here.)
+        let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id,
+            valid_time: anchor.to_string(),
+            transaction_time: Some(anchor.to_string()),
+        });
+        let at_time: serde_json::Value = serde_json::from_str(&at_time_response).unwrap();
+        assert!(
+            at_time.get("error").is_none(),
+            "get_node_at_time anchored before the delete must still see the \
+             pre-delete version: {at_time}"
+        );
+        let temporal = temporal_of(&at_time["node"]);
+        let transaction_to = temporal["transaction_to"].as_str().unwrap_or_else(|| {
+            panic!("deleted version's transaction_to must be a closed RFC3339 bound: {temporal}")
+        });
+        assert!(
+            rfc3339_to_micros(transaction_to) > anchor,
+            "transaction_to must be the delete's commit time, strictly after \
+             the anchor: {temporal}"
+        );
+        assert_eq!(
+            temporal["is_current"],
+            serde_json::json!(false),
+            "a deleted version must report is_current: false: {temporal}"
+        );
     }
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -8759,3 +8759,398 @@ mod temporal_extent_tests {
         assert_eq!(labels[0]["label"], serde_json::json!("Person"));
     }
 }
+
+// ============================================================================
+// Temporal bounds on read responses (Issue #3232)
+// ============================================================================
+
+mod temporal_bounds_tests {
+    use super::*;
+
+    /// Extract the `temporal` block from an entity JSON object, failing the
+    /// test if it is absent.
+    fn temporal_of(entity: &serde_json::Value) -> serde_json::Value {
+        entity
+            .get("temporal")
+            .unwrap_or_else(|| panic!("response must carry a `temporal` block: {entity}"))
+            .clone()
+    }
+
+    /// Parse an RFC3339 string back to microseconds since epoch.
+    fn rfc3339_to_micros(s: &str) -> i64 {
+        chrono::DateTime::parse_from_rfc3339(s)
+            .unwrap_or_else(|e| panic!("`{s}` must be RFC3339: {e}"))
+            .timestamp_micros()
+    }
+
+    /// Assert the shape shared by every current (live) version: RFC3339
+    /// `*_from` bounds, explicit-null open `*_to` bounds (present, never
+    /// omitted), and `is_current: true`.
+    fn assert_current_open_bounds(temporal: &serde_json::Value) {
+        for key in ["valid_from", "transaction_from"] {
+            let s = temporal[key]
+                .as_str()
+                .unwrap_or_else(|| panic!("`{key}` must be an RFC3339 string: {temporal}"));
+            rfc3339_to_micros(s);
+        }
+        for key in ["valid_to", "transaction_to"] {
+            let v = temporal.get(key).unwrap_or_else(|| {
+                panic!("`{key}` must be present (as null), not omitted: {temporal}")
+            });
+            assert!(
+                v.is_null(),
+                "`{key}` must be JSON null for open bounds: {temporal}"
+            );
+        }
+        assert_eq!(
+            temporal["is_current"],
+            serde_json::json!(true),
+            "a live version must report is_current: true: {temporal}"
+        );
+    }
+
+    fn create_person(server: &AletheiaMcpServer, name: &str) -> serde_json::Value {
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!(name));
+        let response = server.create_node(CreateNodeRequest {
+            valid_time: None,
+            label: "Person".to_string(),
+            properties: Some(props),
+            provenance: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("error").is_none(), "create_node failed: {value}");
+        value
+    }
+
+    fn create_knows_edge(
+        server: &AletheiaMcpServer,
+        source_id: u64,
+        target_id: u64,
+    ) -> serde_json::Value {
+        let response = server.create_edge(CreateEdgeRequest {
+            source_id,
+            target_id,
+            label: "KNOWS".to_string(),
+            properties: None,
+            valid_time: None,
+            provenance: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(value.get("error").is_none(), "create_edge failed: {value}");
+        value
+    }
+
+    fn now_micros() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as i64
+    }
+
+    #[test]
+    fn test_create_and_get_node_carry_temporal_bounds() {
+        let server = create_test_server();
+
+        let created = create_person(&server, "Alice");
+        assert_current_open_bounds(&temporal_of(&created));
+
+        let get_response = server.get_node(GetNodeRequest {
+            node_id: created["id"].as_u64().unwrap(),
+            include_vectors: None,
+        });
+        let retrieved: serde_json::Value = serde_json::from_str(&get_response).unwrap();
+        assert_current_open_bounds(&temporal_of(&retrieved));
+
+        // Existing top-level fields are unchanged (additive contract) and the
+        // typed response still round-trips.
+        let typed: NodeResponse = parse_response(&get_response).expect("typed parse must work");
+        assert_eq!(typed.label, "Person");
+        assert_eq!(
+            typed.properties.get("name"),
+            Some(&serde_json::json!("Alice"))
+        );
+    }
+
+    #[test]
+    fn test_create_and_get_edge_carry_temporal_bounds() {
+        let server = create_test_server();
+
+        let a = create_person(&server, "Alice")["id"].as_u64().unwrap();
+        let b = create_person(&server, "Bob")["id"].as_u64().unwrap();
+
+        let created = create_knows_edge(&server, a, b);
+        assert_current_open_bounds(&temporal_of(&created));
+
+        let get_response = server.get_edge(GetEdgeRequest {
+            edge_id: created["id"].as_u64().unwrap(),
+            include_vectors: None,
+        });
+        let retrieved: serde_json::Value = serde_json::from_str(&get_response).unwrap();
+        assert_current_open_bounds(&temporal_of(&retrieved));
+
+        let typed: EdgeResponse = parse_response(&get_response).expect("typed parse must work");
+        assert_eq!(typed.label, "KNOWS");
+        assert_eq!(typed.source_id, a);
+        assert_eq!(typed.target_id, b);
+
+        // Point-in-time edge read carries the block too.
+        let at_time_response = server.get_edge_at_time(GetEdgeAtTimeRequest {
+            edge_id: created["id"].as_u64().unwrap(),
+            valid_time: now_micros().to_string(),
+            transaction_time: Some(now_micros().to_string()),
+        });
+        let at_time: serde_json::Value = serde_json::from_str(&at_time_response).unwrap();
+        assert!(
+            at_time.get("error").is_none(),
+            "get_edge_at_time failed: {at_time}"
+        );
+        assert_current_open_bounds(&temporal_of(&at_time["edge"]));
+    }
+
+    #[test]
+    fn test_list_nodes_and_traverse_stamp_each_node() {
+        let server = create_test_server();
+
+        let a = create_person(&server, "Alice")["id"].as_u64().unwrap();
+        let b = create_person(&server, "Bob")["id"].as_u64().unwrap();
+        create_knows_edge(&server, a, b);
+
+        let list_response = server.list_nodes(ListNodesRequest {
+            label: Some("Person".to_string()),
+            property_key: None,
+            property_value: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+        });
+        let listed: serde_json::Value = serde_json::from_str(&list_response).unwrap();
+        let nodes = listed["nodes"].as_array().expect("nodes array");
+        assert_eq!(nodes.len(), 2);
+        for node in nodes {
+            assert_current_open_bounds(&temporal_of(node));
+        }
+
+        let traverse_response = server.traverse(TraverseRequest {
+            start_node_id: a,
+            edge_label: "KNOWS".to_string(),
+            direction: None,
+            depth: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+            as_of_valid_time: None,
+            as_of_transaction_time: None,
+        });
+        let traversed: serde_json::Value = serde_json::from_str(&traverse_response).unwrap();
+        let results = traversed["results"].as_array().expect("results array");
+        assert_eq!(results.len(), 1);
+        for result in results {
+            assert_current_open_bounds(&temporal_of(&result["node"]));
+        }
+    }
+
+    #[test]
+    fn test_adjacency_and_update_responses_carry_temporal_bounds() {
+        let server = create_test_server();
+
+        let a = create_person(&server, "Alice")["id"].as_u64().unwrap();
+        let b = create_person(&server, "Bob")["id"].as_u64().unwrap();
+        let edge_id = create_knows_edge(&server, a, b)["id"].as_u64().unwrap();
+
+        for response in [
+            server.get_outgoing_edges(GetOutgoingEdgesRequest {
+                node_id: a,
+                label: None,
+                include_vectors: None,
+            }),
+            server.get_incoming_edges(GetIncomingEdgesRequest {
+                node_id: b,
+                label: None,
+                include_vectors: None,
+            }),
+        ] {
+            let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+            let edges = value["edges"].as_array().expect("edges array");
+            assert_eq!(edges.len(), 1);
+            for edge in edges {
+                assert_current_open_bounds(&temporal_of(edge));
+            }
+        }
+
+        // update_node / update_edge responses reflect the NEW version's
+        // bounds: still open-ended and current.
+        let mut props = HashMap::new();
+        props.insert("age".to_string(), serde_json::json!(31));
+        let update_node_response = server.update_node(UpdateNodeRequest {
+            valid_time: None,
+            node_id: a,
+            properties: props.clone(),
+            provenance: None,
+        });
+        let updated_node: serde_json::Value = serde_json::from_str(&update_node_response).unwrap();
+        assert_current_open_bounds(&temporal_of(&updated_node));
+
+        let update_edge_response = server.update_edge(UpdateEdgeRequest {
+            edge_id,
+            properties: props,
+            valid_time: None,
+            provenance: None,
+        });
+        let updated_edge: serde_json::Value = serde_json::from_str(&update_edge_response).unwrap();
+        assert_current_open_bounds(&temporal_of(&updated_edge));
+    }
+
+    #[test]
+    fn test_superseded_version_has_closed_bounds_and_is_not_current() {
+        let server = create_test_server();
+
+        let node_id = create_person(&server, "Alice")["id"].as_u64().unwrap();
+
+        // Anchor a bi-temporal coordinate strictly after the create and
+        // strictly before the update.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let anchor = now_micros();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!("Alice v2"));
+        parse_response::<NodeResponse>(&server.update_node(UpdateNodeRequest {
+            valid_time: None,
+            node_id,
+            properties: props,
+            provenance: None,
+        }))
+        .expect("update must succeed");
+
+        // The at-time read anchored before the update returns the superseded
+        // version: both bounds closed, not current.
+        let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id,
+            valid_time: anchor.to_string(),
+            transaction_time: Some(anchor.to_string()),
+        });
+        let at_time: serde_json::Value = serde_json::from_str(&at_time_response).unwrap();
+        assert!(
+            at_time.get("error").is_none(),
+            "get_node_at_time failed: {at_time}"
+        );
+        let superseded = temporal_of(&at_time["node"]);
+        let valid_to = superseded["valid_to"].as_str().unwrap_or_else(|| {
+            panic!("superseded valid_to must be a closed RFC3339 bound: {superseded}")
+        });
+        let transaction_to = superseded["transaction_to"].as_str().unwrap_or_else(|| {
+            panic!("superseded transaction_to must be a closed RFC3339 bound: {superseded}")
+        });
+        assert!(rfc3339_to_micros(valid_to) > anchor - 60_000_000);
+        assert!(rfc3339_to_micros(transaction_to) > anchor - 60_000_000);
+        assert_eq!(
+            superseded["is_current"],
+            serde_json::json!(false),
+            "a superseded version must report is_current: false: {superseded}"
+        );
+
+        // A current read after the update shows the NEW version's bounds:
+        // open-ended, current, and starting after the anchor.
+        let current_response = server.get_node(GetNodeRequest {
+            node_id,
+            include_vectors: None,
+        });
+        let current: serde_json::Value = serde_json::from_str(&current_response).unwrap();
+        let current_temporal = temporal_of(&current);
+        assert_current_open_bounds(&current_temporal);
+        assert!(
+            rfc3339_to_micros(current_temporal["transaction_from"].as_str().unwrap()) > anchor,
+            "current version must start after the anchor: {current_temporal}"
+        );
+    }
+
+    #[test]
+    fn test_temporal_bounds_agree_with_node_history() {
+        let server = create_test_server();
+
+        let node_id = create_person(&server, "Alice")["id"].as_u64().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let anchor = now_micros();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), serde_json::json!("Alice v2"));
+        parse_response::<NodeResponse>(&server.update_node(UpdateNodeRequest {
+            valid_time: None,
+            node_id,
+            properties: props,
+            provenance: None,
+        }))
+        .expect("update must succeed");
+
+        let history_response = server.get_node_history(GetNodeHistoryRequest { node_id });
+        let history: serde_json::Value = serde_json::from_str(&history_response).unwrap();
+        let versions = history["versions"].as_array().expect("versions array");
+        assert_eq!(versions.len(), 2, "expected two versions: {history}");
+
+        // History emits micros-as-string; the temporal block's RFC3339 must
+        // decode to the same microsecond values for the same version.
+        let history_micros = |v: &serde_json::Value, key: &str| -> Option<i64> {
+            let field = v.get(key).unwrap_or(&serde_json::Value::Null);
+            if field.is_null() {
+                None
+            } else {
+                Some(field.as_str().unwrap().parse::<i64>().unwrap())
+            }
+        };
+        let temporal_micros = |t: &serde_json::Value, key: &str| -> Option<i64> {
+            let field = t.get(key).unwrap_or_else(|| {
+                panic!("temporal block must always carry `{key}` (null when open): {t}")
+            });
+            if field.is_null() {
+                None
+            } else {
+                Some(rfc3339_to_micros(field.as_str().unwrap()))
+            }
+        };
+
+        let superseded_history = versions
+            .iter()
+            .find(|v| !v["transaction_to"].is_null())
+            .expect("one superseded version");
+        let current_history = versions
+            .iter()
+            .find(|v| v["transaction_to"].is_null())
+            .expect("one current version");
+
+        let at_time_response = server.get_node_at_time(GetNodeAtTimeRequest {
+            node_id,
+            valid_time: anchor.to_string(),
+            transaction_time: Some(anchor.to_string()),
+        });
+        let at_time: serde_json::Value = serde_json::from_str(&at_time_response).unwrap();
+        let superseded_temporal = temporal_of(&at_time["node"]);
+
+        let current_response = server.get_node(GetNodeRequest {
+            node_id,
+            include_vectors: None,
+        });
+        let current: serde_json::Value = serde_json::from_str(&current_response).unwrap();
+        let current_temporal = temporal_of(&current);
+
+        for key in [
+            "valid_from",
+            "valid_to",
+            "transaction_from",
+            "transaction_to",
+        ] {
+            assert_eq!(
+                temporal_micros(&superseded_temporal, key),
+                history_micros(superseded_history, key),
+                "superseded `{key}` must agree with history: {superseded_temporal} vs {superseded_history}"
+            );
+            assert_eq!(
+                temporal_micros(&current_temporal, key),
+                history_micros(current_history, key),
+                "current `{key}` must agree with history: {current_temporal} vs {current_history}"
+            );
+        }
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -941,10 +941,14 @@ pub struct TemporalBounds {
     /// When this version was superseded/removed, or `null` if still current
     /// in the database.
     pub transaction_to: Option<String>,
-    /// `true` iff both the valid-time and transaction-time intervals contain
-    /// the current time -- i.e. the returned version is the live, current
-    /// version. `false` for superseded versions returned by point-in-time
-    /// reads and for facts whose valid time has ended (or not yet begun).
+    /// `true` iff the version's transaction interval is still open (it *is*
+    /// the currently-recorded version) AND the current wallclock time falls
+    /// within its valid interval -- i.e. the returned version is the live,
+    /// current version. `false` for superseded versions returned by
+    /// point-in-time reads and for facts whose valid time has ended (or not
+    /// yet begun). The valid-time comparison is at wallclock (microsecond)
+    /// granularity, so the HLC logical component of a commit timestamp never
+    /// affects the answer.
     pub is_current: bool,
 }
 
@@ -977,15 +981,36 @@ impl TemporalBounds {
 
 impl From<&crate::core::temporal::BiTemporalInterval> for TemporalBounds {
     fn from(interval: &crate::core::temporal::BiTemporalInterval) -> Self {
-        // One shared "now" so both dimensions are judged at the same instant.
+        // `is_current` semantics (Issue #3232):
+        //
+        // Transaction dimension: current iff the transaction interval is
+        // open-ended. An open transaction interval IS by definition the
+        // currently-recorded version; comparing the HLC commit timestamp
+        // against SystemTime-now would be a clock artifact (HLC stamps carry
+        // a logical component that orders after SystemTime-now within the
+        // same microsecond, and the HLC frontier can legitimately run ahead
+        // of SystemTime for a while after a tolerated backward OS-clock
+        // step), transiently misreporting a live head version as not
+        // current.
+        //
+        // Valid dimension: still distinguishes not-yet-valid (future
+        // valid_from) and expired (past valid_to) facts, but compared at
+        // wallclock (microsecond) granularity so the HLC logical component
+        // cannot flip the answer within the current microsecond.
+        // Sub-microsecond edge rounding toward "current" is acceptable for a
+        // convenience boolean; the authoritative data is the bounds
+        // themselves.
         let now = crate::core::temporal::time::now();
+        let valid = interval.valid_time();
+        let tx_open = interval.transaction_time().is_current();
+        let valid_contains_now = valid.start().wallclock() <= now.wallclock()
+            && (valid.is_current() || now.wallclock() < valid.end().wallclock());
         TemporalBounds {
-            valid_from: Self::to_rfc3339_micros(interval.valid_time().start()),
-            valid_to: Self::end_bound(interval.valid_time().end()),
+            valid_from: Self::to_rfc3339_micros(valid.start()),
+            valid_to: Self::end_bound(valid.end()),
             transaction_from: Self::to_rfc3339_micros(interval.transaction_time().start()),
             transaction_to: Self::end_bound(interval.transaction_time().end()),
-            is_current: interval.valid_time().contains(now)
-                && interval.transaction_time().contains(now),
+            is_current: tx_open && valid_contains_now,
         }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -919,6 +919,70 @@ pub struct TemporalExtentRequest {
 // Response Types (for serialization)
 // ============================================================================
 
+/// Bi-temporal bounds of the exact version a read response reflects
+/// (Issue #3232).
+///
+/// Stamped on every node/edge read response so an LLM/caller always knows
+/// *when* the returned fact was true in reality (valid time) and *when* it
+/// was recorded (transaction time), without a follow-up history call.
+///
+/// Bounds are RFC 3339 strings with microsecond precision. Open-ended bounds
+/// (a still-valid fact / a still-recorded version) are serialized as explicit
+/// JSON `null` -- the keys are always present, never omitted. Intervals are
+/// half-open (`[start, end)`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemporalBounds {
+    /// When the fact became true in reality (RFC 3339).
+    pub valid_from: String,
+    /// When the fact stopped being true, or `null` if still valid.
+    pub valid_to: Option<String>,
+    /// When this version was recorded in the database (RFC 3339).
+    pub transaction_from: String,
+    /// When this version was superseded/removed, or `null` if still current
+    /// in the database.
+    pub transaction_to: Option<String>,
+    /// `true` iff both the valid-time and transaction-time intervals contain
+    /// the current time -- i.e. the returned version is the live, current
+    /// version. `false` for superseded versions returned by point-in-time
+    /// reads and for facts whose valid time has ended (or not yet begun).
+    pub is_current: bool,
+}
+
+impl TemporalBounds {
+    /// Format a timestamp's wallclock microseconds as an RFC 3339 string
+    /// with microsecond precision (e.g. `2026-07-07T12:00:00.000000+00:00`).
+    fn to_rfc3339_micros(ts: crate::core::temporal::Timestamp) -> String {
+        chrono::DateTime::from_timestamp_micros(ts.wallclock())
+            .unwrap_or_default()
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, false)
+    }
+
+    /// Convert a range end bound: `TIMESTAMP_MAX` (open-ended) becomes
+    /// `None` (serialized as JSON `null`), anything else an RFC 3339 string.
+    fn end_bound(ts: crate::core::temporal::Timestamp) -> Option<String> {
+        if ts == crate::core::temporal::TIMESTAMP_MAX {
+            None
+        } else {
+            Some(Self::to_rfc3339_micros(ts))
+        }
+    }
+}
+
+impl From<&crate::core::temporal::BiTemporalInterval> for TemporalBounds {
+    fn from(interval: &crate::core::temporal::BiTemporalInterval) -> Self {
+        // One shared "now" so both dimensions are judged at the same instant.
+        let now = crate::core::temporal::time::now();
+        TemporalBounds {
+            valid_from: Self::to_rfc3339_micros(interval.valid_time().start()),
+            valid_to: Self::end_bound(interval.valid_time().end()),
+            transaction_from: Self::to_rfc3339_micros(interval.transaction_time().start()),
+            transaction_to: Self::end_bound(interval.transaction_time().end()),
+            is_current: interval.valid_time().contains(now)
+                && interval.transaction_time().contains(now),
+        }
+    }
+}
+
 /// Serializable node representation for MCP responses.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeResponse {
@@ -929,6 +993,11 @@ pub struct NodeResponse {
     /// (never a fabricated `null`) when the version has none (Issue #3224).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provenance: Option<crate::core::provenance::Provenance>,
+    /// Bi-temporal bounds of the exact version this response reflects
+    /// (Issue #3232). Always present on normal reads; `None` only as a
+    /// best-effort degrade when the version metadata could not be loaded.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub temporal: Option<TemporalBounds>,
 }
 
 /// Serializable edge representation for MCP responses.
@@ -943,6 +1012,11 @@ pub struct EdgeResponse {
     /// (never a fabricated `null`) when the version has none (Issue #3224).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provenance: Option<crate::core::provenance::Provenance>,
+    /// Bi-temporal bounds of the exact version this response reflects
+    /// (Issue #3232). Always present on normal reads; `None` only as a
+    /// best-effort degrade when the version metadata could not be loaded.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub temporal: Option<TemporalBounds>,
 }
 
 /// Similarity search result.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -950,11 +950,18 @@ pub struct TemporalBounds {
 
 impl TemporalBounds {
     /// Format a timestamp's wallclock microseconds as an RFC 3339 string
-    /// with microsecond precision (e.g. `2026-07-07T12:00:00.000000+00:00`).
+    /// with microsecond precision (e.g. `2026-07-07T12:00:00.000000Z`).
+    ///
+    /// Total: a wallclock value outside chrono's representable range falls
+    /// back to the raw microsecond count as a string (mirroring
+    /// `time::to_iso8601`'s totality) instead of silently rendering the
+    /// 1970 epoch.
     fn to_rfc3339_micros(ts: crate::core::temporal::Timestamp) -> String {
-        chrono::DateTime::from_timestamp_micros(ts.wallclock())
-            .unwrap_or_default()
-            .to_rfc3339_opts(chrono::SecondsFormat::Micros, false)
+        let micros = ts.wallclock();
+        match chrono::DateTime::from_timestamp_micros(micros) {
+            Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+            None => micros.to_string(),
+        }
     }
 
     /// Convert a range end bound: `TIMESTAMP_MAX` (open-ended) becomes

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -1473,6 +1473,46 @@ impl HistoricalStorage {
         Ok(provenance)
     }
 
+    /// Get the provenance bundle and bi-temporal interval of a specific node
+    /// version in a single lookup (Issue #3232).
+    ///
+    /// Like [`get_node_version_provenance`](Self::get_node_version_provenance),
+    /// this resolves an exact, caller-supplied version (typically a `Node`
+    /// snapshot's `current_version`) so the returned metadata is consistent
+    /// with the properties already read from that snapshot -- including for
+    /// point-in-time reads, whose lookup paths set `current_version` to the
+    /// matched historical version. Fetching both fields together keeps read
+    /// responses at one historical lookup per entity.
+    ///
+    /// Returns `Ok(None)` when the version cannot be found in any tier.
+    pub fn get_node_version_read_metadata(
+        &self,
+        version_id: VersionId,
+    ) -> Result<Option<(Option<Provenance>, BiTemporalInterval)>> {
+        if let Some(v) = self.node_versions.get(&version_id) {
+            // Fast path: read from hot storage without cloning version data.
+            return Ok(Some((v.provenance.as_deref().cloned(), v.temporal)));
+        }
+        Ok(self
+            .get_node_version_tiered(version_id)?
+            .map(|v| (v.provenance.as_deref().cloned(), v.temporal)))
+    }
+
+    /// Edge counterpart of
+    /// [`get_node_version_read_metadata`](Self::get_node_version_read_metadata).
+    pub fn get_edge_version_read_metadata(
+        &self,
+        version_id: VersionId,
+    ) -> Result<Option<(Option<Provenance>, BiTemporalInterval)>> {
+        if let Some(v) = self.edge_versions.get(&version_id) {
+            // Fast path: read from hot storage without cloning version data.
+            return Ok(Some((v.provenance.as_deref().cloned(), v.temporal)));
+        }
+        Ok(self
+            .get_edge_version_tiered(version_id)?
+            .map(|v| (v.provenance.as_deref().cloned(), v.temporal)))
+    }
+
     /// Get the node's true creation time: the `valid_from` of its first-ever version.
     ///
     /// Walks `prev_version` links from the current head back to the terminal (oldest)

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4907,3 +4907,191 @@ fn test_reconstruct_nonexistent_edge_version_returns_version_not_found() {
         err => panic!("Expected VersionNotFound for a never-added edge version, got: {err:?}"),
     }
 }
+
+// ============================================================================
+// Version read metadata: provenance + bi-temporal interval (Issue #3232)
+// ============================================================================
+
+#[test]
+fn test_get_node_version_read_metadata_hot_tier_hit() {
+    let mut storage = HistoricalStorage::new();
+    let node_id = NodeId::new(1).unwrap();
+    let version_id = VersionId::new(100).unwrap();
+    let label = GLOBAL_INTERNER.intern("Person").unwrap();
+    let props = PropertyMapBuilder::new().insert("name", "Alice").build();
+    let provenance = Arc::new(
+        Provenance::builder()
+            .source("test-suite")
+            .confidence(0.9)
+            .build()
+            .unwrap(),
+    );
+
+    storage
+        .add_node_version_with_provenance(
+            node_id,
+            version_id,
+            1_000.into(),
+            2_000.into(),
+            label,
+            props,
+            false,
+            Some(Arc::clone(&provenance)),
+        )
+        .unwrap();
+
+    let (prov, interval) = storage
+        .get_node_version_read_metadata(version_id)
+        .unwrap()
+        .expect("hot-tier version must be found");
+    let prov = prov.expect("provenance stored on the version must be returned");
+    assert_eq!(prov.source(), Some("test-suite"));
+    assert_eq!(prov.confidence(), Some(0.9));
+    assert_eq!(interval.valid_time().start(), 1_000.into());
+    assert_eq!(interval.transaction_time().start(), 2_000.into());
+    assert!(interval.transaction_time().is_current());
+}
+
+#[test]
+fn test_get_node_version_read_metadata_missing_version_returns_none() {
+    // A version id that exists in no tier (and with no tiered storage
+    // configured) must resolve to Ok(None) via the tiered fallback path,
+    // never an error: the MCP layer relies on this to distinguish
+    // "no metadata" from "metadata lookup failed".
+    let storage = HistoricalStorage::new();
+    let missing = VersionId::new(424_242).unwrap();
+    assert!(
+        storage
+            .get_node_version_read_metadata(missing)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn test_get_edge_version_read_metadata_hot_tier_hit() {
+    let mut storage = HistoricalStorage::new();
+    let edge_id = EdgeId::new(10).unwrap();
+    let version_id = VersionId::new(200).unwrap();
+    let label = GLOBAL_INTERNER.intern("KNOWS").unwrap();
+    let props = PropertyMapBuilder::new().insert("weight", 1.0f64).build();
+    let provenance = Arc::new(
+        Provenance::builder()
+            .source("edge-test-suite")
+            .note("hot tier")
+            .build()
+            .unwrap(),
+    );
+
+    storage
+        .add_edge_version_with_provenance(
+            edge_id,
+            version_id,
+            3_000.into(),
+            4_000.into(),
+            label,
+            NodeId::new(1).unwrap(),
+            NodeId::new(2).unwrap(),
+            props,
+            false,
+            Some(Arc::clone(&provenance)),
+        )
+        .unwrap();
+
+    let (prov, interval) = storage
+        .get_edge_version_read_metadata(version_id)
+        .unwrap()
+        .expect("hot-tier version must be found");
+    let prov = prov.expect("provenance stored on the version must be returned");
+    assert_eq!(prov.source(), Some("edge-test-suite"));
+    assert_eq!(prov.note(), Some("hot tier"));
+    assert_eq!(interval.valid_time().start(), 3_000.into());
+    assert_eq!(interval.transaction_time().start(), 4_000.into());
+    assert!(interval.transaction_time().is_current());
+}
+
+#[test]
+fn test_get_edge_version_read_metadata_missing_version_returns_none() {
+    // Edge mirror of the node missing-version case above.
+    let storage = HistoricalStorage::new();
+    let missing = VersionId::new(424_243).unwrap();
+    assert!(
+        storage
+            .get_edge_version_read_metadata(missing)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn test_get_node_version_read_metadata_cold_tier_fallback() {
+    use crate::storage::redb_cold_storage::RedbColdStorage;
+    use crate::storage::tiered_storage::TieredStorage;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("cold.redb");
+    let cold = Arc::new(RedbColdStorage::with_default_config(&db_path).unwrap());
+    let tiered = Arc::new(TieredStorage::with_default_config(cold));
+
+    let version_id = VersionId::new(7_100).unwrap();
+    let temporal = BiTemporalInterval::with_valid_time(1_000.into(), 2_000.into());
+    let version = NodeVersion::new_anchor(
+        version_id,
+        NodeId::new(7).unwrap(),
+        temporal,
+        GLOBAL_INTERNER.intern("Person").unwrap(),
+        PropertyMapBuilder::new()
+            .insert("name", "Cold Alice")
+            .build(),
+    );
+    tiered.store_node_version(&version).unwrap();
+
+    let mut storage = HistoricalStorage::new();
+    storage.set_tiered_storage(tiered);
+
+    // The version was never added to the hot tier, so the lookup must fall
+    // back through the tiered path and hit cold storage.
+    let (prov, interval) = storage
+        .get_node_version_read_metadata(version_id)
+        .unwrap()
+        .expect("cold-tier version must be found");
+    assert!(prov.is_none(), "anchor was stored without provenance");
+    assert_eq!(interval.valid_time().start(), 1_000.into());
+    assert_eq!(interval.transaction_time().start(), 2_000.into());
+}
+
+#[test]
+fn test_get_edge_version_read_metadata_cold_tier_fallback() {
+    use crate::storage::redb_cold_storage::RedbColdStorage;
+    use crate::storage::tiered_storage::TieredStorage;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("cold.redb");
+    let cold = Arc::new(RedbColdStorage::with_default_config(&db_path).unwrap());
+    let tiered = Arc::new(TieredStorage::with_default_config(cold));
+
+    let version_id = VersionId::new(7_200).unwrap();
+    let temporal = BiTemporalInterval::with_valid_time(3_000.into(), 4_000.into());
+    let version = EdgeVersion::new_anchor(
+        version_id,
+        EdgeId::new(70).unwrap(),
+        temporal,
+        GLOBAL_INTERNER.intern("KNOWS").unwrap(),
+        NodeId::new(7).unwrap(),
+        NodeId::new(8).unwrap(),
+        PropertyMapBuilder::new().insert("weight", 2.0f64).build(),
+    );
+    tiered.store_edge_version(&version).unwrap();
+
+    let mut storage = HistoricalStorage::new();
+    storage.set_tiered_storage(tiered);
+
+    // Edge mirror of the node cold-tier fallback case above.
+    let (prov, interval) = storage
+        .get_edge_version_read_metadata(version_id)
+        .unwrap()
+        .expect("cold-tier version must be found");
+    assert!(prov.is_none(), "anchor was stored without provenance");
+    assert_eq!(interval.valid_time().start(), 3_000.into());
+    assert_eq!(interval.transaction_time().start(), 4_000.into());
+}


### PR DESCRIPTION
# Stamp valid-time/transaction-time bounds on MCP read responses

Closes #3232

## Before / After (what an MCP consumer sees)

**Before**: a read response told the caller *what* a node/edge looks like (`id`, `label`, `properties`, `provenance`) but not *when* that answer holds. An LLM that asked "who is Alice?" couldn't tell whether the fact it got back is the live current version, a superseded version from a point-in-time read, or a fact whose validity has already ended — without a follow-up `get_node_history` call.

**After**: every node/edge read response carries an additive `temporal` block stamping the bi-temporal bounds of the exact version returned:

```json
"temporal": {
  "valid_from": "2026-07-07T12:00:00.000000Z",
  "valid_to": null,
  "transaction_from": "2026-07-07T12:00:00.000000Z",
  "transaction_to": null,
  "is_current": true
}
```

- Timestamps are RFC 3339 strings with microsecond precision and a `Z` (UTC) suffix; intervals are half-open `[start, end)`.
- Open-ended bounds are **explicit JSON `null`** — the keys are always present, never omitted.
- `is_current` is `true` iff the version's transaction interval is still open (it *is* the currently-recorded version) and the wallclock now falls within its valid interval: a live node reports `true`; a superseded version returned by an at-time read, a fact whose `valid_to` has passed, or a not-yet-valid fact (future `valid_from`) reports `false`. The valid-time comparison is at wallclock (microsecond) granularity.
- The shape is identical for nodes and edges, current-state and point-in-time reads.

Covered tools: `get_node`, `create_node`, `update_node`, `get_edge`, `create_edge`, `update_edge`, `list_nodes`, `traverse`, `get_outgoing_edges`, `get_incoming_edges`, `find_similar`, `hybrid_query`, `get_node_at_time`, `get_edge_at_time`, `get_node_at_valid_time`, `get_node_at_transaction_time`, `get_edge_at_valid_time`, `get_edge_at_transaction_time`. (`list_edges` remains the existing `edges: []` stub — nothing to stamp per-edge.)

## How

- **`TemporalBounds`** (`src/mcp/tools.rs`): new serializable struct plus a reusable `From<&BiTemporalInterval>` conversion (RFC 3339 formatting, `TIMESTAMP_MAX` → `null`, `is_current` via `TimeRange::contains` at a single shared "now"). Re-exported from `aletheiadb::mcp` so upcoming issues (#3236/#3230) can reuse the conversion directly. The formatter is total: a wallclock value outside chrono's representable range degrades to the raw microsecond count rather than silently rendering the 1970 epoch.
- **`get_node_version_read_metadata` / `get_edge_version_read_metadata`** (`src/storage/historical/mod.rs`, `src/db/ops.rs`): fetch provenance and bi-temporal interval in **one historical read per entity** (hot path avoids cloning version data; cold path uses the tiered lookup so migrated versions still resolve). These replace the provenance-only lookup in the MCP response constructors, with the same best-effort degrade convention (log + omit, never fail the whole response).
- **Wiring** (`src/mcp/server.rs`): `node_to_response`/`edge_to_response` now stamp `temporal`, so every constructing tool gets it uniformly. The bounds are correct for point-in-time reads because those lookup paths set the snapshot's `current_version` to the matched historical version.
- **Fields on `NodeResponse`/`EdgeResponse`** are `Option` with `skip_serializing_if` purely as a defensive degrade when version metadata can't be loaded (mirroring provenance); on all normal paths the block is present.

## Review round (applied on top of the original implementation)

- **UTC `Z` suffix**: bounds now serialize as `...Z` instead of `...+00:00` (docs and examples updated to match).
- **Total formatter**: out-of-range wallclock values fall back to the raw microsecond count instead of `unwrap_or_default()`'s silent 1970 epoch.
- **`TemporalBounds` re-exported** from `aletheiadb::mcp` for #3236/#3230 reuse.
- **Three new tests**: not-yet-valid fact (future `valid_from` ⇒ `is_current: false` with open bounds — isolates the valid-time conjunct), backdated create (`valid_from` reflects the supplied valid time exactly; `transaction_from` is the later system-assigned commit time), and deleted node via at-time read (closed `transaction_to` strictly after the anchor, `is_current: false`).
- **Tightened assertions**: superseded-version bounds are now asserted strictly-after-anchor (not the loose `anchor - 60s`); `get_edge_at_time`'s two dimensions anchor one shared "now".
- **Docs**: explicit note (guide + CLAUDE.md) that the *whole* `temporal` block is omitted (mirroring `provenance`) only in the rare case version metadata cannot be loaded; open bounds within a present block are always explicit `null`.
- Deliberately **not** changed: hoisting `now()` out of the per-entity `From` conversion for bulk responses — correct as-is; potential micro-optimization for a follow-up.

**Final hardening round — `is_current` vs HLC clock artifacts**: the conversion no longer compares HLC commit timestamps against SystemTime-now, which could report a genuinely live, open-ended head version as `is_current: false` — transiently within the same microsecond as its commit (an HLC stamp's logical component orders after SystemTime-now), and for minutes while the HLC frontier legitimately runs ahead of SystemTime after a tolerated backward OS-clock step. The rule is now: the transaction dimension is current iff the transaction interval is open-ended (an open interval *is* by definition the currently-recorded version), and the valid dimension is compared at wallclock (microsecond) granularity — `is_current = tx_open && valid_contains_now_at_wallclock_granularity`. Five new conversion-level unit tests on hand-constructed `BiTemporalInterval`s cover the same-microsecond logical>0 repro, the skewed-commit-stamp window, an explicit future `valid_from` (still `false`), a closed transaction interval (`false`), and an expired valid interval (`false`); all nine pre-existing `temporal_bounds_tests` pass unchanged. The `is_current` doc comment, MCP guide, and CLAUDE.md were updated to the new semantics sentence.

## Compatibility notes

- **Purely additive / non-breaking**: no existing field moved or changed shape; `id`/`label`/`properties`/`provenance` and all top-level payload fields are unchanged.
- **History format deliberately unchanged**: `get_node_history` keeps emitting microseconds-as-string. A dedicated test asserts the new RFC 3339 bounds decode to exactly the same microsecond values history reports for the same version.
- **Rebased onto trunk with #3342 merged** (structured MCP error codes): the append/append conflicts in `src/mcp/tests.rs` and the MCP guide were resolved by keeping both new sections; this PR's code does not construct errors, so no adaptation to `src/mcp/error.rs` was needed.

## Testing

TDD (red → green): 9 tests in `src/mcp/tests.rs` (`temporal_bounds_tests`) covering create/get node, create/get edge (incl. `get_edge_at_time`), `list_nodes`/`traverse` per-entity stamping, adjacency + update responses, superseded-version closed bounds with `is_current: false`, RFC3339↔micros agreement with `get_node_history`, not-yet-valid facts, backdated creates, and deleted-node at-time reads. The final hardening round adds 5 conversion-level unit tests (14 total in `temporal_bounds_tests`).

Gates (re-run after the rebase onto trunk @ 6e8d684, and again after the final hardening round): `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean; `cargo test --features mcp-server,cypher --no-fail-fast` — 138 test binaries, all pass except the two pre-existing, environment-caused failures (`havoc_flush_deadlock::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`) which fail identically on untouched trunk (I/O-error-injection tests running as root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaebJV4qYRPD22D7dZXERD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaebJV4qYRPD22D7dZXERD)_