### PR TITLE
Add find_nodes_at_time MCP tool: point-in-time node find by label and property (Issue #3236)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,28 +394,37 @@ Each returned node is reconstructed **as it existed** at
 `(valid_time, transaction_time)` -- not its current state -- and nodes that
 did not exist (or whose property value did not hold) at that point are
 excluded. With both dimensions at now, the result set equals the
-current-state `list_nodes` property lookup. The response echoes the resolved
+current-state `list_nodes` property lookup *for nodes whose valid interval
+has begun* (a #3221 future-dated `valid_from` node is in current state but
+not yet visible at `(now, now)`). The response echoes the resolved
 `valid_time`/`transaction_time` (RFC 3339). Nodes since deleted from current
 state are found too (candidates come from history, not the live index), but
 recalling superseded or deleted states requires anchoring *both* dimensions
 before the superseding write, exactly as with #3225. Backed by the
 `AletheiaDB::find_nodes_at_time` / `find_nodes_by_property_at` convenience
-API. v1 iterates historical version heads (a scan; a temporal label index is
-a deliberate follow-up). See
+API (returning `NodesAtTime`). v1 scans historical version heads, capped at
+the same `max_schema_as_of_entities` limit bi-temporal `get_schema` uses
+(default 50,000, lowest node ids kept); when truncated the response sets
+`sampled: true` and `total_matching` counts matches within the sampled
+candidate set only. Properties are reconstructed only for label matches; a
+temporal label index is a deliberate follow-up. See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#point-in-time-as-of-node-find-by-label-and-property).
 
 **Vector properties are elided by default (Issue #3220)**: `get_node`,
 `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,
-`get_incoming_edges`, `traverse`, `find_similar`, and `hybrid_query` replace
-vector/embedding properties with a `{type, dim, elided: true}` descriptor
+`get_incoming_edges`, `traverse`, `find_similar`, `hybrid_query`, and
+`find_nodes_at_time` replace vector/embedding properties with a
+`{type, dim, elided: true}` descriptor
 (or `{type: "sparse_vector", dim, nnz, elided: true}` for sparse vectors)
 instead of the raw float array -- a single embedding can otherwise cost
 thousands of tokens of context an LLM can't reason over. Pass
 `include_vectors: true` on the request to receive the full array. This does
 not affect `find_similar`'s `score` or `hybrid_query`'s `similarity_score`,
 which are always returned in full, nor the write path (`create_node`,
-`update_node`, `create_edge`, `update_edge`) or temporal/history tools,
-which are unaffected by this flag and always return full vectors.
+`update_node`, `create_edge`, `update_edge`) or the single-entity
+temporal/history tools (`get_node_at_time`, `get_edge_at_time`,
+`get_node_history`), which have no `include_vectors` flag and always return
+full vectors.
 
 **Temporal extent (Issue #3238)**: `temporal_extent` reports the dataset's
 queryable bi-temporal extent — the earliest/latest valid-time and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ cargo run --bin aletheia-mcp --features mcp-server
 | **Edges** | `get_edge`, `create_edge`, `update_edge`, `delete_edge`, `get_outgoing_edges`, `get_incoming_edges` |
 | **Traversal** | `traverse` (multi-hop graph traversal; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
 | **Vector** | `find_similar`, `enable_vector_index`, `list_vector_indexes` |
-| **Temporal** | `get_node_at_time`, `get_edge_at_time`, `temporal_extent` (dataset's queryable bi-temporal extent; optional by_label breakdown) |
+| **Temporal** | `get_node_at_time`, `get_edge_at_time`, `find_nodes_at_time` (point-in-time find by label/property, no NodeId needed), `temporal_extent` (dataset's queryable bi-temporal extent; optional by_label breakdown) |
 | **Hybrid** | `hybrid_query` (combined graph + vector + temporal) |
 | **Query** | `query` (execute a single read-only Cypher/AQL statement; see below) |
 | **Schema** | `get_schema` (node labels, edge types, and property keys, each with counts; optional bi-temporal `as_of_valid_time`/`as_of_transaction_time`) |
@@ -381,6 +381,28 @@ convention -- note that recalling a since-deleted edge requires anchoring
 *both* dimensions before the deletion, not just `as_of_valid_time` (see the
 guide below for why). See
 [docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#point-in-time-as-of-graph-traversal).
+
+**Point-in-time (AS OF) node find (Issue #3236)**: `find_nodes_at_time`
+resolves *"the Person named Alice, as of 2024-01-01"* in one call, without a
+prior `NodeId` -- the entry-point resolver the #3225 AS OF traversal assumes
+the caller already has. It accepts `label` (required), optional
+`property_key` + `property_value` (both-or-neither, mirroring `list_nodes`),
+`valid_time` (required, ISO 8601 / RFC 3339 or microseconds since epoch),
+optional `transaction_time` (defaults to now), and `limit`/`offset` (same
+clamps as `list_nodes`; results sorted by node id for stable pagination).
+Each returned node is reconstructed **as it existed** at
+`(valid_time, transaction_time)` -- not its current state -- and nodes that
+did not exist (or whose property value did not hold) at that point are
+excluded. With both dimensions at now, the result set equals the
+current-state `list_nodes` property lookup. The response echoes the resolved
+`valid_time`/`transaction_time` (RFC 3339). Nodes since deleted from current
+state are found too (candidates come from history, not the live index), but
+recalling superseded or deleted states requires anchoring *both* dimensions
+before the superseding write, exactly as with #3225. Backed by the
+`AletheiaDB::find_nodes_at_time` / `find_nodes_by_property_at` convenience
+API. v1 iterates historical version heads (a scan; a temporal label index is
+a deliberate follow-up). See
+[docs/guides/mcp-query-tool.md](docs/guides/mcp-query-tool.md#point-in-time-as-of-node-find-by-label-and-property).
 
 **Vector properties are elided by default (Issue #3220)**: `get_node`,
 `list_nodes`, `get_edge`, `list_edges`, `get_outgoing_edges`,

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -282,7 +282,11 @@ historical version visible at that coordinate. Nodes that did not exist at
 the queried point, or whose property value did not hold there, are excluded:
 a node whose `name` became "Alice" only after T is not returned for a query
 at T. With both dimensions at the current time, the result set equals the
-current-state `list_nodes` property lookup.
+current-state `list_nodes` property lookup **for nodes whose valid interval
+has begun** -- the one divergence is future-dated facts: a node created with
+a `valid_from` in the future (Issue #3221) is already present in current
+state (so `list_nodes` returns it) but is not yet visible at `(now, now)` in
+the bi-temporal view, so this tool excludes it until its valid time arrives.
 
 ```jsonc
 // tools/call -> "find_nodes_at_time"
@@ -299,6 +303,7 @@ current-state `list_nodes` property lookup.
 //      "count": 1,
 //      "offset": 0,
 //      "limit": 100,
+//      "sampled": false,  // true if the candidate scan was capped (see below)
 //      "valid_time": "2024-01-01T00:00:00.000000Z",       // resolved coordinate,
 //      "transaction_time": "2024-01-01T00:00:00.000000Z", // echoed as RFC 3339
 //      "has_more": false,
@@ -334,12 +339,19 @@ Validation errors are structured, consistent with `list_nodes`:
              "message": "Invalid valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." } }
 ```
 
-Performance note (v1): the tool iterates every node that has ever had a
-version recorded (the same candidate enumeration bi-temporal `get_schema`
-uses) and reconstructs each at the queried coordinate -- complete, including
-deleted nodes, but a scan. A dedicated temporal label index is a deliberate
-follow-up if this misses its latency target at scale. The edge equivalent
-(`find_edges_at_time`) is a planned fast-follow.
+Performance note (v1): the tool scans every node that has ever had a version
+recorded (the same candidate enumeration bi-temporal `get_schema` uses,
+**capped at the same configurable limit** -- `max_schema_as_of_entities`,
+default 50,000), resolving each candidate's version at the queried coordinate
+and reconstructing properties only for candidates whose at-time label
+matches -- complete, including deleted nodes, but a scan. When the cap is
+hit, the lowest `cap` node ids are kept (a deterministic subset, so
+pagination stays stable) and the response sets `sampled: true`, exactly as
+`get_schema`'s AS OF form does; `total_matching` and `has_more` are then
+honest only about the **sampled candidate set**, so a `sampled: true`
+response may be missing matches with higher node ids. A dedicated temporal
+label index is a deliberate follow-up if this misses its latency target at
+scale. The edge equivalent (`find_edges_at_time`) is a planned fast-follow.
 
 ## Structured error codes and the retriable contract
 

--- a/docs/guides/mcp-query-tool.md
+++ b/docs/guides/mcp-query-tool.md
@@ -253,6 +253,94 @@ returns a structured error instead of silently traversing current state:
 `MAX_TRAVERSAL_DEPTH` and `MAX_RESULT_LIMIT` apply identically whether or not
 a temporal coordinate is supplied.
 
+## Point-in-time (AS OF) node find by label and property
+
+`find_nodes_at_time` resolves a real-world identifier to an entity's state at
+a past bi-temporal point **without a prior `NodeId`** -- the entry-point
+resolver the AS OF traversal above assumes the caller already has. Where
+`list_nodes` answers "who is named Alice *now*?" and `get_node_at_time`
+answers "what did node 42 look like at T?", this tool answers *"the Person
+named Alice, as she was at T"* in one call (Issue #3236).
+
+Parameters:
+
+- `label` (**required**) -- the node label to match.
+- `property_key` + `property_value` (optional, **both-or-neither**, mirroring
+  `list_nodes`) -- exact-match property filter. Omit both for a label-only
+  AS OF scan.
+- `valid_time` (**required**) -- ISO 8601 / RFC 3339 or microseconds since
+  epoch, like every other MCP temporal field.
+- `transaction_time` (optional) -- defaults to **now**.
+- `limit` / `offset` -- same pagination and `MAX_RESULT_LIMIT` /
+  `MAX_PAGINATION_OFFSET` clamps as `list_nodes`; results are sorted by node
+  id, so pages are stable.
+- `include_vectors` -- vector properties are elided by default, as elsewhere.
+
+Each returned node is **reconstructed as it existed at
+`(valid_time, transaction_time)`** -- not its current state -- from the
+historical version visible at that coordinate. Nodes that did not exist at
+the queried point, or whose property value did not hold there, are excluded:
+a node whose `name` became "Alice" only after T is not returned for a query
+at T. With both dimensions at the current time, the result set equals the
+current-state `list_nodes` property lookup.
+
+```jsonc
+// tools/call -> "find_nodes_at_time"
+{
+  "label": "Person",
+  "property_key": "name",
+  "property_value": "Alice",
+  "valid_time": "2024-01-01T00:00:00Z",
+  "transaction_time": "2024-01-01T00:00:00Z"
+}
+// -> {
+//      "nodes": [ { "id": 7, "label": "Person",
+//                   "properties": {"name": "Alice", "title": "Engineer"} } ],
+//      "count": 1,
+//      "offset": 0,
+//      "limit": 100,
+//      "valid_time": "2024-01-01T00:00:00.000000Z",       // resolved coordinate,
+//      "transaction_time": "2024-01-01T00:00:00.000000Z", // echoed as RFC 3339
+//      "has_more": false,
+//      "total_matching": 1
+//    }
+```
+
+The response always echoes the **resolved** coordinate it was answered at --
+an omitted `transaction_time` comes back as the concrete "now" it resolved
+to, so the answer is reproducible later.
+
+**Recalling superseded or deleted states requires anchoring *both*
+dimensions**, exactly as with AS OF traversal above: a later update (or
+delete) closes the previous version's *transaction* interval, so with
+`transaction_time` defaulted to now only the latest recorded version is
+visible. If Alice was renamed to "Alicia" yesterday, finding her as "Alice"
+requires both `valid_time` *and* `transaction_time` anchored before the
+rename; supplying only a past `valid_time` asks "using everything recorded so
+far, who was named Alice at that instant?" -- and the current record says she
+was already on her way to being Alicia. The same holds for since-deleted
+nodes: this tool *does* find nodes that no longer exist in current state
+(they are enumerated from history, not the live index), but only at a
+`transaction_time` before the deletion was committed.
+
+Validation errors are structured, consistent with `list_nodes`:
+
+```jsonc
+// property_key without property_value (or vice versa)
+{ "error": { "code": "INVALID_ARGUMENT", "retriable": false,
+             "message": "Both 'property_key' and 'property_value' are required together" } }
+// unparseable/empty valid_time
+{ "error": { "code": "INVALID_ARGUMENT", "retriable": false,
+             "message": "Invalid valid_time: Invalid timestamp format: 'not-a-timestamp'. ..." } }
+```
+
+Performance note (v1): the tool iterates every node that has ever had a
+version recorded (the same candidate enumeration bi-temporal `get_schema`
+uses) and reconstructs each at the queried coordinate -- complete, including
+deleted nodes, but a scan. A dedicated temporal label index is a deliberate
+follow-up if this misses its latency target at scale. The edge equivalent
+(`find_edges_at_time`) is a planned fast-follow.
+
 ## Structured error codes and the retriable contract
 
 Every MCP tool error — across **all** tools, not just `query` — is a JSON

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -52,6 +52,7 @@ pub mod vector_builder;
 pub use crate::storage::backup::BackupSummary;
 pub use constraint_builder::UniqueConstraintBuilder;
 pub use extent::{LabelExtent, TemporalExtent, TimeBounds};
+pub use ops::NodesAtTime;
 pub use schema::{EdgeTypeSchema, GraphSchema, LabelSchema, SchemaInstant};
 pub use similarity_query::{SimilarityQuery, SimilaritySource};
 pub use vector_builder::VectorIndexBuilder;

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -12,6 +12,39 @@ use crate::db::AletheiaDB;
 use crate::storage::current::{IncomingEdgesIter, OutgoingEdgesIter};
 use crate::storage::wal::WalOperation;
 
+/// How many candidate node ids the AS OF node-find scan reconstructs per
+/// historical read-guard acquisition (Issue #3236). Chunking keeps cold-tier
+/// I/O during property reconstruction from pinning the guard -- and thereby
+/// blocking writers -- for the whole scan.
+const AS_OF_FIND_CHUNK_SIZE: usize = 4096;
+
+/// Result of a point-in-time (AS OF) node find (Issue #3236): the matching
+/// nodes plus a disclosure flag for candidate-set truncation.
+///
+/// Returned by [`AletheiaDB::find_nodes_at_time`] and
+/// [`AletheiaDB::find_nodes_by_property_at`].
+#[derive(Debug, Clone, Default)]
+pub struct NodesAtTime {
+    /// Matching nodes, reconstructed at the queried bi-temporal coordinate
+    /// and sorted by node id (so pagination over the set is deterministic).
+    pub nodes: Vec<Node>,
+    /// `true` when the candidate set (every node that has ever had a version
+    /// recorded) exceeded the configured cap
+    /// ([`crate::config::HistoricalConfigBuilder::max_schema_as_of_entities`],
+    /// default 50,000) and was truncated to the lowest `cap` node ids before
+    /// scanning. When set, `nodes` -- and any count derived from it -- may
+    /// be incomplete: they reflect only the sampled candidate set. Mirrors
+    /// [`GraphSchema::sampled`](crate::db::schema::GraphSchema::sampled).
+    pub sampled: bool,
+}
+
+impl NodesAtTime {
+    /// An empty, un-truncated result (e.g. for a never-interned label).
+    fn empty() -> Self {
+        Self::default()
+    }
+}
+
 impl AletheiaDB {
     /// Create a node with the given label and properties.
     ///
@@ -665,20 +698,32 @@ impl AletheiaDB {
     /// deterministic. A label that has never been written yields an empty
     /// result, never an error.
     ///
+    /// # Completeness and the candidate cap
+    ///
+    /// Candidates are every node that has ever had a version recorded (the
+    /// same enumeration [`schema_as_of`](Self::schema_as_of) uses), capped
+    /// at the same configurable limit
+    /// ([`crate::config::HistoricalConfigBuilder::max_schema_as_of_entities`],
+    /// default 50,000) to keep a single call bounded on databases with
+    /// substantial bi-temporal history. When the cap is hit, the lowest
+    /// `cap` node ids are kept (a deterministic set, so pagination stays
+    /// stable) and [`NodesAtTime::sampled`] is `true` to disclose that the
+    /// result -- including its length -- reflects only the sampled
+    /// candidate set.
+    ///
     /// # Performance
     ///
-    /// Iterates every node that has ever had a version recorded (the same
-    /// candidate enumeration [`schema_as_of`](Self::schema_as_of) uses) and
-    /// reconstructs each at the queried coordinate. A dedicated temporal
-    /// label index is a deliberate follow-up if this path proves too slow at
-    /// scale.
+    /// Version-at-time resolution runs for every candidate, but property
+    /// reconstruction runs only for candidates whose at-time label matches.
+    /// A dedicated temporal label index is a deliberate follow-up if this
+    /// path proves too slow at scale.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_nodes_at_time(
         &self,
         label: &str,
         valid_time: Timestamp,
         transaction_time: Timestamp,
-    ) -> Result<Vec<Node>> {
+    ) -> Result<NodesAtTime> {
         self.find_nodes_at_time_filtered(label, None, valid_time, transaction_time)
     }
 
@@ -689,12 +734,19 @@ impl AletheiaDB {
     /// [`find_nodes_by_property`](Self::find_nodes_by_property): the property
     /// comparison runs against each node's state **at**
     /// `(valid_time, transaction_time)`, so a node whose property only
-    /// matched before (or after) the queried point is excluded. With both
-    /// dimensions at the current time this returns the same node set as
-    /// `find_nodes_by_property`.
+    /// matched before (or after) the queried point is excluded.
+    ///
+    /// With both dimensions at the current time this returns the same node
+    /// set as `find_nodes_by_property` **for nodes whose valid interval has
+    /// begun**. The one divergence is future-dated facts: a node created
+    /// with a `valid_from` in the future is already present in current
+    /// storage (and thus in `find_nodes_by_property`) but is not yet visible
+    /// at `(now, now)` in the bi-temporal view, so this method excludes it
+    /// until its valid time arrives.
     ///
     /// See [`find_nodes_at_time`](Self::find_nodes_at_time) for ordering,
-    /// completeness, and performance characteristics.
+    /// completeness (including the candidate cap and
+    /// [`NodesAtTime::sampled`]), and performance characteristics.
     #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
     pub fn find_nodes_by_property_at(
         &self,
@@ -703,7 +755,7 @@ impl AletheiaDB {
         property_value: &PropertyValue,
         valid_time: Timestamp,
         transaction_time: Timestamp,
-    ) -> Result<Vec<Node>> {
+    ) -> Result<NodesAtTime> {
         self.find_nodes_at_time_filtered(
             label,
             Some((property_key, property_value)),
@@ -713,26 +765,28 @@ impl AletheiaDB {
     }
 
     /// Shared implementation for the AS OF node-find methods: enumerate every
-    /// node that has ever had a version recorded, reconstruct each at the
-    /// queried bi-temporal coordinate, and keep those whose *at-time* state
-    /// matches the label (and optional exact property) filter.
+    /// node that has ever had a version recorded (capped, see
+    /// [`find_nodes_at_time`](Self::find_nodes_at_time)), resolve each
+    /// candidate's version at the queried bi-temporal coordinate, and
+    /// reconstruct properties only for those whose *at-time* label matches,
+    /// then apply the optional exact-property filter.
     fn find_nodes_at_time_filtered(
         &self,
         label: &str,
         property_filter: Option<(&str, &PropertyValue)>,
         valid_time: Timestamp,
         transaction_time: Timestamp,
-    ) -> Result<Vec<Node>> {
+    ) -> Result<NodesAtTime> {
         // A label (or property key) that has never been interned has never
         // been written anywhere -- current or historical -- so the result is
         // an empty set, never an error (mirroring `find_nodes_by_property`).
         let Some(label_id) = GLOBAL_INTERNER.get_id(label) else {
-            return Ok(Vec::new());
+            return Ok(NodesAtTime::empty());
         };
         let key_filter = match property_filter {
             Some((key, value)) => match GLOBAL_INTERNER.get_id(key) {
                 Some(key_id) => Some((key_id, value)),
-                None => return Ok(Vec::new()),
+                None => return Ok(NodesAtTime::empty()),
             },
             None => None,
         };
@@ -741,31 +795,56 @@ impl AletheiaDB {
         // Unlike the current-state label index, this stays complete for nodes
         // deleted from current state (deletion closes the version's
         // transaction interval but the version head remains), so anchoring
-        // both dimensions before a deletion still recalls the node. Sorted so
-        // the result order (and thus pagination) is deterministic.
-        let mut node_ids = self.historical.read().versioned_node_ids();
-        node_ids.sort_unstable();
+        // both dimensions before a deletion still recalls the node.
+        //
+        // The set is capped at the same configurable limit `schema_as_of`
+        // uses, keeping the lowest `cap` ids -- a deterministic subset, so
+        // pagination over a sampled result is still stable. Sorted so the
+        // result order (and thus pagination) is deterministic.
+        let (node_ids, sampled) = {
+            let historical = self.historical.read();
+            let mut ids = historical.versioned_node_ids();
+            let cap = historical.max_schema_as_of_entities();
+            drop(historical);
+            let sampled = crate::db::schema::cap_ids(&mut ids, cap);
+            ids.sort_unstable();
+            (ids, sampled)
+        };
 
+        // Reconstruct in chunks, re-acquiring the historical read guard per
+        // chunk, so cold-tier I/O during property reconstruction cannot pin
+        // the guard (and block writers) for the entire scan. Recorded
+        // history is immutable and every candidate is resolved at the same
+        // fixed bi-temporal coordinate, so for a past `transaction_time`
+        // anchor the chunked scan is exactly as consistent as a
+        // single-acquisition scan. The only skew window is a
+        // `transaction_time` at/near now: a write committed between chunks
+        // can be visible to later chunks but not earlier ones -- the same
+        // race a caller already has against writes committed immediately
+        // before or after a single-acquisition call.
         let mut matches = Vec::new();
-        for (_, node) in self.get_nodes_at_time(&node_ids, valid_time, transaction_time)? {
-            // `None` = not visible at the queried bi-temporal point.
-            let Some(node) = node else {
-                continue;
-            };
-            if node.label != label_id {
-                continue;
+        for chunk in node_ids.chunks(AS_OF_FIND_CHUNK_SIZE) {
+            let chunk_nodes = self
+                .historical
+                .read()
+                .get_nodes_at_time_with_label(chunk, label_id, valid_time, transaction_time)
+                .record_error_metric()?;
+            for node in chunk_nodes {
+                if let Some((key_id, expected)) = &key_filter
+                    && !node
+                        .properties
+                        .get_by_interned_key(key_id)
+                        .is_some_and(|v| v == *expected)
+                {
+                    continue;
+                }
+                matches.push(node);
             }
-            if let Some((key_id, expected)) = &key_filter
-                && !node
-                    .properties
-                    .get_by_interned_key(key_id)
-                    .is_some_and(|v| v == *expected)
-            {
-                continue;
-            }
-            matches.push(node);
         }
-        Ok(matches)
+        Ok(NodesAtTime {
+            nodes: matches,
+            sampled,
+        })
     }
 
     // ========================================================================
@@ -1277,8 +1356,8 @@ mod tests {
             PropertyMapBuilder::new().insert("name", name).build()
         }
 
-        fn ids(nodes: &[crate::core::graph::Node]) -> Vec<NodeId> {
-            nodes.iter().map(|n| n.id).collect()
+        fn ids(found: &crate::db::NodesAtTime) -> Vec<NodeId> {
+            found.nodes.iter().map(|n| n.id).collect()
         }
 
         /// Capture a bi-temporal anchor strictly after every previously
@@ -1311,11 +1390,12 @@ mod tests {
             assert_eq!(ids(&found), vec![id]);
             // ...and the returned node carries the AT-TIME property value,
             // not the current one.
-            assert_eq!(found[0].properties.get("name"), Some(&alice));
+            assert_eq!(found.nodes[0].properties.get("name"), Some(&alice));
             // "Bob" did not hold yet at t1.
             assert!(
                 db.find_nodes_by_property_at("Person", "name", &bob, t1, t1)
                     .unwrap()
+                    .nodes
                     .is_empty()
             );
 
@@ -1324,10 +1404,11 @@ mod tests {
                 .find_nodes_by_property_at("Person", "name", &bob, t2, t2)
                 .unwrap();
             assert_eq!(ids(&found), vec![id]);
-            assert_eq!(found[0].properties.get("name"), Some(&bob));
+            assert_eq!(found.nodes[0].properties.get("name"), Some(&bob));
             assert!(
                 db.find_nodes_by_property_at("Person", "name", &alice, t2, t2)
                     .unwrap()
+                    .nodes
                     .is_empty()
             );
         }
@@ -1344,6 +1425,7 @@ mod tests {
             assert!(
                 db.find_nodes_by_property_at("Person", "name", &alice, t0, t0)
                     .unwrap()
+                    .nodes
                     .is_empty(),
                 "a node created after T must not be found at T"
             );
@@ -1379,7 +1461,32 @@ mod tests {
             assert!(
                 db.find_nodes_by_property_at("Person", "name", &alice, t_after, t_after)
                     .unwrap()
+                    .nodes
                     .is_empty()
+            );
+        }
+
+        /// T2 (review): the documented "both dimensions required" contract,
+        /// pinned as a *negative* test -- a deleted node must NOT be
+        /// recalled when only `valid_time` is anchored before the deletion
+        /// and `transaction_time` stays at now (the MCP default), because
+        /// the deletion already closed the version's transaction interval.
+        #[test]
+        fn deleted_node_not_recalled_with_only_valid_time_anchored() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("Alice");
+
+            let _id = db.create_node("Person", name_props("Alice")).unwrap();
+            let v_before = anchor_after_commits();
+            db.delete_node_with_valid_time(_id, None).unwrap();
+            let tx_now = anchor_after_commits();
+
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &alice, v_before, tx_now)
+                    .unwrap()
+                    .nodes
+                    .is_empty(),
+                "past valid_time + current transaction_time must NOT recall a deleted node"
             );
         }
 
@@ -1435,6 +1542,110 @@ mod tests {
             );
         }
 
+        /// D1 regression (review): the current-state equivalence claim does
+        /// NOT hold for future-dated facts, and the documentation says so.
+        /// A node created with `valid_from` in the future is present in
+        /// current storage (so `find_nodes_by_property` returns it) but its
+        /// valid interval has not begun, so the bi-temporal view at
+        /// `(now, now)` must exclude it.
+        #[test]
+        fn future_valid_from_node_visible_currently_but_not_at_now_now() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("FutureAlice");
+
+            let future = crate::core::temporal::Timestamp::from(
+                time::now().wallclock() + 3_600_000_000, // now + 1 hour
+            );
+            let id = db
+                .create_node_with_valid_time("Person", name_props("FutureAlice"), Some(future))
+                .unwrap();
+            let now = anchor_after_commits();
+
+            // Current-state lookup sees the future-dated node...
+            assert_eq!(
+                db.find_nodes_by_property("Person", "name", &alice),
+                vec![id],
+                "current storage must contain the future-dated node"
+            );
+            // ...but the bi-temporal view at (now, now) must not: its valid
+            // interval has not begun yet.
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &alice, now, now)
+                    .unwrap()
+                    .nodes
+                    .is_empty(),
+                "a future-dated valid_from node must be invisible at (now, now)"
+            );
+            // Once the valid dimension reaches the fact's start, it appears
+            // (transaction dimension already contains the write).
+            let after_start = crate::core::temporal::Timestamp::from(future.wallclock() + 1);
+            assert_eq!(
+                ids(&db
+                    .find_nodes_by_property_at("Person", "name", &alice, after_start, now)
+                    .unwrap()),
+                vec![id]
+            );
+        }
+
+        /// T1 (review, mutation killer): the two temporal dimensions are
+        /// passed in the correct order. A backdated `valid_from` makes the
+        /// dimensions observably different: (valid=past-but-after-valid_from,
+        /// tx=now) finds the node, while swapping the arguments would anchor
+        /// the *transaction* dimension before the write was recorded and
+        /// find nothing.
+        #[test]
+        fn backdated_valid_time_distinguishes_the_two_dimensions() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("BackdatedAlice");
+
+            // valid_from one hour in the past; the write itself is recorded now.
+            let v0 = crate::core::temporal::Timestamp::from(
+                time::now().wallclock() - 3_600_000_000, // now - 1 hour
+            );
+            // A wall-clock instant after v0 but strictly before the write is
+            // recorded: inside the valid interval, outside the tx interval.
+            let t_mid = anchor_after_commits();
+            let id = db
+                .create_node_with_valid_time("Person", name_props("BackdatedAlice"), Some(v0))
+                .unwrap();
+            let t_now = anchor_after_commits();
+
+            // (valid = t_mid, tx = t_now): valid interval [v0, inf) contains
+            // t_mid and the write is recorded by t_now -> FOUND. With the
+            // dimensions swapped this becomes (valid = t_now, tx = t_mid),
+            // anchoring the transaction dimension before the write existed
+            // -> empty, so a dimension-swap mutation fails here.
+            assert_eq!(
+                ids(&db
+                    .find_nodes_by_property_at("Person", "name", &alice, t_mid, t_now)
+                    .unwrap()),
+                vec![id],
+                "backdated fact must be found at (valid=past, tx=now)"
+            );
+
+            // And the genuinely-swapped coordinate must be empty: at
+            // transaction time t_mid nothing had been recorded yet.
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &alice, t_now, t_mid)
+                    .unwrap()
+                    .nodes
+                    .is_empty(),
+                "(valid=now, tx=before-the-write) must find nothing"
+            );
+
+            // Same discrimination for the label-only path.
+            assert_eq!(
+                ids(&db.find_nodes_at_time("Person", t_mid, t_now).unwrap()),
+                vec![id]
+            );
+            assert!(
+                db.find_nodes_at_time("Person", t_now, t_mid)
+                    .unwrap()
+                    .nodes
+                    .is_empty()
+            );
+        }
+
         #[test]
         fn unknown_label_or_property_key_returns_empty_not_error() {
             let (_tmp, db) = create_test_db().unwrap();
@@ -1444,6 +1655,7 @@ mod tests {
             assert!(
                 db.find_nodes_at_time("NeverInternedLabel3236", now, now)
                     .unwrap()
+                    .nodes
                     .is_empty()
             );
             assert!(
@@ -1455,6 +1667,7 @@ mod tests {
                     now
                 )
                 .unwrap()
+                .nodes
                 .is_empty()
             );
         }
@@ -1462,15 +1675,97 @@ mod tests {
         #[test]
         fn results_are_sorted_by_node_id_for_stable_pagination() {
             let (_tmp, db) = create_test_db().unwrap();
+
+            // Many nodes with delete + recreate interleaving, so the
+            // sorted-order contract is pinned across a realistic churn
+            // pattern (guards against future changes to the version-head
+            // map's iteration order; today's identity-hashed map happens to
+            // iterate sequential ids in order, so the deterministic
+            // sort-removal killer is the capped test below, where
+            // `cap_ids`'s select_nth_unstable provably scrambles the ids).
             let mut created = Vec::new();
-            for _ in 0..5 {
+            for _ in 0..60 {
                 created.push(db.create_node("Person", name_props("Alice")).unwrap());
             }
-            created.sort_unstable();
+            let mut expected: Vec<NodeId> = Vec::new();
+            for (i, &id) in created.iter().enumerate() {
+                if i % 3 == 0 {
+                    db.delete_node_with_valid_time(id, None).unwrap();
+                } else {
+                    expected.push(id);
+                }
+            }
+            for _ in 0..30 {
+                expected.push(db.create_node("Person", name_props("Alice")).unwrap());
+            }
+            expected.sort_unstable();
 
             let now = anchor_after_commits();
             let found = ids(&db.find_nodes_at_time("Person", now, now).unwrap());
-            assert_eq!(found, created, "results must be sorted by node id");
+            assert_eq!(found, expected, "results must be sorted by node id");
+        }
+
+        /// T7 (review): candidate-set truncation (C1) is disclosed. Reuses
+        /// the `max_schema_as_of_entities` cap exactly like
+        /// `schema_as_of`, injected small so the test doesn't need 50,000+
+        /// entities.
+        ///
+        /// Sized deliberately (cap 32, 64 candidates): `cap_ids`'s
+        /// `select_nth_unstable` provably scrambles a pre-sorted id vector
+        /// at this size, so this test also verifies the post-cap
+        /// `sort_unstable` is load-bearing (a sort-removal mutant fails
+        /// here deterministically -- the identity-hashed head map otherwise
+        /// yields sequential ids in already-sorted order).
+        #[test]
+        fn candidate_cap_truncates_deterministically_and_discloses_sampling() {
+            use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder};
+            use crate::test_utils::create_test_db_with_config;
+
+            let config = AletheiaDBConfig::builder()
+                .historical(
+                    HistoricalConfigBuilder::new()
+                        .max_schema_as_of_entities(32)
+                        .build(),
+                )
+                .build();
+            let (_tmp, db) = create_test_db_with_config(config).unwrap();
+
+            let mut created = Vec::new();
+            for _ in 0..64 {
+                created.push(db.create_node("Person", name_props("Alice")).unwrap());
+            }
+            created.sort_unstable();
+            let now = anchor_after_commits();
+
+            let found = db.find_nodes_at_time("Person", now, now).unwrap();
+            assert!(
+                found.sampled,
+                "a cap of 32 with 64 versioned nodes must disclose truncation"
+            );
+            // The cap keeps the LOWEST ids, returned in sorted order -- a
+            // deterministic subset, so pagination over a sampled result is
+            // stable.
+            assert_eq!(
+                ids(&found),
+                created[..32].to_vec(),
+                "the sampled candidate set must be the lowest node ids, sorted"
+            );
+
+            // Under the cap, results are complete and sampled is false.
+            let alice = PropertyValue::from("Alice");
+            let filtered = db
+                .find_nodes_by_property_at("Person", "name", &alice, now, now)
+                .unwrap();
+            assert!(filtered.sampled, "property path shares the same cap");
+
+            // A db whose history fits under the cap never reports sampling.
+            let (_tmp2, small_db) = create_test_db().unwrap();
+            let id = small_db.create_node("Person", name_props("Alice")).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            let now2 = time::now();
+            let small = small_db.find_nodes_at_time("Person", now2, now2).unwrap();
+            assert!(!small.sampled);
+            assert_eq!(ids(&small), vec![id]);
         }
     }
 }

--- a/src/db/ops.rs
+++ b/src/db/ops.rs
@@ -652,6 +652,122 @@ impl AletheiaDB {
         self.current.get_nodes_by_label(label)
     }
 
+    /// Find nodes by label as of a bi-temporal point (AS OF scan, Issue #3236).
+    ///
+    /// Returns every node with the given label **as it existed** at
+    /// `(valid_time, transaction_time)`, with properties reconstructed from
+    /// the historical version visible at that coordinate. Nodes that did not
+    /// exist at the queried point are excluded; nodes since deleted from
+    /// current state are still found when both dimensions anchor before the
+    /// deletion.
+    ///
+    /// Results are sorted by node ID so pagination over the result set is
+    /// deterministic. A label that has never been written yields an empty
+    /// result, never an error.
+    ///
+    /// # Performance
+    ///
+    /// Iterates every node that has ever had a version recorded (the same
+    /// candidate enumeration [`schema_as_of`](Self::schema_as_of) uses) and
+    /// reconstructs each at the queried coordinate. A dedicated temporal
+    /// label index is a deliberate follow-up if this path proves too slow at
+    /// scale.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes_at_time(
+        &self,
+        label: &str,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+    ) -> Result<Vec<Node>> {
+        self.find_nodes_at_time_filtered(label, None, valid_time, transaction_time)
+    }
+
+    /// Find nodes by label and exact property match as of a bi-temporal
+    /// point (Issue #3236).
+    ///
+    /// The bi-temporal counterpart of
+    /// [`find_nodes_by_property`](Self::find_nodes_by_property): the property
+    /// comparison runs against each node's state **at**
+    /// `(valid_time, transaction_time)`, so a node whose property only
+    /// matched before (or after) the queried point is excluded. With both
+    /// dimensions at the current time this returns the same node set as
+    /// `find_nodes_by_property`.
+    ///
+    /// See [`find_nodes_at_time`](Self::find_nodes_at_time) for ordering,
+    /// completeness, and performance characteristics.
+    #[must_use = "this Result must be used; ignoring errors can lead to silent failures"]
+    pub fn find_nodes_by_property_at(
+        &self,
+        label: &str,
+        property_key: &str,
+        property_value: &PropertyValue,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+    ) -> Result<Vec<Node>> {
+        self.find_nodes_at_time_filtered(
+            label,
+            Some((property_key, property_value)),
+            valid_time,
+            transaction_time,
+        )
+    }
+
+    /// Shared implementation for the AS OF node-find methods: enumerate every
+    /// node that has ever had a version recorded, reconstruct each at the
+    /// queried bi-temporal coordinate, and keep those whose *at-time* state
+    /// matches the label (and optional exact property) filter.
+    fn find_nodes_at_time_filtered(
+        &self,
+        label: &str,
+        property_filter: Option<(&str, &PropertyValue)>,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+    ) -> Result<Vec<Node>> {
+        // A label (or property key) that has never been interned has never
+        // been written anywhere -- current or historical -- so the result is
+        // an empty set, never an error (mirroring `find_nodes_by_property`).
+        let Some(label_id) = GLOBAL_INTERNER.get_id(label) else {
+            return Ok(Vec::new());
+        };
+        let key_filter = match property_filter {
+            Some((key, value)) => match GLOBAL_INTERNER.get_id(key) {
+                Some(key_id) => Some((key_id, value)),
+                None => return Ok(Vec::new()),
+            },
+            None => None,
+        };
+
+        // Candidate set: every node that has ever had a version recorded.
+        // Unlike the current-state label index, this stays complete for nodes
+        // deleted from current state (deletion closes the version's
+        // transaction interval but the version head remains), so anchoring
+        // both dimensions before a deletion still recalls the node. Sorted so
+        // the result order (and thus pagination) is deterministic.
+        let mut node_ids = self.historical.read().versioned_node_ids();
+        node_ids.sort_unstable();
+
+        let mut matches = Vec::new();
+        for (_, node) in self.get_nodes_at_time(&node_ids, valid_time, transaction_time)? {
+            // `None` = not visible at the queried bi-temporal point.
+            let Some(node) = node else {
+                continue;
+            };
+            if node.label != label_id {
+                continue;
+            }
+            if let Some((key_id, expected)) = &key_filter
+                && !node
+                    .properties
+                    .get_by_interned_key(key_id)
+                    .is_some_and(|v| v == *expected)
+            {
+                continue;
+            }
+            matches.push(node);
+        }
+        Ok(matches)
+    }
+
     // ========================================================================
     // Uniqueness constraint API
     // ========================================================================
@@ -1143,6 +1259,218 @@ mod tests {
                 .create_edge(source, target, "KNOWS", PropertyMapBuilder::new().build())
                 .unwrap();
             assert!(db.get_edge_at_valid_time(edge_id, time::now()).is_ok());
+        }
+    }
+
+    /// Tests for the point-in-time (AS OF) node find API (Issue #3236):
+    /// `find_nodes_at_time` (label-only) and `find_nodes_by_property_at`
+    /// (label + exact property match), both reconstructing each candidate
+    /// node from the historical version visible at `(valid_time,
+    /// transaction_time)`.
+    mod find_nodes_at_time_tests {
+        use super::*;
+        use crate::core::id::NodeId;
+        use crate::core::property::PropertyValue;
+        use crate::core::temporal::time;
+
+        fn name_props(name: &str) -> crate::core::property::PropertyMap {
+            PropertyMapBuilder::new().insert("name", name).build()
+        }
+
+        fn ids(nodes: &[crate::core::graph::Node]) -> Vec<NodeId> {
+            nodes.iter().map(|n| n.id).collect()
+        }
+
+        /// Capture a bi-temporal anchor strictly after every previously
+        /// committed write. A bare `time::now()` carries logical component 0,
+        /// while an HLC commit stamp in the *same microsecond* carries a
+        /// logical component > 0 and therefore orders *after* the anchor;
+        /// sleeping past the microsecond boundary first makes the anchor's
+        /// wallclock strictly greater than all prior commit wallclocks.
+        fn anchor_after_commits() -> crate::core::temporal::Timestamp {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            time::now()
+        }
+
+        #[test]
+        fn property_changed_across_versions_matches_value_at_t_only() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("Alice");
+            let bob = PropertyValue::from("Bob");
+
+            let id = db.create_node("Person", name_props("Alice")).unwrap();
+            let t1 = anchor_after_commits();
+            db.update_node_with_valid_time(id, name_props("Bob"), None)
+                .unwrap();
+            let t2 = anchor_after_commits();
+
+            // At (t1, t1) the name was still "Alice"...
+            let found = db
+                .find_nodes_by_property_at("Person", "name", &alice, t1, t1)
+                .unwrap();
+            assert_eq!(ids(&found), vec![id]);
+            // ...and the returned node carries the AT-TIME property value,
+            // not the current one.
+            assert_eq!(found[0].properties.get("name"), Some(&alice));
+            // "Bob" did not hold yet at t1.
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &bob, t1, t1)
+                    .unwrap()
+                    .is_empty()
+            );
+
+            // At (t2, t2) the situation is exactly reversed.
+            let found = db
+                .find_nodes_by_property_at("Person", "name", &bob, t2, t2)
+                .unwrap();
+            assert_eq!(ids(&found), vec![id]);
+            assert_eq!(found[0].properties.get("name"), Some(&bob));
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &alice, t2, t2)
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+
+        #[test]
+        fn node_created_after_t_is_excluded() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("Alice");
+
+            let t0 = anchor_after_commits();
+            let id = db.create_node("Person", name_props("Alice")).unwrap();
+            let t1 = anchor_after_commits();
+
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &alice, t0, t0)
+                    .unwrap()
+                    .is_empty(),
+                "a node created after T must not be found at T"
+            );
+            assert_eq!(
+                ids(&db
+                    .find_nodes_by_property_at("Person", "name", &alice, t1, t1)
+                    .unwrap()),
+                vec![id]
+            );
+        }
+
+        #[test]
+        fn node_deleted_before_t_found_when_both_dimensions_anchor_before_deletion() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("Alice");
+
+            let id = db.create_node("Person", name_props("Alice")).unwrap();
+            let t_before = anchor_after_commits();
+            db.delete_node_with_valid_time(id, None).unwrap();
+            let t_after = anchor_after_commits();
+
+            // Anchoring both dimensions before the deletion recalls the node
+            // -- this is the case a current-state label index alone would
+            // miss, since the node no longer exists in current storage.
+            assert_eq!(
+                ids(&db
+                    .find_nodes_by_property_at("Person", "name", &alice, t_before, t_before)
+                    .unwrap()),
+                vec![id]
+            );
+
+            // At a coordinate after the deletion it is gone.
+            assert!(
+                db.find_nodes_by_property_at("Person", "name", &alice, t_after, t_after)
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+
+        #[test]
+        fn label_only_as_of_scan_without_property_filter() {
+            let (_tmp, db) = create_test_db().unwrap();
+
+            let a = db.create_node("Person", name_props("Alice")).unwrap();
+            let b = db.create_node("Person", name_props("Bob")).unwrap();
+            let c = db.create_node("Company", name_props("Acme")).unwrap();
+            let t1 = anchor_after_commits();
+            db.delete_node_with_valid_time(b, None).unwrap();
+            let t2 = anchor_after_commits();
+
+            // Before the deletion both Person nodes are visible (sorted by id).
+            assert_eq!(
+                ids(&db.find_nodes_at_time("Person", t1, t1).unwrap()),
+                vec![a, b]
+            );
+            // After the deletion only `a` remains.
+            assert_eq!(
+                ids(&db.find_nodes_at_time("Person", t2, t2).unwrap()),
+                vec![a]
+            );
+            // Label filtering holds on the AS OF path.
+            assert_eq!(
+                ids(&db.find_nodes_at_time("Company", t1, t1).unwrap()),
+                vec![c]
+            );
+        }
+
+        #[test]
+        fn current_state_equivalence_with_find_nodes_by_property() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let alice = PropertyValue::from("Alice");
+
+            let _a = db.create_node("Person", name_props("Alice")).unwrap();
+            let _b = db.create_node("Person", name_props("Bob")).unwrap();
+            let _c = db.create_node("Person", name_props("Alice")).unwrap();
+            let d = db.create_node("Person", name_props("Alice")).unwrap();
+            db.delete_node_with_valid_time(d, None).unwrap();
+
+            let now = anchor_after_commits();
+            let mut current = db.find_nodes_by_property("Person", "name", &alice);
+            current.sort_unstable();
+            let at_now = ids(&db
+                .find_nodes_by_property_at("Person", "name", &alice, now, now)
+                .unwrap());
+
+            assert_eq!(
+                at_now, current,
+                "valid_time=now + transaction_time=now must equal the current-state result set"
+            );
+        }
+
+        #[test]
+        fn unknown_label_or_property_key_returns_empty_not_error() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let _ = db.create_node("Person", name_props("Alice")).unwrap();
+            let now = anchor_after_commits();
+
+            assert!(
+                db.find_nodes_at_time("NeverInternedLabel3236", now, now)
+                    .unwrap()
+                    .is_empty()
+            );
+            assert!(
+                db.find_nodes_by_property_at(
+                    "Person",
+                    "never_interned_key_3236",
+                    &PropertyValue::from("x"),
+                    now,
+                    now
+                )
+                .unwrap()
+                .is_empty()
+            );
+        }
+
+        #[test]
+        fn results_are_sorted_by_node_id_for_stable_pagination() {
+            let (_tmp, db) = create_test_db().unwrap();
+            let mut created = Vec::new();
+            for _ in 0..5 {
+                created.push(db.create_node("Person", name_props("Alice")).unwrap());
+            }
+            created.sort_unstable();
+
+            let now = anchor_after_commits();
+            let found = ids(&db.find_nodes_at_time("Person", now, now).unwrap());
+            assert_eq!(found, created, "results must be sorted by node id");
         }
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -221,12 +221,14 @@ impl AletheiaDB {
 /// though not necessarily in sorted order -- the order among the kept
 /// elements doesn't matter, since they're only used as a scan input, not
 /// exposed to callers). Returns `true` if truncation actually happened, so
-/// the caller can disclose it via [`GraphSchema::sampled`].
+/// the caller can disclose it via [`GraphSchema::sampled`] (or
+/// [`crate::db::NodesAtTime::sampled`] on the AS OF node-find path, which
+/// shares this cap).
 ///
 /// Uses a partial selection (`select_nth_unstable`, O(n) average) rather
 /// than a full sort (O(n log n)), since only membership in the smallest-`cap`
 /// set matters here, not a total order.
-fn cap_ids<T: Ord>(ids: &mut Vec<T>, cap: usize) -> bool {
+pub(crate) fn cap_ids<T: Ord>(ids: &mut Vec<T>, cap: usize) -> bool {
     if ids.len() > cap {
         ids.select_nth_unstable(cap);
         ids.truncate(cap);

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -35,11 +35,11 @@ pub use server::AletheiaMcpServer;
 // Re-export tool request/response types for testing (alphabetically sorted)
 pub use tools::{
     CountEdgesRequest, CountNodesRequest, CreateEdgeRequest, CreateNodeRequest, DeleteEdgeRequest,
-    DeleteNodeCascadeRequest, DeleteNodeRequest, EnableVectorIndexRequest, FindSimilarRequest,
-    GetEdgeAtTimeRequest, GetEdgeRequest, GetIncomingEdgesRequest, GetNodeAtTimeRequest,
-    GetNodeRequest, GetOutgoingEdgesRequest, HybridQueryRequest, ListChangesRequest,
-    ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest, QueryRequest, TraverseRequest,
-    UpdateEdgeRequest, UpdateNodeRequest,
+    DeleteNodeCascadeRequest, DeleteNodeRequest, EnableVectorIndexRequest, FindNodesAtTimeRequest,
+    FindSimilarRequest, GetEdgeAtTimeRequest, GetEdgeRequest, GetIncomingEdgesRequest,
+    GetNodeAtTimeRequest, GetNodeRequest, GetOutgoingEdgesRequest, HybridQueryRequest,
+    ListChangesRequest, ListEdgesRequest, ListNodesRequest, ListVectorIndexesRequest, QueryRequest,
+    TraverseRequest, UpdateEdgeRequest, UpdateNodeRequest,
 };
 
 #[cfg(test)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -22,7 +22,7 @@
 //! | **Nodes** | `get_node`, `create_node`, `update_node` | CRUD operations for nodes |
 //! | **Edges** | `get_edge`, `create_edge`, `traverse` | CRUD and traversal for edges |
 //! | **Vector** | `find_similar`, `enable_vector_index` | Semantic similarity search |
-//! | **Temporal** | `get_node_at_time`, `get_node_history`, `temporal_extent` | Time-travel queries, history, and dataset extent |
+//! | **Temporal** | `get_node_at_time`, `find_nodes_at_time`, `get_node_history`, `temporal_extent` | Time-travel queries, history, and dataset extent |
 //! | **Hybrid** | `hybrid_query` | Combined graph + vector + temporal queries |
 //! | **Schema** | `get_schema` | Discover node labels, edge types, and property keys (optionally bi-temporal) |
 //!
@@ -618,6 +618,18 @@ impl AletheiaMcpServer {
         ))
     }
 
+    /// Find nodes by label (and optional exact property match) as of a
+    /// bi-temporal point (Issue #3236).
+    ///
+    /// The entry-point resolver for "the Person named Alice, as of
+    /// 2024-01-01" when no `NodeId` is known: each returned node is
+    /// reconstructed as it existed at `(valid_time, transaction_time)`.
+    pub fn find_nodes_at_time(&self, req: FindNodesAtTimeRequest) -> String {
+        Self::extract_text(self.handle_find_nodes_at_time(
+            serde_json::to_value(req).expect("request serialization should not fail"),
+        ))
+    }
+
     /// Discover the graph's schema: distinct node labels and edge types,
     /// their counts, and the property keys observed on each.
     ///
@@ -996,6 +1008,20 @@ impl AletheiaMcpServer {
     /// Format transaction time for response, using the constant for current time.
     fn format_tx_time_response(tx_time: Option<String>) -> String {
         tx_time.unwrap_or_else(|| TRANSACTION_TIME_NOW.to_string())
+    }
+
+    /// Format a resolved bi-temporal coordinate as an RFC 3339 UTC string
+    /// with microsecond precision and a `Z` suffix (e.g.
+    /// `2024-01-15T10:00:00.000000Z`).
+    ///
+    /// Total: a wallclock value outside chrono's representable range degrades
+    /// to the raw microsecond count rather than silently rendering the 1970
+    /// epoch.
+    fn format_timestamp_rfc3339(ts: Timestamp) -> String {
+        match DateTime::<Utc>::from_timestamp_micros(ts.wallclock()) {
+            Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+            None => ts.wallclock().to_string(),
+        }
     }
 
     fn matches_label(&self, interned: crate::core::InternedString, label: &str) -> bool {
@@ -2364,6 +2390,104 @@ impl AletheiaMcpServer {
         }
     }
 
+    /// Find nodes by label (and optional exact property match) as of a
+    /// bi-temporal point (Issue #3236).
+    ///
+    /// Validation mirrors `handle_list_nodes` (both-or-neither property
+    /// filter, same limit/offset clamps); the temporal reconstruction is
+    /// delegated to `AletheiaDB::find_nodes_at_time` /
+    /// `find_nodes_by_property_at`, which reconstruct each candidate from
+    /// the historical version visible at the queried coordinate -- so nodes
+    /// deleted from current state are still found when both dimensions
+    /// anchor before the deletion.
+    fn handle_find_nodes_at_time(&self, args: serde_json::Value) -> CallToolResult {
+        let req: FindNodesAtTimeRequest = match serde_json::from_value(args) {
+            Ok(r) => r,
+            Err(e) => return self.invalid_argument(&format!("Invalid arguments: {}", e)),
+        };
+
+        // Validate property filter: both key and value are required together
+        // (mirroring list_nodes).
+        if req.property_key.is_some() != req.property_value.is_some() {
+            return self.invalid_argument(
+                "Both 'property_key' and 'property_value' are required together",
+            );
+        }
+
+        let valid_time = match self.parse_timestamp(&req.valid_time) {
+            Ok(t) => t,
+            Err(e) => return self.invalid_argument(&format!("Invalid valid_time: {}", e)),
+        };
+        let tx_time = match self.parse_optional_tx_time(req.transaction_time.as_deref()) {
+            Ok(t) => t,
+            Err(e) => return self.invalid_argument(&format!("Invalid transaction_time: {}", e)),
+        };
+
+        // Apply resource limits exactly like list_nodes: a page must be able
+        // to carry a continuation cursor, so the limit is at least 1.
+        let limit = req
+            .limit
+            .unwrap_or(DEFAULT_RESULT_LIMIT)
+            .clamp(1, MAX_RESULT_LIMIT);
+        let offset = req.offset.unwrap_or(0).min(MAX_PAGINATION_OFFSET);
+
+        let matches =
+            if let (Some(prop_key), Some(prop_val)) = (&req.property_key, &req.property_value) {
+                let property_value = match self.json_to_property_value(prop_val) {
+                    Some(v) => v,
+                    None => return self.invalid_argument(
+                        "Unsupported property_value type. Use strings, numbers, booleans, or null.",
+                    ),
+                };
+                self.db.find_nodes_by_property_at(
+                    &req.label,
+                    prop_key,
+                    &property_value,
+                    valid_time,
+                    tx_time,
+                )
+            } else {
+                self.db.find_nodes_at_time(&req.label, valid_time, tx_time)
+            };
+
+        match matches {
+            Ok(matches) => {
+                // The full matching set is already materialized (sorted by
+                // node id for stable pagination), so the total is cheap to
+                // report and `has_more` is exact.
+                let total_matching = matches.len();
+                let include_vectors = req.include_vectors.unwrap_or(false);
+                let nodes: Vec<NodeResponse> = matches
+                    .iter()
+                    .skip(offset)
+                    .take(limit)
+                    .map(|node| self.node_to_response(node, include_vectors))
+                    .collect();
+
+                let has_more = offset.saturating_add(limit) < total_matching;
+                let mut response = json!({
+                    "nodes": nodes,
+                    "count": nodes.len(),
+                    "offset": offset,
+                    "limit": limit,
+                    // The resolved coordinate this answer holds at -- the
+                    // omitted transaction_time resolves to a concrete "now".
+                    "valid_time": Self::format_timestamp_rfc3339(valid_time),
+                    "transaction_time": Self::format_timestamp_rfc3339(tx_time),
+                });
+                Self::attach_completeness(
+                    &mut response,
+                    offset,
+                    limit,
+                    has_more,
+                    Some(total_matching),
+                );
+                self.success_json(response)
+            }
+            Err(e) => self.db_error(e),
+        }
+    }
+
     fn handle_list_changes(&self, args: serde_json::Value) -> CallToolResult {
         let req: ListChangesRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -3521,6 +3645,7 @@ impl AletheiaMcpServer {
             "list_unique_constraints" => self.handle_list_unique_constraints(args),
             "get_node_at_time" => self.handle_get_node_at_time(args),
             "get_edge_at_time" => self.handle_get_edge_at_time(args),
+            "find_nodes_at_time" => self.handle_find_nodes_at_time(args),
             "list_changes" => self.handle_list_changes(args),
             "get_node_at_valid_time" => self.handle_get_node_at_valid_time(args),
             "get_node_at_transaction_time" => self.handle_get_node_at_transaction_time(args),
@@ -3855,6 +3980,22 @@ fn tool_definitions() -> Vec<Tool> {
             "get_edge_at_time",
             "Get edge state at a specific time.",
             make_input_schema::<GetEdgeAtTimeRequest>(),
+        ),
+        Tool::new(
+            "find_nodes_at_time",
+            "Find nodes by label (and optional exact property_key/property_value match) as of \
+                     a bi-temporal point -- resolve e.g. \"the Person named Alice as of \
+                     2024-01-01\" in one call, without knowing any node ID. `valid_time` is \
+                     required (ISO 8601 or microseconds since epoch); `transaction_time` is \
+                     optional and defaults to now. Each returned node is reconstructed AS IT \
+                     EXISTED at that coordinate (not its current state); nodes that did not \
+                     exist, or whose property value did not hold, at that point are excluded. \
+                     Recalling a since-deleted node requires anchoring BOTH dimensions before \
+                     the deletion. Results are sorted by node id; the response echoes the \
+                     resolved valid_time/transaction_time and carries `has_more`/`next_offset`/\
+                     `total_matching` pagination metadata. Vector/embedding properties are \
+                     elided by default; pass `include_vectors: true` for full arrays.",
+            make_input_schema::<FindNodesAtTimeRequest>(),
         ),
         Tool::new(
             "list_changes",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2399,7 +2399,11 @@ impl AletheiaMcpServer {
     /// `find_nodes_by_property_at`, which reconstruct each candidate from
     /// the historical version visible at the queried coordinate -- so nodes
     /// deleted from current state are still found when both dimensions
-    /// anchor before the deletion.
+    /// anchor before the deletion. The candidate set is capped at the same
+    /// `max_schema_as_of_entities` limit bi-temporal `get_schema` uses; when
+    /// truncated, the response discloses it via `sampled: true` and
+    /// `total_matching`/`has_more` count matches within the sampled
+    /// candidate set only.
     fn handle_find_nodes_at_time(&self, args: serde_json::Value) -> CallToolResult {
         let req: FindNodesAtTimeRequest = match serde_json::from_value(args) {
             Ok(r) => r,
@@ -2452,9 +2456,14 @@ impl AletheiaMcpServer {
 
         match matches {
             Ok(matches) => {
-                // The full matching set is already materialized (sorted by
-                // node id for stable pagination), so the total is cheap to
-                // report and `has_more` is exact.
+                // The matching set is already materialized (sorted by node
+                // id for stable pagination), so the total is cheap to report
+                // and `has_more` is exact *within the candidate set*. When
+                // `sampled` is true the candidate enumeration was truncated
+                // at the configured cap, so `total_matching` is honest only
+                // about the sampled candidates -- the flag discloses that.
+                let sampled = matches.sampled;
+                let matches = matches.nodes;
                 let total_matching = matches.len();
                 let include_vectors = req.include_vectors.unwrap_or(false);
                 let nodes: Vec<NodeResponse> = matches
@@ -2470,6 +2479,9 @@ impl AletheiaMcpServer {
                     "count": nodes.len(),
                     "offset": offset,
                     "limit": limit,
+                    // Candidate-set truncation disclosure, mirroring
+                    // get_schema's `sampled` (same underlying cap).
+                    "sampled": sampled,
                     // The resolved coordinate this answer holds at -- the
                     // omitted transaction_time resolves to a concrete "now".
                     "valid_time": Self::format_timestamp_rfc3339(valid_time),
@@ -3993,7 +4005,10 @@ fn tool_definitions() -> Vec<Tool> {
                      Recalling a since-deleted node requires anchoring BOTH dimensions before \
                      the deletion. Results are sorted by node id; the response echoes the \
                      resolved valid_time/transaction_time and carries `has_more`/`next_offset`/\
-                     `total_matching` pagination metadata. Vector/embedding properties are \
+                     `total_matching` pagination metadata. On databases with very large \
+                     bi-temporal history the candidate scan is capped; the response then sets \
+                     `sampled: true` and `total_matching` counts matches within the sampled \
+                     candidate set only. Vector/embedding properties are \
                      elided by default; pass `include_vectors: true` for full arrays.",
             make_input_schema::<FindNodesAtTimeRequest>(),
         ),

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -7796,6 +7796,32 @@ mod find_nodes_at_time_tests {
         assert_eq!(node_ids(&value), vec![id]);
     }
 
+    /// T2 (review): the "both dimensions required" contract as a NEGATIVE
+    /// test. Anchoring only `valid_time` before a deletion while
+    /// `transaction_time` defaults to now must NOT recall the deleted node
+    /// -- the deletion already closed the version's transaction interval.
+    #[test]
+    fn deleted_node_not_recalled_when_transaction_time_omitted() {
+        let server = create_test_server();
+        let id = create_named(&server, "Person", "Alice");
+        let t_before = anchor_after_commits();
+        delete(&server, id);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        // valid_time anchored before the deletion, transaction_time omitted
+        // (defaults to now): empty, per the documented contract.
+        let value = find(&server, name_req("Person", "Alice", &t_before));
+        assert!(
+            node_ids(&value).is_empty(),
+            "past valid_time + defaulted transaction_time must not recall a deleted node: {value}"
+        );
+        assert_eq!(value["total_matching"], serde_json::json!(0));
+
+        // Label-only path obeys the same contract.
+        let value = find(&server, base_req("Person", &t_before));
+        assert!(node_ids(&value).is_empty(), "{value}");
+    }
+
     #[test]
     fn node_deleted_before_t_recalled_when_both_dimensions_anchored() {
         let server = create_test_server();
@@ -7907,7 +7933,9 @@ mod find_nodes_at_time_tests {
         assert_eq!(page1["has_more"], serde_json::json!(true));
         assert_eq!(page1["next_offset"], serde_json::json!(1));
 
-        // Page 2 continues where page 1 left off.
+        // Page 2 continues where page 1 left off, and its continuation
+        // metadata advances from the requested offset (T6: next_offset must
+        // be exercised at offset > 0, not just on page 1).
         let page2 = find(
             &server,
             FindNodesAtTimeRequest {
@@ -7917,6 +7945,8 @@ mod find_nodes_at_time_tests {
             },
         );
         assert_eq!(node_ids(&page2), vec![created[1]], "{page2}");
+        assert_eq!(page2["has_more"], serde_json::json!(true));
+        assert_eq!(page2["next_offset"], serde_json::json!(2));
 
         // Final page reports has_more: false.
         let page3 = find(
@@ -7929,6 +7959,36 @@ mod find_nodes_at_time_tests {
         );
         assert_eq!(node_ids(&page3), vec![created[2]], "{page3}");
         assert_eq!(page3["has_more"], serde_json::json!(false));
+    }
+
+    /// T4 (review, mutation killer): `limit: 0` is clamped UP to 1 (a page
+    /// must be able to carry a continuation cursor), exactly like
+    /// `list_nodes` -- one node comes back, not zero.
+    #[test]
+    fn limit_zero_is_clamped_up_to_one() {
+        let server = create_test_server();
+        let mut created: Vec<u64> = (0..2)
+            .map(|_| create_named(&server, "Person", "Alice"))
+            .collect();
+        created.sort_unstable();
+        let now = anchor_after_commits();
+
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                limit: Some(0),
+                ..name_req("Person", "Alice", &now)
+            },
+        );
+        assert!(value.get("error").is_none(), "{value}");
+        assert_eq!(value["limit"], serde_json::json!(1));
+        assert_eq!(
+            node_ids(&value),
+            vec![created[0]],
+            "limit 0 must clamp to 1 and return one node, not zero: {value}"
+        );
+        assert_eq!(value["count"], serde_json::json!(1));
+        assert_eq!(value["has_more"], serde_json::json!(true));
     }
 
     #[test]
@@ -8044,6 +8104,87 @@ mod find_nodes_at_time_tests {
         assert!(node_ids(&value).is_empty());
         assert_eq!(value["total_matching"], serde_json::json!(0));
         assert_eq!(value["has_more"], serde_json::json!(false));
+        assert_eq!(value["sampled"], serde_json::json!(false));
+    }
+
+    /// T3 (review): vector/embedding properties follow the #3220 elision
+    /// convention on this tool -- elided `{type, dim, elided: true}`
+    /// descriptor by default, full float array with `include_vectors: true`.
+    #[test]
+    fn vector_properties_elided_by_default_and_full_with_include_vectors() {
+        let server = create_test_server();
+        let embedding: Vec<f32> = (0..16).map(|i| (i as f32) * 0.001 + 0.1).collect();
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: "Document".to_string(),
+            properties: Some(HashMap::from([
+                ("name".to_string(), serde_json::json!("Doc1")),
+                ("embedding".to_string(), serde_json::json!(embedding)),
+            ])),
+            valid_time: None,
+            provenance: None,
+        }))
+        .expect("create should succeed");
+        let now = anchor_after_commits();
+
+        // Default: elided descriptor, exactly like list_nodes.
+        let value = find(&server, base_req("Document", &now));
+        assert_eq!(node_ids(&value), vec![node.id], "{value}");
+        assert_eq!(
+            value["nodes"][0]["properties"]["embedding"],
+            serde_json::json!({"type": "vector", "dim": 16, "elided": true})
+        );
+        // Non-vector properties are untouched.
+        assert_eq!(value["nodes"][0]["properties"]["name"], "Doc1");
+
+        // include_vectors: true restores the full, lossless array.
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                include_vectors: Some(true),
+                ..base_req("Document", &now)
+            },
+        );
+        let returned: Vec<f32> = value["nodes"][0]["properties"]["embedding"]
+            .as_array()
+            .expect("embedding should be a full array")
+            .iter()
+            .map(|v| v.as_f64().unwrap() as f32)
+            .collect();
+        assert_eq!(returned, embedding);
+    }
+
+    /// T7 (review): candidate-set truncation (the C1 cap) is disclosed via
+    /// `sampled: true`, with `total_matching` counting matches within the
+    /// sampled candidate set only. The cap is the same configurable
+    /// `max_schema_as_of_entities` bi-temporal `get_schema` uses, injected
+    /// small here (mirroring the schema_as_of cap test).
+    #[test]
+    fn truncated_candidate_scan_discloses_sampled_true() {
+        use crate::config::{AletheiaDBConfig, HistoricalConfigBuilder};
+        use crate::test_utils::create_test_db_with_config;
+
+        let config = AletheiaDBConfig::builder()
+            .historical(
+                HistoricalConfigBuilder::new()
+                    .max_schema_as_of_entities(2)
+                    .build(),
+            )
+            .build();
+        let (_tmp, db) = create_test_db_with_config(config).unwrap();
+        let server = AletheiaMcpServer::new(Arc::new(db));
+
+        let mut created: Vec<u64> = (0..4)
+            .map(|_| create_named(&server, "Person", "Alice"))
+            .collect();
+        created.sort_unstable();
+        let now = anchor_after_commits();
+
+        let value = find(&server, name_req("Person", "Alice", &now));
+        assert_eq!(value["sampled"], serde_json::json!(true), "{value}");
+        // total_matching is honest about the sampled candidate set: the cap
+        // keeps the lowest 2 node ids, both of which match.
+        assert_eq!(value["total_matching"], serde_json::json!(2));
+        assert_eq!(node_ids(&value), created[..2].to_vec(), "{value}");
     }
 }
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -7639,6 +7639,415 @@ mod completeness_tests {
 }
 
 // ============================================================================
+// Point-in-time (AS OF) node find by label and property (Issue #3236)
+// ============================================================================
+//
+// `find_nodes_at_time` resolves "the Person named Alice, as of T" without a
+// prior NodeId: it returns each matching node AS IT EXISTED at the queried
+// bi-temporal coordinate, excluding nodes that did not exist (or whose
+// property value did not hold) at that point.
+
+mod find_nodes_at_time_tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    /// Capture an RFC 3339 anchor strictly after every previously committed
+    /// write: an HLC commit stamp in the same microsecond as the anchor
+    /// carries a logical component > 0 and would order *after* it, so sleep
+    /// past the microsecond boundary first.
+    fn anchor_after_commits() -> String {
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        Utc::now().to_rfc3339()
+    }
+
+    fn base_req(label: &str, valid_time: &str) -> FindNodesAtTimeRequest {
+        FindNodesAtTimeRequest {
+            label: label.to_string(),
+            property_key: None,
+            property_value: None,
+            valid_time: valid_time.to_string(),
+            transaction_time: None,
+            limit: None,
+            offset: None,
+            include_vectors: None,
+        }
+    }
+
+    fn name_req(label: &str, name: &str, valid_time: &str) -> FindNodesAtTimeRequest {
+        FindNodesAtTimeRequest {
+            property_key: Some("name".to_string()),
+            property_value: Some(serde_json::json!(name)),
+            ..base_req(label, valid_time)
+        }
+    }
+
+    fn find(server: &AletheiaMcpServer, req: FindNodesAtTimeRequest) -> serde_json::Value {
+        serde_json::from_str(&server.find_nodes_at_time(req))
+            .expect("find_nodes_at_time should return valid JSON")
+    }
+
+    fn node_ids(value: &serde_json::Value) -> Vec<u64> {
+        value["nodes"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected a nodes array, got: {value}"))
+            .iter()
+            .map(|n| n["id"].as_u64().expect("node id should be a u64"))
+            .collect()
+    }
+
+    fn create_named(server: &AletheiaMcpServer, label: &str, name: &str) -> u64 {
+        let node: NodeResponse = parse_response(&server.create_node(CreateNodeRequest {
+            label: label.to_string(),
+            properties: Some(HashMap::from([(
+                "name".to_string(),
+                serde_json::json!(name),
+            )])),
+            valid_time: None,
+            provenance: None,
+        }))
+        .expect("create should succeed");
+        node.id
+    }
+
+    fn rename(server: &AletheiaMcpServer, node_id: u64, name: &str) {
+        let _: NodeResponse = parse_response(&server.update_node(UpdateNodeRequest {
+            node_id,
+            properties: HashMap::from([("name".to_string(), serde_json::json!(name))]),
+            valid_time: None,
+            provenance: None,
+        }))
+        .expect("update should succeed");
+    }
+
+    fn delete(server: &AletheiaMcpServer, node_id: u64) {
+        let response = server.delete_node(DeleteNodeRequest {
+            node_id,
+            detach: None,
+            valid_time: None,
+        });
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["success"], serde_json::json!(true), "{value}");
+    }
+
+    fn assert_invalid_argument(response: &str, must_mention: &str) {
+        let value: serde_json::Value = serde_json::from_str(response).unwrap();
+        assert_eq!(
+            value["error"]["code"],
+            serde_json::json!("INVALID_ARGUMENT"),
+            "expected INVALID_ARGUMENT, got: {value}"
+        );
+        let message = value["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains(must_mention),
+            "error message should mention '{must_mention}': {message}"
+        );
+    }
+
+    /// Build a request anchored at the same instant on BOTH dimensions.
+    /// Recalling a superseded (or deleted) version requires this: the
+    /// superseding write closes the old version's *transaction* interval,
+    /// so with `transaction_time` defaulted to now only the latest recorded
+    /// version is visible (same convention as `traverse`'s `as_of_*`, see
+    /// the guide).
+    fn name_req_at(label: &str, name: &str, t: &str) -> FindNodesAtTimeRequest {
+        FindNodesAtTimeRequest {
+            transaction_time: Some(t.to_string()),
+            ..name_req(label, name, t)
+        }
+    }
+
+    #[test]
+    fn returns_node_as_it_existed_at_t_not_current_state() {
+        let server = create_test_server();
+        let id = create_named(&server, "Person", "Alice");
+        let t1 = anchor_after_commits();
+        rename(&server, id, "Bob");
+        let t2 = anchor_after_commits();
+
+        // At (t1, t1) the node matched "Alice" and its returned properties
+        // are the reconstructed at-time state, not the current one.
+        let value = find(&server, name_req_at("Person", "Alice", &t1));
+        assert_eq!(node_ids(&value), vec![id], "{value}");
+        assert_eq!(value["nodes"][0]["properties"]["name"], "Alice");
+        // "Bob" did not hold yet at t1...
+        let value = find(&server, name_req_at("Person", "Bob", &t1));
+        assert!(node_ids(&value).is_empty(), "{value}");
+        // ...and the situation reverses at t2.
+        let value = find(&server, name_req_at("Person", "Bob", &t2));
+        assert_eq!(node_ids(&value), vec![id]);
+        assert_eq!(value["nodes"][0]["properties"]["name"], "Bob");
+        let value = find(&server, name_req_at("Person", "Alice", &t2));
+        assert!(node_ids(&value).is_empty(), "{value}");
+    }
+
+    #[test]
+    fn node_created_after_t_is_excluded() {
+        let server = create_test_server();
+        let t0 = anchor_after_commits();
+        let id = create_named(&server, "Person", "Alice");
+        let t1 = anchor_after_commits();
+
+        let value = find(&server, name_req("Person", "Alice", &t0));
+        assert!(
+            node_ids(&value).is_empty(),
+            "node created after T must be excluded: {value}"
+        );
+        let value = find(&server, name_req("Person", "Alice", &t1));
+        assert_eq!(node_ids(&value), vec![id]);
+    }
+
+    #[test]
+    fn node_deleted_before_t_recalled_when_both_dimensions_anchored() {
+        let server = create_test_server();
+        let id = create_named(&server, "Person", "Alice");
+        let t_before = anchor_after_commits();
+        delete(&server, id);
+        let t_after = anchor_after_commits();
+
+        // Both dimensions anchored before the deletion recall the node even
+        // though it no longer exists in current state.
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                transaction_time: Some(t_before.clone()),
+                ..name_req("Person", "Alice", &t_before)
+            },
+        );
+        assert_eq!(node_ids(&value), vec![id], "{value}");
+
+        // At a coordinate after the deletion the node is gone.
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                transaction_time: Some(t_after.clone()),
+                ..name_req("Person", "Alice", &t_after)
+            },
+        );
+        assert!(node_ids(&value).is_empty(), "{value}");
+    }
+
+    #[test]
+    fn label_only_as_of_scan_without_property_filter() {
+        let server = create_test_server();
+        let a = create_named(&server, "Person", "Alice");
+        let b = create_named(&server, "Person", "Bob");
+        let _c = create_named(&server, "Company", "Acme");
+        let t1 = anchor_after_commits();
+        delete(&server, b);
+        let t2 = anchor_after_commits();
+
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                transaction_time: Some(t1.clone()),
+                ..base_req("Person", &t1)
+            },
+        );
+        assert_eq!(node_ids(&value), vec![a, b], "{value}");
+
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                transaction_time: Some(t2.clone()),
+                ..base_req("Person", &t2)
+            },
+        );
+        assert_eq!(node_ids(&value), vec![a], "{value}");
+    }
+
+    #[test]
+    fn current_state_equivalence_with_list_nodes_property_filter() {
+        let server = create_test_server();
+        let _a = create_named(&server, "Person", "Alice");
+        let _b = create_named(&server, "Person", "Bob");
+        let _c = create_named(&server, "Person", "Alice");
+        let now = anchor_after_commits();
+
+        let list_value: serde_json::Value =
+            serde_json::from_str(&server.list_nodes(ListNodesRequest {
+                label: Some("Person".to_string()),
+                property_key: Some("name".to_string()),
+                property_value: Some(serde_json::json!("Alice")),
+                limit: None,
+                offset: None,
+                include_vectors: None,
+            }))
+            .unwrap();
+        let mut current_ids = node_ids(&list_value);
+        current_ids.sort_unstable();
+
+        let at_now = find(&server, name_req("Person", "Alice", &now));
+        assert_eq!(
+            node_ids(&at_now),
+            current_ids,
+            "valid_time=now + transaction_time=now must equal the current-state result set"
+        );
+    }
+
+    #[test]
+    fn pagination_limit_offset_and_completeness_metadata() {
+        let server = create_test_server();
+        let mut created: Vec<u64> = (0..3)
+            .map(|_| create_named(&server, "Person", "Alice"))
+            .collect();
+        created.sort_unstable();
+        let now = anchor_after_commits();
+
+        // Page 1 (limit 1): stable ordering, exact total, continuation cursor.
+        let page1 = find(
+            &server,
+            FindNodesAtTimeRequest {
+                limit: Some(1),
+                ..name_req("Person", "Alice", &now)
+            },
+        );
+        assert_eq!(node_ids(&page1), vec![created[0]], "{page1}");
+        assert_eq!(page1["count"], serde_json::json!(1));
+        assert_eq!(page1["total_matching"], serde_json::json!(3));
+        assert_eq!(page1["has_more"], serde_json::json!(true));
+        assert_eq!(page1["next_offset"], serde_json::json!(1));
+
+        // Page 2 continues where page 1 left off.
+        let page2 = find(
+            &server,
+            FindNodesAtTimeRequest {
+                limit: Some(1),
+                offset: Some(1),
+                ..name_req("Person", "Alice", &now)
+            },
+        );
+        assert_eq!(node_ids(&page2), vec![created[1]], "{page2}");
+
+        // Final page reports has_more: false.
+        let page3 = find(
+            &server,
+            FindNodesAtTimeRequest {
+                limit: Some(1),
+                offset: Some(2),
+                ..name_req("Person", "Alice", &now)
+            },
+        );
+        assert_eq!(node_ids(&page3), vec![created[2]], "{page3}");
+        assert_eq!(page3["has_more"], serde_json::json!(false));
+    }
+
+    #[test]
+    fn oversized_limit_and_offset_are_clamped_not_errors() {
+        let server = create_test_server();
+        let _ = create_named(&server, "Person", "Alice");
+        let now = anchor_after_commits();
+
+        // Far beyond MAX_RESULT_LIMIT / MAX_PAGINATION_OFFSET: clamped,
+        // exactly like list_nodes -- never an error.
+        let value = find(
+            &server,
+            FindNodesAtTimeRequest {
+                limit: Some(1_000_000),
+                offset: Some(1_000_000),
+                ..name_req("Person", "Alice", &now)
+            },
+        );
+        assert!(value.get("error").is_none(), "{value}");
+        assert_eq!(value["limit"], serde_json::json!(10_000));
+        assert_eq!(value["offset"], serde_json::json!(10_000));
+        assert!(node_ids(&value).is_empty(), "offset past the end: {value}");
+    }
+
+    #[test]
+    fn invalid_or_empty_timestamps_return_structured_errors() {
+        let server = create_test_server();
+
+        let response = server.find_nodes_at_time(base_req("Person", "not-a-timestamp"));
+        assert_invalid_argument(&response, "valid_time");
+
+        let response = server.find_nodes_at_time(base_req("Person", ""));
+        assert_invalid_argument(&response, "valid_time");
+
+        let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            transaction_time: Some("not-a-timestamp".to_string()),
+            ..base_req("Person", &Utc::now().to_rfc3339())
+        });
+        assert_invalid_argument(&response, "transaction_time");
+    }
+
+    #[test]
+    fn property_key_without_value_and_reverse_return_structured_errors() {
+        let server = create_test_server();
+        let now = Utc::now().to_rfc3339();
+
+        let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            property_key: Some("name".to_string()),
+            ..base_req("Person", &now)
+        });
+        assert_invalid_argument(&response, "property_key");
+
+        let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            property_value: Some(serde_json::json!("Alice")),
+            ..base_req("Person", &now)
+        });
+        assert_invalid_argument(&response, "property_value");
+    }
+
+    #[test]
+    fn unsupported_property_value_type_returns_structured_error() {
+        let server = create_test_server();
+        let response = server.find_nodes_at_time(FindNodesAtTimeRequest {
+            property_key: Some("name".to_string()),
+            property_value: Some(serde_json::json!({"nested": "object"})),
+            ..base_req("Person", &Utc::now().to_rfc3339())
+        });
+        assert_invalid_argument(&response, "property_value");
+    }
+
+    #[test]
+    fn response_carries_resolved_bitemporal_coordinate_as_rfc3339() {
+        let server = create_test_server();
+        let _ = create_named(&server, "Person", "Alice");
+        let anchor = anchor_after_commits();
+        let anchor_micros = DateTime::parse_from_rfc3339(&anchor)
+            .unwrap()
+            .timestamp_micros();
+
+        let value = find(&server, name_req("Person", "Alice", &anchor));
+
+        // The resolved valid_time round-trips to the exact requested instant.
+        let valid_time = value["valid_time"].as_str().expect("valid_time present");
+        assert_eq!(
+            DateTime::parse_from_rfc3339(valid_time)
+                .expect("valid_time should be RFC 3339")
+                .timestamp_micros(),
+            anchor_micros
+        );
+
+        // The omitted transaction_time resolves to a concrete "now", not a
+        // placeholder -- it must parse and be at/after the anchor.
+        let tx_time = value["transaction_time"]
+            .as_str()
+            .expect("transaction_time present");
+        let tx_micros = DateTime::parse_from_rfc3339(tx_time)
+            .expect("transaction_time should be RFC 3339")
+            .timestamp_micros();
+        assert!(
+            tx_micros >= anchor_micros,
+            "resolved transaction_time {tx_time} should not precede the request anchor {anchor}"
+        );
+    }
+
+    #[test]
+    fn unknown_label_returns_empty_set_not_error() {
+        let server = create_test_server();
+        let value = find(
+            &server,
+            base_req("NeverSeenLabel3236", &Utc::now().to_rfc3339()),
+        );
+        assert!(value.get("error").is_none(), "{value}");
+        assert!(node_ids(&value).is_empty());
+        assert_eq!(value["total_matching"], serde_json::json!(0));
+        assert_eq!(value["has_more"], serde_json::json!(false));
+    }
+}
+
+// ============================================================================
 // Structured Error Codes with Retriable Flag (Issue #3234)
 // ============================================================================
 //

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -608,6 +608,63 @@ pub struct GetEdgeAtTimeRequest {
     pub transaction_time: Option<String>,
 }
 
