### PR TITLE
CI: promote mutation testing to a scored gate; fix broken weekly mutants run

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,9 +11,11 @@
 # without adding correctness value. Patterns are matched against the full
 # mutant name, e.g.:
 #   src/db/mod.rs:182:9: replace <impl std::fmt::Debug for AletheiaDB>::fmt -> std::fmt::Result with Ok(Default::default())
+# The trailing `.*>` (not `[^>]*>`) is needed because generic self types
+# close with an extra `>`, e.g. <impl fmt::Debug for NodeConnection<C>>::fmt.
 exclude_re = [
     # Debug impls (also matches operator mutants inside the fmt body).
-    "<impl [^>]*Debug[^>]*>::fmt",
+    "<impl [^>]*Debug.*>::fmt",
     # Display impls.
-    "<impl [^>]*Display[^>]*>::fmt",
+    "<impl [^>]*Display.*>::fmt",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,19 @@
+# cargo-mutants configuration — see https://mutants.rs/ and
+# TESTING.md § Mutation Testing.
+#
+# Scope note: src/mcp/** is deliberately NOT excluded. It is the actively
+# developed LLM-facing surface and must stay under mutation pressure.
+# (ADR-0035 originally described an mcp exclusion, but it never shipped;
+# see the 2026-07-08 addendum in docs/adr/0035-mutation-testing.md.)
+
+# Skip mutants inside `fmt` methods of Debug/Display impls: formatting output
+# is cosmetic, and tests asserting exact Debug/Display strings are brittle
+# without adding correctness value. Patterns are matched against the full
+# mutant name, e.g.:
+#   src/db/mod.rs:182:9: replace <impl std::fmt::Debug for AletheiaDB>::fmt -> std::fmt::Result with Ok(Default::default())
+exclude_re = [
+    # Debug impls (also matches operator mutants inside the fmt body).
+    "<impl [^>]*Debug[^>]*>::fmt",
+    # Display impls.
+    "<impl [^>]*Display[^>]*>::fmt",
+]

--- a/.github/mutants-gate.toml
+++ b/.github/mutants-gate.toml
@@ -1,0 +1,12 @@
+# Mutation-score gate configuration. See TESTING.md § Mutation Testing.
+# Read by .github/scripts/mutants_gate.py in the "Mutation Testing" workflow.
+
+# threshold: minimum mutation score (%) for the mutants touched by a PR diff.
+# Score = (caught + timeout) / (caught + timeout + missed) * 100.
+# PROVISIONAL value — project-wide baseline measurement in progress; will be
+# updated from the measured baseline before this PR merges.
+threshold = 60.0
+
+# Gate only applies when the diff produces at least this many viable mutants;
+# below this, results are reported but never fail the check (small-sample noise).
+min_mutants = 10

--- a/.github/scripts/mutants_gate.py
+++ b/.github/scripts/mutants_gate.py
@@ -25,7 +25,6 @@ import argparse
 import json
 import os
 import sys
-import time
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,7 +35,11 @@ EXIT_GATE_FAIL = 2
 
 OUTCOME_FILES = ("caught.txt", "missed.txt", "timeout.txt", "unviable.txt")
 
-SECONDS_PER_WEEK = 7 * 24 * 3600
+CONFIG_KEYS = {"threshold", "min_mutants"}
+
+# GitHub silently drops step summaries larger than 1 MiB; cap the rendered
+# missed-mutant list and point at the uploaded artifact for the rest.
+MAX_MISSED_LINES = 200
 
 
 class InfraError(Exception):
@@ -60,10 +63,24 @@ class Counts:
         return self.caught + self.timeout
 
     def score(self) -> float | None:
-        """Mutation score in percent, or None when there are no viable mutants."""
+        """Mutation score in percent, FOR DISPLAY ONLY (float division).
+
+        Never compare this against the threshold — 29/50*100 is
+        57.99999999999999 in floats and would fail a 58.0 threshold it
+        actually meets. Use meets() for the verdict.
+        """
         if self.viable == 0:
             return None
         return self.detected / self.viable * 100.0
+
+    def meets(self, threshold: float) -> bool:
+        """Exact threshold comparison without division.
+
+        detected/viable*100 >= threshold  <=>  detected*100 >= threshold*viable
+        (viable > 0; one float multiplication of exact integers is exact for
+        all realistic counts, unlike the divided form).
+        """
+        return self.detected * 100 >= threshold * self.viable
 
     def add(self, other: "Counts") -> None:
         self.caught += other.caught
@@ -81,6 +98,13 @@ def load_config(path: Path) -> dict:
         raise InfraError(f"cannot read gate config {path}: {e}") from e
     except tomllib.TOMLDecodeError as e:
         raise InfraError(f"malformed gate config {path}: {e}") from e
+
+    unknown = sorted(set(raw) - CONFIG_KEYS)
+    if unknown:
+        raise InfraError(
+            f"gate config {path}: unknown key(s) {', '.join(unknown)} "
+            f"(allowed: {', '.join(sorted(CONFIG_KEYS))}) — check for typos"
+        )
 
     threshold = raw.get("threshold")
     min_mutants = raw.get("min_mutants")
@@ -145,14 +169,33 @@ def emit(markdown: str) -> None:
             print(f"warning: could not write GITHUB_STEP_SUMMARY: {e}", file=sys.stderr)
 
 
-def fmt_score(score: float | None) -> str:
-    return "n/a" if score is None else f"{score:.1f}%"
+def fmt_score(score: float | None, threshold: float | None = None) -> str:
+    """Format a score for display.
+
+    When the score sits within 0.05 of the threshold, use 2 decimals so the
+    message never reads like the nonsensical "58.0% < 58.0%".
+    """
+    if score is None:
+        return "n/a"
+    if threshold is not None and abs(score - threshold) < 0.05:
+        return f"{score:.2f}%"
+    return f"{score:.1f}%"
+
+
+def fmt_threshold(threshold: float, score: float | None) -> str:
+    if score is not None and abs(score - threshold) < 0.05:
+        return f"{threshold:.2f}%"
+    return f"{threshold:.1f}%"
 
 
 def missed_details(missed_lines: tuple[str, ...]) -> str:
     if not missed_lines:
         return ""
-    body = "\n".join(missed_lines)
+    shown = missed_lines[:MAX_MISSED_LINES]
+    body = "\n".join(shown)
+    hidden = len(missed_lines) - len(shown)
+    if hidden > 0:
+        body += f"\n… and {hidden} more — see the mutants artifact"
     return (
         "\n<details><summary>Missed mutants "
         f"({len(missed_lines)})</summary>\n\n```\n{body}\n```\n</details>\n"
@@ -165,7 +208,10 @@ def cmd_gate(args: argparse.Namespace) -> int:
     min_mutants: int = config["min_mutants"]
 
     mutants_out = Path(args.mutants_out)
-    if not mutants_out.is_dir() and args.allow_missing:
+    if not mutants_out.exists() and args.allow_missing:
+        # Only a truly ABSENT path counts as "no mutants in diff"; a file
+        # sitting where the directory should be is an infrastructure problem
+        # and falls through to read_counts, which rejects non-directories.
         emit(
             "## Mutation-score gate: PASS\n\n"
             "No mutants output directory was produced — no mutants in diff.\n"
@@ -174,6 +220,8 @@ def cmd_gate(args: argparse.Namespace) -> int:
 
     counts = read_counts(mutants_out)
     score = counts.score()
+    score_s = fmt_score(score, threshold)
+    threshold_s = fmt_threshold(threshold, score)
 
     if counts.viable == 0:
         verdict, reason, code = "PASS", "no mutants in diff", EXIT_PASS
@@ -183,12 +231,12 @@ def cmd_gate(args: argparse.Namespace) -> int:
             f"only {counts.viable} viable mutants (< min_mutants = {min_mutants}); "
             "sample too small to enforce — reported for information only"
         )
-    elif score >= threshold:
+    elif counts.meets(threshold):
         verdict, code = "PASS", EXIT_PASS
-        reason = f"score {fmt_score(score)} >= threshold {threshold:.1f}%"
+        reason = f"score {score_s} >= threshold {threshold_s}"
     else:
         verdict, code = "FAIL", EXIT_GATE_FAIL
-        reason = f"score {fmt_score(score)} < threshold {threshold:.1f}%"
+        reason = f"score {score_s} < threshold {threshold_s}"
 
     lines = [
         f"## Mutation-score gate: {verdict}",
@@ -202,8 +250,8 @@ def cmd_gate(args: argparse.Namespace) -> int:
         f"| Missed | {counts.missed} |",
         f"| Unviable (excluded) | {counts.unviable} |",
         f"| Viable total | {counts.viable} |",
-        f"| Score | {fmt_score(score)} |",
-        f"| Threshold | {threshold:.1f}% |",
+        f"| Score | {score_s} |",
+        f"| Threshold | {threshold_s} |",
         f"| min_mutants floor | {min_mutants} |",
         missed_details(counts.missed_lines),
     ]
@@ -211,25 +259,31 @@ def cmd_gate(args: argparse.Namespace) -> int:
     return code
 
 
-def find_shard_outputs(shards_dir: Path) -> dict[str, Path]:
+def find_shard_outputs(shards_dir: Path) -> tuple[dict[str, Path], list[str]]:
     """Map shard-artifact name -> mutants.out-style directory.
 
     Each immediate subdirectory of shards_dir is one downloaded artifact.
     Outcome files may sit at the artifact root or under a nested mutants.out/.
+    Returns (found, skipped) where skipped lists subdirectories that contain
+    no outcome files at all (e.g. an empty artifact from a crashed job) —
+    these must be surfaced to the caller, never silently dropped.
     """
     if not shards_dir.is_dir():
         raise InfraError(f"shards directory not found: {shards_dir}")
     found: dict[str, Path] = {}
+    skipped: list[str] = []
     for sub in sorted(p for p in shards_dir.iterdir() if p.is_dir()):
         for candidate in (sub, sub / "mutants.out"):
             if candidate.is_dir() and any((candidate / n).is_file() for n in OUTCOME_FILES):
                 found[sub.name] = candidate
                 break
+        else:
+            skipped.append(sub.name)
     if not found:
         raise InfraError(
             f"no shard artifacts with mutants output found under {shards_dir}"
         )
-    return found
+    return found, skipped
 
 
 def cmd_summarize(args: argparse.Namespace) -> int:
@@ -237,7 +291,7 @@ def cmd_summarize(args: argparse.Namespace) -> int:
     threshold: float = config["threshold"]
     shards_dir = Path(args.shards_dir)
 
-    shard_outputs = find_shard_outputs(shards_dir)
+    shard_outputs, skipped = find_shard_outputs(shards_dir)
     total = Counts()
     rows = []
     for name, out_dir in shard_outputs.items():
@@ -248,11 +302,16 @@ def cmd_summarize(args: argparse.Namespace) -> int:
         )
 
     score = total.score()
-    week = int(time.time()) // SECONDS_PER_WEEK
+    week = args.week  # pinned once by the workflow's setup job; may be None locally
+    expected = args.expected_shards
+    partial = bool(skipped) or (expected is not None and len(shard_outputs) < expected)
 
     score_json = {
         "week": week,
         "shards": len(shard_outputs),
+        "expected_shards": expected,
+        "partial": partial,
+        "skipped_shards": skipped,
         "caught": total.caught,
         "timeout": total.timeout,
         "missed": total.missed,
@@ -272,21 +331,35 @@ def cmd_summarize(args: argparse.Namespace) -> int:
     comparison = (
         "no viable mutants in this sample"
         if score is None
-        else f"{fmt_score(score)} vs PR-gate threshold {threshold:.1f}% "
-        + ("(at or above)" if score >= threshold else "(below — informational, does not fail this run)")
+        else f"{fmt_score(score, threshold)} vs PR-gate threshold {fmt_threshold(threshold, score)} "
+        + ("(at or above)" if total.meets(threshold) else "(below — informational, does not fail this run)")
     )
+    week_label = f"week {week}" if week is not None else "week unknown"
+    warnings = []
+    if partial:
+        found_of = f"{len(shard_outputs)}" + (f" of {expected} expected" if expected is not None else "")
+        warnings.append(
+            f"> **:warning: PARTIAL result** — only {found_of} shard artifacts held usable output; "
+            "the score below underestimates the sample and must not be treated as the weekly estimate."
+        )
+    if skipped:
+        warnings.append(
+            "> Skipped shard artifacts with no outcome files: " + ", ".join(skipped)
+        )
     lines = [
-        f"## Weekly mutation score (rotating sample, week {week})",
+        f"## Weekly mutation score (rotating sample, {week_label})",
         "",
-        f"Combined score across {len(shard_outputs)} shard(s): **{fmt_score(score)}** — {comparison}",
+        *warnings,
+        "" if warnings else None,
+        f"Combined score across {len(shard_outputs)} shard(s): **{fmt_score(score, threshold)}** — {comparison}",
         "",
         "| Shard | Caught | Timeout | Missed | Unviable | Score |",
         "|---|---|---|---|---|---|",
         *rows,
-        f"| **Total** | {total.caught} | {total.timeout} | {total.missed} | {total.unviable} | {fmt_score(score)} |",
+        f"| **Total** | {total.caught} | {total.timeout} | {total.missed} | {total.unviable} | {fmt_score(score, threshold)} |",
         missed_details(total.missed_lines),
     ]
-    emit("\n".join(lines))
+    emit("\n".join(line for line in lines if line is not None))
     return EXIT_PASS
 
 
@@ -308,6 +381,20 @@ def main(argv: list[str] | None = None) -> int:
     p_sum = sub.add_parser("summarize", help="aggregate weekly shard artifacts (informational)")
     p_sum.add_argument("--shards-dir", required=True, help="directory of downloaded shard artifacts")
     p_sum.add_argument("--config", required=True, help="path to mutants-gate.toml")
+    p_sum.add_argument(
+        "--week",
+        type=int,
+        default=None,
+        help="epoch-week number pinned by the workflow's setup job "
+        "(recorded verbatim in score.json; never derived from the current time)",
+    )
+    p_sum.add_argument(
+        "--expected-shards",
+        type=int,
+        default=None,
+        help="number of shard artifacts expected this run; fewer usable ones "
+        "marks the published summary and score.json as partial",
+    )
     p_sum.set_defaults(func=cmd_summarize)
 
     args = parser.parse_args(argv)

--- a/.github/scripts/mutants_gate.py
+++ b/.github/scripts/mutants_gate.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Mutation-score gate for cargo-mutants output.
+
+Subcommands:
+  gate       Enforce the PR-diff mutation-score threshold against one
+             mutants.out directory. Exit 0 = pass, 2 = score below threshold,
+             1 = infrastructure error (bad config, unreadable output dir).
+  summarize  Aggregate several weekly shard artifacts (each containing a
+             mutants.out) into a combined, informational project score.
+             Writes score.json and combined-missed.txt into the shards dir.
+             Never exits 2; infrastructure error = 1.
+
+Score formula (see TESTING.md "Mutation Testing"):
+    score = (caught + timeout) / (caught + timeout + missed) * 100
+Timeouts count as caught: the mutant made the test suite hang, i.e. it was
+detected. Unviable mutants (failed to compile) are excluded entirely.
+
+Configuration lives in .github/mutants-gate.toml (threshold, min_mutants).
+Python 3.11+ standard library only (tomllib).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+EXIT_PASS = 0
+EXIT_INFRA = 1
+EXIT_GATE_FAIL = 2
+
+OUTCOME_FILES = ("caught.txt", "missed.txt", "timeout.txt", "unviable.txt")
+
+SECONDS_PER_WEEK = 7 * 24 * 3600
+
+
+class InfraError(Exception):
+    """Configuration or environment problem — not a gate verdict."""
+
+
+@dataclass
+class Counts:
+    caught: int = 0
+    missed: int = 0
+    timeout: int = 0
+    unviable: int = 0
+    missed_lines: tuple[str, ...] = ()
+
+    @property
+    def viable(self) -> int:
+        return self.caught + self.timeout + self.missed
+
+    @property
+    def detected(self) -> int:
+        return self.caught + self.timeout
+
+    def score(self) -> float | None:
+        """Mutation score in percent, or None when there are no viable mutants."""
+        if self.viable == 0:
+            return None
+        return self.detected / self.viable * 100.0
+
+    def add(self, other: "Counts") -> None:
+        self.caught += other.caught
+        self.missed += other.missed
+        self.timeout += other.timeout
+        self.unviable += other.unviable
+        self.missed_lines = self.missed_lines + other.missed_lines
+
+
+def load_config(path: Path) -> dict:
+    try:
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+    except OSError as e:
+        raise InfraError(f"cannot read gate config {path}: {e}") from e
+    except tomllib.TOMLDecodeError as e:
+        raise InfraError(f"malformed gate config {path}: {e}") from e
+
+    threshold = raw.get("threshold")
+    min_mutants = raw.get("min_mutants")
+    if not isinstance(threshold, (int, float)) or isinstance(threshold, bool):
+        raise InfraError(f"gate config {path}: 'threshold' must be a number, got {threshold!r}")
+    if not isinstance(min_mutants, int) or isinstance(min_mutants, bool):
+        raise InfraError(f"gate config {path}: 'min_mutants' must be an integer, got {min_mutants!r}")
+    if not 0.0 <= float(threshold) <= 100.0:
+        raise InfraError(f"gate config {path}: 'threshold' must be within [0, 100], got {threshold}")
+    if min_mutants < 0:
+        raise InfraError(f"gate config {path}: 'min_mutants' must be >= 0, got {min_mutants}")
+    return {"threshold": float(threshold), "min_mutants": min_mutants}
+
+
+def read_lines(path: Path) -> list[str]:
+    try:
+        return [ln for ln in path.read_text(encoding="utf-8", errors="replace").splitlines() if ln.strip()]
+    except OSError as e:
+        raise InfraError(f"cannot read {path}: {e}") from e
+
+
+def read_counts(mutants_out: Path) -> Counts:
+    """Read outcome counts from a mutants.out directory.
+
+    A missing outcome file counts as 0, but only if the directory exists and
+    contains at least one of the four outcome files — otherwise this is an
+    infrastructure error (the run didn't produce usable output).
+    """
+    if not mutants_out.is_dir():
+        raise InfraError(f"mutants output directory not found: {mutants_out}")
+    present = [name for name in OUTCOME_FILES if (mutants_out / name).is_file()]
+    if not present:
+        raise InfraError(
+            f"{mutants_out} exists but contains none of {', '.join(OUTCOME_FILES)}; "
+            "the cargo-mutants run did not produce usable output"
+        )
+
+    def count(name: str) -> int:
+        p = mutants_out / name
+        return len(read_lines(p)) if p.is_file() else 0
+
+    missed_path = mutants_out / "missed.txt"
+    missed_lines = tuple(read_lines(missed_path)) if missed_path.is_file() else ()
+    return Counts(
+        caught=count("caught.txt"),
+        missed=len(missed_lines),
+        timeout=count("timeout.txt"),
+        unviable=count("unviable.txt"),
+        missed_lines=missed_lines,
+    )
+
+
+def emit(markdown: str) -> None:
+    """Print markdown to stdout and append it to $GITHUB_STEP_SUMMARY if set."""
+    print(markdown)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as f:
+                f.write(markdown + "\n")
+        except OSError as e:
+            print(f"warning: could not write GITHUB_STEP_SUMMARY: {e}", file=sys.stderr)
+
+
+def fmt_score(score: float | None) -> str:
+    return "n/a" if score is None else f"{score:.1f}%"
+
+
+def missed_details(missed_lines: tuple[str, ...]) -> str:
+    if not missed_lines:
+        return ""
+    body = "\n".join(missed_lines)
+    return (
+        "\n<details><summary>Missed mutants "
+        f"({len(missed_lines)})</summary>\n\n```\n{body}\n```\n</details>\n"
+    )
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    threshold: float = config["threshold"]
+    min_mutants: int = config["min_mutants"]
+
+    mutants_out = Path(args.mutants_out)
+    if not mutants_out.is_dir() and args.allow_missing:
+        emit(
+            "## Mutation-score gate: PASS\n\n"
+            "No mutants output directory was produced — no mutants in diff.\n"
+        )
+        return EXIT_PASS
+
+    counts = read_counts(mutants_out)
+    score = counts.score()
+
+    if counts.viable == 0:
+        verdict, reason, code = "PASS", "no mutants in diff", EXIT_PASS
+    elif counts.viable < min_mutants:
+        verdict, code = "PASS", EXIT_PASS
+        reason = (
+            f"only {counts.viable} viable mutants (< min_mutants = {min_mutants}); "
+            "sample too small to enforce — reported for information only"
+        )
+    elif score >= threshold:
+        verdict, code = "PASS", EXIT_PASS
+        reason = f"score {fmt_score(score)} >= threshold {threshold:.1f}%"
+    else:
+        verdict, code = "FAIL", EXIT_GATE_FAIL
+        reason = f"score {fmt_score(score)} < threshold {threshold:.1f}%"
+
+    lines = [
+        f"## Mutation-score gate: {verdict}",
+        "",
+        f"{reason}",
+        "",
+        "| Metric | Value |",
+        "|---|---|",
+        f"| Caught | {counts.caught} |",
+        f"| Timeout (counted as caught) | {counts.timeout} |",
+        f"| Missed | {counts.missed} |",
+        f"| Unviable (excluded) | {counts.unviable} |",
+        f"| Viable total | {counts.viable} |",
+        f"| Score | {fmt_score(score)} |",
+        f"| Threshold | {threshold:.1f}% |",
+        f"| min_mutants floor | {min_mutants} |",
+        missed_details(counts.missed_lines),
+    ]
+    emit("\n".join(lines))
+    return code
+
+
+def find_shard_outputs(shards_dir: Path) -> dict[str, Path]:
+    """Map shard-artifact name -> mutants.out-style directory.
+
+    Each immediate subdirectory of shards_dir is one downloaded artifact.
+    Outcome files may sit at the artifact root or under a nested mutants.out/.
+    """
+    if not shards_dir.is_dir():
+        raise InfraError(f"shards directory not found: {shards_dir}")
+    found: dict[str, Path] = {}
+    for sub in sorted(p for p in shards_dir.iterdir() if p.is_dir()):
+        for candidate in (sub, sub / "mutants.out"):
+            if candidate.is_dir() and any((candidate / n).is_file() for n in OUTCOME_FILES):
+                found[sub.name] = candidate
+                break
+    if not found:
+        raise InfraError(
+            f"no shard artifacts with mutants output found under {shards_dir}"
+        )
+    return found
+
+
+def cmd_summarize(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    threshold: float = config["threshold"]
+    shards_dir = Path(args.shards_dir)
+
+    shard_outputs = find_shard_outputs(shards_dir)
+    total = Counts()
+    rows = []
+    for name, out_dir in shard_outputs.items():
+        c = read_counts(out_dir)
+        total.add(c)
+        rows.append(
+            f"| {name} | {c.caught} | {c.timeout} | {c.missed} | {c.unviable} | {fmt_score(c.score())} |"
+        )
+
+    score = total.score()
+    week = int(time.time()) // SECONDS_PER_WEEK
+
+    score_json = {
+        "week": week,
+        "shards": len(shard_outputs),
+        "caught": total.caught,
+        "timeout": total.timeout,
+        "missed": total.missed,
+        "unviable": total.unviable,
+        "viable": total.viable,
+        "score": None if score is None else round(score, 2),
+        "threshold": threshold,
+    }
+    try:
+        (shards_dir / "score.json").write_text(json.dumps(score_json, indent=2) + "\n")
+        (shards_dir / "combined-missed.txt").write_text(
+            "".join(line + "\n" for line in total.missed_lines)
+        )
+    except OSError as e:
+        raise InfraError(f"cannot write aggregate outputs into {shards_dir}: {e}") from e
+
+    comparison = (
+        "no viable mutants in this sample"
+        if score is None
+        else f"{fmt_score(score)} vs PR-gate threshold {threshold:.1f}% "
+        + ("(at or above)" if score >= threshold else "(below — informational, does not fail this run)")
+    )
+    lines = [
+        f"## Weekly mutation score (rotating sample, week {week})",
+        "",
+        f"Combined score across {len(shard_outputs)} shard(s): **{fmt_score(score)}** — {comparison}",
+        "",
+        "| Shard | Caught | Timeout | Missed | Unviable | Score |",
+        "|---|---|---|---|---|---|",
+        *rows,
+        f"| **Total** | {total.caught} | {total.timeout} | {total.missed} | {total.unviable} | {fmt_score(score)} |",
+        missed_details(total.missed_lines),
+    ]
+    emit("\n".join(lines))
+    return EXIT_PASS
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_gate = sub.add_parser("gate", help="enforce PR-diff mutation-score threshold")
+    p_gate.add_argument("--mutants-out", required=True, help="path to mutants.out directory")
+    p_gate.add_argument("--config", required=True, help="path to mutants-gate.toml")
+    p_gate.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="treat a missing mutants.out directory as zero mutants (empty diff) "
+        "instead of an infrastructure error",
+    )
+    p_gate.set_defaults(func=cmd_gate)
+
+    p_sum = sub.add_parser("summarize", help="aggregate weekly shard artifacts (informational)")
+    p_sum.add_argument("--shards-dir", required=True, help="directory of downloaded shard artifacts")
+    p_sum.add_argument("--config", required=True, help="path to mutants-gate.toml")
+    p_sum.set_defaults(func=cmd_summarize)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except InfraError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return EXIT_INFRA
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_mutants_gate.py
+++ b/.github/scripts/test_mutants_gate.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Unit tests for mutants_gate.py (the mutation-score CI gate).
+
+Run directly:  python3 .github/scripts/test_mutants_gate.py
+
+These tests shell out to the script as a subprocess so that exit codes,
+stdout, and $GITHUB_STEP_SUMMARY handling are tested exactly as CI sees them.
+Python 3.11+ standard library only.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "mutants_gate.py"
+
+# Exit-code contract of mutants_gate.py
+EXIT_PASS = 0
+EXIT_INFRA = 1
+EXIT_GATE_FAIL = 2
+
+GOOD_CONFIG = 'threshold = 60.0\nmin_mutants = 10\n'
+
+
+def write_mutants_out(dir_path: Path, caught=0, missed=0, timeout=0, unviable=0,
+                      omit_empty=False):
+    """Create a mutants.out-style directory with N synthetic lines per file.
+
+    With omit_empty=True, files whose count is zero are not created at all
+    (cargo-mutants sometimes writes all four, but the gate must tolerate
+    missing files as long as the directory itself exists with at least one).
+    """
+    dir_path.mkdir(parents=True, exist_ok=True)
+    for name, count in (("caught.txt", caught), ("missed.txt", missed),
+                        ("timeout.txt", timeout), ("unviable.txt", unviable)):
+        if omit_empty and count == 0:
+            continue
+        lines = [f"src/fake.rs:{i}:1: replace thing_{name[:-4]}_{i} with ()"
+                 for i in range(count)]
+        (dir_path / name).write_text("".join(line + "\n" for line in lines))
+
+
+class GateTestBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.config = self.tmp / "gate.toml"
+        self.config.write_text(GOOD_CONFIG)
+        self.summary_file = self.tmp / "step_summary.md"
+
+    def run_cmd(self, *args):
+        env = dict(os.environ)
+        env["GITHUB_STEP_SUMMARY"] = str(self.summary_file)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True, text=True, env=env,
+        )
+
+    def run_gate(self, mutants_out, *extra):
+        return self.run_cmd("gate", "--mutants-out", str(mutants_out),
+                            "--config", str(self.config), *extra)
+
+
+class TestGate(GateTestBase):
+    def test_zero_mutants_passes(self):
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out)  # all four files present, all empty
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("no mutants", r.stdout.lower())
+        self.assertIn("PASS", r.stdout)
+
+    def test_below_min_mutants_does_not_fail(self):
+        # Score 40% < threshold 60%, but only 5 viable mutants < min_mutants 10.
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=2, missed=3)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("PASS", r.stdout)
+        # Must warn that the sample was too small to enforce.
+        self.assertRegex(r.stdout.lower(), r"min_mutants|too few|small sample")
+
+    def test_score_exactly_equal_threshold_passes(self):
+        # 6 caught / 10 viable = exactly 60.0% == threshold.
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=6, missed=4)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("60.0", r.stdout)
+        self.assertIn("PASS", r.stdout)
+
+    def test_score_below_threshold_fails_exit_2(self):
+        # 5 caught / 10 viable = 50.0% < 60%.
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=5, missed=5)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_GATE_FAIL, r.stdout + r.stderr)
+        self.assertIn("FAIL", r.stdout)
+        # Missed mutants must be listed for diagnosis.
+        self.assertIn("thing_missed_0", r.stdout)
+
+    def test_timeout_counts_toward_caught(self):
+        # (5 caught + 2 timeout) / (5+2+3) = 70.0% >= 60%.
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=5, timeout=2, missed=3)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("70.0", r.stdout)
+
+    def test_unviable_excluded_from_denominator(self):
+        # 6/(6+4) = 60.0% passes; if unviable leaked into the denominator the
+        # score would be 6/110 = 5.5% and the gate would fail.
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=6, missed=4, unviable=100)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("60.0", r.stdout)
+
+    def test_missing_outcome_files_tolerated_if_dir_has_one(self):
+        # Only caught.txt exists -> other counts default to 0.
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=12, omit_empty=True)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("100.0", r.stdout)
+
+    def test_missing_mutants_out_dir_is_infra_error(self):
+        r = self.run_gate(self.tmp / "does-not-exist")
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+
+    def test_missing_mutants_out_dir_passes_with_allow_missing(self):
+        r = self.run_gate(self.tmp / "does-not-exist", "--allow-missing")
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("no mutants", r.stdout.lower())
+
+    def test_dir_without_any_outcome_files_is_infra_error(self):
+        out = self.tmp / "mutants.out"
+        out.mkdir()
+        (out / "unrelated.log").write_text("hello\n")
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+
+    def test_malformed_toml_is_infra_error(self):
+        self.config.write_text("threshold = [not valid toml\n")
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=10)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+
+    def test_config_missing_threshold_is_infra_error(self):
+        self.config.write_text("min_mutants = 10\n")
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=10)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+
+    def test_step_summary_written(self):
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=8, missed=2)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS)
+        summary = self.summary_file.read_text()
+        self.assertIn("80.0", summary)
+        self.assertIn("PASS", summary)
+
+
+class TestSummarize(GateTestBase):
+    def make_shards(self):
+        shards = self.tmp / "shards"
+        # Artifact layout: one subdirectory per downloaded artifact. Cover both
+        # layouts: outcome files at the artifact root, and nested mutants.out/.
+        write_mutants_out(shards / "mutants-weekly-shard-0", caught=10, missed=5)
+        write_mutants_out(shards / "mutants-weekly-shard-1" / "mutants.out",
+                          caught=20, missed=5, timeout=5, unviable=3)
+        write_mutants_out(shards / "mutants-weekly-shard-2", caught=30,
+                          missed=10, omit_empty=True)
+        return shards
+
+    def run_summarize(self, shards):
+        return self.run_cmd("summarize", "--shards-dir", str(shards),
+                            "--config", str(self.config))
+
+    def test_summarize_aggregates_three_shards(self):
+        shards = self.make_shards()
+        r = self.run_summarize(shards)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        # Totals: caught 60, timeout 5, missed 20 -> 65/85 = 76.5%
+        self.assertIn("76.5", r.stdout)
+        self.assertIn("mutants-weekly-shard-2", r.stdout)
+
+    def test_summarize_writes_score_json(self):
+        shards = self.make_shards()
+        r = self.run_summarize(shards)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        data = json.loads((shards / "score.json").read_text())
+        self.assertEqual(data["caught"], 60)
+        self.assertEqual(data["timeout"], 5)
+        self.assertEqual(data["missed"], 20)
+        self.assertEqual(data["unviable"], 3)
+        self.assertEqual(data["viable"], 85)
+        self.assertAlmostEqual(data["score"], 65 / 85 * 100, places=1)
+        self.assertEqual(data["shards"], 3)
+        self.assertIn("week", data)
+
+    def test_summarize_never_fails_the_gate(self):
+        # Aggregate score far below threshold -> still exit 0 (informational).
+        shards = self.tmp / "shards"
+        write_mutants_out(shards / "s0", caught=1, missed=99)
+        r = self.run_summarize(shards)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+
+    def test_summarize_empty_dir_is_infra_error(self):
+        shards = self.tmp / "shards"
+        shards.mkdir()
+        r = self.run_summarize(shards)
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+
+    def test_summarize_writes_combined_missed_list(self):
+        shards = self.make_shards()
+        r = self.run_summarize(shards)
+        self.assertEqual(r.returncode, EXIT_PASS)
+        combined = (shards / "combined-missed.txt").read_text()
+        self.assertEqual(len(combined.splitlines()), 20)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_mutants_gate.py
+++ b/.github/scripts/test_mutants_gate.py
@@ -104,6 +104,29 @@ class TestGate(GateTestBase):
         # Missed mutants must be listed for diagnosis.
         self.assertIn("thing_missed_0", r.stdout)
 
