### PR TITLE
Disable index persistence in PersistenceConfig::default() — stop silently reading/writing cwd-relative ./data (#3388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AletheiaDB::open(path)` / `durable_config_for_data_dir(path)`, which are
   unaffected. **Breaking for callers that relied on the implicit default:**
   a config that never touches `PersistenceConfig` no longer persists indexes
-  (the WAL still provides durability when configured).
+  (the WAL still provides durability when configured). TOML configs must now
+  set `enabled = true` under `[persistence]`; a `[persistence]` section that
+  omits `enabled` (even one that sets `data_dir` or `load_on_startup`) is
+  treated as disabled.
 
 - MCP tool error responses are now structured (Issue #3234): every error is
   `{"error": {"code", "message", "retriable", "details"?}}` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `PersistenceConfig::default()` no longer enables index persistence
+  (Issue #3388). The old default (`enabled: true` with the cwd-relative
+  `data_dir: "data"`) made every database built from a default or builder
+  config silently write index snapshots into `./data` on shutdown and load
+  whatever `./data` happened to contain on startup, so unrelated instances
+  sharing a working directory could observe each other's data and a stale
+  `./data` could short-circuit WAL replay (this caused a real CI flake).
+  Index persistence is now opt-in: set `enabled: true` together with an
+  explicit `data_dir`, or use the canonical durable entry points
+  `AletheiaDB::open(path)` / `durable_config_for_data_dir(path)`, which are
+  unaffected. **Breaking for callers that relied on the implicit default:**
+  a config that never touches `PersistenceConfig` no longer persists indexes
+  (the WAL still provides durability when configured).
+
 - MCP tool error responses are now structured (Issue #3234): every error is
   `{"error": {"code", "message", "retriable", "details"?}}` instead of
   `{"error": "<string>"}`. `code` is drawn from a stable seven-value enum

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -226,7 +226,10 @@ max_batch_size = 1000
 > instances that share a working directory observe each other's data. If you
 > relied on that implicit default, opt in explicitly with `enabled: true`
 > and an explicit `data_dir`, or use `AletheiaDB::open(path)` /
-> `durable_config_for_data_dir(path)`.
+> `durable_config_for_data_dir(path)`. TOML configs must now set
+> `enabled = true` under `[persistence]`; a `[persistence]` section that
+> omits `enabled` (even one that sets `data_dir` or `load_on_startup`) is
+> treated as disabled.
 
 #### Persistence Policies
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -214,10 +214,19 @@ max_batch_size = 1000
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `enabled` | bool | false | Enable index persistence |
-| `data_dir` | PathBuf | "data/indexes" | Directory for index files |
-| `load_on_startup` | bool | false | Load indexes on startup |
-| `use_mmap` | bool | false | Use memory-mapped loading |
+| `data_dir` | PathBuf | "data" | Directory for index files (cwd-relative placeholder; always set explicitly when enabling) |
+| `load_on_startup` | bool | true | Load indexes on startup (only applies when enabled) |
+| `use_mmap` | bool | true | Use memory-mapped loading |
 | `policies` | PersistencePolicies | Default | Automatic persistence policies |
+
+> **Note (Issue #3388):** Index persistence is opt-in. Before this change,
+> `PersistenceConfig::default()` had `enabled: true` with the cwd-relative
+> `data_dir: "data"`, so any database built from a default/builder config
+> silently persisted into (and loaded from) `./data`, letting unrelated
+> instances that share a working directory observe each other's data. If you
+> relied on that implicit default, opt in explicitly with `enabled: true`
+> and an explicit `data_dir`, or use `AletheiaDB::open(path)` /
+> `durable_config_for_data_dir(path)`.
 
 #### Persistence Policies
 
@@ -430,6 +439,7 @@ HistoricalConfigBuilder::new()
 // Enable index persistence for fast cold starts
 PersistenceConfig {
     enabled: true,
+    data_dir: "/var/lib/my-app/indexes".into(),  // Always set explicitly when enabling
     load_on_startup: true,
     use_mmap: true,  // Memory-map large indexes
     ..Default::default()

--- a/docs/guides/PERSISTENCE.md
+++ b/docs/guides/PERSISTENCE.md
@@ -19,6 +19,10 @@ Persistence) in one line — see below. Reach for `with_unified_config()`
 directly only when you need to tune durability mode, stripe counts, or add
 cold storage (Pattern 3).
 
+> **Migration note (Issue #3388):** Index persistence is now opt-in —
+> `PersistenceConfig::default()` has `enabled: false`; set `enabled: true`
+> with an explicit `data_dir` (or use `AletheiaDB::open(path)`) to persist.
+
 ## Current Reality (Important)
 
 As of 2026-02, persistence and recovery behave as follows:

--- a/docs/guides/index-persistence-guide.md
+++ b/docs/guides/index-persistence-guide.md
@@ -20,6 +20,10 @@ AletheiaDB's index persistence layer enables **fast cold starts** by saving all 
 - ✅ Temporal indexes (bi-temporal version chains)
 - ✅ String interner (label/property key deduplication)
 
+> **Migration note (Issue #3388):** Index persistence is now opt-in —
+> `PersistenceConfig::default()` has `enabled: false`; set `enabled: true`
+> with an explicit `data_dir` (or use `AletheiaDB::open(path)`) to persist.
+
 ## Current Reality (Important)
 
 As of 2026-02, the active restart/recovery path is:
@@ -555,6 +559,7 @@ println!("LSN: {}", metrics.current_lsn);
 ```rust
 PersistenceConfig {
     enabled: true,
+    data_dir: ".dev-data/indexes".into(),  // Always set explicitly when enabling
     save_interval_secs: 60,      // Save every minute
     save_on_shutdown: true,       // Always save on exit
     ..Default::default()
@@ -565,6 +570,7 @@ PersistenceConfig {
 ```rust
 PersistenceConfig {
     enabled: true,
+    data_dir: "/var/lib/my-app/indexes".into(),  // Always set explicitly when enabling
     save_interval_secs: 300,     // Save every 5 minutes
     save_on_shutdown: true,       // Always save on exit
     save_after_transactions: Some(10000),  // Also save after 10K txns

--- a/src/config.rs
+++ b/src/config.rs
@@ -1534,6 +1534,34 @@ wal_dir = "/custom/path/to/wal"
         assert_eq!(config.wal.wal_dir, PathBuf::from("/custom/path/to/wal"));
     }
 
+    /// Issue #3388: with `#[serde(default)]`, a TOML `[persistence]` section
+    /// that sets other fields but omits `enabled` must inherit the disabled
+    /// default — it must not silently re-enable persistence.
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn toml_persistence_omitting_enabled_stays_disabled() {
+        let c = AletheiaDBConfig::from_toml_str("[persistence]\ndata_dir = \"custom\"\n").unwrap();
+        assert!(
+            !c.persistence.enabled,
+            "TOML [persistence] without `enabled` must inherit the disabled default (Issue #3388)"
+        );
+        let c = AletheiaDBConfig::from_toml_str("").unwrap();
+        assert!(!c.persistence.enabled);
+    }
+
+    /// The canonical durable entry point must keep persistence enabled with
+    /// explicit directories, unaffected by the Issue #3388 default flip.
+    #[test]
+    fn durable_config_keeps_persistence_enabled() {
+        let c = durable_config_for_data_dir("/some/root");
+        assert!(c.persistence.enabled);
+        assert_eq!(
+            c.persistence.data_dir,
+            std::path::Path::new("/some/root/indexes")
+        );
+        assert!(c.persistence.load_on_startup);
+    }
+
     // Validation error tests
 
     #[test]

--- a/src/storage/index_persistence/api.rs
+++ b/src/storage/index_persistence/api.rs
@@ -9,13 +9,33 @@ use serde::{Deserialize, Serialize};
 use super::formats::PersistencePolicies;
 
 /// Configuration for index persistence.
+///
+/// Index persistence is **opt-in**: the default configuration is disabled.
+/// To enable it, set `enabled: true` and point `data_dir` at an explicit,
+/// application-owned directory:
+///
+/// ```ignore
+/// PersistenceConfig {
+///     enabled: true,
+///     data_dir: my_data_dir.join("indexes"),
+///     load_on_startup: true,
+///     ..Default::default()
+/// }
+/// ```
+///
+/// Or use [`crate::AletheiaDB::open`] /
+/// [`crate::config::durable_config_for_data_dir`], which wire this up for you
+/// under a single data-directory root.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "config-toml", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "config-toml", serde(default))]
 pub struct PersistenceConfig {
-    /// Whether persistence is enabled
+    /// Whether persistence is enabled. Defaults to `false`; always pair
+    /// `enabled: true` with an explicit `data_dir`.
     pub enabled: bool,
-    /// Base data directory
+    /// Base data directory. The default `"data"` is a cwd-relative
+    /// placeholder that is inert while `enabled` is `false` — override it
+    /// with an explicit path whenever you enable persistence.
     pub data_dir: PathBuf,
     /// Persistence trigger policies
     pub policies: PersistencePolicies,
@@ -25,10 +45,29 @@ pub struct PersistenceConfig {
     pub use_mmap: bool,
 }
 
+/// The default is **disabled** persistence (Issue #3388).
+///
+/// Prior to Issue #3388 the default was `enabled: true` with the
+/// cwd-relative `data_dir: "data"`. Every database built from a default or
+/// builder config silently wrote index snapshots into `./data` on shutdown
+/// and loaded whatever `./data` happened to contain on startup — so
+/// unrelated processes/tests sharing a working directory could observe each
+/// other's data, and a stale `./data` could short-circuit WAL replay.
+///
+/// # Migration
+///
+/// If you relied on the old implicit default, opt in explicitly:
+///
+/// - set `.persistence(PersistenceConfig { enabled: true, data_dir: <your
+///   path>, load_on_startup: true, ..Default::default() })` on the config
+///   builder, or
+/// - use [`crate::AletheiaDB::open`] (or
+///   [`crate::config::durable_config_for_data_dir`]), the canonical durable
+///   entry points, which always use explicit directories.
 impl Default for PersistenceConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             data_dir: PathBuf::from("data"),
             policies: PersistencePolicies::default(),
             load_on_startup: true,

--- a/tests/regressions/mod.rs
+++ b/tests/regressions/mod.rs
@@ -4,6 +4,7 @@ mod interner_leak_prevention;
 mod interner_property_delta;
 mod interner_wal_labels;
 mod mvcc_snapshot_visibility;
+mod persistence_default_isolation;
 mod persistence_version_ids;
 mod property_deserialization_dos;
 mod temporal_query_visibility;

--- a/tests/regressions/persistence_default_isolation.rs
+++ b/tests/regressions/persistence_default_isolation.rs
@@ -1,0 +1,101 @@
+//! Regression tests for Issue #3388: `PersistenceConfig::default()` must not
+//! silently enable index persistence rooted at a cwd-relative `data` directory.
+//!
+//! Before the fix, the default was `enabled: true` with `data_dir: "data"`, so
+//! any database built from a default/builder config (without an explicit
+//! `.persistence(...)`) would write index snapshots into `./data` on shutdown
+//! and load whatever happened to be in `./data` on startup. Two unrelated
+//! database instances — e.g. two tests, or two test *runs* — could therefore
+//! observe each other's data, and a stale `./data` directory could
+//! short-circuit WAL-replay tests (this caused a real CI flake during the
+//! PR #3347 run).
+
+use aletheiadb::config::{AletheiaDBConfig, WalConfigBuilder};
+use aletheiadb::storage::index_persistence::PersistenceConfig;
+use aletheiadb::{AletheiaDB, PropertyMapBuilder};
+use tempfile::tempdir;
+
+/// The default persistence config must be inert: no directory is read or
+/// written unless the caller opts in with `enabled: true` and an explicit
+/// `data_dir`.
+#[test]
+fn persistence_config_default_is_disabled() {
+    assert!(
+        !PersistenceConfig::default().enabled,
+        "PersistenceConfig::default() must not enable persistence: the default \
+         data_dir is cwd-relative, so an enabled default silently reads/writes \
+         ./data (Issue #3388)"
+    );
+    assert!(
+        !AletheiaDBConfig::default().persistence.enabled,
+        "AletheiaDBConfig::default() (and thus builder configs without \
+         .persistence(...)) must not enable persistence (Issue #3388)"
+    );
+}
+
+/// Two independent database instances created from default configs must not
+/// observe each other's data through the shared cwd-relative `./data`
+/// directory.
+///
+/// Each instance gets its own WAL directory (WAL isolation is orthogonal to
+/// this issue); persistence is deliberately left at its default. Before the
+/// fix, instance A's shutdown snapshot landed in `./data` and instance B
+/// loaded it on startup (`load_on_startup` combined with the enabled
+/// default), so B saw A's node.
+#[test]
+fn default_config_instances_cannot_observe_each_others_data() {
+    let cwd_data = std::path::Path::new("data");
+    let data_preexisted = cwd_data.exists();
+
+    let dir_a = tempdir().expect("create tempdir for instance A");
+    let dir_b = tempdir().expect("create tempdir for instance B");
+
+    // Instance A: default config apart from an isolated WAL dir. Writes one
+    // node, then drops (before the fix, drop triggered a final index snapshot
+    // into the default cwd-relative ./data).
+    {
+        let config = AletheiaDBConfig::builder()
+            .wal(
+                WalConfigBuilder::new()
+                    .wal_dir(dir_a.path().join("wal"))
+                    .build(),
+            )
+            .build();
+        let db = AletheiaDB::with_unified_config(config).expect("create instance A");
+        db.create_node(
+            "Person",
+            PropertyMapBuilder::new().insert("name", "Alice").build(),
+        )
+        .expect("create node in instance A");
+        assert_eq!(db.node_count(), 1);
+    }
+
+    // Instance B: an unrelated database, also on a default config (own WAL
+    // dir, persistence untouched). It must start empty.
+    let config = AletheiaDBConfig::builder()
+        .wal(
+            WalConfigBuilder::new()
+                .wal_dir(dir_b.path().join("wal"))
+                .build(),
+        )
+        .build();
+    let db = AletheiaDB::with_unified_config(config).expect("create instance B");
+    assert_eq!(
+        db.node_count(),
+        0,
+        "an independent database with a default config must not observe \
+         another instance's data (Issue #3388: default persistence leaked \
+         state through the cwd-relative ./data directory)"
+    );
+
+    // The default config must not have materialized a cwd-relative ./data
+    // directory as a side effect. Only assert when the directory did not
+    // already exist, so a genuinely user-created ./data never fails this test.
+    if !data_preexisted {
+        assert!(
+            !cwd_data.exists(),
+            "a default config must not create a cwd-relative ./data directory \
+             (Issue #3388)"
+        );
+    }
+}

--- a/tests/regressions/persistence_default_isolation.rs
+++ b/tests/regressions/persistence_default_isolation.rs
@@ -31,19 +31,37 @@ fn persistence_config_default_is_disabled() {
         "AletheiaDBConfig::default() (and thus builder configs without \
          .persistence(...)) must not enable persistence (Issue #3388)"
     );
+    assert_eq!(
+        PersistenceConfig::default().data_dir,
+        std::path::PathBuf::from("data"),
+        "the default data_dir is a cwd-relative placeholder that must stay \
+         inert while enabled is false (Issue #3388); if this changes, revisit \
+         the migration notes and the isolation test below"
+    );
 }
 
 /// Two independent database instances created from default configs must not
-/// observe each other's data through the shared cwd-relative `./data`
-/// directory.
+/// leak data to each other through the *index-persistence* channel — the
+/// shared cwd-relative `./data` directory the old enabled-by-default
+/// `PersistenceConfig` wrote to and loaded from.
 ///
-/// Each instance gets its own WAL directory (WAL isolation is orthogonal to
-/// this issue); persistence is deliberately left at its default. Before the
-/// fix, instance A's shutdown snapshot landed in `./data` and instance B
-/// loaded it on startup (`load_on_startup` combined with the enabled
-/// default), so B saw A's node.
+/// Scope: this proves the persistence channel is closed. It does NOT cover
+/// the WAL channel: `WalConfig::default().wal_dir` is still the cwd-relative
+/// `"aletheiadb/wal"`, a separate known footgun through which two default
+/// configs sharing a cwd could still observe each other's data via WAL
+/// replay — which is exactly why each instance below is given its own
+/// isolated WAL directory. Fixing that default is a follow-up candidate.
+///
+/// Persistence is deliberately left at its default. Before the fix, instance
+/// A's shutdown snapshot landed in `./data` and instance B loaded it on
+/// startup (`load_on_startup` combined with the enabled default), so B saw
+/// A's node.
+///
+/// Note: if the fix were reverted, the first failure here is clean (B
+/// observes A's node), but the failed run leaves a stray `./data` directory
+/// behind in the checkout.
 #[test]
-fn default_config_instances_cannot_observe_each_others_data() {
+fn default_persistence_cannot_leak_between_instances() {
     let cwd_data = std::path::Path::new("data");
     let data_preexisted = cwd_data.exists();
 


### PR DESCRIPTION
## Before / After

**Before:** `PersistenceConfig::default()` was `enabled: true` with the cwd-relative `data_dir: "data"`. Any database built from a default or builder config — anything that never called `.persistence(...)` — silently wrote index snapshots into `./data` on shutdown and loaded whatever `./data` happened to contain on startup. Two unrelated database instances sharing a working directory (two tests, or two test *runs*) could observe each other's data, and a stray `./data` could short-circuit WAL-replay tests. This caused a real CI flake during the PR #3347 run: a trunk-owned #3346 test failed once from `./data` contamination and passed on rerun.

**After:** Index persistence is opt-in. The default is `enabled: false`; the cwd-relative `data_dir` placeholder is inert until a caller explicitly enables persistence (which should always be paired with an explicit `data_dir`). A default-config database touches no cwd-relative directory, and two independent default-config instances can never observe each other's data.

**Unaffected:** `AletheiaDB::open(path)` and `durable_config_for_data_dir(path)` — the canonical durable entry points — always set explicit directories and behave exactly as before. `AletheiaDB::new()` remains ephemeral/tempdir-backed. Every in-repo call site that enables persistence already sets `data_dir` explicitly, and every call site using `..Default::default()` sets `enabled` explicitly, so no test/example needed changes (full audit below).

**Migration (for external users relying on the old implicit default):** opt in explicitly with `PersistenceConfig { enabled: true, data_dir: "/path/to/indexes".into(), load_on_startup: true, ..Default::default() }`, or use `AletheiaDB::open(path)`. TOML configs must now set `enabled = true` under `[persistence]`; a `[persistence]` section that omits `enabled` (even one that sets `data_dir` or `load_on_startup`) is treated as disabled. Documented in the `PersistenceConfig` rustdoc, `docs/CONFIGURATION.md`, `docs/guides/PERSISTENCE.md`, `docs/guides/index-persistence-guide.md`, and `CHANGELOG.md`.

## How

- `src/storage/index_persistence/api.rs`: `Default for PersistenceConfig` now sets `enabled: false` (all other fields unchanged). Rustdoc on the struct, the `enabled`/`data_dir` fields, and the `Default` impl documents the contract and the migration.
- `tests/regressions/persistence_default_isolation.rs` (new, registered in `tests/regressions/mod.rs`):
  - `persistence_config_default_is_disabled` — the default (and `AletheiaDBConfig::default().persistence`) must be disabled, and the default `data_dir` placeholder is pinned as inert.
  - `default_persistence_cannot_leak_between_instances` — two independent instances on default configs (own WAL dirs; persistence untouched): instance B must start empty and no cwd-relative `./data` may be materialized. Verified RED against the old default: instance B loaded instance A's node from `./data` ("Index restoration completed successfully: 1 nodes"), exactly the reported contamination. Scope: this closes the *persistence* leakage channel; the cwd-relative WAL default is a separate footgun (see follow-ups).
- `src/config.rs` tests: `toml_persistence_omitting_enabled_stays_disabled` pins the `#[serde(default)]` TOML behavior above; `durable_config_keeps_persistence_enabled` pins that the durable entry point still enables persistence with explicit directories.
- `docs/CONFIGURATION.md`: the persistence defaults table previously disagreed with the code (it already claimed `enabled: false` but had wrong values for the other fields); it now matches the code, with a migration note (including the TOML caveat). The read-heavy-tuning example now sets an explicit `data_dir`.
- `docs/guides/PERSISTENCE.md` / `docs/guides/index-persistence-guide.md`: one-line #3388 opt-in migration notes; the guide's Development/Production snippets now set an explicit `data_dir`.
- `CHANGELOG.md`: `Changed` entry describing the behavior change and migration (including the TOML caveat).

### Option analysis (AC 1)

| Option | Verdict |
|---|---|
| **(a) `enabled: false` by default** — chosen | A `Default` must not do disk I/O in the cwd. Minimal diff; all in-repo `..Default::default()` sites already set `enabled` explicitly; the durable entry points already use explicit dirs; and `docs/CONFIGURATION.md` already documented `enabled: false`, so this aligns code with documented intent. |
| (b) Remove `Default` / require explicit `data_dir` | Most type-safe, but breaks `#[serde(default)]` on `AletheiaDBConfig`/`PersistenceConfig` (TOML loading), `AletheiaDBConfig: Default`, and ~40 call sites — disproportionate churn for the same safety outcome. |
| (c) Default to a unique temp dir | `Default::default()` doing I/O (tempdir creation) is a worse footgun: it can fail (Default is infallible), breaks `PartialEq`/serde round-trips, and *silently discards* data users believed persisted. |

## Known-failing sandbox tests (pre-existing, unrelated)

`cargo test --no-fail-fast`: 135 test targets pass; the only failures are the two known fault-injection tests that always fail under uid 0 (permission-based I/O faults don't fire as root): `havoc_suites::wal::havoc_flush_deadlock::test_flush_deadlock_on_io_error` and `regression_flush_corruption::test_metadata_corruption_on_error`.

## Follow-up candidates (out of scope)

- **`CheckpointConfig::default()` has the same cwd-relative `data_dir: "data"` footgun** (`src/storage/checkpoint.rs:100`) — its `CheckpointManager::new(CheckpointConfig::default())` doc-tests create `./data/indexes/*` in the repo root on every `cargo test`. Deserves a sibling issue.
- **Cwd-relative WAL defaults allow cross-instance leakage via full WAL replay**: `WalConfig::default().wal_dir` is `"aletheiadb/wal"` (`src/config.rs:110`), and `ConcurrentWalConfig` / `FlushCoordinatorConfig` both default to `"data/wal"`. Two default-config instances sharing a cwd can still observe each other's data through WAL replay — the same class of footgun this PR closes for index persistence.
- **`enabled: true` + `load_on_startup: false` performs no WAL replay at startup** (`src/db/config.rs:391` / `:496`) — silent data loss on crash-reopen under that combination.
- **`docs/guides/index-persistence-guide.md` documents nonexistent fields** (`base_path`, `save_interval_secs`, `save_on_shutdown`) that don't exist on `PersistenceConfig` — doc drift to clean up.

Closes #3388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XofW5uCwnXmzBiM92R1PpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XofW5uCwnXmzBiM92R1PpN)_