+/// Request to find nodes by label (and optional exact property match) as of
+/// a bi-temporal point (Issue #3236). The entry-point resolver for
+/// "the Person named Alice, as of 2024-01-01" when no `NodeId` is known.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindNodesAtTimeRequest {
+    /// The node label to match (required).
+    #[schemars(description = "The node label to match (required)")]
+    pub label: String,
+
+    /// Filter by property key (requires property_value).
+    #[schemars(
+        description = "Filter by property key. Must be used together with 'property_value'."
+    )]
+    pub property_key: Option<String>,
+
+    /// Filter by exact property value (requires property_key).
+    /// Supports: strings, integers, floats, booleans, and null.
+    #[schemars(
+        description = "Filter by exact property value (JSON). Must be used together with 'property_key'."
+    )]
+    pub property_value: Option<serde_json::Value>,
+
+    /// Valid time as ISO 8601 timestamp (when the fact was true in reality).
+    #[schemars(
+        description = "Valid time (required) as ISO 8601 / RFC 3339 timestamp (e.g., \
+                       '2024-01-15T10:00:00Z') or microseconds since epoch: when the fact was \
+                       true in reality"
+    )]
+    pub valid_time: String,
+
+    /// Transaction time as ISO 8601 timestamp (when the fact was recorded).
+    /// If not provided, uses current time.
+    #[schemars(
+        description = "Transaction time as ISO 8601 / RFC 3339 timestamp or microseconds since \
+                       epoch (when recorded). If not provided, uses current time. Note: recalling \
+                       a since-deleted node requires anchoring BOTH dimensions before the \
+                       deletion, not just valid_time."
+    )]
+    pub transaction_time: Option<String>,
+
+    /// Maximum number of nodes to return (default: 100).
+    #[schemars(description = "Maximum number of nodes to return (default: 100)")]
+    pub limit: Option<usize>,
+
+    /// Number of matching nodes to skip (for pagination).
+    #[schemars(description = "Number of matching nodes to skip (for pagination)")]
+    pub offset: Option<usize>,
+
+    /// When true, return full vector/embedding properties instead of the
+    /// elided descriptor (default: false).
+    #[schemars(
+        description = "When true, return full vector/embedding float arrays instead of the elided \
+                       {type, dim, elided:true} descriptor (default: false)"
+    )]
+    pub include_vectors: Option<bool>,
+}
+
 /// Request to list graph-wide changes (node & edge versions) committed within a
 /// transaction-time window. Read-only; the discovery counterpart to `get_node_history`.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]