+    def test_exact_threshold_pathological_float_ratio_passes(self):
+        # 29 / 50 is exactly 58% but 29/50*100 = 57.99999999999999 in floats.
+        # The gate must compare without division (detected*100 >= threshold*viable).
+        self.config.write_text("threshold = 58.0\nmin_mutants = 10\n")
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=29, missed=21)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("PASS", r.stdout)
+        # Near-threshold scores are displayed with 2 decimals to avoid the
+        # nonsensical-looking "58.0% < 58.0%".
+        self.assertIn("58.00", r.stdout)
+
+    def test_pathological_ratio_against_other_thresholds(self):
+        for threshold, expected in ((57.0, EXIT_PASS), (29.0, EXIT_PASS),
+                                    (58.5, EXIT_GATE_FAIL)):
+            with self.subTest(threshold=threshold):
+                self.config.write_text(f"threshold = {threshold}\nmin_mutants = 10\n")
+                out = self.tmp / f"mutants-{threshold}.out"
+                write_mutants_out(out, caught=29, missed=21)
+                r = self.run_gate(out)
+                self.assertEqual(r.returncode, expected, r.stdout + r.stderr)
+
     def test_timeout_counts_toward_caught(self):
         # (5 caught + 2 timeout) / (5+2+3) = 70.0% >= 60%.
         out = self.tmp / "mutants.out"
