### PR TITLE
Gate Provenance serde derives so --no-default-features compiles

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,6 +51,7 @@ lint:
 
 # Verify each Nova/semantic-search category compiles standalone
 check-features:
+    @echo "=== no default features ===" && cargo check --no-default-features --tests
     @echo "=== semantic-search ===" && cargo check --features semantic-search
     @echo "=== semantic-reasoning ===" && cargo check --features semantic-reasoning
     @echo "=== semantic-temporal ===" && cargo check --features semantic-temporal

--- a/src/core/provenance.rs
+++ b/src/core/provenance.rs
@@ -8,7 +8,6 @@
 //! historical version of a node or edge may carry its own bundle, distinct
 //! from the versions before and after it.
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors that can occur when constructing a [`Provenance`] bundle.
@@ -31,16 +30,37 @@ pub enum ProvenanceError {
 ///
 /// Constructed via [`Provenance::builder`], which validates `confidence`
 /// against `[0.0, 1.0]` (NaN is rejected).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(try_from = "ProvenanceRaw")]
+///
+/// Serde support is feature-gated because `serde` is an optional dependency
+/// (enabled by `config-toml` — a default feature — and `mcp-server`, whose
+/// response types embed [`Provenance`] directly); `--no-default-features`
+/// builds must still compile without it.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    any(feature = "config-toml", feature = "mcp-server"),
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "ProvenanceRaw")
+)]
 pub struct Provenance {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        any(feature = "config-toml", feature = "mcp-server"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        any(feature = "config-toml", feature = "mcp-server"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     confidence: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        any(feature = "config-toml", feature = "mcp-server"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     note: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        any(feature = "config-toml", feature = "mcp-server"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     correlation_id: Option<String>,
 }
 
@@ -178,7 +198,8 @@ impl ProvenanceBuilder {
 /// Unvalidated wire representation used only as the `serde` deserialization
 /// target; [`Provenance`] itself has private fields so it cannot be
 /// deserialized directly without going through validation.
-#[derive(Debug, Deserialize)]
+#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
+#[derive(Debug, serde::Deserialize)]
 struct ProvenanceRaw {
     #[serde(default)]
     source: Option<String>,
@@ -190,6 +211,7 @@ struct ProvenanceRaw {
     correlation_id: Option<String>,
 }
 
+#[cfg(any(feature = "config-toml", feature = "mcp-server"))]
 impl TryFrom<ProvenanceRaw> for Provenance {
     type Error = ProvenanceError;
 
@@ -256,6 +278,7 @@ mod tests {
         assert_eq!(p.confidence(), None);
     }
 
+    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
     #[test]
     fn test_provenance_json_omits_absent_fields() {
         let p = Provenance::builder().source("csv-import").build().unwrap();
@@ -266,6 +289,7 @@ mod tests {
         assert!(!json.contains("correlation_id"));
     }
 
+    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
     #[test]
     fn test_provenance_deserialize_valid_round_trips() {
         let json = r#"{"source":"claude-mcp","confidence":0.8}"#;
@@ -274,6 +298,7 @@ mod tests {
         assert_eq!(p.confidence(), Some(0.8));
     }
 
+    #[cfg(any(feature = "config-toml", feature = "mcp-server"))]
     #[test]
     fn test_provenance_deserialize_rejects_invalid_confidence() {
         let json = r#"{"confidence":2.0}"#;


### PR DESCRIPTION
## Problem

`cargo check --no-default-features` fails on trunk:

```
error[E0432]: unresolved import `serde`
  --> src/core/provenance.rs:11
   |
11 | use serde::{Deserialize, Serialize};
```

followed by a cascade of ``cannot find attribute `serde` in this scope`` errors. `serde` is an **optional** dependency (enabled by the default `config-toml` feature and by `mcp-server`), but `src/core/provenance.rs` imported and derived it unconditionally.

## Fix

Gate every serde touchpoint in `src/core/provenance.rs` behind `#[cfg(any(feature = "config-toml", feature = "mcp-server"))]` — the two features whose consumers actually serialize `Provenance`:

- `derive(serde::Serialize, serde::Deserialize)` + `serde(try_from = "ProvenanceRaw")` on `Provenance` via `cfg_attr`
- the per-field `serde(skip_serializing_if = ...)` attributes via `cfg_attr`
- the `ProvenanceRaw` wire struct and its `TryFrom<ProvenanceRaw> for Provenance` validation impl
- the three serde-dependent round-trip/validation tests

Feature-enabled builds (including the default build) compile exactly the same derives as before — no behavior change.

## Recurrence guard

`just check-features` now begins with:

```
@echo "=== no default features ===" && cargo check --no-default-features --tests
```

so any future unconditional use of an optional dependency fails the same standalone-feature gate that protects the semantic-* cohorts.

## Verification

- **RED** (fix stashed): `cargo check --no-default-features --tests` → `E0432 unresolved import serde` + attribute errors, exit 101
- **GREEN**: `cargo check --no-default-features --tests` → `Finished dev profile`, exit 0
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets --all-features -- -D warnings` → clean (609 crates, 0 warnings)
- `cargo test --no-fail-fast` → **4723 passed, 2 failed**; both failures (`havoc_flush_deadlock::test_flush_deadlock_on_io_error`, `regression_flush_corruption::test_metadata_corruption_on_error`) are pre-existing chmod-based I/O-error-injection tests that cannot pass when the runner is root (root bypasses directory permission bits — verified independently). Neither file is touched by this PR, and the default-features build of `provenance.rs` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZwfbrGyAtHA9NcrPoKRKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZwfbrGyAtHA9NcrPoKRKb)_