--- a/src/storage/historical/mod.rs
+++ b/src/storage/historical/mod.rs
@@ -2295,6 +2295,60 @@ impl HistoricalStorage {
         Ok(results)
     }
 
+    /// Batch point-in-time node lookup restricted to a single label
+    /// (Issue #3236).
+    ///
+    /// For each candidate id, resolves the version visible at
+    /// `(valid_time, transaction_time)` and checks the version's recorded
+    /// `label` **before** reconstructing properties, so an off-label
+    /// candidate costs only the version-at-time lookup, never a property
+    /// chain replay. Candidates that are not visible at the coordinate, or
+    /// whose at-time label differs, are simply skipped (no `None`
+    /// placeholders), so the output length may be shorter than the input.
+    /// Output order follows input order.
+    ///
+    /// Like [`get_nodes_at_time`](Self::get_nodes_at_time), a property
+    /// reconstruction failure is a systemic error and propagates as `Err`.
+    pub(crate) fn get_nodes_at_time_with_label(
+        &self,
+        node_ids: &[NodeId],
+        label: InternedString,
+        valid_time: Timestamp,
+        transaction_time: Timestamp,
+    ) -> Result<Vec<Node>> {
+        #[cfg(feature = "observability")]
+        let _span =
+            crate::observability::historical_storage_query_span("get_nodes_at_time_with_label")
+                .entered();
+
+        let mut results = Vec::new();
+
+        for &node_id in node_ids {
+            let Some(version_id) =
+                self.find_node_version_at_time(node_id, valid_time, transaction_time)
+            else {
+                continue;
+            };
+            let version = self
+                .node_versions
+                .get(&version_id)
+                .ok_or(StorageError::VersionNotFound(version_id))?;
+            if version.label != label {
+                continue;
+            }
+            let (matched_node_id, matched_label) = (version.node_id, version.label);
+            let properties = self.reconstruct_node_properties(version_id)?;
+            results.push(Node::new(
+                matched_node_id,
+                matched_label,
+                properties,
+                version_id,
+            ));
+        }
+
+        Ok(results)
+    }
+
     /// Get multiple edges as they existed at a specific point in bi-temporal space.
     ///
     /// This retrieves edges in batch to minimize overhead.