@@ -137,6 +160,35 @@ class TestGate(GateTestBase):
         r = self.run_gate(self.tmp / "does-not-exist", "--allow-missing")
         self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
         self.assertIn("no mutants", r.stdout.lower())
+
+    def test_allow_missing_rejects_existing_non_directory(self):
+        # A FILE at the mutants.out path is not "no mutants in diff" — it is
+        # an infrastructure problem even with --allow-missing.
+        bogus = self.tmp / "mutants.out"
+        bogus.write_text("i am not a directory\n")
+        r = self.run_gate(bogus, "--allow-missing")
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+
+    def test_missed_list_truncated_at_200_lines(self):
+        # GitHub silently drops step summaries over 1 MiB; the missed list is
+        # capped at 200 entries with a pointer to the artifact.
+        self.config.write_text("threshold = 99.0\nmin_mutants = 10\n")
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=1, missed=250)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_GATE_FAIL, r.stdout + r.stderr)
+        self.assertIn("thing_missed_199 ", r.stdout)      # 200th entry shown
+        self.assertNotIn("thing_missed_200 ", r.stdout)   # 201st entry cut
+        self.assertIn("and 50 more", r.stdout)
+        self.assertIn("artifact", r.stdout)
+
+    def test_unknown_config_key_is_infra_error(self):
+        self.config.write_text(GOOD_CONFIG + "treshold = 90.0\n")
+        out = self.tmp / "mutants.out"
+        write_mutants_out(out, caught=10)
+        r = self.run_gate(out)
+        self.assertEqual(r.returncode, EXIT_INFRA, r.stdout + r.stderr)
+        self.assertIn("treshold", r.stderr)
 
     def test_dir_without_any_outcome_files_is_infra_error(self):
         out = self.tmp / "mutants.out"