--- a/src/storage/historical/tests.rs
+++ b/src/storage/historical/tests.rs
@@ -4907,3 +4907,89 @@ fn test_reconstruct_nonexistent_edge_version_returns_version_not_found() {
         err => panic!("Expected VersionNotFound for a never-added edge version, got: {err:?}"),
     }
 }
+
+#[test]
+fn test_get_nodes_at_time_with_label_filters_on_version_label_before_reconstruction() {
+    // Unit test for the label-aware batch lookup (Issue #3236): the label
+    // check runs on the version record itself, so off-label and not-visible
+    // candidates are skipped (no `None` placeholders) and only label
+    // matches come back, reconstructed at the queried coordinate.
+    let mut storage = HistoricalStorage::new();
+
+    let person = GLOBAL_INTERNER.intern("Person").unwrap();
+    let company = GLOBAL_INTERNER.intern("Company").unwrap();
+
+    let person_id = NodeId::new(1).unwrap();
+    let company_id = NodeId::new(2).unwrap();
+    let late_person_id = NodeId::new(3).unwrap();
+    let never_versioned = NodeId::new(4).unwrap();
+
+    // Two nodes visible from t=1000, one Person created only at t=3000.
+    storage
+        .add_node_version(
+            person_id,
+            VersionId::new(100).unwrap(),
+            1000.into(),
+            1000.into(),
+            person,
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+            false,
+        )
+        .unwrap();
+    storage
+        .add_node_version(
+            company_id,
+            VersionId::new(101).unwrap(),
+            1000.into(),
+            1000.into(),
+            company,
+            PropertyMapBuilder::new().insert("name", "Acme").build(),
+            false,
+        )
+        .unwrap();
+    storage
+        .add_node_version(
+            late_person_id,
+            VersionId::new(102).unwrap(),
+            3000.into(),
+            3000.into(),
+            person,
+            PropertyMapBuilder::new().insert("name", "Bob").build(),
+            false,
+        )
+        .unwrap();
+
+    let candidates = [person_id, company_id, late_person_id, never_versioned];
+
+    // At t=2000 only the first Person matches: the Company is filtered by
+    // label, the late Person is not yet visible, and the never-versioned id
+    // is skipped without error.
+    let found = storage
+        .get_nodes_at_time_with_label(&candidates, person, 2000.into(), 2000.into())
+        .unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].id, person_id);
+    assert_eq!(found[0].label, person);
+    assert_eq!(
+        found[0].properties.get("name"),
+        Some(&crate::core::property::PropertyValue::from("Alice"))
+    );
+
+    // At t=4000 both Person nodes match, in input order.
+    let found = storage
+        .get_nodes_at_time_with_label(&candidates, person, 4000.into(), 4000.into())
+        .unwrap();
+    assert_eq!(
+        found.iter().map(|n| n.id).collect::<Vec<_>>(),
+        vec![person_id, late_person_id]
+    );
+
+    // The Company label sees only the company node.
+    let found = storage
+        .get_nodes_at_time_with_label(&candidates, company, 2000.into(), 2000.into())
+        .unwrap();
+    assert_eq!(
+        found.iter().map(|n| n.id).collect::<Vec<_>>(),
+        vec![company_id]
+    );
+}


### PR DESCRIPTION
Closes #3236.

## Summary

Adds a `find_nodes_at_time` MCP tool: point-in-time node find by label and optional exact property match at a bi-temporal coordinate. This is the missing *entry-point resolver* for temporal exploration — previously an LLM could ask "what did node 42 look like on 2024-01-01?" (`get_node_at_time`) but had no way to ask "which Person named Alice existed on 2024-01-01?" without already knowing the NodeId.

## API

New tool `find_nodes_at_time`:

- `label` (required) — node label to match
- `property_key` / `property_value` (optional, must be supplied together) — exact-match filter; strings, integers, floats, booleans, and null supported
- `valid_time` (required) — ISO 8601 / RFC 3339 or microseconds since epoch
- `transaction_time` (optional) — defaults to current time; recalling a since-deleted node requires anchoring *both* dimensions before the deletion (same convention as `traverse`/`get_schema`)
- `limit` (default 100, clamped) / `offset` — pagination with `returned_count` / `has_more` / `next_offset` completeness metadata (mirrors #3226)
- `include_vectors` (default false) — vector properties elided per #3220

Response carries each node *as it existed at the coordinate* plus the resolved bi-temporal coordinate echoed back as RFC 3339, and a `sampled` flag (see below). Errors use the #3234 structured `{code, message, retriable}` contract (`INVALID_ARGUMENT` for bad timestamps / mismatched property filter args, etc.).

### Bounded candidate scan with truncation disclosure

The candidate enumeration (every node that has ever had a version recorded) is **capped at the same configurable `max_schema_as_of_entities` limit bi-temporal `get_schema` uses** (default 50,000). When the cap is hit, the lowest `cap` node ids are kept — a deterministic subset, so pagination stays stable — and the response sets `sampled: true`, mirroring `get_schema`'s disclosure. `total_matching` / `has_more` are then honest about the *sampled candidate set only*, and the docs say so. The Rust API surfaces the same disclosure via a new `NodesAtTime { nodes, sampled }` return type.

### Current-state equivalence, qualified

With both dimensions at now the result set equals the current-state `list_nodes` / `find_nodes_by_property` lookup **for nodes whose valid interval has begun**: a node created with a future-dated `valid_from` (#3221) is present in current state but not yet visible at `(now, now)`. This divergence is documented (rustdoc, guide, CLAUDE.md) and pinned by a regression test.

## Implementation

- `src/db/ops.rs` — `find_nodes_at_time` / `find_nodes_by_property_at` public Rust APIs + shared `find_nodes_at_time_filtered` core: capped candidate enumeration (shared `cap_ids` helper with `schema_as_of`), NodeId-sorted results for stable pagination, and **chunked reconstruction** (4096 ids per `historical.read()` acquisition) so cold-tier I/O can't pin the read guard for the whole scan
- `src/storage/historical/mod.rs` — new `pub(crate) get_nodes_at_time_with_label`: resolves each candidate's version at the coordinate and checks the version's label **before** property reconstruction, so off-label candidates never pay a property-chain replay
- `src/mcp/tools.rs` — `FindNodesAtTimeRequest` schema
- `src/mcp/server.rs` — handler with timestamp parsing, property-filter validation, pagination clamping, vector elision, `sampled` disclosure, structured errors; tool registered and routed
- `src/mcp/mod.rs` — re-export
- `docs/guides/mcp-query-tool.md` + `CLAUDE.md` — documentation section, tool-table updates, cap/sampled semantics, equivalence qualification, and #3220 elision list updated to include this tool

## Testing

28 feature tests (11 ops-layer, 16 MCP-layer, 1 storage-layer unit test). *Correction: the original PR text claimed 20 new tests; the accurate count at that revision was 19 (7 ops, 12 MCP). Review follow-ups added 9 more.*

Coverage: version reconstruction at T, node created after T excluded, deleted-node recall with both dimensions anchored **and the negative case** (valid-time-only anchoring must NOT recall), backdated-valid-time coordinates that make the two temporal dimensions observably different (kills a dimension-swap mutant that previously survived all tests), future-dated `valid_from` divergence from current state, label-only scan, qualified current-state equivalence, pagination + completeness metadata on pages 1 *and* 2, `limit: 0` clamped up to 1 (kills the clamp mutant), clamping, structured errors, empty-set for unknown label, RFC 3339 coordinate echo, vector elision round-trip, candidate-cap truncation + `sampled: true` disclosure at both layers (injected small cap, mirroring the `schema_as_of` cap test), and version-label pre-filtering at the storage layer. Mutation kills for the dimension-swap, limit-clamp, and sort-removal mutants were verified by applying each mutant locally and confirming test failure (sort-removal fails 3/3 runs via the cap test, which is sized so `select_nth_unstable` provably scrambles the id order).

- `cargo test --lib --features mcp-server` (post-rebase onto trunk @ 8b7b2ff): `3620 passed; 0 failed; 2 ignored`
- `cargo test --doc --features mcp-server`: `409 passed; 0 failed; 111 ignored`
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all`: applied
- The full 138-binary integration suite was not re-run on the follow-up commit due to CI-sandbox disk exhaustion; the lib suite (which contains all MCP and ops tests for this feature) plus doc tests and the documentation-validation integration test are green. The two known failures in `havoc_flush_deadlock` / `regression_flush_corruption` are pre-existing root-sandbox artifacts (fault injection via `chmod` is bypassed at uid 0), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G55DsVso39kbYJtjxZDBpK

---
_Generated by [Claude Code](https://claude.ai/code/session_01G55DsVso39kbYJtjxZDBpK)_