@@ -181,9 +233,9 @@ class TestSummarize(GateTestBase):
                           missed=10, omit_empty=True)
         return shards
 
-    def run_summarize(self, shards):
+    def run_summarize(self, shards, *extra):
         return self.run_cmd("summarize", "--shards-dir", str(shards),
-                            "--config", str(self.config))
+                            "--config", str(self.config), *extra)
 
     def test_summarize_aggregates_three_shards(self):
         shards = self.make_shards()
@@ -226,6 +278,46 @@ class TestSummarize(GateTestBase):
         self.assertEqual(r.returncode, EXIT_PASS)
         combined = (shards / "combined-missed.txt").read_text()
         self.assertEqual(len(combined.splitlines()), 20)
+
+    def test_summarize_week_flag_recorded_in_score_json(self):
+        # The workflow pins WEEK once in a setup job and passes it down;
+        # summarize must record exactly that value, not time.time().
+        shards = self.make_shards()
+        r = self.run_summarize(shards, "--week", "2948")
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        data = json.loads((shards / "score.json").read_text())
+        self.assertEqual(data["week"], 2948)
+
+    def test_summarize_partial_when_fewer_shards_than_expected(self):
+        shards = self.make_shards()  # 3 shard artifacts
+        r = self.run_summarize(shards, "--expected-shards", "12")
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("PARTIAL", r.stdout)
+        data = json.loads((shards / "score.json").read_text())
+        self.assertIs(data["partial"], True)
+        self.assertEqual(data["expected_shards"], 12)
+
+    def test_summarize_not_partial_when_expected_met(self):
+        shards = self.make_shards()
+        r = self.run_summarize(shards, "--expected-shards", "3")
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertNotIn("PARTIAL", r.stdout)
+        data = json.loads((shards / "score.json").read_text())
+        self.assertIs(data["partial"], False)
+
+    def test_summarize_reports_skipped_shard_dirs(self):
+        # A shard directory with no outcome files (e.g. empty artifact from a
+        # crashed job) must be surfaced, not silently dropped.
+        shards = self.make_shards()
+        (shards / "mutants-weekly-shard-3").mkdir()
+        r = self.run_summarize(shards, "--expected-shards", "4")
+        self.assertEqual(r.returncode, EXIT_PASS, r.stdout + r.stderr)
+        self.assertIn("PARTIAL", r.stdout)
+        self.assertIn("mutants-weekly-shard-3", r.stdout)
+        data = json.loads((shards / "score.json").read_text())
+        self.assertIs(data["partial"], True)
+        self.assertEqual(data["skipped_shards"], ["mutants-weekly-shard-3"])
+        self.assertEqual(data["shards"], 3)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -32,7 +32,16 @@ env:
   # (--sharding round-robin requires cargo-mutants 27.x; exit codes per
   # https://mutants.rs/exit-codes.html: 0 = all caught, 2 = missed mutants,
   # 3 = timeouts, everything else = usage/infrastructure error).
+  # cargo-nextest is pinned too so the test harness cannot drift between
+  # weekly windows or PR re-runs.
   CARGO_MUTANTS_VERSION: "27.1.0"
+  CARGO_NEXTEST_VERSION: "0.9.140"
+  # Weekly-sample geometry. TOTAL_SHARDS is provisional and will be finalized
+  # from measured per-mutant nextest timing (alongside the gate threshold).
+  # If you change JOBS_PER_WEEK, also update the matrix idx list below —
+  # GitHub matrices cannot reference env values.
+  TOTAL_SHARDS: 96
+  JOBS_PER_WEEK: 12
 
 jobs:
   # ── PR mode: gate the mutation score of the code touched by the diff ──
@@ -74,7 +83,7 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cargo-mutants and cargo-nextest
-        run: cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}" cargo-nextest
+        run: cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}" "cargo-nextest@${CARGO_NEXTEST_VERSION}"
 
       - name: Generate diff against base branch
         run: |
@@ -125,27 +134,57 @@ jobs:
           path: mutants-run/mutants.out/
           retention-days: 14
           if-no-files-found: ignore
+          # Artifacts are immutable within a run; without this a job re-run
+          # 409s on upload and the stale first-attempt artifact survives.
+          overwrite: true
 
-  # ── Weekly rotating sample: 12 of 96 round-robin shards per week ──────
+  # ── Weekly rotating sample: JOBS_PER_WEEK of TOTAL_SHARDS shards ───────
   #
   # cargo-mutants' DEFAULT sharding is "slice" (contiguous chunks of the
   # mutant list, which follows file order — a biased sample). We pass
   # --sharding round-robin (mutant i runs on shard i % k), so ANY subset of
-  # shards is a systematic, project-wide sample. Each weekly run covers 12
-  # of 96 shards (~12.5% of all mutants) and publishes an unbiased
-  # project-wide score estimate; the rotating start walks through all 96
-  # shards every 8 weeks.
+  # shards is a systematic, project-wide sample. Each weekly run covers
+  # 12 of 96 shards (~12.5% of all mutants) and publishes an unbiased
+  # project-wide score estimate; the rotating start walks through every
+  # shard approximately every TOTAL_SHARDS/JOBS_PER_WEEK (currently 8)
+  # weeks (approximately: skipped/failed weeks miss their window, and code
+  # churn reassigns round-robin positions between weeks).
+  #
+  # WEEK and START are computed ONCE in this setup job and consumed by the
+  # matrix jobs and the aggregate via job outputs. Computing them per-job
+  # would let a shard job re-run after the epoch-week boundary (Thursday
+  # 00:00 UTC) land in next week's window and silently break rotation.
+  mutants-weekly-setup:
+    name: Weekly sample setup
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      week: ${{ steps.calc.outputs.week }}
+      start: ${{ steps.calc.outputs.start }}
+    steps:
+      - name: Compute epoch week and rotating start shard
+        id: calc
+        run: |
+          WEEK=$(( $(date +%s) / 604800 ))
+          START=$(( (WEEK * JOBS_PER_WEEK) % TOTAL_SHARDS ))
+          echo "Week $WEEK -> start shard $START ($JOBS_PER_WEEK jobs of $TOTAL_SHARDS shards)"
+          {
+            echo "week=$WEEK"
+            echo "start=$START"
+          } >> "$GITHUB_OUTPUT"
+
   mutants-weekly:
-    name: Mutants (weekly sample ${{ matrix.idx }}/12)
+    name: Mutants (weekly sample ${{ matrix.idx }})
+    needs: mutants-weekly-setup
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full')
     runs-on: ubuntu-latest
     timeout-minutes: 350
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with env.JOBS_PER_WEEK (matrices cannot read env).
         idx: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    env:
-      TOTAL_SHARDS: 96
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -174,21 +213,22 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cargo-mutants and cargo-nextest
-        run: cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}" cargo-nextest
+        run: cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}" "cargo-nextest@${CARGO_NEXTEST_VERSION}"
 
       - name: Compute rotating shard index
         id: shard
         run: |
-          WEEK=$(( $(date +%s) / 604800 ))
-          START=$(( (WEEK * 12) % TOTAL_SHARDS ))
+          # WEEK/START are pinned by the setup job so re-runs stay in the
+          # same weekly window.
+          START="${{ needs.mutants-weekly-setup.outputs.start }}"
           SHARD=$(( (START + ${{ matrix.idx }}) % TOTAL_SHARDS ))
-          echo "Week $WEEK -> shard $SHARD of $TOTAL_SHARDS (round-robin sharding)"
+          echo "Week ${{ needs.mutants-weekly-setup.outputs.week }} -> shard $SHARD of $TOTAL_SHARDS (round-robin sharding)"
           echo "shard=$SHARD" >> "$GITHUB_OUTPUT"
 
       # NOTE: cargo-mutants shards are 0-indexed — valid values for
       # --shard k/96 are 0..95. (The previous workflow passed 1..4 for
       # --shard k/4, so shard 4/4 errored and shard 0 never ran.)
-      - name: Run mutation tests (shard ${{ steps.shard.outputs.shard }} of 96)
+      - name: Run mutation tests (rotating shard ${{ matrix.idx }})
         run: |
           set +e
           cargo mutants -vV \
@@ -218,11 +258,14 @@ jobs:
           path: mutants-run/mutants.out/
           retention-days: 90
           if-no-files-found: ignore
+          # Allow shard-job re-runs to replace the first attempt's artifact
+          # instead of 409ing and leaving stale partial output behind.
+          overwrite: true
 
       - name: Post shard summary
         if: always()
         run: |
-          echo "## Mutation sample shard ${{ steps.shard.outputs.shard }} of 96 (job ${{ matrix.idx }}/12)" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Mutation sample shard ${{ steps.shard.outputs.shard }} of $TOTAL_SHARDS (job ${{ matrix.idx }})" >> "$GITHUB_STEP_SUMMARY"
           for f in caught missed timeout unviable; do
             p="mutants-run/mutants.out/$f.txt"
             if [ -f "$p" ]; then
@@ -233,8 +276,11 @@ jobs:
   # ── Aggregate the weekly sample into a project-wide score estimate ────
   mutants-weekly-score:
     name: Weekly mutation score (aggregate)
-    needs: mutants-weekly
-    if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full'))
+    needs: [mutants-weekly-setup, mutants-weekly]
+    # !cancelled() (not always()) so a cancelled run cannot publish a
+    # normal-looking 365-day score artifact from whatever shards finished;
+    # failed (non-cancelled) shards still aggregate, marked PARTIAL.
+    if: ${{ !cancelled() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -255,7 +301,9 @@ jobs:
         run: |
           python3 .github/scripts/mutants_gate.py summarize \
             --shards-dir weekly-shards \
-            --config .github/mutants-gate.toml
+            --config .github/mutants-gate.toml \
+            --week "${{ needs.mutants-weekly-setup.outputs.week }}" \
+            --expected-shards "$JOBS_PER_WEEK"
 
       - name: Upload weekly score
         uses: actions/upload-artifact@v7
@@ -265,3 +313,4 @@ jobs:
             weekly-shards/score.json
             weekly-shards/combined-missed.txt
           retention-days: 365
+          overwrite: true

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [trunk]
   schedule:
-    # Weekly full run: Sunday at 03:00 UTC
+    # Weekly rotating-sample run: Sunday at 03:00 UTC
     - cron: "0 3 * * 0"
   workflow_dispatch:
     inputs:
@@ -27,21 +27,29 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  MUTANTS_FEATURES: "config-toml,mcp-server,sharding-rpc"
+  # Pinned for reproducibility and stable flag/exit-code semantics
+  # (--sharding round-robin requires cargo-mutants 27.x; exit codes per
+  # https://mutants.rs/exit-codes.html: 0 = all caught, 2 = missed mutants,
+  # 3 = timeouts, everything else = usage/infrastructure error).
+  CARGO_MUTANTS_VERSION: "27.1.0"
 
 jobs:
-  # ── PR mode: test only changed code (informational) ──────────────────
+  # ── PR mode: gate the mutation score of the code touched by the diff ──
   mutants-pr:
     name: Mutants (PR diff)
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'diff')
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Gate script self-test
+        run: python3 .github/scripts/test_mutants_gate.py
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -65,67 +73,79 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
 
-      - name: Install cargo-mutants
-        run: cargo binstall --no-confirm cargo-mutants
+      - name: Install cargo-mutants and cargo-nextest
+        run: cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}" cargo-nextest
 
       - name: Generate diff against base branch
-        run: git diff origin/${{ github.base_ref }}..HEAD > mutants-diff.patch
+        run: |
+          BASE_REF="${{ github.base_ref }}"
+          git diff "origin/${BASE_REF:-trunk}"..HEAD > mutants-diff.patch
+          wc -c mutants-diff.patch
 
       - name: Run mutation tests on diff
         run: |
+          if [ ! -s mutants-diff.patch ]; then
+            echo "Diff is empty; skipping mutation run (gate passes with no mutants)."
+            exit 0
+          fi
+          set +e
           cargo mutants --in-place -vV \
-            --features "config-toml,mcp-server,sharding-rpc" \
-            --in-diff mutants-diff.patch
+            --features "$MUTANTS_FEATURES" \
+            --test-tool nextest \
+            --in-diff mutants-diff.patch \
+            --output mutants-run
+          status=$?
+          set -e
+          echo "cargo-mutants exit code: $status"
+          # 0 = all caught, 2 = missed mutants found, 3 = timeouts occurred:
+          # all three mean the run itself worked — the gate script decides
+          # pass/fail from the score. Anything else (1 usage, 4 baseline tests
+          # failing, 5/6 diff problems, 70 internal) is an infrastructure
+          # failure and fails this step immediately.
+          case "$status" in
+            0|2|3) exit 0 ;;
+            *)
+              echo "::error::cargo-mutants infrastructure failure (exit $status)"
+              exit "$status"
+              ;;
+          esac
+
+      - name: Enforce mutation-score gate
+        run: |
+          python3 .github/scripts/mutants_gate.py gate \
+            --mutants-out mutants-run/mutants.out \
+            --config .github/mutants-gate.toml \
+            --allow-missing
 
       - name: Upload mutation results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: mutants-pr-results
-          path: mutants.out/
+          path: mutants-run/mutants.out/
           retention-days: 14
+          if-no-files-found: ignore
 
-      - name: Post summary
-        if: always()
-        run: |
-          echo "## Mutation Testing (PR diff)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ -f mutants.out/caught.txt ]; then
-            CAUGHT=$(wc -l < mutants.out/caught.txt)
-            echo "Caught: **$CAUGHT** mutants" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -f mutants.out/missed.txt ]; then
-            MISSED=$(wc -l < mutants.out/missed.txt)
-            echo "Missed: **$MISSED** mutants" >> $GITHUB_STEP_SUMMARY
-            if [ "$MISSED" -gt 0 ]; then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "<details><summary>Missed mutants (click to expand)</summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              cat mutants.out/missed.txt >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
-          if [ -f mutants.out/timeout.txt ]; then
-            TIMEOUT=$(wc -l < mutants.out/timeout.txt)
-            echo "Timeout: **$TIMEOUT** mutants" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -f mutants.out/unviable.txt ]; then
-            UNVIABLE=$(wc -l < mutants.out/unviable.txt)
-            echo "Unviable: **$UNVIABLE** mutants" >> $GITHUB_STEP_SUMMARY
-          fi
-
-  # ── Full mode: sharded across 4 runners (weekly + manual) ────────────
-  mutants-full:
-    name: Mutants (full shard ${{ matrix.shard }}/4)
+  # ── Weekly rotating sample: 12 of 96 round-robin shards per week ──────
+  #
+  # cargo-mutants' DEFAULT sharding is "slice" (contiguous chunks of the
+  # mutant list, which follows file order — a biased sample). We pass
+  # --sharding round-robin (mutant i runs on shard i % k), so ANY subset of
+  # shards is a systematic, project-wide sample. Each weekly run covers 12
+  # of 96 shards (~12.5% of all mutants) and publishes an unbiased
+  # project-wide score estimate; the rotating start walks through all 96
+  # shards every 8 weeks.
+  mutants-weekly:
+    name: Mutants (weekly sample ${{ matrix.idx }}/12)
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 350
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        idx: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    env:
+      TOTAL_SHARDS: 96
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -153,34 +173,95 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
 
-      - name: Install cargo-mutants
-        run: cargo binstall --no-confirm cargo-mutants
+      - name: Install cargo-mutants and cargo-nextest
+        run: cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}" cargo-nextest
 
-      - name: Run mutation tests (shard ${{ matrix.shard }}/4)
+      - name: Compute rotating shard index
+        id: shard
         run: |
-          cargo mutants --in-place -vV \
-            --features "config-toml,mcp-server,sharding-rpc" \
-            --shard ${{ matrix.shard }}/4
+          WEEK=$(( $(date +%s) / 604800 ))
+          START=$(( (WEEK * 12) % TOTAL_SHARDS ))
+          SHARD=$(( (START + ${{ matrix.idx }}) % TOTAL_SHARDS ))
+          echo "Week $WEEK -> shard $SHARD of $TOTAL_SHARDS (round-robin sharding)"
+          echo "shard=$SHARD" >> "$GITHUB_OUTPUT"
 
-      - name: Upload mutation results
+      # NOTE: cargo-mutants shards are 0-indexed — valid values for
+      # --shard k/96 are 0..95. (The previous workflow passed 1..4 for
+      # --shard k/4, so shard 4/4 errored and shard 0 never ran.)
+      - name: Run mutation tests (shard ${{ steps.shard.outputs.shard }} of 96)
+        run: |
+          set +e
+          cargo mutants -vV \
+            --features "$MUTANTS_FEATURES" \
+            --test-tool nextest \
+            --sharding round-robin \
+            --shard "${{ steps.shard.outputs.shard }}/${TOTAL_SHARDS}" \
+            --output mutants-run
+          status=$?
+          set -e
+          echo "cargo-mutants exit code: $status"
+          # Missed mutants (2) and timeouts (3) are results, not failures;
+          # the aggregate job computes the informational weekly score.
+          case "$status" in
+            0|2|3) exit 0 ;;
+            *)
+              echo "::error::cargo-mutants infrastructure failure (exit $status)"
+              exit "$status"
+              ;;
+          esac
+
+      - name: Upload shard results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: mutants-full-shard-${{ matrix.shard }}
-          path: mutants.out/
-          retention-days: 30
+          name: mutants-weekly-shard-${{ matrix.idx }}
+          path: mutants-run/mutants.out/
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: Post shard summary
         if: always()
         run: |
-          echo "## Mutation Testing (shard ${{ matrix.shard }}/4)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ -f mutants.out/caught.txt ]; then
-            echo "Caught: **$(wc -l < mutants.out/caught.txt)** mutants" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -f mutants.out/missed.txt ]; then
-            echo "Missed: **$(wc -l < mutants.out/missed.txt)** mutants" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [ -f mutants.out/timeout.txt ]; then
-            echo "Timeout: **$(wc -l < mutants.out/timeout.txt)** mutants" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "## Mutation sample shard ${{ steps.shard.outputs.shard }} of 96 (job ${{ matrix.idx }}/12)" >> "$GITHUB_STEP_SUMMARY"
+          for f in caught missed timeout unviable; do
+            p="mutants-run/mutants.out/$f.txt"
+            if [ -f "$p" ]; then
+              echo "- $f: **$(wc -l < "$p")**" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+  # ── Aggregate the weekly sample into a project-wide score estimate ────
+  mutants-weekly-score:
+    name: Weekly mutation score (aggregate)
+    needs: mutants-weekly
+    if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'full'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Gate script self-test
+        run: python3 .github/scripts/test_mutants_gate.py
+
+      - name: Download shard artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: mutants-weekly-shard-*
+          path: weekly-shards
+          merge-multiple: false
+
+      - name: Aggregate weekly score (informational)
+        run: |
+          python3 .github/scripts/mutants_gate.py summarize \
+            --shards-dir weekly-shards \
+            --config .github/mutants-gate.toml
+
+      - name: Upload weekly score
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-weekly-score
+          path: |
+            weekly-shards/score.json
+            weekly-shards/combined-missed.txt
+          retention-days: 365

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ pr_description.md
 
 # Re-include Python SDK sources (overrides "*.py" above)
 !python/**/*.py
+
+# Re-include CI helper scripts (overrides "*.py" above)
+!.github/scripts/*.py

--- a/TESTING.md
+++ b/TESTING.md
@@ -268,16 +268,58 @@ Focus on **`missed.txt`** — each entry is a code location where a behavioral c
 
 ### CI Integration
 
-- **On PRs**: `cargo mutants --in-diff` runs on changed code only (informational, non-blocking)
-- **Weekly**: Full sharded run across 4 runners for comprehensive mutation score tracking
-- Results are uploaded as artifacts and summarized in the GitHub job summary
+The "Mutation Testing" workflow (`.github/workflows/mutants.yml`) has two paths:
+
+- **On PRs (blocking gate)**: `cargo mutants --in-diff` runs on the code the PR
+  touches, then `.github/scripts/mutants_gate.py gate` enforces a minimum
+  mutation score. The check name is **`Mutants (PR diff)`**; it fails the PR
+  when the diff's score is below the threshold.
+- **Weekly (informational rotating sample)**: every Sunday, 12 of 96
+  round-robin shards run (~12.5% of all mutants). cargo-mutants' *default*
+  sharding is `slice` (contiguous chunks of the mutant list in file order —
+  a biased sample); we pass `--sharding round-robin` (mutant `i` runs on
+  shard `i % k`) so any subset of shards is a systematic, project-wide
+  sample. Each weekly run therefore publishes an unbiased project-wide score
+  estimate (`mutants-weekly-score` artifact containing `score.json`), and
+  the rotating start index walks through all 96 shards every 8 weeks, so
+  the whole project is covered every 8 weeks. Shard indexes are 0-based
+  (`--shard 0/96` … `--shard 95/96`).
+- Both paths run tests under **cargo-nextest** (`--test-tool nextest`) for
+  faster per-mutant test runs. Note: nextest does not run doctests, so a
+  mutant only caught by a doctest would be reported as missed.
+- Results are uploaded as artifacts and summarized in the GitHub job summary.
+
+### The Mutation-Score Gate
+
+The gate's tuning knobs live in **`.github/mutants-gate.toml`**:
+
+- `threshold` — minimum mutation score (%) for the mutants produced by a PR
+  diff. Score formula:
+
+  ```
+  score = (caught + timeout) / (caught + timeout + missed) × 100
+  ```
+
+  Timeouts count as caught (the mutant made the test suite hang, i.e. it was
+  detected). Unviable mutants (failed to compile) are excluded entirely.
+- `min_mutants` — the gate only enforces when the diff produces at least this
+  many viable mutants; below the floor, results are reported but never fail
+  the check (small-sample noise).
+
+A PR whose diff produces zero mutants (docs-only, CI-only, test-only) always
+passes. The gate distinguishes real gate failures (exit 2) from
+infrastructure errors (exit 1, e.g. unreadable output or malformed config).
+Run it locally against any `mutants.out` with `just mutants-gate`.
 
 ### Configuration
 
-Exclusions are configured in `.cargo/mutants.toml`. Currently excluded:
-- Benchmarks, examples, and integration test helpers
-- MCP server (IO-heavy, tested via integration)
-- `Display`/`Debug` impls and `fmt` methods
+Mutant exclusions are configured in `.cargo/mutants.toml`. Currently excluded:
+
+- `fmt` methods of `Display`/`Debug` impls (cosmetic output; asserting exact
+  strings adds brittleness, not correctness)
+
+`src/mcp/**` is deliberately **not** excluded — it is the actively developed
+LLM-facing surface and must stay under mutation pressure.
 
 ## Profiling
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -281,9 +281,17 @@ The "Mutation Testing" workflow (`.github/workflows/mutants.yml`) has two paths:
   shard `i % k`) so any subset of shards is a systematic, project-wide
   sample. Each weekly run therefore publishes an unbiased project-wide score
   estimate (`mutants-weekly-score` artifact containing `score.json`), and
-  the rotating start index walks through all 96 shards every 8 weeks, so
-  the whole project is covered every 8 weeks. Shard indexes are 0-based
-  (`--shard 0/96` … `--shard 95/96`).
+  the rotating start index walks through all 96 shards so the whole project
+  is covered **approximately** every 8 weeks (approximately: GitHub pauses
+  cron on repository inactivity, a failed week skips its window, and code
+  churn reassigns round-robin positions between weeks). Shard indexes are
+  0-based (`--shard 0/96` … `--shard 95/96`). The epoch-week number and
+  rotating start are pinned **once per run** by a small setup job and passed
+  to the shard jobs and the aggregate via job outputs, so re-running a
+  failed shard hours later (even across the epoch-week boundary) stays in
+  the same weekly window. If any shard artifact is missing or unusable, the
+  published summary and `score.json` are marked **partial** rather than
+  passed off as a full weekly estimate.
 - Both paths run tests under **cargo-nextest** (`--test-tool nextest`) for
   faster per-mutant test runs. Note: nextest does not run doctests, so a
   mutant only caught by a doctest would be reported as missed.
@@ -316,7 +324,8 @@ Run it locally against any `mutants.out` with `just mutants-gate`.
 Mutant exclusions are configured in `.cargo/mutants.toml`. Currently excluded:
 
 - `fmt` methods of `Display`/`Debug` impls (cosmetic output; asserting exact
-  strings adds brittleness, not correctness)
+  strings adds brittleness, not correctness) — 73 mutants at the time of
+  writing (12,301 → 12,228)
 
 `src/mcp/**` is deliberately **not** excluded — it is the actively developed
 LLM-facing surface and must stay under mutation pressure.

--- a/docs/adr/0035-mutation-testing.md
+++ b/docs/adr/0035-mutation-testing.md
@@ -154,10 +154,51 @@ Focus on `missed.txt` — each entry indicates code where a behavioral change we
 - **PR comments**: Add a bot that posts mutation results as PR comments for visibility
 - **Revisit exclusions**: As MCP server tests mature, consider removing the `src/mcp/**` exclusion
 
+## Addendum (2026-07-08): Weekly run was broken since inception; PR gate added
+
+An audit found that the implementation shipped by PR #888 diverged from this
+ADR in several ways, and that the weekly run had **failed on every scheduled
+execution since it was introduced** (all 22 runs):
+
+1. **0-indexed shard bug**: cargo-mutants shards are 0-indexed (`--shard 0/4`
+   … `--shard 3/4`), but the workflow matrix passed `1..4`. Shard `4/4`
+   errored immediately ("shard k must be less than n") and shard 0 never ran.
+2. **Timeout far too small**: with ~12,000 mutants (~3,000 per shard at
+   4 shards) and ~4–5 minutes per mutant on CI runners, the 90-minute
+   timeout covered only ~20 mutants per shard. A true full run was never
+   feasible in this shape.
+3. **`.cargo/mutants.toml` never shipped**: the exclusions described in this
+   ADR (benches/examples, `src/mcp/**`, `Display`/`Debug` fmt impls) were
+   never actually in effect.
+
+What changed (2026-07-08):
+
+- **PR gate**: the PR-diff job is no longer informational. It computes a
+  mutation score over the diff's mutants —
+  `(caught + timeout) / (caught + timeout + missed) × 100` — and fails below
+  the threshold in `.github/mutants-gate.toml` (with a `min_mutants` floor to
+  avoid small-sample noise). This realizes the "enforce mutation score"
+  future consideration above. The threshold now exists and is maintained in
+  that one file.
+- **Weekly run redesigned as a rotating sample**: 12 of 96 shards per week
+  with `--sharding round-robin` (the default `slice` sharding is contiguous
+  and would bias the sample), 0-indexed shard math, and a 350-minute
+  timeout. An aggregate job combines the 12 shard artifacts into a published
+  project-wide score estimate (`mutants-weekly-score` artifact); the
+  rotating window covers all 96 shards every 8 weeks.
+- **`.cargo/mutants.toml` created**, excluding only `Display`/`Debug` `fmt`
+  impls. Deliberate deviation from the original ADR text: `src/mcp/**` is
+  **not** excluded — it is the actively developed LLM-facing surface and
+  must stay under mutation pressure (the exclusion this ADR described never
+  shipped anyway). Benches/examples/tests need no exclusion; cargo-mutants
+  does not generate mutants there by default.
+- Both CI paths now run tests via `--test-tool nextest`.
+
 ## References
 
 - PR #888: Implementation
 - [cargo-mutants documentation](https://mutants.rs/)
+- [cargo-mutants exit codes](https://mutants.rs/exit-codes.html)
 - [Mutation Testing overview (Wikipedia)](https://en.wikipedia.org/wiki/Mutation_testing)
 - ADR-0015: CI/CD Automation Workflow
 - TESTING.md: Testing and coverage guide

--- a/docs/adr/0035-mutation-testing.md
+++ b/docs/adr/0035-mutation-testing.md
@@ -183,9 +183,15 @@ What changed (2026-07-08):
 - **Weekly run redesigned as a rotating sample**: 12 of 96 shards per week
   with `--sharding round-robin` (the default `slice` sharding is contiguous
   and would bias the sample), 0-indexed shard math, and a 350-minute
-  timeout. An aggregate job combines the 12 shard artifacts into a published
-  project-wide score estimate (`mutants-weekly-score` artifact); the
-  rotating window covers all 96 shards every 8 weeks.
+  timeout. The epoch week and rotating start are pinned once per run by a
+  setup job (so shard re-runs across the epoch-week boundary stay in their
+  window). An aggregate job combines the 12 shard artifacts into a published
+  project-wide score estimate (`mutants-weekly-score` artifact), marked
+  partial when shards are missing; the rotating window covers all 96 shards
+  approximately every 8 weeks (cron pauses on repo inactivity, failed weeks
+  skip their window, and code churn reassigns round-robin positions). The
+  shard-count geometry is provisional pending measured per-mutant nextest
+  timing.
 - **`.cargo/mutants.toml` created**, excluding only `Display`/`Debug` `fmt`
   impls. Deliberate deviation from the original ADR text: `src/mcp/**` is
   **not** excluded — it is the actively developed LLM-facing surface and

--- a/justfile
+++ b/justfile
@@ -262,9 +262,11 @@ audit:
     cargo audit
 
 # === Mutation Testing ===
-# CI runs these with --test-tool nextest; locally we stay on cargo test so the
-# recipes work without cargo-nextest installed. Install nextest and add
-# `--test-tool nextest` for CI-identical (and faster) runs.
+# CI runs these with --test-tool nextest and with
+# --features config-toml,mcp-server,sharding-rpc; locally we stay on plain
+# cargo test with default features so the recipes work without cargo-nextest
+# installed. For runs closer to CI, install nextest and add
+# `--test-tool nextest --features config-toml,mcp-server,sharding-rpc`.
 
 # Run mutation tests on all code
 mutants:
@@ -286,7 +288,7 @@ mutants-branch:
 
 # Run the CI mutation-score gate against a local mutants.out directory
 mutants-gate dir="mutants.out":
-    python3 .github/scripts/mutants_gate.py gate --mutants-out {{dir}} --config .github/mutants-gate.toml
+    python3 .github/scripts/mutants_gate.py gate --mutants-out "{{dir}}" --config .github/mutants-gate.toml
 
 # Run the gate script's unit tests
 mutants-gate-test:

--- a/justfile
+++ b/justfile
@@ -262,6 +262,9 @@ audit:
     cargo audit
 
 # === Mutation Testing ===
+# CI runs these with --test-tool nextest; locally we stay on cargo test so the
+# recipes work without cargo-nextest installed. Install nextest and add
+# `--test-tool nextest` for CI-identical (and faster) runs.
 
 # Run mutation tests on all code
 mutants:
@@ -280,6 +283,14 @@ mutants-branch:
     trap 'rm -f mutants-diff.tmp' EXIT
     git diff origin/trunk.. > mutants-diff.tmp
     cargo mutants --in-place -vV --in-diff mutants-diff.tmp
+
+# Run the CI mutation-score gate against a local mutants.out directory
+mutants-gate dir="mutants.out":
+    python3 .github/scripts/mutants_gate.py gate --mutants-out {{dir}} --config .github/mutants-gate.toml
+
+# Run the gate script's unit tests
+mutants-gate-test:
+    python3 .github/scripts/test_mutants_gate.py
 
 # === Miri (Undefined Behavior Detection) ===
 


### PR DESCRIPTION
# CI: promote mutation testing to a scored gate; fix broken weekly mutants run

## Before / After

**Before:**
- The weekly "full" mutation run has **failed on every scheduled execution since it was introduced in February** (all 22 runs). Two independent bugs: cargo-mutants shards are **0-indexed**, but the matrix passed `1..4` — so `--shard 4/4` errored immediately ("shard k must be less than n") and shard 0 never ran; and the 90-minute timeout covered only ~20 of ~3,000 mutants per shard (~4–5 min/mutant on CI), so a full run was never feasible in that shape anyway.
- The PR-diff mutation check was purely informational (`continue-on-error: true`): it posted counts to the step summary and could never fail a PR.
- `.cargo/mutants.toml` — the exclusions file TESTING.md and ADR-0035 describe — **never actually existed**, so none of the documented exclusions were in effect.

**After:**
- The **`Mutants (PR diff)`** check computes a mutation score over the mutants in the PR's diff and **fails when the score is below the threshold** in `.github/mutants-gate.toml`.
- The weekly run is a **rotating sample that actually works**: 12 of 96 round-robin shards per week (~12.5% of all 12,228 mutants), 0-indexed shard math, and an aggregate job that publishes a real project-wide score estimate (`mutants-weekly-score` artifact containing `score.json` + the combined missed-mutant list). The rotating window covers all 96 shards approximately every 8 weeks (approximate because cron pauses on repo inactivity, failed weeks skip their window, and code churn shifts round-robin positions).
- The epoch week and rotating start shard are **pinned once per run by a small setup job** and consumed by the matrix jobs and the aggregate via job outputs — so re-running a failed multi-hour shard job after the epoch-week boundary (Thursday 00:00 UTC) stays in the same weekly window instead of silently jumping to next week's shards and breaking rotation coverage.
- If any shard artifact is missing or holds no usable output, the aggregate summary and `score.json` are visibly marked **PARTIAL** (`"partial": true`, with `skipped_shards` listed) instead of being passed off as a full weekly estimate.
- `.cargo/mutants.toml` now exists and excludes exactly what it claims (Display/Debug `fmt` impls — 73 mutants including generic self types like `<impl fmt::Debug for NodeConnection<C>>::fmt`, verified against `cargo mutants --list`: 12,301 → 12,228).

## How

| File | Change |
|---|---|
| `.github/mutants-gate.toml` | **The one tuning place**: `threshold` (provisional 60.0, see below) and `min_mutants` (10); unknown keys are rejected (typo safety) |
| `.github/scripts/mutants_gate.py` | Stdlib-only Python (tomllib). `gate` enforces the PR threshold; `summarize` aggregates weekly shard artifacts (informational, never fails; supports `--week` and `--expected-shards` for the pinned window and PARTIAL marking). Exit codes: 0 pass, 1 infra error, 2 gate failure |
| `.github/scripts/test_mutants_gate.py` | 27 unit tests, written first (TDD); also run as a fast self-test step in both CI jobs |
| `.github/workflows/mutants.yml` | Rewritten (details below); `TOTAL_SHARDS` / `JOBS_PER_WEEK` are single-definition env values |
| `.cargo/mutants.toml` | Created; excludes only `<impl …Debug/Display…>::fmt` mutants (incl. generic self types), each line commented |
| `TESTING.md`, `docs/adr/0035-mutation-testing.md` | Describe reality; ADR gets a 2026-07-08 addendum on the breakage and redesign |
| `justfile` | New `mutants-gate` / `mutants-gate-test` recipes |
| `.gitignore` | Re-include `.github/scripts/*.py` (the repo globally ignores `*.py`) |

**Score formula:** `score = (caught + timeout) / (caught + timeout + missed) × 100`. Timeouts count as caught — the mutant made the test suite hang, i.e. it *was* detected. Unviable mutants (failed to compile) are excluded from the denominator entirely. The pass/fail **verdict never uses float division**: it compares `detected × 100 ≥ threshold × viable`, so a diff at exactly the threshold (e.g. 29/50 at 58.0%) passes instead of losing to floating-point rounding; the divided score is display-only, rendered with 2 decimals when it sits within 0.05 of the threshold.

**Exit-code handling** (verified against [mutants.rs/exit-codes.html](https://mutants.rs/exit-codes.html), cargo-mutants 27.1.0): the run step treats 0 (all caught), 2 (missed mutants found), and 3 (timeouts) as "the run itself worked" and lets the gate script decide; 1 (usage), 4 (baseline tests failing), 5/6 (diff problems), and 70 (internal) fail the step immediately as infrastructure errors. So "found missed mutants" is never conflated with "the tooling broke".

**Sharding semantics** (verified empirically on this repo): cargo-mutants' *default* sharding is `slice` — contiguous chunks of the mutant list in file order (`--list --shard 0/8` returns exactly the first 1/8th of the full list), which would make any weekly subset a biased slice of adjacent files. We pass **`--sharding round-robin`** (mutant `i` runs on shard `i % k`; verified: shard 0/8 == every 8th mutant), so any subset of shards is a systematic project-wide sample and the weekly score is an unbiased estimate. This also matches how the baseline is being measured (`--shard 0/16 --sharding round-robin`).

**Version pins:** cargo-mutants `27.1.0` and cargo-nextest `0.9.140` are pinned in both jobs — deliberate, for reproducible shard assignment and a test harness that cannot drift between weekly windows or PR re-runs. Both jobs run with `--test-tool nextest` (note: nextest does not run doctests). All artifact uploads set `overwrite: true` so a job re-run replaces its first attempt's artifact instead of 409ing and leaving stale partial output for the aggregate to read; the aggregate itself runs on `!cancelled()` (not `always()`) so a cancelled run can't publish a normal-looking 365-day score artifact.

**Weekly shard geometry is provisional:** at the ADR's historical ~4–5 min/mutant estimate, ~127 mutants/shard would exceed the 350-minute job timeout. Real per-mutant nextest timing is being measured right now; `TOTAL_SHARDS` (and, with it, the number of weeks per full rotation) will be finalized from that measurement in the same commit that sets the final threshold. Until then the geometry is a trivially tunable pair of env values, and any shard that does time out degrades to a PARTIAL-marked weekly score rather than a silent lie.

**Empty-diff plumbing:** a PR with no `.rs` changes produces an empty patch; the run step skips cargo-mutants and the gate's `--allow-missing` flag passes with "no mutants in diff" — the check can never error on docs/CI-only PRs. (`--allow-missing` only forgives a truly *absent* output path; an existing non-directory at that path is still an infrastructure error.)

## Design alternatives considered

1. **Fail on any missed mutant** — rejected: too brittle for a codebase with many known survivors; every PR touching a file with pre-existing gaps would fail on code it didn't write, training people to ignore the check.
2. **Per-file baseline comparison** ("don't make any file worse") — rejected: requires a maintained, trusted baseline artifact. The weekly run that was supposed to produce one has never succeeded, and a baseline goes stale as code moves between files; the machinery to keep it fresh is a project in itself.
3. **Per-PR diff score ≥ threshold (chosen)** — self-contained and stateless: every input comes from the PR itself plus one checked-in config value. No baseline to maintain, no cross-run state, and the incentive is aimed exactly at the code the PR author just wrote. The `min_mutants` floor keeps small-diff noise from flaking the check.

## Edge cases covered by unit tests (27, all green)

- Zero mutants in diff → PASS ("no mutants in diff")
- Viable mutants below `min_mutants` floor with failing score → PASS with warning (never fails)
- Score exactly equal to threshold → PASS, including float-pathological ratios (29 caught / 21 missed at threshold 58.0, where naive division yields 57.99999999999999; also checked against thresholds 57.0, 29.0, and a genuinely-failing 58.5)
- Score below threshold with enough mutants → FAIL, exit 2, missed list rendered
- Timeouts counted toward caught (score reflects it)
- Unviable excluded from the denominator
- Missed-mutant list truncated at 200 entries ("… and N more — see the mutants artifact"; GitHub silently drops step summaries >1 MiB)
- Missing outcome files tolerated when the directory has at least one
- Missing `mutants.out` directory → exit 1 (infra) by default; PASS with `--allow-missing` (empty diff); an existing non-directory at the path → exit 1 even with `--allow-missing`
- Directory with no outcome files at all → exit 1
- Malformed TOML / missing `threshold` key / unknown config keys (typos) → exit 1
- `$GITHUB_STEP_SUMMARY` written when set
- `summarize`: aggregates 3 shard artifacts across both artifact layouts (files at root and nested `mutants.out/`), writes `score.json` with correct totals and `combined-missed.txt`, records the `--week` passed by the setup job verbatim (no wall-clock reads), marks the run PARTIAL when fewer usable shards than `--expected-shards` arrive or a shard dir holds no outcome files (listed in `skipped_shards`), never exits 2 even far below threshold, empty shards dir → exit 1

## Baseline measurement (in progress)

The `threshold = 60.0` in `.github/mutants-gate.toml` is **provisional**. A project-wide baseline measurement (round-robin sample, `--shard 0/16 --sharding round-robin`) is currently running; before this PR merges, the threshold — and the final weekly `TOTAL_SHARDS` geometry, from the same run's per-mutant timing — will be updated from the measured data and this section will be replaced with the measured score and methodology.

## Note for the repo owner

To make the gate actually blocking, add **`Mutants (PR diff)`** to the required status checks in trunk's branch-protection settings — that setting cannot ship in a file. Until then the check runs and reports but a red result won't block merges.

## Local verification performed

This branch touches only CI/workflow/config/docs files (no Rust code), and a long-running mutation-score measurement occupies this machine, so the local `cargo clippy` / `cargo fmt` / `cargo test` gates were deliberately skipped this once to avoid CPU contention corrupting that measurement — CI will run them on this PR. What was verified locally: the 27 gate-script unit tests (red first, then green), YAML parse of the workflow, `bash -n` on all 14 extracted `run` steps, TOML parse of both config files, a smoke run of the gate against a synthetic `mutants.out` with the real config, and `cargo mutants --list` confirming the exclusion regexes remove exactly the 73 Display/Debug `fmt` mutants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpZkyq9CgeJA1s8MR3w9VM